### PR TITLE
Remove ICC and vc10 support and simplify/update vc flags.

### DIFF
--- a/3rdparty/speex-build/speex-build.pro
+++ b/3rdparty/speex-build/speex-build.pro
@@ -49,13 +49,8 @@ win32 {
     QMAKE_CFLAGS_DEBUG -= -arch:SSE
   }
 
-  !CONFIG(intelcpp) {
-    DEFINES+=USE_SMALLFT
-  } else {
-    LIBS	*= -l"\\Program Files (x86)\\Intel/Compiler\\11.1\\054\\ipp\\ia32\\lib\\ippsemerged"
-    LIBS	*= -l"\\Program Files (x86)\\Intel/Compiler\\11.1\\054\\ipp\\ia32\\lib\\ippsmerged"
-    LIBS	*= -l"\\Program Files (x86)\\Intel/Compiler\\11.1\\054\\ipp\\ia32\\lib\\ippcorel"
-  }
+  DEFINES+=USE_SMALLFT
+
 } else {
   CONFIG += staticlib
   INCLUDEPATH += ../speex-build

--- a/compiler.pri
+++ b/compiler.pri
@@ -81,9 +81,9 @@ win32 {
 			QMAKE_CXXFLAGS *= -Qprof-use
 		}
 	} else {
-		QMAKE_CFLAGS_RELEASE *= -Ox -Ot /fp:fast /Qfast_transcendentals -Ob2
-		QMAKE_CXXFLAGS_RELEASE *= -Ox -Ot /fp:fast /Qfast_transcendentals -Ob2
-		QMAKE_LFLAGS_RELEASE *= /NXCOMPAT /DYNAMICBASE
+		QMAKE_CFLAGS_RELEASE *= -Ox /fp:fast
+		QMAKE_CXXFLAGS_RELEASE *= -Ox /fp:fast
+
 		equals(QMAKE_TARGET.arch, x86) {
 			QMAKE_LFLAGS_RELEASE -= /SafeSEH
 		}
@@ -92,11 +92,9 @@ win32 {
 		# unless an explict arch is set.
 		# For our non-64 x86 builds, our binaries should not contain any
 		# SSE2 code, so override the default by using -arch:SSE.
-		win32-msvc2012|win32-msvc2013 {
-			equals(QMAKE_TARGET.arch, x86) {
-				QMAKE_CFLAGS_RELEASE *= -arch:SSE
-				QMAKE_CXXFLAGS_RELEASE *= -arch:SSE
-			}
+		equals(QMAKE_TARGET.arch, x86) {
+			QMAKE_CFLAGS_RELEASE *= -arch:SSE
+			QMAKE_CXXFLAGS_RELEASE *= -arch:SSE
 		}
 
 		# Qt 5.4 uses -Zc:strictStrings by default on MSVS 2013.
@@ -164,14 +162,17 @@ win32 {
 	}
 
 	CONFIG(symbols) {
-		QMAKE_CFLAGS_RELEASE *= -GR -Zi -Oy-
-		QMAKE_CXXFLAGS_RELEASE *= -GR -Zi -Oy-
-
+		# Configure build to be able to properly debug release builds
+		# (https://msdn.microsoft.com/en-us/library/fsk896zz.aspx).
+		# This includes explicitely disabling /Oy to help debugging
+		# (https://msdn.microsoft.com/en-us/library/2kxx5t2c.aspx).
 		QMAKE_CFLAGS_RELEASE -= -Oy
 		QMAKE_CXXFLAGS_RELEASE -= -Oy
 
-		QMAKE_LFLAGS *= /debug
-		QMAKE_LFLAGS *= /OPT:REF /OPT:ICF
+		QMAKE_CFLAGS_RELEASE *= -GR -Zi -Oy-
+		QMAKE_CXXFLAGS_RELEASE *= -GR -Zi -Oy-
+
+		QMAKE_LFLAGS *= /DEBUG /OPT:REF /OPT:ICF /INCREMENTAL:NO
 	}
 
 	CONFIG(vld) {

--- a/compiler.pri
+++ b/compiler.pri
@@ -166,11 +166,13 @@ win32 {
 		# (https://msdn.microsoft.com/en-us/library/fsk896zz.aspx).
 		# This includes explicitely disabling /Oy to help debugging
 		# (https://msdn.microsoft.com/en-us/library/2kxx5t2c.aspx).
+		# Also set /Zo to enhance optimized debugging
+		# (https://msdn.microsoft.com/en-us/library/dn785163.aspx?f=255&MSPPError=-2147217396).
 		QMAKE_CFLAGS_RELEASE -= -Oy
 		QMAKE_CXXFLAGS_RELEASE -= -Oy
 
-		QMAKE_CFLAGS_RELEASE *= -GR -Zi -Oy-
-		QMAKE_CXXFLAGS_RELEASE *= -GR -Zi -Oy-
+		QMAKE_CFLAGS_RELEASE *= -GR -Zi -Zo -Oy-
+		QMAKE_CXXFLAGS_RELEASE *= -GR -Zi -Zo -Oy-
 
 		QMAKE_LFLAGS *= /DEBUG /OPT:REF /OPT:ICF /INCREMENTAL:NO
 	}

--- a/src/mumble/mumble_pch.hpp
+++ b/src/mumble/mumble_pch.hpp
@@ -10,12 +10,7 @@
 #define NOMINMAX
 #define _WINSOCKAPI_
 
-#if defined(__INTEL_COMPILER)
-#define _MSC_EXTENSIONS
-#include <mathimf.h>
-#else
 #define BOOST_TYPEOF_SUPPRESS_UNNAMED_NAMESPACE
-#endif
 
 #ifdef __APPLE__
 #include <Carbon/Carbon.h>
@@ -104,16 +99,11 @@
 #include <shlobj.h>
 #include <tlhelp32.h>
 #include <psapi.h>
-#ifndef Q_CC_INTEL
 #include <math.h>
-#define lroundf(x) ( static_cast<long int>( (x) + ((x) >= 0.0f ? 0.5f : -0.5f) ) )
-#define lround(x) ( static_cast<long int>( (x) + ((x) >= 0.0 ? 0.5 : -0.5) ) )
-#endif
-#ifndef M_PI
-#define M_PI 3.14159265358979323846
-#endif
+
 #define STACKVAR(type, varname, count) type *varname=reinterpret_cast<type *>(_alloca(sizeof(type) * (count)))
-#else
+
+#else // ifndef Q_OS_WIN
 #include <math.h>
 #define STACKVAR(type, varname, count) type varname[count]
 #define CopyMemory(dst,ptr,len) memcpy(dst,ptr,len)

--- a/src/murmur/murmur_pch.h
+++ b/src/murmur/murmur_pch.h
@@ -5,9 +5,6 @@
 #define WIN32_LEAN_AND_MEAN
 
 #define _USE_MATH_DEFINES
-#if defined(__INTEL_COMPILER)
-#include <mathimf.h>
-#endif
 
 #ifdef __APPLE__
 #include <CoreFoundation/CoreFoundation.h>
@@ -83,11 +80,9 @@ extern "C" {
 #endif
 #endif
 
-#if !defined (Q_CC_INTEL) && !defined (Q_OS_WIN)
 #include <math.h>
-#endif
-#if defined (Q_OS_WIN) && (defined (Q_CC_INTEL) || defined (Q_CC_MSVC))
-#define lroundf(x) ( static_cast<int>( (x) + ((x) >= 0 ? 0.5 : -0.5) ) )
+
+#if defined (Q_OS_WIN)
 #define snprintf ::_snprintf
 #define STACKVAR(type, varname, count) type *varname=reinterpret_cast<type *>(_alloca(sizeof(type) * (count)))
 #else


### PR DESCRIPTION
We do not plan on using ICC to build mumble now or in the
foreseeable future. Hence this PR drops it.

Also adjusted compiler custom compiler configuration to
only set flags that weren't set by default anyway.

Further updated compiler.pri to make use of the new /Zo
option to improve our debugging capabilities on optimized
builds.

With this PR we also loose support for Visual Studio 2010.
From now on only VS 2013 Update 3 or later will be supported.