### PR TITLE
Strip schema and path component from new server addresses

### DIFF
--- a/src/mumble/ConnectDialog.cpp
+++ b/src/mumble/ConnectDialog.cpp
@@ -797,11 +797,28 @@ void ConnectDialogEdit::validate() {
 void ConnectDialogEdit::accept() {
 	validate();
 	if (bOk) {
-		if (qleName->text().simplified().isEmpty()) {
-			qleName->setText(qleServer->text());
+		QString server = qleServer->text().simplified();
+
+		// If the user accidentally added a schema or path part drop it now.
+		// We can't do so during editing as that is quite jarring.
+		const int schemaPos = server.indexOf(QLatin1String("://"));
+		if (schemaPos != -1) {
+			server.remove(0, schemaPos + 3);
 		}
+
+		const int pathPos = server.indexOf(QLatin1Char('/'));
+		if (pathPos != -1) {
+			server.resize(pathPos);
+		}
+
+		qleServer->setText(server);
+
+		if (qleName->text().simplified().isEmpty() || !bCustomLabel) {
+			qleName->setText(server);
+		}
+
 		QDialog::accept();
-    }
+	}
 }
 
 void ConnectDialogEdit::on_qcbShowPassword_toggled(bool checked) {


### PR DESCRIPTION
We have had reports that a lot of users out of habit add
http:// or https:// schemas to server addresses when adding
a new server. This patch changes the ConnectDialogEdit to
drop schema and path components from server addresses if
present. This happens automatically when accepting the
dialog.