### PR TITLE
Edit button in Connect Dialog

### DIFF
--- a/src/mumble/ConnectDialog.cpp
+++ b/src/mumble/ConnectDialog.cpp
@@ -785,7 +785,8 @@ ConnectDialog::ConnectDialog(QWidget *p, bool autoconnect) : QDialog(p), bAutoCo
 	connect(qpbAdd, SIGNAL(clicked()), qaFavoriteAddNew, SIGNAL(triggered()));
 	qdbbButtonBox->addButton(qpbAdd, QDialogButtonBox::ActionRole);
 
-	QPushButton *qpbEdit = new QPushButton(tr("&Edit..."), this);
+	qpbEdit = new QPushButton(tr("&Edit..."), this);
+	qpbEdit->setEnabled(false);
 	qpbEdit->setDefault(false);
 	qpbEdit->setAutoDefault(false);
 	connect(qpbEdit, SIGNAL(clicked()), qaFavoriteEdit, SIGNAL(triggered()));
@@ -1118,6 +1119,12 @@ void ConnectDialog::on_qtwServers_itemDoubleClicked(QTreeWidgetItem *item, int) 
 void ConnectDialog::on_qtwServers_currentItemChanged(QTreeWidgetItem *item, QTreeWidgetItem *) {
 	ServerItem *si = static_cast<ServerItem *>(item);
 
+	if (si->siParent == qtwServers->siFavorite) {
+		qpbEdit->setEnabled(true);
+	} else {
+		qpbEdit->setEnabled(false);
+	}
+	
 	bool bOk = (si && ! si->qlAddresses.isEmpty());
 	qdbbButtonBox->button(QDialogButtonBox::Ok)->setEnabled(bOk);
 

--- a/src/mumble/ConnectDialog.h
+++ b/src/mumble/ConnectDialog.h
@@ -199,6 +199,7 @@ class ConnectDialog : public QDialog, public Ui::ConnectDialog {
 
 		QMenu *qmPopup, *qmFilters;
 		QActionGroup *qagFilters;
+		QPushButton *qpbEdit;
 
 		bool bPublicInit;
 		bool bAutoConnect;


### PR DESCRIPTION
Fulfills FR #3291884...

However, I don't really like the fact the button doesn't disable when the selection is invalid. I'm not sure how to accomplish that though - can I store qpbEdit in the ConnectDialog object, or if not where should it go?

I was also thinking about changing the behavior of the "Add" button, so that if a server from the public server list is selected, it's details are filled into the boxes - if not, then go to clipboard contents, current server, then empty - what do you guys think?
