### PR TITLE
Use TCP Keepalive option

### DIFF
--- a/src/Connection.cpp
+++ b/src/Connection.cpp
@@ -95,6 +95,10 @@ void Connection::setToS() {
 		if (setsockopt(qtsSocket->socketDescriptor(), IPPROTO_IP, IP_TOS, &val, sizeof(val)))
 			qWarning("Connection: Failed to set TOS for TCP Socket");
 	}
+	val = 1;
+	if (setsockopt(qtsSocket->socketDescriptor(), SOL_SOCKET, SO_KEEPALIVE, &val, sizeof(val)) < 0) {
+		qWarning("Connection: Failed to set keepalive bit");
+	}
 #if defined(SO_PRIORITY)
 	socklen_t optlen = sizeof(val);
 	if (getsockopt(qtsSocket->socketDescriptor(), SOL_SOCKET, SO_PRIORITY, &val, &optlen) == 0) {


### PR DESCRIPTION
This helps to avoid cases where clients do not notice that the socket
got lost and users have to manually reconnect to get back into a working state

Note: I could not test this much yet beyond verifying that the setsockopt worked.
