### PR TITLE
Fix FTBFS regression from dd7cc7caa7257d2d1525daebbcc070cbb0983915

### DIFF
--- a/src/mumble/main.cpp
+++ b/src/mumble/main.cpp
@@ -101,7 +101,10 @@ int main(int argc, char **argv) {
 	a.setOrganizationName(QLatin1String("Mumble"));
 	a.setOrganizationDomain(QLatin1String("mumble.sourceforge.net"));
 	a.setQuitOnLastWindowClosed(false);
+
+#if QT_VERSION >= 0x050100
 	a.setAttribute(Qt::AA_UseHighDpiPixmaps);
+#endif
 
 #if QT_VERSION >= 0x050000 && defined(Q_OS_WIN)
 	a.installNativeEventFilter(&a);


### PR DESCRIPTION
AA_UseHighDpiPixmaps is an option developed in Qt5 and only recently backported to some Qt4 releases.

When building against Qt 4.8.6, dd7cc7caa7257d2d1525daebbcc070cbb0983915 introduces a FTBFS regression. This conditional fixes the regression in all build environments that were tested but could have more tightened down values for QT_VERSION and OS_VERSION with more testing. There are bug reports that this flag will also not work on MACOSX 10.6 and lower, but this was not tested.
