### PR TITLE
add depend on Hungarian translation of qt

### DIFF
--- a/src/mumble/mumble_qt.qrc
+++ b/src/mumble/mumble_qt.qrc
@@ -6,6 +6,7 @@
  <file>qt_es.qm</file>
  <file>qt_fr.qm</file>
  <file>qt_he.qm</file>
+ <file>qt_hu.qm</file>
  <file>qt_ja.qm</file>
  <file>qt_pl.qm</file>
  <file>qt_pt.qm</file>


### PR DESCRIPTION
add depend on Hungarian translation of qt so Qt strings are translated appropriately.

See also bug report #3507162
https://sourceforge.net/tracker/?func=detail&aid=3507162&group_id=147372&atid=768005

Now only it translation dependency is missing (none in Qt yet).
