### PR TITLE
make the overlay exceptions window more elaborative

### DIFF
--- a/src/mumble/Overlay.ui
+++ b/src/mumble/Overlay.ui
@@ -297,6 +297,13 @@
            <item>
             <layout class="QHBoxLayout" name="horizontalLayout_2">
              <item>
+              <widget class="QLabel" name="qlExcListType">
+               <property name="text">
+                <string>To list exceptions, use a</string>
+               </property>
+              </widget>
+             </item>
+             <item>
               <widget class="QRadioButton" name="qrbBlacklist">
                <property name="text">
                 <string>Blacklist</string>
@@ -335,6 +342,13 @@
               </property>
               <layout class="QVBoxLayout" name="verticalLayout_2">
                <item>
+                <widget class="QLabel" name="qlBlackDesc">
+                 <property name="text">
+                  <string>Show the overlay in all applicable programs except</string>
+                 </property>
+                </widget>
+               </item>
+               <item>
                 <widget class="QListWidget" name="qlwBlacklist"/>
                </item>
               </layout>
@@ -347,6 +361,13 @@
                </sizepolicy>
               </property>
               <layout class="QVBoxLayout" name="verticalLayout_3">
+               <item>
+                <widget class="QLabel" name="qlWhiteDesc">
+                 <property name="text">
+                  <string>Show the overlay only in</string>
+                 </property>
+                </widget>
+               </item>
                <item>
                 <widget class="QListWidget" name="qlwWhitelist"/>
                </item>


### PR DESCRIPTION
- Add a label to the radio-selection
- Add a description label to the lists,
  which describe what the list is used for

This makes the context and concrete logic (more) obvious even to newbies. It also explains what a black- and whitelist are - no need to know that before-hand anymore (and how exactly they work).

Screenshots:
[![Screenshot with Whitelist selected](http://www.abload.de/thumb/mumbleconfiguration_brbjt1.png)](http://www.abload.de/img/mumbleconfiguration_brbjt1.png) [![Screenshot with Blacklist selected](http://www.abload.de/thumb/mumbleconfiguration_wr3knd.png)](http://www.abload.de/img/mumbleconfiguration_wr3knd.png)
