### PR TITLE
AudioInput: compilation fix for builds using celt >= 0.11.0

### DIFF
--- a/src/mumble/AudioInput.cpp
+++ b/src/mumble/AudioInput.cpp
@@ -754,7 +754,12 @@ int AudioInput::encodeCELTFrame(short *psSource, unsigned char *buffer) {
 
 	cCodec->celt_encoder_ctl(ceEncoder, CELT_SET_PREDICTION(0));
 
+#ifdef CELT_SET_VBR_RATE
 	cCodec->celt_encoder_ctl(ceEncoder, CELT_SET_VBR_RATE(iAudioQuality));
+#else
+	cCodec->celt_encoder_ctl(ceEncoder, CELT_SET_BITRATE(iAudioQuality));
+#endif
+
 	int len = cCodec->encode(ceEncoder, psSource, buffer, qMin(iAudioQuality / (8 * 100), 127));
 	iBitrate = len * 100 * 8;
 


### PR DESCRIPTION
As of celt 0.11.0, the macro CELT_SET_VBR_RATE has been moved to CELT_SET_BITRATE.  This adds in a simple check for CELT_SET_VBR_RATE, and if the macro is not defined, use the latest macro, CELT_SET_BITRATE.
