### PR TITLE
Send URLs with empty version parameter over RPC anyway.

### DIFF
--- a/src/mumble/main.cpp
+++ b/src/mumble/main.cpp
@@ -206,20 +206,18 @@ int main(int argc, char **argv) {
 			param.insert(QLatin1String("href"), url);
 #endif
 			MumbleVersion::get(&major, &minor, &patch, version);
-
-			if ((major == 1) && (minor == 2)) {
-				bool sent = false;
+			
+			bool sent = false;
 #ifdef USE_DBUS
-				QDBusInterface qdbi(QLatin1String("net.sourceforge.mumble.mumble"), QLatin1String("/"), QLatin1String("net.sourceforge.mumble.Mumble"));
+			QDBusInterface qdbi(QLatin1String("net.sourceforge.mumble.mumble"), QLatin1String("/"), QLatin1String("net.sourceforge.mumble.Mumble"));
 
-				QDBusMessage reply=qdbi.call(QLatin1String("openUrl"), QLatin1String(url.toEncoded()));
-				sent = (reply.type() == QDBusMessage::ReplyMessage);
+			QDBusMessage reply=qdbi.call(QLatin1String("openUrl"), QLatin1String(url.toEncoded()));
+			sent = (reply.type() == QDBusMessage::ReplyMessage);
 #else
-				sent = SocketRPC::send(QLatin1String("Mumble"), QLatin1String("url"), param);
+			sent = SocketRPC::send(QLatin1String("Mumble"), QLatin1String("url"), param);
 #endif
-				if (sent)
-					return 0;
-			}
+			if (sent)
+				return 0;
 		} else {
 			bool sent = false;
 #ifdef USE_DBUS


### PR DESCRIPTION
This "fixes" the problem of a URL with an empty "version" parameter spawning a new client instead of sending the URL to the old one. I'm not sure if this is the right way to fix it though. I can think of two other ways:

1) Removing that if block all together - of course we probably want to generate some kind of error if the version parameter is there, and it's for 1.1.x.

2) Putting a default value in MumbleVersion::get() - I'm not sure if that would break something elsewhere though.

Update: Removed the conditional completely - having it there means we spawn a new client process just to have it report it doesn't support that URL/version. Removing it means we get that error as a pop-up in the already-spawned process, which makes more sense to me.
