### PR TITLE
--deaf and --mute arguments to control an already running instance of Mumble

### DIFF
--- a/src/mumble/SocketRPC.cpp
+++ b/src/mumble/SocketRPC.cpp
@@ -137,6 +137,14 @@ void SocketRPCClient::processXml() {
 					g.mw->qaAudioMute->trigger();
 				}
 			}
+			iter = qmRequest.find(QLatin1String("unmute"));
+			if (iter != qmRequest.constEnd()) {
+				bool set = iter.value().toBool();
+				if (set == g.s.bMute) {
+					g.mw->qaAudioMute->setChecked(set);
+					g.mw->qaAudioMute->trigger();
+				}
+			}
 			iter = qmRequest.find(QLatin1String("deaf"));
 			if (iter != qmRequest.constEnd()) {
 				bool set = iter.value().toBool();
@@ -145,7 +153,14 @@ void SocketRPCClient::processXml() {
 					g.mw->qaAudioDeaf->trigger();
 				}
 			}
-
+			iter = qmRequest.find(QLatin1String("undeaf"));
+			if (iter != qmRequest.constEnd()) {
+				bool set = iter.value().toBool();
+				if (set == g.s.bDeaf) {
+					g.mw->qaAudioDeaf->setChecked(set);
+					g.mw->qaAudioDeaf->trigger();
+				}
+			}
 			ack = true;
 		} else if (request.nodeName() == QLatin1String("url")) {
 			if (g.sh && g.sh->isRunning() && g.uiSession) {

--- a/src/mumble/main.cpp
+++ b/src/mumble/main.cpp
@@ -390,10 +390,20 @@ int main(int argc, char **argv) {
 	QDBusConnection::sessionBus().registerObject(QLatin1String("/"), g.mw);
 	QDBusConnection::sessionBus().registerService(QLatin1String("net.sourceforge.mumble.mumble"));
 #endif
-
 	SocketRPC *srpc = new SocketRPC(QLatin1String("Mumble"));
 
 	g.l->log(Log::Information, MainWindow::tr("Welcome to Mumble."));
+
+	if(bSetMute)
+	{
+	    g.mw->qaAudioMute->setChecked(false);
+	    g.mw->qaAudioMute->trigger();
+	}
+	if(bSetDeaf)
+	{
+	    g.mw->qaAudioDeaf->setChecked(false);
+	    g.mw->qaAudioDeaf->trigger();
+	}
 
 	// Plugins
 	g.p = new Plugins(NULL);

--- a/src/mumble/main.cpp
+++ b/src/mumble/main.cpp
@@ -155,6 +155,10 @@ int main(int argc, char **argv) {
 					"                Allow multiple instances of the client to be started.\n"
 					"  -n, --noidentity\n"
 					"                Suppress loading of identity files (i.e., certificates.)\n"
+					"  --mute\n"
+					"                Mute self in a currently running instance of Mumble.\n"
+					"  --deaf\n"
+					"                Deafen self in a currently running instance of Mumble.\n"
 					);
 #if defined(Q_OS_WIN)
 				QMessageBox::information(NULL, MainWindow::tr("Invocation"), helpmessage);

--- a/src/mumble/main.cpp
+++ b/src/mumble/main.cpp
@@ -390,6 +390,7 @@ int main(int argc, char **argv) {
 	QDBusConnection::sessionBus().registerObject(QLatin1String("/"), g.mw);
 	QDBusConnection::sessionBus().registerService(QLatin1String("net.sourceforge.mumble.mumble"));
 #endif
+
 	SocketRPC *srpc = new SocketRPC(QLatin1String("Mumble"));
 
 	g.l->log(Log::Information, MainWindow::tr("Welcome to Mumble."));

--- a/src/mumble/main.cpp
+++ b/src/mumble/main.cpp
@@ -174,8 +174,7 @@ int main(int argc, char **argv) {
 				bSetMute = true;
 			} else if (args.at(i) == QLatin1String("--deaf")) {
 				bSetDeaf = true;
-			}
-			else {
+			} else {
 				QUrl u = QUrl::fromEncoded(args.at(i).toUtf8());
 				if (u.isValid() && (u.scheme() == QLatin1String("mumble"))) {
 					url = u;

--- a/src/mumble/main.cpp
+++ b/src/mumble/main.cpp
@@ -390,7 +390,6 @@ int main(int argc, char **argv) {
 	QDBusConnection::sessionBus().registerObject(QLatin1String("/"), g.mw);
 	QDBusConnection::sessionBus().registerService(QLatin1String("net.sourceforge.mumble.mumble"));
 #endif
-
 	SocketRPC *srpc = new SocketRPC(QLatin1String("Mumble"));
 
 	g.l->log(Log::Information, MainWindow::tr("Welcome to Mumble."));

--- a/src/mumble/main.cpp
+++ b/src/mumble/main.cpp
@@ -206,18 +206,15 @@ int main(int argc, char **argv) {
 				g.s.bSuppressIdentity = true;
 			} else if (args.at(i) == QLatin1String("rpc")) {
 				bRpcMode = true;
-				if(args.count()-1>i)
-				{
+				if(args.count()-1>i) {
 					RpcCommand = QString(args.at(i+1));
 				}
-				else
-				{
+				else {
 					printf("Error: No RPC command specified\n");
 					return 1;
 				}
 			} else {
-				if(!bRpcMode || true)
-				{
+				if(!bRpcMode) {
 					QUrl u = QUrl::fromEncoded(args.at(i).toUtf8());
 					if (u.isValid() && (u.scheme() == QLatin1String("mumble"))) {
 						url = u;

--- a/src/mumble/main.cpp
+++ b/src/mumble/main.cpp
@@ -129,8 +129,8 @@ int main(int argc, char **argv) {
 #endif
 
 	bool bAllowMultiple = false;
-	bool bSetMute = false;
-	bool bSetDeaf = false;
+	bool bRpcMode = false;
+	QString RpcCommand;
 	QUrl url;
 	if (a.arguments().count() > 1) {
 		QStringList args = a.arguments();
@@ -140,7 +140,10 @@ int main(int argc, char **argv) {
 				|| args.at(i) == QLatin1String("/?")
 #endif
 			) {
-				QString helpmessage = MainWindow::tr( "Usage: mumble [options] [<url>]\n"
+				QString helpmessage;
+				if(!bRpcMode)
+				{
+					helpmessage = MainWindow::tr( "Usage: mumble [options] [<url>]\n"
 					"\n"
 					"<url> specifies a URL to connect to after startup instead of showing\n"
 					"the connection window, and has the following form:\n"
@@ -155,11 +158,42 @@ int main(int argc, char **argv) {
 					"                Allow multiple instances of the client to be started.\n"
 					"  -n, --noidentity\n"
 					"                Suppress loading of identity files (i.e., certificates.)\n"
-					"  --mute\n"
-					"                Mute self in a currently running instance of Mumble.\n"
-					"  --deaf\n"
-					"                Deafen self in a currently running instance of Mumble.\n"
+					"Remote controlling Mumble:\n"
+					"\n"
+					"Usage: mumble rpc <action> [options]\n"
+					"\n"
+					"It is possible to remote control a running instance of Mumble by using\n"
+					"the 'mumble rpc' command.\n"
+					"\n"
+					"Valid actions are:\n"
+					"  mute\n"
+					"                Mute self\n"
+					"  unmute\n"
+					"                Unmute self\n"
+					"  deaf\n"
+					"                Deafen self\n"
+					"  undeaf\n"
+					"                Undeafen self\n"
 					);
+				}
+				else
+				{
+						helpmessage = MainWindow::tr("Usage: mumble rpc <action> [options]\n"
+						"\n"
+						"It is possible to remote control a running instance of Mumble by using\n"
+						"the 'mumble rpc' command.\n"
+						"\n"
+						"Valid actions are:\n"
+						"  mute\n"
+						"                Mute self\n"
+						"  unmute\n"
+						"                Unmute self\n"
+						"  deaf\n"
+						"                Deafen self\n"
+						"  undeaf\n"
+						"                Undeafen self\n"
+						);
+				}
 #if defined(Q_OS_WIN)
 				QMessageBox::information(NULL, MainWindow::tr("Invocation"), helpmessage);
 #else
@@ -170,18 +204,28 @@ int main(int argc, char **argv) {
 				bAllowMultiple = true;
 			} else if (args.at(i) == QLatin1String("-n") || args.at(i) == QLatin1String("--noidentity")) {
 				g.s.bSuppressIdentity = true;
-			} else if (args.at(i) == QLatin1String("--mute")) {
-				bSetMute = true;
-			} else if (args.at(i) == QLatin1String("--deaf")) {
-				bSetDeaf = true;
+			} else if (args.at(i) == QLatin1String("rpc")) {
+				bRpcMode = true;
+				if(args.count()-1>i)
+				{
+					RpcCommand = QString(args.at(i+1));
+				}
+				else
+				{
+					printf("Error: No RPC command specified\n");
+					return 1;
+				}
 			} else {
-				QUrl u = QUrl::fromEncoded(args.at(i).toUtf8());
-				if (u.isValid() && (u.scheme() == QLatin1String("mumble"))) {
-					url = u;
-				} else {
-					QFile f(args.at(i));
-					if (f.exists()) {
-						url = QUrl::fromLocalFile(f.fileName());
+				if(!bRpcMode || true)
+				{
+					QUrl u = QUrl::fromEncoded(args.at(i).toUtf8());
+					if (u.isValid() && (u.scheme() == QLatin1String("mumble"))) {
+						url = u;
+					} else {
+						QFile f(args.at(i));
+						if (f.exists()) {
+							url = QUrl::fromLocalFile(f.fileName());
+						}
 					}
 				}
 			}
@@ -208,39 +252,18 @@ int main(int argc, char **argv) {
 #endif
 #endif
 
+	if (bRpcMode) {
+		bool sent = false;
+		QMap<QString, QVariant> param;
+		param.insert(RpcCommand,RpcCommand);
+		sent = SocketRPC::send(QLatin1String("Mumble"), QLatin1String("self"),param);
+		if (sent)
+			return 0;
+		else
+			return 1;
+	}
+
 	if (! bAllowMultiple) {
-		if (bSetMute) {
-#ifndef USE_DBUS
-			QMap<QString, QVariant> param;
-			param.insert(QLatin1String("mute"),QLatin1String("mute"));
-#endif
-			bool sent = false;
-#ifdef USE_DBUS
-			QDBusInterface qdbi(QLatin1String("net.sourceforge.mumble.mumble"), QLatin1String("/"), QLatin1String("net.sourceforge.mumble.Mumble"));
-			QDBusMessage reply=qdbi.call(QLatin1String("setSelfMuted"),true);
-			sent = (reply.type() == QDBusMessage::ReplyMessage);
-#else
-			sent = SocketRPC::send(QLatin1String("Mumble"), QLatin1String("self"),param);
-#endif
-			if (sent)
-				return 0;
-		}
-		if (bSetDeaf) {
-#ifndef USE_DBUS
-			QMap<QString, QVariant> param;
-			param.insert(QLatin1String("deaf"), QLatin1String("deaf"));
-#endif
-			bool sent = false;
-#ifdef USE_DBUS
-			QDBusInterface qdbi(QLatin1String("net.sourceforge.mumble.mumble"), QLatin1String("/"), QLatin1String("net.sourceforge.mumble.Mumble"));
-			QDBusMessage reply=qdbi.call(QLatin1String("setSelfDeaf"),true);
-			sent = (reply.type() == QDBusMessage::ReplyMessage);
-#else
-			sent = SocketRPC::send(QLatin1String("Mumble"), QLatin1String("self"),param);
-#endif
-			if (sent)
-				return 0;
-		}
 		if (url.isValid()) {
 #ifndef USE_DBUS
 			QMap<QString, QVariant> param;
@@ -394,17 +417,6 @@ int main(int argc, char **argv) {
 	SocketRPC *srpc = new SocketRPC(QLatin1String("Mumble"));
 
 	g.l->log(Log::Information, MainWindow::tr("Welcome to Mumble."));
-
-	if(bSetMute)
-	{
-	    g.mw->qaAudioMute->setChecked(false);
-	    g.mw->qaAudioMute->trigger();
-	}
-	if(bSetDeaf)
-	{
-	    g.mw->qaAudioDeaf->setChecked(false);
-	    g.mw->qaAudioDeaf->trigger();
-	}
 
 	// Plugins
 	g.p = new Plugins(NULL);


### PR DESCRIPTION
I thought that it'd be useful to be able to mute and deafen myself from the command line or certain scripts. While looking up how to implement this feature, I found you can use the dbus-send command to mute or deafen yourself, but I wasn't able to get this to work properly and decided to make it a bit simpler by just adding the functionality to the program itself.

To deafen yourself on an existing instance, run "mumble --deaf", to mute, run "mumble --mute". Pretty simple.