### PR TITLE
Add deprecation warning for building client with Qt 4

### DIFF
--- a/src/mumble/mumble.pro
+++ b/src/mumble/mumble.pro
@@ -4,6 +4,31 @@ DEFINES		*= MUMBLE
 TEMPLATE	= app
 TARGET		= mumble
 
+!CONFIG(qt4-legacy-compat) {
+  CONFIG += no-qt4-legacy-compat
+}
+
+CONFIG(no-qt4-legacy-compat):isEqual(QT_MAJOR_VERSION, 4) {
+  error("$$escape_expand(\\n)$$escape_expand(\\n)"\
+        "Mumble client support for Qt 4 is deprecated and will be dropped$$escape_expand(\\n)"\
+        "completely in the future. We highly recommend switching to$$escape_expand(\\n)"\
+        "building Mumble with Qt 5. For now CONFIG+=qt4-legacy-compat$$escape_expand(\\n)"\
+        "can be used to build with Qt 4. Note that if built this way$$escape_expand(\\n)"\
+        "mumble might lack certain bug-fixes and capabilities available$$escape_expand(\\n)"\
+        "when built with Qt 5.$$escape_expand(\\n)"\
+        "$$escape_expand(\\n)")
+}
+
+isEqual(QT_MAJOR_VERSION, 4) {
+  warning("$$escape_expand(\\n)$$escape_expand(\\n)"\
+          "Mumble client support for Qt 4 is deprecated and will be dropped$$escape_expand(\\n)"\
+          "completely in the future. We highly recommend switching to$$escape_expand(\\n)"\
+          "building Mumble with Qt 5. When built with Qt 4 mumble might$$escape_expand(\\n)"\
+          "lack certain bug-fixes and capabilities available when built$$escape_expand(\\n)"\
+          "with Qt 5 already.$$escape_expand(\\n)"\
+          "$$escape_expand(\\n)")
+}
+
 CONFIG(static) {
   # On Windows, building a static client
   # means building the main app into a DLL.


### PR DESCRIPTION
Since we plan to drop Qt 4 support for building the client
soon'ish add an explicit 'qt4-legacy-compat' flag that has
to be set to still build the client with qt 4. If the flag
is not set we error out of the build to ensure the maintainer
has to actively aknowledge using a legacy version. Even
when the flag is set we still show a warning as a reminder.