### PR TITLE
Add Microsoft Visual Studio to overlay blacklist

### DIFF
--- a/overlay/overlay_blacklist.h
+++ b/overlay/overlay_blacklist.h
@@ -65,6 +65,7 @@ static const char *overlayBlacklist[] = {
 	"IpOverUsbSvc.exe", // Windows Phone IP over USB Transport
 	"Origin.exe", // EA Origin
 	"HydraSysTray.exe", // Razer Hydra system tray
+	"devenv.exe", // Microsoft Visual Studio
 	NULL
 };
 


### PR DESCRIPTION
Overlay cause UI freeze in Microsoft Visual Studio 2013.
