### PR TITLE
Replaced last traces of MD5 by SHA-1

### DIFF
--- a/src/mumble/ViewCert.cpp
+++ b/src/mumble/ViewCert.cpp
@@ -70,7 +70,7 @@ ViewCert::ViewCert(QList<QSslCertificate> cl, QWidget *p) : QDialog(p) {
 	QMetaObject::connectSlotsByName(this);
 	connect(qdbb, SIGNAL(accepted()), this, SLOT(accept()));
 
-	resize(500,300);
+	resize(510,300);
 }
 
 void ViewCert::on_Chain_currentRowChanged(int idx) {
@@ -93,7 +93,7 @@ void ViewCert::on_Chain_currentRowChanged(int idx) {
 	l << tr("Valid to: %1").arg(c.expiryDate().toString());
 	l << tr("Serial: %1").arg(QString::fromLatin1(c.serialNumber().toHex()));
 	l << tr("Public Key: %1 bits %2").arg(c.publicKey().length()).arg((c.publicKey().algorithm() == QSsl::Rsa) ? tr("RSA") : tr("DSA"));
-	l << tr("Digest (MD5): %1").arg(QString::fromLatin1(c.digest().toHex()));
+	l << tr("Digest (SHA-1): %1").arg(QString::fromLatin1(c.digest(QCryptographicHash::Sha1).toHex()));
 	for (i=alts.constBegin(); i != alts.constEnd(); ++i) {
 		switch (i.key()) {
 			case QSsl::EmailEntry: {

--- a/src/mumble/mumble_cs.ts
+++ b/src/mumble/mumble_cs.ts
@@ -7909,8 +7909,8 @@ Znak přístupu je textový řetězec, který může být použit jako heslo pro
     </message>
     <message>
         <location line="+1"/>
-        <source>Digest (MD5): %1</source>
-        <translation>Digest (MD5): %1</translation>
+        <source>Digest (SHA-1): %1</source>
+        <translation>Digest (SHA-1): %1</translation>
     </message>
     <message>
         <location line="+4"/>

--- a/src/mumble/mumble_da.ts
+++ b/src/mumble/mumble_da.ts
@@ -7908,8 +7908,8 @@ Et adgangsudtryk er en tekststreng, der kan bruges som en adgangskode for meget 
     </message>
     <message>
         <location line="+1"/>
-        <source>Digest (MD5): %1</source>
-        <translation>Digest (MD5): %1</translation>
+        <source>Digest (SHA-1): %1</source>
+        <translation>Digest (SHA-1): %1</translation>
     </message>
     <message>
         <location line="+4"/>

--- a/src/mumble/mumble_de.ts
+++ b/src/mumble/mumble_de.ts
@@ -7980,8 +7980,8 @@ Ein Zugriffscode ist eine Zeichenfolge, die als Passwort für ein sehr einfaches
     </message>
     <message>
         <location line="+1"/>
-        <source>Digest (MD5): %1</source>
-        <translation>Digest (MD5): %1</translation>
+        <source>Digest (SHA-1): %1</source>
+        <translation>Digest (SHA-1): %1</translation>
     </message>
     <message>
         <location line="+4"/>

--- a/src/mumble/mumble_en.ts
+++ b/src/mumble/mumble_en.ts
@@ -7815,7 +7815,7 @@ An access token is a text string, which can be used as a password for very simpl
     </message>
     <message>
         <location line="+1"/>
-        <source>Digest (MD5): %1</source>
+        <source>Digest (SHA-1): %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/src/mumble/mumble_es.ts
+++ b/src/mumble/mumble_es.ts
@@ -7884,8 +7884,8 @@ Una credencial de acceso es una cadena de texto que puede ser usada como contras
     </message>
     <message>
         <location line="+1"/>
-        <source>Digest (MD5): %1</source>
-        <translation>Huella digital (MD5): %1</translation>
+        <source>Digest (SHA-1): %1</source>
+        <translation>Huella digital (SHA-1): %1</translation>
     </message>
     <message>
         <location line="+4"/>

--- a/src/mumble/mumble_fr.ts
+++ b/src/mumble/mumble_fr.ts
@@ -7877,8 +7877,8 @@ Un jeton d&apos;accès est une chaîne de caractères qui peut être utilisée c
     </message>
     <message>
         <location line="+1"/>
-        <source>Digest (MD5): %1</source>
-        <translation>Digest (MD5) : %1</translation>
+        <source>Digest (SHA-1): %1</source>
+        <translation>Digest (SHA-1) : %1</translation>
     </message>
     <message>
         <location line="+4"/>

--- a/src/mumble/mumble_he.ts
+++ b/src/mumble/mumble_he.ts
@@ -7833,7 +7833,7 @@ An access token is a text string, which can be used as a password for very simpl
     </message>
     <message>
         <location line="+1"/>
-        <source>Digest (MD5): %1</source>
+        <source>Digest (SHA-1): %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/src/mumble/mumble_hu.ts
+++ b/src/mumble/mumble_hu.ts
@@ -6998,7 +6998,7 @@ A hozzáférési token egy szöveges karaktersorozat, amely jelszóként haszná
     </message>
     <message>
         <location filename="ViewCert.cpp" line="89"/>
-        <source>Digest (MD5): %1</source>
+        <source>Digest (SHA-1): %1</source>
         <translation>kivonat (MD%): %1</translation>
     </message>
     <message>

--- a/src/mumble/mumble_it.ts
+++ b/src/mumble/mumble_it.ts
@@ -7917,8 +7917,8 @@ An access token is a text string, which can be used as a password for very simpl
     </message>
     <message>
         <location line="+1"/>
-        <source>Digest (MD5): %1</source>
-        <translation>Firma (MD5): %1</translation>
+        <source>Digest (SHA-1): %1</source>
+        <translation>Firma (SHA-1): %1</translation>
     </message>
     <message>
         <location line="+4"/>

--- a/src/mumble/mumble_ja.ts
+++ b/src/mumble/mumble_ja.ts
@@ -7889,8 +7889,8 @@ An access token is a text string, which can be used as a password for very simpl
     </message>
     <message>
         <location line="+1"/>
-        <source>Digest (MD5): %1</source>
-        <translation>ダイジェスト(MD5): %1</translation>
+        <source>Digest (SHA-1): %1</source>
+        <translation>ダイジェスト(SHA-1): %1</translation>
     </message>
     <message>
         <location line="+4"/>

--- a/src/mumble/mumble_pl.ts
+++ b/src/mumble/mumble_pl.ts
@@ -7834,8 +7834,8 @@ An access token is a text string, which can be used as a password for very simpl
     </message>
     <message>
         <location line="+1"/>
-        <source>Digest (MD5): %1</source>
-        <translation>Odcisk (MD5): %1</translation>
+        <source>Digest (SHA-1): %1</source>
+        <translation>Odcisk (SHA-1): %1</translation>
     </message>
     <message>
         <location line="+4"/>

--- a/src/mumble/mumble_pt_BR.ts
+++ b/src/mumble/mumble_pt_BR.ts
@@ -7845,8 +7845,8 @@ Uma credencial de acesso é uma cadeia de caractéres de texto, que podem ser us
     </message>
     <message>
         <location line="+1"/>
-        <source>Digest (MD5): %1</source>
-        <translation>Resumo (MD5): %1</translation>
+        <source>Digest (SHA-1): %1</source>
+        <translation>Resumo (SHA-1): %1</translation>
     </message>
     <message>
         <location line="+4"/>

--- a/src/mumble/mumble_ru.ts
+++ b/src/mumble/mumble_ru.ts
@@ -7824,8 +7824,8 @@ An access token is a text string, which can be used as a password for very simpl
     </message>
     <message>
         <location line="+1"/>
-        <source>Digest (MD5): %1</source>
-        <translation>Контрольная сумма (MD5): %1</translation>
+        <source>Digest (SHA-1): %1</source>
+        <translation>Контрольная сумма (SHA-1): %1</translation>
     </message>
     <message>
         <location line="+4"/>

--- a/src/mumble/mumble_sv.ts
+++ b/src/mumble/mumble_sv.ts
@@ -7890,8 +7890,8 @@ En token är en text sträng som kan användas som ett lösenord för mycket enk
     </message>
     <message>
         <location line="+1"/>
-        <source>Digest (MD5): %1</source>
-        <translation>Klassificering (MD5): %1</translation>
+        <source>Digest (SHA-1): %1</source>
+        <translation>Klassificering (SHA-1): %1</translation>
     </message>
     <message>
         <location line="+4"/>

--- a/src/mumble/mumble_tr.ts
+++ b/src/mumble/mumble_tr.ts
@@ -7853,8 +7853,8 @@ Erişim jetonu bir metindir ve kanallara erişimin çok basit bir şekilde yöne
     </message>
     <message>
         <location line="+1"/>
-        <source>Digest (MD5): %1</source>
-        <translation>MD5 hash değeri: %1</translation>
+        <source>Digest (SHA-1): %1</source>
+        <translation>SHA-1 hash değeri: %1</translation>
     </message>
     <message>
         <location line="+4"/>

--- a/src/mumble/mumble_zh_CN.ts
+++ b/src/mumble/mumble_zh_CN.ts
@@ -7905,8 +7905,8 @@ An access token is a text string, which can be used as a password for very simpl
     </message>
     <message>
         <location line="+1"/>
-        <source>Digest (MD5): %1</source>
-        <translation>摘要(MD5)：%1</translation>
+        <source>Digest (SHA-1): %1</source>
+        <translation>摘要(SHA-1)：%1</translation>
     </message>
     <message>
         <location line="+4"/>

--- a/src/mumble/mumble_zh_TW.ts
+++ b/src/mumble/mumble_zh_TW.ts
@@ -7813,7 +7813,7 @@ An access token is a text string, which can be used as a password for very simpl
     </message>
     <message>
         <location line="+1"/>
-        <source>Digest (MD5): %1</source>
+        <source>Digest (SHA-1): %1</source>
         <translation></translation>
     </message>
     <message>

--- a/src/murmur/Cert.cpp
+++ b/src/murmur/Cert.cpp
@@ -183,5 +183,5 @@ void Server::initializeCert() {
 }
 
 const QString Server::getDigest() const {
-	return QString::fromLatin1(qscCert.digest().toHex());
+	return QString::fromLatin1(qscCert.digest(QCryptographicHash::Sha1).toHex());
 }


### PR DESCRIPTION
MD5 is considered insecure for quite some time now. Fortunately, mumble doesn't use it in its certificate code. However, if a user wants to check a certificate by hand only a md5 hash of the certificate is shown. Although unlikely, an attacker could forge a server certificate with an identical md5 hash to bypass such a check and perform a man in the middle attack by masquerading himself as the genuine server.

This patch replaces MD5 by SHA-1, which is also used in other parts of mumble to verify certificates securely.
