### PR TITLE
Add self-restart capability to Mumble and enable its use in ConfigWidgets

### DIFF
--- a/src/mumble/ConfigDialog.cpp
+++ b/src/mumble/ConfigDialog.cpp
@@ -215,6 +215,15 @@ void ConfigDialog::apply() {
 
 	foreach(ConfigWidget *cw, qmWidgets)
 		cw->accept();
+	
+	if (g.s.requireRestartToApply && QMessageBox::question(
+		        this,
+		        tr("Restart Mumble?"),
+		        tr("Some settings will only apply after a restart of Mumble. Restart Mumble now?"),
+		        QMessageBox::Yes | QMessageBox::No) == QMessageBox::Yes) {
+		
+		qApp->exit(MUMBLE_EXIT_CODE_RESTART);
+	}
 
 	if (!g.s.bAttenuateOthersOnTalk)
 		g.bAttenuateOthers = false;

--- a/src/mumble/Global.h
+++ b/src/mumble/Global.h
@@ -138,6 +138,9 @@ class DeferInit {
 		static void run_destroyers();
 };
 
+/// Special exit code which causes mumble to restart itself. The outward facing return code with be 0
+const int MUMBLE_EXIT_CODE_RESTART = 64738;
+
 // -Wshadow is bugged. If an inline function of a class uses a variable or
 // parameter named 'g', that will generate a warning even if the class header
 // is included long before this definition.

--- a/src/mumble/LookConfig.cpp
+++ b/src/mumble/LookConfig.cpp
@@ -152,10 +152,15 @@ void LookConfig::load(const Settings &r) {
 }
 
 void LookConfig::save() const {
+	const QString oldLanguage = s.qsLanguage;
 	if (qcbLanguage->currentIndex() == 0)
 		s.qsLanguage = QString();
 	else
 		s.qsLanguage = qcbLanguage->itemData(qcbLanguage->currentIndex()).toString();
+	
+	if (s.qsLanguage != oldLanguage) {
+		s.requireRestartToApply = true;
+	}
 
 	if (qcbStyle->currentIndex() == 0)
 		s.qsStyle = QString();
@@ -180,7 +185,12 @@ void LookConfig::save() const {
 
 	s.ceExpand=static_cast<Settings::ChannelExpand>(qcbExpand->currentIndex());
 	s.ceChannelDrag=static_cast<Settings::ChannelDrag>(qcbChannelDrag->currentIndex());
-	s.bUserTop=qcbUsersTop->isChecked();
+	
+	if (qcbUsersTop->isChecked() != s.bUserTop) {
+		s.bUserTop = qcbUsersTop->isChecked();
+		s.requireRestartToApply = true;
+	}
+	
 	s.aotbAlwaysOnTop = static_cast<Settings::AlwaysOnTopBehaviour>(qcbAlwaysOnTop->currentIndex());
 	s.bAskOnQuit = qcbAskOnQuit->isChecked();
 	s.bHideInTray = qcbHideTray->isChecked();

--- a/src/mumble/ServerHandler.cpp
+++ b/src/mumble/ServerHandler.cpp
@@ -46,6 +46,7 @@
 #include "RichTextEditor.h"
 #include "SSL.h"
 #include "User.h"
+#include "Net.h"
 
 ServerHandlerMessageEvent::ServerHandlerMessageEvent(const QByteArray &msg, unsigned int mtype, bool flush) : QEvent(static_cast<QEvent::Type>(SERVERSEND_EVENT)) {
 	qbaMsg = msg;
@@ -846,5 +847,23 @@ void ServerHandler::announceRecordingState(bool recording) {
 	MumbleProto::UserState mpus;
 	mpus.set_recording(recording);
 	sendMessage(mpus);
+}
+
+QUrl ServerHandler::getServerURL(bool withPassword) const {
+	QUrl url;
+	
+	url.setScheme(QLatin1String("mumble"));
+	url.setHost(qsHostName);
+	if (usPort != DEFAULT_MUMBLE_PORT) {
+		url.setPort(usPort);
+	}
+	
+	url.setUserName(qsUserName);
+	
+	if (withPassword && !qsPassword.isEmpty()) {
+		url.setPassword(qsPassword);
+	}
+	
+	return url;
 }
 

--- a/src/mumble/ServerHandler.h
+++ b/src/mumble/ServerHandler.h
@@ -146,6 +146,9 @@ class ServerHandler : public QThread {
 		void requestChannelPermissions(unsigned int channel);
 		void setSelfMuteDeafState(bool mute, bool deaf);
 		void announceRecordingState(bool recording);
+		
+		/// Return connection information as a URL
+		QUrl getServerURL(bool withPassword = false) const;
 
 		void disconnect();
 		void run() Q_DECL_OVERRIDE;

--- a/src/mumble/Settings.cpp
+++ b/src/mumble/Settings.cpp
@@ -404,6 +404,8 @@ Settings::Settings() {
 #endif
 	dPacketLoss = 0;
 	dMaxPacketDelay = 0.0f;
+	
+	requireRestartToApply = false;
 
 	iMaxLogBlocks = 0;
 

--- a/src/mumble/Settings.h
+++ b/src/mumble/Settings.h
@@ -338,6 +338,8 @@ struct Settings {
 	LoopMode lmLoopMode;
 	float dPacketLoss;
 	float dMaxPacketDelay;
+	/// If true settings in this structure require a client restart to apply fully
+	bool requireRestartToApply;
 
 	bool doEcho() const;
 	bool doPositionalAudio() const;


### PR DESCRIPTION
This PR enables Mumble to restart itself when certain configuration options are changed. This enables us to offer the user to restart the client when one of the options we cannot change while the client is running was modified.

I tested the functionality on Windows and Linux and it seemed to work as expected. This leaves OSX. Also we will have to test with a realistic Mumble installation to make sure the versioned directories do not interfere.

For more specific information on the changes see the commit messages and contents.