### PR TITLE
Do not allow installing x86 and x64 side by side.

### DIFF
--- a/installer/Product.wxs
+++ b/installer/Product.wxs
@@ -31,6 +31,12 @@
 
     <MajorUpgrade AllowDowngrades='no' AllowSameVersionUpgrades='yes' MigrateFeatures='yes' Schedule='afterInstallExecute' DowngradeErrorMessage='A later version of [ProductName] is already installed.' />
 
+    <Upgrade Id="$(var.Old64BitProductUpgradeCode)">
+      <!-- 64 bit installers had a seperate upgrade code during the beta. As we do not actually want both versions
+           to be installed at the same time this allows detecting the old 64 bit version and upgrading from it -->
+      <UpgradeVersion Minimum="1.3.0" IncludeMinimum="yes" Maximum="$(var.ProductVersion)" IncludeMaximum="yes" OnlyDetect="no" Property="REMOVEOLD64BITPRODUCT" />
+    </Upgrade>
+
     <Media Id="1" Cabinet="$(var.ProductName).cab" EmbedCab="yes" CompressionLevel="high" />
 
     <UIRef Id="MumbleUI_FeatureTree" />

--- a/installer/Settings.wxi
+++ b/installer/Settings.wxi
@@ -4,11 +4,12 @@
   <?define ProductManufacturer = "The Mumble team" ?>
   <?define ProductVersion = "1.3.0" ?>
 
+  <?define ProductUpgradeCode = B0EEFCC7-8A9c-4471-AB10-CBD35BE3161D ?>
+  <?define Old64BitProductUpgradeCode = E028BDFC-3FE2-4BEE-A33B-EB9C80611555 ?>
+    
   <?if $(sys.BUILDARCH) = "x86" ?>
-    <?define ProductUpgradeCode = B0EEFCC7-8A9c-4471-AB10-CBD35BE3161D ?>
     <?define ArchSpecificProgramFilesFolderId = "ProgramFilesFolder" ?>
   <?elseif $(sys.BUILDARCH) = "x64" ?>
-    <?define ProductUpgradeCode = E028BDFC-3FE2-4BEE-A33B-EB9C80611555 ?>
     <?define ArchSpecificProgramFilesFolderId = "ProgramFiles64Folder" ?>
   <?else?>
     <?error Unsupported build architecture: $(sys.BUILDARCH) ?>


### PR DESCRIPTION
Previous setups used a different upgrade code for x64
installs meaning existing x86 installs wouldn't be replaced.
As we don't actually want to support having x64 and x86
versions installed alongside each other this patch makes
the x64 install use the same upgrade code as x86. Also it
makes the setup detect and upgrade x64 installs which used
the old upgrade code allowing smooth future updates for
existing users of these snapshots.
