### PR TITLE
Add Spotify to the overlay blacklist. It can cause Mumble to freeze/hang for multiple seconds.

### DIFF
--- a/overlay/overlay_blacklist.h
+++ b/overlay/overlay_blacklist.h
@@ -66,6 +66,7 @@ static const char *overlayBlacklist[] = {
 	"Origin.exe", // EA Origin
 	"HydraSysTray.exe", // Razer Hydra system tray
 	"devenv.exe", // Microsoft Visual Studio
+	"spotify.exe", // Spotify
 	NULL
 };
 


### PR DESCRIPTION
See PR #1456 for more information about how this was diagnosed.
