### PR TITLE
Allow non-modal ConfigDialog.

### DIFF
--- a/src/mumble/Global.h
+++ b/src/mumble/Global.h
@@ -34,6 +34,7 @@
 
 #include <boost/shared_ptr.hpp>
 #include <QtCore/QDir>
+#include <QtCore/QPointer>
 
 #include "ACL.h"
 #include "Settings.h"
@@ -68,6 +69,7 @@ public:
 	boost::shared_ptr<ServerHandler> sh;
 	boost::shared_ptr<AudioInput> ai;
 	boost::shared_ptr<AudioOutput> ao;
+	QPointer<QDialog> cd;
 	Database *db;
 	Log *l;
 	Plugins *p;

--- a/src/mumble/MainWindow.h
+++ b/src/mumble/MainWindow.h
@@ -167,6 +167,8 @@ class MainWindow : public QMainWindow, public MessageHandler, public Ui::MainWin
 		void customEvent(QEvent *evt) Q_DECL_OVERRIDE;
 		void findDesiredChannel();
 		void setupView(bool toggle_minimize = true);
+		void reloadViewStateFromSettings();
+
 		void closeEvent(QCloseEvent *e) Q_DECL_OVERRIDE;
 		void hideEvent(QHideEvent *e) Q_DECL_OVERRIDE;
 		void showEvent(QShowEvent *e) Q_DECL_OVERRIDE;
@@ -278,6 +280,9 @@ class MainWindow : public QMainWindow, public MessageHandler, public Ui::MainWin
 		void whisperReleased(QVariant scdata);
 		void onResetAudio();
 		void on_qaFilterToggle_triggered();
+		/// Emitted by the ConfigDialog window when using a non-modal
+		/// ConfigDialog.
+		void configDialogFinished(int);
 
 	public:
 		MainWindow(QWidget *parent);

--- a/src/mumble/Settings.cpp
+++ b/src/mumble/Settings.cpp
@@ -330,6 +330,12 @@ Settings::Settings() {
 	wlWindowLayout = LayoutClassic;
 	bShowContextMenuInMenuBar = false;
 
+#ifdef Q_OS_MAC
+	bModalConfigDialog = false;
+#else
+	bModalConfigDialog = true;
+#endif
+
 	ssFilter = ShowReachable;
 
 	iOutputDelay = 5;
@@ -680,6 +686,7 @@ void Settings::load(QSettings* settings_ptr) {
 	SAVELOAD(bFilterActive, "ui/filteractive");
 	SAVELOAD(qsImagePath, "ui/imagepath");
 	SAVELOAD(bShowContextMenuInMenuBar, "ui/showcontextmenuinmenubar");
+	SAVELOAD(bModalConfigDialog, "ui/modalconfigdialog");
 	SAVELOAD(qbaConnectDialogGeometry, "ui/connect/geometry");
 	SAVELOAD(qbaConnectDialogHeader, "ui/connect/header");
 	SAVELOAD(bHighContrast, "ui/HighContrast");
@@ -970,6 +977,7 @@ void Settings::save() {
 	SAVELOAD(bFilterActive, "ui/filteractive");
 	SAVELOAD(qsImagePath, "ui/imagepath");
 	SAVELOAD(bShowContextMenuInMenuBar, "ui/showcontextmenuinmenubar");
+	SAVELOAD(bModalConfigDialog, "ui/modalconfigdialog");
 	SAVELOAD(qbaConnectDialogGeometry, "ui/connect/geometry");
 	SAVELOAD(qbaConnectDialogHeader, "ui/connect/header");
 	SAVELOAD(bHighContrast, "ui/HighContrast");

--- a/src/mumble/Settings.h
+++ b/src/mumble/Settings.h
@@ -263,6 +263,7 @@ struct Settings {
 	bool bFilterActive;
 	QByteArray qbaConnectDialogHeader, qbaConnectDialogGeometry;
 	bool bShowContextMenuInMenuBar;
+	bool bModalConfigDialog;
 
 	QString qsUsername;
 	QString qsLastServer;


### PR DESCRIPTION
We need this for OS X, where some system APIs spawn dialogs
that won't get foregrounded or get the focus if the ConfigDialog
is modal.

To avoid a lot of ifdefs, the decision whether to spawn a modal
or non-modal config dialog is controlled by Settings::bModalConfigDialog.
This means the code is built for all platforms, and can even be enabled
on all platforms by manually fiddling with the config file/store.
