### PR TITLE
Clock in Overlay

### DIFF
--- a/src/mumble/Overlay.h
+++ b/src/mumble/Overlay.h
@@ -240,14 +240,17 @@ class OverlayConfig : public ConfigWidget, public Ui::OverlayConfig {
 		void initDisplay();
 		void refreshFpsDemo();
 		void refreshFpsLive();
+		void refreshTimeLive();
 	protected:
 		QPixmap qpScreen;
 		QGraphicsPixmapItem *qgpiScreen;
 		QGraphicsScene qgs;
 		QGraphicsScene qgsFpsPreview;
 		BasepointPixmap bpFpsDemo;
+		BasepointPixmap bpTimeDemo;
 		QGraphicsPixmapItem *qgpiFpsDemo;
 		QGraphicsPixmapItem *qgpiFpsLive;
+		QGraphicsPixmapItem *qgpiTimeLive;
 		OverlayUserGroup *oug;
 		QGraphicsTextItem *qgtiInstructions;
 
@@ -274,6 +277,7 @@ class OverlayConfig : public ConfigWidget, public Ui::OverlayConfig {
 		void on_qrbBlacklist_toggled(bool);
 		void on_qcbEnable_stateChanged(int);
 		void on_qcbShowFps_stateChanged(int);
+		void on_qcbShowTime_stateChanged(int);
 		void on_qpbFpsFont_clicked();
 		void on_qpbFpsColor_clicked();
 		void on_qpbLoadPreset_clicked();
@@ -316,6 +320,7 @@ class OverlayClient : public QObject {
 		QGraphicsPixmapItem *qgpiCursor;
 		QGraphicsPixmapItem *qgpiLogo;
 		QGraphicsPixmapItem *qgpiFPS;
+		QGraphicsPixmapItem *qgpiTime;
 
 		quint64 uiPid;
 		QGraphicsScene qgs;
@@ -352,6 +357,7 @@ class OverlayClient : public QObject {
 		void scheduleDelete();
 		void updateMouse();
 		void updateFPS();
+		void updateTime();
 		bool update();
 		void openEditor();
 };

--- a/src/mumble/Overlay.ui
+++ b/src/mumble/Overlay.ui
@@ -34,7 +34,7 @@
          </property>
          <layout class="QHBoxLayout" name="horizontalLayout_9" stretch="0,0">
           <property name="spacing">
-           <number>-1</number>
+           <number>6</number>
           </property>
           <property name="sizeConstraint">
            <enum>QLayout::SetDefaultConstraint</enum>
@@ -132,7 +132,7 @@
              </sizepolicy>
             </property>
             <property name="title">
-             <string>FPS Display</string>
+             <string>FPS and Clock Display</string>
             </property>
             <layout class="QHBoxLayout" name="horizontalLayout_8">
              <item>
@@ -147,6 +147,20 @@
                  </property>
                  <property name="text">
                   <string>Show FPS counter</string>
+                 </property>
+                </widget>
+               </item>
+               <item>
+                <widget class="QCheckBox" name="qcbShowTime">
+                 <property name="toolTip">
+                  <string>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
+&lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
+p, li { white-space: pre-wrap; }
+&lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:'MS Shell Dlg 2'; font-size:8.25pt; font-weight:400; font-style:normal;&quot;&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-size:8pt;&quot;&gt;Display a simple clock in the overlay&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                 </property>
+                 <property name="text">
+                  <string>Show Clock</string>
                  </property>
                 </widget>
                </item>
@@ -201,6 +215,12 @@
                  <horstretch>0</horstretch>
                  <verstretch>0</verstretch>
                 </sizepolicy>
+               </property>
+               <property name="minimumSize">
+                <size>
+                 <width>256</width>
+                 <height>100</height>
+                </size>
                </property>
                <property name="maximumSize">
                 <size>

--- a/src/mumble/OverlayClient.cpp
+++ b/src/mumble/OverlayClient.cpp
@@ -78,6 +78,12 @@ OverlayClient::OverlayClient(QLocalSocket *socket, QObject *p) :
 	qgpiFPS->setPos(g.s.os.qrfFps.x(), g.s.os.qrfFps.y());
 	qgpiFPS->show();
 
+	// Time
+	qgpiTime = new QGraphicsPixmapItem();
+	qgs.addItem(qgpiTime);
+	qgpiTime->setPos(g.s.os.qrfTime.x(), g.s.os.qrfTime.y());
+	qgpiTime->show();
+
 	qgpiLogo = NULL;
 
 	iOffsetX = iOffsetY = 0;
@@ -87,6 +93,7 @@ OverlayClient::OverlayClient(QLocalSocket *socket, QObject *p) :
 
 OverlayClient::~OverlayClient() {
 	delete qgpiFPS;
+	delete qgpiTime;
 	delete qgpiCursor;
 	delete qgpiLogo;
 
@@ -114,6 +121,16 @@ void OverlayClient::updateFPS() {
 		qgpiFPS->setOffset(-pm.qpBasePoint + QPoint(0, pm.iAscent));
 	} else {
 		qgpiFPS->setPixmap(QPixmap());
+	}
+}
+
+void OverlayClient::updateTime() {
+		if (g.s.os.bTime) {
+			const BasepointPixmap &pm = OverlayTextLine(QString(QLatin1String("%1")).arg(QTime::currentTime().toString()), g.s.os.qfFps).createPixmap(g.s.os.qcFps);
+			qgpiTime->setPixmap(pm);
+			qgpiTime->setOffset(-pm.qpBasePoint + QPoint(0, pm.iAscent));
+		} else {
+			qgpiTime->setPixmap(QPixmap());
 	}
 }
 
@@ -527,6 +544,7 @@ void OverlayClient::setupScene(bool show) {
 	}
 	ougUsers.updateUsers();
 	updateFPS();
+	updateTime();
 }
 
 void OverlayClient::setupRender() {
@@ -557,6 +575,7 @@ bool OverlayClient::update() {
 
 	ougUsers.updateUsers();
 	updateFPS();
+	updateTime();
 
 	if (qlsSocket->bytesToWrite() > 1024) {
 		return (t.elapsed() <= 5000000ULL);

--- a/src/mumble/OverlayConfig.cpp
+++ b/src/mumble/OverlayConfig.cpp
@@ -73,7 +73,10 @@ void OverlayConfig::initDisplay() {
 
 	qgpiFpsLive = new QGraphicsPixmapItem();
 	qgpiFpsLive->setZValue(-2.0f);
-	refreshFpsLive();
+	qgpiTimeLive = new QGraphicsPixmapItem();
+	qgpiTimeLive->setZValue(-2.0f);
+ 	refreshFpsLive();
+	refreshTimeLive();
 
 	qgtiInstructions = new QGraphicsTextItem();
 	qgtiInstructions->setHtml(QString::fromLatin1("<ul><li>%1</li><li>%2</li><li>%3</li></ul>").arg(
@@ -94,6 +97,9 @@ void OverlayConfig::initDisplay() {
 
 	qgs.addItem(qgpiFpsLive);
 	qgpiFpsLive->show();
+
+	qgs.addItem(qgpiTimeLive);
+	qgpiTimeLive->show();
 
 	oug = new OverlayUserGroup(&s.os);
 	oug->bShowExamples = true;
@@ -121,6 +127,18 @@ void OverlayConfig::refreshFpsLive() {
 		qgpiFpsLive->setOffset((-bpFpsDemo.qpBasePoint + QPoint(0, bpFpsDemo.iAscent)) * fViewScale);
 	} else {
 		qgpiFpsLive->setPixmap(QPixmap());
+	}
+}
+
+void OverlayConfig::refreshTimeLive() {
+	if (s.os.bTime) {
+		bpTimeDemo = OverlayTextLine(QString::fromLatin1("%1").arg(QTime::currentTime().toString()), s.os.qfFps).createPixmap(s.os.qcFps);
+		qgpiTimeLive->setPixmap(bpTimeDemo);
+		qgpiTimeLive->setPos(s.os.qrfTime.topLeft() * fViewScale);
+		qgpiTimeLive->setPixmap(bpTimeDemo.scaled(bpTimeDemo.size() * fViewScale));
+		qgpiTimeLive->setOffset((-bpTimeDemo.qpBasePoint + QPoint(0, bpTimeDemo.iAscent)) * fViewScale);
+	} else {
+		qgpiTimeLive->setPixmap(QPixmap());
 	}
 }
 
@@ -264,6 +282,7 @@ void OverlayConfig::load(const Settings &r) {
 
 	loadCheckBox(qcbEnable, s.os.bEnable);
 	qcbShowFps->setChecked(s.os.bFps);
+	qcbShowTime->setChecked(s.os.bTime);
 	qgpFps->setEnabled(s.os.bEnable);
 
 	qlwBlacklist->clear();
@@ -312,6 +331,7 @@ QIcon OverlayConfig::icon() const {
 void OverlayConfig::save() const {
 	s.os.bEnable = qcbEnable->isChecked();
 	s.os.bFps = qcbShowFps->isChecked();
+	s.os.bTime = qcbShowTime->isChecked();
 
 	// Directly save overlay config
 	s.os.qslBlacklist.clear();
@@ -362,6 +382,7 @@ void OverlayConfig::resizeScene(bool force) {
 
 	fViewScale = static_cast<float>(qgpiScreen->pixmap().height()) / static_cast<float>(qpScreen.height());
 	refreshFpsLive();
+	refreshTimeLive();
 
 	QFont f = qgtiInstructions->font();
 	f.setPointSizeF(qgs.sceneRect().height() / 20.0f);
@@ -441,6 +462,12 @@ void OverlayConfig::on_qcbShowFps_stateChanged(int state) {
 	refreshFpsLive();
 }
 
+void OverlayConfig::on_qcbShowTime_stateChanged(int state) {
+	Q_UNUSED(state);
+	s.os.bTime = qcbShowTime->isChecked();
+	refreshTimeLive();
+}
+
 void OverlayConfig::on_qpbFpsFont_clicked() {
 	bool ok;
 	QFont new_font = QFontDialog::getFont(&ok, s.os.qfFps);
@@ -450,6 +477,7 @@ void OverlayConfig::on_qpbFpsFont_clicked() {
 
 		refreshFpsDemo();
 		refreshFpsLive();
+		refreshTimeLive();
 	}
 }
 
@@ -461,6 +489,7 @@ void OverlayConfig::on_qpbFpsColor_clicked() {
 
 		refreshFpsDemo();
 		refreshFpsLive();
+		refreshTimeLive();
 	}
 }
 

--- a/src/mumble/Settings.cpp
+++ b/src/mumble/Settings.cpp
@@ -145,12 +145,14 @@ OverlaySettings::OverlaySettings() {
 
 	setPreset();
 
-	// FPS display settings
+	// FPS and Time display settings
 	qcFps = Qt::white;
 	fFps = 0.75f;
 	qfFps = qfUserName;
-	qrfFps = QRectF(10, 10, -1, 0.023438f);
+	qrfFps = QRectF(10, 50, -1, 0.023438f);
 	bFps = false;
+	qrfTime = QRectF(10, 10, -1, 0.023438f);
+	bTime = false;
 
 	bUseWhitelist = false;
 
@@ -504,6 +506,7 @@ void OverlaySettings::load(QSettings* settings_ptr) {
 	SAVELOAD(bAvatar, "avatarshow");
 	SAVELOAD(bBox, "boxshow");
 	SAVELOAD(bFps, "fpsshow");
+	SAVELOAD(bTime, "timeshow");
 
 	SAVELOAD(fUserName, "useropacity");
 	SAVELOAD(fChannel, "channelopacity");
@@ -791,6 +794,7 @@ void OverlaySettings::save(QSettings* settings_ptr) {
 	SAVELOAD(bAvatar, "avatarshow");
 	SAVELOAD(bBox, "boxshow");
 	SAVELOAD(bFps, "fpsshow");
+	SAVELOAD(bTime, "timeshow");
 
 	SAVELOAD(fUserName, "useropacity");
 	SAVELOAD(fChannel, "channelopacity");

--- a/src/mumble/Settings.h
+++ b/src/mumble/Settings.h
@@ -124,6 +124,7 @@ struct OverlaySettings {
 	bool bAvatar;
 	bool bBox;
 	bool bFps;
+	bool bTime;
 
 	qreal fUserName;
 	qreal fChannel;
@@ -137,6 +138,7 @@ struct OverlaySettings {
 	QRectF qrfMutedDeafened;
 	QRectF qrfAvatar;
 	QRectF qrfFps;
+	QRectF qrfTime;
 
 	Qt::Alignment qaUserName;
 	Qt::Alignment qaChannel;


### PR DESCRIPTION
Simple clock in Overlay, shares Font and Color settings from FPS Counter.

Settings preview:
![Konfiguracja_Mumble_2013-03-01_20-34-55](https://f.cloud.github.com/assets/521035/211088/1817ff70-82a9-11e2-90c2-d67c39b2d8af.png)

In game preview:
![2013-03-01_20-37-38](https://f.cloud.github.com/assets/521035/211080/b4f457e0-82a8-11e2-86e1-1792546cd78e.jpg)
