### PR TITLE
Disable connect button in the connect dialog until a server is selected

### DIFF
--- a/src/mumble/ConnectDialog.cpp
+++ b/src/mumble/ConnectDialog.cpp
@@ -821,6 +821,7 @@ ConnectDialog::ConnectDialog(QWidget *p, bool autoconnect) : QDialog(p), bAutoCo
 		qlPublicServers.clear();
 	}
 
+	qdbbButtonBox->button(QDialogButtonBox::Ok)->setEnabled(false);
 	qdbbButtonBox->button(QDialogButtonBox::Ok)->setText(tr("&Connect"));
 
 	QPushButton *qpbAdd = new QPushButton(tr("&Add New..."), this);

--- a/src/mumble/ConnectDialog.cpp
+++ b/src/mumble/ConnectDialog.cpp
@@ -966,7 +966,7 @@ ConnectDialog::~ConnectDialog() {
 void ConnectDialog::accept() {
 	ServerItem *si = static_cast<ServerItem *>(qtwServers->currentItem());
 	if (! si || si->qlAddresses.isEmpty() || si->qsHostname.isEmpty()) {
-		qWarning() << "Sad panda";
+		qWarning() << "Invalid server";
 		return;
 	}
 


### PR DESCRIPTION
Currently, if no server is selected in the connect dialog and you press Connect, "Sad panda" is written to stdout and nothing happens. Disabling the button initially works fine, and shouldn't interfere with the last connected to server, which is loaded and set after the fact, thus re-enabling the button. I also figured I should change the message, in case someone stumbles upon it again.