### PR TITLE
Adjust build error text (missing submodule dir)

### DIFF
--- a/3rdparty/fx11-build/fx11-build.pro
+++ b/3rdparty/fx11-build/fx11-build.pro
@@ -4,11 +4,7 @@ BUILDDIR=$$basename(PWD)
 SOURCEDIR=$$replace(BUILDDIR,-build,-src)
 
 !exists(../$$SOURCEDIR/Effect.h) {
-	message("The $$SOURCEDIR/ directory was not found. You need to do one of the following:")
-	message("")
-	message("git submodule init")
-	message("git submodule update")
-	message("")
+	message("The $$SOURCEDIR/ directory was not found. Please update your submodules (git submodule update --init).")
 	error("Aborting configuration")
 }
 

--- a/celt-0.11.0-build/celt-0.11.0-build.pro
+++ b/celt-0.11.0-build/celt-0.11.0-build.pro
@@ -6,15 +6,7 @@ VERSION=$$replace(BUILDDIR,-build,)
 VERSION=$$replace(VERSION,celt-,)
 
 !exists(../$$SOURCEDIR/COPYING) {
-	message("The $$SOURCEDIR/ directory was not found. You need to do one of the following:")
-	message("")
-	message("Option 1: Use CELT Git:")
-	message("git submodule init")
-	message("git submodule update")
-	message("")
-	message("Option 2: Use system celt libraries (it's your job to ensure you have all of them):")
-	message("qmake CONFIG+=no-bundled-celt -recursive")
-	message("")
+	message("The $$SOURCEDIR/ directory was not found. Please update your submodules (git submodule update --init) or build with no-bundled-celt.")
 	error("Aborting configuration")
 }
 

--- a/celt-0.7.0-build/celt-0.7.0-build.pro
+++ b/celt-0.7.0-build/celt-0.7.0-build.pro
@@ -6,15 +6,7 @@ VERSION=$$replace(BUILDDIR,-build,)
 VERSION=$$replace(VERSION,celt-,)
 
 !exists(../$$SOURCEDIR/COPYING) {
-	message("The $$SOURCEDIR/ directory was not found. You need to do one of the following:")
-	message("")
-	message("Option 1: Use CELT Git:")
-	message("git submodule init")
-	message("git submodule update")
-	message("")
-	message("Option 2: Use system celt libraries (it's your job to ensure you have all of them):")
-	message("qmake CONFIG+=no-bundled-celt -recursive")
-	message("")
+	message("The $$SOURCEDIR/ directory was not found. Please update your submodules (git submodule update --init) or build with no-bundled-celt.")
 	error("Aborting configuration")
 }
 

--- a/opus-build/opus-build.pro
+++ b/opus-build/opus-build.pro
@@ -8,11 +8,7 @@ SOURCEDIR=$$replace(BUILDDIR,-build,-src)
 }
 
 !exists(../$$SOURCEDIR/COPYING) {
-	message("The $$SOURCEDIR/ directory was not found. You need to do one of the following:")
-	message("")
-	message("git submodule init")
-	message("git submodule update")
-	message("")
+	message("The $$SOURCEDIR/ directory was not found. Please update your submodules (git submodule update --init).")
 	error("Aborting configuration")
 }
 

--- a/sbcelt-helper-build/sbcelt-helper-build.pro
+++ b/sbcelt-helper-build/sbcelt-helper-build.pro
@@ -5,12 +5,7 @@ SOURCEDIR=$$replace(BUILDDIR,-helper-build,-src)
 CELTDIR=../celt-0.7.0-src/libcelt
 
 !exists($$CELTDIR/../COPYING) {
-        message("The $$CELTDIR/ directory was not found. You need to do the following:")
-        message("")
-        message("Use CELT Git:")
-        message("git submodule init")
-        message("git submodule update")
-        message("")
+        message("The $$CELTDIR/ directory was not found. Please update your submodules (git submodule update --init).")
         error("Aborting configuration")
 }
 

--- a/sbcelt-lib-build/sbcelt-lib-build.pro
+++ b/sbcelt-lib-build/sbcelt-lib-build.pro
@@ -5,12 +5,7 @@ SOURCEDIR=$$replace(BUILDDIR,-lib-build,-src)
 CELTDIR=../celt-0.7.0-src
 
 !exists($$CELTDIR/COPYING) {
-        message("The $$CELTDIR/ directory was not found. You need to do the following:")
-        message("")
-        message("Use CELT Git:")
-        message("git submodule init")
-        message("git submodule update")
-        message("")
+        message("The $$CELTDIR/ directory was not found. Please update your submodules (git submodule update --init).")
         error("Aborting configuration")
 }
 


### PR DESCRIPTION
- Adjust the error text of when the build notices a git submodule
  for a third party library was not initialized.
  The new text should be more precise and compact.

Is this the type of text we want?
No commands at all?
More descriptive and explicit differentiation for the celt submodules, for bundled vs not bundled?
