### PR TITLE
scripts/release.pl: remove slicer-specific deployment functionality.

### DIFF
--- a/scripts/release.pl
+++ b/scripts/release.pl
@@ -223,7 +223,3 @@ my $gz=gzopen("mumble-${ver}.tar.gz", "w");
 $gz->gzwrite($tar->write());
 $gz->gzclose();
 $zip->writeToFileNamed("mumble-${ver}.zip");
-
-copy("mumble-${ver}.tar.gz", "../deb-mumble/tarballs/mumble_${ver}.orig.tar.gz");
-system("/usr/bin/gpg", "--armor", "--default-key", "DEBA6F3E", "--sign", "--detach-sign", "--output", "mumble-${ver}.tar.gz.sig", "mumble-${ver}.tar.gz");
-system("/usr/bin/scp", "-4", "mumble-${ver}.tar.gz", "mumble-${ver}.tar.gz.sig", "slicer\@mumble.hive.no:/var/www/snapshot/");


### PR DESCRIPTION
Nobody is using release.pl for deploying tarballs
automatically anymore.

Our builder bots were manually sed'ing out these
parts of the code before running release.pl, so by
dropping it completely, we can clean up their build
scripts a bit.
