### PR TITLE
Fr1119 toolbar transmit mode drop-down

### DIFF
--- a/src/mumble/LookConfig.cpp
+++ b/src/mumble/LookConfig.cpp
@@ -132,6 +132,7 @@ void LookConfig::load(const Settings &r) {
 	loadCheckBox(qcbStateInTray, r.bStateInTray);
 	loadCheckBox(qcbShowUserCount, r.bShowUserCount);
 	loadCheckBox(qcbShowContextMenuInMenuBar, r.bShowContextMenuInMenuBar);
+	loadCheckBox(qcbShowTransmitModeComboBox, r.bShowTransmitModeComboBox);
 	loadCheckBox(qcbHighContrast, r.bHighContrast);
 	loadCheckBox(qcbChatBarUseSelection, r.bChatBarUseSelection);
 	loadCheckBox(qcbFilterHidesEmptyChannels, r.bFilterHidesEmptyChannels);
@@ -174,6 +175,7 @@ void LookConfig::save() const {
 	s.bStateInTray = qcbStateInTray->isChecked();
 	s.bShowUserCount = qcbShowUserCount->isChecked();
 	s.bShowContextMenuInMenuBar = qcbShowContextMenuInMenuBar->isChecked();
+	s.bShowTransmitModeComboBox = qcbShowTransmitModeComboBox->isChecked();
 	s.bHighContrast = qcbHighContrast->isChecked();
 	s.bChatBarUseSelection = qcbChatBarUseSelection->isChecked();
 	s.bFilterHidesEmptyChannels = qcbFilterHidesEmptyChannels->isChecked();

--- a/src/mumble/LookConfig.ui
+++ b/src/mumble/LookConfig.ui
@@ -20,6 +20,73 @@
       <string>Look and Feel</string>
      </property>
      <layout class="QGridLayout" name="gridLayout">
+      <item row="3" column="1">
+       <widget class="QPushButton" name="qpbSkinFile">
+        <property name="text">
+         <string>&amp;Browse...</string>
+        </property>
+       </widget>
+      </item>
+      <item row="3" column="0">
+       <widget class="QLineEdit" name="qleCSS">
+        <property name="toolTip">
+         <string>Skin file to use</string>
+        </property>
+        <property name="whatsThis">
+         <string>&lt;b&gt;This sets which skin Mumble should use.&lt;/b&gt;&lt;br /&gt;The skin is a style file applied on top of the basic widget style. If there are icons in the same directory as the style sheet, those will replace the default icons.</string>
+        </property>
+       </widget>
+      </item>
+      <item row="6" column="0">
+       <widget class="QCheckBox" name="qcbHighContrast">
+        <property name="toolTip">
+         <string>Apply some high contrast optimizations for visually impaired users</string>
+        </property>
+        <property name="text">
+         <string>Optimize for high contrast</string>
+        </property>
+       </widget>
+      </item>
+      <item row="4" column="0">
+       <widget class="QLabel" name="qliLanguage">
+        <property name="text">
+         <string>Language</string>
+        </property>
+        <property name="buddy">
+         <cstring>qcbLanguage</cstring>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="0">
+       <widget class="QLabel" name="qliCSS">
+        <property name="text">
+         <string>Skin</string>
+        </property>
+       </widget>
+      </item>
+      <item row="8" column="0">
+       <spacer name="verticalSpacer">
+        <property name="orientation">
+         <enum>Qt::Vertical</enum>
+        </property>
+        <property name="sizeHint" stdset="0">
+         <size>
+          <width>20</width>
+          <height>40</height>
+         </size>
+        </property>
+       </spacer>
+      </item>
+      <item row="5" column="0" colspan="2">
+       <widget class="QComboBox" name="qcbLanguage">
+        <property name="toolTip">
+         <string>Language to use (requires restart)</string>
+        </property>
+        <property name="whatsThis">
+         <string>&lt;b&gt;This sets which language Mumble should use.&lt;/b&gt;&lt;br /&gt;You have to restart Mumble to use the new language.</string>
+        </property>
+       </widget>
+      </item>
       <item row="0" column="0">
        <widget class="QLabel" name="qliStyle">
         <property name="text">
@@ -37,72 +104,12 @@
         </property>
        </widget>
       </item>
-      <item row="2" column="0">
-       <widget class="QLabel" name="qliCSS">
-        <property name="text">
-         <string>Skin</string>
-        </property>
-       </widget>
-      </item>
-      <item row="3" column="0">
-       <widget class="QLineEdit" name="qleCSS">
-        <property name="toolTip">
-         <string>Skin file to use</string>
-        </property>
-        <property name="whatsThis">
-         <string>&lt;b&gt;This sets which skin Mumble should use.&lt;/b&gt;&lt;br /&gt;The skin is a style file applied on top of the basic widget style. If there are icons in the same directory as the style sheet, those will replace the default icons.</string>
-        </property>
-       </widget>
-      </item>
-      <item row="3" column="1">
-       <widget class="QPushButton" name="qpbSkinFile">
-        <property name="text">
-         <string>&amp;Browse...</string>
-        </property>
-       </widget>
-      </item>
-      <item row="4" column="0">
-       <widget class="QLabel" name="qliLanguage">
-        <property name="text">
-         <string>Language</string>
-        </property>
-        <property name="buddy">
-         <cstring>qcbLanguage</cstring>
-        </property>
-       </widget>
-      </item>
-      <item row="5" column="0" colspan="2">
-       <widget class="QComboBox" name="qcbLanguage">
-        <property name="toolTip">
-         <string>Language to use (requires restart)</string>
-        </property>
-        <property name="whatsThis">
-         <string>&lt;b&gt;This sets which language Mumble should use.&lt;/b&gt;&lt;br /&gt;You have to restart Mumble to use the new language.</string>
-        </property>
-       </widget>
-      </item>
-      <item row="6" column="0">
-       <widget class="QCheckBox" name="qcbHighContrast">
-        <property name="toolTip">
-         <string>Apply some high contrast optimizations for visually impaired users</string>
-        </property>
-        <property name="text">
-         <string>Optimize for high contrast</string>
-        </property>
-       </widget>
-      </item>
       <item row="7" column="0">
-       <spacer name="verticalSpacer">
-        <property name="orientation">
-         <enum>Qt::Vertical</enum>
+       <widget class="QCheckBox" name="qcbShowTransmitModeComboBox">
+        <property name="text">
+         <string>Show transmit mode dropdown in toolbar</string>
         </property>
-        <property name="sizeHint" stdset="0">
-         <size>
-          <width>20</width>
-          <height>40</height>
-         </size>
-        </property>
-       </spacer>
+       </widget>
       </item>
      </layout>
     </widget>

--- a/src/mumble/MainWindow.cpp
+++ b/src/mumble/MainWindow.cpp
@@ -247,6 +247,9 @@ void MainWindow::createActions() {
 	gsCycleTransmitMode=new GlobalShortcut(this, idx++, tr("Cycle Transmit Mode", "Global Shortcut"));
 	gsCycleTransmitMode->setObjectName(QLatin1String("gsCycleTransmitMode"));
 
+	gsChannelFilter=new GlobalShortcut(this, idx++, tr("Channel Filter", "Global Shortcut"), false, 0);
+	gsChannelFilter->setObjectName(QLatin1String("gsChannelFilter"));
+
 #ifndef Q_OS_MAC
 	qstiIcon->show();
 #endif
@@ -348,6 +351,7 @@ void MainWindow::setupGui()  {
 	qstiIcon->setContextMenu(qmTray);
 
 	updateTrayIcon();
+	updateTransmitModeIcons();
 
 #ifdef USE_COCOA
 	setWindowOpacity(1.0f);
@@ -495,6 +499,29 @@ void MainWindow::updateTrayIcon() {
 	} else {
 		qstiIcon->setIcon(qiIcon);
 	}
+}
+
+void MainWindow::updateTransmitModeIcons() {
+
+	switch (g.s.atTransmit)
+	{
+		case Settings::Continous:
+			qaSetTransmitModeContinous->setChecked(true);
+			qaSetTransmitModePushToTalk->setChecked(false);
+			qaSetTransmitModeVAD->setChecked(false);
+			return;
+		case Settings::VAD:
+			qaSetTransmitModeContinous->setChecked(false);
+			qaSetTransmitModePushToTalk->setChecked(false);
+			qaSetTransmitModeVAD->setChecked(true);
+			return;
+		case Settings::PushToTalk:
+			qaSetTransmitModeContinous->setChecked(false);
+			qaSetTransmitModePushToTalk->setChecked(true);
+			qaSetTransmitModeVAD->setChecked(false);
+			return;
+	}
+
 }
 
 Channel *MainWindow::getContextMenuChannel() {
@@ -995,6 +1022,30 @@ void MainWindow::on_qaSelfRegister_triggered() {
 
 	if (result == QMessageBox::Yes)
 		g.sh->registerUser(p->uiSession);
+}
+
+void MainWindow::on_qaSetTransmitModeContinous_triggered() {
+	g.s.atTransmit = Settings::Continous;
+
+	g.l->log(Log::Information, tr("Transmit Mode set to Continuous"));
+
+	updateTransmitModeIcons();
+}
+
+void MainWindow::on_qaSetTransmitModePushToTalk_triggered() {
+	g.s.atTransmit = Settings::PushToTalk;
+
+	g.l->log(Log::Information, tr("Transmit Mode set to Push to Talk"));
+
+	updateTransmitModeIcons();
+}
+
+void MainWindow::on_qaSetTransmitModeVAD_triggered() {
+	g.s.atTransmit = Settings::VAD;
+
+	g.l->log(Log::Information, tr("Transmit Mode set to Voice Activity"));
+
+	updateTransmitModeIcons();
 }
 
 void MainWindow::on_qmServer_aboutToShow() {
@@ -2370,6 +2421,8 @@ void MainWindow::on_gsCycleTransmitMode_triggered(bool down, QVariant scdata)
 
 		g.l->log(Log::Information, tr("Cycled Transmit Mode to %1").arg(qsNewMode));
 	}
+
+	updateTransmitModeIcons();
 }
 
 void MainWindow::whisperReleased(QVariant scdata) {

--- a/src/mumble/MainWindow.cpp
+++ b/src/mumble/MainWindow.cpp
@@ -324,6 +324,22 @@ void MainWindow::setupGui()  {
 	        SIGNAL(currentChanged(const QModelIndex &, const QModelIndex &)),
 	        SLOT(qtvUserCurrentChanged(const QModelIndex &, const QModelIndex &)));
 
+	// QtCreator and uic.exe do not allow adding arbitrary widgets
+	// such as a QComboBox to a QToolbar, even though they are supported.
+	qcbTransmitMode = new QComboBox(qtIconToolbar);
+	qcbTransmitMode->setObjectName(QLatin1String("qcbTransmitMode"));
+	qcbTransmitMode->addItem(tr("Continuous"));
+	qcbTransmitMode->addItem(tr("Voice Activity"));
+	qcbTransmitMode->addItem(tr("Push-to-Talk"));
+
+	qaTransmitModeSeparator = qtIconToolbar->insertSeparator(qaConfigDialog);
+	qaTransmitMode = qtIconToolbar->insertWidget(qaTransmitModeSeparator, qcbTransmitMode);
+
+	// TODO:  Figure out why this signal would not auto-register.
+	connect(qcbTransmitMode, SIGNAL(activated(int)), this, SLOT(on_qcbTransmitMode_activated(int)));
+
+	updateTransmitModeComboBox();
+
 #ifndef Q_OS_MAC
 	setupView(false);
 #endif
@@ -348,22 +364,6 @@ void MainWindow::setupGui()  {
 	qstiIcon->setContextMenu(qmTray);
 
 	updateTrayIcon();
-
-	// QtCreator and uic.exe do not allow adding arbitrary widgets
-	// such as a QComboBox to a QToolbar, even though they are supported.
-	qcbTransmitMode = new QComboBox(qtIconToolbar);
-	qcbTransmitMode->addItem(tr("Continuous"));
-	qcbTransmitMode->addItem(tr("Voice Activity"));
-	qcbTransmitMode->addItem(tr("Push-to-Talk"));
-
-	qcbTransmitMode->setVisible(true);
-
-	QAction *qaSeperator = qtIconToolbar->insertSeparator(qaConfigDialog);
-	qtIconToolbar->insertWidget(qaSeperator, qcbTransmitMode);
-
-	connect(qcbTransmitMode, SIGNAL(activated(int)), this, SLOT(on_qcbTransmitMode_activated(int)));
-
-	updateTransmitModeComboBox();
 
 #ifdef USE_COCOA
 	setWindowOpacity(1.0f);
@@ -915,6 +915,16 @@ void MainWindow::setupView(bool toggle_minimize) {
 		resize(geometry().width()-newgeom.width()+geom.width(),
 		       geometry().height()-newgeom.height()+geom.height());
 		move(geom.x(), geom.y());
+	}
+
+	// Display the Transmit Mode Dropdown, if configured to do so, otherwise
+	// hide it.
+	if (g.s.bShowTransmitModeComboBox) {
+		qaTransmitMode->setVisible(true);
+		qaTransmitModeSeparator->setVisible(true);
+	} else {
+		qaTransmitMode->setVisible(false);
+		qaTransmitModeSeparator->setVisible(false);
 	}
 
 	show();

--- a/src/mumble/MainWindow.h
+++ b/src/mumble/MainWindow.h
@@ -97,8 +97,8 @@ class MainWindow : public QMainWindow, public MessageHandler, public Ui::MainWin
 		QIcon qiTalkingOn, qiTalkingWhisper, qiTalkingShout, qiTalkingOff;
 
 		GlobalShortcut *gsPushTalk, *gsResetAudio, *gsMuteSelf, *gsDeafSelf;
-		GlobalShortcut *gsUnlink, *gsPushMute, *gsMetaChannel, *gsToggleOverlay;
-		GlobalShortcut *gsMinimal, *gsVolumeUp, *gsVolumeDown, *gsWhisper, *gsMetaLink;
+		GlobalShortcut *gsUnlink, *gsPushMute, *gsJoinChannel, *gsToggleOverlay;
+		GlobalShortcut *gsMinimal, *gsVolumeUp, *gsVolumeDown, *gsWhisper, *gsLinkChannel;
 		GlobalShortcut *gsCycleTransmitMode;
 		DockTitleBar *dtbLogDockTitle, *dtbChatDockTitle;
 
@@ -130,7 +130,7 @@ class MainWindow : public QMainWindow, public MessageHandler, public Ui::MainWin
 		void setOnTop(bool top);
 		void setShowDockTitleBars(bool doShow);
 		void updateTrayIcon();
-		void updateTransmitModeIcons();
+		void updateTransmitModeComboBox();
 		QPair<QByteArray, QImage> openImageFile();
 		static const QString defaultStyleSheet;
 
@@ -159,6 +159,8 @@ class MainWindow : public QMainWindow, public MessageHandler, public Ui::MainWin
 
 		PTTButtonWidget *qwPTTButtonWidget;
 
+		QComboBox *qcbTransmitMode;
+
 		void createActions();
 		void setupGui();
 		void customEvent(QEvent *evt);
@@ -185,9 +187,7 @@ class MainWindow : public QMainWindow, public MessageHandler, public Ui::MainWin
 		void on_qmSelf_aboutToShow();
 		void on_qaSelfComment_triggered();
 		void on_qaSelfRegister_triggered();
-		void on_qaSetTransmitModeContinous_triggered();
-		void on_qaSetTransmitModePushToTalk_triggered();
-		void on_qaSetTransmitModeVAD_triggered();
+		void on_qcbTransmitMode_activated(int index);
 		void qmUser_aboutToShow();
 		void on_qaUserCommentReset_triggered();
 		void on_qaUserCommentView_triggered();

--- a/src/mumble/MainWindow.h
+++ b/src/mumble/MainWindow.h
@@ -97,8 +97,8 @@ class MainWindow : public QMainWindow, public MessageHandler, public Ui::MainWin
 		QIcon qiTalkingOn, qiTalkingWhisper, qiTalkingShout, qiTalkingOff;
 
 		GlobalShortcut *gsPushTalk, *gsResetAudio, *gsMuteSelf, *gsDeafSelf;
-		GlobalShortcut *gsUnlink, *gsPushMute, *gsJoinChannel, *gsToggleOverlay;
-		GlobalShortcut *gsMinimal, *gsVolumeUp, *gsVolumeDown, *gsWhisper, *gsLinkChannel;
+		GlobalShortcut *gsUnlink, *gsPushMute, *gsMetaChannel, *gsToggleOverlay;
+		GlobalShortcut *gsMinimal, *gsVolumeUp, *gsVolumeDown, *gsWhisper, *gsMetaLink;
 		GlobalShortcut *gsCycleTransmitMode;
 		DockTitleBar *dtbLogDockTitle, *dtbChatDockTitle;
 
@@ -130,6 +130,7 @@ class MainWindow : public QMainWindow, public MessageHandler, public Ui::MainWin
 		void setOnTop(bool top);
 		void setShowDockTitleBars(bool doShow);
 		void updateTrayIcon();
+		void updateTransmitModeIcons();
 		QPair<QByteArray, QImage> openImageFile();
 		static const QString defaultStyleSheet;
 
@@ -184,6 +185,9 @@ class MainWindow : public QMainWindow, public MessageHandler, public Ui::MainWin
 		void on_qmSelf_aboutToShow();
 		void on_qaSelfComment_triggered();
 		void on_qaSelfRegister_triggered();
+		void on_qaSetTransmitModeContinous_triggered();
+		void on_qaSetTransmitModePushToTalk_triggered();
+		void on_qaSetTransmitModeVAD_triggered();
 		void qmUser_aboutToShow();
 		void on_qaUserCommentReset_triggered();
 		void on_qaUserCommentView_triggered();

--- a/src/mumble/MainWindow.h
+++ b/src/mumble/MainWindow.h
@@ -160,6 +160,8 @@ class MainWindow : public QMainWindow, public MessageHandler, public Ui::MainWin
 		PTTButtonWidget *qwPTTButtonWidget;
 
 		QComboBox *qcbTransmitMode;
+		QAction *qaTransmitMode;
+		QAction *qaTransmitModeSeparator;
 
 		void createActions();
 		void setupGui();

--- a/src/mumble/MainWindow.ui
+++ b/src/mumble/MainWindow.ui
@@ -182,6 +182,10 @@
    <addaction name="separator"/>
    <addaction name="qaSelfComment"/>
    <addaction name="separator"/>
+   <addaction name="qaSetTransmitModeVAD"/>
+   <addaction name="qaSetTransmitModePushToTalk"/>
+   <addaction name="qaSetTransmitModeContinous"/>
+   <addaction name="separator"/>
    <addaction name="qaConfigDialog"/>
    <addaction name="separator"/>
    <addaction name="qaFilterToggle"/>
@@ -827,6 +831,57 @@ the channel's context menu.</string>
    </property>
    <property name="toolTip">
     <string>Change your own comment</string>
+   </property>
+   <property name="iconVisibleInMenu">
+    <bool>false</bool>
+   </property>
+  </action>
+  <action name="qaSetTransmitModeContinous">
+   <property name="checkable">
+    <bool>true</bool>
+   </property>
+   <property name="iconText">
+    <string>C</string>
+   </property>
+   <property name="text">
+    <string>&amp;Continuous</string>
+   </property>
+   <property name="toolTip">
+    <string>Set Transmit Mode to Continuous</string>
+   </property>
+   <property name="iconVisibleInMenu">
+    <bool>false</bool>
+   </property>
+  </action>
+  <action name="qaSetTransmitModeVAD">
+   <property name="checkable">
+    <bool>true</bool>
+   </property>
+   <property name="iconText">
+    <string>VA</string>
+   </property>
+   <property name="text">
+    <string>&amp;Voice Activity</string>
+   </property>
+   <property name="toolTip">
+    <string>Set Transmit Mode to Voice Activity</string>
+   </property>
+   <property name="iconVisibleInMenu">
+    <bool>false</bool>
+   </property>
+  </action>
+  <action name="qaSetTransmitModePushToTalk">
+   <property name="checkable">
+    <bool>true</bool>
+   </property>
+   <property name="iconText">
+    <string>PTT</string>
+   </property>
+   <property name="text">
+    <string>&amp;Push to Talk</string>
+   </property>
+   <property name="toolTip">
+    <string>Set Transmit Mode to Push to Talk</string>
    </property>
    <property name="iconVisibleInMenu">
     <bool>false</bool>

--- a/src/mumble/MainWindow.ui
+++ b/src/mumble/MainWindow.ui
@@ -182,10 +182,7 @@
    <addaction name="separator"/>
    <addaction name="qaSelfComment"/>
    <addaction name="separator"/>
-   <addaction name="qaSetTransmitModeVAD"/>
-   <addaction name="qaSetTransmitModePushToTalk"/>
-   <addaction name="qaSetTransmitModeContinous"/>
-   <addaction name="separator"/>
+   <!-- Transmit Mode ComboBox and seperator will be added here. -->
    <addaction name="qaConfigDialog"/>
    <addaction name="separator"/>
    <addaction name="qaFilterToggle"/>
@@ -831,57 +828,6 @@ the channel's context menu.</string>
    </property>
    <property name="toolTip">
     <string>Change your own comment</string>
-   </property>
-   <property name="iconVisibleInMenu">
-    <bool>false</bool>
-   </property>
-  </action>
-  <action name="qaSetTransmitModeContinous">
-   <property name="checkable">
-    <bool>true</bool>
-   </property>
-   <property name="iconText">
-    <string>C</string>
-   </property>
-   <property name="text">
-    <string>&amp;Continuous</string>
-   </property>
-   <property name="toolTip">
-    <string>Set Transmit Mode to Continuous</string>
-   </property>
-   <property name="iconVisibleInMenu">
-    <bool>false</bool>
-   </property>
-  </action>
-  <action name="qaSetTransmitModeVAD">
-   <property name="checkable">
-    <bool>true</bool>
-   </property>
-   <property name="iconText">
-    <string>VA</string>
-   </property>
-   <property name="text">
-    <string>&amp;Voice Activity</string>
-   </property>
-   <property name="toolTip">
-    <string>Set Transmit Mode to Voice Activity</string>
-   </property>
-   <property name="iconVisibleInMenu">
-    <bool>false</bool>
-   </property>
-  </action>
-  <action name="qaSetTransmitModePushToTalk">
-   <property name="checkable">
-    <bool>true</bool>
-   </property>
-   <property name="iconText">
-    <string>PTT</string>
-   </property>
-   <property name="text">
-    <string>&amp;Push to Talk</string>
-   </property>
-   <property name="toolTip">
-    <string>Set Transmit Mode to Push to Talk</string>
    </property>
    <property name="iconVisibleInMenu">
     <bool>false</bool>

--- a/src/mumble/Settings.cpp
+++ b/src/mumble/Settings.cpp
@@ -371,6 +371,8 @@ Settings::Settings() {
 	iMaxImageHeight = 1024;
 	bSuppressIdentity = false;
 
+	bShowTransmitModeComboBox = false;
+
 	// Accessibility
 	bHighContrast = false;
 
@@ -677,6 +679,7 @@ void Settings::load(QSettings* settings_ptr) {
 	SAVELOAD(bShowContextMenuInMenuBar, "ui/showcontextmenuinmenubar");
 	SAVELOAD(qbaConnectDialogGeometry, "ui/connect/geometry");
 	SAVELOAD(qbaConnectDialogHeader, "ui/connect/header");
+	SAVELOAD(bShowTransmitModeComboBox, "ui/transmitmodecombobox");
 	SAVELOAD(bHighContrast, "ui/HighContrast");
 	SAVELOAD(iMaxLogBlocks, "ui/MaxLogBlocks");
 
@@ -964,6 +967,7 @@ void Settings::save() {
 	SAVELOAD(bShowContextMenuInMenuBar, "ui/showcontextmenuinmenubar");
 	SAVELOAD(qbaConnectDialogGeometry, "ui/connect/geometry");
 	SAVELOAD(qbaConnectDialogHeader, "ui/connect/header");
+	SAVELOAD(bShowTransmitModeComboBox, "ui/transmitmodecombobox");
 	SAVELOAD(bHighContrast, "ui/HighContrast");
 	SAVELOAD(iMaxLogBlocks, "ui/MaxLogBlocks");
 

--- a/src/mumble/Settings.h
+++ b/src/mumble/Settings.h
@@ -295,6 +295,8 @@ struct Settings {
 	KeyPair kpCertificate;
 	bool bSuppressIdentity;
 
+	bool bShowTransmitModeComboBox;
+
 	// Accessibility
 	bool bHighContrast;
 


### PR DESCRIPTION
Revisit of #174, implementing [FR 1119](https://sourceforge.net/p/mumble/feature-requests/1119/).

- Using a dropdown menu instead unclear buttons.
- Gated by an option in the LookConfig dialog.

Just a note that in #174 it was mentioned that having a customizable toolbar with plugins would be nice and I entirely agree.  I'd be willing to start looking into how to accomplish that with Qt (and C++, which isn't my native language :D) in my spare time.