### PR TITLE
fixed plugin for build 4777 (latest), re-enabled states support

### DIFF
--- a/plugins/l4d2/l4d2.cpp
+++ b/plugins/l4d2/l4d2.cpp
@@ -72,7 +72,6 @@ static int trylock(const std::multimap<std::wstring, unsigned long long int> &pi
 	if (! initialize(pids, L"left4dead2.exe", L"client.dll"))
 		return false;
 
-	// let's finally fix those addreses, huh? // d-rez
 	posptr = pModule + 0x641A4C;
 	rotptr = pModule + 0x641A08;
 	stateptr = pModule + 0x6A1AF4;


### PR DESCRIPTION
Found and fixed proper addresses for avatar/camera position.
I also accidentally found a separate camera position vector, but failed at finding camera top and front vectors. Maybe another time :)
