### PR TITLE
Added ability to set a custom timestamp format for chat log messages

### DIFF
--- a/icons/tango/actions/list-add.svg
+++ b/icons/tango/actions/list-add.svg
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+<svg id="svg6431" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns="http://www.w3.org/2000/svg" sodipodi:docname="list-add.svg" xmlns:sodipodi="http://inkscape.sourceforge.net/DTD/sodipodi-0.dtd" height="48px" sodipodi:version="0.32" width="48px" xmlns:cc="http://web.resource.org/cc/" xmlns:xlink="http://www.w3.org/1999/xlink" sodipodi:docbase="/home/jimmac/src/cvs/tango-icon-theme/scalable/actions" xmlns:dc="http://purl.org/dc/elements/1.1/">
+ <defs id="defs6433">
+  <linearGradient id="linearGradient4975" y2="48.548" gradientUnits="userSpaceOnUse" x2="45.919" gradientTransform="translate(-18.018 -13.571)" y1="36.423" x1="34.893">
+   <stop id="stop1324" stop-color="#729fcf" offset="0"/>
+   <stop id="stop1326" stop-color="#5187d6" offset="1"/>
+  </linearGradient>
+  <linearGradient id="linearGradient7922" y2="34.977" gradientUnits="userSpaceOnUse" x2="27.901" y1="22.852" x1="16.875">
+   <stop id="stop7918" stop-color="#fff" offset="0"/>
+   <stop id="stop7920" stop-color="#fff" stop-opacity=".34021" offset="1"/>
+  </linearGradient>
+  <radialGradient id="radialGradient2097" gradientUnits="userSpaceOnUse" cy="35.127" cx="23.071" gradientTransform="matrix(.91481 .012650 -.0082150 .21356 2.2539 27.189)" r="10.319">
+   <stop id="stop2093" offset="0"/>
+   <stop id="stop2095" stop-opacity="0" offset="1"/>
+  </radialGradient>
+ </defs>
+ <sodipodi:namedview id="base" bordercolor="#666666" pagecolor="#ffffff" showgrid="false" borderopacity="0.15686275" showguides="true"/>
+ <metadata id="metadata6436">
+  <rdf:RDF>
+   <cc:Work rdf:about="">
+    <dc:format>image/svg+xml</dc:format>
+    <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
+    <dc:title>Add</dc:title>
+    <dc:date>2006-01-04</dc:date>
+    <dc:creator>
+     <cc:Agent>
+      <dc:title>Andreas Nilsson</dc:title>
+     </cc:Agent>
+    </dc:creator>
+    <dc:source>http://tango-project.org</dc:source>
+    <dc:subject>
+     <rdf:Bag>
+      <rdf:li>add</rdf:li>
+      <rdf:li>plus</rdf:li>
+     </rdf:Bag>
+    </dc:subject>
+    <cc:license rdf:resource="http://creativecommons.org/licenses/by-sa/2.0/"/>
+   </cc:Work>
+   <cc:License rdf:about="http://creativecommons.org/licenses/by-sa/2.0/">
+    <cc:permits rdf:resource="http://web.resource.org/cc/Reproduction"/>
+    <cc:permits rdf:resource="http://web.resource.org/cc/Distribution"/>
+    <cc:requires rdf:resource="http://web.resource.org/cc/Notice"/>
+    <cc:requires rdf:resource="http://web.resource.org/cc/Attribution"/>
+    <cc:permits rdf:resource="http://web.resource.org/cc/DerivativeWorks"/>
+    <cc:requires rdf:resource="http://web.resource.org/cc/ShareAlike"/>
+   </cc:License>
+  </rdf:RDF>
+ </metadata>
+ <g id="layer1">
+  <path id="path1361" sodipodi:rx="10.319340" sodipodi:ry="2.3201940" sodipodi:type="arc" d="m33.278 34.941a10.319 2.3202 0 1 1 -20.638 0 10.319 2.3202 0 1 1 20.638 0z" opacity=".2" transform="matrix(1.5505 0 0 1.293 -11.597 -8.1782)" sodipodi:cy="34.940620" sodipodi:cx="22.958872" fill="url(#radialGradient2097)"/>
+  <path id="text1314" d="m27.514 37.543v-9.027l9.979-0.04v-6.996h-9.97l-0.009-9.96-7.016 0.011 0.005 9.931-9.99 0.074-0.036 6.969 10.034-0.029 0.007 9.04 6.996 0.027z" sodipodi:nodetypes="ccccccccccccc" stroke="#3465a4" stroke-width="1px" fill="#75a1d0"/>
+  <path id="path7076" opacity=".40860" d="m26.499 36.534v-9.034h10.002l-0.006-5.025h-9.987v-9.995l-4.995 0.018 0.009 9.977-10.026 0.018-0.027 4.973 10.064 0.009-0.013 9.028 4.979 0.031z" sodipodi:nodetypes="ccccccccccccc" stroke="url(#linearGradient7922)" stroke-width="1px" fill="url(#linearGradient4975)"/>
+  <path id="path7914" opacity=".31183" d="m11 25c0 1.938 25.984-0.969 25.984-0.031v-3l-9.984 0.031v-9.965h-6v9.965h-10v3z" fill-rule="evenodd" sodipodi:nodetypes="ccccccccc" fill="#fff"/>
+ </g>
+</svg>

--- a/src/mumble/Log.h
+++ b/src/mumble/Log.h
@@ -45,9 +45,11 @@ class LogConfig : public ConfigWidget, public Ui::LogConfig {
 	private:
 		Q_OBJECT
 		Q_DISABLE_COPY(LogConfig)
+		QMenu *qmTimeFormatList;
 	public:
 		enum Column { ColMessage, ColConsole, ColNotification, ColTTS, ColStaticSound, ColStaticSoundPath };
 		LogConfig(Settings &st);
+		~LogConfig();
 		virtual QString title() const;
 		virtual QIcon icon() const;
 	public slots:
@@ -56,6 +58,7 @@ class LogConfig : public ConfigWidget, public Ui::LogConfig {
 		virtual void load(const Settings &);
 		virtual bool expert(bool);
 
+		void on_qtbTimeFormatList_triggered(QAction *action);
 		void on_qtwMessages_itemChanged(QTreeWidgetItem*, int);
 		void on_qtwMessages_itemClicked(QTreeWidgetItem*, int);
 		void on_qtwMessages_itemDoubleClicked(QTreeWidgetItem*, int);

--- a/src/mumble/Log.ui
+++ b/src/mumble/Log.ui
@@ -206,7 +206,7 @@
       <item row="0" column="3">
        <widget class="QLabel" name="qlTimeFormat">
         <property name="text">
-         <string>Custom time format</string>
+         <string>Custom timestamp format</string>
         </property>
        </widget>
       </item>

--- a/src/mumble/Log.ui
+++ b/src/mumble/Log.ui
@@ -225,6 +225,9 @@
         <property name="popupMode">
          <enum>QToolButton::InstantPopup</enum>
         </property>
+        <property name="toolTip">
+         <string>Insert an element into your custom timestamp format</string>
+        </property>
         <property name="icon">
          <iconset resource="mumble_tango.qrc">
           <normaloff>skin:actions/list-add.svg</normaloff>skin:actions/list-add.svg</iconset>

--- a/src/mumble/Log.ui
+++ b/src/mumble/Log.ui
@@ -203,24 +203,41 @@
         </property>
        </widget>
       </item>
-      <item row="0" column="2">
-       <spacer name="horizontalSpacer">
-        <property name="orientation">
-         <enum>Qt::Horizontal</enum>
+      <item row="0" column="3">
+       <widget class="QLabel" name="qlTimeFormat">
+        <property name="text">
+         <string>Custom time format</string>
         </property>
-        <property name="sizeHint" stdset="0">
-         <size>
-          <width>8</width>
-          <height>16</height>
-         </size>
+       </widget>
+      </item>
+      <item row="0" column="4">
+       <widget class="QLineEdit" name="qleTimeFormat">
+        <property name="placeholderText">
+         <string>Type to override default</string>
         </property>
-       </spacer>
+        <property name="maxLength">
+         <number>100</number>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="5">
+       <widget class="QToolButton" name="qtbTimeFormatList">
+        <property name="popupMode">
+         <enum>QToolButton::InstantPopup</enum>
+        </property>
+        <property name="icon">
+         <iconset resource="mumble_tango.qrc">
+          <normaloff>skin:actions/list-add.svg</normaloff>skin:actions/list-add.svg</iconset>
+        </property>
+       </widget>
       </item>
      </layout>
     </widget>
    </item>
   </layout>
  </widget>
- <resources/>
+ <resources>
+  <include location="mumble_tango.qrc"/>
+ </resources>
  <connections/>
 </ui>

--- a/src/mumble/Settings.cpp
+++ b/src/mumble/Settings.cpp
@@ -681,6 +681,7 @@ void Settings::load(QSettings* settings_ptr) {
 	SAVELOAD(qbaConnectDialogHeader, "ui/connect/header");
 	SAVELOAD(bHighContrast, "ui/HighContrast");
 	SAVELOAD(iMaxLogBlocks, "ui/MaxLogBlocks");
+	SAVELOAD(qsLogTimeFormat, "ui/LogTimeFormat");
 
 	// PTT Button window
 	SAVELOAD(bShowPTTButtonWindow, "ui/showpttbuttonwindow");
@@ -971,6 +972,7 @@ void Settings::save() {
 	SAVELOAD(qbaConnectDialogHeader, "ui/connect/header");
 	SAVELOAD(bHighContrast, "ui/HighContrast");
 	SAVELOAD(iMaxLogBlocks, "ui/MaxLogBlocks");
+	SAVELOAD(qsLogTimeFormat, "ui/LogTimeFormat");
 
 	// PTT Button window
 	SAVELOAD(bShowPTTButtonWindow, "ui/showpttbuttonwindow");

--- a/src/mumble/Settings.h
+++ b/src/mumble/Settings.h
@@ -237,6 +237,7 @@ struct Settings {
 
 	enum MessageLog { LogNone = 0x00, LogConsole = 0x01, LogTTS = 0x02, LogBalloon = 0x04, LogSoundfile = 0x08};
 	int iMaxLogBlocks;
+	QString qsLogTimeFormat;
 	QMap<int, QString> qmMessageSounds;
 	QMap<int, quint32> qmMessages;
 

--- a/src/mumble/mumble_tango.qrc
+++ b/src/mumble/mumble_tango.qrc
@@ -1,6 +1,7 @@
 <RCC>
   <qresource>
     <file alias="actions/media-record.svg" >../../icons/tango/actions/media-record.svg</file>
+    <file alias="actions/list-add.svg" >../../icons/tango/actions/list-add.svg</file>
     <file alias="actions/audio-input-microphone.svg" >../../icons/tango/actions/audio-input-microphone.svg</file>
     <file alias="actions/audio-input-microphone-muted.svg" >../../icons/tango/actions/audio-input-microphone-muted.svg</file>
     <file alias="actions/bookmark-new.svg" >../../icons/tango/actions/bookmark-new.svg</file>
@@ -15,6 +16,6 @@
     <file alias="places/network-workgroup.svg" >../../icons/tango/places/network-workgroup.svg</file>
     <file alias="mimetypes/image-x-generic.svg" >../../icons/tango/mimetypes/image-x-generic.svg</file>
     <file alias="mimetypes/text-html.svg" >../../icons/tango/mimetypes/text-html.svg</file>
-	<file alias="status/text-missing.svg" >../../icons/tango/status/text-missing.svg</file>
+    <file alias="status/text-missing.svg" >../../icons/tango/status/text-missing.svg</file>
   </qresource>
 </RCC>


### PR DESCRIPTION
Adding a setting to the Mumble client which allows users to customize the timestamp format for chat log messages.

**Screenshot**
![Screenshot](https://cloud.githubusercontent.com/assets/110883/2691265/b3957c36-c379-11e3-88a8-fa09075c4136.png)
