### PR TITLE
Support for DNS SRV records

### DIFF
--- a/src/mumble/ServerHandler.cpp
+++ b/src/mumble/ServerHandler.cpp
@@ -298,7 +298,18 @@ void ServerHandler::run() {
 #else
 	qtsSock->setProtocol(QSsl::TlsV1);
 #endif
-	qtsSock->connectToHostEncrypted(qsHostName, usPort);
+
+	// Perform a DNS SRV lookup
+	qdlSrvLookup = new QDnsLookup(this);
+	connect(qdlSrvLookup, SIGNAL(finished()), this, SLOT(handleSrvRecords()));
+	qdlSrvLookup->setType(QDnsLookup::SRV);
+	// RFC2782 requires "_protocol" in the name of SRV records.
+	// Mumble uses both TCP and UDP and routing the two channels to different servers would make absolutely no sense.
+	// Since finding the mumble server is the only purpose of this record and the "_protocol" has no technical effect at all,
+	// we can just choose "_tcp" and everything will work.
+	qdlSrvLookup->setName(QStringLiteral("_mumble._tcp.") + qsHostName);
+	iCurrentSrvRecord = -1;
+	qdlSrvLookup->lookup();
 
 	tTimestamp.restart();
 
@@ -344,6 +355,29 @@ void ServerHandler::run() {
 		msleep(100);
 	}
 	delete qtsSock;
+}
+
+void ServerHandler::handleSrvRecords() {
+	if (qdlSrvLookup->error() != QDnsLookup::NoError) {
+		// There is no SRV record, so we can connect directly.
+		qtsSock->connectToHostEncrypted(qsHostName, usPort);
+		delete qdlSrvLookup;
+		return;
+	}
+
+	// start trying to connect to mumble servers
+	tryNextSrvRecord();
+}
+
+bool ServerHandler::tryNextSrvRecord() {
+	iCurrentSrvRecord++;
+	QList<QDnsServiceRecord>& records = qdlSrvLookup->serviceRecords();
+	if (records.size() <= iCurrentSrvRecord)
+		// out of records to try :/
+		return false;
+
+	qtsSock->connectToHostEncrypted(records[iCurrentSrvRecord].name(), records[iCurrentSrvRecord].port());
+	return true;
 }
 
 #ifdef Q_OS_WIN
@@ -521,6 +555,10 @@ void ServerHandler::serverConnectionTimeoutOnConnect() {
 	ConnectionPtr connection(cConnection);
 	if (connection)
 		connection->disconnectSocket(true);
+
+	// Try all the SRV records
+	if (tryNextSrvRecord())
+		return;
 
 	serverConnectionClosed(QAbstractSocket::SocketTimeoutError, tr("Connection timed out"));
 }

--- a/src/mumble/ServerHandler.h
+++ b/src/mumble/ServerHandler.h
@@ -47,6 +47,7 @@
 #include <QtNetwork/QHostAddress>
 #include <QtNetwork/QSslCipher>
 #include <QtNetwork/QSslError>
+#include <QtNetwork/QDnsLookup>
 
 #ifdef Q_OS_WIN
 #include <windows.h>
@@ -91,10 +92,13 @@ class ServerHandler : public QThread {
 		DWORD dwFlowUDP;
 #endif
 
+		int iCurrentSrvRecord;
+		QDnsLookup *qdlSrvLookup;
 		QHostAddress qhaRemote;
 		QUdpSocket *qusUdp;
 		QMutex qmUdp;
 
+		void tryNextSrvRecord();
 		void handleVoicePacket(unsigned int msgFlags, PacketDataStream &pds, MessageHandler::UDPMessageType type);
 	public:
 		Timer tTimestamp;
@@ -154,6 +158,7 @@ class ServerHandler : public QThread {
 		void connected();
 	protected slots:
 		void message(unsigned int, const QByteArray &);
+		void handleSrvRecords();
 		void serverConnectionConnected();
 		void serverConnectionTimeoutOnConnect();
 		void serverConnectionStateChanged(QAbstractSocket::SocketState);


### PR DESCRIPTION
This implements mumble-voip/mumble#1242.

Please note that I'm not familiar with either the mumble codebase or Qt.
And because I was too lazy to set up a full Qt Windows devenv, I didn't
even try to compile this.

And I have no idea whether the retry/cycle-through-srv-records part could
work. And the server list probably needs similar code.

So now that we know that this commit is probably entirely broken and shit,
why did I do it? Because it clearly shows that adding support for SRV
records to mumble, a feature I would really appreciate, is trivial.
