### PR TITLE
Allow PulseAudio monitors

### DIFF
--- a/src/mumble/PulseAudio.cpp
+++ b/src/mumble/PulseAudio.cpp
@@ -425,8 +425,7 @@ void PulseAudioSystem::source_callback(pa_context *, const pa_source_info *i, in
 	pas->qhSpecMap.insert(name, i->sample_spec);
 	pas->qhChanMap.insert(name, i->channel_map);
 
-	if (i->monitor_of_sink == PA_INVALID_INDEX)
-		pas->qhInput.insert(QLatin1String(i->name), QLatin1String(i->description));
+	pas->qhInput.insert(QLatin1String(i->name), QLatin1String(i->description));
 }
 
 void PulseAudioSystem::server_callback(pa_context *, const pa_server_info *i, void *userdata) {


### PR DESCRIPTION
PulseAudio automatically creates monitors to devices. This devices have explicitly be excluded from the list of input devices. Excluding this devices blocks people from combining multiple streams into mumble.

Scenario:

Requirement:
- One wants to combine headset input and sound output of a script into mumble.

Solution:
- With PulseAudio one creates a virtual sink. Let's call it "vscrd1".
- Headset input is looped to vscrd1.
- Script audio output is directly directed to vscrd1.
- Configure mumble to input device "vscrd1.monitor"

Now one can talk and send sound to mumble at the same time.
It also helps much when using sound bots (music etc.).

My suggestion therefore: Allow PulseAudio monitors to be used as input.