### PR TITLE
MainWindow: allow OS X minimal view to be resized.

### DIFF
--- a/src/mumble/MainWindow.cpp
+++ b/src/mumble/MainWindow.cpp
@@ -843,6 +843,9 @@ void MainWindow::setupView(bool toggle_minimize) {
 		} else {
 			// Window should only have a system menu, title bar, minimize and close button
 			f |= Qt::CustomizeWindowHint | Qt::WindowSystemMenuHint | Qt::WindowCloseButtonHint | Qt::WindowMinimizeButtonHint;
+#ifdef Q_OS_MAC
+			f |= Qt::WindowMaximizeButtonHint;
+#endif
 		}
 	}
 	


### PR DESCRIPTION
I am not able to resize the OS X main window when it's in minimal view with current Git master.

This patch fixes it.  However, I'd like some comments on this -- maybe it makes sense to also have the maximize button on the other OSes?
