### PR TITLE
Use a versioned directory hierarchy for Mumble installations on Windows

### DIFF
--- a/installer/Files.wxs
+++ b/installer/Files.wxs
@@ -2,31 +2,14 @@
 <Wix xmlns="http://schemas.microsoft.com/wix/2006/wi">
   <?include "Settings.wxi" ?>
 
-  <!-- Mumble -->
+  <!-- Mumble Version Specific -->
   <Fragment>
-    <DirectoryRef Id="INSTALLDIR">
-      <Component Id="MumbleDesktopShortcutComponent" Guid="$(var.MumbleDesktopShortcutGuid)" KeyPath="yes">
-        <Shortcut Id="MumbleDesktopShortcut"
-                  Directory="DesktopFolder"
-                  Name="Mumble"
-                  WorkingDirectory="INSTALLDIR"
-                  Target="[INSTALLDIR]mumble.exe">
-          <ShortcutProperty Key="System.AppUserModel.ID" Value="net.sourceforge.mumble.Mumble" />
-        </Shortcut>
-      </Component>
-      
-      <Component Id="mumble.exe" Guid="$(var.MumbleExeGuid)">
-        <File Id="mumble.exe" Source="$(var.SourceDir)\release\mumble.exe" KeyPath="yes">
-          <Shortcut Id="MumbleShortcut" Directory="ApplicationProgramsFolder" Name="Mumble" WorkingDirectory="INSTALLDIR">
-            <ShortcutProperty Key="System.AppUserModel.ID" Value="net.sourceforge.mumble.Mumble" />
-          </Shortcut>
-        </File>
+      <?ifdef VersionSubDir ?>
+        <DirectoryRef Id="VersionFolder">
+      <?else VersionSubDir ?>
+        <DirectoryRef Id="INSTALLDIR">
+      <?endif ?>
 
-        <RegistryValue Root="HKCR" Key="mumble" Value="URL:Mumble" Type="string" />
-        <RegistryValue Root="HKCR" Key="mumble" Name="URL Protocol" Value="" Type="string" />
-        <RegistryValue Root="HKCR" Key="mumble\DefaultIcon" Value="[#mumble.exe]" Type="string" />
-        <RegistryValue Root="HKCR" Key="mumble\shell\open\command" Value="[#mumble.exe] &quot;%1&quot;" Type="string" />
-      </Component>
       <?ifdef StaticBuild ?>
         <Component Id="mumble_app.dll">
           <File Source="$(var.SourceDir)\release\mumble_app.dll" KeyPath="yes" />
@@ -85,6 +68,61 @@
         </Component>
       <?endif ?>
 
+      <?ifdef RedistDirVC12 ?>
+      <Component Id="msvcp120.dll">
+        <File Source="$(var.RedistDirVC12)\msvcp120.dll" KeyPath="yes" />
+      </Component>
+      <Component Id="msvcr120.dll">
+        <File Source="$(var.RedistDirVC12)\msvcr120.dll" KeyPath="yes" />
+      </Component>
+      <?endif ?>
+
+      <Component Id="dbghelp.dll">
+        <File Source="$(var.DebugToolsDir)\dbghelp.dll" KeyPath="yes" />
+      </Component>
+
+      <?ifdef D3DCompilerDLL ?>
+        <Component Id="d3dcompiler_43.dll">
+          <File Source="$(var.System32x86Dir)\d3dcompiler_43.dll" KeyPath="yes" />
+        </Component>
+        <Component Id="d3dcompiler_47.dll">
+          <File Source="$(var.Win81SDKDir)\Redist\D3D\x64\d3dcompiler_47.dll" KeyPath="yes" />
+        </Component>
+      <?endif ?>
+
+    <?ifdef VersionSubDir ?>
+      </DirectoryRef>
+    <?else ?>
+      </DirectoryRef>
+    <?endif ?>
+  </Fragment>
+
+  <!-- Mumble -->
+  <Fragment>
+    <DirectoryRef Id="INSTALLDIR">
+      <Component Id="MumbleDesktopShortcutComponent" Guid="$(var.MumbleDesktopShortcutGuid)" KeyPath="yes">
+        <Shortcut Id="MumbleDesktopShortcut"
+                  Directory="DesktopFolder"
+                  Name="Mumble"
+                  WorkingDirectory="INSTALLDIR"
+                  Target="[INSTALLDIR]mumble.exe">
+          <ShortcutProperty Key="System.AppUserModel.ID" Value="net.sourceforge.mumble.Mumble" />
+        </Shortcut>
+      </Component>
+      
+      <Component Id="mumble.exe" Guid="$(var.MumbleExeGuid)">
+        <File Id="mumble.exe" Source="$(var.SourceDir)\release\mumble.exe" KeyPath="yes">
+          <Shortcut Id="MumbleShortcut" Directory="ApplicationProgramsFolder" Name="Mumble" WorkingDirectory="INSTALLDIR">
+            <ShortcutProperty Key="System.AppUserModel.ID" Value="net.sourceforge.mumble.Mumble" />
+          </Shortcut>
+        </File>
+
+        <RegistryValue Root="HKCR" Key="mumble" Value="URL:Mumble" Type="string" />
+        <RegistryValue Root="HKCR" Key="mumble" Name="URL Protocol" Value="" Type="string" />
+        <RegistryValue Root="HKCR" Key="mumble\DefaultIcon" Value="[#mumble.exe]" Type="string" />
+        <RegistryValue Root="HKCR" Key="mumble\shell\open\command" Value="[#mumble.exe] &quot;%1&quot;" Type="string" />
+      </Component>
+
       <Component Id="MurmurDesktopShortcutComponent" Guid="$(var.MurmurDesktopShortcutGuid)" KeyPath="yes">
         <Shortcut Id="MurmurDesktopShortcut"
                   Directory="DesktopFolder"
@@ -105,6 +143,19 @@
       </Component>
       <Component Id="Murmur.ice">
         <File Source="$(var.SourceDir)\src\murmur\Murmur.ice" KeyPath="yes" />
+      </Component>
+
+      <?ifdef RedistDirVC12 ?>
+      <Component Id="Murmur_msvcp120.dll">
+        <File Id="Murmur_msvcp120.dll" Source="$(var.RedistDirVC12)\msvcp120.dll" KeyPath="yes" />
+      </Component>
+      <Component Id="Murmur_msvcr120.dll">
+        <File Id="Murmur_msvcr120.dll" Source="$(var.RedistDirVC12)\msvcr120.dll" KeyPath="yes" />
+      </Component>
+      <?endif ?>
+
+      <Component Id="Murmur_dbghelp.dll">
+        <File Id="Murmur_dbghelp.dll" Source="$(var.DebugToolsDir)\dbghelp.dll" KeyPath="yes" />
       </Component>
 
       <?ifndef StaticBuild ?>
@@ -129,33 +180,12 @@
         <File Source="$(var.SourceDir)\installer\qt.txt" KeyPath="yes" />
       </Component>
 
-      <Component Id="dbghelp.dll">
-        <File Source="$(var.DebugToolsDir)\dbghelp.dll" KeyPath="yes" />
-      </Component>
-
       <?ifdef IntelCppDir ?>
       <Component Id="libmmd.dll">
         <File Source="$(var.IntelCppDir)\libmmd.dll" KeyPath="yes" />
       </Component>
       <?endif ?>
 
-      <?ifdef RedistDirVC12 ?>
-      <Component Id="msvcp120.dll">
-        <File Source="$(var.RedistDirVC12)\msvcp120.dll" KeyPath="yes" />
-      </Component>
-      <Component Id="msvcr120.dll">
-        <File Source="$(var.RedistDirVC12)\msvcr120.dll" KeyPath="yes" />
-      </Component>
-      <?endif ?>
-
-      <?ifdef D3DCompilerDLL ?>
-        <Component Id="d3dcompiler_43.dll">
-          <File Source="$(var.System32x86Dir)\d3dcompiler_43.dll" KeyPath="yes" />
-        </Component>
-        <Component Id="d3dcompiler_47.dll">
-          <File Source="$(var.Win81SDKDir)\Redist\D3D\x64\d3dcompiler_47.dll" KeyPath="yes" />
-        </Component>
-      <?endif ?>
     </DirectoryRef>
   </Fragment>
 
@@ -364,7 +394,15 @@
   <!-- Directory tree -->
     <Fragment>
       <DirectoryRef Id="INSTALLDIR">
-        <Directory Id="PluginFolder" Name="plugins" />
+        <?ifdef VersionSubDir ?>
+          <Directory Id="VersionContainerFolder" Name="Versions">
+            <Directory Id="VersionFolder" Name="$(var.VersionSubDir)">
+              <Directory Id="PluginFolder" Name="plugins" />
+            </Directory>
+          </Directory>
+        <?else ?>
+          <Directory Id="PluginFolder" Name="plugins" />
+        <?endif ?>
         <?ifndef StaticBuild ?>
           <Directory Id="QtPluginFolder" Name="QtPlugins">
             <Directory Id="QtPluginIconEnginesFolder" Name="iconengines" />

--- a/installer/Files.wxs
+++ b/installer/Files.wxs
@@ -145,18 +145,19 @@
         <File Source="$(var.SourceDir)\src\murmur\Murmur.ice" KeyPath="yes" />
       </Component>
 
-      <?ifdef RedistDirVC12 ?>
-      <Component Id="Murmur_msvcp120.dll" Guid="8a683ad2-541b-4434-8ec2-84c3b4cbe9c8">
-        <File Id="Murmur_msvcp120.dll" Source="$(var.RedistDirVC12)\msvcp120.dll" KeyPath="yes" />
-      </Component>
-      <Component Id="Murmur_msvcr120.dll" Guid="8e3a70d3-a695-4b3c-9fdd-8cd7fc77c097">
-        <File Id="Murmur_msvcr120.dll" Source="$(var.RedistDirVC12)\msvcr120.dll" KeyPath="yes" />
-      </Component>
+      <?ifdef VersionSubDir ?>
+        <?ifdef RedistDirVC12 ?>
+        <Component Id="Murmur_msvcp120.dll">
+          <File Id="Murmur_msvcp120.dll" Source="$(var.RedistDirVC12)\msvcp120.dll" KeyPath="yes" />
+        </Component>
+        <Component Id="Murmur_msvcr120.dll">
+          <File Id="Murmur_msvcr120.dll" Source="$(var.RedistDirVC12)\msvcr120.dll" KeyPath="yes" />
+        </Component>
+        <?endif ?>
+        <Component Id="Murmur_dbghelp.dll">
+          <File Id="Murmur_dbghelp.dll" Source="$(var.DebugToolsDir)\dbghelp.dll" KeyPath="yes" />
+        </Component>
       <?endif ?>
-
-      <Component Id="Murmur_dbghelp.dll" Guid="b8aed776-1159-4211-8510-5054d86a13a7">
-        <File Id="Murmur_dbghelp.dll" Source="$(var.DebugToolsDir)\dbghelp.dll" KeyPath="yes" />
-      </Component>
 
       <?ifndef StaticBuild ?>
         <Component Id="qt.conf">

--- a/installer/Files.wxs
+++ b/installer/Files.wxs
@@ -6,7 +6,7 @@
   <Fragment>
       <?ifdef VersionSubDir ?>
         <DirectoryRef Id="VersionFolder">
-      <?else VersionSubDir ?>
+      <?else ?>
         <DirectoryRef Id="INSTALLDIR">
       <?endif ?>
 
@@ -146,15 +146,15 @@
       </Component>
 
       <?ifdef RedistDirVC12 ?>
-      <Component Id="Murmur_msvcp120.dll">
+      <Component Id="Murmur_msvcp120.dll" Guid="8a683ad2-541b-4434-8ec2-84c3b4cbe9c8">
         <File Id="Murmur_msvcp120.dll" Source="$(var.RedistDirVC12)\msvcp120.dll" KeyPath="yes" />
       </Component>
-      <Component Id="Murmur_msvcr120.dll">
+      <Component Id="Murmur_msvcr120.dll" Guid="8e3a70d3-a695-4b3c-9fdd-8cd7fc77c097">
         <File Id="Murmur_msvcr120.dll" Source="$(var.RedistDirVC12)\msvcr120.dll" KeyPath="yes" />
       </Component>
       <?endif ?>
 
-      <Component Id="Murmur_dbghelp.dll">
+      <Component Id="Murmur_dbghelp.dll" Guid="b8aed776-1159-4211-8510-5054d86a13a7">
         <File Id="Murmur_dbghelp.dll" Source="$(var.DebugToolsDir)\dbghelp.dll" KeyPath="yes" />
       </Component>
 

--- a/installer/Product.wxs
+++ b/installer/Product.wxs
@@ -15,6 +15,9 @@
       <ProgressText Action="NSISUninstall">Uninstalling old version</ProgressText>
     </UI>
 
+    <Property Id="QtExecCmdLine" Value='"$(env.SystemRoot)\System32\taskkill.exe" /f /im mumble.exe' />
+    <CustomAction Id="CloseApplication" BinaryKey="WixCA" DllEntry="CAQuietExec" Execute="immediate" Return="ignore" />
+
     <Property Id="WixShellExecTarget" Value="[#mumble.exe]" />
     <CustomAction Id="LaunchApplication" BinaryKey="WixCA" DllEntry="WixShellExec" Impersonate="yes" />
     <UI>
@@ -41,6 +44,7 @@
     <Property Id="ARPURLINFOABOUT" Value="http://www.mumble.info/" />
     <Property Id="ARPURLUPDATEINFO" Value="http://www.mumble.info/" />
     <Property Id='ARPPRODUCTICON'>mumble.ico</Property>
+    <Property Id="MSIRESTARTMANAGERCONTROL" Value="Disable" />
 
     <WixVariable Id="WixUILicenseRtf" Value="$(var.SourceDir)\installer\gpl.rtf" />
     <WixVariable Id="WixUIBannerBmp" Value="$(var.SourceDir)\installer\bannrbmp.bmp" />
@@ -116,8 +120,6 @@
       <ComponentRef Id="Changes.txt" />
       <ComponentRef Id="qt.txt" />
 
-      <ComponentRef Id="dbghelp.dll" />
-
       <?ifndef StaticBuild ?>
         <?ifdef ProtoBufDir ?>
           <ComponentRef Id="libprotobuf.dll" />
@@ -129,16 +131,6 @@
 
       <?ifdef IntelCppDir ?>
         <ComponentRef Id="libmmd.dll"/>
-      <?endif ?>
-
-      <?ifdef RedistDirVC12 ?>
-        <ComponentRef Id="msvcp120.dll" />
-        <ComponentRef Id="msvcr120.dll" />
-      <?endif ?>
-
-      <?ifdef D3DCompilerDLL ?>
-        <ComponentRef Id="d3dcompiler_43.dll" />
-        <ComponentRef Id="d3dcompiler_47.dll" />
       <?endif ?>
     </ComponentGroup>
 
@@ -176,6 +168,18 @@
         <ComponentRef Id="mumble_g15_helper.exe" />
       <?endif ?>
 
+      <?ifdef RedistDirVC12 ?>
+        <ComponentRef Id="msvcp120.dll" />
+        <ComponentRef Id="msvcr120.dll" />
+      <?endif ?>
+
+      <ComponentRef Id="dbghelp.dll" />
+
+      <?ifdef D3DCompilerDLL ?>
+        <ComponentRef Id="d3dcompiler_43.dll" />
+        <ComponentRef Id="d3dcompiler_47.dll" />
+      <?endif ?>
+
       <Feature Id="MumbleDesktopShortcutFeature" Title="!(loc.MUMBLE_SEC_DesktopShortcut)" Description="!(loc.DESC_DesktopShortcut)" InstallDefault="followParent" AllowAdvertise="no">
         <ComponentRef Id="MumbleDesktopShortcutComponent" />
       </Feature>
@@ -196,7 +200,14 @@
       <ComponentRef Id="murmur.exe" />
       <ComponentRef Id="murmur.ini" />
       <ComponentRef Id="Murmur.ice" />
-      
+
+      <?ifdef RedistDirVC12 ?>
+        <ComponentRef Id="Murmur_msvcp120.dll" />
+        <ComponentRef Id="Murmur_msvcr120.dll" />
+      <?endif ?>
+
+      <ComponentRef Id="Murmur_dbghelp.dll" />
+
       <Feature Id="MurmurDesktopShortcutFeature" Title="!(loc.MUMBLE_SEC_DesktopShortcut)" Description="!(loc.DESC_DesktopShortcut)"  InstallDefault="followParent" AllowAdvertise="no">
         <ComponentRef Id="MurmurDesktopShortcutComponent" />
       </Feature>
@@ -220,6 +231,7 @@
       <AppSearch Sequence='1' />
       <Custom Action="SetNSISPath" After="AppSearch">NSISINSTALL</Custom>
       <Custom Action='NSISUninstall' After='InstallInitialize'>NSISINSTALL AND NOT Installed</Custom>
+      <Custom Action="CloseApplication" Before="InstallValidate">WIX_UPGRADE_DETECTED</Custom>
     </InstallExecuteSequence>
   </Product>
 </Wix>

--- a/installer/Product.wxs
+++ b/installer/Product.wxs
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<Wix xmlns="http://schemas.microsoft.com/wix/2006/wi">
+<Wix xmlns="http://schemas.microsoft.com/wix/2006/wi"
+     xmlns:util="http://schemas.microsoft.com/wix/UtilExtension">
   <?include "Settings.wxi" ?>
 
   <Product Id="*" Name="$(var.ProductName) $(var.ProductVersion)" Language="!(loc.LANG)" Version="$(var.ProductVersion)" Manufacturer="$(var.ProductManufacturer)" UpgradeCode="$(var.ProductUpgradeCode)">
@@ -15,8 +16,7 @@
       <ProgressText Action="NSISUninstall">Uninstalling old version</ProgressText>
     </UI>
 
-    <Property Id="QtExecCmdLine" Value='"$(env.SystemRoot)\System32\taskkill.exe" /f /im mumble.exe' />
-    <CustomAction Id="CloseApplication" BinaryKey="WixCA" DllEntry="CAQuietExec" Execute="immediate" Return="ignore" />
+    <util:CloseApplication Id="CloseMumble" RebootPrompt="no" EndSessionMessage="yes" Target="mumble.exe" />
 
     <Property Id="WixShellExecTarget" Value="[#mumble.exe]" />
     <CustomAction Id="LaunchApplication" BinaryKey="WixCA" DllEntry="WixShellExec" Impersonate="yes" />
@@ -231,7 +231,7 @@
       <AppSearch Sequence='1' />
       <Custom Action="SetNSISPath" After="AppSearch">NSISINSTALL</Custom>
       <Custom Action='NSISUninstall' After='InstallInitialize'>NSISINSTALL AND NOT Installed</Custom>
-      <Custom Action="CloseApplication" Before="InstallValidate">WIX_UPGRADE_DETECTED</Custom>
+      <Custom Action="WixCloseApplications" Before="InstallValidate">WIX_UPGRADE_DETECTED</Custom>
     </InstallExecuteSequence>
   </Product>
 </Wix>

--- a/installer/Product.wxs
+++ b/installer/Product.wxs
@@ -201,12 +201,13 @@
       <ComponentRef Id="murmur.ini" />
       <ComponentRef Id="Murmur.ice" />
 
-      <?ifdef RedistDirVC12 ?>
-        <ComponentRef Id="Murmur_msvcp120.dll" />
-        <ComponentRef Id="Murmur_msvcr120.dll" />
+      <?ifdef VersionSubDir ?>
+        <?ifdef RedistDirVC12 ?>
+          <ComponentRef Id="Murmur_msvcp120.dll" />
+          <ComponentRef Id="Murmur_msvcr120.dll" />
+        <?endif ?>
+        <ComponentRef Id="Murmur_dbghelp.dll" />
       <?endif ?>
-
-      <ComponentRef Id="Murmur_dbghelp.dll" />
 
       <Feature Id="MurmurDesktopShortcutFeature" Title="!(loc.MUMBLE_SEC_DesktopShortcut)" Description="!(loc.DESC_DesktopShortcut)"  InstallDefault="followParent" AllowAdvertise="no">
         <ComponentRef Id="MurmurDesktopShortcutComponent" />

--- a/installer/Settings.wxi
+++ b/installer/Settings.wxi
@@ -155,4 +155,8 @@
     <?define D3DCompilerDLL = true ?>
   <?endif ?>
 
+  <?ifdef env.MumbleVersionSubDir ?>
+    <?define VersionSubDir = "$(env.MumbleVersionSubDir)" ?>
+  <?endif ?>
+
 </Include>

--- a/src/mumble/CELTCodec.cpp
+++ b/src/mumble/CELTCodec.cpp
@@ -34,6 +34,7 @@
 
 #include "Audio.h"
 #include "Version.h"
+#include "MumbleApplication.h"
 
 #ifdef Q_CC_GNU
 #define RESOLVE(var) { var = reinterpret_cast<__typeof__(var)>(qlCELT.resolve(#var)); bValid = bValid && (var != NULL); }
@@ -80,7 +81,7 @@ CELTCodec::CELTCodec(const QString &version) {
 	alternatives << QString::fromLatin1("celt0.%1.dll").arg(version);
 #endif
 	foreach(const QString &lib, alternatives) {
-		qlCELT.setFileName(QApplication::instance()->applicationDirPath() + QLatin1String("/") + lib);
+		qlCELT.setFileName(MumbleApplication::instance()->applicationVersionRootPath() + QLatin1String("/") + lib);
 		if (qlCELT.load()) {
 			bValid = true;
 			break;

--- a/src/mumble/G15LCDEngine_helper.cpp
+++ b/src/mumble/G15LCDEngine_helper.cpp
@@ -33,6 +33,8 @@
 
 #include "G15LCDEngine_helper.h"
 
+#include "MumbleApplication.h"
+
 static LCDEngine *G15LCDEngineNew() {
 	return new G15LCDEngineHelper();
 }
@@ -44,9 +46,9 @@ G15LCDEngineHelper::G15LCDEngineHelper() : LCDEngine() {
 	bUnavailable = true;
 
 #if defined(Q_OS_WIN)
-	qsHelperExecutable = QString::fromLatin1("\"%1/mumble-g15-helper.exe\"").arg(qApp->applicationDirPath());
+	qsHelperExecutable = QString::fromLatin1("\"%1/mumble-g15-helper.exe\"").arg(MumbleApplication::instance()->applicationVersionRootPath());
 #elif defined(Q_OS_MAC)
-	qsHelperExecutable = QString::fromLatin1("%1/mumble-g15-helper").arg(qApp->applicationDirPath());
+	qsHelperExecutable = QString::fromLatin1("\"%1/mumble-g15-helper\"").arg(MumbleApplication::instance()->applicationVersionRootPath());
 #endif
 
 	qpHelper = new QProcess(this);

--- a/src/mumble/MumbleApplication.cpp
+++ b/src/mumble/MumbleApplication.cpp
@@ -36,6 +36,10 @@
 #include "GlobalShortcut.h"
 #include "Global.h"
 
+MumbleApplication *MumbleApplication::instance() {
+	return static_cast<MumbleApplication *>(QCoreApplication::instance());
+}
+
 MumbleApplication::MumbleApplication(int &pargc, char **pargv)
     : QApplication(pargc, pargv) {
 	
@@ -43,6 +47,14 @@ MumbleApplication::MumbleApplication(int &pargc, char **pargv)
 	        SIGNAL(commitDataRequest(QSessionManager&)),
 	        SLOT(onCommitDataRequest(QSessionManager&)),
 	        Qt::DirectConnection);
+}
+
+QString MumbleApplication::applicationVersionRootPath() {
+	QByteArray versionRoot = qgetenv("MUMBLE_VERSION_ROOT");
+	if (versionRoot.count() > 0) {
+		return QString::fromUtf8(versionRoot.constData());
+	}
+	return this->applicationDirPath();
 }
 
 void MumbleApplication::onCommitDataRequest(QSessionManager &) {

--- a/src/mumble/MumbleApplication.h
+++ b/src/mumble/MumbleApplication.h
@@ -44,8 +44,12 @@ class MumbleApplication : public QApplication {
 #endif
 		Q_OBJECT
 	public:
+		static MumbleApplication *instance();
+
 		MumbleApplication(int &pargc, char **pargv);
-		
+
+		QString applicationVersionRootPath();
+
 		bool event(QEvent *e) Q_DECL_OVERRIDE;
 #ifdef Q_OS_WIN
 # if QT_VERSION >= 0x050000

--- a/src/mumble/MumbleApplication.h
+++ b/src/mumble/MumbleApplication.h
@@ -44,10 +44,29 @@ class MumbleApplication : public QApplication {
 #endif
 		Q_OBJECT
 	public:
+
+		/// The instance function returns an instance
+		/// of the MumbleApplication singleton.
 		static MumbleApplication *instance();
 
 		MumbleApplication(int &pargc, char **pargv);
 
+		/// applicationVersionRootPath returns
+		/// Mumble's "versioned root"-path.
+		///
+		/// This is a version-specific path that contains
+		/// supplementary binaries and other products
+		/// that Mumble needs to function.
+		///
+		/// In the current implementation, the versioned
+		/// root path is set by the MUMBLE_VERSION_ROOT
+		/// environment variable. This environment variable
+		/// is set in the mumble.exe launcher.
+		///
+		/// If a versioned root path has not been
+		/// configured in the environment, the function
+		/// returns the same path as Qt's own
+		/// QApplication::applicationDirPath().
 		QString applicationVersionRootPath();
 
 		bool event(QEvent *e) Q_DECL_OVERRIDE;

--- a/src/mumble/Overlay_win.cpp
+++ b/src/mumble/Overlay_win.cpp
@@ -38,6 +38,7 @@
 #include "OverlayConfig.h"
 #include "MainWindow.h"
 #include "Global.h"
+#include "MumbleApplication.h"
 
 #include "Overlay_win.h"
 
@@ -98,7 +99,7 @@ OverlayPrivateWin::OverlayPrivateWin(QObject *p) : OverlayPrivate(p) {
 		return;
 	}
 
-	m_helper_exe_path = QString::fromLatin1("%1/mumble_ol_helper.exe").arg(qApp->applicationDirPath());
+	m_helper_exe_path = QString::fromLatin1("%1/mumble_ol_helper.exe").arg(MumbleApplication::instance()->applicationVersionRootPath());
 	m_helper_exe_args << QString::number(OVERLAY_MAGIC_NUMBER)
 	                  << QString::number(reinterpret_cast<quintptr>(m_mumble_handle));
 	m_helper_process = new QProcess(this);
@@ -121,7 +122,7 @@ OverlayPrivateWin::OverlayPrivateWin(QObject *p) : OverlayPrivate(p) {
 		m_helper_enabled = false;
 	}
 
-	m_helper64_exe_path = QString::fromLatin1("%1/mumble_ol_helper_x64.exe").arg(qApp->applicationDirPath());
+	m_helper64_exe_path = QString::fromLatin1("%1/mumble_ol_helper_x64.exe").arg(MumbleApplication::instance()->applicationVersionRootPath());
 	m_helper64_exe_args = m_helper_exe_args;
 	m_helper64_process = new QProcess(this);
 

--- a/src/mumble/Plugins.cpp
+++ b/src/mumble/Plugins.cpp
@@ -39,6 +39,7 @@
 #include "ServerHandler.h"
 #include "../../plugins/mumble_plugin.h"
 #include "WebFetch.h"
+#include "MumbleApplication.h"
 
 #ifdef Q_OS_WIN
 // from os_win.cpp
@@ -228,9 +229,8 @@ Plugins::Plugins(QObject *p) : QObject(p) {
 
 #ifdef QT_NO_DEBUG
 #ifndef PLUGIN_PATH
-#ifndef Q_OS_MAC
-	qsSystemPlugins=QString::fromLatin1("%1/plugins").arg(qApp->applicationDirPath());
-#else
+	qsSystemPlugins=QString::fromLatin1("%1/plugins").arg(MumbleApplication::instance()->applicationVersionRootPath());
+#ifdef Q_OS_MAC
 	qsSystemPlugins=QString::fromLatin1("%1/../Plugins").arg(qApp->applicationDirPath());
 #endif
 #else
@@ -239,7 +239,7 @@ Plugins::Plugins(QObject *p) : QObject(p) {
 
 	qsUserPlugins = g.qdBasePath.absolutePath() + QLatin1String("/Plugins");
 #else
-	qsSystemPlugins = QString::fromLatin1("%1/plugins").arg(qApp->applicationDirPath());
+	qsSystemPlugins = QString::fromLatin1("%1/plugins").arg(MumbleApplication::instance()->applicationVersionRootPath());
 	qsUserPlugins = QString();
 #endif
 

--- a/src/mumble/main.cpp
+++ b/src/mumble/main.cpp
@@ -113,8 +113,7 @@ int main(int argc, char **argv) {
 
 	#ifdef USE_SBCELT
 	{
-		// For now, force Mumble to use sbcelt-helper from the same directory as the 'mumble' executable.
-		QDir d(a.applicationDirPath());
+		QDir d(a.applicationVersionRootPath());
 		QString helper = d.absoluteFilePath(QString::fromLatin1("sbcelt-helper"));
 		setenv("SBCELT_HELPER_BINARY", helper.toUtf8().constData(), 1);
 	}
@@ -236,7 +235,7 @@ int main(int argc, char **argv) {
 		if (reqSize > 0) {
 			STACKVAR(wchar_t, buff, reqSize+1);
 			_wgetenv_s(&reqSize, buff, reqSize, L"PATH");
-			QString path = QString::fromLatin1("%1;%2").arg(QDir::toNativeSeparators(a.applicationDirPath())).arg(QString::fromWCharArray(buff));
+			QString path = QString::fromLatin1("%1;%2").arg(QDir::toNativeSeparators(MumbleApplication::instance()->applicationVersionRootPath())).arg(QString::fromWCharArray(buff));
 			STACKVAR(wchar_t, buffout, path.length() + 1);
 			path.toWCharArray(buffout);
 			_wputenv_s(L"PATH", buffout);

--- a/src/mumble/mumble.pro
+++ b/src/mumble/mumble.pro
@@ -356,7 +356,7 @@ win32 {
   HEADERS	*= GlobalShortcut_win.h Overlay_win.h TaskList.h
   SOURCES	*= GlobalShortcut_win.cpp TextToSpeech_win.cpp Overlay_win.cpp SharedMemory_win.cpp Log_win.cpp os_win.cpp TaskList.cpp ../../overlay/HardHook.cpp ../../overlay/ods.cpp
   LIBS		*= -ldxguid -ldinput8 -lsapi -lole32 -lws2_32 -ladvapi32 -lwintrust -ldbghelp -llibsndfile-1 -lshell32 -lshlwapi -luser32 -lgdi32 -lpsapi
-  LIBS		*= -ldelayimp -delayload:speex.dll -delayload:shell32.dll
+  LIBS		*= -ldelayimp -delayload:shell32.dll
 
   equals(QMAKE_TARGET.arch, x86_64) {
     DEFINES += USE_MINHOOK

--- a/src/mumble_exe/mumble_exe.cpp
+++ b/src/mumble_exe/mumble_exe.cpp
@@ -45,6 +45,20 @@ static void Alert(LPCWSTR title, LPCWSTR msg) {
 	MessageBox(NULL, msg, title, MB_OK|MB_ICONERROR);
 }
 
+// Get the current Mumble version built into this executable.
+// If no version is available, this function returns an empty
+// string.
+static std::wstring GetMumbleVersion() {
+#ifdef MUMBLE_VERSION
+#  define MUMXTEXT(X) L#X
+#  define MUMTEXT(X) MUMXTEXT(X)
+
+	std::wstring version(MUMTEXT(MUMBLE_VERSION));
+	return version;
+#endif
+	return std::wstring();
+}
+
 // GetExecutableDirPath returns the directory that
 // mumble.exe resides in.
 static std::wstring GetExecutableDirPath() {
@@ -76,15 +90,41 @@ static bool ConfigureEnvironment() {
 	return true;
 }
 
+// GetVersionedRootPath returns the versioned root path if
+// Mumble is configured to work with versioned paths.
+// If Mumble is not configured for versioned paths, this
+// function returns an empty string.
+static std::wstring GetVersionedRootPath() {
+	std::wstring versionedRootPath = GetExecutableDirPath();
+	if (versionedRootPath.empty()) {
+		return std::wstring();
+	}
+
+	std::wstring version = GetMumbleVersion();
+	if (version.length() > 0) {
+		versionedRootPath.append(L"Versions\\");
+		versionedRootPath.append(version);
+		return versionedRootPath;
+	}
+
+	return std::wstring();
+}
+
 // GetAbsoluteMumbleAppDllPath returns the absolute path to
 // mumble_app.dll - the DLL containing the Mumble client
 // application code.
-static std::wstring GetAbsoluteMumbleAppDllPath() {
-	std::wstring exe_path = GetExecutableDirPath();
-	if (exe_path.empty())
-		return std::wstring();
+static std::wstring GetAbsoluteMumbleAppDllPath(std::wstring suggested_base_dir) {
+	std::wstring base_dir = suggested_base_dir;
 
-	std::wstring abs_dll_path(exe_path);
+	if (base_dir.empty()) {
+		base_dir = GetExecutableDirPath();
+	}
+
+	if (base_dir.empty()) {
+		return std::wstring();
+	}
+
+	std::wstring abs_dll_path(base_dir);
 	abs_dll_path.append(L"\\");
 	abs_dll_path.append(L"mumble_app.dll");
 	return abs_dll_path;
@@ -97,7 +137,20 @@ int main(int argc, char **argv) {
 		return -1;
 	}
 
-	std::wstring abs_dll_path = GetAbsoluteMumbleAppDllPath();
+	std::wstring versioned_root_path = GetVersionedRootPath();
+
+	bool ok = false;
+	if (!versioned_root_path.empty()) {
+		if (PathFileExists(versioned_root_path.c_str())) {
+			_wputenv_s(L"MUMBLE_VERSION_ROOT", versioned_root_path.c_str());
+			ok = true;
+		}
+	}
+	if (!ok) {
+		_wputenv_s(L"MUMBLE_VERSION_ROOT", L"");
+	}
+
+	std::wstring abs_dll_path = GetAbsoluteMumbleAppDllPath(ok ? versioned_root_path : std::wstring());
 	if (abs_dll_path.empty()) {
 		Alert(L"Mumble Launcher Error -2", L"Unable to find the absolute path of mumble_app.dll.");
 		return -2;
@@ -127,7 +180,20 @@ int APIENTRY wWinMain(HINSTANCE instance, HINSTANCE prevInstance, wchar_t *cmdAr
 		return -1;
 	}
 
-	std::wstring abs_dll_path = GetAbsoluteMumbleAppDllPath();
+	std::wstring versioned_root_path = GetVersionedRootPath();
+
+	bool ok = false;
+	if (!versioned_root_path.empty()) {
+		if (PathFileExists(versioned_root_path.c_str())) {
+			_wputenv_s(L"MUMBLE_VERSION_ROOT", versioned_root_path.c_str());
+			ok = true;
+		}
+	}
+	if (!ok) {
+		_wputenv_s(L"MUMBLE_VERSION_ROOT", L"");
+	}
+
+	std::wstring abs_dll_path = GetAbsoluteMumbleAppDllPath(ok ? versioned_root_path : std::wstring());
 	if (abs_dll_path.empty()) {
 		Alert(L"Mumble Launcher Error -2", L"Unable to find the absolute path of mumble_app.dll.");
 		return -2;

--- a/src/mumble_exe/mumble_exe.cpp
+++ b/src/mumble_exe/mumble_exe.cpp
@@ -48,20 +48,19 @@ static void Alert(LPCWSTR title, LPCWSTR msg) {
 // Get the current Mumble version built into this executable.
 // If no version is available, this function returns an empty
 // string.
-static std::wstring GetMumbleVersion() {
+static const std::wstring GetMumbleVersion() {
 #ifdef MUMBLE_VERSION
-#  define MUMXTEXT(X) L#X
-#  define MUMTEXT(X) MUMXTEXT(X)
-
-	std::wstring version(MUMTEXT(MUMBLE_VERSION));
+#   define MUMTEXT(X) L#X
+	const std::wstring version(MUMTEXT(MUMBLE_VERSION));
 	return version;
-#endif
+#else
 	return std::wstring();
+#endif
 }
 
 // GetExecutableDirPath returns the directory that
 // mumble.exe resides in.
-static std::wstring GetExecutableDirPath() {
+static const std::wstring GetExecutableDirPath() {
 	wchar_t path[MAX_PATH];
 
 	if (GetModuleFileNameW(NULL, path, MAX_PATH) == 0)
@@ -77,7 +76,7 @@ static std::wstring GetExecutableDirPath() {
 // ConfigureEnvironment prepares mumble.exe's environment to
 // run mumble_app.dll.
 static bool ConfigureEnvironment() {
-	std::wstring exe_path = GetExecutableDirPath();
+	const std::wstring exe_path = GetExecutableDirPath();
 
 	// Remove the current directory from the DLL search path.
 	if (!SetDllDirectoryW(L""))
@@ -94,17 +93,15 @@ static bool ConfigureEnvironment() {
 // Mumble is configured to work with versioned paths.
 // If Mumble is not configured for versioned paths, this
 // function returns an empty string.
-static std::wstring GetVersionedRootPath() {
-	std::wstring versionedRootPath = GetExecutableDirPath();
+static const std::wstring GetVersionedRootPath() {
+	const std::wstring versionedRootPath = GetExecutableDirPath();
 	if (versionedRootPath.empty()) {
 		return std::wstring();
 	}
 
-	std::wstring version = GetMumbleVersion();
+	const std::wstring version = GetMumbleVersion();
 	if (version.length() > 0) {
-		versionedRootPath.append(L"Versions\\");
-		versionedRootPath.append(version);
-		return versionedRootPath;
+		return versionedRootPath + L"Versions\\" + version;
 	}
 
 	return std::wstring();
@@ -113,7 +110,7 @@ static std::wstring GetVersionedRootPath() {
 // GetAbsoluteMumbleAppDllPath returns the absolute path to
 // mumble_app.dll - the DLL containing the Mumble client
 // application code.
-static std::wstring GetAbsoluteMumbleAppDllPath(std::wstring suggested_base_dir) {
+static const std::wstring GetAbsoluteMumbleAppDllPath(std::wstring suggested_base_dir) {
 	std::wstring base_dir = suggested_base_dir;
 
 	if (base_dir.empty()) {
@@ -124,10 +121,7 @@ static std::wstring GetAbsoluteMumbleAppDllPath(std::wstring suggested_base_dir)
 		return std::wstring();
 	}
 
-	std::wstring abs_dll_path(base_dir);
-	abs_dll_path.append(L"\\");
-	abs_dll_path.append(L"mumble_app.dll");
-	return abs_dll_path;
+	return base_dir + L"\\mumble_app.dll";
 }
 
 #ifdef DEBUG


### PR DESCRIPTION
This PR changes Mumble to use "versioned root" directory.

In this scheme, a typical Mumble installation would look something like this
(rooted the install target, typically "C:\Program Files (x86)\Mumble"):

      /mumble.exe
      /Versions/1.3.0/mumble_app.dll
      /Versions/1.3.0/mumble_ol.dll
      /Versions/1.3.0/mumble_ol_x64.dll
      /Versions/1.3.0/mumble_ol_helper.exe
      /Versions/1.3.0/mumble_ol_helper_x64.exe
      /Versions/1.3.0/mumble-g15-helper.exe
      /Versions/1.3.0/[various runtime DLLs, D3DCompiler, MSVCRT, etc.]

This new hierarchy prepares us for easier updating the appliaction in the future (download, verify, extract and point to the correct "versioned root" -- maybe even in %APPDATA%).

This new hierarchy also makes the process of upgrading an existing Mumble installation a lot easier for users. It eliminates the scary and confusing "files in use" dialog that would always appear when upgrading a Mumble installation that had active users of the Mumble overlay.

It can eliminate the dialog because an upgrade of Mumble will install the files that are in use to a new path -- and the existing files that are in use can simply be scheduled to be removed on next reboot.