### PR TITLE
Added an option to restrict server lookups on start.

### DIFF
--- a/src/mumble/ConnectDialog.cpp
+++ b/src/mumble/ConnectDialog.cpp
@@ -855,7 +855,7 @@ ConnectDialog::ConnectDialog(QWidget *p, bool autoconnect) : QDialog(p), bAutoCo
 
 #ifdef USE_BONJOUR
 	// Make sure the we got the objects we need, then wire them up
-	if (g.bc->bsbBrowser && g.bc->bsrResolver) {
+	if (g.bc->bsbBrowser && g.bc->bsrResolver && !g.s.bRestrictLANServerLookups) {
 		connect(g.bc->bsbBrowser, SIGNAL(error(DNSServiceErrorType)),
 		        this, SLOT(onLanBrowseError(DNSServiceErrorType)));
 		connect(g.bc->bsbBrowser, SIGNAL(currentBonjourRecordsChanged(const QList<BonjourRecord> &)),
@@ -1159,7 +1159,7 @@ void ConnectDialog::on_qtwServers_itemExpanded(QTreeWidgetItem *item) {
 }
 
 void ConnectDialog::initList() {
-	if (bPublicInit || (qlPublicServers.count() > 0) || g.s.bRestrictServerLookups)
+	if (bPublicInit || (qlPublicServers.count() > 0) || g.s.bRestrictPublicServerLookups)
 		return;
 
 	bPublicInit = true;

--- a/src/mumble/ConnectDialog.cpp
+++ b/src/mumble/ConnectDialog.cpp
@@ -1362,6 +1362,10 @@ void ConnectDialog::timeTick() {
 void ConnectDialog::startDns(ServerItem *si) {
 	QString host = si->qsHostname.toLower();
 
+	QNetworkProxy currProxy = QNetworkProxy::applicationProxy();
+	if (currProxy.capabilites() & QNetworkProxy::HostNameLookupCapability) return;
+		
+	}
 	if (si->qlAddresses.isEmpty()) {
 		QHostAddress qha(si->qsHostname);
 		if (! qha.isNull())

--- a/src/mumble/ConnectDialog.cpp
+++ b/src/mumble/ConnectDialog.cpp
@@ -1159,7 +1159,7 @@ void ConnectDialog::on_qtwServers_itemExpanded(QTreeWidgetItem *item) {
 }
 
 void ConnectDialog::initList() {
-	if (bPublicInit || (qlPublicServers.count() > 0))
+	if (bPublicInit || (qlPublicServers.count() > 0) || g.s.bRestrictServerLookups)
 		return;
 
 	bPublicInit = true;

--- a/src/mumble/ConnectDialog.cpp
+++ b/src/mumble/ConnectDialog.cpp
@@ -855,7 +855,7 @@ ConnectDialog::ConnectDialog(QWidget *p, bool autoconnect) : QDialog(p), bAutoCo
 
 #ifdef USE_BONJOUR
 	// Make sure the we got the objects we need, then wire them up
-	if (g.bc->bsbBrowser && g.bc->bsrResolver && !g.s.bRestrictLANServerLookups) {
+	if (g.bc->bsbBrowser && g.bc->bsrResolver && g.s.bEnableLANServerList) {
 		connect(g.bc->bsbBrowser, SIGNAL(error(DNSServiceErrorType)),
 		        this, SLOT(onLanBrowseError(DNSServiceErrorType)));
 		connect(g.bc->bsbBrowser, SIGNAL(currentBonjourRecordsChanged(const QList<BonjourRecord> &)),
@@ -1148,8 +1148,10 @@ void ConnectDialog::on_qtwServers_currentItemChanged(QTreeWidgetItem *item, QTre
 
 void ConnectDialog::on_qtwServers_itemExpanded(QTreeWidgetItem *item) {
 	if (item == qtwServers->siPublic) {
-		initList();
-		fillList();
+		if (g.s.bEnablePublicServerList) {
+			initList();
+			fillList();
+		}
 	}
 
 	ServerItem *p = static_cast<ServerItem *>(item);
@@ -1159,7 +1161,7 @@ void ConnectDialog::on_qtwServers_itemExpanded(QTreeWidgetItem *item) {
 }
 
 void ConnectDialog::initList() {
-	if (bPublicInit || (qlPublicServers.count() > 0) || g.s.bRestrictPublicServerLookups)
+	if (bPublicInit || (qlPublicServers.count() > 0))
 		return;
 
 	bPublicInit = true;

--- a/src/mumble/NetworkConfig.cpp
+++ b/src/mumble/NetworkConfig.cpp
@@ -66,6 +66,7 @@ void NetworkConfig::load(const Settings &r) {
 	loadCheckBox(qcbQoS, s.bQoS);
 	loadCheckBox(qcbAutoReconnect, s.bReconnect);
 	loadCheckBox(qcbAutoConnect, s.bAutoConnect);
+	loadCheckBox(qcbRestrictServerLookups, s.bRestrictServerLookups);
 	loadCheckBox(qcbSuppressIdentity, s.bSuppressIdentity);
 	loadComboBox(qcbType, s.ptProxyType);
 
@@ -98,6 +99,7 @@ void NetworkConfig::save() const {
 	s.bQoS = qcbQoS->isChecked();
 	s.bReconnect = qcbAutoReconnect->isChecked();
 	s.bAutoConnect = qcbAutoConnect->isChecked();
+	s.bRestrictServerLookups = qcbRestrictServerLookups->isChecked();
 	s.bSuppressIdentity = qcbSuppressIdentity->isChecked();
 
 	s.ptProxyType = static_cast<Settings::ProxyType>(qcbType->currentIndex());
@@ -166,6 +168,7 @@ void NetworkConfig::accept() const {
 bool NetworkConfig::expert(bool b) {
 	qcbTcpMode->setVisible(b);
 	qcbQoS->setVisible(b);
+	qcbRestrictServerLookups->setVisible(b);
 	qgbProxy->setVisible(b);
 	qcbUsage->setVisible(b);
 

--- a/src/mumble/NetworkConfig.cpp
+++ b/src/mumble/NetworkConfig.cpp
@@ -66,7 +66,8 @@ void NetworkConfig::load(const Settings &r) {
 	loadCheckBox(qcbQoS, s.bQoS);
 	loadCheckBox(qcbAutoReconnect, s.bReconnect);
 	loadCheckBox(qcbAutoConnect, s.bAutoConnect);
-	loadCheckBox(qcbRestrictServerLookups, s.bRestrictServerLookups);
+	loadCheckBox(qcbRestrictPublicServerLookups, s.bRestrictPublicServerLookups);
+	loadCheckBox(qcbRestrictLANServerLookups, s.bRestrictLANServerLookups);
 	loadCheckBox(qcbSuppressIdentity, s.bSuppressIdentity);
 	loadComboBox(qcbType, s.ptProxyType);
 
@@ -99,7 +100,8 @@ void NetworkConfig::save() const {
 	s.bQoS = qcbQoS->isChecked();
 	s.bReconnect = qcbAutoReconnect->isChecked();
 	s.bAutoConnect = qcbAutoConnect->isChecked();
-	s.bRestrictServerLookups = qcbRestrictServerLookups->isChecked();
+	s.bRestrictPublicServerLookups = qcbRestrictPublicServerLookups->isChecked();
+	s.bRestrictLANServerLookups = qcbRestrictLANServerLookups->isChecked();
 	s.bSuppressIdentity = qcbSuppressIdentity->isChecked();
 
 	s.ptProxyType = static_cast<Settings::ProxyType>(qcbType->currentIndex());
@@ -168,7 +170,8 @@ void NetworkConfig::accept() const {
 bool NetworkConfig::expert(bool b) {
 	qcbTcpMode->setVisible(b);
 	qcbQoS->setVisible(b);
-	qcbRestrictServerLookups->setVisible(b);
+	qcbRestrictPublicServerLookups->setVisible(b);
+	qcbRestrictLANServerLookups->setVisible(b);
 	qgbProxy->setVisible(b);
 	qcbUsage->setVisible(b);
 

--- a/src/mumble/NetworkConfig.cpp
+++ b/src/mumble/NetworkConfig.cpp
@@ -66,9 +66,11 @@ void NetworkConfig::load(const Settings &r) {
 	loadCheckBox(qcbQoS, s.bQoS);
 	loadCheckBox(qcbAutoReconnect, s.bReconnect);
 	loadCheckBox(qcbAutoConnect, s.bAutoConnect);
-	loadCheckBox(qcbRestrictPublicServerLookups, s.bRestrictPublicServerLookups);
-	loadCheckBox(qcbRestrictLANServerLookups, s.bRestrictLANServerLookups);
 	loadCheckBox(qcbSuppressIdentity, s.bSuppressIdentity);
+
+	loadCheckBox(qcbEnablePublicServerList, s.bEnablePublicServerList);
+	loadCheckBox(qcbEnableLANServerList, s.bEnableLANServerList);
+
 	loadComboBox(qcbType, s.ptProxyType);
 
 	qleHostname->setText(r.qsProxyHost);
@@ -100,9 +102,10 @@ void NetworkConfig::save() const {
 	s.bQoS = qcbQoS->isChecked();
 	s.bReconnect = qcbAutoReconnect->isChecked();
 	s.bAutoConnect = qcbAutoConnect->isChecked();
-	s.bRestrictPublicServerLookups = qcbRestrictPublicServerLookups->isChecked();
-	s.bRestrictLANServerLookups = qcbRestrictLANServerLookups->isChecked();
 	s.bSuppressIdentity = qcbSuppressIdentity->isChecked();
+
+	s.bEnablePublicServerList = qcbEnablePublicServerList->isChecked();
+	s.bEnableLANServerList = qcbEnableLANServerList->isChecked();
 
 	s.ptProxyType = static_cast<Settings::ProxyType>(qcbType->currentIndex());
 	s.qsProxyHost = qleHostname->text();
@@ -170,10 +173,11 @@ void NetworkConfig::accept() const {
 bool NetworkConfig::expert(bool b) {
 	qcbTcpMode->setVisible(b);
 	qcbQoS->setVisible(b);
-	qcbRestrictPublicServerLookups->setVisible(b);
-	qcbRestrictLANServerLookups->setVisible(b);
 	qgbProxy->setVisible(b);
 	qcbUsage->setVisible(b);
+
+	qcbEnablePublicServerList->setVisible(b);
+	qcbEnableLANServerList->setVisible(b);
 
 	qgbMisc->setVisible(b); // For now Misc only contains elements visible in expert mode
 	qcbImageDownload->setVisible(b);

--- a/src/mumble/NetworkConfig.ui
+++ b/src/mumble/NetworkConfig.ui
@@ -76,6 +76,19 @@
        </widget>
       </item>
       <item>
+       <widget class="QCheckBox" name="qcbRestrictServerLookups">
+        <property name="toolTip">
+         <string>Don't look for public Mumble servers on startup.</string>
+        </property>
+        <property name="whatsThis">
+         <string>&lt;b&gt;This will prevent the client from finding public servers at startup.&lt;/b&gt;&lt;p&gt;The client will not retrieve any information about public Mumble servers. This option should only be enabled if you already know the hostname or IP address of the server you want to join.&lt;/p&gt;</string>
+        </property>
+        <property name="text">
+         <string>Restrict server lookups</string>
+        </property>   
+       </widget>
+      </item>
+      <item>
        <widget class="QCheckBox" name="qcbSuppressIdentity">
         <property name="toolTip">
          <string>Don't send certificate to server and don't save passwords. (Not saved).</string>

--- a/src/mumble/NetworkConfig.ui
+++ b/src/mumble/NetworkConfig.ui
@@ -76,15 +76,28 @@
        </widget>
       </item>
       <item>
-       <widget class="QCheckBox" name="qcbRestrictServerLookups">
+       <widget class="QCheckBox" name="qcbRestrictPublicServerLookups">
         <property name="toolTip">
-         <string>Don't look for public Mumble servers on startup.</string>
+         <string>Don't send UDP multicasts out to the internet on startup.</string>
         </property>
         <property name="whatsThis">
-         <string>&lt;b&gt;This will prevent the client from finding public servers at startup.&lt;/b&gt;&lt;p&gt;The client will not retrieve any information about public Mumble servers. This option should only be enabled if you already know the hostname or IP address of the server you want to join.&lt;/p&gt;</string>
+         <string>&lt;b&gt;This will prevent the client from locating servers on the public internet at startup.&lt;/b&gt;&lt;p&gt; You may still connect to public servers if you specify them by hostname or IP address.&lt;/p&gt;</string>
         </property>
         <property name="text">
-         <string>Restrict server lookups</string>
+         <string>Don't look for Mumble servers on the public internet.</string>
+        </property>   
+       </widget>
+      </item>
+      <item>
+       <widget class="QCheckBox" name="qcbRestrictLANServerLookups">
+        <property name="toolTip">
+         <string>Don't send UDP multicasts over the LAN on startup.</string>
+        </property>
+        <property name="whatsThis">
+         <string>&lt;b&gt;This will prevent the client from locating servers on the LAN at startup.&lt;/b&gt;&lt;p&gt; You may still connect to LAN servers if you specify them by hostname or IP address.&lt;/p&gt;</string>
+        </property>
+        <property name="text">
+         <string>Don't look for Mumble servers on the LAN.</string>
         </property>   
        </widget>
       </item>

--- a/src/mumble/NetworkConfig.ui
+++ b/src/mumble/NetworkConfig.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>576</width>
-    <height>567</height>
+    <height>867</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -76,32 +76,6 @@
        </widget>
       </item>
       <item>
-       <widget class="QCheckBox" name="qcbRestrictPublicServerLookups">
-        <property name="toolTip">
-         <string>Don't send UDP multicasts out to the internet on startup.</string>
-        </property>
-        <property name="whatsThis">
-         <string>&lt;b&gt;This will prevent the client from locating servers on the public internet at startup.&lt;/b&gt;&lt;p&gt; You may still connect to public servers if you specify them by hostname or IP address.&lt;/p&gt;</string>
-        </property>
-        <property name="text">
-         <string>Don't look for Mumble servers on the public internet.</string>
-        </property>   
-       </widget>
-      </item>
-      <item>
-       <widget class="QCheckBox" name="qcbRestrictLANServerLookups">
-        <property name="toolTip">
-         <string>Don't send UDP multicasts over the LAN on startup.</string>
-        </property>
-        <property name="whatsThis">
-         <string>&lt;b&gt;This will prevent the client from locating servers on the LAN at startup.&lt;/b&gt;&lt;p&gt; You may still connect to LAN servers if you specify them by hostname or IP address.&lt;/p&gt;</string>
-        </property>
-        <property name="text">
-         <string>Don't look for Mumble servers on the LAN.</string>
-        </property>   
-       </widget>
-      </item>
-      <item>
        <widget class="QCheckBox" name="qcbSuppressIdentity">
         <property name="toolTip">
          <string>Don't send certificate to server and don't save passwords. (Not saved).</string>
@@ -111,6 +85,47 @@
         </property>
         <property name="text">
          <string>Suppress certificate and password storage</string>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item>
+    <widget class="QGroupBox" name="qgbServerLists">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Preferred" vsizetype="Minimum">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="title">
+      <string>Server lists</string>
+     </property>
+     <layout class="QVBoxLayout">
+      <item>
+       <widget class="QCheckBox" name="qcbEnablePublicServerList">
+        <property name="toolTip">
+         <string>This option enables the public server list in Mumble's connect dialog</string>
+        </property>
+        <property name="whatsThis">
+         <string>&lt;b&gt;Enable public server list&lt;/b&gt;.&lt;br /&gt;Turning this option off will prevent Mumble from sending automatic UDP and DNS network traffic related to public server lookups.</string>
+        </property>
+        <property name="text">
+         <string>Enable public server list</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QCheckBox" name="qcbEnableLANServerList">
+        <property name="toolTip">
+         <string>This option enables the LAN server list in Mumble's connect dialog</string>
+        </property>
+        <property name="whatsThis">
+         <string>&lt;b&gt;Enable LAN server list&lt;/b&gt;.&lt;br /&gt;Turning this option off will prevent Mumble from sending automatic DHCP queries to look for servers on the local network.</string>
+        </property>
+        <property name="text">
+         <string>Enable LAN server list</string>
         </property>
        </widget>
       </item>

--- a/src/mumble/Settings.cpp
+++ b/src/mumble/Settings.cpp
@@ -362,8 +362,8 @@ Settings::Settings() {
 	bQoS = true;
 	bReconnect = true;
 	bAutoConnect = false;
-        bRestrictPublicServerLookups = false;
-        bRestrictLANServerLookups = false;
+        bEnablePublicServerList = true;
+        bEnableLANServerList = true;
 	ptProxyType = NoProxy;
 	usProxyPort = 0;
 
@@ -629,8 +629,8 @@ void Settings::load(QSettings* settings_ptr) {
 	SAVELOAD(bQoS, "net/qos");
 	SAVELOAD(bReconnect, "net/reconnect");
 	SAVELOAD(bAutoConnect, "net/autoconnect");
-        SAVELOAD(bRestrictPublicServerLookups, "net/restrictpublicserverlookups");
-        SAVELOAD(bRestrictLANServerLookups, "net/restrictlanserverlookups");
+	SAVELOAD(bEnablePublicServerList, "net/enablepublicserverlist");
+	SAVELOAD(bEnableLANServerList, "net/enablelanserverlist");
 	SAVELOAD(bSuppressIdentity, "net/suppress");
 	LOADENUM(ptProxyType, "net/proxytype");
 	SAVELOAD(qsProxyHost, "net/proxyhost");
@@ -920,8 +920,8 @@ void Settings::save() {
 	SAVELOAD(bQoS, "net/qos");
 	SAVELOAD(bReconnect, "net/reconnect");
 	SAVELOAD(bAutoConnect, "net/autoconnect");
-        SAVELOAD(bRestrictPublicServerLookups, "net/restrictinternetserverlookups");
-        SAVELOAD(bRestrictLANServerLookups, "net/restrictlanserverlookups");
+	SAVELOAD(bEnablePublicServerList, "net/enablepublicserverlist");
+	SAVELOAD(bEnableLANServerList, "net/enablelanserverlist");
 	SAVELOAD(ptProxyType, "net/proxytype");
 	SAVELOAD(qsProxyHost, "net/proxyhost");
 	SAVELOAD(usProxyPort, "net/proxyport");

--- a/src/mumble/Settings.cpp
+++ b/src/mumble/Settings.cpp
@@ -362,6 +362,7 @@ Settings::Settings() {
 	bQoS = true;
 	bReconnect = true;
 	bAutoConnect = false;
+        bRestrictServerLookups = false;
 	ptProxyType = NoProxy;
 	usProxyPort = 0;
 
@@ -627,6 +628,7 @@ void Settings::load(QSettings* settings_ptr) {
 	SAVELOAD(bQoS, "net/qos");
 	SAVELOAD(bReconnect, "net/reconnect");
 	SAVELOAD(bAutoConnect, "net/autoconnect");
+        SAVELOAD(bRestrictServerLookups, "net/restrictserverlookups");
 	SAVELOAD(bSuppressIdentity, "net/suppress");
 	LOADENUM(ptProxyType, "net/proxytype");
 	SAVELOAD(qsProxyHost, "net/proxyhost");
@@ -916,6 +918,7 @@ void Settings::save() {
 	SAVELOAD(bQoS, "net/qos");
 	SAVELOAD(bReconnect, "net/reconnect");
 	SAVELOAD(bAutoConnect, "net/autoconnect");
+        SAVELOAD(bRestrictServerLookups, "net/restrictserverlookups");
 	SAVELOAD(ptProxyType, "net/proxytype");
 	SAVELOAD(qsProxyHost, "net/proxyhost");
 	SAVELOAD(usProxyPort, "net/proxyport");

--- a/src/mumble/Settings.cpp
+++ b/src/mumble/Settings.cpp
@@ -362,7 +362,8 @@ Settings::Settings() {
 	bQoS = true;
 	bReconnect = true;
 	bAutoConnect = false;
-        bRestrictServerLookups = false;
+        bRestrictPublicServerLookups = false;
+        bRestrictLANServerLookups = false;
 	ptProxyType = NoProxy;
 	usProxyPort = 0;
 
@@ -628,7 +629,8 @@ void Settings::load(QSettings* settings_ptr) {
 	SAVELOAD(bQoS, "net/qos");
 	SAVELOAD(bReconnect, "net/reconnect");
 	SAVELOAD(bAutoConnect, "net/autoconnect");
-        SAVELOAD(bRestrictServerLookups, "net/restrictserverlookups");
+        SAVELOAD(bRestrictPublicServerLookups, "net/restrictpublicserverlookups");
+        SAVELOAD(bRestrictLANServerLookups, "net/restrictlanserverlookups");
 	SAVELOAD(bSuppressIdentity, "net/suppress");
 	LOADENUM(ptProxyType, "net/proxytype");
 	SAVELOAD(qsProxyHost, "net/proxyhost");
@@ -918,7 +920,8 @@ void Settings::save() {
 	SAVELOAD(bQoS, "net/qos");
 	SAVELOAD(bReconnect, "net/reconnect");
 	SAVELOAD(bAutoConnect, "net/autoconnect");
-        SAVELOAD(bRestrictServerLookups, "net/restrictserverlookups");
+        SAVELOAD(bRestrictPublicServerLookups, "net/restrictinternetserverlookups");
+        SAVELOAD(bRestrictLANServerLookups, "net/restrictlanserverlookups");
 	SAVELOAD(ptProxyType, "net/proxytype");
 	SAVELOAD(qsProxyHost, "net/proxyhost");
 	SAVELOAD(usProxyPort, "net/proxyport");

--- a/src/mumble/Settings.h
+++ b/src/mumble/Settings.h
@@ -281,6 +281,7 @@ struct Settings {
 	bool bTCPCompat;
 	bool bReconnect;
 	bool bAutoConnect;
+        bool bRestrictServerLookups;
 	bool bQoS;
 	ProxyType ptProxyType;
 	QString qsProxyHost, qsProxyUsername, qsProxyPassword;

--- a/src/mumble/Settings.h
+++ b/src/mumble/Settings.h
@@ -281,9 +281,9 @@ struct Settings {
 	bool bTCPCompat;
 	bool bReconnect;
 	bool bAutoConnect;
-        bool bRestrictPublicServerLookups;
-        bool bRestrictLANServerLookups;
 	bool bQoS;
+        bool bEnablePublicServerList;
+        bool bEnableLANServerList;
 	ProxyType ptProxyType;
 	QString qsProxyHost, qsProxyUsername, qsProxyPassword;
 	unsigned short usProxyPort;

--- a/src/mumble/Settings.h
+++ b/src/mumble/Settings.h
@@ -281,7 +281,8 @@ struct Settings {
 	bool bTCPCompat;
 	bool bReconnect;
 	bool bAutoConnect;
-        bool bRestrictServerLookups;
+        bool bRestrictPublicServerLookups;
+        bool bRestrictLANServerLookups;
 	bool bQoS;
 	ProxyType ptProxyType;
 	QString qsProxyHost, qsProxyUsername, qsProxyPassword;


### PR DESCRIPTION
This option, disabled and not visible by default, if enabled, prevents hundreds of DNS requests being sent out when you start Mumble. This is useful if you already know the IP address of the server you want to join. 