### PR TITLE
Kick/Ban Reasons

### DIFF
--- a/src/mumble/Log.cpp
+++ b/src/mumble/Log.cpp
@@ -118,6 +118,12 @@ void LogConfig::load(const Settings &r) {
 	qsbThreshold->setValue(r.iTTSThreshold);
 	qcbReadBackOwn->setChecked(r.bTTSMessageReadBack);
 	qcbWhisperFriends->setChecked(r.bWhisperFriends);
+
+	qcbEnableranmsgs->setChecked(r.bEnableRanKBMsgs);
+	qlwReasons->addItems(r.qslKickBanReasons);
+	for(int i=0; i<qlwReasons->count(); i++) {
+		qlwReasons->item(i)->setFlags(qlwReasons->item(i)->flags() | Qt::ItemIsEditable);
+	}
 }
 
 void LogConfig::save() const {
@@ -143,6 +149,12 @@ void LogConfig::save() const {
 	s.iTTSThreshold=qsbThreshold->value();
 	s.bTTSMessageReadBack = qcbReadBackOwn->isChecked();
 	s.bWhisperFriends = qcbWhisperFriends->isChecked();
+
+	s.bEnableRanKBMsgs = qcbEnableranmsgs->isChecked();
+	s.qslKickBanReasons.clear();
+	for (int i=0; i<qlwReasons->count(); i++) {
+		s.qslKickBanReasons.append(qlwReasons->item(i)->text());
+	}
 }
 
 void LogConfig::accept() const {
@@ -630,4 +642,22 @@ void LogDocument::finished() {
 	} else qWarning() << "Image "<< rep->url().toString() << " download failed.";
 
 	rep->deleteLater();
+}
+
+void LogConfig::on_qpb_add_clicked() {
+	QString messageText = QInputDialog::getText(this, tr("Add reason"),tr("Input text for the new reason:"));
+
+	if (messageText.isNull())
+		return;
+
+	QListWidgetItem *newMessage = new QListWidgetItem;
+	newMessage->setText(messageText);
+
+	int row = qlwReasons->row(qlwReasons->currentItem());
+	newMessage->setFlags (newMessage->flags() | Qt::ItemIsEditable);
+	qlwReasons->insertItem(row, newMessage);
+}
+
+void LogConfig::on_qpb_remove_clicked() {
+	qDeleteAll(qlwReasons->selectedItems());
 }

--- a/src/mumble/Log.h
+++ b/src/mumble/Log.h
@@ -60,6 +60,9 @@ class LogConfig : public ConfigWidget, public Ui::LogConfig {
 		void on_qtwMessages_itemClicked(QTreeWidgetItem*, int);
 		void on_qtwMessages_itemDoubleClicked(QTreeWidgetItem*, int);
 		void browseForAudioFile();
+	private slots:
+		void on_qpb_add_clicked();
+		void on_qpb_remove_clicked();
 };
 
 class ClientUser;
@@ -123,6 +126,53 @@ class LogDocument : public QTextDocument {
 	public slots:
 		void receivedHead();
 		void finished();
+};
+
+static const char *kickBanReasons[] = {
+	"|Z| - there's the exit",
+	"A pity you have to leave so early",
+	"Absence makes the heart grow fonder",
+	"And now eat my poo-poo",
+	"Boo-hoo",
+	"Come back when you've finally learned not to be lame",
+	"Cya later - much later",
+	"Enough for today rookie",
+	"Everybody be cool, YOU - be cool",
+	"Get lost",
+	"Go play leapfrog with a unicorn",
+	"I didn't invite you, did I?",
+	"I love pressing this button",
+	"I rather want you to stay at teletubbies.com",
+	"I wonder what this button does?",
+	"Insufficient maturity detected",
+	"It's not that I hate you, it's just... that I don't like you",
+	"Kick sponsored by mumble.info",
+	"Ladies and Gentlemen - may I present: King Admin",
+	"Lame and fake - that's you",
+	"Look behind you, a three-headed monkey!",
+	"My channel, my rules",
+	"No Homers",
+	"Nope - no wrong button",
+	"Oops, I did it again",
+	"Perhaps you should try real life for a while",
+	"Pimp your brain",
+	"Pissing me off is one of your skills",
+	"See you in hell",
+	"Sometimes there is no other solution",
+	"Sorry, but you are dismissed",
+	"Testing... Worked.",
+	"Thank you, drive through",
+	"Thanks for your visit",
+	"The admin is always right",
+	"This random message was censored by popular request",
+	"Waste your time wherever you want, but not here",
+	"Yes, I have admin rights",
+	"You didn't understand any of this",
+	"You really wanted it, right?",
+	"You're falling in a bottomless pit of loneliness",
+	"You're not welcome here",
+	"You've been dying since the day you were born",
+	NULL
 };
 
 #endif

--- a/src/mumble/Log.ui
+++ b/src/mumble/Log.ui
@@ -13,210 +13,309 @@
   <property name="windowTitle">
    <string>Messages</string>
   </property>
-  <layout class="QVBoxLayout">
-   <item>
-    <widget class="QTreeWidget" name="qtwMessages">
-     <property name="alternatingRowColors">
-      <bool>true</bool>
+  <layout class="QGridLayout" name="gridLayout_3">
+   <item row="1" column="0">
+    <widget class="QTabWidget" name="tabWidget">
+     <property name="currentIndex">
+      <number>0</number>
      </property>
-     <property name="selectionMode">
-      <enum>QAbstractItemView::SingleSelection</enum>
-     </property>
-     <property name="rootIsDecorated">
-      <bool>false</bool>
-     </property>
-     <property name="uniformRowHeights">
-      <bool>true</bool>
-     </property>
-     <property name="itemsExpandable">
-      <bool>false</bool>
-     </property>
-     <column>
-      <property name="text">
-       <string>Message</string>
-      </property>
-     </column>
-     <column>
-      <property name="text">
-       <string>Console</string>
-      </property>
-     </column>
-     <column>
-      <property name="text">
-       <string>Notification</string>
-      </property>
-     </column>
-     <column>
-      <property name="text">
-       <string>Text-To-Speech</string>
-      </property>
-     </column>
-     <column>
-      <property name="text">
-       <string>Soundfile</string>
-      </property>
-     </column>
-     <column>
-      <property name="text">
-       <string>Path</string>
-      </property>
-     </column>
-    </widget>
-   </item>
-   <item>
-    <widget class="QGroupBox" name="qgbTTS">
-     <property name="title">
-      <string>Text To Speech</string>
-     </property>
-     <layout class="QGridLayout">
-      <item row="0" column="0">
-       <widget class="QLabel" name="qlVolume">
-        <property name="text">
-         <string>Volume</string>
-        </property>
-        <property name="buddy">
-         <cstring>qsVolume</cstring>
-        </property>
-       </widget>
-      </item>
-      <item row="0" column="1" colspan="3">
-       <widget class="QSlider" name="qsVolume">
-        <property name="toolTip">
-         <string>Volume of Text-To-Speech Engine</string>
-        </property>
-        <property name="whatsThis">
-         <string>&lt;b&gt;This is the volume used for the speech synthesis.&lt;/b&gt;</string>
-        </property>
-        <property name="maximum">
-         <number>100</number>
-        </property>
-        <property name="singleStep">
-         <number>5</number>
-        </property>
-        <property name="pageStep">
-         <number>20</number>
-        </property>
-        <property name="orientation">
-         <enum>Qt::Horizontal</enum>
-        </property>
-        <property name="tickPosition">
-         <enum>QSlider::TicksBelow</enum>
-        </property>
-        <property name="tickInterval">
-         <number>5</number>
-        </property>
-       </widget>
-      </item>
-      <item row="1" column="0">
-       <widget class="QLabel" name="qlThreshold">
-        <property name="text">
-         <string>Length threshold</string>
-        </property>
-        <property name="buddy">
-         <cstring>qsbThreshold</cstring>
-        </property>
-       </widget>
-      </item>
-      <item row="1" column="1">
-       <widget class="QSpinBox" name="qsbThreshold">
-        <property name="toolTip">
-         <string>Message length threshold for Text-To-Speech Engine</string>
-        </property>
-        <property name="whatsThis">
-         <string>&lt;b&gt;This is the length threshold used for the Text-To-Speech Engine.&lt;/b&gt;&lt;br /&gt;Messages longer than this limit will not be read aloud in their full length.</string>
-        </property>
-        <property name="buttonSymbols">
-         <enum>QAbstractSpinBox::PlusMinus</enum>
-        </property>
-        <property name="suffix">
-         <string> Characters</string>
-        </property>
-        <property name="maximum">
-         <number>5000</number>
-        </property>
-        <property name="singleStep">
-         <number>10</number>
-        </property>
-       </widget>
-      </item>
-      <item row="1" column="3">
-       <widget class="QCheckBox" name="qcbReadBackOwn">
-        <property name="toolTip">
-         <string>If enabled text messages you send will be read back to you with TTS</string>
-        </property>
-        <property name="text">
-         <string>Read back own messages</string>
-        </property>
-       </widget>
-      </item>
-     </layout>
-    </widget>
-   </item>
-   <item>
-    <widget class="QGroupBox" name="qgbWhisper">
-     <property name="title">
-      <string>Whisper</string>
-     </property>
-     <layout class="QVBoxLayout" name="verticalLayout">
-      <item>
-       <widget class="QCheckBox" name="qcbWhisperFriends">
-        <property name="toolTip">
-         <string>If checked you will only hear whispers from users you added to your friend list.</string>
-        </property>
-        <property name="text">
-         <string>Only accept whispers from friends</string>
-        </property>
-       </widget>
-      </item>
-     </layout>
-    </widget>
-   </item>
-   <item>
-    <widget class="QGroupBox" name="qgbMaxBlocks">
-     <property name="title">
-      <string>Chat Log</string>
-     </property>
-     <layout class="QGridLayout" name="gridLayout">
-      <item row="0" column="0">
-       <widget class="QLabel" name="qlMaxBlocks">
-        <property name="text">
-         <string>Maximum chat length</string>
-        </property>
-       </widget>
-      </item>
-      <item row="0" column="1">
-       <widget class="QSpinBox" name="qsbMaxBlocks">
-        <property name="buttonSymbols">
-         <enum>QAbstractSpinBox::PlusMinus</enum>
-        </property>
-        <property name="specialValueText">
-         <string>Unlimited</string>
-        </property>
-        <property name="suffix">
-         <string> Lines</string>
-        </property>
-        <property name="maximum">
-         <number>1000000</number>
-        </property>
-        <property name="singleStep">
-         <number>100</number>
-        </property>
-       </widget>
-      </item>
-      <item row="0" column="2">
-       <spacer name="horizontalSpacer">
-        <property name="orientation">
-         <enum>Qt::Horizontal</enum>
-        </property>
-        <property name="sizeHint" stdset="0">
-         <size>
-          <width>8</width>
-          <height>16</height>
-         </size>
-        </property>
-       </spacer>
-      </item>
-     </layout>
+     <widget class="QWidget" name="tab_log">
+      <attribute name="title">
+       <string>Messages</string>
+      </attribute>
+      <layout class="QGridLayout" name="gridLayout_2">
+       <item row="0" column="0">
+        <widget class="QTreeWidget" name="qtwMessages">
+         <property name="alternatingRowColors">
+          <bool>true</bool>
+         </property>
+         <property name="selectionMode">
+          <enum>QAbstractItemView::SingleSelection</enum>
+         </property>
+         <property name="rootIsDecorated">
+          <bool>false</bool>
+         </property>
+         <property name="uniformRowHeights">
+          <bool>true</bool>
+         </property>
+         <property name="itemsExpandable">
+          <bool>false</bool>
+         </property>
+         <column>
+          <property name="text">
+           <string>Message</string>
+          </property>
+         </column>
+         <column>
+          <property name="text">
+           <string>Console</string>
+          </property>
+         </column>
+         <column>
+          <property name="text">
+           <string>Notification</string>
+          </property>
+         </column>
+         <column>
+          <property name="text">
+           <string>Text-To-Speech</string>
+          </property>
+         </column>
+         <column>
+          <property name="text">
+           <string>Soundfile</string>
+          </property>
+         </column>
+         <column>
+          <property name="text">
+           <string>Path</string>
+          </property>
+         </column>
+        </widget>
+       </item>
+       <item row="1" column="0">
+        <widget class="QGroupBox" name="qgbTTS">
+         <property name="title">
+          <string>Text To Speech</string>
+         </property>
+         <layout class="QGridLayout">
+          <item row="1" column="0">
+           <widget class="QLabel" name="qlThreshold">
+            <property name="text">
+             <string>Length threshold</string>
+            </property>
+            <property name="buddy">
+             <cstring>qsbThreshold</cstring>
+            </property>
+           </widget>
+          </item>
+          <item row="0" column="0">
+           <widget class="QLabel" name="qlVolume">
+            <property name="text">
+             <string>Volume</string>
+            </property>
+            <property name="buddy">
+             <cstring>qsVolume</cstring>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="3">
+           <widget class="QCheckBox" name="qcbReadBackOwn">
+            <property name="toolTip">
+             <string>If enabled text messages you send will be read back to you with TTS</string>
+            </property>
+            <property name="text">
+             <string>Read back own messages</string>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="1">
+           <widget class="QSpinBox" name="qsbThreshold">
+            <property name="toolTip">
+             <string>Message length threshold for Text-To-Speech Engine</string>
+            </property>
+            <property name="whatsThis">
+             <string>&lt;b&gt;This is the length threshold used for the Text-To-Speech Engine.&lt;/b&gt;&lt;br /&gt;Messages longer than this limit will not be read aloud in their full length.</string>
+            </property>
+            <property name="buttonSymbols">
+             <enum>QAbstractSpinBox::PlusMinus</enum>
+            </property>
+            <property name="suffix">
+             <string> Characters</string>
+            </property>
+            <property name="maximum">
+             <number>5000</number>
+            </property>
+            <property name="singleStep">
+             <number>10</number>
+            </property>
+           </widget>
+          </item>
+          <item row="0" column="1" colspan="3">
+           <widget class="QSlider" name="qsVolume">
+            <property name="toolTip">
+             <string>Volume of Text-To-Speech Engine</string>
+            </property>
+            <property name="whatsThis">
+             <string>&lt;b&gt;This is the volume used for the speech synthesis.&lt;/b&gt;</string>
+            </property>
+            <property name="maximum">
+             <number>100</number>
+            </property>
+            <property name="singleStep">
+             <number>5</number>
+            </property>
+            <property name="pageStep">
+             <number>20</number>
+            </property>
+            <property name="orientation">
+             <enum>Qt::Horizontal</enum>
+            </property>
+            <property name="tickPosition">
+             <enum>QSlider::TicksBelow</enum>
+            </property>
+            <property name="tickInterval">
+             <number>5</number>
+            </property>
+           </widget>
+          </item>
+         </layout>
+        </widget>
+       </item>
+       <item row="2" column="0">
+        <widget class="QGroupBox" name="qgbWhisper">
+         <property name="title">
+          <string>Whisper</string>
+         </property>
+         <layout class="QVBoxLayout" name="verticalLayout">
+          <item>
+           <widget class="QCheckBox" name="qcbWhisperFriends">
+            <property name="toolTip">
+             <string>If checked you will only hear whispers from users you added to your friend list.</string>
+            </property>
+            <property name="text">
+             <string>Only accept whispers from friends</string>
+            </property>
+           </widget>
+          </item>
+         </layout>
+        </widget>
+       </item>
+       <item row="3" column="0">
+        <widget class="QGroupBox" name="qgbMaxBlocks">
+         <property name="title">
+          <string>Chat Log</string>
+         </property>
+         <layout class="QGridLayout" name="gridLayout">
+          <item row="0" column="0">
+           <widget class="QLabel" name="qlMaxBlocks">
+            <property name="text">
+             <string>Maximum chat length</string>
+            </property>
+           </widget>
+          </item>
+          <item row="0" column="1">
+           <widget class="QSpinBox" name="qsbMaxBlocks">
+            <property name="buttonSymbols">
+             <enum>QAbstractSpinBox::PlusMinus</enum>
+            </property>
+            <property name="specialValueText">
+             <string>Unlimited</string>
+            </property>
+            <property name="suffix">
+             <string> Lines</string>
+            </property>
+            <property name="maximum">
+             <number>1000000</number>
+            </property>
+            <property name="singleStep">
+             <number>100</number>
+            </property>
+           </widget>
+          </item>
+          <item row="0" column="2">
+           <spacer name="horizontalSpacer">
+            <property name="orientation">
+             <enum>Qt::Horizontal</enum>
+            </property>
+            <property name="sizeHint" stdset="0">
+             <size>
+              <width>8</width>
+              <height>16</height>
+             </size>
+            </property>
+           </spacer>
+          </item>
+         </layout>
+        </widget>
+       </item>
+      </layout>
+     </widget>
+     <widget class="QWidget" name="tab_kickbanmsgs">
+      <attribute name="title">
+       <string>Kick/Ban Reasons</string>
+      </attribute>
+      <layout class="QGridLayout" name="gridLayout_5">
+       <item row="0" column="0">
+        <widget class="QCheckBox" name="qcbEnableranmsgs">
+         <property name="text">
+          <string>Enable random reasons</string>
+         </property>
+        </widget>
+       </item>
+       <item row="0" column="1" colspan="3">
+        <spacer name="horizontalSpacer_2">
+         <property name="orientation">
+          <enum>Qt::Horizontal</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>40</width>
+           <height>20</height>
+          </size>
+         </property>
+        </spacer>
+       </item>
+       <item row="1" column="0" colspan="4">
+        <widget class="QGroupBox" name="qgb_kickbanmsgs">
+         <property name="title">
+          <string>Kick/Ban Reasons</string>
+         </property>
+         <layout class="QGridLayout" name="gridLayout_4">
+          <item row="1" column="0">
+           <widget class="QListWidget" name="qlwReasons">
+            <property name="selectionMode">
+             <enum>QAbstractItemView::MultiSelection</enum>
+            </property>
+            <property name="sortingEnabled">
+             <bool>false</bool>
+            </property>
+           </widget>
+          </item>
+         </layout>
+        </widget>
+       </item>
+       <item row="2" column="0" colspan="2">
+        <spacer name="horizontalSpacer_3">
+         <property name="orientation">
+          <enum>Qt::Horizontal</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>287</width>
+           <height>20</height>
+          </size>
+         </property>
+        </spacer>
+       </item>
+       <item row="2" column="2">
+        <widget class="QPushButton" name="qpb_add">
+         <property name="maximumSize">
+          <size>
+           <width>87</width>
+           <height>27</height>
+          </size>
+         </property>
+         <property name="text">
+          <string>Add</string>
+         </property>
+        </widget>
+       </item>
+       <item row="2" column="3">
+        <widget class="QPushButton" name="qpb_remove">
+         <property name="maximumSize">
+          <size>
+           <width>86</width>
+           <height>27</height>
+          </size>
+         </property>
+         <property name="text">
+          <string>Remove</string>
+         </property>
+        </widget>
+       </item>
+      </layout>
+     </widget>
     </widget>
    </item>
   </layout>

--- a/src/mumble/MainWindow.cpp
+++ b/src/mumble/MainWindow.cpp
@@ -1375,6 +1375,16 @@ void MainWindow::on_qaUserFriendRemove_triggered() {
 	pmModel->setFriendName(p, QString());
 }
 
+int randInt(int low, int high) { // returns a random integer value between low and high
+	return qrand() % ((high + 1) - low) + low;
+}
+
+QString MainWindow::randomReason() {
+
+	QString rReason = g.s.qslKickBanReasons[randInt(0,g.s.qslKickBanReasons.count()-1)];
+	return rReason;
+}
+
 void MainWindow::on_qaUserKick_triggered() {
 	ClientUser *p = getContextMenuUser();
 	if (!p)
@@ -1390,7 +1400,11 @@ void MainWindow::on_qaUserKick_triggered() {
 		return;
 
 	if (ok) {
-		g.sh->kickBanUser(p->uiSession, reason, false);
+		if ((reason.length() == 0) && g.s.bEnableRanKBMsgs) {
+			g.sh->kickBanUser(p->uiSession, randomReason(), false);
+		} else {
+			g.sh->kickBanUser(p->uiSession, reason, false);
+		}
 	}
 }
 
@@ -1408,7 +1422,11 @@ void MainWindow::on_qaUserBan_triggered() {
 		return;
 
 	if (ok) {
-		g.sh->kickBanUser(p->uiSession, reason, true);
+		if ((reason.length() == 0) && g.s.bEnableRanKBMsgs) {
+			g.sh->kickBanUser(p->uiSession, randomReason(), true);
+		} else {
+			g.sh->kickBanUser(p->uiSession, reason, true);
+		}
 	}
 }
 

--- a/src/mumble/MainWindow.h
+++ b/src/mumble/MainWindow.h
@@ -111,6 +111,7 @@ class MainWindow : public QMainWindow, public MessageHandler, public Ui::MainWin
 
 		MumbleProto::Reject_RejectType rtLast;
 		QString qsDesiredChannel;
+		QString randomReason();
 
 		bool bSuppressAskOnQuit;
 		bool bAutoUnmute;

--- a/src/mumble/Settings.cpp
+++ b/src/mumble/Settings.cpp
@@ -290,6 +290,13 @@ Settings::Settings() {
 	uiDoublePush = 0;
 	uiPTTHold = 0;
 	bExpert = false;
+	bEnableRanKBMsgs = false;
+
+	int ii = 0;
+	while (kickBanReasons[ii]) {
+		qslKickBanReasons << QLatin1String(kickBanReasons[ii]);
+		ii++;
+	}
 
 #ifdef NO_UPDATE_CHECK
 	bUpdateCheck = false;
@@ -695,6 +702,10 @@ void Settings::load(QSettings* settings_ptr) {
 	SAVELOAD(iLCDUserViewMinColWidth, "lcd/userview/mincolwidth");
 	SAVELOAD(iLCDUserViewSplitterWidth, "lcd/userview/splitterwidth");
 
+	// Kick/Ban Reasons
+	SAVELOAD(bEnableRanKBMsgs, "log/bkbmessages");
+	SAVELOAD(qslKickBanReasons, "log/kbmessages");
+
 	QByteArray qba = qvariant_cast<QByteArray> (settings_ptr->value(QLatin1String("net/certificate")));
 	if (! qba.isEmpty())
 		kpCertificate = CertWizard::importCert(qba);
@@ -980,6 +991,10 @@ void Settings::save() {
 	// LCD
 	SAVELOAD(iLCDUserViewMinColWidth, "lcd/userview/mincolwidth");
 	SAVELOAD(iLCDUserViewSplitterWidth, "lcd/userview/splitterwidth");
+
+	// Kick/Ban Reasons
+	SAVELOAD(bEnableRanKBMsgs, "log/bkbmessages");
+	SAVELOAD(qslKickBanReasons, "log/kbmessages");
 
 	QByteArray qba = CertWizard::exportCert(kpCertificate);
 	settings_ptr->setValue(QLatin1String("net/certificate"), qba);

--- a/src/mumble/Settings.h
+++ b/src/mumble/Settings.h
@@ -315,6 +315,10 @@ struct Settings {
 	float dPacketLoss;
 	float dMaxPacketDelay;
 
+	// Kick/Ban Reasons
+	bool bEnableRanKBMsgs;
+	QStringList qslKickBanReasons;
+
 	bool doEcho() const;
 	bool doPositionalAudio() const;
 


### PR DESCRIPTION
My second attempt with predefined kick/ban reasons, this time with GUI where user can add/edit/remove own reason. Reasons from this list are used when user leaves kick/ban dialog empty.
Feature is disabled by default.

To dD0t: When yours ban editor will be ready you can easily move this to it. (and thanks for help with SAVE/LOAD)

Preview:
![kickban](https://f.cloud.github.com/assets/521035/1231595/dccd8024-2862-11e3-9743-d7cb412577ac.png)
