### PR TITLE
Overlay Code: Rework reference counting and hook freeing

### DIFF
--- a/overlay/d3d9.cpp
+++ b/overlay/d3d9.cpp
@@ -79,7 +79,6 @@ class DevState : public Pipe {
 
 		IDirect3DDevice9* getDevice() { return dev; }
 
-		DWORD releaseDevice();
 		void createCleanState();
 		void releaseStateBlock();
 		void releaseTexture();
@@ -91,6 +90,7 @@ class DevState : public Pipe {
 		virtual void newTexture(unsigned int width, unsigned int height);
 	private:
 		IDirect3DDevice9 *dev;
+		DWORD releaseDevice();
 };
 
 /// Vtable offset; see d3d9.h of win-/D3D-API.

--- a/overlay/d3d9.cpp
+++ b/overlay/d3d9.cpp
@@ -76,9 +76,11 @@ class DevState : public Pipe {
 		unsigned int frameCount;
 
 		DevState(IDirect3DDevice9 *device);
+		~DevState();
 
 		IDirect3DDevice9* getDevice() { return dev; }
 
+		DWORD releaseDevice();
 		void createCleanState();
 		void releaseStateBlock();
 		void releaseTexture();
@@ -108,8 +110,7 @@ DevState::DevState(IDirect3DDevice9 *device) {
 	texTexture = NULL;
 	dev = device;
 
-	dev->AddRef();
-	refCount = dev->Release();
+	refCount = dev->AddRef();
 
 	timeT = clock();
 	frameCount = 0;
@@ -119,6 +120,22 @@ DevState::DevState(IDirect3DDevice9 *device) {
 		vertices[i].tu = vertices[i].tv = 0.0f;
 		vertices[i].z = vertices[i].rhw = 1.0f;
 	}
+}
+
+DevState::~DevState() {
+	releaseAll();
+	releaseDevice();
+	ods("Deleted DevState with final refCount %d", refCount);
+}
+
+DWORD DevState::releaseDevice() {
+	if (dev) {
+		refCount = dev->Release();
+		dev = NULL;
+	} else {
+		ods("D3D9: DevState::releaseDevice called but nothing to release ...");
+	}
+	return refCount;
 }
 
 void DevState::blit(unsigned int x, unsigned int y, unsigned int w, unsigned int h) {

--- a/overlay/d3d9.cpp
+++ b/overlay/d3d9.cpp
@@ -537,6 +537,9 @@ typedef HRESULT(__stdcall *ResetType)(IDirect3DDevice9 *, D3DPRESENT_PARAMETERS 
 static HRESULT __stdcall myReset(IDirect3DDevice9 *idd, D3DPRESENT_PARAMETERS *param) {
 	ods("D3D9: Chaining Reset");
 
+	// Shared resource devMap
+	Mutex m;
+
 	DevMapType::iterator it = devMap.find(idd);
 	DevState *ds = it != devMap.end() ? it->second : NULL;
 	if (ds) {
@@ -564,6 +567,9 @@ static HRESULT __stdcall myReset(IDirect3DDevice9 *idd, D3DPRESENT_PARAMETERS *p
 typedef HRESULT(__stdcall *ResetExType)(IDirect3DDevice9Ex *, D3DPRESENT_PARAMETERS *, D3DDISPLAYMODEEX *);
 static HRESULT __stdcall myResetEx(IDirect3DDevice9Ex *idd, D3DPRESENT_PARAMETERS *param, D3DDISPLAYMODEEX *param2) {
 	ods("D3D9: Chaining ResetEx");
+
+	// Shared resource devMap
+	Mutex m;
 
 	DevMapType::iterator it = devMap.find(idd);
 	DevState *ds = it != devMap.end() ? it->second : NULL;
@@ -809,11 +815,10 @@ static IDirect3DDevice9* findOriginalDevice(IDirect3DDevice9 *device) {
 
 typedef HRESULT(__stdcall *CreateDeviceType)(IDirect3D9 *, UINT, D3DDEVTYPE, HWND, DWORD, D3DPRESENT_PARAMETERS *, IDirect3DDevice9 **);
 static HRESULT __stdcall myCreateDevice(IDirect3D9 *id3d, UINT Adapter, D3DDEVTYPE DeviceType, HWND hFocusWindow, DWORD BehaviorFlags, D3DPRESENT_PARAMETERS *pPresentationParameters, IDirect3DDevice9 **ppReturnedDeviceInterface) {
-	Mutex m;
-
 	ods("D3D9: Chaining CreateDevice");
 
-//	BehaviorFlags &= ~D3DCREATE_PUREDEVICE;
+	// Shared resource devMap
+	Mutex m;
 
 	//TODO: Move logic to HardHook.
 	// Call base without active hook in case of no trampoline.
@@ -885,10 +890,10 @@ static HRESULT __stdcall myCreateDevice(IDirect3D9 *id3d, UINT Adapter, D3DDEVTY
 
 typedef HRESULT(__stdcall *CreateDeviceExType)(IDirect3D9Ex *, UINT, D3DDEVTYPE, HWND, DWORD, D3DPRESENT_PARAMETERS *, D3DDISPLAYMODEEX *, IDirect3DDevice9Ex **);
 static HRESULT __stdcall myCreateDeviceEx(IDirect3D9Ex *id3d, UINT Adapter, D3DDEVTYPE DeviceType, HWND hFocusWindow, DWORD BehaviorFlags, D3DPRESENT_PARAMETERS *pPresentationParameters, D3DDISPLAYMODEEX *pFullscreenDisplayMode, IDirect3DDevice9Ex **ppReturnedDeviceInterface) {
-	Mutex m;
 	ods("D3D9: Chaining CreateDeviceEx");
 
-//	BehaviorFlags &= ~D3DCREATE_PUREDEVICE;
+	// Shared resource devMap
+	Mutex m;
 
 	//TODO: Move logic to HardHook.
 	// Call base without active hook in case of no trampoline.

--- a/overlay/d3d9.cpp
+++ b/overlay/d3d9.cpp
@@ -460,6 +460,7 @@ static void doPresent(IDirect3DDevice9 *idd) {
 			if (ds == NULL || FAILED(hres)) {
 				pStateBlock->Release();
 				pRenderTarget->Release();
+				pTarget->Release();
 				return;
 			}
 		}
@@ -480,10 +481,10 @@ static void doPresent(IDirect3DDevice9 *idd) {
 			DevState *ds = it != devMap.end() ? it->second : NULL;
 			if (ds != NULL) {
 				ds->draw();
-				hres = idd->EndScene();
-				if (FAILED(hres)) {
-					ods("D3D9: Failure in doPresent: Could not IDirect3DDevice9::EndScene(). Continuing anyway.");
-				}
+			}
+			hres = idd->EndScene();
+			if (FAILED(hres)) {
+				ods("D3D9: Failure in doPresent: Could not IDirect3DDevice9::EndScene(). Continuing anyway.");
 			}
 		}
 

--- a/overlay/d3d9.cpp
+++ b/overlay/d3d9.cpp
@@ -687,16 +687,17 @@ static IDirect3DDevice9* findOriginalDevice(IDirect3DDevice9 *device) {
 	IDirect3DSwapChain9 *pSwap = NULL;
 	device->GetSwapChain(0, &pSwap);
 	if (pSwap) {
-
 		IDirect3DDevice9 *originalDevice = NULL;
 		if (SUCCEEDED(pSwap->GetDevice(&originalDevice))) {
-
 			if (originalDevice == device) {
 				// Found the original device. Release responsibility is passed
 				// to the caller.
-			} else {
-				device = findOriginalDevice(originalDevice);
+				// No ref for ourselves. We hook and catch calls to Release of
+				// the device itself.
 				originalDevice->Release();
+			} else {
+				device->Release();
+				device = findOriginalDevice(originalDevice);
 			}
 
 		} else {

--- a/overlay/lib.cpp
+++ b/overlay/lib.cpp
@@ -120,6 +120,10 @@ void Mutex::init() {
 	InitializeCriticalSection(&cs);
 }
 
+void Mutex::deinit() {
+	DeleteCriticalSection(&cs);
+}
+
 Mutex::Mutex() {
 	if (! TryEnterCriticalSection(&cs)) {
 		ods("Lib: Mutex: CritFail - blocking until able to enter critical section");
@@ -743,6 +747,8 @@ static void dllmainProcDetach() {
 		CloseHandle(hMapObject);
 	if (hHookMutex)
 		CloseHandle(hHookMutex);
+
+	Mutex::deinit();
 }
 
 static void dllmainThreadAttach() {

--- a/overlay/lib.cpp
+++ b/overlay/lib.cpp
@@ -36,8 +36,6 @@ static HANDLE hMapObject = NULL;
 static HANDLE hHookMutex = NULL;
 static HHOOK hhookWnd = 0;
 
-BOOL bIsWin8 = FALSE;
-
 static BOOL bMumble = FALSE;
 static BOOL bDebug = FALSE;
 static BOOL bBlackListed = FALSE;
@@ -528,16 +526,6 @@ static void dllmainProcAttach(char *procname) {
 			return;
 		}
 	}
-
-
-	OSVERSIONINFOEX ovi;
-	memset(&ovi, 0, sizeof(ovi));
-	ovi.dwOSVersionInfoSize = sizeof(ovi);
-	GetVersionEx(reinterpret_cast<OSVERSIONINFO *>(&ovi));
-	bIsWin8 = (ovi.dwMajorVersion >= 7) || ((ovi.dwMajorVersion == 6) && (ovi.dwBuildNumber >= 9200));
-
-	ods("Lib: bIsWin8: %i", bIsWin8);
-
 
 	hHookMutex = CreateMutex(NULL, false, "MumbleHookMutex");
 	if (hHookMutex == NULL) {

--- a/overlay/lib.cpp
+++ b/overlay/lib.cpp
@@ -30,6 +30,7 @@
 
 #include "lib.h"
 
+#include <assert.h>
 #include "overlay_blacklist.h"
 
 static HANDLE hMapObject = NULL;
@@ -140,6 +141,21 @@ void __cdecl ods(const char *format, ...) {
 	va_start(args, format);
 	_ods_out(format, &args);
 	va_end(args);
+}
+
+void __cdecl odsAssertFn(const wchar_t * message, const wchar_t *file, unsigned line, const char *failureFormattext, ...) {
+	va_list args;
+	va_start(args, failureFormattext);
+	_ods_out(failureFormattext, &args);
+	va_end(args);
+
+#ifndef DEBUG
+	if (bDebug) {
+#endif
+		_wassert(message, file, line);
+#ifndef DEBUG
+	}
+#endif
 }
 
 void __cdecl checkForWPF() {

--- a/overlay/lib.h
+++ b/overlay/lib.h
@@ -54,6 +54,9 @@ using namespace std;
 
 void __cdecl ods(const char *format, ...);
 
+#define odsAssert(expectedCondition, failureFormattext, ...) (void)( (!!(expectedCondition)) || (odsAssertFn(_CRT_WIDE(#expectedCondition), _CRT_WIDE(__FILE__), __LINE__, failureFormattext, __VA_ARGS__), 0) )
+void __cdecl odsAssertFn(const wchar_t * message, const wchar_t *file, unsigned line, const char *failureFormattext, ...);
+
 const int MODULEFILEPATH_BUFLEN = 2048;
 const int PROCNAMEFILEPATH_BUFLEN = 1024;
 const int PROCNAMEFILEPATH_EXTENDED_EXTLEN = 64;

--- a/overlay/lib.h
+++ b/overlay/lib.h
@@ -110,6 +110,7 @@ class Mutex {
 		static CRITICAL_SECTION cs;
 	public:
 		static void init();
+		static void deinit();
 		Mutex();
 		~Mutex();
 };


### PR DESCRIPTION
- Before, we had rather complex logic to try to hide ourselves from the outside
  world. This transparency comes with complexity in our code which is hard to
  follow and thus error-prone. The enforced transparency was achieved through
  faking.
- As a result of this change, the reference counting is more consistent to
  the outside world as well. The DX SDK Sample SimpleSample for example has
  refcount debugging enabled and no longer indicates non-freed objects on exit.
  (We actually were not transparent before.)
- The previous take on determining how many references we have ourselves and
  when we should release the device because we are the only one left with
  references was through setting the current threadId at various places where
  we expect to change the refcount. The AddRef and Release methods then counted
  a separate counter as. This changes to knowing which data objects
  actually change the refcount of the device offsetting the refcount at
  which we release by that amount (depending on the existence of those
  objects). (See updateRefcount for that logic.)
- Remove the custom refCount logic and use the native IUnknown refcount logic
  instead.
- Be aware of our own refCount influences (namely StateBlock pSB and Texture
  texTexture) and clean up our objects when we are the only one left owning
  references to the device.
  *\* The clean up now includes cleaning up device hooks.
- Clean up the hook freeing. It was incorrect
  (writing on no-longer-existant object in memory).
- Add missing releaseStateBlock in createCleanState method
- Fix findOriginalDevice which was not releasing everything it references
- Make D3D9State hold a reference count to the d3ddevice
- Add asserts and debugging output
- Adjust DevState to make use of constructor and destructor
- Clean up DevState release methods
- In createDevice create own objects only once we know we need them
- Remove win8 special case
- Harmonize/unify
- Remove obsolete thread specific logic
- Introduce (hook) restoration of original device state before final release
  (in case D3D/COM continues to do fancy stuff with it)
- More Mutex locks where they seem appropriate.
  I guess the mutex should not be limited to AddRef and Release, but should
  be used where ever devMap and DevState is referenced.
- Error checks
