### PR TITLE
initialize member variable DevState::initRefCount in constructor

### DIFF
--- a/overlay/d3d9.cpp
+++ b/overlay/d3d9.cpp
@@ -81,6 +81,7 @@ DevState::DevState() {
 	dev = NULL;
 	pSB = NULL;
 	dwMyThread = 0;
+	initRefCount = 0;
 	refCount = 0;
 	myRefCount = 0;
 	texTexture = NULL;


### PR DESCRIPTION
Fix uninitialized member variable
