### PR TITLE
BF3 identity+context support, patch is ready for testing

### DIFF
--- a/plugins/bf3/bf3.cpp
+++ b/plugins/bf3/bf3.cpp
@@ -68,26 +68,25 @@ enum state_values {
     STATE_IN_MENU = 3
 };
 
-inline bool resolve_ptrs()
-{
+inline bool resolve_ptrs() {
     team_state_ptr = squad_state_ptr = squad_lead_state_ptr = NULL;
 
     /*
     Magic:
-        state : 0x023C7A9C                                                      BYTE		2 when playing
+        state : 0x023C7A9C                                                      BYTE        2 when playing
                                                                                             3 while in menu/dead
 
     Context:
-        IP:Port of server: 0x02396F40                                           char[128]	ip:port of the server
+        IP:Port of server: 0x02396F40                                           char[128]   ip:port of the server
 
     Identity:
-        Squad state: BF3.exe+0x01F24F58 + 0x1C + 0xBC + 0x36C + 0x8 + 0x104     BYTE		0 is not in squad; 1 is in Alpha squad, 2 Bravo, ... , 9 India
+        Squad state: BF3.exe+0x01F24F58 + 0x1C + 0xBC + 0x36C + 0x8 + 0x104     BYTE        0 is not in squad; 1 is in Alpha squad, 2 Bravo, ... , 9 India
         SLead state: BF3.exe+0x01F24F58 + 0x1c + 0xBC + 0x36C + 0x8 + 0x108     BYTE        0 is not lead; 1 is lead
-        Team state:  BF3.exe+0x01F24F58 + 0x1C + 0xBC + 0x31C                   BYTE		1 is blufor (US team, for example), 2 is opfor (RU), 0 is probably upcoming spec mode
+        Team state:  BF3.exe+0x01F24F58 + 0x1C + 0xBC + 0x31C                   BYTE        1 is blufor (US team, for example), 2 is opfor (RU), 0 is probably upcoming spec mode
     */
 
     BYTE *base_bf3 = peekProc<BYTE *>(pmodule_bf3 + base_offset);
-    if(!base_bf3)
+    if (!base_bf3)
         return false;
 
     BYTE *offset_ptr1 = peekProc<BYTE *>(base_bf3 + identity_offset1);
@@ -98,34 +97,34 @@ inline bool resolve_ptrs()
     squad_state_ptr = offset_ptr4 + squad_state_offset;
     squad_lead_state_ptr = offset_ptr4 + squad_lead_state_offset;
     team_state_ptr = offset_ptr2 + team_state_offset;
-    if(!squad_state_ptr || !squad_lead_state_ptr || !team_state_ptr)
+    if (!squad_state_ptr || !squad_lead_state_ptr || !team_state_ptr)
         return false;
 
     return true;
 }
 
 static int fetch(float *avatar_pos, float *avatar_front, float *avatar_top, float *camera_pos, float *camera_front, float *camera_top, std::string &context, std::wstring &identity) {
-	for (int i=0;i<3;i++)
-		avatar_pos[i] = avatar_front[i] = avatar_top[i] = camera_pos[i] = camera_front[i] = camera_top[i] = 0.0f;
+    for (int i=0;i<3;i++)
+        avatar_pos[i] = avatar_front[i] = avatar_top[i] = camera_pos[i] = camera_front[i] = camera_top[i] = 0.0f;
 
     char ccontext[128];
-	char state;
+    char state;
     BYTE squad_state;
     BYTE is_squadleader;
     BYTE team_state;
-	bool ok;
+    bool ok;
 
     ok = peekProc(state_ptr, &state, 1); // State value
-	if (! ok)
-		return false;
+    if (! ok)
+        return false;
 
-    if(state != STATE_IN_GAME && state != STATE_IN_MENU) {
+    if (state != STATE_IN_GAME && state != STATE_IN_MENU) {
         ptr_chain_valid = false;
         context.clear();
         identity.clear();
         return true;
-    } else if(!ptr_chain_valid) {
-        if(!resolve_ptrs())
+    } else if (!ptr_chain_valid) {
+        if (!resolve_ptrs())
             return false;
         ptr_chain_valid = true;
     }
@@ -138,8 +137,8 @@ static int fetch(float *avatar_pos, float *avatar_front, float *avatar_top, floa
         peekProc(team_state_ptr,&team_state,1) &&
         peekProc(ipport_ptr,ccontext,128);
 
-	if (! ok)
-		return false;
+    if (! ok)
+        return false;
 
     ccontext[127] = 0;
     if (ccontext[0] != '0') {
@@ -155,54 +154,54 @@ static int fetch(float *avatar_pos, float *avatar_front, float *avatar_top, floa
         oidentity << "{"
         << "\"squad\":" << static_cast<unsigned int>(squad_state) << ","
         << "\"squad_leader\":" << (is_squadleader ? "true" : "false") << ",";
-        if(team_state == 0)
+        if (team_state == 0)
             oidentity << "\"team\": \"SPEC\"";
-        else if(team_state == 1)
+        else if (team_state == 1)
             oidentity << "\"team\": \"US\"";
-        else if(team_state == 2)
+        else if (team_state == 2)
             oidentity << "\"team\": \"RU\"";
         oidentity << "}";
         identity = oidentity.str();
     }
 
-	// Flip our front vector
-	for (int i=0;i<3;i++) {
-		avatar_front[i] = -avatar_front[i];
-	}
+    // Flip our front vector
+    for (int i=0;i<3;i++) {
+        avatar_front[i] = -avatar_front[i];
+    }
 
-	// Convert from right to left handed
-	avatar_pos[0] = -avatar_pos[0];
-	avatar_front[0] = -avatar_front[0];
-	avatar_top[0] = -avatar_top[0];
+    // Convert from right to left handed
+    avatar_pos[0] = -avatar_pos[0];
+    avatar_front[0] = -avatar_front[0];
+    avatar_top[0] = -avatar_top[0];
 
-	for (int i=0;i<3;i++) {
-		camera_pos[i] = avatar_pos[i];
-		camera_front[i] = avatar_front[i];
-		camera_top[i] = avatar_top[i];
-	}
+    for (int i=0;i<3;i++) {
+        camera_pos[i] = avatar_pos[i];
+        camera_front[i] = avatar_front[i];
+        camera_top[i] = avatar_top[i];
+    }
 
-	return ok;
+    return ok;
 }
 
 static int trylock(const std::multimap<std::wstring, unsigned long long int> &pids) {
 
-	if (! initialize(pids, L"bf3.exe"))
-		return false;
-
-    pmodule_bf3 = getModuleAddr(L"bf3.exe");
-    if(!pmodule_bf3)
+    if (! initialize(pids, L"bf3.exe"))
         return false;
 
-	float apos[3], afront[3], atop[3], cpos[3], cfront[3], ctop[3];
-	std::string context;
-	std::wstring identity;
+    pmodule_bf3 = getModuleAddr(L"bf3.exe");
+    if (!pmodule_bf3)
+        return false;
 
-	if (!fetch(apos, afront, atop, cpos, cfront, ctop, context, identity)) {
-		generic_unlock();
-		return false;
-	}
+    float apos[3], afront[3], atop[3], cpos[3], cfront[3], ctop[3];
+    std::string context;
+    std::wstring identity;
 
-	return true;
+    if (!fetch(apos, afront, atop, cpos, cfront, ctop, context, identity)) {
+        generic_unlock();
+        return false;
+    }
+
+    return true;
 }
 
 static const std::wstring longdesc() {
@@ -213,31 +212,31 @@ static std::wstring description(L"Battlefield 3 v944019");
 static std::wstring shortname(L"Battlefield 3");
 
 static int trylock1() {
-	return trylock(std::multimap<std::wstring, unsigned long long int>());
+    return trylock(std::multimap<std::wstring, unsigned long long int>());
 }
 
 static MumblePlugin bf3plug = {
-	MUMBLE_PLUGIN_MAGIC,
-	description,
-	shortname,
-	NULL,
-	NULL,
-	trylock1,
-	generic_unlock,
-	longdesc,
-	fetch
+    MUMBLE_PLUGIN_MAGIC,
+    description,
+    shortname,
+    NULL,
+    NULL,
+    trylock1,
+    generic_unlock,
+    longdesc,
+    fetch
 };
 
 static MumblePlugin2 bf3plug2 = {
-	MUMBLE_PLUGIN_MAGIC_2,
-	MUMBLE_PLUGIN_VERSION,
-	trylock
+    MUMBLE_PLUGIN_MAGIC_2,
+    MUMBLE_PLUGIN_VERSION,
+    trylock
 };
 
 extern "C" __declspec(dllexport) MumblePlugin *getMumblePlugin() {
-	return &bf3plug;
+    return &bf3plug;
 }
 
 extern "C" __declspec(dllexport) MumblePlugin2 *getMumblePlugin2() {
-	return &bf3plug2;
+    return &bf3plug2;
 }


### PR DESCRIPTION
I did some tests myself on populated servers and I think I can conclude that I found some good pointer chains, maybe there are shorter ones but I found these were pretty reliable.

JSON layout can be changed, I tried to find a compromise between the BF2 plugin and what is currently used in BF3. As for team_state value: I believe DICE plans on adding a spectator mode, hence team_state alternates between 0(SPECTATOR), 1(US) and 2(RU) now, instead of 0(US) and 1(RU/OPFOR).
