### PR TITLE
Added "Copy URL" to channel context menu.

### DIFF
--- a/src/mumble/ConnectDialog.cpp
+++ b/src/mumble/ConnectDialog.cpp
@@ -570,23 +570,43 @@ FavoriteServer ServerItem::toFavoriteServer() const {
 	return fs;
 }
 
+
+/*!
+  \fn QMimeData *ServerItem::toMimeData() const
+  This function turns a ServerItem object into a QMimeData object holding a URL to the server.
+*/
 QMimeData *ServerItem::toMimeData() const {
+	QMimeData *mime = ServerItem::toMimeData(qsName, qsHostname, usPort);
+
+	if (itType == FavoriteType)
+		mime->setData(QLatin1String("OriginatedInMumble"), QByteArray());
+
+	return mime;
+}
+
+/*!
+  \fn QMimeData *ServerItem::toMimeData(const QString &name, const QString &host, unsigned short port, const QString &channel)
+  This function creates a QMimeData object containing a URL to the server at \a host and \a port. \a name is passed in the 
+  query string as "title", which is used for adding a server to favorites. \a channel may be omitted, but if specified it 
+  should be in the format of "/path/to/channel".
+*/
+QMimeData *ServerItem::toMimeData(const QString &name, const QString &host, unsigned short port, const QString &channel) {
 	QUrl url;
 	url.setScheme(QLatin1String("mumble"));
-	url.setHost(qsHostname);
-	url.setPort(usPort);
-	url.addQueryItem(QLatin1String("title"), qsName);
-	if (! qsUrl.isEmpty())
-		url.addQueryItem(QLatin1String("url"), qsUrl);
+	url.setHost(host);
+	if (port != 64738)
+		url.setPort(port);
+	url.setPath(channel);
+	url.addQueryItem(QLatin1String("title"), name);
 	url.addQueryItem(QLatin1String("version"), QLatin1String("1.2.0"));
-
+	
 	QString qs = QLatin1String(url.toEncoded());
 
 	QMimeData *mime = new QMimeData;
-
+	
 #ifdef Q_OS_WIN
 	QString contents = QString::fromLatin1("[InternetShortcut]\r\nURL=%1\r\n").arg(qs);
-	QString urlname = QString::fromLatin1("%1.url").arg(qsName);
+	QString urlname = QString::fromLatin1("%1.url").arg(name);
 
 	FILEGROUPDESCRIPTORA fgda;
 	ZeroMemory(&fgda, sizeof(fgda));
@@ -622,10 +642,7 @@ QMimeData *ServerItem::toMimeData() const {
 	mime->setUrls(urls);
 
 	mime->setText(qs);
-	mime->setHtml(QString::fromLatin1("<a href=\"%1\">%2</a>").arg(qs).arg(qsName));
-
-	if (itType == FavoriteType)
-		mime->setData(QLatin1String("OriginatedInMumble"), QByteArray());
+	mime->setHtml(QString::fromLatin1("<a href=\"%1\">%2</a>").arg(qs).arg(name));
 
 	return mime;
 }

--- a/src/mumble/ConnectDialog.h
+++ b/src/mumble/ConnectDialog.h
@@ -155,6 +155,7 @@ class ServerItem : public QTreeWidgetItem, public PingStats {
 
 		FavoriteServer toFavoriteServer() const;
 		QMimeData *toMimeData() const;
+		static QMimeData *toMimeData(const QString &name, const QString &host, unsigned short port, const QString &channel = QString());
 
 		static QIcon loadIcon(const QString &name);
 

--- a/src/mumble/MainWindow.cpp
+++ b/src/mumble/MainWindow.cpp
@@ -1555,6 +1555,7 @@ void MainWindow::qmChannel_aboutToShow() {
 	qmChannel->addAction(qaChannelUnlinkAll);
 	qmChannel->addSeparator();
 	qmChannel->addAction(qaChannelSendMessage);
+	qmChannel->addAction(qaChannelCopyURL);
 
 #ifndef Q_OS_MAC
 	if (g.s.bMinimalView) {
@@ -1724,6 +1725,26 @@ void MainWindow::on_qaChannelSendMessage_triggered() {
 			g.l->log(Log::TextMessage, tr("To %1: %2").arg(Log::formatChannel(c), texm->message()), tr("Message to channel %1").arg(c->qsName), true);
 	}
 	delete texm;
+}
+
+void MainWindow::on_qaChannelCopyURL_triggered() {
+	Channel *c = getContextMenuChannel();
+	QString host, uname, pw, channel;
+	unsigned short port;
+	
+	if (!c)
+		return;
+
+	g.sh->getConnectionInfo(host, port, uname, pw);
+	
+	// walk back up the channel list to build the URL.
+	while (c->cParent != NULL) {
+		channel.prepend(c->qsName);
+		channel.prepend(QLatin1String("/"));
+		c = c->cParent;
+	}
+	
+	QApplication::clipboard()->setMimeData(ServerItem::toMimeData(c->qsName, host, port, channel), QClipboard::Clipboard);
 }
 
 void MainWindow::updateMenuPermissions() {

--- a/src/mumble/MainWindow.h
+++ b/src/mumble/MainWindow.h
@@ -188,6 +188,7 @@ class MainWindow : public QMainWindow, public MessageHandler, public Ui::MainWin
 		void on_qaChannelUnlink_triggered();
 		void on_qaChannelUnlinkAll_triggered();
 		void on_qaChannelSendMessage_triggered();
+		void on_qaChannelCopyURL_triggered();
 		void on_qaAudioReset_triggered();
 		void on_qaAudioMute_triggered();
 		void on_qaAudioDeaf_triggered();

--- a/src/mumble/MainWindow.ui
+++ b/src/mumble/MainWindow.ui
@@ -607,6 +607,17 @@
     <string>Sends a text message to all users in a channel.</string>
    </property>
   </action>
+  <action name="qaChannelCopyURL">
+   <property name="text">
+    <string>&amp;Copy URL</string>
+   </property>
+   <property name="toolTip">
+    <string>Copies a link to this channel to the clipboard.</string>
+   </property>
+   <property name="whatsThis">
+    <string>Copies a link to this channel to the clipboard.</string>
+   </property>
+  </action>
   <action name="qaConfigMinimal">
    <property name="checkable">
     <bool>true</bool>


### PR DESCRIPTION
Ability to right click any channel on the current server, and copy a URL to the system clipboard.

Upon dD0T's advice, I tore out a bunch of my URL-constructing code and used the stuff in ServerItem instead. I created a new overload for ServerItem::ServerItem(), which accepts a path string argument called "channel", and modified ServerItem()::toMimeData() to spit it back out if it's available. I don't think I broke anything in the process.

A couple concerns I have with toMimeData() - I think from reading the docs that the setText() and setHtml() functions on QMimeData blow away the previous setUrls(). I might be reading the docs for QMimeData wrong though.I'm also wondering if all the stuff inside the #ifdef Q_OS_WIN block shouldn't be already inside QMimeData or QClipboard for QT? My build environment on Windows doesn't quite work so I can't confirm that the URL copy works on win32 or not. :(

Another issue is that by using setHtml(), it appears to break the ability to paste into the server dialog, to favorite a server. This worked with using a plaintext url, and a mime-type url, but once I used toMimeData(), it stopped working. I may take a look at the paste stuff in ConnectDialog and see if I can fix that later.

Edit: I figured it out, the ServerItem() constructor I was using was setting the type to Favorite, rather than Public, which Mumble assumes is someone pasting to/from the favorites dialog. Explicitly setting this re-enables the functionality. What I can't figure out is why it worked on windows when the path was null (right clicking the root of the server). Fixed it in the latest commit.
