### PR TITLE
PulseAudio: Cork audio input when it isn't needed

### DIFF
--- a/src/mumble/AudioWizard.cpp
+++ b/src/mumble/AudioWizard.cpp
@@ -36,6 +36,7 @@ AudioWizard::AudioWizard(QWidget *p) : QWizard(p) {
 	bInit = true;
 	bLastActive = false;
 	g.bInAudioWizard = true;
+	g.mw->onChangeMute();
 
 	ticker = new QTimer(this);
 	ticker->setObjectName(QLatin1String("Ticker"));
@@ -398,6 +399,7 @@ void AudioWizard::reject() {
 		ao->wipe();
 	aosSource = NULL;
 	g.bInAudioWizard = false;
+	g.mw->onChangeMute();
 
 	QWizard::reject();
 }
@@ -433,6 +435,7 @@ void AudioWizard::accept() {
 	g.bPosTest = false;
 	restartAudio();
 	g.bInAudioWizard = false;
+	g.mw->onChangeMute();
 	QWizard::accept();
 }
 

--- a/src/mumble/MainWindow.cpp
+++ b/src/mumble/MainWindow.cpp
@@ -2306,6 +2306,7 @@ void MainWindow::on_qaAudioMute_triggered() {
 		g.sh->setSelfMuteDeafState(g.s.bMute, g.s.bDeaf);
 	}
 
+	onChangeMute();
 	updateTrayIcon();
 }
 
@@ -2342,6 +2343,7 @@ void MainWindow::on_qaAudioDeaf_triggered() {
 		g.sh->setSelfMuteDeafState(g.s.bMute, g.s.bDeaf);
 	}
 
+	onChangeMute();
 	updateTrayIcon();
 }
 
@@ -2790,6 +2792,15 @@ void MainWindow::whisperReleased(QVariant scdata) {
 	updateTarget();
 }
 
+void MainWindow::onChangeMute()
+{
+	if (!g.ai) {
+		return;
+	}
+
+	emit corkAudioInputStream(g.s.bMute && !g.bInAudioWizard);
+}
+
 void MainWindow::onResetAudio()
 {
 	qWarning("MainWindow: Start audio reset");
@@ -2849,6 +2860,7 @@ void MainWindow::serverConnected() {
 
 	if (g.s.bMute || g.s.bDeaf) {
 		g.sh->setSelfMuteDeafState(g.s.bMute, g.s.bDeaf);
+		onChangeMute();
 	}
 
 	// Update QActions and menues

--- a/src/mumble/MainWindow.h
+++ b/src/mumble/MainWindow.h
@@ -269,6 +269,9 @@ class MainWindow : public QMainWindow, public MessageHandler, public Ui::MainWin
 		void pttReleased();
 		void whisperReleased(QVariant scdata);
 		void onResetAudio();
+		/// Called whenever the self-mute state may have changed. Dispatches
+		/// corkAudioInputStream() if the desire for audio input has changed.
+		void onChangeMute();
 		void showRaiseWindow();
 		void on_qaFilterToggle_triggered();
 		/// Opens a save dialog for the image referenced by qtcSaveImageCursor.
@@ -279,7 +282,16 @@ class MainWindow : public QMainWindow, public MessageHandler, public Ui::MainWin
 		/// Updates the user's image directory to the given path (any included
 		/// filename is discarded).
 		void updateImagePath(QString filepath) const;
-
+	signals:
+		/// Reports that audio input is now, or is no longer, required.
+		///
+		/// Signal allows an \ref AudioInput to suspend the input stream
+		/// when it is not required.
+		///
+		/// @param cork  If true, the audio backend MAY now cork/suspend
+		/// the input stream. If false, the audio backend MUST immediately
+		/// un-cork/resume the stream.
+		void corkAudioInputStream(const bool cork);
 	public:
 		MainWindow(QWidget *parent);
 		~MainWindow() Q_DECL_OVERRIDE;

--- a/src/mumble/PulseAudio.cpp
+++ b/src/mumble/PulseAudio.cpp
@@ -301,6 +301,11 @@ void PulseAudioSystem::eventCallback(pa_mainloop_api *api, pa_defer_event *) {
 			qsInputCache = idev;
 
 			pa_stream_connect_record(pasInput, qPrintable(idev), &buff, PA_STREAM_ADJUST_LATENCY);
+
+			// Ensure stream is initially un-muted
+			pa_stream_cork(pasInput, 0, NULL, NULL);
+
+			connect(g.mw, &MainWindow::corkAudioInputStream, this, &PulseAudioSystem::corkAudioInputStream);
 		}
 	}
 
@@ -368,6 +373,15 @@ void PulseAudioSystem::eventCallback(pa_mainloop_api *api, pa_defer_event *) {
 
 			pa_stream_connect_record(pasSpeaker, qPrintable(edev), &buff, PA_STREAM_ADJUST_LATENCY);
 		}
+	}
+}
+
+void PulseAudioSystem::corkAudioInputStream(const bool cork)
+{
+	if (pasInput) {
+		pa_threaded_mainloop_lock(pam);
+		pa_stream_cork(pasInput, cork, nullptr, nullptr);
+		pa_threaded_mainloop_unlock(pam);
 	}
 }
 

--- a/src/mumble/PulseAudio.h
+++ b/src/mumble/PulseAudio.h
@@ -80,6 +80,9 @@ class PulseAudioSystem : public QObject {
 		void setVolumes();
 		PulseAttenuation* getAttenuation(QString stream_restore_id);
 
+	public slots:
+		void corkAudioInputStream(const bool cork);
+
 	public:
 		QHash<QString, QString> qhInput;
 		QHash<QString, QString> qhOutput;

--- a/src/mumble/main.cpp
+++ b/src/mumble/main.cpp
@@ -479,6 +479,7 @@ int main(int argc, char **argv) {
 	g.p->rescanPlugins();
 
 	Audio::start();
+	g.mw->onChangeMute();
 
 	a.setQuitOnLastWindowClosed(false);
 


### PR DESCRIPTION
As noted in https://sourceforge.net/p/mumble/bugs/868/ , mumble consumes a great deal of CPU when it is idle. The vast majority of this usage can be traced to the audio input DSP. When mumble is self-muted, these operations are largely unnecessary and unhelpful. To save CPU, the audio input stream can be "corked" (muted) when it is not needed. This blocks the audio input DSP when it isn't needed.

This update automatically corks the PulseAudio input when the user is self-muted. In order to do this, `MainWindow` emits a new signal, `corkStream(bool)`, whenever the audio input is or is not required. This signal is slotted by the PulseAudio source, which passes it to the underlying PulseAudio server. This implementation will enable the fix to be ported to other sound servers and systems (i.e., Windows).

A downside to this fix is that the AEC will stop updating while Mumble is muted. If the user is truly idling or AFK, however, there probably won't be much sound with which to update it. While this patch appears to work, I would welcome more widespread testing.