### PR TITLE
Avoid "jump to label crosses initialization" error.

### DIFF
--- a/src/mumble/OSS.cpp
+++ b/src/mumble/OSS.cpp
@@ -243,9 +243,9 @@ void OSSInput::run() {
 	eMicFormat = SampleShort;
 	initializeMixer();
 
-	short buffer[iMicLength];
-
 	while (bRunning) {
+		short buffer[iMicLength];
+
 		int len = static_cast<int>(iMicLength * iMicChannels * sizeof(short));
 		ssize_t l = read(fd, buffer, len);
 		if (l != len) {


### PR DESCRIPTION
Move variable "buffer" into the while loop to avoid a compile error
with g++ 4.9.0.

Although earlier compiler versions did accept the code, jumping into the
scope of an variable length array is not allowed:
http://gcc.gnu.org/onlinedocs/gcc-4.3.0/gcc/Variable-Length.html
