### PR TITLE
Context bugfix for LoL, TF2 and L4D2: Forgot about null-termination characters :)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,11 @@ local/
 indent.sh
 *.bat
 *.pdb
+*.sln
+*.sdf
+*.suo
+*.vcxproj
+*.vcxproj.*
 *~
 *.pb.h
 *.pb.cc

--- a/src/mumble/MainWindow.cpp
+++ b/src/mumble/MainWindow.cpp
@@ -2510,6 +2510,13 @@ void MainWindow::trayAboutToShow() {
 	}
 }
 
+void MainWindow::on_Icon_messageClicked() {
+	if (isMinimized())
+		setWindowState((windowState() & ~Qt::WindowMinimized) | Qt::WindowActive);
+	show();
+	raise();
+	activateWindow();
+}
 
 void MainWindow::on_Icon_activated(QSystemTrayIcon::ActivationReason reason) {
 	// FIXME: Workaround for activated sending both doubleclick and trigger

--- a/src/mumble/MainWindow.h
+++ b/src/mumble/MainWindow.h
@@ -226,6 +226,7 @@ class MainWindow : public QMainWindow, public MessageHandler, public Ui::MainWin
 		void on_gsDeafSelf_down(QVariant);
 		void on_gsWhisper_triggered(bool, QVariant);
 		void on_Reconnect_timeout();
+		void on_Icon_messageClicked();
 		void on_Icon_activated(QSystemTrayIcon::ActivationReason);
 		void voiceRecorderDialog_finished(int);
 		void qtvUserCurrentChanged(const QModelIndex &, const QModelIndex &);

--- a/src/murmur/Messages.cpp
+++ b/src/murmur/Messages.cpp
@@ -507,6 +507,10 @@ void Server::msgUserState(ServerUser *uSource, MumbleProto::UserState &msg) {
 			PERM_DENIED_TYPE(SuperUser);
 			return;
 		}
+		if (uSource->cChannel->bTemporary) {
+			PERM_DENIED_TYPE(TemporaryChannel);
+			return;
+		}
 		if (! hasPermission(uSource, pDstServerUser->cChannel, ChanACL::MuteDeafen) || msg.suppress()) {
 			PERM_DENIED(uSource, pDstServerUser->cChannel, ChanACL::MuteDeafen);
 			return;


### PR DESCRIPTION
If maximum length of text is 15 ("111.111.111.111"), then we need an array of 16 characters, not 15! There must be space left for the null-termination character. My bad

minor improvements in TF2 and L4D2 plugin (disable positional audio when playing on a local server)

switched to using string.clear() instead of assigning a new empty string (std::string(""))
