### PR TITLE
Fix typo in Finnish translation

### DIFF
--- a/installer/Product.wxs
+++ b/installer/Product.wxs
@@ -3,7 +3,7 @@
   <?include "Settings.wxi" ?>
 
   <Product Id="*" Name="$(var.ProductName) $(var.ProductVersion)" Language="!(loc.LANG)" Version="$(var.ProductVersion)" Manufacturer="$(var.ProductManufacturer)" UpgradeCode="$(var.ProductUpgradeCode)">
-    <Package Id="*" InstallerVersion="300" Compressed="yes" Languages="0,1028,1029,1030,1031,1033,1034,1036,1040,1041,1043,1044,1045,1046,1049,1053,1055,2052" />
+    <Package Id="*" InstallerVersion="300" Compressed="yes" Languages="0,1028,1029,1030,1031,1033,1034,1035,1036,1040,1041,1043,1044,1045,1046,1049,1053,1055,2052" />
 
     <Property Id='NSISINSTALL'>
       <RegistrySearch Id='NSISSearch' Win64='no' Root='HKLM' Key='SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\Mumble' Type='directory' Name='InstallLocation' />

--- a/installer/Translations/Finnish.wxl
+++ b/installer/Translations/Finnish.wxl
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <WixLocalization Culture="fi-fi" xmlns="http://schemas.microsoft.com/wix/2006/localization">
-  <String Id="LANG">1035 </String>
+  <String Id="LANG">1035</String>
 
   <!-- By Sami Laine <sami.v.laine@gmail.com> -->
   <String Id="MUMBLE_CREATE_SHORTCUT">Luo pikakuvake työpöydälle</String>


### PR DESCRIPTION
Possibly fixing "Error applying transforms." when trying to start the installer in Finnish Windows