### PR TITLE
...refacs; initialization, var-scope reduction, replace c-style casts, rm u

### DIFF
--- a/overlay/HardHook.cpp
+++ b/overlay/HardHook.cpp
@@ -227,9 +227,6 @@ void *HardHook::cloneCode(void **porig) {
  * @param replacement Pointer to code to redirect to.
  */
 void HardHook::setup(voidFunc func, voidFunc replacement) {
-	int i;
-	DWORD oldProtect, restoreProtect;
-
 	if (baseptr)
 		return;
 
@@ -248,18 +245,20 @@ void HardHook::setup(voidFunc func, voidFunc replacement) {
 		call = func;
 	}
 
+	DWORD oldProtect;
 	if (VirtualProtect(fptr, 16, PAGE_EXECUTE_READ, &oldProtect)) {
 		unsigned char **iptr = reinterpret_cast<unsigned char **>(&replace[1]);
 		replace[0] = 0x68; // PUSH immediate        1 Byte
 		*iptr = nptr;      // (imm. value = nptr)   4 Byte
 		replace[5] = 0xc3; // RETN                  1 Byte
 
-		for (i=0;i<6;i++) // Save original 6 bytes at start of original function
+		for (int i=0;i<6;i++) // Save original 6 bytes at start of original function
 			orig[i] = fptr[i];
 
 		baseptr = fptr;
 		inject(true);
 
+		DWORD restoreProtect;
 		VirtualProtect(fptr, 16, oldProtect, &restoreProtect);
 	} else {
 		fods("HardHook: Failed vprotect");
@@ -314,17 +313,17 @@ void HardHook::inject(bool force) {
  * @param force If true injection will be performed even when trampoline is available.
  */
 void HardHook::restore(bool force) {
-	DWORD oldProtect, restoreProtect;
-	int i;
 
 	if (! baseptr)
 		return;
 	if (! force && bTrampoline)
 		return;
 
+	DWORD oldProtect;
 	if (VirtualProtect(baseptr, 6, PAGE_EXECUTE_READWRITE, &oldProtect)) {
-		for (i=0;i<6;i++)
+		for (int i=0;i<6;i++)
 			baseptr[i] = orig[i];
+		DWORD restoreProtect;
 		VirtualProtect(baseptr, 6, oldProtect, &restoreProtect);
 		FlushInstructionCache(GetCurrentProcess(), baseptr, 6);
 	}

--- a/overlay/d3d10.cpp
+++ b/overlay/d3d10.cpp
@@ -271,6 +271,8 @@ void D10State::init() {
 
 	ID3D10Texture2D* pBackBuffer = NULL;
 	hr = pSwapChain->GetBuffer(0, __uuidof(*pBackBuffer), (LPVOID*)&pBackBuffer);
+	if (FAILED(hr))
+		ods("D3D10: pSwapChain->GetBuffer failure!");
 
 	pDevice->ClearState();
 
@@ -287,6 +289,8 @@ void D10State::init() {
 	pDevice->RSSetViewports(1, &vp);
 
 	hr = pDevice->CreateRenderTargetView(pBackBuffer, NULL, &pRTV);
+	if (FAILED(hr))
+		ods("D3D10: pDevice->CreateRenderTargetView failure!");
 
 	pDevice->OMSetRenderTargets(1, &pRTV, NULL);
 
@@ -324,6 +328,8 @@ void D10State::init() {
 	D3D10_PASS_DESC PassDesc;
 	pTechnique->GetPassByIndex(0)->GetDesc(&PassDesc);
 	hr = pDevice->CreateInputLayout(layout, numElements, PassDesc.pIAInputSignature, PassDesc.IAInputSignatureSize, &pVertexLayout);
+	if (FAILED(hr))
+		ods("D3D10: pDevice->CreateInputLayout failure!");
 	pDevice->IASetInputLayout(pVertexLayout);
 
 	D3D10_BUFFER_DESC bd;
@@ -334,6 +340,8 @@ void D10State::init() {
 	bd.CPUAccessFlags = D3D10_CPU_ACCESS_WRITE;
 	bd.MiscFlags = 0;
 	hr = pDevice->CreateBuffer(&bd, NULL, &pVertexBuffer);
+	if (FAILED(hr))
+		ods("D3D10: pDevice->CreateBuffer failure!");
 
 	DWORD indices[] = {
 		0,1,3,
@@ -349,6 +357,8 @@ void D10State::init() {
 	ZeroMemory(&InitData, sizeof(InitData));
 	InitData.pSysMem = indices;
 	hr = pDevice->CreateBuffer(&bd, &InitData, &pIndexBuffer);
+	if (FAILED(hr))
+		ods("D3D10: pDevice->CreateBuffer failure!");
 
 	// Set index buffer
 	pDevice->IASetIndexBuffer(pIndexBuffer, DXGI_FORMAT_R32_UINT, 0);
@@ -616,9 +626,10 @@ extern "C" __declspec(dllexport) void __cdecl PrepareDXGI() {
 			CreateDXGIFactoryType pCreateDXGIFactory = reinterpret_cast<CreateDXGIFactoryType>(GetProcAddress(hDXGI, "CreateDXGIFactory"));
 			ods("Got %p", pCreateDXGIFactory);
 			if (pCreateDXGIFactory) {
-				HRESULT hr;
 				IDXGIFactory * pFactory;
-				hr = pCreateDXGIFactory(__uuidof(IDXGIFactory), (void**)(&pFactory));
+				HRESULT hr = pCreateDXGIFactory(__uuidof(IDXGIFactory), (void**)(&pFactory));
+				if (FAILED(hr))
+					ods("D3D10: pCreateDXGIFactory failure!");
 				if (pFactory) {
 					HWND hwnd = CreateWindowW(L"STATIC", L"Mumble DXGI Window", WS_OVERLAPPEDWINDOW,
 					                          CW_USEDEFAULT, CW_USEDEFAULT, 640, 480, 0,
@@ -662,6 +673,8 @@ extern "C" __declspec(dllexport) void __cdecl PrepareDXGI() {
 					desc.SwapEffect = DXGI_SWAP_EFFECT_DISCARD;
 
 					hr = pD3D10CreateDeviceAndSwapChain(pAdapter, D3D10_DRIVER_TYPE_HARDWARE, NULL, 0, D3D10_SDK_VERSION, &desc, &pSwapChain, &pDevice);
+					if (FAILED(hr))
+						ods("D3D10: pD3D10CreateDeviceAndSwapChain failure!");
 
 					if (pDevice && pSwapChain) {
 						HMODULE hRef;

--- a/overlay/d3d9.cpp
+++ b/overlay/d3d9.cpp
@@ -675,12 +675,12 @@ extern "C" __declspec(dllexport) void __cdecl PrepareD3D9() {
 
 	ods("Preparing static data for D3D9 Injection");
 
-	char buffb[2048];
-
 	HMODULE hD3D = LoadLibrary("D3D9.DLL");
-	HMODULE hRef;
 
 	if (hD3D != NULL) {
+		HMODULE hRef;
+		char buffb[2048];
+
 		GetModuleFileName(hD3D, d3dd->cFileName, 2048);
 		pDirect3DCreate9 d3dc9 = reinterpret_cast<pDirect3DCreate9>(GetProcAddress(hD3D, "Direct3DCreate9"));
 		if (! d3dc9) {

--- a/overlay/lib.cpp
+++ b/overlay/lib.cpp
@@ -617,7 +617,7 @@ extern "C" BOOL WINAPI DllMain(HINSTANCE, DWORD fdwReason, LPVOID) {
 
 				bool bInit = (GetLastError() != ERROR_ALREADY_EXISTS);
 
-				sd = (SharedData *) MapViewOfFile(hMapObject, FILE_MAP_ALL_ACCESS, 0, 0, dwSharedSize);
+				sd = static_cast<SharedData *>(MapViewOfFile(hMapObject, FILE_MAP_ALL_ACCESS, 0, 0, dwSharedSize));
 
 				if (sd == NULL) {
 					ods("MapViewOfFile Failed");
@@ -628,8 +628,8 @@ extern "C" BOOL WINAPI DllMain(HINSTANCE, DWORD fdwReason, LPVOID) {
 					memset(sd, 0, dwSharedSize);
 
 				unsigned char *raw = (unsigned char *) sd;
-				d3dd = (Direct3D9Data *)(raw + sizeof(SharedData));
-				dxgi = (DXGIData *)(raw + sizeof(SharedData) + sizeof(Direct3D9Data));
+				d3dd = reinterpret_cast<Direct3D9Data *>(raw + sizeof(SharedData));
+				dxgi = reinterpret_cast<DXGIData *>(raw + sizeof(SharedData) + sizeof(Direct3D9Data));
 
 
 				if (! bMumble) {

--- a/plugins/l4d/l4d.cpp
+++ b/plugins/l4d/l4d.cpp
@@ -76,13 +76,14 @@ static int trylock(const std::multimap<std::wstring, unsigned long long int> &pi
 
 	float pos[3];
 	float rot[3];
-	float opos[3], top[3], front[3];
 
 	bool ok = peekProc(posptr, pos, 12) &&
 	          peekProc(rotptr, rot, 12);
 
-	if (ok)
+	if (ok) {
+		float opos[3], top[3], front[3];
 		return calcout(pos, rot, opos, top, front);
+	}
 
 	generic_unlock();
 

--- a/plugins/l4d2/l4d2.cpp
+++ b/plugins/l4d2/l4d2.cpp
@@ -81,15 +81,16 @@ static int trylock(const std::multimap<std::wstring, unsigned long long int> &pi
 	
 	float pos[3];
 	float rot[3];
-	float opos[3], top[3], front[3];
 	char state, _context[21];
 	bool ok = peekProc(posptr, pos, 12) &&
 	          peekProc(rotptr, rot, 12) &&
 			  peekProc(stateptr, &state, 1) &&
 			  peekProc(contextptr, _context);
 
-	if (ok)
+	if (ok) {
+		float opos[3], top[3], front[3];
 		return calcout(pos, rot, opos, top, front);
+	}
 
 	generic_unlock();
 

--- a/plugins/link/link.cpp
+++ b/plugins/link/link.cpp
@@ -162,7 +162,7 @@ BOOL WINAPI DllMain(HINSTANCE, DWORD fdwReason, LPVOID) {
 				if (hMapObject == NULL)
 					return false;
 			}
-			lm = (LinkedMem *) MapViewOfFile(hMapObject, FILE_MAP_ALL_ACCESS, 0, 0, 0);
+			lm = static_cast<LinkedMem *>(MapViewOfFile(hMapObject, FILE_MAP_ALL_ACCESS, 0, 0, 0));
 			if (lm == NULL) {
 				CloseHandle(hMapObject);
 				hMapObject = NULL;

--- a/speexbuild/AGC.cpp
+++ b/speexbuild/AGC.cpp
@@ -19,14 +19,12 @@
 
 template<class T>
 static inline double veccomp(const QVector<T> &a, const QVector<T> &b, const char *n) {
-	long double rms = 0.0;
 	long double gdiff = 0.0;
 	if (a.size() != b.size()) {
 		qFatal("%s: %d <=> %d", n, a.size(), b.size());
 	}
 	for (int i=0;i<a.size();++i) {
 		double diff = fabs(a[i] - b[i]);
-		rms += diff * diff;
 		if (diff > gdiff)
 			gdiff = diff;
 #ifdef EXACT
@@ -46,7 +44,6 @@ static inline double veccomp(const QVector<T> &a, const QVector<T> &b, const cha
 		}
 	}
 	return gdiff;
-	return sqrt(rms / a.size());
 }
 
 int main(int argc, char **argv) {

--- a/speexbuild/ResampMark.cpp
+++ b/speexbuild/ResampMark.cpp
@@ -33,14 +33,12 @@ static const int loops = 2000 / qual;
 
 template<class T>
 static inline double veccomp(const QVector<T> &a, const QVector<T> &b, const char *n) {
-	long double rms = 0.0;
 	long double gdiff = 0.0;
 	if (a.size() != b.size()) {
 		qFatal("%s: %d <=> %d", n, a.size(), b.size());
 	}
 	for (int i=0;i<a.size();++i) {
 		double diff = fabs(a[i] - b[i]);
-		rms += diff * diff;
 		if (diff > gdiff)
 			gdiff = diff;
 #ifdef EXACT
@@ -60,7 +58,6 @@ static inline double veccomp(const QVector<T> &a, const QVector<T> &b, const cha
 		}
 	}
 	return gdiff;
-	return sqrt(rms / a.size());
 }
 
 template<class T>
@@ -189,7 +186,6 @@ int main(int argc, char **argv) {
 		qWarning("Application: Failed to set priority!");
 #endif
 
-	int len;
 	spx_uint32_t inlen;
 	spx_uint32_t outlen;
 

--- a/speexbuild/SpeexMark.cpp
+++ b/speexbuild/SpeexMark.cpp
@@ -104,7 +104,6 @@ int main(int argc, char **argv) {
 
 	float oframe[2048];
 	float resampframe[32768];
-	float verifyframe[32768];
 
 	const float sfraq1 = tfreq1 / 16000.0f;
 	float fOutSize1 = iFrameSize * sfraq1;

--- a/src/mumble/ASIOInput.cpp
+++ b/src/mumble/ASIOInput.cpp
@@ -79,10 +79,7 @@ class ASIOInit : public DeferInit {
 void ASIOInit::initialize() {
 	HKEY hkDevs;
 	HKEY hk;
-	WCHAR keyname[255];
-	DWORD keynamelen = 255;
 	FILETIME ft;
-	HRESULT hr;
 
 	airASIO = NULL;
 	crASIO = NULL;
@@ -98,6 +95,8 @@ void ASIOInit::initialize() {
 #endif
 	if (RegOpenKeyEx(HKEY_LOCAL_MACHINE, L"Software\\ASIO", 0, KEY_READ, &hkDevs) == ERROR_SUCCESS) {
 		DWORD idx = 0;
+		DWORD keynamelen = 255;
+		WCHAR keyname[keynamelen];
 		while (RegEnumKeyEx(hkDevs, idx++, keyname, &keynamelen, NULL, NULL, NULL, &ft)  == ERROR_SUCCESS) {
 			QString name=QString::fromUtf16(reinterpret_cast<ushort *>(keyname),keynamelen);
 			if (RegOpenKeyEx(hkDevs, keyname, 0, KEY_READ, &hk) == ERROR_SUCCESS) {
@@ -109,7 +108,7 @@ void ASIOInit::initialize() {
 					if (datasize > 76)
 						datasize = 76;
 					QString qsCls = QString::fromUtf16(reinterpret_cast<ushort *>(wclsid), datasize / 2).toLower().trimmed();
-					if (! blacklist.contains(qsCls.toLower()) && ! FAILED(hr =CLSIDFromString(wclsid, &clsid))) {
+					if (! blacklist.contains(qsCls.toLower()) && ! FAILED(CLSIDFromString(wclsid, &clsid))) {
 						bFound = true;
 					}
 				}

--- a/src/mumble/AudioOutputSample.cpp
+++ b/src/mumble/AudioOutputSample.cpp
@@ -208,10 +208,10 @@ SoundFile* AudioOutputSample::loadSndfile(const QString &filename) {
 }
 
 QString AudioOutputSample::browseForSndfile() {
-	SoundFile *sf = NULL;
 	QString file = QFileDialog::getOpenFileName(NULL, tr("Choose sound file"), QString(), QLatin1String("*.wav *.ogg *.ogv *.oga *.flac"));
 	if (! file.isEmpty()) {
-		if ((sf = AudioOutputSample::loadSndfile(file)) == NULL) {
+		SoundFile *sf = AudioOutputSample::loadSndfile(file);
+		if (sf == NULL) {
 			QMessageBox::critical(NULL,
 			                      tr("Invalid sound file"),
 			                      tr("The file '%1' cannot be used by Mumble. Please select a file with a compatible format and encoding.").arg(file));

--- a/src/mumble/AudioOutputSample.h
+++ b/src/mumble/AudioOutputSample.h
@@ -78,7 +78,6 @@ class AudioOutputSample : public AudioOutputUser {
 
 		SoundFile *sfHandle;
 
-		bool bLastAlive;
 		bool bLoop;
 		bool bEof;
 	signals:

--- a/src/mumble/AudioOutputSpeech.cpp
+++ b/src/mumble/AudioOutputSpeech.cpp
@@ -54,6 +54,7 @@ AudioOutputSpeech::AudioOutputSpeech(ClientUser *user, unsigned int freq, Messag
 	dsSpeex = NULL;
 	opusState = NULL;
 
+	bHasTerminator = false;
 	bStereo = false;
 
 	iSampleRate = SAMPLE_RATE;

--- a/src/mumble/DirectSound.cpp
+++ b/src/mumble/DirectSound.cpp
@@ -225,10 +225,6 @@ void DXAudioOutput::run() {
 	LPDIRECTSOUNDBUFFER       pDSBOutput = NULL;
 	LPDIRECTSOUNDNOTIFY8       pDSNotify = NULL;
 
-	DWORD	dwBufferSize;
-	DWORD	dwLastWritePos;
-	DWORD	dwLastPlayPos;
-	DWORD	dwTotalPlayPos;
 	int iLastwriteblock;
 	LPVOID aptr1, aptr2;
 	DWORD nbytes1, nbytes2;
@@ -386,7 +382,6 @@ void DXAudioOutput::run() {
 		goto cleanup;
 	}
 
-	dwBufferSize = nbytes1 + nbytes2;
 	if (aptr1)
 		ZeroMemory(aptr1, nbytes1);
 	if (aptr2)
@@ -401,10 +396,6 @@ void DXAudioOutput::run() {
 		qWarning("DXAudioOutputUser: Play failed: hr=0x%08lx", hr);
 		goto cleanup;
 	}
-
-	dwLastWritePos = 0;
-	dwLastPlayPos = 0;
-	dwTotalPlayPos = 0;
 
 	iLastwriteblock = (NBLOCKS - 1 + g.s.iOutputDelay) % NBLOCKS;
 
@@ -492,8 +483,6 @@ void DXAudioInput::run() {
 
 	DWORD dwBufferSize;
 	bool bOk;
-	DWORD dwReadyBytes = 0;
-	DWORD dwLastReadPos = 0;
 	DWORD dwReadPosition;
 	DWORD dwCapturePosition;
 
@@ -511,9 +500,6 @@ void DXAudioInput::run() {
 	bOk = false;
 
 	bool failed = false;
-	float safety = 2.0f;
-	bool didsleep = false;
-	bool firstsleep = false;
 
 	Timer t;
 
@@ -562,9 +548,13 @@ void DXAudioInput::run() {
 	if (FAILED(hr = pDSCaptureBuffer->Start(DSCBSTART_LOOPING))) {
 		qWarning("DXAudioInput: Start failed: hr=0x%08lx", hr);
 	} else {
+		DWORD dwReadyBytes = 0;
+		DWORD dwLastReadPos = 0;
+		float safety = 2.0f;
+
 		while (bRunning) {
-			firstsleep = true;
-			didsleep = false;
+			bool firstsleep = true;
+			bool didsleep = false;
 
 			do {
 				if (FAILED(hr = pDSCaptureBuffer->GetCurrentPosition(&dwCapturePosition, &dwReadPosition))) {

--- a/src/mumble/GlobalShortcut_win.cpp
+++ b/src/mumble/GlobalShortcut_win.cpp
@@ -108,10 +108,9 @@ GlobalShortcutWin::~GlobalShortcutWin() {
 
 void GlobalShortcutWin::run() {
 	HMODULE hSelf;
-	HRESULT hr;
 	QTimer *timer;
 
-	if (FAILED(hr = DirectInput8Create(GetModuleHandle(NULL), DIRECTINPUT_VERSION, IID_IDirectInput8, reinterpret_cast<void **>(&pDI), NULL))) {
+	if (FAILED(DirectInput8Create(GetModuleHandle(NULL), DIRECTINPUT_VERSION, IID_IDirectInput8, reinterpret_cast<void **>(&pDI), NULL))) {
 		qFatal("GlobalShortcutWin: Failed to create d8input");
 		return;
 	}

--- a/src/murmur/DBus.h
+++ b/src/murmur/DBus.h
@@ -94,7 +94,7 @@ struct ACLInfo {
 	int playerid;
 	QString group;
 	unsigned int allow, deny;
-	ACLInfo() : applyHere(false), applySubs(false), inherited(false) { };
+	ACLInfo() : applyHere(false), applySubs(false), inherited(false), playerid(-1), allow(0), deny(0) { };
 	ACLInfo(const ChanACL *acl);
 };
 Q_DECLARE_METATYPE(ACLInfo);

--- a/src/murmur/Messages.cpp
+++ b/src/murmur/Messages.cpp
@@ -1543,8 +1543,6 @@ void Server::msgUserStats(ServerUser*uSource, MumbleProto::UserStats &msg) {
 	const CryptState &cs = pDstServerUser->csCrypt;
 	const BandwidthRecord &bwr = pDstServerUser->bwr;
 	const QList<QSslCertificate> &certs = pDstServerUser->peerCertificateChain();
-	MumbleProto::UserStats_Stats *mpusss;
-	MumbleProto::Version *mpv;
 
 	bool extend = (uSource == pDstServerUser) || hasPermission(uSource, qhChannels.value(0), ChanACL::Register);
 
@@ -1571,6 +1569,8 @@ void Server::msgUserStats(ServerUser*uSource, MumbleProto::UserStats &msg) {
 	}
 
 	if (local) {
+		MumbleProto::UserStats_Stats *mpusss;
+
 		mpusss = msg.mutable_from_client();
 		mpusss->set_good(cs.uiGood);
 		mpusss->set_late(cs.uiLate);
@@ -1592,6 +1592,8 @@ void Server::msgUserStats(ServerUser*uSource, MumbleProto::UserStats &msg) {
 	msg.set_tcp_ping_var(pDstServerUser->dTCPPingVar);
 
 	if (details) {
+		MumbleProto::Version *mpv;
+
 		mpv = msg.mutable_version();
 		if (pDstServerUser->uiVersion)
 			mpv->set_version(pDstServerUser->uiVersion);


### PR DESCRIPTION
I did another CPPCheck run. Here’s some refactoring results. :)
Hope you take everything!?

refacs; initialization, var-scope reduction, replace c-style casts, rm unused
- DBus.h, AudioOutputSpeech.cpp: initialize uninitialized members,
- d3d10.cpp: actually use assigned results for a dbg output
- lib.cpp, link.cpp: c-style to c++-style casts
- jc2.cpp, SpeexMark.cpp, ResampMark.cpp: rm unused var
- AGC.cpp, ResampMark.cpp:
  rm unused var (ineffective return statement after prior return;
  thus removing unused code - but someone check if sth. was missed there)
