### PR TITLE
Fix bug #3200725 @ SF - RichTextEditor disregarding g.uiImageLength.

### DIFF
--- a/src/mumble/RichTextEditor.cpp
+++ b/src/mumble/RichTextEditor.cpp
@@ -237,8 +237,8 @@ void RichTextEditor::on_qaImage_triggered() {
 	if (qba.isEmpty())
 		return;
 
-	if (qba.length() > 65536) {
-		QMessageBox::warning(this, tr("Failed to load image"), tr("Image file too large to embed in document. Please use images smaller than %1 kB.").arg(65536/1024));
+	if ((g.uiImageLength > 0) && (qba.length() > g.uiImageLength)) {
+		QMessageBox::warning(this, tr("Failed to load image"), tr("Image file too large to embed in document. Please use images smaller than %1 kB.").arg(g.uiImageLength /1024));
 		return;
 	}
 


### PR DESCRIPTION
Okay, for real this time. RichTextEditor was ignoring g.uiImageLength and simply using an arbitrary 64kB image size limit, and this two-line patch fixes that. I don't think it has any side effects, and I don't believe that was intended behavior.

Screwed up my tree on the other pull request - apologies for that, git bested me this day. :(
