### PR TITLE
Extended recording notification to linked channels

### DIFF
--- a/src/mumble/Messages.cpp
+++ b/src/mumble/Messages.cpp
@@ -301,7 +301,7 @@ void MainWindow::msgUserState(const MumbleProto::UserState &msg) {
 				} else {
 					g.l->log(Log::Recording, tr("Recording stopped"));
 				}
-			} else if (pDst->cChannel == pSelf->cChannel) {
+			} else if (pDst->cChannel->allLinks().contains(pSelf->cChannel)) {
 				if (pDst->bRecording) {
 					g.l->log(Log::Recording, tr("%1 started recording.").arg(Log::formatClientUser(pDst, Log::Source)));
 				} else {


### PR DESCRIPTION
To respect ones privacy, mumble notifies the user as soon as someone starts recording a conversation. However, this only applies if the recoding user is in the same channel as the recorded user, although the recorded user can reside in a linked channel and thus still be heard by the recording user.

This patch fixes this issue and notifies all recorded users in all linked channels.
