### PR TITLE
PulseAudio: Fixed multi-speaker setup problem

### DIFF
--- a/src/mumble/PulseAudio.h
+++ b/src/mumble/PulseAudio.h
@@ -58,7 +58,7 @@ class PulseAudioSystem : public QObject {
 		bool bPositionalCache;
 		QHash<QString, QString> qhEchoMap;
 		QHash<QString, pa_sample_spec> qhSpecMap;
-		QHash<QString, int> qhIndexMap;
+		QHash<QString, pa_channel_map> qhChanMap;
 
 		static void defer_event_callback(pa_mainloop_api *a, pa_defer_event *e, void *userdata);
 		static void context_state_callback(pa_context *c, void *userdata);


### PR DESCRIPTION
When using PulseAudio together with positional audio you sometimes end up with a strange speaker configuration setup for mumble. This happens when one uses a speaker setup that included a subwoofer/LFE channel. This was due to the fact that now channel map was given when initializing a new pa_stream. Also when I would pick a 7.1 speaker setup in the PulseAudio volume manager mumble would crash.

This patch sets the channel map equal to the channel map of the output device. This also fixed the 7.1 crash.

I also comment out a QHash, as it seemed to be unused. And completed the QHash.clear() list in PulseAudioSystem::query(), for possible unnecessary memory usage.
