### PR TITLE
Add setting 'asio/enable' to allow users to disable ASIO via the Mumble configuration.

### DIFF
--- a/src/mumble/ASIOInput.cpp
+++ b/src/mumble/ASIOInput.cpp
@@ -89,6 +89,10 @@ void ASIOInit::initialize() {
 
 	bool bFound = false;
 
+	if (!g.s.bASIOEnable) {
+		return;
+	}
+
 	// List of devices known to misbehave or be totally useless
 	QStringList blacklist;
 	blacklist << QLatin1String("{a91eaba1-cf4c-11d3-b96a-00a0c9c7b61a}"); // ASIO DirectX

--- a/src/mumble/Settings.cpp
+++ b/src/mumble/Settings.cpp
@@ -324,6 +324,8 @@ Settings::Settings() {
 
 	iOutputDelay = 5;
 
+	bASIOEnable = true;
+
 	qsALSAInput=QLatin1String("default");
 	qsALSAOutput=QLatin1String("default");
 
@@ -589,6 +591,7 @@ void Settings::load(QSettings* settings_ptr) {
 	SAVELOAD(iJitterBufferSize, "net/jitterbuffer");
 	SAVELOAD(iFramesPerPacket, "net/framesperpacket");
 
+	SAVELOAD(bASIOEnable, "asio/enable");
 	SAVELOAD(qsASIOclass, "asio/class");
 	SAVELOAD(qlASIOmic, "asio/mic");
 	SAVELOAD(qlASIOspeaker, "asio/speaker");
@@ -882,6 +885,7 @@ void Settings::save() {
 	SAVELOAD(iJitterBufferSize, "net/jitterbuffer");
 	SAVELOAD(iFramesPerPacket, "net/framesperpacket");
 
+	SAVELOAD(bASIOEnable, "asio/enable");
 	SAVELOAD(qsASIOclass, "asio/class");
 	SAVELOAD(qlASIOmic, "asio/mic");
 	SAVELOAD(qlASIOspeaker, "asio/speaker");

--- a/src/mumble/Settings.h
+++ b/src/mumble/Settings.h
@@ -210,9 +210,12 @@ struct Settings {
 	QString qsPulseAudioInput, qsPulseAudioOutput;
 	QString qsOSSInput, qsOSSOutput;
 	int iPortAudioInput, iPortAudioOutput;
+
+	bool bASIOEnable;
 	QString qsASIOclass;
 	QList<QVariant> qlASIOmic;
 	QList<QVariant> qlASIOspeaker;
+
 	QString qsCoreAudioInput, qsCoreAudioOutput;
 	QString qsWASAPIInput, qsWASAPIOutput;
 	QByteArray qbaDXInput, qbaDXOutput;


### PR DESCRIPTION
For issue #1516