### PR TITLE
Proposal: ensure up-to-date built-in overlay blacklist.

### DIFF
--- a/overlay/lib.cpp
+++ b/overlay/lib.cpp
@@ -634,7 +634,18 @@ static bool dllmainProcAttachCheckProcessIsBlacklisted(char procname[], char *p)
 			}
 		}
 	} else {
-		// If there is no list in the registry, fallback to using the default blacklist
+		ods("Lib: no blacklist/whitelist found in the registry");
+	}
+
+	// As a last resort, if we're using blacklisting, check built-in blacklist.
+	//
+	// If the registry query failed this means we're guaranteed to check the
+	// built-in list.
+	//
+	// If the list in the registry is out of sync, for example because the built-
+	// in list in overlay_blacklist.h was updated got updated, we're also
+	// guaranteed that we include all built-in blacklisted items in our check.
+	if (!usewhitelist) {
 		ods("Lib: Overlay fallback to default blacklist");
 		int i = 0;
 		while (overlayBlacklist[i]) {

--- a/src/mumble/Settings.cpp
+++ b/src/mumble/Settings.cpp
@@ -38,7 +38,6 @@
 #include "Log.h"
 #include "Global.h"
 #include "../../overlay/overlay.h"
-#include "../../overlay/overlay_blacklist.h"
 
 bool Shortcut::isServerSpecific() const {
 	if (qvData.canConvert<ShortcutTarget>()) {
@@ -155,15 +154,6 @@ OverlaySettings::OverlaySettings() {
 	bTime = false;
 
 	bUseWhitelist = false;
-
-#ifdef Q_OS_WIN
-	int i = 0;
-	while (overlayBlacklist[i]) {
-		qslBlacklist << QLatin1String(overlayBlacklist[i]);
-		i++;
-	}
-#endif
-
 }
 
 void OverlaySettings::setPreset(const OverlayPresets preset) {


### PR DESCRIPTION
Things are only added to the built-in blacklist if they
create real problems for users. Most recently, I added
Spotify to the list because it could cause my Mumble
client's main thread to hang. (Causing, for example,
in-progress push-to-talk to continue transmitting until
Mumble un-freezes.)

Right now, the overlay DLL only uses the built-in blacklist
if nothing is specified in the registry key for the blacklist.
However, if a blacklist is specified in the registry, that list
is used, disregarding any new items added to the built-in blacklist.

Right now, the client doesn't try to solve that issue, but it seems
to me that it really is a problem.

After I added the spotify.exe entry, it wasn't added to my blacklist
until I wiped the blackley key in my registry.

Since this behavior of the built-in blacklist would mask a bugfix from
_all_ existing Mumble users, I think it's time to revisit how we treat
the built-in blacklist.

This changeset makes the following modifications:
1. The overlay DLL is changed to always consider the built-in blacklist,
   even if a blacklist is present in the registry.
   For Mumble users who have been running with the old blacklist behavior,
   this means that we'll be doing some duplicate checking for blacklist
   entries, but I don't think this matters in practice.
2. Settings.cpp is changed to not do anything with overlay_blacklist.h.
   Effectively, this means that qslBlacklist now represents the items
   the user has added to the blacklist, and not the combination of both
   an outdated built-in list and the user's own entries.
3. OverlayConfig.cpp is changed to always show all entries from
   overlay_blacklist.h. Entries from the built-in list are 'disabled',
   so they can't be interacted with.
   Possibly not the best UX for signalling that the items are from the
   built-in list. I'm open to ideas for how we should show it.
   I think this is fine for now, though. See screenshot below:

![image](https://cloud.githubusercontent.com/assets/36527/4877284/a7f8098e-62e3-11e4-957f-4270fa58a88a.png)

I think this is a very reasonable way to handle the built-in blacklist
going forward. And the amount of code changed is minimal.

Comments welcomed.
