### PR TITLE
Remove __DATE__ and __TIME__.

### DIFF
--- a/src/Version.h
+++ b/src/Version.h
@@ -36,7 +36,7 @@
 #define MUMTEXT(X) MUMXTEXT(X)
 
 #ifndef MUMBLE_VERSION
-#define MUMBLE_RELEASE "Compiled " __DATE__ " " __TIME__
+#define MUMBLE_RELEASE "Compiled by User"
 #else
 #define MUMBLE_RELEASE MUMTEXT(MUMBLE_VERSION)
 #endif

--- a/src/mumble/VersionCheck.cpp
+++ b/src/mumble/VersionCheck.cpp
@@ -44,8 +44,6 @@ VersionCheck::VersionCheck(bool autocheck, QObject *p, bool focus) : QObject(p) 
 
 	QList<QPair<QString, QString> > queryItems;
 	queryItems << qMakePair(QString::fromLatin1("ver"), QString::fromLatin1(QUrl::toPercentEncoding(QLatin1String(MUMBLE_RELEASE))));
-	queryItems << qMakePair(QString::fromLatin1("date"), QString::fromLatin1(QUrl::toPercentEncoding(QLatin1String(__DATE__))));
-	queryItems << qMakePair(QString::fromLatin1("time"), QString::fromLatin1(QUrl::toPercentEncoding(QLatin1String(__TIME__))));
 #if defined(Q_OS_WIN)
 # if defined(Q_OS_WIN64)
 	queryItems << qMakePair(QString::fromLatin1("os"), QString::fromLatin1("WinX64"));


### PR DESCRIPTION
This removes the date and time macro to attempt to get us to
reproducible builds [1]. While I do like the date and time included, it
doesn't really add that much value to our users.

[1] https://reproducible.debian.net/rb-pkg/sid/amd64/mumble.html
