### PR TITLE
add thunderbird and instantbird to overlay blacklist (new hw-accelerated 

### DIFF
--- a/overlay/overlay_blacklist.h
+++ b/overlay/overlay_blacklist.h
@@ -42,6 +42,8 @@ static const char *overlayBlacklist[] = {
 	"explorer.exe",
 	"wmpnscfg.exe",
 	"firefox.exe",
+	"thunderbird.exe",
+	"instantbird.exe",
 	"wlmail.exe",   // Windows Live Suite (mshtml.dll)
 	"msnmsgr.exe",
 	"MovieMaker.exe",


### PR DESCRIPTION
add thunderbird and instantbird to overlay blacklist (new hw-accelerated versions)
