### PR TITLE
Follow XDG directory spec for RPC socket & overlay pipe

### DIFF
--- a/overlay_gl/overlay.c
+++ b/overlay_gl/overlay.c
@@ -180,7 +180,13 @@ static void newContext(Context * ctx) {
 		}
 	}
 
-	if (home) {
+	char *xdgRuntimeDir = getenv("XDG_RUNTIME_DIR");
+
+	if (xdgRuntimeDir != NULL) {
+		ctx->saName.sun_family = PF_UNIX;
+		strcpy(ctx->saName.sun_path, xdgRuntimeDir);
+		strcat(ctx->saName.sun_path, "/MumbleOverlayPipe");
+	} else if (home) {
 		ctx->saName.sun_family = PF_UNIX;
 		strcpy(ctx->saName.sun_path, home);
 		strcat(ctx->saName.sun_path, "/.MumbleOverlayPipe");

--- a/src/mumble/Overlay.cpp
+++ b/src/mumble/Overlay.cpp
@@ -92,7 +92,17 @@ Overlay::Overlay() : QObject() {
 #ifdef Q_OS_WIN
 	pipepath = QLatin1String("MumbleOverlayPipe");
 #else
-	pipepath = QDir::home().absoluteFilePath(QLatin1String(".MumbleOverlayPipe"));
+	{
+		QString xdgRuntimePath = QProcessEnvironment::systemEnvironment().value(QLatin1String("XDG_RUNTIME_DIR"));
+		QDir xdgRuntimeDir = QDir(xdgRuntimePath);
+
+		if (! xdgRuntimePath.isNull() && xdgRuntimeDir.exists()) {
+			pipepath = xdgRuntimeDir.absoluteFilePath(QLatin1String("MumbleOverlayPipe"));
+		} else {
+			pipepath = QDir::home().absoluteFilePath(QLatin1String(".MumbleOverlayPipe"));
+		}
+	}
+
 	{
 		QFile f(pipepath);
 		if (f.exists()) {

--- a/src/mumble/SocketRPC.cpp
+++ b/src/mumble/SocketRPC.cpp
@@ -231,7 +231,17 @@ SocketRPC::SocketRPC(const QString &basename, QObject *p) : QObject(p) {
 #ifdef Q_OS_WIN
 	pipepath = basename;
 #else
-	pipepath = QDir::home().absoluteFilePath(QLatin1String(".") + basename + QLatin1String("Socket"));
+	{
+		QString xdgRuntimePath = QProcessEnvironment::systemEnvironment().value(QLatin1String("XDG_RUNTIME_DIR"));
+		QDir xdgRuntimeDir = QDir(xdgRuntimePath);
+
+		if (! xdgRuntimePath.isNull() && xdgRuntimeDir.exists()) {
+			pipepath = xdgRuntimeDir.absoluteFilePath(basename + QLatin1String("Socket"));
+		} else {
+			pipepath = QDir::home().absoluteFilePath(QLatin1String(".") + basename + QLatin1String("Socket"));
+		}
+	}
+
 	{
 		QFile f(pipepath);
 		if (f.exists()) {


### PR DESCRIPTION
Follow up on #1499.

I'm sure I might have missed something here, looking for some review :-)

Some possible concerns

 * Backwards compatibility as mentioned in feature-request. What is the current usage of the RPC socket and overlay pipe in linux land? I'm personally not aware of anything, but honestly really haven't dug very deep.

 * This creates the `mumble` directory in the user's runtime directory, but will *not* cleanup after itself upon exiting. Usually the runtime directory is some kind of temporary file system, so I didn't think too hard about this since personally I don't think it's too big of a problem. But maybe we should be more vigilant and pick up after ourselves.

   I can't imagine it would be too tricky to check for the existance of the directory and attempt to remove it in the `Overlay` and `SocketRPC` destructors if it's empty.

 * I noticed there's a bit of code duplication going on here, it's not too bad, but perhaps the small bit of logic for creating the `mumble` runtime directory could be extracted out into a small utility kind of thing somewhere?

Thanks!