### PR TITLE
Update slice path for Ice 3.4.2

### DIFF
--- a/src/murmur/murmur.pro
+++ b/src/murmur/murmur.pro
@@ -71,7 +71,7 @@ ice {
 	win32 {
 		slice.commands = slice2cpp --checksum -I\"$$ICE_PATH/slice\" ${QMAKE_FILE_NAME}
 	} else {
-		slice.commands = slice2cpp --checksum -I/usr/local/share/Ice -I/usr/share/Ice/slice -I/usr/share/slice -I/usr/share/Ice-3.4.1/slice/ -I/usr/share/Ice-3.3.1/slice/ ${QMAKE_FILE_NAME}
+		slice.commands = slice2cpp --checksum -I/usr/local/share/Ice -I/usr/share/Ice/slice -I/usr/share/slice -I/usr/share/Ice-3.4.1/slice/ -I/usr/share/Ice-3.3.1/slice/ -I/usr/share/Ice-3.4.2/slice/ ${QMAKE_FILE_NAME}
 	}
 	slice.input = SLICEFILES
 	slice.CONFIG *= no_link explicit_dependencies


### PR DESCRIPTION
Prevent compile errors and allow to use Ice 3.4.2 slice files.
Tested on Fedora & Gentoo.
