### PR TITLE
Fix debug output for overlay chain notice

### DIFF
--- a/overlay/d3d10.cpp
+++ b/overlay/d3d10.cpp
@@ -541,8 +541,8 @@ static void HookResizeRaw(voidFunc vfResize) {
 
 void checkDXGIHook(bool preonly) {
 	if (bChaining) {
-		return;
 		ods("DXGI: Causing a chain");
+		return;
 	}
 
 	if (! dxgi->iOffsetPresent || ! dxgi->iOffsetResize)

--- a/overlay/d3d9.cpp
+++ b/overlay/d3d9.cpp
@@ -619,8 +619,8 @@ static void HookCreateRawEx(voidFunc vfCreate) {
 
 void checkD3D9Hook(bool preonly) {
 	if (bChaining) {
-		return;
 		ods("D3D9: Causing a chain");
+		return;
 	}
 
 	bChaining = true;

--- a/overlay/opengl.cpp
+++ b/overlay/opengl.cpp
@@ -369,8 +369,8 @@ static BOOL __stdcall mywglSwapLayerBuffers(HDC hdc, UINT fuPlanes) {
 
 void checkOpenGLHook() {
 	if (bChaining) {
-		return;
 		ods("Causing a chain");
+		return;
 	}
 
 	bChaining = true;


### PR DESCRIPTION
The debug outputs were placed after the return statements, rendering them useless.
Place them in front, so they are executed.
