### PR TITLE
MainWindow: directly set the window icon

### DIFF
--- a/src/mumble/MainWindow.cpp
+++ b/src/mumble/MainWindow.cpp
@@ -165,6 +165,10 @@ MainWindow::MainWindow(QWidget *p) : QMainWindow(p) {
 	// current open document (i.e. you can copy the open document anywhere
 	// simply by dragging this icon).
 	qApp->setWindowIcon(qiIcon);
+	
+	// Set the icon on the MainWindow directly. This fixes the icon not
+	// being set on the MainWindow in certain environments (Ex: GTK+).
+	setWindowIcon(qiIcon);
 #endif
 
 #ifdef Q_OS_WIN


### PR DESCRIPTION
This is simple patch resolves an issue that seems to appear only in GTK+ environments.  The MainWindow's icon appears to not be noticed by GTK+ based desktop environments, such as XFCE.  After a bit of poking around, this bit of "hackery" seems to do the trick in resolving the issue.

Tracker Artifact: http://sourceforge.net/tracker/?func=detail&aid=3491289&group_id=147372&atid=768005
