### PR TITLE
Fixed Ice method getLogLen() requiring write secret instead of read secret.

### DIFF
--- a/src/murmur/MurmurIce.cpp
+++ b/src/murmur/MurmurIce.cpp
@@ -829,6 +829,7 @@ static void impl_Server_getLog(const ::Murmur::AMD_Server_getLogPtr cb, int serv
 	cb->ice_response(ll);
 }
 
+#define ACCESS_Server_getLogLen_READ
 static void impl_Server_getLogLen(const ::Murmur::AMD_Server_getLogLenPtr cb, int server_id) {
 	NEED_SERVER_EXISTS;
 


### PR DESCRIPTION
IRC user ipnoz reported that getLogLen() requires write permissions over Ice. Whoops.
