### PR TITLE
Make the Link plugin export symbol "lm" and update version from 1.2.0 to 1.2.1.

### DIFF
--- a/plugins/link/link-posix.cpp
+++ b/plugins/link/link-posix.cpp
@@ -208,7 +208,7 @@ static void unload_plugin() {
 	shm_unlink(memname);
 }
 
-static std::wstring description(L"Link v1.2.0");
+static std::wstring description(L"Link v1.2.1");
 
 static MumblePlugin linkplug = {
 	MUMBLE_PLUGIN_MAGIC,

--- a/plugins/link/link.cpp
+++ b/plugins/link/link.cpp
@@ -185,7 +185,7 @@ BOOL WINAPI DllMain(HINSTANCE, DWORD fdwReason, LPVOID) {
 	return true;
 }
 
-static std::wstring description(L"Link v1.2.0");
+static std::wstring description(L"Link v1.2.1");
 
 static MumblePlugin linkplug = {
 	MUMBLE_PLUGIN_MAGIC,


### PR DESCRIPTION
This simple change would allow games to use the Link plugin's library file itself to talk to the Link plugin running in a Mumble instance.
