### PR TITLE
Add the forceExternalAuth option

### DIFF
--- a/src/murmur/Meta.cpp
+++ b/src/murmur/Meta.cpp
@@ -71,6 +71,7 @@ MetaParams::MetaParams() {
 	bBonjour = true;
 	bAllowPing = true;
 	bCertRequired = false;
+	bForceExternalAuth = false;
 
 	iBanTries = 10;
 	iBanTimeframe = 120;
@@ -269,6 +270,7 @@ void MetaParams::read(QString fname) {
 	iMaxUsersPerChannel = typeCheckedFromSettings("usersperchannel", iMaxUsersPerChannel);
 	qsWelcomeText = typeCheckedFromSettings("welcometext", qsWelcomeText);
 	bCertRequired = typeCheckedFromSettings("certrequired", bCertRequired);
+	bForceExternalAuth = typeCheckedFromSettings("forceExternalAuth", bForceExternalAuth);
 
 	qsDatabase = typeCheckedFromSettings("database", qsDatabase);
 
@@ -474,6 +476,7 @@ void MetaParams::read(QString fname) {
 	qmConfig.insert(QLatin1String("username"),qrUserName.pattern());
 	qmConfig.insert(QLatin1String("channelname"),qrChannelName.pattern());
 	qmConfig.insert(QLatin1String("certrequired"), bCertRequired ? QLatin1String("true") : QLatin1String("false"));
+	qmConfig.insert(QLatin1String("forceExternalAuth"), bForceExternalAuth ? QLatin1String("true") : QLatin1String("false"));
 	qmConfig.insert(QLatin1String("suggestversion"), qvSuggestVersion.isNull() ? QString() : qvSuggestVersion.toString());
 	qmConfig.insert(QLatin1String("suggestpositional"), qvSuggestPositional.isNull() ? QString() : qvSuggestPositional.toString());
 	qmConfig.insert(QLatin1String("suggestpushtotalk"), qvSuggestPushToTalk.isNull() ? QString() : qvSuggestPushToTalk.toString());

--- a/src/murmur/Meta.h
+++ b/src/murmur/Meta.h
@@ -67,6 +67,7 @@ public:
 	QString qsPassword;
 	QString qsWelcomeText;
 	bool bCertRequired;
+	bool bForceExternalAuth;
 
 	int iBanTries;
 	int iBanTimeframe;

--- a/src/murmur/Server.cpp
+++ b/src/murmur/Server.cpp
@@ -329,6 +329,7 @@ void Server::readParams() {
 	bBonjour = Meta::mp.bBonjour;
 	bAllowPing = Meta::mp.bAllowPing;
 	bCertRequired = Meta::mp.bCertRequired;
+	bForceExternalAuth = Meta::mp.bForceExternalAuth;
 	qrUserName = Meta::mp.qrUserName;
 	qrChannelName = Meta::mp.qrChannelName;
 	qvSuggestVersion = Meta::mp.qvSuggestVersion;
@@ -385,6 +386,7 @@ void Server::readParams() {
 	bBonjour = getConf("bonjour", bBonjour).toBool();
 	bAllowPing = getConf("allowping", bAllowPing).toBool();
 	bCertRequired = getConf("certrequired", bCertRequired).toBool();
+	bForceExternalAuth = getConf("forceExternalAuth", bForceExternalAuth).toBool();
 
 	qvSuggestVersion = getConf("suggestversion", qvSuggestVersion);
 	if (qvSuggestVersion.toUInt() == 0)
@@ -492,6 +494,8 @@ void Server::setLiveConf(const QString &key, const QString &value) {
 		qurlRegWeb = !v.isNull() ? v : Meta::mp.qurlRegWeb;
 	else if (key == "certrequired")
 		bCertRequired = !v.isNull() ? QVariant(v).toBool() : Meta::mp.bCertRequired;
+	else if (key == "forceExternalAuth")
+		bForceExternalAuth = !v.isNull() ? QVariant(v).toBool() : Meta::mp.bForceExternalAuth;
 	else if (key == "bonjour") {
 		bBonjour = !v.isNull() ? QVariant(v).toBool() : Meta::mp.bBonjour;
 #ifdef USE_BONJOUR

--- a/src/murmur/Server.h
+++ b/src/murmur/Server.h
@@ -141,6 +141,7 @@ class Server : public QThread {
 		QString qsPassword;
 		QString qsWelcomeText;
 		bool bCertRequired;
+		bool bForceExternalAuth;
 
 		QString qsRegName;
 		QString qsRegPassword;

--- a/src/murmur/ServerDB.cpp
+++ b/src/murmur/ServerDB.cpp
@@ -843,7 +843,7 @@ QMap<int, QString> Server::getRegistration(int id) {
 /// @return UserID of authenticated user, -1 for authentication failures, -2 for unknown user (fallthrough),
 ///         -3 for authentication failures where the data could (temporarily) not be verified.
 int Server::authenticate(QString &name, const QString &pw, int sessionId, const QStringList &emails, const QString &certhash, bool bStrongCert, const QList<QSslCertificate> &certs) {
-	int res = -2;
+	int res = bForceExternalAuth ? -3 : -2;
 
 	emit authenticateSig(res, name, sessionId, certs, certhash, bStrongCert, pw);
 


### PR DESCRIPTION
Without this option (or when it's set to false), murmur's default authentication will kick in when your external authenticator plugin crashes and basically allow _anyone_ to login and register.

When it's enabled, murmur will instead return a temporary login failure to the client.
