### PR TITLE
Added an address masking option.

### DIFF
--- a/src/murmur/Messages.cpp
+++ b/src/murmur/Messages.cpp
@@ -1586,14 +1586,24 @@ void Server::msgUserStats(ServerUser*uSource, MumbleProto::UserStats &msg) {
 			msg.add_celt_versions(v);
 		msg.set_opus(pDstServerUser->bOpus);
 
-		msg.set_address(pDstServerUser->haAddress.toStdString());
+                if (meta->mp.bMaskAddr) {
+                    msg.set_address("::"); //set the address to localhost
+                } else {
+                    msg.set_address(pDstServerUser->haAddress.toStdString());
+                }
+
 	}
 
-	if (local)
-		msg.set_bandwidth(bwr.bandwidth());
+        if (local) {
+            msg.set_bandwidth(bwr.bandwidth());
+            msg.set_idlesecs(bwr.idleSeconds());
+        }
+
+        // if (local)
+        // 	msg.set_bandwidth(bwr.bandwidth());
 	msg.set_onlinesecs(bwr.onlineSeconds());
-	if (local)
-		msg.set_idlesecs(bwr.idleSeconds());
+        // if (local)
+       //      msg.set_idlesecs(bwr.idleSeconds());
 
 	sendMessage(uSource, msg);
 }

--- a/src/murmur/Meta.cpp
+++ b/src/murmur/Meta.cpp
@@ -58,6 +58,7 @@ MetaParams::MetaParams() {
 	bAllowHTML = true;
 	iDefaultChan = 0;
 	bRememberChan = true;
+        bMaskAddr = false;
 	qsWelcomeText = QString("Welcome to this server");
 	qsDatabase = QString();
 	iDBPort = 0;
@@ -233,6 +234,7 @@ void MetaParams::read(QString fname) {
 	iMaxBandwidth = qsSettings->value("bandwidth", iMaxBandwidth).toInt();
 	iDefaultChan = qsSettings->value("defaultchannel", iDefaultChan).toInt();
 	bRememberChan = qsSettings->value("rememberchannel", bRememberChan).toBool();
+        bMaskAddr = qsSettings->value("maskaddresses", bMaskAddr).toBool();
 	iMaxUsers = qsSettings->value("users", iMaxUsers).toInt();
 	iMaxUsersPerChannel = qsSettings->value("usersperchannel", iMaxUsersPerChannel).toInt();
 	qsWelcomeText = qsSettings->value("welcometext", qsWelcomeText).toString();
@@ -424,7 +426,8 @@ void MetaParams::read(QString fname) {
 	qmConfig.insert(QLatin1String("bandwidth"),QString::number(iMaxBandwidth));
 	qmConfig.insert(QLatin1String("users"),QString::number(iMaxUsers));
 	qmConfig.insert(QLatin1String("defaultchannel"),QString::number(iDefaultChan));
-	qmConfig.insert(QLatin1String("rememberchannel"),bRememberChan ? QLatin1String("true") : QLatin1String("false"));
+        qmConfig.insert(QLatin1String("rememberchannel"),bRememberChan ? QLatin1String("true") : QLatin1String("false"));
+        qmConfig.insert(QLatin1String("maskaddresses"),bMaskAddr ? QLatin1String("true") : QLatin1String("false"));
 	qmConfig.insert(QLatin1String("welcometext"),qsWelcomeText);
 	qmConfig.insert(QLatin1String("registername"),qsRegName);
 	qmConfig.insert(QLatin1String("registerpassword"),qsRegPassword);

--- a/src/murmur/Meta.h
+++ b/src/murmur/Meta.h
@@ -58,6 +58,7 @@ struct MetaParams {
 	int iMaxUsersPerChannel;
 	int iDefaultChan;
 	bool bRememberChan;
+        bool bMaskAddr;
 	int iMaxTextMessageLength;
 	int iMaxImageMessageLength;
 	bool bAllowHTML;


### PR DESCRIPTION
Privacy is a huge issue with anything and I and the server I run touted mumble as being exactly that. Well, it is, except that people whom were very private would not join because if someone could join the channel and/or register (I don't remember the exact conversation, but there's a lot of people who could because we like it when people get registered :)) they would be able to see everyone in the channel's IP, and this is an issue that I'm positive other servers have come across as well. I want people to be able to see the specific details about a person, their idle time, etc however what I do not want is for IP's to be public, because that scares people (I do know better...but there are people who don't and even if they did they still are not comfortable). So, I'm proposing this utterly simple patch that deals with this concern very...simply. If there is a more elegant way of accomplishing this (For example, a specific ACL option or something) I am open for change.
