### PR TITLE
Update Retail version of Battlefield: Bad Company 2 to build #795745.

### DIFF
--- a/plugins/bfbc2/bfbc2.cpp
+++ b/plugins/bfbc2/bfbc2.cpp
@@ -61,9 +61,9 @@ static int fetch(float *avatar_pos, float *avatar_front, float *avatar_top, floa
 		     peekProc((BYTE *) 0x01571E80, avatar_front, 12) &&
 		     peekProc((BYTE *) 0x01571E70, avatar_top, 12);
 	} else {
-		ok = peekProc((BYTE *) 0x0156F0E0, avatar_pos, 12) &&
-		     peekProc((BYTE *) 0x0156F0D0, avatar_front, 12) &&
-		     peekProc((BYTE *) 0x0156F0C0, avatar_top, 12);
+		ok = peekProc((BYTE *) 0x01579600, avatar_pos, 12) &&
+		     peekProc((BYTE *) 0x015795F0, avatar_front, 12) &&
+		     peekProc((BYTE *) 0x015795E0, avatar_top, 12);
 	}
 
 	if (! ok)


### PR DESCRIPTION
This plugin should be 100% up to date now.

bcconser @ SF confirmed it works for them too.
