### PR TITLE
Make the Minimal View a Qt::Window, not a Qt::Tool

### DIFF
--- a/src/mumble/MainWindow.cpp
+++ b/src/mumble/MainWindow.cpp
@@ -829,7 +829,7 @@ void MainWindow::setupView(bool toggle_minimize) {
 		f = Qt::Window | Qt::FramelessWindowHint;
 #ifndef Q_OS_MAC
 	else if (!showit)
-		f = Qt::Tool;
+		f = Qt::Window;
 #else
 	f |= Qt::MacWindowToolBarButtonHint | Qt::WindowTitleHint | Qt::WindowSystemMenuHint | Qt::WindowMinMaxButtonsHint | Qt::WindowCloseButtonHint;
 #endif


### PR DESCRIPTION
Making the Minimal View a tool window (Qt::Tool) stops the window from showing up in the taskbar and makes it impossible to use ALT-TAB to get to the window. Instead, this patch makes the Minimal View a regular window, so that it shows up in the taskbar, can be recalled using ALT-TAB, and has minimise/maximise window decorations.

**Rationale for this pull request:**

For blind users, using Minimal View is the easiest way to get to the channel list, as otherwise it's easy to get the focus trapped in the chat text box, from which you cannot use TAB or SHIFT-TAB to escape it (as it will either auto-complete names or produce tab characters instead), and the log panel contains too much text for a screen reader to keep up. This modification will make it far easier for these users to get back to the window.

**Considerations:**
- I do not have a Mac and have not modified the line that is executed if you have a Mac. This will need to be reviewed to see whether a similar change needs to be made for Macs.
- I am not regularly a Qt developer and may have made a mistake. I do not believe I have as the change seems to work, but I would appreciate having an extra set of eyes to make sure that nothing is a problem. (I can see from https://qt-project.org/doc/qt-4.8/qt.html#WindowType-enum that Qt::Tool is a combination of Qt::Dialog and Qt::Popup, but it seems that just removing Qt::Popup does not restore the minimise and maximise buttons, which may be useful to some people, so I'm guessing that Qt::Window is probably the best choice here.)

Thanks for considering this pull request!
