### PR TITLE
Add Portuguese Brazilian to Windows installer

### DIFF
--- a/installer/Translations/Portuguese.wxl
+++ b/installer/Translations/Portuguese.wxl
@@ -1,0 +1,48 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<WixLocalization Culture="pt-br" xmlns="http://schemas.microsoft.com/wix/2006/localization">
+  <String Id="LANG">1046</String>
+
+  <!-- By Thorvald Natvig <slicer@users.sourceforge.net> -->
+  <String Id="MUMBLE_CREATE_SHORTCUT">Criar Atalho no Desktopt</String>
+  <String Id="MUMBLE_DONATE">Doar para o projeto do Mumble</String>
+  <String Id="MUMBLE_TERMINATE_DBUS">O DBus, daemon usado pelo Mumble está em execução atualmente. Fechar o daemon para que ele possa ser atualizado?</String>
+  <String Id="MUMBLE_NO_SSE">O Mumble requer SSE, disponível somente nos processadores Intel Pentium III, AMD Athlon XP ou mais recentes. SSE não foi detectado em seu processador, e o Mumble provavelmente não funcionará. Você ainda quer instalá-lo?</String>
+  <String Id="MUMBLE_NO_XP">O Mumble funcionará somente no Windows XP SP2 ou mais recente. Uma versão incompatível foi dectada, e o Mumble provavelmente não funcionará. Você ainda quer instalá-lo?</String>
+  <String Id="MUMBLE_START">Iniciar o Mumble</String>
+
+  <!-- For the start menu -->
+  <String Id="MUMBLE_README_LNK">Leiame do Mumble</String>
+  <String Id="MUMBLE_LICENSE_LNK">Licença do Mumble</String>
+  <String Id="MUMBLE_QT_LNK">Licença do Qt</String>
+  <String Id="MUMBLE_SPEEX_LNK">Licença do Speex</String>
+  <String Id="MUMBLE_UNINSTALL_LNK">Desinstalar o Mumble</String>
+  <String Id="MUMBLE_COMPAT_LNK">Mumble (Compatibilidade Antiga)</String>
+
+  <!-- Install types -->
+  <String Id="INSTALL_FULL">Completa</String>
+  <String Id="INSTALL_CLIENT">Cliente apenas</String>
+  <String Id="INSTALL_SERVER">Servidor apenas</String>
+
+  <!-- Install sections -->
+  <String Id="MUMBLE_SEC_MUMBLE">Mumble (cliente)</String>
+  <String Id="MUMBLE_SEC_MUMBLE11X">Mumble (cliente para compatibilidade anterior)</String>
+  <String Id="MUMBLE_SEC_MURMUR">Murmur (servidor)</String>
+  <String Id="MUMBLE_SEC_BONJOUR">Bonjour para Windows</String>
+  <String Id="DESC_SectionMumble">O cliente do Mumble, que você precisará para conectar a um servidor.</String>
+  <String Id="DESC_SectionMumble11X">O cliente do Mumble para conectar a servidores antigos.</String>
+  <String Id="DESC_SectionMurmur">O servidor para o Mumble. Inclui todo o necessário para rodar seu próprio servidor.</String>
+  <String Id="DESC_SectionBonjour">Bonjour permite anúncio e descobrimento de servidores Murmur na sua LAN. Isso baixará e executará o instalador do Bonjour.</String>
+
+  <!-- Uninstall sections -->
+  <String Id="MUMBLE_UNSEC_BASE">Mumble e Murmur</String>
+  <String Id="MUMBLE_UNSEC_ALL">Preferências e Base de Dados</String>
+  <String Id="DESC_SectionUninstBase">Deinstalar os programas Mumble de Murmur</String>
+  <String Id="DESC_SectionUninstAll">Deinstalar todos os traços do Mumble e do Murmur, inclusive preferências e as bases de dados.</String>
+
+  <!-- Already installed -->
+  <String Id="MUMBLE_ALREADY_INSTALLED">O Mumble já está instalado. É recomendado que você deinstale a versão atual antes de instalá-lo. Selecione a operação que deseja realizar e clique Proximo para continuar.</String>
+  <String Id="MUMBLE_ALREADY_INSTALLED_HEAD">Já Instalado</String>
+  <String Id="MUMBLE_ALREADY_INSTALLED_SUBTEXT">Selecione como quer instalar o Mumble.</String>
+  <String Id="MUMBLE_UNINSTALL">Deinstalar antes de instalar</String>
+  <String Id="MUMBLE_NO_UNINSTALL">Não desinstalar</String>
+</WixLocalization>


### PR DESCRIPTION
Since it's just a xml file I tried to translate it by creating a new file using my text editor, I also got the LANG id from Google (so maybe it's worth double checking that too). Also, I see that all wxl are referenced in the MumbleInstall.wixproj, but I preferred not to touch it.
