### PR TITLE
PulseAudio: This will add property info to the PulseAudio streams

### DIFF
--- a/src/mumble/PulseAudio.cpp
+++ b/src/mumble/PulseAudio.cpp
@@ -99,7 +99,16 @@ PulseAudioSystem::PulseAudioSystem() {
 	pam = pa_threaded_mainloop_new();
 	pa_mainloop_api *api = pa_threaded_mainloop_get_api(pam);
 
-	pacContext = pa_context_new(api, "Mumble");
+	pa_proplist     *proplist;
+
+	proplist = pa_proplist_new ();
+	pa_proplist_sets (proplist, PA_PROP_APPLICATION_NAME, "Mumble");
+	pa_proplist_sets (proplist, PA_PROP_APPLICATION_ID, "net.sourceforge.mumble.mumble");
+	pa_proplist_sets (proplist, PA_PROP_APPLICATION_ICON_NAME, "mumble");
+	pa_proplist_sets (proplist, PA_PROP_MEDIA_ROLE, "phone");
+
+	pacContext = pa_context_new_with_proplist (api, NULL, proplist);
+	pa_proplist_free (proplist);
 
 	pa_context_set_subscribe_callback(pacContext, subscribe_callback, this);
 


### PR DESCRIPTION
The original patch can be found [here](http://sourceforge.net/tracker/?func=detail&aid=3199734&group_id=147372&atid=768007), made by ronoc. I only removed a trailing space. The patch is also handy for the future, if we want to add more property information to the PulseAudio streams.

The commit message is a bit long, so it could clutter the log of mumble. This I can change if you want.
