### PR TITLE
mumble, mumble_exe: fix overlay self-detection for the mumble_app.dll build

### DIFF
--- a/src/mumble/Overlay_win.cpp
+++ b/src/mumble/Overlay_win.cpp
@@ -40,7 +40,11 @@ typedef unsigned int (__cdecl *GetOverlayMagicVersionProc)();
 typedef void (__cdecl *PrepProc)();
 typedef void (__cdecl *PrepDXGIProc)();
 
-// Used by the overlay to detect whether we injected into ourselve
+// Used by the overlay to detect whether we injected into ourselves.
+//
+// A similar declaration can be found in mumble_exe's Overlay.cpp,
+// for the overlay's self-detection checks to continue working in a
+// mumble_app.dll world.
 extern "C" __declspec(dllexport) void mumbleSelfDetection() {};
 
 OverlayPrivateWin::OverlayPrivateWin(QObject *p) : OverlayPrivate(p) {

--- a/src/mumble_exe/Overlay.cpp
+++ b/src/mumble_exe/Overlay.cpp
@@ -1,0 +1,39 @@
+/* Copyright (C) 2013, Mikkel Krautz <mikkel@krautz.dk>
+
+   All rights reserved.
+
+   Redistribution and use in source and binary forms, with or without
+   modification, are permitted provided that the following conditions
+   are met:
+
+   - Redistributions of source code must retain the above copyright notice,
+     this list of conditions and the following disclaimer.
+   - Redistributions in binary form must reproduce the above copyright notice,
+     this list of conditions and the following disclaimer in the documentation
+     and/or other materials provided with the distribution.
+   - Neither the name of the Mumble Developers nor the names of its
+     contributors may be used to endorse or promote products derived from this
+     software without specific prior written permission.
+
+   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+   ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+   LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+   A PARTICULAR PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE FOUNDATION OR
+   CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+   EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+   PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+   PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+   LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+   NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+   SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+// Used by the overlay to detect whether we injected into ourselves.
+//
+// This code also lives in Overlay_win.cpp, where it serves the same purpose.
+//
+// When running in "mumble_app.dll"-mode, it's convenient for this symbol to be
+// defined here in mumble.exe (alongside the symbol in mumble_app.dll) because that
+// allows older versions of mumble_ol.dll that are not "mumble_app.dll"-aware at all
+// to continue to work in that world.
+extern "C" __declspec(dllexport) void mumbleSelfDetection() {};

--- a/src/mumble_exe/mumble_exe.pro
+++ b/src/mumble_exe/mumble_exe.pro
@@ -20,7 +20,7 @@ win32 {
   }
 }
 
-SOURCES *= mumble_exe.cpp
+SOURCES *= mumble_exe.cpp Overlay.cpp
 
 !CONFIG(no-elevation) {
   CONFIG(release, debug|release) {


### PR DESCRIPTION
When Mumble was built as the mumble.exe/mumble_app.dll pair, mumble_ol.dll's
overlay self-detection logic didn't work, because it failed to find the
special "mumbleSelfDetection" symbol.

This change adds that symbol to mumble_exe. It is perhaps not the cleanest
solution to the problem, but doing it this way allows older mumble_ol.dlls
to continue to work with mumble_app.dll builds, and we avoid changing the
overlay self-detection check in mumble_ol.dll.

Fixes issue #1053.
