### PR TITLE
Fixed a switched vector

### DIFF
--- a/plugins/bf3/bf3.cpp
+++ b/plugins/bf3/bf3.cpp
@@ -39,9 +39,9 @@ static BYTE *pmodule_bf3;
 static BYTE* const state_ptr = (BYTE *) 0x0234A36C;
 
 // Vector ptrs
-static BYTE* const avatar_pos_ptr = (BYTE *) 0x0234A340;
-static BYTE* const avatar_front_ptr = (BYTE *) 0x234A320;
-static BYTE* const avatar_top_ptr = (BYTE *) 0x234A330;
+static BYTE* const avatar_pos_ptr = (BYTE *) 0x0234A300;
+static BYTE* const avatar_front_ptr = (BYTE *) 0x234A330;
+static BYTE* const avatar_top_ptr = (BYTE *) 0x234A320;
 
 // Context ptrs
 static BYTE* const ipport_ptr = (BYTE *) 0x023344D0;


### PR DESCRIPTION
Has been tested with two people on an otherwise empty server. For future reference:

All vectors are twice in bf3 memory, use the first set. Its order of vectors is, position vector first then top vector then front vector.
