### PR TITLE
Refactor Windows OpenGL overlay code + robustness

### DIFF
--- a/overlay/opengl.cpp
+++ b/overlay/opengl.cpp
@@ -42,15 +42,12 @@ GLDEF(void, glDeleteTextures, (GLsizei, GLuint *));
 GLDEF(void, glEnable, (GLenum));
 GLDEF(void, glDisable, (GLenum));
 GLDEF(void, glBlendFunc, (GLenum, GLenum));
-GLDEF(void, glColorMaterial, (GLenum, GLenum));
 GLDEF(void, glViewport, (GLint, GLint, GLsizei, GLsizei));
 GLDEF(void, glMatrixMode, (GLenum));
 GLDEF(void, glLoadIdentity, (void));
 GLDEF(void, glOrtho, (GLdouble, GLdouble, GLdouble, GLdouble, GLdouble, GLdouble));
 GLDEF(void, glBindTexture, (GLenum, GLuint));
 GLDEF(void, glPushMatrix, (void));
-GLDEF(void, glColor4ub, (GLubyte, GLubyte, GLubyte, GLubyte));
-GLDEF(void, glTranslatef, (GLfloat, GLfloat, GLfloat));
 GLDEF(void, glBegin, (GLenum));
 GLDEF(void, glEnd, (void));
 GLDEF(void, glTexCoord2f, (GLfloat, GLfloat));
@@ -69,9 +66,9 @@ GLDEF(int, GetDeviceCaps, (HDC, int));
 #define INJDEF(ret, name, arg) GLDEF(ret, name, arg); static HardHook hh##name
 #define INJECT(name) { o##name = reinterpret_cast<t##name>(GetProcAddress(hGL, #name)); if (o##name) { hh##name.setup(reinterpret_cast<voidFunc>(o##name), reinterpret_cast<voidFunc>(my##name)); o##name = (t##name) hh##name.call; } else { ods("OpenGL: No GetProc for %s", #name);} }
 
-INJDEF(BOOL, wglSwapLayerBuffers, (HDC, UINT));
+//INJDEF(BOOL, wglSwapLayerBuffers, (HDC, UINT));
 INJDEF(BOOL, wglSwapBuffers, (HDC));
-INJDEF(BOOL, SwapBuffers, (HDC));
+//INJDEF(BOOL, SwapBuffers, (HDC));
 
 static bool bHooked = false;
 
@@ -310,25 +307,25 @@ static BOOL __stdcall mywglSwapBuffers(HDC hdc) {
 	return ret;
 }
 
-static BOOL __stdcall mySwapBuffers(HDC hdc) {
-	ods("OpenGL: SwapBuffers");
+//static BOOL __stdcall mySwapBuffers(HDC hdc) {
+//	ods("OpenGL: SwapBuffers");
+//
+//	hhSwapBuffers.restore();
+//	BOOL ret=oSwapBuffers(hdc);
+//	hhSwapBuffers.inject();
+//
+//	return ret;
+//}
 
-	hhSwapBuffers.restore();
-	BOOL ret=oSwapBuffers(hdc);
-	hhSwapBuffers.inject();
-
-	return ret;
-}
-
-static BOOL __stdcall mywglSwapLayerBuffers(HDC hdc, UINT fuPlanes) {
-	ods("OpenGL: SwapLayerBuffers %x",fuPlanes);
-
-	hhwglSwapLayerBuffers.restore();
-	BOOL ret=owglSwapLayerBuffers(hdc, fuPlanes);
-	hhwglSwapLayerBuffers.inject();
-
-	return ret;
-}
+//static BOOL __stdcall mywglSwapLayerBuffers(HDC hdc, UINT fuPlanes) {
+//	ods("OpenGL: SwapLayerBuffers %x",fuPlanes);
+//
+//	hhwglSwapLayerBuffers.restore();
+//	BOOL ret=owglSwapLayerBuffers(hdc, fuPlanes);
+//	hhwglSwapLayerBuffers.inject();
+//
+//	return ret;
+//}
 
 
 #undef GLDEF
@@ -365,15 +362,12 @@ void checkOpenGLHook() {
 			GLDEF(glEnable);
 			GLDEF(glDisable);
 			GLDEF(glBlendFunc);
-			GLDEF(glColorMaterial);
 			GLDEF(glViewport);
 			GLDEF(glMatrixMode);
 			GLDEF(glLoadIdentity);
 			GLDEF(glOrtho);
 			GLDEF(glBindTexture);
 			GLDEF(glPushMatrix);
-			GLDEF(glColor4ub);
-			GLDEF(glTranslatef);
 			GLDEF(glBegin);
 			GLDEF(glEnd);
 			GLDEF(glTexCoord2f);


### PR DESCRIPTION
* Separate code into files.
* Create OpenGLFunctions structure to store function pointers
** As before, declared as a local, static variable in opengl.cpp,
but now passed to the Context class for use.
* Add some checks for function pointer to prevent possible null pointer
access (especially for GetDeviceCaps, which comes from a different DLL
than the other functions).
* Store device handle as well as OpenGL context in Context class.

Details:
* Most code moved out from opengl.cpp
** Local, static function pointers for the hooks, as well as the
checkOpenGLHook function are left here
* The Pipe/Context class is extracted to the class OpenGLOverlayContext in
the file openglcontext.h/.cpp
** It now remembers device handle and opengl context
** It handles OpenGL context switching and restoration transparently
within the draw method now
* Those of the local, static function pointers that are not used for
hooking, but only for the overlay drawing (by OpenGLOverlayContext) moved
to openglfunctions.h
* Most helper-defines moved to openglfunctions.h