### PR TITLE
Default port constant

### DIFF
--- a/src/Net.h
+++ b/src/Net.h
@@ -31,6 +31,10 @@
 #ifndef _NET_H
 #define _NET_H
 
+#ifndef DEFAULT_MUMBLE_PORT 
+#define DEFAULT_MUMBLE_PORT 64738
+#endif
+
 #include "murmur_pch.h"
 
 struct HostAddress {

--- a/src/mumble/ConnectDialog.cpp
+++ b/src/mumble/ConnectDialog.cpp
@@ -409,7 +409,7 @@ ServerItem *ServerItem::fromMimeData(const QMimeData *mime, QWidget *p) {
 	if (! url.hasQueryItem(QLatin1String("title")))
 		url.addQueryItem(QLatin1String("title"), url.host());
 
-	ServerItem *si = new ServerItem(url.queryItemValue(QLatin1String("title")), url.host(), static_cast<unsigned short>(url.port(64738)), url.userName(), url.password());
+	ServerItem *si = new ServerItem(url.queryItemValue(QLatin1String("title")), url.host(), static_cast<unsigned short>(url.port(DEFAULT_MUMBLE_PORT)), url.userName(), url.password());
 
 	if (url.hasQueryItem(QLatin1String("url")))
 		si->qsUrl = url.queryItemValue(QLatin1String("url"));
@@ -594,7 +594,7 @@ QMimeData *ServerItem::toMimeData(const QString &name, const QString &host, unsi
 	QUrl url;
 	url.setScheme(QLatin1String("mumble"));
 	url.setHost(host);
-	if (port != 64738)
+	if (port != DEFAULT_MUMBLE_PORT)
 		url.setPort(port);
 	url.setPath(channel);
 	url.addQueryItem(QLatin1String("title"), name);
@@ -942,7 +942,7 @@ void ConnectDialog::on_qaFavoriteAdd_triggered() {
 void ConnectDialog::on_qaFavoriteAddNew_triggered() {
 	QString host, user, pw;
 	QString name;
-	unsigned short port = 64738;
+	unsigned short port = DEFAULT_MUMBLE_PORT;
 
 	// Try to fill out fields if possible
 	{

--- a/src/mumble/ConnectDialog.h
+++ b/src/mumble/ConnectDialog.h
@@ -34,6 +34,7 @@
 #include "mumble_pch.hpp"
 #include "Timer.h"
 #include "Database.h"
+#include "Net.h"
 
 #ifdef USE_BONJOUR
 #include "BonjourClient.h"
@@ -187,7 +188,7 @@ class ConnectDialogEdit : public QDialog, protected Ui::ConnectDialogEdit {
 	public:
 		QString qsName, qsHostname, qsUsername, qsPassword;
 		unsigned short usPort;
-		ConnectDialogEdit(QWidget *parent, const QString &name = QString(), const QString &host = QString(), const QString &user = QString(), unsigned short port = 64738, const QString &password = QString(), bool add = false);
+		ConnectDialogEdit(QWidget *parent, const QString &name = QString(), const QString &host = QString(), const QString &user = QString(), unsigned short port = DEFAULT_MUMBLE_PORT, const QString &password = QString(), bool add = false);
 };
 
 class ConnectDialog : public QDialog, public Ui::ConnectDialog {

--- a/src/mumble/Database.cpp
+++ b/src/mumble/Database.cpp
@@ -31,6 +31,8 @@
 #include "Database.h"
 #include "Global.h"
 #include "Message.h"
+#include "Net.h"
+#include "Version.h"
 
 Database::Database() {
 	QSqlDatabase db = QSqlDatabase::addDatabase(QLatin1String("QSQLITE"));
@@ -94,7 +96,7 @@ Database::Database() {
 
 	QSqlQuery query;
 
-	query.exec(QLatin1String("CREATE TABLE IF NOT EXISTS `servers` (`id` INTEGER PRIMARY KEY AUTOINCREMENT, `name` TEXT, `hostname` TEXT, `port` INTEGER DEFAULT 64738, `username` TEXT, `password` TEXT)"));
+	query.exec(QLatin1String("CREATE TABLE IF NOT EXISTS `servers` (`id` INTEGER PRIMARY KEY AUTOINCREMENT, `name` TEXT, `hostname` TEXT, `port` INTEGER DEFAULT " MUMTEXT(DEFAULT_MUMBLE_PORT) ", `username` TEXT, `password` TEXT)"));
 	query.exec(QLatin1String("ALTER TABLE `servers` ADD COLUMN `url` TEXT"));
 
 	query.exec(QLatin1String("CREATE TABLE IF NOT EXISTS `comments` (`who` TEXT, `comment` BLOB, `seen` DATE)"));

--- a/src/mumble/MainWindow.cpp
+++ b/src/mumble/MainWindow.cpp
@@ -49,6 +49,7 @@
 #include "AudioStats.h"
 #include "Plugins.h"
 #include "Log.h"
+#include "Net.h"
 #include "Overlay.h"
 #include "Global.h"
 #include "Database.h"
@@ -692,7 +693,7 @@ void MainWindow::openUrl(const QUrl &url) {
 	}
 
 	QString host = url.host();
-	unsigned short port = static_cast<unsigned short>(url.port(64738));
+	unsigned short port = static_cast<unsigned short>(url.port(DEFAULT_MUMBLE_PORT));
 	QString user = url.userName();
 	QString pw = url.password();
 	qsDesiredChannel = url.path();

--- a/src/murmur/Meta.cpp
+++ b/src/murmur/Meta.cpp
@@ -31,6 +31,7 @@
 #include "ServerDB.h"
 #include "Server.h"
 #include "Meta.h"
+#include "Net.h"
 #include "DBus.h"
 #include "OSInfo.h"
 
@@ -42,7 +43,7 @@ HANDLE Meta::hQoS = NULL;
 
 MetaParams::MetaParams() {
 	qsPassword = QString();
-	usPort = 64738;
+	usPort = DEFAULT_MUMBLE_PORT;
 	iTimeout = 30;
 	iMaxBandwidth = 72000;
 	iMaxUsers = 1000;


### PR DESCRIPTION
I'm pretty sure everything builds okay now. I had to add #include "Net.h" to a few files to get it to build correctly, and now I don't see any warnings.

I went ahead and put a #ifndef around the #define, because (if I understand qmake correctly) that would allow people to override it on the command line if for some sick sad reason they so desire to.
