### PR TITLE
Add QMAKE_TARGET_BUNDLE_PREFIX to the manual plugin's .qmake.cache file.

### DIFF
--- a/plugins/manual/.qmake.cache
+++ b/plugins/manual/.qmake.cache
@@ -1,1 +1,2 @@
 QMAKEFEATURES=$$_PRO_FILE_PWD_/features/
+QMAKE_TARGET_BUNDLE_PREFIX=net.sourceforge.mumble


### PR DESCRIPTION
Due to Qt change f9a8cf99bc0, qmake will forcefully
add the bundle prefix set in Xcode to any .qmake.cache
file it encounters. This causes unnecessary noise in
Git, and extra work for developers.

Full change URL:
https://qt.gitorious.org/qt/qtbase/commit/f9a8cf99bc0b9afda44c0b3e7e8af141003bbd9b

To avoid having qmake change the manual plugin's
.qmake.cache file behind our backs, we simply
add a pre-set QMAKE_TARGET_BUNDLE_PREFIX to the
.qmake.cache file. The manual plugin is not a
bundle, so the bundle prefix is not applied.

This skips the querying-and-caching step for the
bundle identifier -- because now, one is already
set.
