### PR TITLE
Ensure that the MAX macro is always defined.

### DIFF
--- a/src/murmur/Server.cpp
+++ b/src/murmur/Server.cpp
@@ -49,6 +49,10 @@
 #include "BonjourServiceRegister.h"
 #endif
 
+#ifndef MAX
+#define MAX(a,b) ((a)>(b) ? (a):(b))
+#endif
+
 #define UDP_PACKET_SIZE 1024
 
 LogEmitter::LogEmitter(QObject *p) : QObject(p) {


### PR DESCRIPTION
On some systems, none of the (directly or indirectly) included headers does
provide that macro. First reported in https://bugs.gentoo.org/460524
