### PR TITLE
Removed setting high priority class on windows

### DIFF
--- a/src/mumble/os_win.cpp
+++ b/src/mumble/os_win.cpp
@@ -285,9 +285,6 @@ void os_init() {
 	if (wcscpy_s(wcCrashDumpPath, PATH_MAX, dump.toStdWString().c_str()) == 0)
 		SetUnhandledExceptionFilter(MumbleUnhandledExceptionFilter);
 
-	// Increase our priority class to live alongside games.
-	if (!SetPriorityClass(GetCurrentProcess(),HIGH_PRIORITY_CLASS))
-		qWarning("Application: Failed to set priority!");
 #endif
 
 	g.qdBasePath.mkpath(QLatin1String("Snapshots"));


### PR DESCRIPTION
Almost all games use a normal priority class, so the comment is no longer valid. Also, what follows is that setting mumble's priority class higher than the game can cause inconsistency for input timing.