### PR TITLE
Add 'Crimecraft: Bleedout' to default overlay blacklist.

### DIFF
--- a/overlay/overlay_blacklist.h
+++ b/overlay/overlay_blacklist.h
@@ -35,6 +35,7 @@ static const char *overlayBlacklist[] = {
 	"iexplore.exe",
 	"ieuser.exe",
 	"vlc.exe",
+	"crimecraft.exe",
 	"dbgview.exe",
 	"opera.exe",
 	"chrome.exe",


### PR DESCRIPTION
Apparently the anti-cheater stuff on this Free2Play game is causing people to get booted, per several forum posts like this: http://www.crimecraft.com/forums/General-Support/topics/Turns-out-I-cheat-

Maybe we can work something out with the developers, because they use HackShield and I've used the Mumble overlay with HackShield-based games before. I'm guessing they probably just need to request a whitelist entry from HackShield, but they probably don't even know what Mumble is.

I'll post in that thread and see what's up, and leave it up to you guys to figure out whether blacklisting this game by default is a good idea or not. :)
