### PR TITLE
Reordered Mumble.proto to match ordering in Message.h

### DIFF
--- a/src/Mumble.proto
+++ b/src/Mumble.proto
@@ -51,14 +51,6 @@ message Reject {
 	optional string reason = 2;
 }
 
-message ServerConfig {
-	optional uint32 max_bandwidth = 1;
-	optional string welcome_text = 2;
-	optional bool allow_html = 3;
-	optional uint32 message_length = 4;
-	optional uint32 image_message_length = 5;
-}
-
 message ServerSync {
 	optional uint32 session = 1;
 	optional uint32 max_bandwidth = 2;
@@ -281,14 +273,22 @@ message UserStats {
 	optional bool opus = 19 [default = false];
 }
 
-message SuggestConfig {
-	optional uint32 version = 1;
-	optional bool positional = 2;
-	optional bool push_to_talk = 3;
-}
-
 message RequestBlob {
 	repeated uint32 session_texture = 1;
 	repeated uint32 session_comment = 2;
 	repeated uint32 channel_description = 3;
+}
+
+message ServerConfig {
+	optional uint32 max_bandwidth = 1;
+	optional string welcome_text = 2;
+	optional bool allow_html = 3;
+	optional uint32 message_length = 4;
+	optional uint32 image_message_length = 5;
+}
+
+message SuggestConfig {
+	optional uint32 version = 1;
+	optional bool positional = 2;
+	optional bool push_to_talk = 3;
 }


### PR DESCRIPTION
While this should have no affect on the output, making the order of definitions
match makes it easier for third party implementers who are likely to work from
the .proto file.

**Note** I am currently unable to build a client - my build environment doesn't have a GUI, and vice versa - so have been unable to test this. Certainly the server compiles.
