### PR TITLE
Use QStandardPaths's DataLocation instead of GenericDataLocation when looking up AppData directory.

### DIFF
--- a/src/mumble/Database.cpp
+++ b/src/mumble/Database.cpp
@@ -69,7 +69,7 @@ Database::Database() {
 
 	datapaths << g.qdBasePath.absolutePath();
 #if QT_VERSION >= QT_VERSION_CHECK(5, 0, 0)
-	datapaths << QStandardPaths::writableLocation(QStandardPaths::GenericDataLocation);
+	datapaths << QStandardPaths::writableLocation(QStandardPaths::DataLocation);
 #else
 	datapaths << QDesktopServices::storageLocation(QDesktopServices::DataLocation);
 #endif

--- a/src/mumble/Global.cpp
+++ b/src/mumble/Global.cpp
@@ -38,7 +38,7 @@ static void migrateDataDir() {
 #ifdef Q_OS_MAC
 	QString olddir = QDir::homePath() + QLatin1String("/Library/Preferences/Mumble");
 #if QT_VERSION >= QT_VERSION_CHECK(5, 0, 0)
-	QString newdir = QStandardPaths::writableLocation(QStandardPaths::GenericDataLocation);
+	QString newdir = QStandardPaths::writableLocation(QStandardPaths::DataLocation);
 #else
 	QString newdir = QDesktopServices::storageLocation(QDesktopServices::DataLocation);
 #endif
@@ -113,7 +113,7 @@ Global::Global() {
 	QStringList qsl;
 	qsl << QCoreApplication::instance()->applicationDirPath();
 #if QT_VERSION >= QT_VERSION_CHECK(5, 0, 0)
-	qsl << QStandardPaths::writableLocation(QStandardPaths::GenericDataLocation);
+	qsl << QStandardPaths::writableLocation(QStandardPaths::DataLocation);
 #else
 	qsl << QDesktopServices::storageLocation(QDesktopServices::DataLocation);
 #endif
@@ -147,7 +147,7 @@ Global::Global() {
 #else
 		migrateDataDir();
 #if QT_VERSION >= QT_VERSION_CHECK(5, 0, 0)
-		qdBasePath = QStandardPaths::writableLocation(QStandardPaths::GenericDataLocation);
+		qdBasePath = QStandardPaths::writableLocation(QStandardPaths::DataLocation);
 #else
 		qdBasePath = QDesktopServices::storageLocation(QDesktopServices::DataLocation);
 #endif

--- a/src/murmur/Meta.cpp
+++ b/src/murmur/Meta.cpp
@@ -126,7 +126,7 @@ void MetaParams::read(QString fname) {
 
 #if defined(Q_OS_WIN)
 #if QT_VERSION >= QT_VERSION_CHECK(5, 0, 0)
-		datapaths << QStandardPaths::writableLocation(QStandardPaths::GenericDataLocation);
+		datapaths << QStandardPaths::writableLocation(QStandardPaths::DataLocation);
 #else
 		datapaths << QDesktopServices::storageLocation(QDesktopServices::DataLocation);
 #endif


### PR DESCRIPTION
GenericDataLocation returns a directory shared by all applications
whereas DataLocation returns an application-specific version.

For example, on OS X, GenericDataLocation returns

```
$HOME/Library/Application Support
```

but DataLocation returns

```
$HOME/Library/Application Support/Mumble/Mumble
```

Fixes #1340
