### PR TITLE
New server auto label

### DIFF
--- a/src/mumble/ConnectDialog.cpp
+++ b/src/mumble/ConnectDialog.cpp
@@ -732,6 +732,7 @@ ConnectDialogEdit::ConnectDialogEdit(QWidget *p, const QString &name, const QStr
 
 	usPort = 0;
 	bOk = true;
+	bCustomLabel = ! name.simplified().isEmpty();
 
 	connect(qleName, SIGNAL(textChanged(const QString &)), this, SLOT(validate()));
 	connect(qleServer, SIGNAL(textChanged(const QString &)), this, SLOT(validate()));
@@ -740,6 +741,29 @@ ConnectDialogEdit::ConnectDialogEdit(QWidget *p, const QString &name, const QStr
 	connect(qlePassword, SIGNAL(textChanged(const QString &)), this, SLOT(validate()));
 
 	validate();
+}
+
+void ConnectDialogEdit::on_qleName_textEdited(const QString& name) {
+	if (bCustomLabel) {
+		// If empty, then reset to automatic label.
+		// NOTE(nik@jnstw.us): You may be tempted to set qleName to qleServer, but that results in the odd
+		// UI behavior that clearing the field doesn't clear it; it'll immediately equal qleServer. Instead,
+		// leave it empty and let it update the next time qleServer updates. Code in accept will default it
+		// to qleServer if it isn't updated beforehand.
+		if (name.simplified().isEmpty()) {
+			bCustomLabel = false;
+		}
+	} else {
+		// If manually edited, set to Custom
+		bCustomLabel = true;
+	}
+}
+
+void ConnectDialogEdit::on_qleServer_textEdited(const QString& server) {
+	// If using automatic label, update it
+	if (!bCustomLabel) {
+		qleName->setText(server);
+	}
 }
 
 void ConnectDialogEdit::validate() {

--- a/src/mumble/ConnectDialog.cpp
+++ b/src/mumble/ConnectDialog.cpp
@@ -765,14 +765,18 @@ void ConnectDialogEdit::validate() {
 		adjustSize();
 	}
 
-	bOk = ! qsName.isEmpty() && ! qsHostname.isEmpty() && ! qsUsername.isEmpty() && usPort;
+	bOk = ! qsHostname.isEmpty() && ! qsUsername.isEmpty() && usPort;
 	qdbbButtonBox->button(QDialogButtonBox::Ok)->setEnabled(bOk);
 }
 
 void ConnectDialogEdit::accept() {
 	validate();
-	if (bOk)
+	if (bOk) {
+		if (qleName->text().simplified().isEmpty()) {
+			qleName->setText(qleServer->text());
+		}
 		QDialog::accept();
+    }
 }
 
 void ConnectDialogEdit::on_qcbShowPassword_toggled(bool checked) {

--- a/src/mumble/ConnectDialog.h
+++ b/src/mumble/ConnectDialog.h
@@ -190,11 +190,14 @@ class ConnectDialogEdit : public QDialog, protected Ui::ConnectDialogEdit {
 		Q_DISABLE_COPY(ConnectDialogEdit)
 	protected:
 		bool bOk;
+		bool bCustomLabel;
 	public slots:
 		void validate();
 		void accept();
 
 		void on_qcbShowPassword_toggled(bool);
+		void on_qleName_textEdited(const QString&);
+		void on_qleServer_textEdited(const QString&);
 	public:
 		QString qsName, qsHostname, qsUsername, qsPassword;
 		unsigned short usPort;

--- a/src/mumble/ConnectDialogEdit.ui
+++ b/src/mumble/ConnectDialogEdit.ui
@@ -161,6 +161,7 @@ Label of the server. This is what the server will be named like in your server l
   <tabstop>qlePort</tabstop>
   <tabstop>qleUsername</tabstop>
   <tabstop>qlePassword</tabstop>
+  <tabstop>qleName</tabstop>
   <tabstop>qcbShowPassword</tabstop>
   <tabstop>qdbbButtonBox</tabstop>
  </tabstops>

--- a/src/mumble/ConnectDialogEdit.ui
+++ b/src/mumble/ConnectDialogEdit.ui
@@ -133,7 +133,7 @@ Password to be sent to the server on connect. This password is needed when conne
    <item row="6" column="0">
     <widget class="QLabel" name="qliName">
      <property name="text">
-      <string>Label</string>
+      <string>Label (optional)</string>
      </property>
      <property name="buddy">
       <cstring>qleName</cstring>

--- a/src/mumble/ConnectDialogEdit.ui
+++ b/src/mumble/ConnectDialogEdit.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>243</width>
-    <height>194</height>
+    <height>197</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -20,30 +20,6 @@
    <string>Edit Server</string>
   </property>
   <layout class="QGridLayout" name="gridLayout">
-   <item row="0" column="0">
-    <widget class="QLabel" name="qliName">
-     <property name="text">
-      <string>Label</string>
-     </property>
-     <property name="buddy">
-      <cstring>qleName</cstring>
-     </property>
-    </widget>
-   </item>
-   <item row="0" column="1">
-    <widget class="QLineEdit" name="qleName">
-     <property name="toolTip">
-      <string>Name of the server</string>
-     </property>
-     <property name="whatsThis">
-      <string>&lt;b&gt;Label&lt;/b&gt;&lt;br/&gt;
-Label of the server. This is what the server will be named like in your server list and can be chosen freely.</string>
-     </property>
-     <property name="placeholderText">
-      <string>Local server label</string>
-     </property>
-    </widget>
-   </item>
    <item row="1" column="0">
     <widget class="QLabel" name="qliServer">
      <property name="text">
@@ -92,7 +68,7 @@ Port on which the server is listening. If the server is identified by a Bonjour 
      </property>
     </widget>
    </item>
-   <item row="3" column="0">
+   <item row="4" column="0">
     <widget class="QLabel" name="qliUsername">
      <property name="text">
       <string>&amp;Username</string>
@@ -102,7 +78,14 @@ Port on which the server is listening. If the server is identified by a Bonjour 
      </property>
     </widget>
    </item>
-   <item row="3" column="1">
+   <item row="5" column="0">
+    <widget class="QLabel" name="qliPassword">
+     <property name="text">
+      <string>Password</string>
+     </property>
+    </widget>
+   </item>
+   <item row="4" column="1">
     <widget class="QLineEdit" name="qleUsername">
      <property name="toolTip">
       <string>Username to send to the server</string>
@@ -116,21 +99,14 @@ Username to send to the server. Be aware that the server can impose restrictions
      </property>
     </widget>
    </item>
-   <item row="6" column="1">
+   <item row="8" column="1">
     <widget class="QDialogButtonBox" name="qdbbButtonBox">
      <property name="standardButtons">
       <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
      </property>
     </widget>
    </item>
-   <item row="4" column="0">
-    <widget class="QLabel" name="qliPassword">
-     <property name="text">
-      <string>Password</string>
-     </property>
-    </widget>
-   </item>
-   <item row="4" column="1">
+   <item row="5" column="1">
     <widget class="QLineEdit" name="qlePassword">
      <property name="toolTip">
       <string>Password to send to the server</string>
@@ -144,7 +120,7 @@ Password to be sent to the server on connect. This password is needed when conne
      </property>
     </widget>
    </item>
-   <item row="5" column="1">
+   <item row="7" column="1">
     <widget class="QCheckBox" name="qcbShowPassword">
      <property name="toolTip">
       <string/>
@@ -154,10 +130,33 @@ Password to be sent to the server on connect. This password is needed when conne
      </property>
     </widget>
    </item>
+   <item row="6" column="0">
+    <widget class="QLabel" name="qliName">
+     <property name="text">
+      <string>Label</string>
+     </property>
+     <property name="buddy">
+      <cstring>qleName</cstring>
+     </property>
+    </widget>
+   </item>
+   <item row="6" column="1">
+    <widget class="QLineEdit" name="qleName">
+     <property name="toolTip">
+      <string>Name of the server</string>
+     </property>
+     <property name="whatsThis">
+      <string>&lt;b&gt;Label&lt;/b&gt;&lt;br/&gt;
+Label of the server. This is what the server will be named like in your server list and can be chosen freely.</string>
+     </property>
+     <property name="placeholderText">
+      <string>Local server label</string>
+     </property>
+    </widget>
+   </item>
   </layout>
  </widget>
  <tabstops>
-  <tabstop>qleName</tabstop>
   <tabstop>qleServer</tabstop>
   <tabstop>qlePort</tabstop>
   <tabstop>qleUsername</tabstop>

--- a/src/mumble/ConnectDialogEdit.ui
+++ b/src/mumble/ConnectDialogEdit.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>243</width>
+    <width>265</width>
     <height>197</height>
    </rect>
   </property>
@@ -133,7 +133,7 @@ Password to be sent to the server on connect. This password is needed when conne
    <item row="6" column="0">
     <widget class="QLabel" name="qliName">
      <property name="text">
-      <string>Label (optional)</string>
+      <string>Label</string>
      </property>
      <property name="buddy">
       <cstring>qleName</cstring>


### PR DESCRIPTION
Adds a small new server workflow improvement by making server Label field optional and default to the hostname. This patch also moves the Label text box below the Username text box since it's no longer as important as the actual destination.

![mumble-pr](https://cloud.githubusercontent.com/assets/892332/7447330/ad89adf6-f1ab-11e4-80a2-c9e8fe8b61a2.png)
