### PR TITLE
Murmur: Support restricting clients to recognised CA.

### DIFF
--- a/src/murmur/Meta.cpp
+++ b/src/murmur/Meta.cpp
@@ -355,6 +355,8 @@ void MetaParams::read(QString fname) {
 	QString qsSSLCA = qsSettings->value("sslCA").toString();
 
 	qbaPassPhrase = qsSettings->value("sslPassPhrase").toByteArray();
+	
+	bool CACertsEmpty = true;
 
 	if (! qsSSLCA.isEmpty()) {
 		QFile pem(qsSSLCA);
@@ -365,7 +367,11 @@ void MetaParams::read(QString fname) {
 			if (ql.isEmpty()) {
 				qCritical("Failed to parse any CA certificates from %s", qPrintable(qsSSLCA));
 			} else {
-				QSslSocket::addDefaultCaCertificates(ql);
+				CACertsEmpty = false;
+				if(bRequireCAMatch)
+					QSslSocket::setDefaultCaCertificates(ql);
+				else
+					QSslSocket::addDefaultCaCertificates(ql);
 			}
 		} else {
 			qCritical("Failed to read %s", qPrintable(qsSSLCA));
@@ -423,7 +429,10 @@ void MetaParams::read(QString fname) {
 			qFatal("Failed to find certificate matching private key.");
 		}
 		if (ql.size() > 0) {
-			QSslSocket::addDefaultCaCertificates(ql);
+			if(bRequireCAMatch && CACertsEmpty)
+				QSslSocket::setDefaultCaCertificates(ql);
+			else
+				QSslSocket::addDefaultCaCertificates(ql);
 			qCritical("Adding %d CA certificates from certificate file.", ql.size());
 		}
 	}

--- a/src/murmur/Meta.cpp
+++ b/src/murmur/Meta.cpp
@@ -71,6 +71,7 @@ MetaParams::MetaParams() {
 	bBonjour = true;
 	bAllowPing = true;
 	bCertRequired = false;
+	bRequireCAMatch = false;
 
 	iBanTries = 10;
 	iBanTimeframe = 120;
@@ -265,6 +266,7 @@ void MetaParams::read(QString fname) {
 	iMaxUsersPerChannel = typeCheckedFromSettings("usersperchannel", iMaxUsersPerChannel);
 	qsWelcomeText = typeCheckedFromSettings("welcometext", qsWelcomeText);
 	bCertRequired = typeCheckedFromSettings("certrequired", bCertRequired);
+	bRequireCAMatch = typeCheckedFromSettings("requireca", bRequireCAMatch);
 
 	qsDatabase = typeCheckedFromSettings("database", qsDatabase);
 
@@ -470,6 +472,7 @@ void MetaParams::read(QString fname) {
 	qmConfig.insert(QLatin1String("username"),qrUserName.pattern());
 	qmConfig.insert(QLatin1String("channelname"),qrChannelName.pattern());
 	qmConfig.insert(QLatin1String("certrequired"), bCertRequired ? QLatin1String("true") : QLatin1String("false"));
+	qmConfig.insert(QLatin1String("requireca"), bRequireCAMatch ? QLatin1String("true") : QLatin1String("false"));
 	qmConfig.insert(QLatin1String("suggestversion"), qvSuggestVersion.isNull() ? QString() : qvSuggestVersion.toString());
 	qmConfig.insert(QLatin1String("suggestpositional"), qvSuggestPositional.isNull() ? QString() : qvSuggestPositional.toString());
 	qmConfig.insert(QLatin1String("suggestpushtotalk"), qvSuggestPushToTalk.isNull() ? QString() : qvSuggestPushToTalk.toString());

--- a/src/murmur/Meta.h
+++ b/src/murmur/Meta.h
@@ -67,6 +67,7 @@ public:
 	QString qsPassword;
 	QString qsWelcomeText;
 	bool bCertRequired;
+	bool bRequireCAMatch;
 
 	int iBanTries;
 	int iBanTimeframe;

--- a/src/murmur/Server.cpp
+++ b/src/murmur/Server.cpp
@@ -325,6 +325,7 @@ void Server::readParams() {
 	bBonjour = Meta::mp.bBonjour;
 	bAllowPing = Meta::mp.bAllowPing;
 	bCertRequired = Meta::mp.bCertRequired;
+	bRequireCAMatch = Meta::mp.bRequireCAMatch;
 	qrUserName = Meta::mp.qrUserName;
 	qrChannelName = Meta::mp.qrChannelName;
 	qvSuggestVersion = Meta::mp.qvSuggestVersion;
@@ -381,6 +382,7 @@ void Server::readParams() {
 	bBonjour = getConf("bonjour", bBonjour).toBool();
 	bAllowPing = getConf("allowping", bAllowPing).toBool();
 	bCertRequired = getConf("certrequired", bCertRequired).toBool();
+	bRequireCAMatch = getConf("requireca", bRequireCAMatch).toBool();
 
 	qvSuggestVersion = getConf("suggestversion", qvSuggestVersion);
 	if (qvSuggestVersion.toUInt() == 0)
@@ -488,6 +490,8 @@ void Server::setLiveConf(const QString &key, const QString &value) {
 		qurlRegWeb = !v.isNull() ? v : Meta::mp.qurlRegWeb;
 	else if (key == "certrequired")
 		bCertRequired = !v.isNull() ? QVariant(v).toBool() : Meta::mp.bCertRequired;
+	else if (key == "requireca")
+		bRequireCAMatch = !v.isNull() ? QVariant(v).toBool() : Meta::mp.bRequireCAMatch;
 	else if (key == "bonjour") {
 		bBonjour = !v.isNull() ? QVariant(v).toBool() : Meta::mp.bBonjour;
 #ifdef USE_BONJOUR
@@ -1165,6 +1169,20 @@ void Server::encrypted() {
 		uSource->qsHash = cert.digest(QCryptographicHash::Sha1).toHex();
 		if (! uSource->qslEmail.isEmpty() && uSource->bVerified) {
 			log(uSource, QString("Strong certificate for %1 <%2> (signed by %3)").arg(cert.subjectInfo(QSslCertificate::CommonName)).arg(uSource->qslEmail.join(", ")).arg(certs.first().issuerInfo(QSslCertificate::CommonName)));
+		}
+
+		if(bRequireCAMatch) {
+			bool CAMatched = false;
+			foreach(const QSslCertificate cacert, certs)
+				if(QSslSocket::defaultCaCertificates().contains(cacert)) {
+					CAMatched = true;
+					break;
+				}
+			if(!CAMatched)
+			{
+				log(uSource, QString("Certificate CA doesn't match any in the local trust chain."));
+				uSource->disconnectSocket();
+			}
 		}
 
 		foreach(const Ban &ban, qlBans) {

--- a/src/murmur/Server.h
+++ b/src/murmur/Server.h
@@ -137,6 +137,7 @@ class Server : public QThread {
 		QString qsPassword;
 		QString qsWelcomeText;
 		bool bCertRequired;
+		bool bRequireCAMatch;
 
 		QString qsRegName;
 		QString qsRegPassword;


### PR DESCRIPTION
This commit allows specifying "requireca" as an option in Murmur.ini to
only allow clients who have a certificate signed by a recognised CA -
this can be either the CA who signed the server's certificate or any
that is explicitly provided within the configuration file.
