### PR TITLE
Fix typo in French translation per WarT (blabla29 @ sf - Bug #3439985).

### DIFF
--- a/src/mumble/mumble_fr.ts
+++ b/src/mumble/mumble_fr.ts
@@ -6745,7 +6745,7 @@ This field describes the size of an LCD device. The size is given either in pixe
     <message>
         <location line="+2"/>
         <source>%1 unmuted and undeafened by %2.</source>
-        <translation>%2 a rendu la porole et l&apos;ouïe à %1.</translation>
+        <translation>%2 a rendu la parole et l&apos;ouïe à %1.</translation>
     </message>
     <message>
         <location line="+18"/>


### PR DESCRIPTION
I speak absolutely zero french, but from peeking at the language file it appears this is a simple typo on the part of the translator.

See also the [relevant SF artifact](https://sourceforge.net/tracker/?func=detail&aid=3439985&group_id=147372&atid=768005). 
