### PR TITLE
Add Global Shortcut for cycling through transmit modes.

### DIFF
--- a/src/mumble/MainWindow.cpp
+++ b/src/mumble/MainWindow.cpp
@@ -286,6 +286,9 @@ void MainWindow::createActions() {
 	gsMetaLink=new GlobalShortcut(this, idx++, tr("Link Channel", "Global Shortcut"));
 	gsMetaLink->setObjectName(QLatin1String("MetaLink"));
 
+	gsCycleTransmitMode=new GlobalShortcut(this, idx++, tr("Cycle Transmit Mode", "Global Shortcut"));
+	gsCycleTransmitMode->setObjectName(QLatin1String("gsCycleTransmitMode"));
+
 #ifndef Q_OS_MAC
 	qstiIcon->show();
 #endif
@@ -2294,6 +2297,32 @@ void MainWindow::on_gsWhisper_triggered(bool down, QVariant scdata) {
 		SignalCurry *fwd = new SignalCurry(scdata, true, this);
 		connect(fwd, SIGNAL(called(QVariant)), SLOT(whisperReleased(QVariant)));
 		QTimer::singleShot(g.s.uiPTTHold, fwd, SLOT(call()));
+	}
+}
+
+void MainWindow::on_gsCycleTransmitMode_triggered(bool down, QVariant scdata) 
+{
+	if (down) 
+	{
+		QString qsNewMode;
+
+		switch (g.s.atTransmit)
+		{
+			case Settings::Continous:
+				g.s.atTransmit = Settings::VAD;
+				qsNewMode = QString::fromLatin1("Voice Activity");
+				break;
+			case Settings::VAD:
+				g.s.atTransmit = Settings::PushToTalk;
+				qsNewMode = QString::fromLatin1("Push To Talk");
+				break;
+			case Settings::PushToTalk:
+				g.s.atTransmit = Settings::Continous;
+				qsNewMode = QString::fromLatin1("Continuous");
+				break;
+		}
+
+		g.l->log(Log::Information, tr("Cycled Transmit Mode to %1").arg(qsNewMode));
 	}
 }
 

--- a/src/mumble/MainWindow.h
+++ b/src/mumble/MainWindow.h
@@ -99,6 +99,7 @@ class MainWindow : public QMainWindow, public MessageHandler, public Ui::MainWin
 		GlobalShortcut *gsPushTalk, *gsResetAudio, *gsMuteSelf, *gsDeafSelf;
 		GlobalShortcut *gsUnlink, *gsPushMute, *gsMetaChannel, *gsToggleOverlay;
 		GlobalShortcut *gsMinimal, *gsVolumeUp, *gsVolumeDown, *gsWhisper, *gsMetaLink;
+		GlobalShortcut *gsCycleTransmitMode;
 		DockTitleBar *dtbLogDockTitle, *dtbChatDockTitle;
 
 		ACLEditor *aclEdit;
@@ -243,6 +244,7 @@ class MainWindow : public QMainWindow, public MessageHandler, public Ui::MainWin
 		void on_gsMuteSelf_down(QVariant);
 		void on_gsDeafSelf_down(QVariant);
 		void on_gsWhisper_triggered(bool, QVariant);
+		void on_gsCycleTransmitMode_triggered(bool, QVariant);
 		void on_Reconnect_timeout();
 		void on_Icon_messageClicked();
 		void on_Icon_activated(QSystemTrayIcon::ActivationReason);


### PR DESCRIPTION
This is a feature I've personally found very useful.  I did see a post about implementing this via audio profiles and then creating shortcuts to apply audio profiles, but this might provide use to some people in the meantime.

Please let me know if you need me to update any additional files for this change.
