### PR TITLE
Implemented feature request #1474 and ran updatetranslations.sh

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,4 @@ src/murmur/murmur_plugin_import.cpp
 doc/doxygen/
 .qmake.cache
 .qmake.stash
+*.swp

--- a/src/mumble/LanguageChangeNotice.cpp
+++ b/src/mumble/LanguageChangeNotice.cpp
@@ -1,0 +1,16 @@
+#include "LanguageChangeNotice.h"
+
+LanguageChangeNotice::LanguageChangeNotice(QLabel *languageLabel, int startLanguageID) {
+	this->languageLabel = languageLabel;
+	this->startLanguageID = startLanguageID;
+	this->originalLabelText = languageLabel->text();
+	this->restartNotice = QString::fromUtf8(" <span style=\" color:#ff0000;\">(Mumble restart needed)</span>");
+}
+
+void LanguageChangeNotice::languageChanged(int newLanguageID) {
+	if (newLanguageID == startLanguageID) {
+		languageLabel->setText(originalLabelText);
+	} else {
+		languageLabel->setText(originalLabelText + restartNotice);
+	}
+}

--- a/src/mumble/LanguageChangeNotice.cpp
+++ b/src/mumble/LanguageChangeNotice.cpp
@@ -4,7 +4,7 @@ LanguageChangeNotice::LanguageChangeNotice(QLabel *languageLabel, int startLangu
 	this->languageLabel = languageLabel;
 	this->startLanguageID = startLanguageID;
 	this->originalLabelText = languageLabel->text();
-	this->restartNotice = QString::fromUtf8(" <span style=\" color:#ff0000;\">(Mumble restart needed)</span>");
+	this->restartNotice = QString::fromUtf8(" <span style=\" color:#ff0000;\">(%1)</span>").arg(tr("Mumble restart needed"));
 }
 
 void LanguageChangeNotice::languageChanged(int newLanguageID) {

--- a/src/mumble/LanguageChangeNotice.h
+++ b/src/mumble/LanguageChangeNotice.h
@@ -1,0 +1,25 @@
+#ifndef MUMBLE_MUMBLE_LANGUAGE_CHANGE_NOTICE_H
+#define MUMBLE_MUMBLE_LANGUAGE_CHANGE_NOTICE_H
+
+#include <QtCore/QObject>
+
+class LanguageChangeNotice : public QObject {
+	private:
+		Q_OBJECT
+	
+	protected:
+		QLabel *languageLabel;
+		int startLanguageID;
+		QString originalLabelText;
+		QString restartNotice;
+	
+	public:
+		LanguageChangeNotice(QLabel *languageLabel, int startLanguageID);
+	
+	public slots:
+		void languageChanged(int);
+};
+
+
+
+#endif

--- a/src/mumble/LookConfig.cpp
+++ b/src/mumble/LookConfig.cpp
@@ -37,6 +37,7 @@
 #include "AudioOutput.h"
 #include "Global.h"
 #include "MainWindow.h"
+#include "LanguageChangeNotice.h"
 
 static ConfigWidget *LookConfigNew(Settings &st) {
 	return new LookConfig(st);
@@ -149,6 +150,9 @@ void LookConfig::load(const Settings &r) {
 	loadCheckBox(qcbChatBarUseSelection, r.bChatBarUseSelection);
 	loadCheckBox(qcbFilterHidesEmptyChannels, r.bFilterHidesEmptyChannels);
 	
+	LanguageChangeNotice *languageChangeNotice = new LanguageChangeNotice(qliLanguage, qcbLanguage->currentIndex());
+	languageChangeNotice->setParent(qliLanguage);
+	connect(qcbLanguage, SIGNAL(currentIndexChanged(int)), languageChangeNotice, SLOT(languageChanged(int)));
 }
 
 void LookConfig::save() const {

--- a/src/mumble/mumble.pro
+++ b/src/mumble/mumble.pro
@@ -120,7 +120,8 @@ HEADERS *= BanEditor.h \
     OverlayEditor.h \
     OverlayEditorScene.h \
     MumbleApplication.h \
-    ApplicationPalette.h
+    ApplicationPalette.h \
+    LanguageChangeNotice.h
 
 SOURCES *= BanEditor.cpp \
     ACLEditor.cpp \
@@ -180,7 +181,8 @@ SOURCES *= BanEditor.cpp \
     VoiceRecorderDialog.cpp \
     WebFetch.cpp \
     MumbleApplication.cpp \
-    smallft.cpp
+    smallft.cpp \
+    LanguageChangeNotice.cpp
 
 DIST		*= ../../icons/mumble.ico licenses.h smallft.h ../../icons/mumble.xpm murmur_pch.h mumble.plist
 RESOURCES	*= mumble.qrc mumble_translations.qrc mumble_flags.qrc

--- a/src/mumble/mumble_en.ts
+++ b/src/mumble/mumble_en.ts
@@ -514,7 +514,7 @@ Contains the list of members inherited by the current channel. Uncheck &lt;i&gt;
 <context>
     <name>ASIOConfig</name>
     <message>
-        <location filename="ASIOInput.cpp" line="+228"/>
+        <location filename="ASIOInput.cpp" line="+233"/>
         <source>%1 (version %2)</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2428,7 +2428,7 @@ Speak loudly, as when you are annoyed or excited. Decrease the volume in the sou
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="main.cpp" line="+419"/>
+        <location filename="main.cpp" line="+478"/>
         <source>&lt;b&gt;Certificate Expiry:&lt;/b&gt; Your certificate is about to expire. You need to renew it, or you will no longer be able to connect to servers you are registered on.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3783,6 +3783,14 @@ This field describes the size of an LCD device. The size is given either in pixe
     </message>
 </context>
 <context>
+    <name>LanguageChangeNotice</name>
+    <message>
+        <location filename="LanguageChangeNotice.cpp" line="+7"/>
+        <source>Mumble restart needed</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>Log</name>
     <message>
         <location filename="Log.cpp" line="+225"/>
@@ -4120,7 +4128,7 @@ This field describes the size of an LCD device. The size is given either in pixe
 <context>
     <name>LookConfig</name>
     <message>
-        <location filename="LookConfig.cpp" line="+55"/>
+        <location filename="LookConfig.cpp" line="+56"/>
         <location line="+23"/>
         <source>System default</source>
         <translation type="unfinished"></translation>
@@ -4161,7 +4169,7 @@ This field describes the size of an LCD device. The size is given either in pixe
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+157"/>
+        <location line="+162"/>
         <source>Choose skin file</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4421,17 +4429,22 @@ This field describes the size of an LCD device. The size is given either in pixe
         <source>Filter automatically hides empty channels</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <location/>
+        <source>Show transmit mode dropdown in toolbar</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>MainWindow</name>
     <message>
         <location filename="MainWindow.cpp" line="+139"/>
-        <location line="+2324"/>
+        <location line="+2386"/>
         <source>Root</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-2270"/>
+        <location line="-2332"/>
         <source>Push-to-Talk</source>
         <comment>Global Shortcut</comment>
         <translation type="unfinished"></translation>
@@ -4510,28 +4523,28 @@ This field describes the size of an LCD device. The size is given either in pixe
     <message>
         <location filename="MainWindow.cpp" line="+4"/>
         <location line="+19"/>
-        <location line="+2394"/>
+        <location line="+2456"/>
         <source>Mumble -- %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-2389"/>
+        <location line="-2451"/>
         <source>&amp;Window</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location line="+2"/>
-        <location line="+140"/>
+        <location line="+156"/>
         <source>Minimize</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-140"/>
+        <location line="-156"/>
         <source>Ctrl+M</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+139"/>
+        <location line="+155"/>
         <source>Close</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4541,7 +4554,7 @@ This field describes the size of an LCD device. The size is given either in pixe
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-200"/>
+        <location line="-216"/>
         <source>Mute Self</source>
         <comment>Global Shortcut</comment>
         <translation type="unfinished"></translation>
@@ -4584,13 +4597,13 @@ This field describes the size of an LCD device. The size is given either in pixe
     </message>
     <message>
         <location line="+67"/>
-        <location line="+2410"/>
+        <location line="+2472"/>
         <source>&lt;center&gt;Not connected&lt;/center&gt;</source>
         <oldsource>Not connected</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-2110"/>
+        <location line="-2142"/>
         <source>Clear</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4636,7 +4649,7 @@ This field describes the size of an LCD device. The size is given either in pixe
     </message>
     <message>
         <location line="+15"/>
-        <location line="+196"/>
+        <location line="+206"/>
         <source>Connecting to server %1.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4646,7 +4659,7 @@ This field describes the size of an LCD device. The size is given either in pixe
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+148"/>
+        <location line="+167"/>
         <source>&lt;p&gt;No build information or OS version available.&lt;/p&gt;</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4661,14 +4674,14 @@ This field describes the size of an LCD device. The size is given either in pixe
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-104"/>
-        <location line="+357"/>
+        <location line="-123"/>
+        <location line="+376"/>
         <source>Register yourself as %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-357"/>
-        <location line="+357"/>
+        <location line="-376"/>
+        <location line="+376"/>
         <source>&lt;p&gt;You are about to register yourself on this server. This action cannot be undone, and your username cannot be changed once this is done. You will forever be known as &apos;%1&apos; on this server.&lt;/p&gt;&lt;p&gt;Are you sure you want to register yourself?&lt;/p&gt;</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4704,7 +4717,7 @@ This field describes the size of an LCD device. The size is given either in pixe
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+635"/>
+        <location line="+638"/>
         <source>Connected.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4754,12 +4767,12 @@ This field describes the size of an LCD device. The size is given either in pixe
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1776"/>
+        <location line="-1779"/>
         <source>Voice channel is sent over control channel.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-950"/>
+        <location line="-1009"/>
         <source>&amp;User</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4794,17 +4807,47 @@ This field describes the size of an LCD device. The size is given either in pixe
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+157"/>
+        <location line="+84"/>
+        <source>Continuous</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Voice Activity</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+1"/>
+        <source>Push-to-Talk</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+87"/>
         <source>Cancel</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+577"/>
+        <location line="+601"/>
         <source>Change your comment</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+105"/>
+        <location line="+36"/>
+        <source>Transmit Mode set to Continous</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>Transmit Mode set to Voice Activity</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+5"/>
+        <source>Transmit Mode set to Push-to-Talk</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+78"/>
         <source>&lt;h2&gt;Version&lt;/h2&gt;&lt;p&gt;Protocol %1.&lt;/p&gt;</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4860,12 +4903,12 @@ This field describes the size of an LCD device. The size is given either in pixe
     </message>
     <message>
         <location line="+4"/>
-        <location line="+1446"/>
+        <location line="+1449"/>
         <source>&amp;View Certificate</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1168"/>
+        <location line="-1171"/>
         <location line="+19"/>
         <source>Enter reason</source>
         <translation type="unfinished"></translation>
@@ -4951,7 +4994,7 @@ This field describes the size of an LCD device. The size is given either in pixe
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+92"/>
+        <location line="+93"/>
         <source>About Qt</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4961,7 +5004,7 @@ This field describes the size of an LCD device. The size is given either in pixe
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+148"/>
+        <location line="+150"/>
         <source>SSL Verification failed: %1</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6039,7 +6082,7 @@ Otherwise abort and check your certificate and username.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="main.cpp" line="-278"/>
+        <location filename="main.cpp" line="-335"/>
         <source>Usage: mumble [options] [&lt;url&gt;]
 
 &lt;url&gt; specifies a URL to connect to after startup instead of showing
@@ -6055,16 +6098,54 @@ Valid options are:
                 Allow multiple instances of the client to be started.
   -n, --noidentity
                 Suppress loading of identity files (i.e., certificates.)
+
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+17"/>
+        <location line="+18"/>
+        <source>Remote controlling Mumble:
+
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
+        <source>Usage: mumble rpc &lt;action&gt; [options]
+
+It is possible to remote control a running instance of Mumble by using
+the &apos;mumble rpc&apos; command.
+
+Valid actions are:
+  mute
+                Mute self
+  unmute
+                Unmute self
+  deaf
+                Deafen self
+  undeaf
+                Undeafen self
+
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+24"/>
         <source>Invocation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+196"/>
+        <location line="+15"/>
+        <source>Error: No RPC command specified</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
+        <source>RPC</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+207"/>
         <source>Welcome to Mumble.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7256,7 +7337,7 @@ To upgrade these files to their latest versions, click the button below.</source
 <context>
     <name>PulseAudioSystem</name>
     <message>
-        <location filename="PulseAudio.cpp" line="+772"/>
+        <location filename="PulseAudio.cpp" line="+771"/>
         <source>Default Input</source>
         <translation type="unfinished"></translation>
     </message>


### PR DESCRIPTION
Impements #1474, The text "(mumble restart needed)" is concatenated on the Language label when a different language  than the current language is selected.

![image](https://cloud.githubusercontent.com/assets/4629607/6110144/2ba4204e-b080-11e4-8ca7-555c4e125484.png)
![image](https://cloud.githubusercontent.com/assets/4629607/6110190/51178a1e-b080-11e4-852e-22c89a026c80.png)

Maybe it's better to show  "Restart required", "Restart to apply", or anything else that is shorter/more clear. Let me know if there is anything I can improve.