### PR TITLE
AGC: remove redundant speex_preprocess_ctl call

### DIFF
--- a/speexbuild/AGC.cpp
+++ b/speexbuild/AGC.cpp
@@ -77,7 +77,6 @@ int main(int argc, char **argv) {
 	iarg = 0;
 	speex_preprocess_ctl(spp, SPEEX_PREPROCESS_SET_VAD, &iarg);
 	speex_preprocess_ctl(spp, SPEEX_PREPROCESS_SET_DENOISE, &iarg);
-	speex_preprocess_ctl(spp, SPEEX_PREPROCESS_SET_AGC, &iarg);
 	speex_preprocess_ctl(spp, SPEEX_PREPROCESS_SET_DEREVERB, &iarg);
 
 	iarg = 1;


### PR DESCRIPTION
SET_AGC 1 is called immediately after this, so there's no point in calling it the first time.
