### PR TITLE
Fixed broken Mumble log links on large text messages

### DIFF
--- a/src/mumble/Log.cpp
+++ b/src/mumble/Log.cpp
@@ -419,7 +419,7 @@ QString Log::validHtml(const QString &html, bool allowReplacement, QTextCursor *
 	}
 }
 
-void Log::log(MsgType mt, const QString &console, const QString &terse, bool ownMessage) {
+void Log::log(MsgType mt, const QString &console, const QString &terse, bool ownMessage, const QString &prefix) {
 	QDateTime dt = QDateTime::currentDateTime();
 
 	int ignore = qmIgnore.value(mt);
@@ -460,6 +460,9 @@ void Log::log(MsgType mt, const QString &console, const QString &terse, bool own
 			tc.insertBlock();
 		}
 		tc.insertHtml(Log::msgColor(QString::fromLatin1("[%1] ").arg(dt.time().toString(Qt::DefaultLocaleShortDate)), Log::Time));
+		if (!prefix.isNull()) {
+			tc.insertHtml(prefix);
+		}
 		validHtml(console, true, &tc);
 		tc.movePosition(QTextCursor::End);
 		g.mw->qteLog->setTextCursor(tc);

--- a/src/mumble/Log.h
+++ b/src/mumble/Log.h
@@ -97,7 +97,7 @@ class Log : public QObject {
 		static QString formatClientUser(ClientUser *cu, LogColorType t);
 		static QString formatChannel(::Channel *c);
 	public slots:
-		void log(MsgType t, const QString &console, const QString &terse=QString(), bool ownMessage = false);
+		void log(MsgType t, const QString &console, const QString &terse=QString(), bool ownMessage = false, const QString &prefix=QString());
 };
 
 class ValidDocument : public QTextDocument {

--- a/src/mumble/MainWindow.cpp
+++ b/src/mumble/MainWindow.cpp
@@ -1441,7 +1441,8 @@ void MainWindow::openTextMessageDialog(ClientUser *p) {
 
 		if (! msg.isEmpty()) {
 			g.sh->sendUserTextMessage(p->uiSession, msg);
-			g.l->log(Log::TextMessage, tr("To %1: %2").arg(Log::formatClientUser(p, Log::Target), texm->message()), tr("Message to %1").arg(p->qsName), true);
+			g.l->log(Log::TextMessage, texm->message(), tr("Message to %1").arg(p->qsName),
+				true, tr("To %1: ").arg(Log::formatClientUser(p, Log::Target)));
 		}
 	}
 	delete texm;
@@ -1524,11 +1525,13 @@ void MainWindow::sendChatbarMessage(QString qsText) {
 			c = ClientUser::get(g.uiSession)->cChannel;
 
 		g.sh->sendChannelTextMessage(c->iId, qsText, false);
-		g.l->log(Log::TextMessage, tr("To %1: %2").arg(Log::formatChannel(c), qsText), tr("Message to channel %1").arg(c->qsName), true);
+		g.l->log(Log::TextMessage, qsText, tr("Message to channel %1").arg(c->qsName), true,
+			tr("To %1: ").arg(Log::formatChannel(c)));
 	} else {
 		// User message
 		g.sh->sendUserTextMessage(p->uiSession, qsText);
-		g.l->log(Log::TextMessage, tr("To %1: %2").arg(Log::formatClientUser(p, Log::Target), qsText), tr("Message to %1").arg(p->qsName), true);
+		g.l->log(Log::TextMessage, qsText, tr("Message to %1").arg(p->qsName), true,
+			tr("To %1: ").arg(Log::formatClientUser(p, Log::Target)));
 	}
 
 	qteChat->clear();
@@ -1785,9 +1788,11 @@ void MainWindow::on_qaChannelSendMessage_triggered() {
 		g.sh->sendChannelTextMessage(id, texm->message(), texm->bTreeMessage);
 
 		if (texm->bTreeMessage)
-			g.l->log(Log::TextMessage, tr("To %1 (Tree): %2").arg(Log::formatChannel(c), texm->message()), tr("Message to tree %1").arg(c->qsName), true);
+			g.l->log(Log::TextMessage, texm->message(), tr("Message to tree %1").arg(c->qsName), true,
+				tr("To %1 (Tree): ").arg(Log::formatChannel(c)));
 		else
-			g.l->log(Log::TextMessage, tr("To %1: %2").arg(Log::formatChannel(c), texm->message()), tr("Message to channel %1").arg(c->qsName), true);
+			g.l->log(Log::TextMessage, texm->message(), tr("Message to channel %1").arg(c->qsName), true,
+				tr("To %1: ").arg(Log::formatChannel(c)));
 	}
 	delete texm;
 }

--- a/src/mumble/Messages.cpp
+++ b/src/mumble/Messages.cpp
@@ -641,8 +641,8 @@ void MainWindow::msgTextMessage(const MumbleProto::TextMessage &msg) {
 		target += tr("(Channel) ");
 	}
 
-	g.l->log(Log::TextMessage, tr("%2%1: %3").arg(name).arg(target).arg(u8(msg.message())),
-	         tr("Message from %1").arg(plainName));
+	g.l->log(Log::TextMessage, u8(msg.message()), tr("Message from %1").arg(plainName),
+		false, tr("%2%1: ").arg(name).arg(target));
 }
 
 void MainWindow::msgACL(const MumbleProto::ACL &msg) {

--- a/src/mumble/mumble_cs.ts
+++ b/src/mumble/mumble_cs.ts
@@ -2377,8 +2377,6 @@ Mluvte nahlas, jako kdybyste byli podráždění nebo nadšení. Snižujte hlasi
         <source>Ban List - %n Ban(s)</source>
         <translation type="unfinished">
             <numerusform></numerusform>
-            <numerusform></numerusform>
-            <numerusform></numerusform>
         </translation>
     </message>
 </context>
@@ -5135,8 +5133,8 @@ Platné možnosti jsou:
         <location line="+83"/>
         <location line="+4"/>
         <location line="+259"/>
-        <source>To %1: %2</source>
-        <translation>Pro %1: %2</translation>
+        <source>To %1: </source>
+        <translation>Pro %1: </translation>
     </message>
     <message>
         <location line="-346"/>
@@ -5566,8 +5564,8 @@ Platné možnosti jsou:
     </message>
     <message>
         <location line="+3"/>
-        <source>%2%1: %3</source>
-        <translation>%2%1: %3</translation>
+        <source>%2%1: </source>
+        <translation>%2%1: </translation>
     </message>
     <message>
         <location line="+1"/>
@@ -5792,9 +5790,9 @@ Platné možnosti jsou:
     </message>
     <message>
         <location line="+301"/>
-        <source>To %1 (Tree): %2</source>
+        <source>To %1 (Tree): </source>
         <oldsource>(Tree) %1: %2</oldsource>
-        <translation>Do %1 (Strom): %2</translation>
+        <translation>Do %1 (Strom): </translation>
     </message>
     <message>
         <location line="+574"/>
@@ -7689,8 +7687,6 @@ Znak přístupu je textový řetězec, který může být použit jako heslo pro
         <location filename="UserEdit.cpp" line="-64"/>
         <source>Registered users: %n account(s)</source>
         <translation type="unfinished">
-            <numerusform></numerusform>
-            <numerusform></numerusform>
             <numerusform></numerusform>
         </translation>
     </message>

--- a/src/mumble/mumble_cs.ts
+++ b/src/mumble/mumble_cs.ts
@@ -5791,7 +5791,6 @@ Platné možnosti jsou:
     <message>
         <location line="+301"/>
         <source>To %1 (Tree): </source>
-        <oldsource>(Tree) %1: %2</oldsource>
         <translation>Do %1 (Strom): </translation>
     </message>
     <message>

--- a/src/mumble/mumble_da.ts
+++ b/src/mumble/mumble_da.ts
@@ -2371,7 +2371,6 @@ Tal højlydt som når du er irriteret og ophidset. Formindsk nu lydstyrken i lyd
         <source>Ban List - %n Ban(s)</source>
         <translation type="unfinished">
             <numerusform></numerusform>
-            <numerusform></numerusform>
         </translation>
     </message>
 </context>
@@ -4878,8 +4877,8 @@ Dette felt beskriver størrelsen af en LCD-enhed. Størrelsen er enten opgivet i
         <location line="+83"/>
         <location line="+4"/>
         <location line="+259"/>
-        <source>To %1: %2</source>
-        <translation>Til %1: %2</translation>
+        <source>To %1: </source>
+        <translation>Til %1: </translation>
     </message>
     <message>
         <location line="-346"/>
@@ -4942,9 +4941,9 @@ Dette felt beskriver størrelsen af en LCD-enhed. Størrelsen er enten opgivet i
     </message>
     <message>
         <location line="+678"/>
-        <source>To %1 (Tree): %2</source>
+        <source>To %1 (Tree): </source>
         <oldsource>(Tree) %1: %2</oldsource>
-        <translation>Til %1 (træ): %2</translation>
+        <translation>Til %1 (træ): </translation>
     </message>
     <message>
         <location line="+163"/>
@@ -5935,8 +5934,8 @@ Otherwise abort and check your certificate and username.</source>
     </message>
     <message>
         <location line="+3"/>
-        <source>%2%1: %3</source>
-        <translation>%2%1: %3</translation>
+        <source>%2%1: </source>
+        <translation>%2%1: </translation>
     </message>
     <message>
         <location line="-281"/>
@@ -7688,7 +7687,6 @@ Et adgangsudtryk er en tekststreng, der kan bruges som en adgangskode for meget 
         <location filename="UserEdit.cpp" line="-64"/>
         <source>Registered users: %n account(s)</source>
         <translation type="unfinished">
-            <numerusform></numerusform>
             <numerusform></numerusform>
         </translation>
     </message>

--- a/src/mumble/mumble_da.ts
+++ b/src/mumble/mumble_da.ts
@@ -4942,7 +4942,6 @@ Dette felt beskriver størrelsen af en LCD-enhed. Størrelsen er enten opgivet i
     <message>
         <location line="+678"/>
         <source>To %1 (Tree): </source>
-        <oldsource>(Tree) %1: %2</oldsource>
         <translation>Til %1 (træ): </translation>
     </message>
     <message>

--- a/src/mumble/mumble_de.ts
+++ b/src/mumble/mumble_de.ts
@@ -2387,7 +2387,6 @@ Verringern Sie die Mikrofonlautstärke in Ihren Ton-Einstellungen so weit, dass 
         <source>Ban List - %n Ban(s)</source>
         <translation type="unfinished">
             <numerusform></numerusform>
-            <numerusform></numerusform>
         </translation>
     </message>
 </context>
@@ -5237,8 +5236,8 @@ Wenn gewählt veranlasst Mumble, dass %1 Ereignisse vorgelesen werden. Text-zu-S
     </message>
     <message>
         <location line="+3"/>
-        <source>%2%1: %3</source>
-        <translation>%2%1: %3</translation>
+        <source>%2%1: </source>
+        <translation>%2%1: </translation>
     </message>
     <message>
         <location line="+201"/>
@@ -5567,18 +5566,18 @@ Falls nicht, brechen Sie ab und überprüfen Sie Ihr Zertifikat und Ihren Benutz
     </message>
     <message>
         <location line="+301"/>
-        <source>To %1 (Tree): %2</source>
+        <source>To %1 (Tree): </source>
         <oldsource>(Tree) %1: %2</oldsource>
-        <translation>An %1 (Baum): %2</translation>
+        <translation>An %1 (Baum): </translation>
     </message>
     <message>
         <location line="-344"/>
         <location line="+83"/>
         <location line="+4"/>
         <location line="+259"/>
-        <source>To %1: %2</source>
         <oldsource>%1: %2</oldsource>
-        <translation>An %1: %2</translation>
+        <source>To %1: </source>
+        <translation>An %1: </translation>
     </message>
     <message>
         <location line="-1570"/>
@@ -7753,7 +7752,6 @@ Ein Zugriffscode ist eine Zeichenfolge, die als Passwort für ein sehr einfaches
         <location filename="UserEdit.cpp" line="-71"/>
         <source>Registered users: %n account(s)</source>
         <translation type="unfinished">
-            <numerusform></numerusform>
             <numerusform></numerusform>
         </translation>
     </message>

--- a/src/mumble/mumble_de.ts
+++ b/src/mumble/mumble_de.ts
@@ -5567,7 +5567,6 @@ Falls nicht, brechen Sie ab und überprüfen Sie Ihr Zertifikat und Ihren Benutz
     <message>
         <location line="+301"/>
         <source>To %1 (Tree): </source>
-        <oldsource>(Tree) %1: %2</oldsource>
         <translation>An %1 (Baum): </translation>
     </message>
     <message>
@@ -5575,7 +5574,6 @@ Falls nicht, brechen Sie ab und überprüfen Sie Ihr Zertifikat und Ihren Benutz
         <location line="+83"/>
         <location line="+4"/>
         <location line="+259"/>
-        <oldsource>%1: %2</oldsource>
         <source>To %1: </source>
         <translation>An %1: </translation>
     </message>

--- a/src/mumble/mumble_en.ts
+++ b/src/mumble/mumble_en.ts
@@ -4843,7 +4843,7 @@ This field describes the size of an LCD device. The size is given either in pixe
         <location line="+83"/>
         <location line="+4"/>
         <location line="+259"/>
-        <source>To %1: %2</source>
+        <source>To %1: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -4874,7 +4874,7 @@ This field describes the size of an LCD device. The size is given either in pixe
     </message>
     <message>
         <location line="+0"/>
-        <source>To %1 (Tree): %2</source>
+        <source>To %1 (Tree): </source>
         <oldsource>(Tree) %1: %2</oldsource>
         <translation type="unfinished"></translation>
     </message>
@@ -5807,7 +5807,7 @@ Otherwise abort and check your certificate and username.</source>
     </message>
     <message>
         <location line="+3"/>
-        <source>%2%1: %3</source>
+        <source>%2%1: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/src/mumble/mumble_en.ts
+++ b/src/mumble/mumble_en.ts
@@ -4875,7 +4875,6 @@ This field describes the size of an LCD device. The size is given either in pixe
     <message>
         <location line="+0"/>
         <source>To %1 (Tree): </source>
-        <oldsource>(Tree) %1: %2</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/src/mumble/mumble_es.ts
+++ b/src/mumble/mumble_es.ts
@@ -5777,7 +5777,6 @@ De lo contrario, aborte y compruebe su certificado y nombre de usuario.</transla
     <message>
         <location line="+301"/>
         <source>To %1 (Tree): </source>
-        <oldsource>(Tree) %1: %2</oldsource>
         <translation>Al (Árbol) %1: </translation>
     </message>
     <message>

--- a/src/mumble/mumble_es.ts
+++ b/src/mumble/mumble_es.ts
@@ -2368,7 +2368,6 @@ Hable fuerte en voz alta, como cuando está molesto o entusiasmado. Baje el volu
         <source>Ban List - %n Ban(s)</source>
         <translation type="unfinished">
             <numerusform></numerusform>
-            <numerusform></numerusform>
         </translation>
     </message>
 </context>
@@ -5177,8 +5176,8 @@ Las opciones válidas son:
     </message>
     <message>
         <location line="+3"/>
-        <source>%2%1: %3</source>
-        <translation>%2%1: %3</translation>
+        <source>%2%1: </source>
+        <translation>%2%1: </translation>
     </message>
     <message>
         <location line="+201"/>
@@ -5398,8 +5397,8 @@ Las opciones válidas son:
         <location line="+83"/>
         <location line="+4"/>
         <location line="+259"/>
-        <source>To %1: %2</source>
-        <translation>A %1: %2</translation>
+        <source>To %1: </source>
+        <translation>A %1: </translation>
     </message>
     <message>
         <location line="-346"/>
@@ -5777,9 +5776,9 @@ De lo contrario, aborte y compruebe su certificado y nombre de usuario.</transla
     </message>
     <message>
         <location line="+301"/>
-        <source>To %1 (Tree): %2</source>
+        <source>To %1 (Tree): </source>
         <oldsource>(Tree) %1: %2</oldsource>
-        <translation>Al (Árbol) %1: %2</translation>
+        <translation>Al (Árbol) %1: </translation>
     </message>
     <message>
         <location line="+574"/>
@@ -7676,7 +7675,6 @@ Una credencial de acceso es una cadena de texto que puede ser usada como contras
         <location filename="UserEdit.cpp" line="-64"/>
         <source>Registered users: %n account(s)</source>
         <translation type="unfinished">
-            <numerusform></numerusform>
             <numerusform></numerusform>
         </translation>
     </message>

--- a/src/mumble/mumble_fr.ts
+++ b/src/mumble/mumble_fr.ts
@@ -5351,8 +5351,8 @@ Les options valides sont :
     </message>
     <message>
         <location line="+3"/>
-        <source>%2%1: %3</source>
-        <translation>%2%1 : %3</translation>
+        <source>%2%1: </source>
+        <translation>%2%1 : </translation>
     </message>
     <message>
         <location line="+201"/>
@@ -5506,8 +5506,8 @@ Les options valides sont :
         <location line="+83"/>
         <location line="+4"/>
         <location line="+259"/>
-        <source>To %1: %2</source>
-        <translation>À %1 : %2</translation>
+        <source>To %1: </source>
+        <translation>À %1 : </translation>
     </message>
     <message>
         <location line="-346"/>
@@ -5527,9 +5527,9 @@ Les options valides sont :
     </message>
     <message>
         <location line="+301"/>
-        <source>To %1 (Tree): %2</source>
+        <source>To %1 (Tree): </source>
         <oldsource>(Tree) %1: %2</oldsource>
-        <translation>À l&apos;arborescence %1 : %2</translation>
+        <translation>À l&apos;arborescence %1 : </translation>
     </message>
     <message>
         <location line="+803"/>

--- a/src/mumble/mumble_fr.ts
+++ b/src/mumble/mumble_fr.ts
@@ -5528,7 +5528,6 @@ Les options valides sont :
     <message>
         <location line="+301"/>
         <source>To %1 (Tree): </source>
-        <oldsource>(Tree) %1: %2</oldsource>
         <translation>À l&apos;arborescence %1 : </translation>
     </message>
     <message>

--- a/src/mumble/mumble_he.ts
+++ b/src/mumble/mumble_he.ts
@@ -2406,7 +2406,6 @@ Speak loudly, as when you are annoyed or excited. Decrease the volume in the sou
         <source>Ban List - %n Ban(s)</source>
         <translation type="unfinished">
             <numerusform></numerusform>
-            <numerusform></numerusform>
         </translation>
     </message>
 </context>
@@ -4763,7 +4762,7 @@ This field describes the size of an LCD device. The size is given either in pixe
     </message>
     <message>
         <location line="-2"/>
-        <source>To %1 (Tree): %2</source>
+        <source>To %1 (Tree): </source>
         <translation>אל %1 (עץ): %2</translation>
     </message>
     <message>
@@ -4935,8 +4934,8 @@ This field describes the size of an LCD device. The size is given either in pixe
         <location line="+83"/>
         <location line="+4"/>
         <location line="+259"/>
-        <source>To %1: %2</source>
-        <translation type="unfinished">&lt;p dir=&quot;RTL&quot;&gt;אל %1: %2&lt;/p&gt;</translation>
+        <source>To %1: </source>
+        <translation type="unfinished">אל %1: </translation>
     </message>
     <message>
         <location line="-346"/>
@@ -5910,8 +5909,8 @@ Otherwise abort and check your certificate and username.</source>
     </message>
     <message>
         <location line="+3"/>
-        <source>%2%1: %3</source>
-        <translation>%2%1: %3</translation>
+        <source>%2%1: </source>
+        <translation>%2%1: </translation>
     </message>
     <message>
         <location line="+201"/>
@@ -7712,7 +7711,6 @@ An access token is a text string, which can be used as a password for very simpl
         <location filename="UserEdit.cpp" line="-64"/>
         <source>Registered users: %n account(s)</source>
         <translation type="unfinished">
-            <numerusform></numerusform>
             <numerusform></numerusform>
         </translation>
     </message>

--- a/src/mumble/mumble_hu.ts
+++ b/src/mumble/mumble_hu.ts
@@ -4801,8 +4801,8 @@ Ez a mező mutatja egy LCD eszköz méretét. A méret vagy pixelben (a grafikus
         <location line="+83"/>
         <location line="+4"/>
         <location line="+259"/>
-        <source>To %1: %2</source>
-        <translation>%1 felhasználónak: %2</translation>
+        <source>To %1: </source>
+        <translation>%1 felhasználónak: </translation>
     </message>
     <message>
         <location line="-346"/>
@@ -4892,7 +4892,7 @@ Ez a mező mutatja egy LCD eszköz méretét. A méret vagy pixelben (a grafikus
     </message>
     <message>
         <location line="+0"/>
-        <source>To %1 (Tree): %2</source>
+        <source>To %1 (Tree): </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -5990,8 +5990,8 @@ Otherwise abort and check your certificate and username.</source>
     </message>
     <message>
         <location line="+3"/>
-        <source>%2%1: %3</source>
-        <translation>%2%1: %3</translation>
+        <source>%2%1: </source>
+        <translation>%2%1: </translation>
     </message>
     <message>
         <location line="+174"/>

--- a/src/mumble/mumble_it.ts
+++ b/src/mumble/mumble_it.ts
@@ -4801,7 +4801,6 @@ certificato ed il nome utente.</translation>
     <message>
         <location line="-2"/>
         <source>To %1 (Tree): </source>
-        <oldsource>(Tree) %1: %2</oldsource>
         <translation type="unfinished">Per il canale %1 e sottocanali: </translation>
     </message>
     <message>
@@ -4809,7 +4808,6 @@ certificato ed il nome utente.</translation>
         <location line="+83"/>
         <location line="+4"/>
         <location line="+259"/>
-        <oldsource>%1: %2</oldsource>
         <source>To %1: </source>
         <translation>Per %1: </translation>
     </message>

--- a/src/mumble/mumble_it.ts
+++ b/src/mumble/mumble_it.ts
@@ -2369,7 +2369,6 @@ Parla ad alta voce, come quando sei infastidito o eccitato. Poi diminuisci il vo
         <source>Ban List - %n Ban(s)</source>
         <translation type="unfinished">
             <numerusform></numerusform>
-            <numerusform></numerusform>
         </translation>
     </message>
 </context>
@@ -4801,18 +4800,18 @@ certificato ed il nome utente.</translation>
     </message>
     <message>
         <location line="-2"/>
-        <source>To %1 (Tree): %2</source>
+        <source>To %1 (Tree): </source>
         <oldsource>(Tree) %1: %2</oldsource>
-        <translation>Per il canale %1 e sottocanali:%2</translation>
+        <translation type="unfinished">Per il canale %1 e sottocanali: </translation>
     </message>
     <message>
         <location line="-344"/>
         <location line="+83"/>
         <location line="+4"/>
         <location line="+259"/>
-        <source>To %1: %2</source>
         <oldsource>%1: %2</oldsource>
-        <translation>Per %1: %2</translation>
+        <source>To %1: </source>
+        <translation>Per %1: </translation>
     </message>
     <message>
         <location line="+623"/>
@@ -5845,8 +5844,8 @@ certificato ed il nome utente.</translation>
     </message>
     <message>
         <location line="+3"/>
-        <source>%2%1: %3</source>
-        <translation>%2%1: %3</translation>
+        <source>%2%1: </source>
+        <translation>%2%1: </translation>
     </message>
     <message>
         <location line="+201"/>
@@ -7681,7 +7680,6 @@ Un token di accesso è una stringa di testo, che può essere usata come password
         <location filename="UserEdit.cpp" line="-64"/>
         <source>Registered users: %n account(s)</source>
         <translation type="unfinished">
-            <numerusform></numerusform>
             <numerusform></numerusform>
         </translation>
     </message>

--- a/src/mumble/mumble_ja.ts
+++ b/src/mumble/mumble_ja.ts
@@ -5199,7 +5199,7 @@ This field describes the size of an LCD device. The size is given either in pixe
     </message>
     <message>
         <location line="+3"/>
-        <source>%2%1: %3</source>
+        <source>%2%1: </source>
         <translation></translation>
     </message>
     <message>
@@ -5416,8 +5416,8 @@ Valid options are:
         <location line="+83"/>
         <location line="+4"/>
         <location line="+259"/>
-        <source>To %1: %2</source>
-        <translation>%1 宛: %2</translation>
+        <source>To %1: </source>
+        <translation>%1 宛: </translation>
     </message>
     <message>
         <location line="-346"/>
@@ -5437,9 +5437,9 @@ Valid options are:
     </message>
     <message>
         <location line="+301"/>
-        <source>To %1 (Tree): %2</source>
+        <source>To %1 (Tree): </source>
         <oldsource>(Tree) %1: %2</oldsource>
-        <translation>(ツリー） %1宛: %2</translation>
+        <translation>(ツリー） %1宛: </translation>
     </message>
     <message>
         <location line="+803"/>

--- a/src/mumble/mumble_ja.ts
+++ b/src/mumble/mumble_ja.ts
@@ -5438,7 +5438,6 @@ Valid options are:
     <message>
         <location line="+301"/>
         <source>To %1 (Tree): </source>
-        <oldsource>(Tree) %1: %2</oldsource>
         <translation>(ツリー） %1宛: </translation>
     </message>
     <message>

--- a/src/mumble/mumble_nl.ts
+++ b/src/mumble/mumble_nl.ts
@@ -2345,7 +2345,6 @@ Speak loudly, as when you are annoyed or excited. Decrease the volume in the sou
         <source>Ban List - %n Ban(s)</source>
         <translation type="unfinished">
             <numerusform></numerusform>
-            <numerusform></numerusform>
         </translation>
     </message>
 </context>
@@ -4860,7 +4859,7 @@ This field describes the size of an LCD device. The size is given either in pixe
         <location line="+83"/>
         <location line="+4"/>
         <location line="+259"/>
-        <source>To %1: %2</source>
+        <source>To %1: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -4891,7 +4890,7 @@ This field describes the size of an LCD device. The size is given either in pixe
     </message>
     <message>
         <location line="+0"/>
-        <source>To %1 (Tree): %2</source>
+        <source>To %1 (Tree): </source>
         <oldsource>(Tree) %1: %2</oldsource>
         <translation type="unfinished"></translation>
     </message>
@@ -5824,7 +5823,7 @@ Otherwise abort and check your certificate and username.</source>
     </message>
     <message>
         <location line="+3"/>
-        <source>%2%1: %3</source>
+        <source>%2%1: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -7601,7 +7600,6 @@ An access token is a text string, which can be used as a password for very simpl
         <location filename="UserEdit.cpp" line="-64"/>
         <source>Registered users: %n account(s)</source>
         <translation type="unfinished">
-            <numerusform></numerusform>
             <numerusform></numerusform>
         </translation>
     </message>

--- a/src/mumble/mumble_nl.ts
+++ b/src/mumble/mumble_nl.ts
@@ -4891,7 +4891,6 @@ This field describes the size of an LCD device. The size is given either in pixe
     <message>
         <location line="+0"/>
         <source>To %1 (Tree): </source>
-        <oldsource>(Tree) %1: %2</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/src/mumble/mumble_pl.ts
+++ b/src/mumble/mumble_pl.ts
@@ -5003,8 +5003,8 @@ Te pole opisuje rozmiar urządzenia LCD. Rozmiar jest podany w pikselach lub w z
     </message>
     <message>
         <location line="+3"/>
-        <source>%2%1: %3</source>
-        <translation>%2%1: %3</translation>
+        <source>%2%1: </source>
+        <translation>%2%1: </translation>
     </message>
     <message>
         <location line="+201"/>
@@ -5493,8 +5493,8 @@ W przeciwnym razie proszę przerwać i sprawdzić swój certyfikat oraz nazwę u
         <location line="+83"/>
         <location line="+4"/>
         <location line="+259"/>
-        <source>To %1: %2</source>
-        <translation>Do %1: %2</translation>
+        <source>To %1: </source>
+        <translation>Do %1: </translation>
     </message>
     <message>
         <location line="-346"/>
@@ -5514,9 +5514,9 @@ W przeciwnym razie proszę przerwać i sprawdzić swój certyfikat oraz nazwę u
     </message>
     <message>
         <location line="+301"/>
-        <source>To %1 (Tree): %2</source>
+        <source>To %1 (Tree): </source>
         <oldsource>(Tree) %1: %2</oldsource>
-        <translation>(Do drzewa kanałów) %1: %2</translation>
+        <translation>(Do drzewa kanałów) %1: </translation>
     </message>
     <message>
         <location line="+625"/>

--- a/src/mumble/mumble_pl.ts
+++ b/src/mumble/mumble_pl.ts
@@ -5515,7 +5515,6 @@ W przeciwnym razie proszę przerwać i sprawdzić swój certyfikat oraz nazwę u
     <message>
         <location line="+301"/>
         <source>To %1 (Tree): </source>
-        <oldsource>(Tree) %1: %2</oldsource>
         <translation>(Do drzewa kanałów) %1: </translation>
     </message>
     <message>

--- a/src/mumble/mumble_pt_BR.ts
+++ b/src/mumble/mumble_pt_BR.ts
@@ -2350,7 +2350,6 @@ Fale alto, como quando você está incomodado ou animado. Diminua o volume no pa
         <source>Ban List - %n Ban(s)</source>
         <translation type="unfinished">
             <numerusform></numerusform>
-            <numerusform></numerusform>
         </translation>
     </message>
 </context>
@@ -4875,8 +4874,8 @@ Este campo descreve o tamanho de um dispositivo LCD. O tamanho é dado em pixels
         <location line="+83"/>
         <location line="+4"/>
         <location line="+259"/>
-        <source>To %1: %2</source>
-        <translation>Para %1: %2</translation>
+        <source>To %1: </source>
+        <translation>Para %1: </translation>
     </message>
     <message>
         <location line="-346"/>
@@ -4906,8 +4905,8 @@ Este campo descreve o tamanho de um dispositivo LCD. O tamanho é dado em pixels
     </message>
     <message>
         <location line="+0"/>
-        <source>To %1 (Tree): %2</source>
-        <translation>Para %1 (Árvore): %2</translation>
+        <source>To %1 (Tree): </source>
+        <translation>Para %1 (Árvore): </translation>
     </message>
     <message>
         <location line="+163"/>
@@ -5839,8 +5838,8 @@ seu certificado e nome de usuário.</translation>
     </message>
     <message>
         <location line="+3"/>
-        <source>%2%1: %3</source>
-        <translation>%2%1: %3</translation>
+        <source>%2%1: </source>
+        <translation>%2%1: </translation>
     </message>
     <message>
         <location line="+201"/>
@@ -7635,7 +7634,6 @@ Uma credencial de acesso é uma cadeia de caracteres de texto, que podem ser usa
         <location filename="UserEdit.cpp" line="-64"/>
         <source>Registered users: %n account(s)</source>
         <translation type="unfinished">
-            <numerusform></numerusform>
             <numerusform></numerusform>
         </translation>
     </message>

--- a/src/mumble/mumble_pt_PT.ts
+++ b/src/mumble/mumble_pt_PT.ts
@@ -4935,7 +4935,6 @@ Este campo descreve o tamanho de um dispositivo LCD. O tamanho é dado em pixels
     <message>
         <location line="+0"/>
         <source>To %1 (Tree): </source>
-        <oldsource>(Tree) %1: %2</oldsource>
         <translation>Para %1 (Árvore): </translation>
     </message>
     <message>

--- a/src/mumble/mumble_pt_PT.ts
+++ b/src/mumble/mumble_pt_PT.ts
@@ -2366,7 +2366,6 @@ Fale alto, como quando está incomodado ou animado. Diminua o volume no painel d
         <source>Ban List - %n Ban(s)</source>
         <translation type="unfinished">
             <numerusform></numerusform>
-            <numerusform></numerusform>
         </translation>
     </message>
 </context>
@@ -4904,8 +4903,8 @@ Este campo descreve o tamanho de um dispositivo LCD. O tamanho é dado em pixels
         <location line="+83"/>
         <location line="+4"/>
         <location line="+259"/>
-        <source>To %1: %2</source>
-        <translation>Para %1: %2</translation>
+        <source>To %1: </source>
+        <translation>Para %1: </translation>
     </message>
     <message>
         <location line="-346"/>
@@ -4935,9 +4934,9 @@ Este campo descreve o tamanho de um dispositivo LCD. O tamanho é dado em pixels
     </message>
     <message>
         <location line="+0"/>
-        <source>To %1 (Tree): %2</source>
+        <source>To %1 (Tree): </source>
         <oldsource>(Tree) %1: %2</oldsource>
-        <translation>Para %1 (Árvore): %2</translation>
+        <translation>Para %1 (Árvore): </translation>
     </message>
     <message>
         <location line="+163"/>
@@ -5871,8 +5870,8 @@ o seu certificado e nome de utilizador.</translation>
     </message>
     <message>
         <location line="+3"/>
-        <source>%2%1: %3</source>
-        <translation>%2%1: %3</translation>
+        <source>%2%1: </source>
+        <translation>%2%1: </translation>
     </message>
     <message>
         <location line="+201"/>
@@ -7672,7 +7671,6 @@ Uma credencial de acesso é uma sequência de texto, que pode ser usada como uma
         <location filename="UserEdit.cpp" line="-64"/>
         <source>Registered users: %n account(s)</source>
         <translation type="unfinished">
-            <numerusform></numerusform>
             <numerusform></numerusform>
         </translation>
     </message>

--- a/src/mumble/mumble_ru.ts
+++ b/src/mumble/mumble_ru.ts
@@ -5378,7 +5378,6 @@ mumble://[&lt;логин&gt;[:&lt;пароль&gt;]@]&lt;хост&gt;[:&lt;по�
     <message>
         <location line="+301"/>
         <source>To %1 (Tree): </source>
-        <oldsource>(Tree) %1: %2</oldsource>
         <translation>Для %1 (Дерево): </translation>
     </message>
     <message>

--- a/src/mumble/mumble_ru.ts
+++ b/src/mumble/mumble_ru.ts
@@ -2334,8 +2334,6 @@ Speak loudly, as when you are annoyed or excited. Decrease the volume in the sou
         <source>Ban List - %n Ban(s)</source>
         <translation type="unfinished">
             <numerusform></numerusform>
-            <numerusform></numerusform>
-            <numerusform></numerusform>
         </translation>
     </message>
 </context>
@@ -5145,8 +5143,8 @@ This field describes the size of an LCD device. The size is given either in pixe
     </message>
     <message>
         <location line="+3"/>
-        <source>%2%1: %3</source>
-        <translation>%2%1: %3</translation>
+        <source>%2%1: </source>
+        <translation>%2%1: </translation>
     </message>
     <message>
         <location line="+201"/>
@@ -5363,8 +5361,8 @@ mumble://[&lt;логин&gt;[:&lt;пароль&gt;]@]&lt;хост&gt;[:&lt;по�
         <location line="+83"/>
         <location line="+4"/>
         <location line="+259"/>
-        <source>To %1: %2</source>
-        <translation>Для %1: %2</translation>
+        <source>To %1: </source>
+        <translation>Для %1: </translation>
     </message>
     <message>
         <location line="-346"/>
@@ -5379,9 +5377,9 @@ mumble://[&lt;логин&gt;[:&lt;пароль&gt;]@]&lt;хост&gt;[:&lt;по�
     </message>
     <message>
         <location line="+301"/>
-        <source>To %1 (Tree): %2</source>
+        <source>To %1 (Tree): </source>
         <oldsource>(Tree) %1: %2</oldsource>
-        <translation>Для %1 (Дерево): %2</translation>
+        <translation>Для %1 (Дерево): </translation>
     </message>
     <message>
         <location line="+803"/>
@@ -7615,8 +7613,6 @@ An access token is a text string, which can be used as a password for very simpl
         <location filename="UserEdit.cpp" line="-64"/>
         <source>Registered users: %n account(s)</source>
         <translation type="unfinished">
-            <numerusform></numerusform>
-            <numerusform></numerusform>
             <numerusform></numerusform>
         </translation>
     </message>

--- a/src/mumble/mumble_sv.ts
+++ b/src/mumble/mumble_sv.ts
@@ -2367,7 +2367,6 @@ Tala högt, som om du är irriterad eller upphetsad. Minska volymen i kontrollpa
         <source>Ban List - %n Ban(s)</source>
         <translation type="unfinished">
             <numerusform></numerusform>
-            <numerusform></numerusform>
         </translation>
     </message>
 </context>
@@ -4909,8 +4908,8 @@ Detta fält beskriver storleken av en LCD-enhet. Storleken mäts i pixlar (för 
         <location line="+83"/>
         <location line="+4"/>
         <location line="+259"/>
-        <source>To %1: %2</source>
-        <translation>Till %1: %2</translation>
+        <source>To %1: </source>
+        <translation>Till %1: </translation>
     </message>
     <message>
         <location line="-346"/>
@@ -4940,9 +4939,9 @@ Detta fält beskriver storleken av en LCD-enhet. Storleken mäts i pixlar (för 
     </message>
     <message>
         <location line="+0"/>
-        <source>To %1 (Tree): %2</source>
+        <source>To %1 (Tree): </source>
         <oldsource>(Tree) %1: %2</oldsource>
-        <translation>Till %1 (Träd): %2</translation>
+        <translation>Till %1 (Träd): </translation>
     </message>
     <message>
         <location line="+163"/>
@@ -5875,8 +5874,8 @@ Om inte, avbryt och kontrollera ditt certifikat eller användarnamn.</translatio
     </message>
     <message>
         <location line="+3"/>
-        <source>%2%1: %3</source>
-        <translation>%2%1: %3</translation>
+        <source>%2%1: </source>
+        <translation>%2%1: </translation>
     </message>
     <message>
         <location line="+201"/>
@@ -7677,7 +7676,6 @@ En token är en textsträng, som kan användas som ett lösenord för enkel till
         <location filename="UserEdit.cpp" line="-64"/>
         <source>Registered users: %n account(s)</source>
         <translation type="unfinished">
-            <numerusform></numerusform>
             <numerusform></numerusform>
         </translation>
     </message>

--- a/src/mumble/mumble_sv.ts
+++ b/src/mumble/mumble_sv.ts
@@ -4940,7 +4940,6 @@ Detta fält beskriver storleken av en LCD-enhet. Storleken mäts i pixlar (för 
     <message>
         <location line="+0"/>
         <source>To %1 (Tree): </source>
-        <oldsource>(Tree) %1: %2</oldsource>
         <translation>Till %1 (Träd): </translation>
     </message>
     <message>

--- a/src/mumble/mumble_tr.ts
+++ b/src/mumble/mumble_tr.ts
@@ -4878,8 +4878,8 @@ Bu alan LCD cihazın boyutunu belirtir. Boyut ya piksel olarak (Grafik LCD ekran
         <location line="+83"/>
         <location line="+4"/>
         <location line="+259"/>
-        <source>To %1: %2</source>
-        <translation>Şuna: %1: %2</translation>
+        <source>To %1: </source>
+        <translation>Şuna: %1: </translation>
     </message>
     <message>
         <location line="-346"/>
@@ -4909,8 +4909,8 @@ Bu alan LCD cihazın boyutunu belirtir. Boyut ya piksel olarak (Grafik LCD ekran
     </message>
     <message>
         <location line="+0"/>
-        <source>To %1 (Tree): %2</source>
-        <translation>Şuna: %1 (Ağaç): %2</translation>
+        <source>To %1 (Tree): </source>
+        <translation>Şuna: %1 (Ağaç): </translation>
     </message>
     <message>
         <location line="+163"/>
@@ -5841,8 +5841,8 @@ deneyiniz. Yoksa iptal edip parolanızı kontrol ediniz.</translation>
     </message>
     <message>
         <location line="+3"/>
-        <source>%2%1: %3</source>
-        <translation>%2%1: %3</translation>
+        <source>%2%1: </source>
+        <translation>%2%1: </translation>
     </message>
     <message>
         <location line="+201"/>

--- a/src/mumble/mumble_zh_CN.ts
+++ b/src/mumble/mumble_zh_CN.ts
@@ -4954,7 +4954,6 @@ This field describes the size of an LCD device. The size is given either in pixe
     <message>
         <location line="+0"/>
         <source>To %1 (Tree): </source>
-        <oldsource>(Tree) %1: %2</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/src/mumble/mumble_zh_CN.ts
+++ b/src/mumble/mumble_zh_CN.ts
@@ -4922,7 +4922,7 @@ This field describes the size of an LCD device. The size is given either in pixe
         <location line="+83"/>
         <location line="+4"/>
         <location line="+259"/>
-        <source>To %1: %2</source>
+        <source>To %1: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -4953,7 +4953,7 @@ This field describes the size of an LCD device. The size is given either in pixe
     </message>
     <message>
         <location line="+0"/>
-        <source>To %1 (Tree): %2</source>
+        <source>To %1 (Tree): </source>
         <oldsource>(Tree) %1: %2</oldsource>
         <translation type="unfinished"></translation>
     </message>
@@ -5887,7 +5887,7 @@ Otherwise abort and check your certificate and username.</source>
     </message>
     <message>
         <location line="+3"/>
-        <source>%2%1: %3</source>
+        <source>%2%1: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/src/mumble/mumble_zh_TW.ts
+++ b/src/mumble/mumble_zh_TW.ts
@@ -4705,7 +4705,6 @@ This field describes the size of an LCD device. The size is given either in pixe
     <message>
         <location line="-2"/>
         <source>To %1 (Tree): </source>
-        <oldsource>(Tree) %1: %2</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -4713,7 +4712,6 @@ This field describes the size of an LCD device. The size is given either in pixe
         <location line="+83"/>
         <location line="+4"/>
         <location line="+259"/>
-        <oldsource>%1: %2</oldsource>
         <source>To %1: </source>
         <translation type="unfinished">發送給 %1: </translation>
     </message>

--- a/src/mumble/mumble_zh_TW.ts
+++ b/src/mumble/mumble_zh_TW.ts
@@ -4704,7 +4704,7 @@ This field describes the size of an LCD device. The size is given either in pixe
     </message>
     <message>
         <location line="-2"/>
-        <source>To %1 (Tree): %2</source>
+        <source>To %1 (Tree): </source>
         <oldsource>(Tree) %1: %2</oldsource>
         <translation type="unfinished"></translation>
     </message>
@@ -4713,9 +4713,9 @@ This field describes the size of an LCD device. The size is given either in pixe
         <location line="+83"/>
         <location line="+4"/>
         <location line="+259"/>
-        <source>To %1: %2</source>
         <oldsource>%1: %2</oldsource>
-        <translation type="unfinished">發送給 %1: %2</translation>
+        <source>To %1: </source>
+        <translation type="unfinished">發送給 %1: </translation>
     </message>
     <message>
         <location line="-716"/>
@@ -5772,7 +5772,7 @@ Otherwise abort and check your certificate and username.</source>
     </message>
     <message>
         <location line="+3"/>
-        <source>%2%1: %3</source>
+        <source>%2%1: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>


### PR DESCRIPTION
Fix of issue #1188.  If a text message was too big to be displayed in the log, it would be converted to plain text, including any Mumble prefix containing user or channel links.  This PR prevents those links from being converted to plain text, as seen below:

**Before patch**:
![Before](https://cloud.githubusercontent.com/assets/110883/2687257/821936a0-c245-11e3-815e-4b71c684c43f.png)

**With patch**:
![With](https://cloud.githubusercontent.com/assets/110883/2687258/821a83a2-c245-11e3-848f-8a65c0bd7e43.png)

Fixes #1188