### PR TITLE
Replace static bCheckHook checks with robust interlocks

### DIFF
--- a/overlay/d3d10.cpp
+++ b/overlay/d3d10.cpp
@@ -609,8 +609,9 @@ static void HookAddRelease(voidFunc vfAdd, voidFunc vfRelease) {
 static void hookD3D10(HMODULE hD3D10, bool preonly);
 
 void checkDXGI10Hook(bool preonly) {
-	static bool bCheckHookActive = false;
-	if (bCheckHookActive) {
+	static long active = 0;
+	long isAlreadyActive = InterlockedCompareExchange(&active, 1, 0);
+	if (isAlreadyActive == 1) {
 		ods("D3D10: Recursion in checkDXGI10Hook");
 		return;
 	}
@@ -618,8 +619,6 @@ void checkDXGI10Hook(bool preonly) {
 	if (d3d10->iOffsetAddRef == 0 || d3d10->iOffsetRelease == 0) {
 		return;
 	}
-
-	bCheckHookActive = true;
 
 	HMODULE hD3D10 = GetModuleHandleW(L"D3D10CORE.DLL");
 
@@ -637,7 +636,7 @@ void checkDXGI10Hook(bool preonly) {
 		#endif
 	}
 
-	bCheckHookActive = false;
+	InterlockedExchange(&active, 0);
 }
 
 /// @param hD3D10 must be a valid module handle

--- a/overlay/d3d11.cpp
+++ b/overlay/d3d11.cpp
@@ -608,8 +608,9 @@ static void HookAddRelease(voidFunc vfAdd, voidFunc vfRelease) {
 void hookD3D11(HMODULE hD3D11, bool preonly);
 
 void checkDXGI11Hook(bool preonly) {
-	static bool bCheckHookActive = false;
-	if (bCheckHookActive) {
+	static long active = 0;
+	long isAlreadyActive = InterlockedCompareExchange(&active, 1, 0);
+	if (isAlreadyActive == 1) {
 		ods("D3D11: Recursion in checkDXGI11Hook");
 		return;
 	}
@@ -617,8 +618,6 @@ void checkDXGI11Hook(bool preonly) {
 	if (d3d11->iOffsetAddRef == 0 || d3d11->iOffsetRelease == 0) {
 		return;
 	}
-
-	bCheckHookActive = true;
 
 	HMODULE hDXGI = GetModuleHandleW(L"DXGI.DLL");
 	HMODULE hD3D11 = GetModuleHandleW(L"D3D11.DLL");
@@ -637,7 +636,7 @@ void checkDXGI11Hook(bool preonly) {
 		#endif
 	}
 
-	bCheckHookActive = false;
+	InterlockedExchange(&active, 0);
 }
 
 /// @param hD3D11 must be a valid module handle

--- a/overlay/d3d9.cpp
+++ b/overlay/d3d9.cpp
@@ -898,13 +898,12 @@ static void hookD3D9(HMODULE hD3D, bool preonly);
 //                patch Direct3DCreate9.
 //                Should be true on PROC_ATTACH, and false on THREAD_ATTACH. (?)
 void checkD3D9Hook(bool preonly) {
-	static bool bCheckHookActive = false;
-	if (bCheckHookActive) {
+	static long active = 0;
+	long isAlreadyActive = InterlockedCompareExchange(&active, 1, 0);
+	if (isAlreadyActive == 1) {
 		ods("D3D9: Recursion in checkD3D9Hook");
 		return;
 	}
-
-	bCheckHookActive = true;
 
 	HMODULE hD3D = GetModuleHandle("D3D9.DLL");
 
@@ -918,7 +917,7 @@ void checkD3D9Hook(bool preonly) {
 		#endif
 	}
 
-	bCheckHookActive = false;
+	InterlockedExchange(&active, 0);
 }
 
 static void hookD3D9(HMODULE hD3D, bool preonly) {

--- a/overlay/dxgi.cpp
+++ b/overlay/dxgi.cpp
@@ -109,16 +109,15 @@ static void HookResizeRaw(voidFunc vfResize) {
 void hookDXGI(HMODULE hDXGI, bool preonly);
 
 void checkDXGIHook(bool preonly) {
-	static bool bCheckHookActive = false;
-	if (bCheckHookActive) {
+	static long active = 0;
+	long isAlreadyActive = InterlockedCompareExchange(&active, 1, 0);
+	if (isAlreadyActive == 1) {
 		ods("DXGI: Recursion in checkDXGIHook");
 		return;
 	}
 
 	if (dxgi->iOffsetPresent == 0 || dxgi->iOffsetResize == 0)
 		return;
-
-	bCheckHookActive = true;
 
 	HMODULE hDXGI = GetModuleHandleW(L"DXGI.DLL");
 
@@ -132,7 +131,7 @@ void checkDXGIHook(bool preonly) {
 	#endif
 	}
 
-	bCheckHookActive = false;
+	InterlockedExchange(&active, 0);
 }
 
 /// @param hDXGI must be a valid module handle.

--- a/overlay/opengl.cpp
+++ b/overlay/opengl.cpp
@@ -373,13 +373,12 @@ static BOOL __stdcall mywglSwapLayerBuffers(HDC hdc, UINT fuPlanes) {
 #define GLDEF(name) o##name = reinterpret_cast<t##name>(GetProcAddress(hGL, #name))
 
 void checkOpenGLHook() {
-	static bool bCheckHookActive = false;
-	if (bCheckHookActive) {
+	static long active = 0;
+	long isAlreadyActive = InterlockedCompareExchange(&active, 1, 0);
+	if (isAlreadyActive == 1) {
 		ods("OpenGL: Recursion in checkOpenGLHook");
 		return;
 	}
-
-	bCheckHookActive = true;
 
 	HMODULE hGL = GetModuleHandle("OpenGL32.DLL");
 
@@ -438,5 +437,5 @@ void checkOpenGLHook() {
 		}
 	}
 
-	bCheckHookActive = false;
+	InterlockedExchange(&active, 0);
 }


### PR DESCRIPTION
- The check-and-set used before was not atomic and thus not really thread-safe.

As pointed out in the D3D PR: https://github.com/mumble-voip/mumble/pull/1082#discussion-diff-8705107
