### PR TITLE
fix for syntax highlighting in murmur.pro

### DIFF
--- a/src/murmur/murmur.pro
+++ b/src/murmur/murmur.pro
@@ -69,7 +69,7 @@ ice {
 
 	slice.output = ${QMAKE_FILE_BASE}.cpp
 	win32 {
-		slice.commands = slice2cpp --checksum -I\"$$ICE_PATH/slice\" ${QMAKE_FILE_NAME}
+		slice.commands = slice2cpp --checksum -I\"$$ICE_PATH/slice\" ${QMAKE_FILE_NAME} #" fix GitHub syntax highlighting
 	} else {
 		slice.commands = slice2cpp --checksum -I/usr/local/share/Ice -I/usr/share/Ice/slice -I/usr/share/slice -I/usr/share/Ice-3.4.1/slice/ -I/usr/share/Ice-3.3.1/slice/ -I/usr/share/Ice-3.4.2/slice/ ${QMAKE_FILE_NAME}
 	}


### PR DESCRIPTION
I added a double quote in a comment in `murmur.pro` so that GitHub doesn't highlight the rest of the file as a string.
