### PR TITLE
Correctly disable 'Disconnect' option when you abort a reconnection.

### DIFF
--- a/src/mumble/MainWindow.cpp
+++ b/src/mumble/MainWindow.cpp
@@ -1016,8 +1016,10 @@ void MainWindow::on_qmServer_aboutToShow() {
 }
 
 void MainWindow::on_qaServerDisconnect_triggered() {
-	if (qtReconnect->isActive())
+	if (qtReconnect->isActive()) {
 		qtReconnect->stop();
+		qaServerDisconnect->setEnabled(false);
+	}
 	if (g.sh && g.sh->isRunning())
 		g.sh->disconnect();
 }


### PR DESCRIPTION
I think this is the right place to fix this, but I'm not sure.

If you connect to a server, then disconnect, the "Disconnect" option is disabled as expected. It's disabled when you start Mumble, until you connect to a server.

However if you connect to a server that doesn't exist, or get disconnected from a server (ie, when I kill my development server while I'm still on it), then click "Disconnect" to abort the reconnection, the "Disconnect" option is not disabled. :)
