### PR TITLE
PulseAudio: only attenuate same sink

### DIFF
--- a/src/mumble/PulseAudio.h
+++ b/src/mumble/PulseAudio.h
@@ -74,6 +74,7 @@ class PulseAudioSystem : public QObject {
 
 		bool bAttenuating;
 		int iRemainingOperations;
+		int iSinkId;
 		QHash<uint32_t, PulseAttenuation> qhVolumes;
 		QList<uint32_t> qlMatchedSinks;
 		QHash<QString, PulseAttenuation> qhUnmatchedSinks;
@@ -85,6 +86,7 @@ class PulseAudioSystem : public QObject {
 		static void sink_callback(pa_context *c, const pa_sink_info *i, int eol, void *userdata);
 		static void source_callback(pa_context *c, const pa_source_info *i, int eol, void *userdata);
 		static void server_callback(pa_context *c, const pa_server_info *i, void *userdata);
+		static void sink_info_callback(pa_context *c, const pa_sink_info *i, int eol, void *userdata);
 		static void stream_callback(pa_stream *s, void *userdata);
 		static void read_callback(pa_stream *s, size_t bytes, void *userdata);
 		static void write_callback(pa_stream *s, size_t bytes, void *userdata);


### PR DESCRIPTION
With custom PulseAudio setups, it may be undesirable for Mumble to attenuate certain applications.

Scenario: Say you are live streaming a game. You have set up a PulseAudio with two virtual sinks: "stream_spkr" that has a loopback to the hardware output and a loopback to "stream", and "stream" that allows for streaming audio to the live stream without having to hear it through the hardware output. The live stream audio is recorded from "stream.monitor". If you attach a music application to the "stream" sink, it will not be coming through the speaker, yet Mumble will still attenuate it as if it were, even though there are no inputs from "stream" to "stream_spkr" or the hardware sink.

This can be undesirable behavior sometimes. If I were live streaming a game and had the sound routed to the "stream" sink and I were running mumble attached to the hardware sink, then Mumble's audio would not be flowing through to the "stream" sink and there would be no reason for Mumble to attenuate it --  yet it does. This would leave the viewers confused as to why the audio is constantly changing volume.

This patch allows for effective whitelisting of applications to prevent them from being attenuated if it's not desired. In order to do this, one simply has to map the application's output to another sink. This is really targeted toward advance audio setups and advance PulseAudio users. It won't affect 99.9% of Mumble users in any way. However, it's a boon to those of us who have custom audio setups like described and want better control over our audio output.