### PR TITLE
Make logdays=-1 purge log table in database.

### DIFF
--- a/src/murmur/ServerDB.cpp
+++ b/src/murmur/ServerDB.cpp
@@ -1598,6 +1598,13 @@ void Server::dblog(const QString &str) {
 	SQLEXEC();
 }
 
+void ServerDB::wipeLogs() {
+	TransactionHolder th;
+	QSqlQuery &query = *th.qsqQuery;
+
+	SQLDO("DELETE FROM %1slog");
+}
+
 QList<QPair<unsigned int, QString> > ServerDB::getLog(int server_id, unsigned int offs_min, unsigned int offs_max) {
 	TransactionHolder th;
 	QSqlQuery &query = *th.qsqQuery;

--- a/src/murmur/ServerDB.h
+++ b/src/murmur/ServerDB.h
@@ -59,6 +59,7 @@ class ServerDB {
 		static void setConf(int server_id, const QString &key, const QVariant &value = QVariant());
 		static QList<LogRecord> getLog(int server_id, unsigned int offs_min, unsigned int offs_max);
 		static int getLogLen(int server_id);
+		static void wipeLogs();
 		static bool prepare(QSqlQuery &, const QString &, bool fatal = true, bool warn = true);
 		static bool exec(QSqlQuery &, const QString &str = QString(), bool fatal= true, bool warn = true);
 		static bool execBatch(QSqlQuery &, const QString &str = QString(), bool fatal= true);

--- a/src/murmur/main.cpp
+++ b/src/murmur/main.cpp
@@ -194,6 +194,7 @@ int main(int argc, char **argv) {
 	QString inifile;
 	QString supw;
 	bool wipeSsl = false;
+	bool wipeLogs = false;
 	int sunum = 1;
 #ifndef Q_OS_WIN
 	bool readPw = false;
@@ -240,6 +241,8 @@ int main(int argc, char **argv) {
 			inifile=argv[i];
 		} else if ((arg == "-wipessl")) {
 			wipeSsl = true;
+		} else if ((arg == "-wipelogs")) {
+			wipeLogs = true;
 		} else if ((arg == "-fg")) {
 			detach = false;
 		} else if ((arg == "-v")) {
@@ -258,6 +261,7 @@ int main(int argc, char **argv) {
 			       "  -v               Add verbose output.\n"
 			       "  -fg              Don't detach from console [Unix-like systems only].\n"
 			       "  -wipessl         Remove SSL certificates from database.\n"
+			       "  -wipelogs        Remove all log entries from database.\n"
 			       "  -version         Show version information.\n"
 			       "If no inifile is provided, murmur will search for one in \n"
 			       "default locations.", argv[0]);
@@ -351,6 +355,11 @@ int main(int argc, char **argv) {
 			ServerDB::setConf(sid, "certificate");
 			ServerDB::setConf(sid, "passphrase");
 		}
+	}
+
+	if (wipeLogs) {
+		qWarning("Removing all log entries from the database.");
+		ServerDB::wipeLogs();
 	}
 
 #ifdef Q_OS_UNIX


### PR DESCRIPTION
I'm not sure if this is a bug or not - currently logdays=-1 does not prune any old log entries from the DB. Instead of causing murmurd starting with logdays=-1 to obliterate all historical logs, it was instead recommended that an option to blow away logs be added:

./murmurd -wipelogs

It can be used with logdays >= 0, which will result in just the startup stuff being left in the DB. If logdays is less than 0, the log table will be empty.
