### PR TITLE
Add an option to avoid attenuating applications on other outputs (sinks)

### DIFF
--- a/src/mumble/AudioConfigDialog.cpp
+++ b/src/mumble/AudioConfigDialog.cpp
@@ -455,6 +455,14 @@ void AudioOutputDialog::load(const Settings &r) {
 	loadCheckBox(qcbAttenuateOthers, r.bAttenuateOthers);
 	loadCheckBox(qcbAttenuateUsersOnPrioritySpeak, r.bAttenuateUsersOnPrioritySpeak);
 	loadCheckBox(qcbOnlyAttenuateSameSink, r.bOnlyAttenuateSameSink);
+	loadCheckBox(qcbAttenuateLoopbacks, r.bAttenuateLoopbacks);
+	if (AudioOutputRegistrar::current == QString::fromAscii("PulseAudio")){
+		qcbOnlyAttenuateSameSink->setVisible(true);
+		qcbAttenuateLoopbacks->setVisible(true);
+	} else {
+		qcbOnlyAttenuateSameSink->setVisible(false);
+		qcbAttenuateLoopbacks->setVisible(false);
+	}
 	loadSlider(qsJitter, r.iJitterBufferSize);
 	loadComboBox(qcbLoopback, r.lmLoopMode);
 	loadSlider(qsPacketDelay, static_cast<int>(r.dMaxPacketDelay));
@@ -477,6 +485,7 @@ void AudioOutputDialog::save() const {
 	s.bAttenuateOthersOnTalk = qcbAttenuateOthersOnTalk->isChecked();
 	s.bAttenuateOthers = qcbAttenuateOthers->isChecked();
 	s.bOnlyAttenuateSameSink = qcbOnlyAttenuateSameSink->isChecked();
+	s.bAttenuateLoopbacks = qcbAttenuateLoopbacks->isChecked();
 	s.bAttenuateUsersOnPrioritySpeak = qcbAttenuateUsersOnPrioritySpeak->isChecked();
 	s.iJitterBufferSize = qsJitter->value();
 	s.qsAudioOutput = qcbSystem->currentText();
@@ -524,7 +533,17 @@ void AudioOutputDialog::on_qcbSystem_currentIndexChanged(int) {
 		bool canmute = aor->canMuteOthers();
 		qsOtherVolume->setEnabled(canmute);
 		qcbAttenuateOthersOnTalk->setEnabled(canmute);
-		qcbOnlyAttenuateSameSink->setEnabled((aor->name == QString::fromAscii("PulseAudio")?true:false));
+		if (aor->name == QString::fromAscii("PulseAudio")){
+			qcbOnlyAttenuateSameSink->setVisible(true);
+			qcbOnlyAttenuateSameSink->setEnabled(true);
+			qcbAttenuateLoopbacks->setVisible(true);
+			qcbAttenuateLoopbacks->setEnabled(true);
+		} else {
+			qcbOnlyAttenuateSameSink->setVisible(false);
+			qcbOnlyAttenuateSameSink->setEnabled(false);
+			qcbAttenuateLoopbacks->setVisible(false);
+			qcbAttenuateLoopbacks->setEnabled(false);
+		}
 		qcbAttenuateOthers->setEnabled(canmute);
 		qlOtherVolume->setEnabled(canmute);
 
@@ -614,4 +633,8 @@ void AudioOutputDialog::on_qcbAttenuateOthers_clicked(bool checked) {
 	bool b = qcbAttenuateOthersOnTalk->isChecked() || checked;
 	qsOtherVolume->setEnabled(b);
 	qlOtherVolume->setEnabled(b);
+}
+
+void AudioOutputDialog::on_qcbOnlyAttenuateSameSink_clicked(bool checked) {
+	qcbAttenuateLoopbacks->setEnabled(checked);
 }

--- a/src/mumble/AudioConfigDialog.cpp
+++ b/src/mumble/AudioConfigDialog.cpp
@@ -454,6 +454,7 @@ void AudioOutputDialog::load(const Settings &r) {
 	loadCheckBox(qcbAttenuateOthersOnTalk, r.bAttenuateOthersOnTalk);
 	loadCheckBox(qcbAttenuateOthers, r.bAttenuateOthers);
 	loadCheckBox(qcbAttenuateUsersOnPrioritySpeak, r.bAttenuateUsersOnPrioritySpeak);
+	loadCheckBox(qcbOnlyAttenuateSameSink, r.bOnlyAttenuateSameSink);
 	loadSlider(qsJitter, r.iJitterBufferSize);
 	loadComboBox(qcbLoopback, r.lmLoopMode);
 	loadSlider(qsPacketDelay, static_cast<int>(r.dMaxPacketDelay));
@@ -475,6 +476,7 @@ void AudioOutputDialog::save() const {
 	s.fOtherVolume = 1.0f - (static_cast<float>(qsOtherVolume->value()) / 100.0f);
 	s.bAttenuateOthersOnTalk = qcbAttenuateOthersOnTalk->isChecked();
 	s.bAttenuateOthers = qcbAttenuateOthers->isChecked();
+	s.bOnlyAttenuateSameSink = qcbOnlyAttenuateSameSink->isChecked();
 	s.bAttenuateUsersOnPrioritySpeak = qcbAttenuateUsersOnPrioritySpeak->isChecked();
 	s.iJitterBufferSize = qsJitter->value();
 	s.qsAudioOutput = qcbSystem->currentText();
@@ -522,6 +524,7 @@ void AudioOutputDialog::on_qcbSystem_currentIndexChanged(int) {
 		bool canmute = aor->canMuteOthers();
 		qsOtherVolume->setEnabled(canmute);
 		qcbAttenuateOthersOnTalk->setEnabled(canmute);
+		qcbOnlyAttenuateSameSink->setEnabled((aor->name == QString::fromAscii("PulseAudio")?true:false));
 		qcbAttenuateOthers->setEnabled(canmute);
 		qlOtherVolume->setEnabled(canmute);
 

--- a/src/mumble/AudioConfigDialog.h
+++ b/src/mumble/AudioConfigDialog.h
@@ -103,6 +103,7 @@ class AudioOutputDialog : public ConfigWidget, public Ui::AudioOutput {
 		void on_qcbPositional_stateChanged(int);
 		void on_qcbAttenuateOthersOnTalk_clicked(bool checked);
 		void on_qcbAttenuateOthers_clicked(bool checked);
+		void on_qcbOnlyAttenuateSameSink_clicked(bool checked);
 };
 
 #endif

--- a/src/mumble/AudioOutput.ui
+++ b/src/mumble/AudioOutput.ui
@@ -330,6 +330,20 @@
         </item>
        </layout>
       </item>
+      <item row="6" column="1">
+       <layout class="QHBoxLayout" name="horizontalLayout_2">
+        <item>
+         <widget class="QCheckBox" name="qcbOnlyAttenuateSameSink">
+          <property name="toolTip">
+           <string>If checked, Mumble will only attenuate applications that are using the same output source as Mumble</string>
+          </property>
+          <property name="text">
+           <string>Only attenuate same output</string>
+          </property>
+         </widget>
+        </item>
+       </layout>
+      </item>
      </layout>
     </widget>
    </item>

--- a/src/mumble/AudioOutput.ui
+++ b/src/mumble/AudioOutput.ui
@@ -337,8 +337,24 @@
           <property name="toolTip">
            <string>If checked, Mumble will only attenuate applications that are using the same output source as Mumble</string>
           </property>
+          <property name="whatsThis">
+           <string>&lt;b&gt;Attenuate only applications using the same output as Mumble&lt;/b&gt;&lt;br /&gt;If checked, applications that use a different output than Mumble will not be attenuated.</string>
+          </property>
           <property name="text">
-           <string>Only attenuate same output</string>
+           <string>Only same output</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QCheckBox" name="qcbAttenuateLoopbacks">
+          <property name="toolTip">
+           <string>PulseAudio only: If checked, loopback modules will be attenuated</string>
+          </property>
+          <property name="whatsThis">
+           <string>&lt;b&gt;PulseAudio only: Also attenuate loopback modules.&lt;/b&gt;&lt;br /&gt;If loopback modules are linked to Mumble's output/sink, they will also be attenuated.</string>
+          </property>
+          <property name="text">
+           <string>Include loopbacks</string>
           </property>
          </widget>
         </item>

--- a/src/mumble/PulseAudio.cpp
+++ b/src/mumble/PulseAudio.cpp
@@ -630,9 +630,8 @@ void PulseAudioSystem::volume_sink_input_list_callback(pa_context *c, const pa_s
 	  	//If we're not attenuating diffent sinks and the input is not on this sink, don't attenuate
 		//If the input is a loopback driver and connected to Mumble's sink, also ignore it (loopbacks are used to connect
                 //sinks). An attenuated loopback means an indirect application attenuation.
-		if ( g.s.bOnlyAttenuateSameSink && pas->iSinkId > -1 )
-		{
-			if (int(i->sink) != pas->iSinkId || (int(i->sink) == pas->iSinkId && !strcmp(i->driver, "module-loopback.c")))
+		if ( g.s.bOnlyAttenuateSameSink && pas->iSinkId > -1 ){
+			if (int(i->sink) != pas->iSinkId || (int(i->sink) == pas->iSinkId && !strcmp(i->driver, "module-loopback.c") && !g.s.bAttenuateLoopbacks))
 				return;
 		}
 		// ensure we're not attenuating ourselves!

--- a/src/mumble/PulseAudio.cpp
+++ b/src/mumble/PulseAudio.cpp
@@ -106,6 +106,7 @@ PulseAudioSystem::PulseAudioSystem() {
 	bAttenuating = false;
 	iRemainingOperations = 0;
 	bPulseIsGood = false;
+	iSinkId = -1;
 
 	pam = pa_threaded_mainloop_new();
 	pa_mainloop_api *api = pa_threaded_mainloop_get_api(pam);
@@ -229,6 +230,7 @@ void PulseAudioSystem::eventCallback(pa_mainloop_api *api, pa_defer_event *) {
 		if (do_stop) {
 			qWarning("PulseAudio: Stopping output");
 			pa_stream_disconnect(pasOutput);
+			iSinkId = -1;
 		} else if (do_start) {
 			qWarning("PulseAudio: Starting output: %s", qPrintable(odev));
 			pa_buffer_attr buff;
@@ -245,6 +247,7 @@ void PulseAudioSystem::eventCallback(pa_mainloop_api *api, pa_defer_event *) {
 			qsOutputCache = odev;
 
 			pa_stream_connect_playback(pasOutput, qPrintable(odev), &buff, PA_STREAM_ADJUST_LATENCY, NULL, NULL);
+			pa_context_get_sink_info_by_name(pacContext, qPrintable(odev), sink_info_callback, this);
 		}
 	}
 
@@ -438,6 +441,16 @@ void PulseAudioSystem::server_callback(pa_context *, const pa_server_info *i, vo
 	pas->wakeup();
 }
 
+void PulseAudioSystem::sink_info_callback(pa_context *, const pa_sink_info *i, int eol, void *userdata) {
+	PulseAudioSystem *pas = reinterpret_cast<PulseAudioSystem *>(userdata);
+
+	if( !i || eol )
+		return;
+
+	pas->iSinkId = i->index;
+}
+
+
 void PulseAudioSystem::stream_callback(pa_stream *s, void *userdata) {
 	PulseAudioSystem *pas = reinterpret_cast<PulseAudioSystem *>(userdata);
 	switch (pa_stream_get_state(s)) {
@@ -614,6 +627,14 @@ void PulseAudioSystem::volume_sink_input_list_callback(pa_context *c, const pa_s
 	PulseAudioSystem *pas = reinterpret_cast<PulseAudioSystem *>(userdata);
 
 	if (eol == 0) {
+	  	//If we're not attenuating diffent sinks and the input is not on this sink, don't attenuate
+		//If the input is a loopback driver and connected to Mumble's sink, also ignore it (loopbacks are used to connect
+                //sinks). An attenuated loopback means an indirect application attenuation.
+		if ( g.s.bOnlyAttenuateSameSink && pas->iSinkId > -1 )
+		{
+			if (int(i->sink) != pas->iSinkId || (int(i->sink) == pas->iSinkId && !strcmp(i->driver, "module-loopback.c")))
+				return;
+		}
 		// ensure we're not attenuating ourselves!
 		if (strcmp(i->name, mumble_sink_input) != 0) {
 			// create a new entry

--- a/src/mumble/PulseAudio.h
+++ b/src/mumble/PulseAudio.h
@@ -74,6 +74,7 @@ class PulseAudioSystem : public QObject {
 
 		bool bAttenuating;
 		int iRemainingOperations;
+		int iSinkId;
 		QHash<uint32_t, PulseAttenuation> qhVolumes;
 		QList<uint32_t> qlMatchedSinks;
 		QHash<QString, PulseAttenuation> qhUnmatchedSinks;
@@ -85,6 +86,7 @@ class PulseAudioSystem : public QObject {
 		static void sink_callback(pa_context *c, const pa_sink_info *i, int eol, void *userdata);
 		static void source_callback(pa_context *c, const pa_source_info *i, int eol, void *userdata);
 		static void server_callback(pa_context *c, const pa_server_info *i, void *userdata);
+		static void sink_info_callback(pa_context *c, const pa_sink_info *i, int eol, void *userdata);
 		static void stream_callback(pa_stream *s, void *userdata);
 		static void read_callback(pa_stream *s, size_t bytes, void *userdata);
 		static void write_callback(pa_stream *s, size_t bytes, void *userdata);

--- a/src/mumble/Settings.cpp
+++ b/src/mumble/Settings.cpp
@@ -257,6 +257,7 @@ Settings::Settings() {
 	bAttenuateOthers = true;
 	bAttenuateUsersOnPrioritySpeak = false;
 	bOnlyAttenuateSameSink = false;
+	bAttenuateLoopbacks = false;
 	iMinLoudness = 1000;
 	iVoiceHold = 50;
 	iJitterBufferSize = 1;
@@ -572,6 +573,7 @@ void Settings::load(QSettings* settings_ptr) {
 	SAVELOAD(bAttenuateOthersOnTalk, "audio/attenuateothersontalk");
 	SAVELOAD(bAttenuateUsersOnPrioritySpeak, "audio/attenuateusersonpriorityspeak");
 	SAVELOAD(bOnlyAttenuateSameSink, "audio/onlyattenuatesamesink");
+	SAVELOAD(bAttenuateLoopbacks, "audio/attenuateloopbacks");
 	LOADENUM(vsVAD, "audio/vadsource");
 	SAVELOAD(fVADmin, "audio/vadmin");
 	SAVELOAD(fVADmax, "audio/vadmax");
@@ -873,6 +875,7 @@ void Settings::save() {
 	SAVELOAD(bAttenuateOthersOnTalk, "audio/attenuateothersontalk");
 	SAVELOAD(bAttenuateUsersOnPrioritySpeak, "audio/attenuateusersonpriorityspeak");
 	SAVELOAD(bOnlyAttenuateSameSink, "audio/onlyattenuatesamesink");
+	SAVELOAD(bAttenuateLoopbacks, "audio/attenuateloopbacks");
 	SAVELOAD(vsVAD, "audio/vadsource");
 	SAVELOAD(fVADmin, "audio/vadmin");
 	SAVELOAD(fVADmax, "audio/vadmax");

--- a/src/mumble/Settings.cpp
+++ b/src/mumble/Settings.cpp
@@ -256,6 +256,7 @@ Settings::Settings() {
 	bAttenuateOthersOnTalk = false;
 	bAttenuateOthers = true;
 	bAttenuateUsersOnPrioritySpeak = false;
+	bOnlyAttenuateSameSink = false;
 	iMinLoudness = 1000;
 	iVoiceHold = 50;
 	iJitterBufferSize = 1;
@@ -570,6 +571,7 @@ void Settings::load(QSettings* settings_ptr) {
 	SAVELOAD(bAttenuateOthers, "audio/attenuateothers");
 	SAVELOAD(bAttenuateOthersOnTalk, "audio/attenuateothersontalk");
 	SAVELOAD(bAttenuateUsersOnPrioritySpeak, "audio/attenuateusersonpriorityspeak");
+	SAVELOAD(bOnlyAttenuateSameSink, "audio/onlyattenuatesamesink");
 	LOADENUM(vsVAD, "audio/vadsource");
 	SAVELOAD(fVADmin, "audio/vadmin");
 	SAVELOAD(fVADmax, "audio/vadmax");
@@ -870,6 +872,7 @@ void Settings::save() {
 	SAVELOAD(bAttenuateOthers, "audio/attenuateothers");
 	SAVELOAD(bAttenuateOthersOnTalk, "audio/attenuateothersontalk");
 	SAVELOAD(bAttenuateUsersOnPrioritySpeak, "audio/attenuateusersonpriorityspeak");
+	SAVELOAD(bOnlyAttenuateSameSink, "audio/onlyattenuatesamesink");
 	SAVELOAD(vsVAD, "audio/vadsource");
 	SAVELOAD(fVADmin, "audio/vadmin");
 	SAVELOAD(fVADmax, "audio/vadmax");

--- a/src/mumble/Settings.h
+++ b/src/mumble/Settings.h
@@ -205,6 +205,7 @@ struct Settings {
 	bool bAttenuateOthers;
 	bool bAttenuateUsersOnPrioritySpeak;
 	bool bOnlyAttenuateSameSink;
+	bool bAttenuateLoopbacks;
 	int iOutputDelay;
 
 	QString qsALSAInput, qsALSAOutput;

--- a/src/mumble/Settings.h
+++ b/src/mumble/Settings.h
@@ -204,6 +204,7 @@ struct Settings {
 	bool bAttenuateOthersOnTalk;
 	bool bAttenuateOthers;
 	bool bAttenuateUsersOnPrioritySpeak;
+	bool bOnlyAttenuateSameSink;
 	int iOutputDelay;
 
 	QString qsALSAInput, qsALSAOutput;


### PR DESCRIPTION
Add an option to avoid attenuating applications on other outputs (sinks) that Mumble is not attached to (i.e. HDMI output or an external headset). Also, avoid attenuating module-loopback devices attached to Mumble's sink. Loopback modules are used to link sinks in advanced setups, and if an application was specifically moved to another sink to avoid attenuation but the output is fed back to Mumble's sink via a loopback, the loopback would be attenuated (it would be a sink input) leading to an indirect application attenuation.

Before this commit, Mumble indiscriminately attenuates applications. A simple example: it would attenuate applications that were set to output to HDMI -- something that wasn't always desirable. My HDMI wouldn't need to be attenuated because I am able to physically distinguish between sound coming from either my HDMI or my laptop and "tune in" accordingly.

A more advanced use case is my PulseAudio streaming setup (adiagram of which is available at http://208.68.38.147/PA_Config.odg). I create two additional sinks: "stream" and "stream_spkr." The "stream" sink is used when I want to send audio from an application to my stream but not to my speakers/headset (i.e., background music or something). In this case, before this commit Mumble would attenuate my program playing the background music. If I am running Mumble off-stream (which I often am), this leads the background music volume fluctuating for seemingly no reason.

The second sink, "stream_spkr" routes both to "stream" and my speakers/headset via two module-loopbacks. In this way, anything I attach to stream_spkr can be heard both by my viewers and myself.

As far as dodging module-loopback inputs, I can think of reasons to do this as well as reasons not to. It should be done in the case where a user explicitly moves an application to another sink that is module-loopbacked to Mumble's sink for the sole reason of avoiding attenuating for that program. However, in scenarios like my streaming setup, this wouldn't be ideal. Another option should probably be added to turn this on and off. However, adding another option would essentially fill out the options dialog, so I hesitate to do so.

I only supported PulseAudio in this patch, but this functionality could probably be extended to other audio systems