### PR TITLE
Harden systemd service

### DIFF
--- a/scripts/murmur.service
+++ b/scripts/murmur.service
@@ -7,6 +7,10 @@ Type=forking
 PIDFile=/run/murmur/murmur.pid
 ExecStart=/usr/bin/murmurd -ini /etc/murmur.ini
 Restart=always
+PrivateDevices=true
+PrivateTmp=true
+ProtectSystem=full
+ProtectHome=true
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
Directives should be somewhat self-explanatory. For reference there is a [man page]. I've been running this configuration on a few servers without a hitch.

There is also pretty powerful `CapabilityBoundingSet` directive, but I'm not sure what value would be best for murmur.

[man page]: http://www.freedesktop.org/software/systemd/man/systemd.exec.html