### PR TITLE
Support logging to syslog

### DIFF
--- a/src/murmur/UnixMurmur.cpp
+++ b/src/murmur/UnixMurmur.cpp
@@ -182,7 +182,9 @@ void UnixMurmur::handleSigHup() {
 	ssize_t len = ::read(iHupFd[1], &tmp, sizeof(tmp));
 	Q_UNUSED(len);
 
-	if (! qfLog) {
+	if (logToSyslog) {
+		qWarning("Caught SIGHUP, but logging to syslog");
+	} else if (! qfLog) {
 		qWarning("Caught SIGHUP, but logfile not in use");
 	} else if (! qfLog->isOpen()) {
 		qWarning("Caught SIGHUP, but logfile not in use -- interpreting as hint to quit");

--- a/src/murmur/UnixMurmur.h
+++ b/src/murmur/UnixMurmur.h
@@ -66,6 +66,8 @@ class UnixMurmur : public QObject {
 		void handleSigHup();
 		void handleSigTerm();
 	public:
+		bool logToSyslog;
+
 		void setuid();
 		void initialcap();
 		void finalcap();

--- a/src/murmur/murmur_pch.h
+++ b/src/murmur/murmur_pch.h
@@ -58,6 +58,7 @@ extern "C" {
 #include <sys/socket.h>
 #include <sys/time.h>
 #include <sys/resource.h>
+#include <syslog.h>
 #ifdef Q_OS_LINUX
 #include <linux/types.h> // needed to work around evil magic stuff in capability.h
 #include <sys/capability.h>


### PR DESCRIPTION
Simply set the logfile path to "syslog" and murmur will log to syslog.

This should be stable, it has approximately 4 user-months of testing.
