### PR TITLE
add 'status' command to the init script

### DIFF
--- a/scripts/murmur.init
+++ b/scripts/murmur.init
@@ -79,6 +79,19 @@ case "$1" in
 		2) [ "$VERBOSE" != no ] && log_end_msg 1 ;;
 	esac
 	;;
+  status)
+	if start-stop-daemon --test --stop --quiet \
+		--pidfile $PIDFILE \
+		--user $USER \
+		--exec $DAEMON
+	then
+		[ "$VERBOSE" != no ] && echo "$DESC is running."
+		exit 0
+	else
+		[ "$VERBOSE" != no ] && echo "$DESC is not running"
+		exit 3
+	fi
+	;;
   force-reload)
 	start-stop-daemon --stop --test --quiet \
 		--pidfile $PIDFILE \


### PR DESCRIPTION
I've added a status command to the init script that reports whether or not the script is running.

Exit status 3 for "not running" is needed for Pacemaker compatibility, just in case: http://www.clusterlabs.org/doc/en-US/Pacemaker/1.0/html/Pacemaker_Explained/ap-lsb.html
