### PR TITLE
Rename overlay helpers to avoid PDB name clashes with DLLs.

### DIFF
--- a/installer/Files.wxs
+++ b/installer/Files.wxs
@@ -35,14 +35,14 @@
       <Component Id="mumble_ol.dll">
         <File Source="$(var.SourceDir)\release\mumble_ol.dll" KeyPath="yes" />
       </Component>
-      <Component Id="mumble_ol.exe">
-         <File Source="$(var.SourceDir)\release\mumble_ol.exe" KeyPath="yes" />
+      <Component Id="mumble_ol_helper.exe">
+         <File Source="$(var.SourceDir)\release\mumble_ol_helper.exe" KeyPath="yes" />
       </Component>
       <Component Id="mumble_ol_x64.dll">
         <File Source="$(var.SourceDir)\release\mumble_ol_x64.dll" KeyPath="yes" />
       </Component>
-      <Component Id="mumble_ol_x64.exe">
-         <File Source="$(var.SourceDir)\release\mumble_ol_x64.exe" KeyPath="yes" />
+      <Component Id="mumble_ol_helper_x64.exe">
+         <File Source="$(var.SourceDir)\release\mumble_ol_helper_x64.exe" KeyPath="yes" />
       </Component>
       <Component Id="celt0.0.7.0.dll">
         <File Source="$(var.SourceDir)\release\celt0.0.7.0.dll" KeyPath="yes" />

--- a/installer/Product.wxs
+++ b/installer/Product.wxs
@@ -169,9 +169,9 @@
       <?endif ?>
       <ComponentRef Id="mumble.exe" />
       <ComponentRef Id="mumble_ol.dll" />
-      <ComponentRef Id="mumble_ol.exe" />
+      <ComponentRef Id="mumble_ol_helper.exe" />
       <ComponentRef Id="mumble_ol_x64.dll" />
-      <ComponentRef Id="mumble_ol_x64.exe" />
+      <ComponentRef Id="mumble_ol_helper_x64.exe" />
       <?ifdef G15 ?>
         <ComponentRef Id="mumble_g15_helper.exe" />
       <?endif ?>

--- a/overlay/overlay_exe/overlay_exe-shared.pro
+++ b/overlay/overlay_exe/overlay_exe-shared.pro
@@ -3,7 +3,7 @@ include(../../compiler.pri)
 TEMPLATE = app
 CONFIG -= qt
 CONFIG += debug_and_release
-TARGET = mumble_ol
+TARGET = mumble_ol_helper
 
 win32 {
   DEFINES += WIN32 _WIN32

--- a/overlay/overlay_exe/overlay_exe.cpp
+++ b/overlay/overlay_exe/overlay_exe.cpp
@@ -54,7 +54,7 @@ static void Alert(LPCWSTR title, LPCWSTR msg) {
 }
 
 // GetExecutableDirPath returns the directory that
-// mumble_ol.exe resides in.
+// mumble_ol_helper.exe resides in.
 static std::wstring GetExecutableDirPath() {
 	wchar_t path[MAX_PATH];
 
@@ -68,7 +68,7 @@ static std::wstring GetExecutableDirPath() {
 	return exePath.append(L"\\");
 }
 
-// ConfigureEnvironment prepares mumble_ol.exe's environment to
+// ConfigureEnvironment prepares mumble_ol_helper.exe's environment to
 // run mumble_ol.dll's OverlayHelperProcessMain() function.
 static bool ConfigureEnvironment() {
 	std::wstring exePath = GetExecutableDirPath();
@@ -77,7 +77,7 @@ static bool ConfigureEnvironment() {
 	if (!SetDllDirectoryW(L""))
 		return false;
 
-	// Set mumble_ol.exe's directory as the current working directory.
+	// Set mumble_ol_helper.exe's directory as the current working directory.
 	if (!SetCurrentDirectoryW(exePath.c_str()))
 		return false;
 

--- a/overlay/overlay_exe/overlay_exe.h
+++ b/overlay/overlay_exe/overlay_exe.h
@@ -38,7 +38,7 @@ const wchar_t *MUMBLE_OVERLAY_DLL_NAME = L"mumble_ol_x64.dll";
 #endif
 
 /// OverlayHelperError represents exit codes returned by the
-/// overlay helper process (mumble_ol.exe) on Windows.
+/// overlay helper process (mumble_ol_helper.exe) on Windows.
 enum OverlayHelperError {
 	/// The overlay helper process was not passed any
 	/// arguments.

--- a/overlay/overlay_exe/overlay_exe.rc
+++ b/overlay/overlay_exe/overlay_exe.rc
@@ -30,7 +30,7 @@ VS_VERSION_INFO VERSIONINFO
 				VALUE "FileVersion", "1.3.0"
 				VALUE "ProductVersion", "1.3.0"
 				VALUE "LegalCopyright", "Copyright (C) 2005-2011, Thorvald Natvig <thorvald@natvig.com>"
-				VALUE "OriginalFilename", "mumble_ol.exe"
+				VALUE "OriginalFilename", "mumble_ol_helper.exe"
 				VALUE "ProductName", "Mumble"
 #ifdef SNAPSHOT_BUILD
 				VALUE "SpecialBuild", "Snapshot development release"

--- a/overlay_winx64/overlay_exe_winx64/overlay_exe.rc
+++ b/overlay_winx64/overlay_exe_winx64/overlay_exe.rc
@@ -30,7 +30,7 @@ VS_VERSION_INFO VERSIONINFO
 				VALUE "FileVersion", "1.3.0"
 				VALUE "ProductVersion", "1.3.0"
 				VALUE "LegalCopyright", "Copyright (C) 2005-2011, Thorvald Natvig <thorvald@natvig.com>"
-				VALUE "OriginalFilename", "mumble_ol_x64.exe"
+				VALUE "OriginalFilename", "mumble_ol_helper_x64.exe"
 				VALUE "ProductName", "Mumble"
 #ifdef SNAPSHOT_BUILD
 				VALUE "SpecialBuild", "Snapshot development release"

--- a/overlay_winx64/overlay_exe_winx64/overlay_exe_winx64.pro
+++ b/overlay_winx64/overlay_exe_winx64/overlay_exe_winx64.pro
@@ -1,4 +1,4 @@
 CONFIG += force-x86_64-toolchain
 VPATH = ../../overlay/overlay_exe
 include(../../overlay/overlay_exe/overlay_exe-shared.pro)
-TARGET = mumble_ol_x64
+TARGET = mumble_ol_helper_x64

--- a/src/mumble/Overlay_win.cpp
+++ b/src/mumble/Overlay_win.cpp
@@ -98,7 +98,7 @@ OverlayPrivateWin::OverlayPrivateWin(QObject *p) : OverlayPrivate(p) {
 		return;
 	}
 
-	m_helper_exe_path = QString::fromLatin1("%1/mumble_ol.exe").arg(qApp->applicationDirPath());
+	m_helper_exe_path = QString::fromLatin1("%1/mumble_ol_helper.exe").arg(qApp->applicationDirPath());
 	m_helper_exe_args << QString::number(OVERLAY_MAGIC_NUMBER)
 	                  << QString::number(reinterpret_cast<quintptr>(m_mumble_handle));
 	m_helper_process = new QProcess(this);
@@ -117,11 +117,11 @@ OverlayPrivateWin::OverlayPrivateWin(QObject *p) : OverlayPrivate(p) {
 	connect(m_helper_restart_timer, SIGNAL(timeout()), this, SLOT(onDelayedRestartTimerTriggered()));
 
 	if (!g.s.bOverlayWinHelperX86Enable) {
-		qWarning("OverlayPrivateWin: mumble_ol.exe (32-bit overlay helper) disabled via 'overlay_win/enable_x86_helper' config option.");
+		qWarning("OverlayPrivateWin: mumble_ol_helper.exe (32-bit overlay helper) disabled via 'overlay_win/enable_x86_helper' config option.");
 		m_helper_enabled = false;
 	}
 
-	m_helper64_exe_path = QString::fromLatin1("%1/mumble_ol_x64.exe").arg(qApp->applicationDirPath());
+	m_helper64_exe_path = QString::fromLatin1("%1/mumble_ol_helper_x64.exe").arg(qApp->applicationDirPath());
 	m_helper64_exe_args = m_helper_exe_args;
 	m_helper64_process = new QProcess(this);
 
@@ -139,10 +139,10 @@ OverlayPrivateWin::OverlayPrivateWin(QObject *p) : OverlayPrivate(p) {
 	connect(m_helper64_restart_timer, SIGNAL(timeout()), this, SLOT(onDelayedRestartTimerTriggered()));
 
 	if (!canRun64BitPrograms()) {
-		qWarning("OverlayPrivateWin: mumble_ol_x64.exe (64-bit overlay helper) disabled because the host is not x64 capable.");
+		qWarning("OverlayPrivateWin: mumble_ol_helper_x64.exe (64-bit overlay helper) disabled because the host is not x64 capable.");
 		m_helper64_enabled = false;
 	} else if (!g.s.bOverlayWinHelperX64Enable) {
-		qWarning("OverlayPrivateWin: mumble_ol_x64.exe (64-bit overlay helper) disabled via 'overlay_win/enable_x64_helper' config option.");
+		qWarning("OverlayPrivateWin: mumble_ol_helper_x64.exe (64-bit overlay helper) disabled via 'overlay_win/enable_x64_helper' config option.");
 		m_helper64_enabled = false;
 	}
 }


### PR DESCRIPTION
Right now, we do not get PDB files for our overlay DLLs because
the overlay DLL PDB files share their name with the overlay helper
PDB files.

To avoid this madness, we rename the overlay helpers as follows:

  mumble_ol.exe -> mumble_ol_helper.exe
  mumble_ol_x64.exe -> mumble_ol_helper_x64.exe