### PR TITLE
Refactored how sql exec and prepare errors are handled in murmur

### DIFF
--- a/src/murmur/ServerDB.h
+++ b/src/murmur/ServerDB.h
@@ -63,9 +63,11 @@ class ServerDB {
 		static QList<LogRecord> getLog(int server_id, unsigned int offs_min, unsigned int offs_max);
 		static int getLogLen(int server_id);
 		static void wipeLogs();
-		static bool prepare(QSqlQuery &, const QString &, bool fatal = true, bool warn = true);
-		static bool exec(QSqlQuery &, const QString &str = QString(), bool fatal= true, bool warn = true);
-		static bool execBatch(QSqlQuery &, const QString &str = QString(), bool fatal= true);
+		static bool prepare(QSqlQuery &, const QString &, bool fatal = false);
+		static bool exec(QSqlQuery &, const QString &str = QString(), bool fatal = false);
+		static bool execBatch(QSqlQuery &, const QString &str = QString(), bool fatal = false);
+		static bool connectionFailure();
+		static bool reconnect(int retries = 20);
 };
 
 #endif


### PR DESCRIPTION
- By default now errors aren't fatal, to try and ensure the best uptime of master servers which could be running many virtual servers.
- "disconnect" errors are now detected and the command retried where possible.

Note: Due to the lack of Qt driver agnostic method for detecting disconnections, this is done the hard way.

For additional info see:-
https://sourceforge.net/tracker/?func=detail&atid=768005&aid=3566322&group_id=147372
