### PR TITLE
Move ban action further up the chain into authentication in order to all...

### DIFF
--- a/src/murmur/Messages.cpp
+++ b/src/murmur/Messages.cpp
@@ -128,27 +128,13 @@ void Server::msgAuthenticate(ServerUser *uSource, MumbleProto::Authenticate &msg
 	QString reason;
 	MumbleProto::Reject_RejectType rtType = MumbleProto::Reject_RejectType_None;
 
-	short banned = 0;
+	bool banned = false;
 	//Check the banlist for the user to give a meaningful ban message (not just a server rejection as before)
 	foreach(const Ban &ban, qlBans) {
 		if (ban.qsHash == uSource->qsHash) {
-			banned |= 1;
+			banned = true;
 			reason = ban.qsReason;
 		}
-		if (ban.haAddress.match(uSource->haAddress, ban.iMask)) {
-			banned |= 2;
-			reason = ban.qsReason;
-		}
-	}
-
-	QString bantype;
-	if (banned > 0) {
-		if( banned == 1 )
-			bantype = QLatin1String("IP has");
-		if( banned == 2 )
-			bantype = QLatin1String("certificate has");
-		if( banned == 3 )
-			bantype = QLatin1String("IP and certificate have");
 	}
 
 	if (id==-2 && ! nameok) {
@@ -164,7 +150,7 @@ void Server::msgAuthenticate(ServerUser *uSource, MumbleProto::Authenticate &msg
 		reason = "Your account information can not be verified currently. Please try again later";
 		rtType = MumbleProto::Reject_RejectType_AuthenticatorFail;
 	} else if (banned) {
-		reason = QString::fromLatin1("Your %1 been banned. Reason: %2").arg(bantype).arg(reason);
+		reason = QString::fromLatin1("You have been banned. Reason: %2").arg(reason);
 		//This is a bit hacky but I don't think this is use and there isn't a Reject_RejectType_Ban.
 		rtType = MumbleProto::Reject_RejectType_None;
 	} else {

--- a/src/murmur/Messages.cpp
+++ b/src/murmur/Messages.cpp
@@ -128,6 +128,29 @@ void Server::msgAuthenticate(ServerUser *uSource, MumbleProto::Authenticate &msg
 	QString reason;
 	MumbleProto::Reject_RejectType rtType = MumbleProto::Reject_RejectType_None;
 
+	short banned = 0;
+	//Check the banlist for the user to give a meaningful ban message (not just a server rejection as before)
+	foreach(const Ban &ban, qlBans) {
+		if (ban.qsHash == uSource->qsHash) {
+			banned |= 1;
+			reason = ban.qsReason;
+		}
+		if (ban.haAddress.match(uSource->haAddress, ban.iMask)) {
+			banned |= 2;
+			reason = ban.qsReason;
+		}
+	}
+
+	QString bantype;
+	if (banned > 0) {
+		if( banned == 1 )
+			bantype = QLatin1String("IP has");
+		if( banned == 2 )
+			bantype = QLatin1String("certificate has");
+		if( banned == 3 )
+			bantype = QLatin1String("IP and certificate have");
+	}
+
 	if (id==-2 && ! nameok) {
 		reason = "Invalid username";
 		rtType = MumbleProto::Reject_RejectType_InvalidUsername;
@@ -140,6 +163,10 @@ void Server::msgAuthenticate(ServerUser *uSource, MumbleProto::Authenticate &msg
 	} else if (id==-3) {
 		reason = "Your account information can not be verified currently. Please try again later";
 		rtType = MumbleProto::Reject_RejectType_AuthenticatorFail;
+	} else if (banned) {
+		reason = QString::fromLatin1("Your %1 been banned. Reason: %2").arg(bantype).arg(reason);
+		//This is a bit hacky but I don't think this is use and there isn't a Reject_RejectType_Ban.
+		rtType = MumbleProto::Reject_RejectType_None;
 	} else {
 		ok = true;
 	}

--- a/src/murmur/Server.cpp
+++ b/src/murmur/Server.cpp
@@ -1111,15 +1111,6 @@ void Server::newClient() {
 			saveBans();
 		}
 
-		foreach(const Ban &ban, qlBans) {
-			if (ban.haAddress.match(ha, ban.iMask)) {
-				log(QString("Ignoring connection: %1 (Server ban)").arg(addressToString(sock->peerAddress(), sock->peerPort())));
-				sock->disconnectFromHost();
-				sock->deleteLater();
-				return;
-			}
-		}
-
 		sock->setPrivateKey(qskKey);
 		sock->setLocalCertificate(qscCert);
 		sock->addCaCertificate(qscCert);
@@ -1211,13 +1202,6 @@ void Server::encrypted() {
 			QString issuer = certs.first().issuerInfo(QSslCertificate::CommonName);
 #endif
 			log(uSource, QString::fromUtf8("Strong certificate for %1 <%2> (signed by %3)").arg(subject).arg(uSource->qslEmail.join(", ")).arg(issuer));
-		}
-
-		foreach(const Ban &ban, qlBans) {
-			if (ban.qsHash == uSource->qsHash) {
-				log(uSource, QString("Certificate hash is banned."));
-				uSource->disconnectSocket();
-			}
 		}
 	}
 }

--- a/src/murmur/Server.cpp
+++ b/src/murmur/Server.cpp
@@ -1111,7 +1111,7 @@ void Server::newClient() {
 			saveBans();
 		}
 
-    foreach(const Ban &ban, qlBans) {
+		foreach(const Ban &ban, qlBans) {
 			if (ban.haAddress.match(ha, ban.iMask)) {
 				log(QString("Ignoring connection: %1 (Server ban)").arg(addressToString(sock->peerAddress(), sock->peerPort())));
 				sock->disconnectFromHost();

--- a/src/murmur/Server.cpp
+++ b/src/murmur/Server.cpp
@@ -1111,6 +1111,15 @@ void Server::newClient() {
 			saveBans();
 		}
 
+    foreach(const Ban &ban, qlBans) {
+			if (ban.haAddress.match(ha, ban.iMask)) {
+				log(QString("Ignoring connection: %1 (Server ban)").arg(addressToString(sock->peerAddress(), sock->peerPort())));
+				sock->disconnectFromHost();
+				sock->deleteLater();
+				return;
+			}
+		}
+
 		sock->setPrivateKey(qskKey);
 		sock->setLocalCertificate(qscCert);
 		sock->addCaCertificate(qscCert);


### PR DESCRIPTION
...ow for meaniningful ban notifications. "Remote server refused the connection" is not a meaningful ban notification.