### PR TITLE
Add rules to compiler.pri to fix FreeBSD builds w/ Qt5

### DIFF
--- a/compiler.pri
+++ b/compiler.pri
@@ -176,6 +176,12 @@ unix {
 	}
 }
 
+freebsd-clang {
+	QMAKE_CFLAGS *= -isystem /usr/local/include
+	QMAKE_CXXFLAGS	*= -isystem /usr/local/include
+	QMAKE_LFLAGS *= -L/usr/local/lib -lssl
+}
+
 unix:!macx {
 	CONFIG(debug, debug|release) {
 		QMAKE_CFLAGS *= -fstack-protector -fPIE -pie


### PR DESCRIPTION
I don't think there's any issues here, it seems to work for me. If I've messed up any of the rules just let me know and I'll fix it. :)

Tested with clang, on Qt4 and Qt5. Currently don't have any working build for gcc48 as the Makefile needs a bit of work for that :(