### PR TITLE
Reduce Linux build warnings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@ indent.sh
 *.pro.user
 ui_*.h
 *.qm
+*.pb.*
 installer/Mumble.exe
 overlay/*.hex
 overlay_winx64/*.hex
@@ -29,8 +30,6 @@ src/mumble/mumble_plugin_import.cpp
 src/mumble/mumble_app_plugin_import.cpp
 src/murmur/murmurd_plugin_import.cpp
 src/murmur/murmur_plugin_import.cpp
-src/mumble/protobuf/
-src/murmur/protobuf/
 doxygen/
 .qmake.cache
 .qmake.stash

--- a/.gitignore
+++ b/.gitignore
@@ -14,8 +14,6 @@ indent.sh
 *.vcxproj
 *.vcxproj.*
 *~
-*.pb.h
-*.pb.cc
 *.pro.user
 ui_*.h
 *.qm
@@ -31,6 +29,8 @@ src/mumble/mumble_plugin_import.cpp
 src/mumble/mumble_app_plugin_import.cpp
 src/murmur/murmurd_plugin_import.cpp
 src/murmur/murmur_plugin_import.cpp
+src/mumble/protobuf/
+src/murmur/protobuf/
 doxygen/
 .qmake.cache
 .qmake.stash

--- a/3rdparty/celt-0.11.0-build/celt-0.11.0-build.pro
+++ b/3rdparty/celt-0.11.0-build/celt-0.11.0-build.pro
@@ -13,8 +13,6 @@ VERSION=$$replace(VERSION,celt-,)
 TEMPLATE = lib
 CONFIG -= qt
 CONFIG += debug_and_release
-CONFIG -= warn_on
-CONFIG += warn_off
 CONFIG += no_include_pwd
 VPATH	= ../$$SOURCEDIR/libcelt
 TARGET = celt0
@@ -25,6 +23,13 @@ TARGET_VERSION_EXT = .$$VERSION
 CONFIG(static) {
 	CONFIG -= static
 	CONFIG += shared
+}
+
+!CONFIG(third-party-warnings) {
+	# We ignore warnings in third party builds. We won't actually look
+	# at them and they clutter out our warnings.
+	CONFIG -= warn_on
+	CONFIG += warn_off
 }
 
 QMAKE_CFLAGS -= -fPIE -pie

--- a/3rdparty/celt-0.7.0-build/celt-0.7.0-build.pro
+++ b/3rdparty/celt-0.7.0-build/celt-0.7.0-build.pro
@@ -32,6 +32,13 @@ CONFIG(sbcelt) {
 	}
 }
 
+!CONFIG(third-party-warnings) {
+	# We ignore warnings in third party builds. We won't actually look
+	# at them and they clutter out our warnings.
+	CONFIG -= warn_on
+	CONFIG += warn_off
+}
+
 QMAKE_CFLAGS -= -fPIE -pie
 
 win32 {

--- a/3rdparty/opus-build/opus-build.pro
+++ b/3rdparty/opus-build/opus-build.pro
@@ -15,12 +15,17 @@ SOURCEDIR=$$replace(BUILDDIR,-build,-src)
 TEMPLATE = lib
 CONFIG -= qt
 CONFIG += debug_and_release
-#CONFIG -= warn_on
-#CONFIG += warn_off
 CONFIG += no_include_pwd
 VPATH	= ../$$SOURCEDIR
 TARGET = opus
 DEFINES += HAVE_CONFIG_H
+
+!CONFIG(third-party-warnings) {
+	# We ignore warnings in third party builds. We won't actually look
+	# at them and they clutter out our warnings.
+	CONFIG -= warn_on
+	CONFIG += warn_off
+}
 
 QMAKE_CFLAGS -= -fPIE -pie
 

--- a/main.pro
+++ b/main.pro
@@ -1,6 +1,8 @@
 TEMPLATE = subdirs
 CONFIG *= ordered debug_and_release
 
+SUBDIRS *= src/mumble_proto
+
 !CONFIG(no-client) {
   unix:!CONFIG(bundled-speex):system(pkg-config --atleast-version=1.2 speexdsp):system(pkg-config --atleast-version=1.2 speex) {
     CONFIG *= no-bundled-speex

--- a/overlay_gl/overlay.c
+++ b/overlay_gl/overlay.c
@@ -529,7 +529,7 @@ static void drawContext(Context * ctx, int width, int height) {
 	glPushAttrib(GL_ALL_ATTRIB_BITS);
 	glPushClientAttrib(GL_ALL_ATTRIB_BITS);
 	glGetIntegerv(GL_VIEWPORT, viewport);
-	glGetIntegerv(GL_CURRENT_PROGRAM, (GLint*)&program);
+	glGetIntegerv(GL_CURRENT_PROGRAM, (GLint *)&program);
 
 	glViewport(0, 0, width, height);
 
@@ -642,8 +642,8 @@ static void drawContext(Context * ctx, int width, int height) {
 	glEnableClientState(GL_TEXTURE_COORD_ARRAY);
 
 	GLuint bound = 0, vbobound = 0;
-	glGetIntegerv(GL_PIXEL_UNPACK_BUFFER_BINDING, (GLint*)&bound);
-	glGetIntegerv(GL_ARRAY_BUFFER_BINDING, (GLint*)&vbobound);
+	glGetIntegerv(GL_PIXEL_UNPACK_BUFFER_BINDING, (GLint *)&bound);
+	glGetIntegerv(GL_ARRAY_BUFFER_BINDING, (GLint *)&vbobound);
 
 	if (bound != 0) {
 		glBindBuffer(GL_PIXEL_UNPACK_BUFFER_ARB, 0);

--- a/overlay_gl/overlay.c
+++ b/overlay_gl/overlay.c
@@ -52,6 +52,7 @@
 #include <math.h>
 #include <errno.h>
 #include <time.h>
+#include <limits.h>
 
 #if defined(TARGET_UNIX)
 # define GLX_GLXEXT_LEGACY
@@ -322,7 +323,7 @@ static void drawOverlay(Context *ctx, unsigned int width, unsigned int height) {
 
 	// receive and process overlay messages
 	while (1) {
-		if (ctx->omMsg.omh.iLength == -1) {
+		if (ctx->omMsg.omh.iLength < 0) {
 			// receive the overlay message header
 			ssize_t length = recv(ctx->iSocket, ctx->omMsg.headerbuffer, sizeof(struct OverlayMsgHeader), 0);
 			if (length < 0) {
@@ -337,7 +338,7 @@ static void drawOverlay(Context *ctx, unsigned int width, unsigned int height) {
 			}
 		} else {
 			// receive the overlay message body
-			ssize_t  length = recv(ctx->iSocket, ctx->omMsg.msgbuffer, ctx->omMsg.omh.iLength, 0);
+			ssize_t length = recv(ctx->iSocket, ctx->omMsg.msgbuffer, (size_t)ctx->omMsg.omh.iLength, 0);
 			if (length < 0) {
 				if ((errno == EAGAIN) || (errno == EWOULDBLOCK))
 					break;
@@ -362,8 +363,8 @@ static void drawOverlay(Context *ctx, unsigned int width, unsigned int height) {
 							struct stat buf;
 							fstat(fd, &buf);
 							if (buf.st_size >= ctx->uiWidth * ctx->uiHeight * 4) {
-								ctx->uiMappedLength = buf.st_size;
-								ctx->a_ucTexture = mmap(NULL, buf.st_size, PROT_READ, MAP_SHARED, fd, 0);
+								ctx->uiMappedLength = (unsigned int)buf.st_size;
+								ctx->a_ucTexture = mmap(NULL, (size_t)buf.st_size, PROT_READ, MAP_SHARED, fd, 0);
 								if (ctx->a_ucTexture != MAP_FAILED) {
 									// mmap successfull; send a new bodyless sharedmemory overlay message and regenerate the overlay texture
 									struct OverlayMsg om;
@@ -508,7 +509,7 @@ static void drawContext(Context * ctx, int width, int height) {
 		om.omh.uiMagic = OVERLAY_MAGIC_NUMBER;
 		om.omh.uiType = OVERLAY_MSGTYPE_FPS;
 		om.omh.iLength = sizeof(struct OverlayMsgFps);
-		om.omf.fps = ctx->frameCount / elapsed;
+		om.omf.fps = (float)ctx->frameCount / elapsed;
 
 		sendMessage(ctx, &om);
 
@@ -516,14 +517,14 @@ static void drawContext(Context * ctx, int width, int height) {
 		ctx->timeT = t;
 	}
 
-	GLint program;
+	GLuint program;
 	GLint viewport[4];
 	int i;
 
 	glPushAttrib(GL_ALL_ATTRIB_BITS);
 	glPushClientAttrib(GL_ALL_ATTRIB_BITS);
 	glGetIntegerv(GL_VIEWPORT, viewport);
-	glGetIntegerv(GL_CURRENT_PROGRAM, &program);
+	glGetIntegerv(GL_CURRENT_PROGRAM, (GLint*)&program);
 
 	glViewport(0, 0, width, height);
 
@@ -635,9 +636,9 @@ static void drawContext(Context * ctx, int width, int height) {
 	glEnableClientState(GL_VERTEX_ARRAY);
 	glEnableClientState(GL_TEXTURE_COORD_ARRAY);
 
-	GLint bound = 0, vbobound = 0;
-	glGetIntegerv(GL_PIXEL_UNPACK_BUFFER_BINDING, &bound);
-	glGetIntegerv(GL_ARRAY_BUFFER_BINDING, &vbobound);
+	GLuint bound = 0, vbobound = 0;
+	glGetIntegerv(GL_PIXEL_UNPACK_BUFFER_BINDING, (GLint*)&bound);
+	glGetIntegerv(GL_ARRAY_BUFFER_BINDING, (GLint*)&vbobound);
 
 	if (bound != 0) {
 		glBindBuffer(GL_PIXEL_UNPACK_BUFFER_ARB, 0);

--- a/plugins/link/link-posix.cpp
+++ b/plugins/link/link-posix.cpp
@@ -66,10 +66,11 @@ struct LinkedMem {
 	wchar_t description[2048];
 };
 
-static int32_t GetTickCount() {
+/// Non-monotonic tick count in ms resolution
+static int64_t GetTickCount() {
 	struct timeval tv;
 	gettimeofday(&tv,NULL);
-
+	
 	return tv.tv_usec / 1000 + tv.tv_sec * 1000;
 }
 
@@ -77,7 +78,7 @@ static int32_t GetTickCount() {
 static struct LinkedMem *lm = lm_invalid;
 static int shmfd = -1;
 
-static uint32_t last_tick = 0;
+static int64_t last_tick = 0;
 static uint32_t last_count = 0;
 
 static void unlock() {

--- a/plugins/link/link-posix.cpp
+++ b/plugins/link/link-posix.cpp
@@ -70,7 +70,7 @@ struct LinkedMem {
 static int64_t GetTickCount() {
 	struct timeval tv;
 	gettimeofday(&tv,NULL);
-	
+
 	return tv.tv_usec / 1000 + tv.tv_sec * 1000;
 }
 

--- a/src/mumble.pri
+++ b/src/mumble.pri
@@ -2,28 +2,14 @@ include(../compiler.pri)
 include(../qt.pri)
 
 VERSION		= 1.3.0
-DIST		= mumble.pri Message.h PacketDataStream.h CryptState.h Timer.h Version.h OSInfo.h SSL.h Mumble.proto
+DIST		= mumble.pri Message.h PacketDataStream.h CryptState.h Timer.h Version.h OSInfo.h SSL.h
 CONFIG		+= qt thread debug_and_release warn_on
 DEFINES		*= MUMBLE_VERSION_STRING=$$VERSION
-INCLUDEPATH	+= $$PWD .
+INCLUDEPATH	+= $$PWD . ../mumble_proto
 VPATH		+= $$PWD
 HEADERS		*= ACL.h Channel.h CryptState.h Connection.h Group.h User.h Net.h OSInfo.h Timer.h SSL.h Version.h
 SOURCES 	*= ACL.cpp Group.cpp Channel.cpp Connection.cpp User.cpp Timer.cpp CryptState.cpp OSInfo.cpp Net.cpp SSL.cpp Version.cpp
-PROTOBUF	*= ../Mumble.proto
-
-pbh.output = protobuf/${QMAKE_FILE_BASE}.pb.h
-pbh.depends = protobuf/${QMAKE_FILE_BASE}.pb.cc
-pbh.commands = $$escape_expand(\\n)
-pbh.input = PROTOBUF
-pbh.CONFIG *= no_link explicit_dependencies target_predeps
-pbh.variable_out = HEADERS
-
-pb.output = protobuf/${QMAKE_FILE_BASE}.pb.cc
-pb.commands = protoc --cpp_out=protobuf/ -I. -I.. ${QMAKE_FILE_NAME}
-pb.input = PROTOBUF
-pb.CONFIG *= no_link explicit_dependencies
-pb.variable_out = SOURCES
-
+LIBS		*= -lmumble_proto
 # Note: Protobuf generates into its own directory so we can mark it as a
 #       system include folder for unix. Otherwise the generated code creates
 #       a lot of spurious warnings in ours.
@@ -56,8 +42,8 @@ unix {
 		PKG_CONFIG = pkg-config --static
 	}
 
-	QMAKE_CFLAGS *= -isystem protobuf
-	QMAKE_CXXFLAGS *= -isystem protobuf
+	QMAKE_CFLAGS *= -isystem ../mumble_proto
+	QMAKE_CXXFLAGS *= -isystem ../mumble_proto
 
 	CONFIG *= link_pkgconfig
 	LIBS *= -lprotobuf
@@ -75,9 +61,6 @@ isEqual(QT_MAJOR_VERSION, 4) {
 	DEFINES *= Q_DECL_OVERRIDE=
 	DEFINES *= Q_DECL_FINAL=
 }
-
-
-QMAKE_EXTRA_COMPILERS *= pb pbh
 
 CONFIG(debug, debug|release) {
   CONFIG += console

--- a/src/mumble.pri
+++ b/src/mumble.pri
@@ -16,6 +16,7 @@ pbh.depends = protobuf/${QMAKE_FILE_BASE}.pb.cc
 pbh.commands = $$escape_expand(\\n)
 pbh.input = PROTOBUF
 pbh.CONFIG *= no_link explicit_dependencies target_predeps
+pbh.variable_out = HEADERS
 
 pb.output = protobuf/${QMAKE_FILE_BASE}.pb.cc
 pb.commands = protoc --cpp_out=protobuf/ -I. -I.. ${QMAKE_FILE_NAME}
@@ -55,8 +56,8 @@ unix {
 		PKG_CONFIG = pkg-config --static
 	}
 
-	QMAKE_CFLAGS = -isystem protobuf
-	QMAKE_CXXFLAGS = -isystem protobuf
+	QMAKE_CFLAGS *= -isystem protobuf
+	QMAKE_CXXFLAGS *= -isystem protobuf
 
 	CONFIG *= link_pkgconfig
 	LIBS *= -lprotobuf

--- a/src/mumble.pri
+++ b/src/mumble.pri
@@ -11,17 +11,21 @@ HEADERS		*= ACL.h Channel.h CryptState.h Connection.h Group.h User.h Net.h OSInf
 SOURCES 	*= ACL.cpp Group.cpp Channel.cpp Connection.cpp User.cpp Timer.cpp CryptState.cpp OSInfo.cpp Net.cpp SSL.cpp Version.cpp
 PROTOBUF	*= ../Mumble.proto
 
-pbh.output = ${QMAKE_FILE_BASE}.pb.h
-pbh.depends = ${QMAKE_FILE_BASE}.pb.cc
+pbh.output = protobuf/${QMAKE_FILE_BASE}.pb.h
+pbh.depends = protobuf/${QMAKE_FILE_BASE}.pb.cc
 pbh.commands = $$escape_expand(\\n)
 pbh.input = PROTOBUF
 pbh.CONFIG *= no_link explicit_dependencies target_predeps
 
-pb.output = ${QMAKE_FILE_BASE}.pb.cc
-pb.commands = protoc --cpp_out=. -I. -I.. ${QMAKE_FILE_NAME}
+pb.output = protobuf/${QMAKE_FILE_BASE}.pb.cc
+pb.commands = protoc --cpp_out=protobuf/ -I. -I.. ${QMAKE_FILE_NAME}
 pb.input = PROTOBUF
 pb.CONFIG *= no_link explicit_dependencies
 pb.variable_out = SOURCES
+
+# Note: Protobuf generates into its own directory so we can mark it as a
+#       system include folder for unix. Otherwise the generated code creates
+#       a lot of spurious warnings in ours.
 
 CONFIG(packaged) {
 	MUMDEFVER = $$find(DEFINES, "MUMBLE_VERSION=")
@@ -31,7 +35,7 @@ CONFIG(packaged) {
 }
 
 win32 {
-	INCLUDEPATH *= "$$PROTOBUF_PATH/vsprojects/include" "$$PROTOBUF_PATH/src"
+	INCLUDEPATH *= "$$PROTOBUF_PATH/vsprojects/include" "$$PROTOBUF_PATH/src" protobuf
 	CONFIG(debug, debug|release) {
 		QMAKE_LIBDIR *= "$$PROTOBUF_PATH/vsprojects/Debug"
 	} else {
@@ -50,6 +54,9 @@ unix {
 	CONFIG(static) {
 		PKG_CONFIG = pkg-config --static
 	}
+
+	QMAKE_CFLAGS = -isystem protobuf
+	QMAKE_CXXFLAGS = -isystem protobuf
 
 	CONFIG *= link_pkgconfig
 	LIBS *= -lprotobuf

--- a/src/mumble/AudioInput.cpp
+++ b/src/mumble/AudioInput.cpp
@@ -845,7 +845,7 @@ void AudioInput::encodeAudioFrame() {
 	EncodingOutputBuffer buffer;
 	Q_ASSERT(buffer.size() >= static_cast<size_t>(iAudioQuality / 100 * iAudioFrames / 8));
 	
-	int len;
+	int len = 0;
 
 	bool encoded = true;
 	if (!selectCodec())

--- a/src/mumble/Log.cpp
+++ b/src/mumble/Log.cpp
@@ -604,9 +604,9 @@ void Log::postQtNotification(MsgType mt, const QString &plain) {
 
 LogDocument::LogDocument(QObject *p)
 	: QTextDocument(p)
+	, m_allowHTTPResources(true)
 	, m_valid(true)
-	, m_onlyLoadDataURLs(false)
-	, m_allowHTTPResources(true) {
+	, m_onlyLoadDataURLs(false) {
 }
 
 QVariant LogDocument::loadResource(int type, const QUrl &url) {

--- a/src/mumble/Log.ui
+++ b/src/mumble/Log.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>524</width>
-    <height>338</height>
+    <width>446</width>
+    <height>334</height>
    </rect>
   </property>
   <property name="windowTitle">

--- a/src/mumble/Log.ui
+++ b/src/mumble/Log.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>446</width>
-    <height>334</height>
+    <width>524</width>
+    <height>338</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -176,7 +176,7 @@
      <property name="title">
       <string>Chat Log</string>
      </property>
-     <layout class="QGridLayout" name="gridLayout">
+     <layout class="QGridLayout" name="_2">
       <item row="0" column="0">
        <widget class="QLabel" name="qlMaxBlocks">
         <property name="text">

--- a/src/mumble/MainWindow.cpp
+++ b/src/mumble/MainWindow.cpp
@@ -2449,7 +2449,7 @@ void MainWindow::removeTarget(ShortcutTarget *st)
 		qmCurrentTargets[*st] -= 1;
 }
 
-void MainWindow::on_gsCycleTransmitMode_triggered(bool down, QVariant /*scdata*/)
+void MainWindow::on_gsCycleTransmitMode_triggered(bool down, QVariant)
 {
 	if (down) 
 	{

--- a/src/mumble/MainWindow.cpp
+++ b/src/mumble/MainWindow.cpp
@@ -2449,7 +2449,7 @@ void MainWindow::removeTarget(ShortcutTarget *st)
 		qmCurrentTargets[*st] -= 1;
 }
 
-void MainWindow::on_gsCycleTransmitMode_triggered(bool down, QVariant scdata) 
+void MainWindow::on_gsCycleTransmitMode_triggered(bool down, QVariant /*scdata*/)
 {
 	if (down) 
 	{

--- a/src/mumble/OverlayClient.cpp
+++ b/src/mumble/OverlayClient.cpp
@@ -44,12 +44,13 @@
 #include "MainWindow.h"
 #include "GlobalShortcut.h"
 
-OverlayClient::OverlayClient(QLocalSocket *socket, QObject *p) :
-		QObject(p),
-		ougUsers(&g.s.os),
-		iMouseX(0),
-		iMouseY(0),
-		fFps(0) {
+OverlayClient::OverlayClient(QLocalSocket *socket, QObject *p)
+	: QObject(p)
+	, fFps(0)
+	, ougUsers(&g.s.os)
+	, iMouseX(0)
+	, iMouseY(0) {
+	
 	qlsSocket = socket;
 	qlsSocket->setParent(NULL);
 	connect(qlsSocket, SIGNAL(readyRead()), this, SLOT(readyRead()));

--- a/src/mumble/OverlayConfig.cpp
+++ b/src/mumble/OverlayConfig.cpp
@@ -45,7 +45,9 @@
 #include "MainWindow.h"
 #include "GlobalShortcut.h"
 
+#ifdef Q_OS_WIN
 #include "../../overlay/overlay_blacklist.h"
+#endif
 
 static ConfigWidget *OverlayConfigDialogNew(Settings &st) {
 	return new OverlayConfig(st);

--- a/src/mumble/OverlayText.cpp
+++ b/src/mumble/OverlayText.cpp
@@ -57,16 +57,17 @@ BasepointPixmap::BasepointPixmap(int w, int h, const QPoint& bp) :
 		iAscent(-1),
 		iDescent(-1) { }
 
-OverlayTextLine::OverlayTextLine(const QString& s, const QFont& f) :
-		fEdgeFactor(0.05f),
-		qsText(s),
-		qfFont(f),
-		iCurWidth(-1),
-		iCurHeight(-1),
-		fBaseliningThreshold(0.5f),
-		bElided(false),
-		fXCorrection(0.0),
-		fYCorrection(0.0) {
+OverlayTextLine::OverlayTextLine(const QString& s, const QFont& f)
+	: fEdgeFactor(0.05f)
+	, qsText(s)
+	, qfFont(f)
+	, fXCorrection(0.0)
+	, fYCorrection(0.0)
+	, iCurWidth(-1)
+	, iCurHeight(-1)
+	, fBaseliningThreshold(0.5f)
+	, bElided(false) {
+	
 	QFontMetrics fm(f);
 	fAscent = static_cast<float>(fm.ascent());
 	fDescent = static_cast<float>(fm.descent());

--- a/src/mumble/PulseAudio.cpp
+++ b/src/mumble/PulseAudio.cpp
@@ -775,7 +775,7 @@ void PulseAudioSystem::stream_restore_read_callback(pa_context *c, const pa_ext_
 	}
 }
 
-void PulseAudioSystem::restore_volume_success_callback(pa_context * /*c*/, int /*success*/, void *userdata) {
+void PulseAudioSystem::restore_volume_success_callback(pa_context *, int, void *userdata) {
 	PulseAudioSystem *pas = reinterpret_cast<PulseAudioSystem *>(userdata);
 
 	pas->iRemainingOperations--;

--- a/src/mumble/PulseAudio.cpp
+++ b/src/mumble/PulseAudio.cpp
@@ -775,7 +775,7 @@ void PulseAudioSystem::stream_restore_read_callback(pa_context *c, const pa_ext_
 	}
 }
 
-void PulseAudioSystem::restore_volume_success_callback(pa_context *c, int success, void *userdata) {
+void PulseAudioSystem::restore_volume_success_callback(pa_context * /*c*/, int /*success*/, void *userdata) {
 	PulseAudioSystem *pas = reinterpret_cast<PulseAudioSystem *>(userdata);
 
 	pas->iRemainingOperations--;

--- a/src/mumble/mumble.pro
+++ b/src/mumble/mumble.pro
@@ -525,7 +525,7 @@ bonjour {
 
 dbus {
 	DEFINES *= USE_DBUS
-	CONFIG *= qdbus
+	QT *= dbus
 	HEADERS *= DBus.h
 	SOURCES *= DBus.cpp
 }

--- a/src/mumble_proto/mumble_proto.pro
+++ b/src/mumble_proto/mumble_proto.pro
@@ -1,0 +1,43 @@
+include(../../compiler.pri)
+
+PROTOBUF	*= ../Mumble.proto
+
+pbh.output = ${QMAKE_FILE_BASE}.pb.h
+pbh.depends = ${QMAKE_FILE_BASE}.pb.cc
+pbh.commands = $$escape_expand(\\n)
+pbh.input = PROTOBUF
+pbh.CONFIG *= no_link explicit_dependencies target_predeps
+pbh.variable_out = HEADERS
+
+pb.output = ${QMAKE_FILE_BASE}.pb.cc
+pb.commands = protoc --cpp_out=. -I. -I.. ${QMAKE_FILE_NAME}
+pb.input = PROTOBUF
+pb.CONFIG *= no_link explicit_dependencies
+pb.variable_out = SOURCES
+
+TEMPLATE = lib
+CONFIG -= qt
+CONFIG += debug_and_release
+CONFIG += staticlib
+
+INCLUDEPATH *= "$$PROTOBUF_PATH/vsprojects/include" "$$PROTOBUF_PATH/src" protobuf
+
+QMAKE_EXTRA_COMPILERS *= pb pbh
+
+!CONFIG(third-party-warnings) {
+    # We ignore warnings in third party builds. We won't actually look
+    # at them and they clutter out our warnings.
+    CONFIG -= warn_on
+    CONFIG += warn_off
+}
+
+CONFIG(debug, debug|release) {
+	DESTDIR = ../../debug
+}
+
+CONFIG(release, debug|release) {
+	DESTDIR = ../../release
+}
+
+include(../../symbols.pri)
+

--- a/src/murmur/Server.cpp
+++ b/src/murmur/Server.cpp
@@ -757,6 +757,7 @@ void Server::run() {
 				msg.msg_controllen = sizeof(controldata);
 
 				len=static_cast<quint32>(::recvmsg(sock, &msg, MSG_TRUNC));
+				Q_UNUSED(fromlen);
 #else
 				len=static_cast<qint32>(::recvfrom(sock, encrypt, UDP_PACKET_SIZE, MSG_TRUNC, reinterpret_cast<struct sockaddr *>(&from), &fromlen));
 #endif

--- a/src/murmur/main.cpp
+++ b/src/murmur/main.cpp
@@ -150,14 +150,14 @@ static void murmurMessageOutputQString(QtMsgType type, const QString &msg) {
 	}
 }
 
-static void murmurMessageOutput(QtMsgType type, const char *msg) {
-	murmurMessageOutputQString(type, QString::fromUtf8(msg));
-}
-
 #if QT_VERSION >= 0x050000
 static void murmurMessageOutputWithContext(QtMsgType type, const QMessageLogContext &ctx, const QString &msg) {
 	Q_UNUSED(ctx);
 	murmurMessageOutputQString(type, msg);
+}
+#else
+static void murmurMessageOutput(QtMsgType type, const char *msg) {
+	murmurMessageOutputQString(type, QString::fromUtf8(msg));
 }
 #endif
 

--- a/src/murmur/murmur.pro
+++ b/src/murmur/murmur.pro
@@ -68,7 +68,7 @@ macx {
 
 dbus {
 	DEFINES *= USE_DBUS
-	CONFIG *= qdbus
+	QT *= dbus
 	HEADERS *= DBus.h
 	SOURCES *= DBus.cpp
 }


### PR DESCRIPTION
This PR significantly reduces the amount of warnings emitted during a Linux build with gcc 4.9. See the separate commits for more specific information.

To cleanly remove the leftover warnings will require bigger refactoring or semantic changes and will be performed in follow-up. The two big left-over areas is the interface to OpenGL for the overlay where we have a lot of conversion warnings left as well as a deprecation warning in the shortcut code which has to be more closely investigated.