### PR TITLE
MumbleApplication: include QUrl in MumbleApplication.h to fix non-PCH build.

### DIFF
--- a/src/mumble/MumbleApplication.h
+++ b/src/mumble/MumbleApplication.h
@@ -32,6 +32,7 @@
 #define MUMBLE_MUMBLE_MUMBLEAPPLICATION_H
 
 #include <QApplication>
+#include <QUrl>
 
 /**
  * @brief Implements custom system shutdown behavior as well as event filtering.


### PR DESCRIPTION
The OS X build is currently broken due to this issue. However, it's not OS X specific.  It's a PCH issue.  We don't use PCH on OS X for various reasons, so this only affected OS X in the CI system.
