### PR TITLE
Log, TextMessage: remove $ as an illegal character in our simple URL regexp.

### DIFF
--- a/src/mumble/Log.cpp
+++ b/src/mumble/Log.cpp
@@ -507,7 +507,7 @@ void Log::log(MsgType mt, const QString &console, const QString &terse, bool own
 		return;
 
 	// Apply simplifications to spoken text
-	QRegExp identifyURL(QLatin1String("[a-z-]+://[^ <$]*"),
+	QRegExp identifyURL(QLatin1String("[a-z-]+://[^ <]*"),
 	                    Qt::CaseInsensitive,
 	                    QRegExp::RegExp2);
 

--- a/src/mumble/TextMessage.cpp
+++ b/src/mumble/TextMessage.cpp
@@ -61,7 +61,7 @@ QString TextMessage::autoFormat(QString qsPlain) {
 	qr.setPattern(QLatin1String("\"([^\"]+)\""));
 	qsPlain.replace(qr, QLatin1String("\"<i>\\1</i>\""));
 
-	qr.setPattern(QLatin1String("[a-z-]+://[^ <$]*"));
+	qr.setPattern(QLatin1String("[a-z-]+://[^ <]*"));
 	qr.setMinimal(false);
 
 	int idx = 0;


### PR DESCRIPTION
Per RFC 3986, $ is legal in various parts of a well-formed URL.

Note that we run matches of these regexps through QUrl, so
we'll always end up with a valid URL in any case.

Fixes issue 1345
