### PR TITLE
Don't display "Welcome message: " in client if none was sent.

### DIFF
--- a/src/mumble/Messages.cpp
+++ b/src/mumble/Messages.cpp
@@ -121,7 +121,12 @@ void MainWindow::msgServerSync(const MumbleProto::ServerSync &msg) {
 	g.uiSession = msg.session();
 	g.pPermissions = ChanACL::Permissions(static_cast<unsigned int>(msg.permissions()));
 	g.l->clearIgnore();
-	g.l->log(Log::Information, tr("Welcome message: %1").arg(u8(msg.welcome_text())));
+	if (msg.has_welcome_text()) {
+		QString str = u8(msg.welcome_text());
+		if (!str.isEmpty()) {
+			g.l->log(Log::Information, tr("Welcome message: %1").arg(str));
+		}
+	}
 	pmModel->ensureSelfVisible();
 	pmModel->recheckLinks();
 
@@ -171,8 +176,12 @@ void MainWindow::msgServerSync(const MumbleProto::ServerSync &msg) {
 
 
 void MainWindow::msgServerConfig(const MumbleProto::ServerConfig &msg) {
-	if (msg.has_welcome_text())
-		g.l->log(Log::Information, tr("Welcome message: %1").arg(u8(msg.welcome_text())));
+	if (msg.has_welcome_text()) {
+		QString str = u8(msg.welcome_text());
+		if (!str.isEmpty()) {
+			g.l->log(Log::Information, tr("Welcome message: %1").arg(str));
+		}
+	}
 	if (msg.has_max_bandwidth())
 		AudioInput::setMaxBandwidth(msg.max_bandwidth());
 	if (msg.has_allow_html())

--- a/src/murmur/Meta.cpp
+++ b/src/murmur/Meta.cpp
@@ -59,7 +59,7 @@ MetaParams::MetaParams() {
 	bAllowHTML = true;
 	iDefaultChan = 0;
 	bRememberChan = true;
-	qsWelcomeText = QString("Welcome to this server");
+	qsWelcomeText = QString();
 	qsDatabase = QString();
 	iDBPort = 0;
 	qsDBusService = "net.sourceforge.mumble.murmur";

--- a/src/murmur/Server.cpp
+++ b/src/murmur/Server.cpp
@@ -471,11 +471,9 @@ void Server::setLiveConf(const QString &key, const QString &value) {
 		QString text = !v.isNull() ? v : Meta::mp.qsWelcomeText;
 		if (text != qsWelcomeText) {
 			qsWelcomeText = text;
-			if (! qsWelcomeText.isEmpty()) {
-				MumbleProto::ServerConfig mpsc;
-				mpsc.set_welcome_text(u8(qsWelcomeText));
-				sendAll(mpsc);
-			}
+			MumbleProto::ServerConfig mpsc;
+			mpsc.set_welcome_text(u8(qsWelcomeText));
+			sendAll(mpsc);
 		}
 	} else if (key == "registername") {
 		QString text = !v.isNull() ? v : Meta::mp.qsRegName;


### PR DESCRIPTION
Fixes #1675