### PR TITLE
Text-To-Speech verbosity options

### DIFF
--- a/src/mumble/Log.ui
+++ b/src/mumble/Log.ui
@@ -149,6 +149,36 @@
         </property>
        </widget>
       </item>
+      <item row="2" column="0">
+       <widget class="QLabel" name="qlVerbosity">
+        <property name="text">
+         <string>Message verbosity</string>
+        </property>
+        <property name="buddy">
+         <cstring>qsbVerbosity</cstring>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="1">
+       <widget class="QCheckBox" name="qcbReadMsgScope">
+        <property name="toolTip">
+         <string>If enabled the scope of text messages will be read with TTS</string>
+        </property>
+        <property name="text">
+         <string>Read message scope</string>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="2">
+       <widget class="QCheckBox" name="qcbReadMsgAuthor">
+        <property name="toolTip">
+         <string>If enabled the author of text messages will be read with TTS</string>
+        </property>
+        <property name="text">
+         <string>Read message author</string>
+        </property>
+       </widget>
+      </item>
      </layout>
     </widget>
    </item>

--- a/src/mumble/Settings.cpp
+++ b/src/mumble/Settings.cpp
@@ -258,6 +258,8 @@ Settings::Settings() {
 	bMute = bDeaf = false;
 	bTTS = true;
 	bTTSMessageReadBack = false;
+	bTTSReadMsgScope = true;
+	bTTSReadMsgAuthor = true;
 	iTTSVolume = 75;
 	iTTSThreshold = 250;
 	iQuality = 40000;

--- a/src/mumble/Settings.h
+++ b/src/mumble/Settings.h
@@ -187,6 +187,8 @@ struct Settings {
 	bool bUserTop;
 	bool bWhisperFriends;
 	bool bTTSMessageReadBack;
+	bool bTTSReadMsgScope;
+	bool bTTSReadMsgAuthor;
 	int iTTSVolume, iTTSThreshold;
 	int iQuality, iMinLoudness, iVoiceHold, iJitterBufferSize;
 	int iNoiseSuppress;


### PR DESCRIPTION
I'm part of a group that recently switched to using Mumble and a significant fraction of them were annoyed by the default Text-To-Speech behavior, so I added options to make the behavior more customizable.

As an example, in this chatlog sample 

> (Channel) myuser: this is a TextMessage
> (Channel) myuser: this is another TextMessage
> (Channel) myuser: this is a third text TextMessage

let's call "(Channel)" the scope, and "myuser" the author. It was generally undesirable to have TTS reading out the scope and author every time someone posted a text message, especially when text messages are being used heavily. In some other cases only the scope readout was undesirable.

To fix this, I added options to prevent those portions of the relevant QString from being sent to TTS readout while still maintaining the TTS readout for the body of the message. I have users currently using this client build.

The following screenshot shows the added TTS options. A new "Message verbosity" label is added, with two checkboxes that control whether the scope and author will be read out by TTS.
![](http://puu.sh/aQjRA/c71e941d2b.png)

As applied to the example TextMessages, the "Read message scope" box changes whether "Channel" is read out by TTS, and the "Read message author" box changes whether "myuser" is read out. For a user's own messages there is no "author" portion of the string, and I think I've handled that properly.

This pull does not remove or alter any of the lines of code already in place, and should only remove portions of the the TextMessage QStrings that are passed to TTS when one or both of the relevant settings boxes are checked. 
