### PR TITLE
scripts/mkini-win32.bat: use ',' as substitution delimiter; also fix regexp.

### DIFF
--- a/scripts/mkini-win32.bat
+++ b/scripts/mkini-win32.bat
@@ -1,4 +1,4 @@
 copy murmur.ini murmur.ini.win32
 
-perl -pi.bak -e "s!^(#^|)ice=!ice=!" murmur.ini.win32
+perl -pi.bak -e "s,^(#|)ice=,ice=," murmur.ini.win32
 


### PR DESCRIPTION
Using '!' as the delimiter has an unfortunate clash with cmd.exe's
delayed expansion feature. When delayed expansion is enabled, the
substitution would fail with a syntax error because cmd.exe had
mangled the substitution string before passing it to Perl.

This commit also fixes the regular expression to match the one
found in mkini.sh.
