### PR TITLE
Do not show TTS options, when speechd is disabled. (Fix #961)

### DIFF
--- a/src/mumble/AudioWizard.cpp
+++ b/src/mumble/AudioWizard.cpp
@@ -118,15 +118,21 @@ AudioWizard::AudioWizard(QWidget *p) : QWizard(p) {
 	for (int i = Log::firstMsgType;i <= Log::lastMsgType; ++i) {
 		iMessage |= (g.s.qmMessages[i] & (Settings::LogSoundfile | Settings::LogTTS));
 	}
-
+#if !defined(Q_OS_LINUX) || (defined(Q_OS_LINUX) && defined(USE_SPEECHD)) //TTS enabled
 	if (iMessage == Settings::LogTTS && g.s.bTTS)
 		qrbNotificationTTS->setChecked(true);
 	else if (iMessage == Settings::LogSoundfile)
 		qrbNotificationSounds->setChecked(true);
 	else // If we find mixed message types or only tts with main tts disable assume custom
 		qrbNotificationCustom->setChecked(true);
-
 	qrbNotificationCustom->setVisible(qrbNotificationCustom->isChecked());
+#else // No tts on Linux
+	qrbNotificationCustom->setChecked(false);
+	qrbNotificationCustom->setDisabled(true);
+	qrbNotificationTTS->setChecked(false);
+	qrbNotificationTTS->setDisabled(true);
+	qrbNotificationSounds->setChecked(true);
+#endif
 
 	qrbQualityCustom->setVisible(qrbQualityCustom->isChecked());
 	qlQualityCustom->setVisible(qrbQualityCustom->isChecked());

--- a/src/mumble/AudioWizard.cpp
+++ b/src/mumble/AudioWizard.cpp
@@ -118,7 +118,14 @@ AudioWizard::AudioWizard(QWidget *p) : QWizard(p) {
 	for (int i = Log::firstMsgType;i <= Log::lastMsgType; ++i) {
 		iMessage |= (g.s.qmMessages[i] & (Settings::LogSoundfile | Settings::LogTTS));
 	}
-#if !defined(Q_OS_LINUX) || (defined(Q_OS_LINUX) && defined(USE_SPEECHD)) //TTS enabled
+
+#ifdef USE_NO_TTS
+	qrbNotificationCustom->setChecked(false);
+	qrbNotificationCustom->setDisabled(true);
+	qrbNotificationTTS->setChecked(false);
+	qrbNotificationTTS->setDisabled(true);
+	qrbNotificationSounds->setChecked(true);
+#else
 	if (iMessage == Settings::LogTTS && g.s.bTTS)
 		qrbNotificationTTS->setChecked(true);
 	else if (iMessage == Settings::LogSoundfile)
@@ -126,12 +133,6 @@ AudioWizard::AudioWizard(QWidget *p) : QWizard(p) {
 	else // If we find mixed message types or only tts with main tts disable assume custom
 		qrbNotificationCustom->setChecked(true);
 	qrbNotificationCustom->setVisible(qrbNotificationCustom->isChecked());
-#else // No tts on Linux
-	qrbNotificationCustom->setChecked(false);
-	qrbNotificationCustom->setDisabled(true);
-	qrbNotificationTTS->setChecked(false);
-	qrbNotificationTTS->setDisabled(true);
-	qrbNotificationSounds->setChecked(true);
 #endif
 
 	qrbQualityCustom->setVisible(qrbQualityCustom->isChecked());

--- a/src/mumble/Log.cpp
+++ b/src/mumble/Log.cpp
@@ -52,6 +52,10 @@ static ConfigRegistrar registrar(4000, LogConfigDialogNew);
 LogConfig::LogConfig(Settings &st) : ConfigWidget(st) {
 	setupUi(this);
 
+#if defined(Q_OS_LINUX) && !defined(USE_SPEECHD) //Using Linux, but without TTS
+	qgbTTS->setDisabled(true);
+#endif
+
 #if QT_VERSION >= 0x050000
 	qtwMessages->header()->setSectionResizeMode(ColMessage, QHeaderView::Stretch);
 	qtwMessages->header()->setSectionResizeMode(ColConsole, QHeaderView::ResizeToContents);
@@ -76,20 +80,23 @@ LogConfig::LogConfig(Settings &st) : ConfigWidget(st) {
 		twi->setText(ColMessage, messageName);
 		twi->setCheckState(ColConsole, Qt::Unchecked);
 		twi->setCheckState(ColNotification, Qt::Unchecked);
-		twi->setCheckState(ColTTS, Qt::Unchecked);
 		twi->setCheckState(ColStaticSound, Qt::Unchecked);
 
 		twi->setToolTip(ColConsole, tr("Toggle console for %1 events").arg(messageName));
 		twi->setToolTip(ColNotification, tr("Toggle pop-up notifications for %1 events").arg(messageName));
-		twi->setToolTip(ColTTS, tr("Toggle Text-To-Speech for %1 events").arg(messageName));
 		twi->setToolTip(ColStaticSound, tr("Click here to toggle sound notification for %1 events").arg(messageName));
 		twi->setToolTip(ColStaticSoundPath, tr("Path to sound file used for sound notifications in the case of %1 events<br />Single click to play<br />Double-click to change").arg(messageName));
 
 		twi->setWhatsThis(ColConsole, tr("Click here to toggle console output for %1 events.<br />If checked, this option makes Mumble output all %1 events in its message log.").arg(messageName));
 		twi->setWhatsThis(ColNotification, tr("Click here to toggle pop-up notifications for %1 events.<br />If checked, a notification pop-up will be created by Mumble for every %1 event.").arg(messageName));
-		twi->setWhatsThis(ColTTS, tr("Click here to toggle Text-To-Speech for %1 events.<br />If checked, Mumble uses Text-To-Speech to read %1 events out loud to you. Text-To-Speech is also able to read the contents of the event which is not true for sound files. Text-To-Speech and sound files cannot be used at the same time.").arg(messageName));
 		twi->setWhatsThis(ColStaticSound, tr("Click here to toggle sound notification for %1 events.<br />If checked, Mumble uses a sound file predefined by you to indicate %1 events. Sound files and Text-To-Speech cannot be used at the same time.").arg(messageName));
 		twi->setWhatsThis(ColStaticSoundPath, tr("Path to sound file used for sound notifications in the case of %1 events.<br />Single click to play<br />Double-click to change<br />Ensure that sound notifications for these events are enabled or this field will not have any effect.").arg(messageName));
+// On Linux: Disabled when TTS is disabled
+#if !defined(Q_OS_LINUX) || (defined(Q_OS_LINUX) && defined(USE_SPEECHD))
+		twi->setCheckState(ColTTS, Qt::Unchecked);
+		twi->setToolTip(ColTTS, tr("Toggle Text-To-Speech for %1 events").arg(messageName));
+		twi->setWhatsThis(ColTTS, tr("Click here to toggle Text-To-Speech for %1 events.<br />If checked, Mumble uses Text-To-Speech to read %1 events out loud to you. Text-To-Speech is also able to read the contents of the event which is not true for sound files. Text-To-Speech and sound files cannot be used at the same time.").arg(messageName));
+#endif
 	}
 }
 
@@ -110,16 +117,22 @@ void LogConfig::load(const Settings &r) {
 
 		i->setCheckState(ColConsole, (ml & Settings::LogConsole) ? Qt::Checked : Qt::Unchecked);
 		i->setCheckState(ColNotification, (ml & Settings::LogBalloon) ? Qt::Checked : Qt::Unchecked);
+#if !defined(Q_OS_LINUX) || (defined(Q_OS_LINUX) && defined(USE_SPEECHD))
 		i->setCheckState(ColTTS, (ml & Settings::LogTTS) ? Qt::Checked : Qt::Unchecked);
+#endif
 		i->setCheckState(ColStaticSound, (ml & Settings::LogSoundfile) ? Qt::Checked : Qt::Unchecked);
 		i->setText(ColStaticSoundPath, r.qmMessageSounds.value(mt));
 	}
 	
 	qsbMaxBlocks->setValue(r.iMaxLogBlocks);
 
+#if !defined(Q_OS_LINUX) || (defined(Q_OS_LINUX) && defined(USE_SPEECHD))
 	loadSlider(qsVolume, r.iTTSVolume);
 	qsbThreshold->setValue(r.iTTSThreshold);
 	qcbReadBackOwn->setChecked(r.bTTSMessageReadBack);
+#else
+	qtwMessages->hideColumn(ColTTS);
+#endif
 	qcbWhisperFriends->setChecked(r.bWhisperFriends);
 }
 
@@ -133,8 +146,10 @@ void LogConfig::save() const {
 			v |= Settings::LogConsole;
 		if (i->checkState(ColNotification) == Qt::Checked)
 			v |= Settings::LogBalloon;
+#if !defined(Q_OS_LINUX) || (defined(Q_OS_LINUX) && defined(USE_SPEECHD))
 		if (i->checkState(ColTTS) == Qt::Checked)
 			v |= Settings::LogTTS;
+#endif
 		if (i->checkState(ColStaticSound) == Qt::Checked)
 			v |= Settings::LogSoundfile;
 		s.qmMessages[mt] = v;
@@ -142,9 +157,11 @@ void LogConfig::save() const {
 	}
 	s.iMaxLogBlocks = qsbMaxBlocks->value();
 
+#if !defined(Q_OS_LINUX) || (defined(Q_OS_LINUX) && defined(USE_SPEECHD))
 	s.iTTSVolume=qsVolume->value();
 	s.iTTSThreshold=qsbThreshold->value();
 	s.bTTSMessageReadBack = qcbReadBackOwn->isChecked();
+#endif
 	s.bWhisperFriends = qcbWhisperFriends->isChecked();
 }
 

--- a/src/mumble/MainWindow.cpp
+++ b/src/mumble/MainWindow.cpp
@@ -285,11 +285,11 @@ void MainWindow::setupGui()  {
 
 	qaAudioMute->setChecked(g.s.bMute);
 	qaAudioDeaf->setChecked(g.s.bDeaf);
-#if !defined(Q_OS_LINUX) || (defined(Q_OS_LINUX) && defined(USE_SPEECHD)) //With TTS
-	qaAudioTTS->setChecked(g.s.bTTS);
-#else //Linux but no TTS:
+#ifdef USE_NO_TTS
 	qaAudioTTS->setChecked(false);
 	qaAudioTTS->setDisabled(true);
+#else
+	qaAudioTTS->setChecked(g.s.bTTS);
 #endif
 	qaFilterToggle->setChecked(g.s.bFilterActive);
 

--- a/src/mumble/MainWindow.cpp
+++ b/src/mumble/MainWindow.cpp
@@ -285,7 +285,12 @@ void MainWindow::setupGui()  {
 
 	qaAudioMute->setChecked(g.s.bMute);
 	qaAudioDeaf->setChecked(g.s.bDeaf);
+#if !defined(Q_OS_LINUX) || (defined(Q_OS_LINUX) && defined(USE_SPEECHD)) //With TTS
 	qaAudioTTS->setChecked(g.s.bTTS);
+#else //Linux but no TTS:
+	qaAudioTTS->setChecked(false);
+	qaAudioTTS->setDisabled(true);
+#endif
 	qaFilterToggle->setChecked(g.s.bFilterActive);
 
 	qaHelpWhatsThis->setShortcuts(QKeySequence::WhatsThis);

--- a/src/mumble/mumble.pro
+++ b/src/mumble/mumble.pro
@@ -437,6 +437,8 @@ unix {
 
     !CONFIG(no-speechd) {
       CONFIG *= speechd
+    } else {
+      DEFINES *= USE_NO_TTS
     }
   }
 }


### PR DESCRIPTION
This will fix #961. So If you are using Linux and have disabled TTS (no-speechd), UI elements for TTS options are disabled.