### PR TITLE
add period after "renamed to" message.

### DIFF
--- a/src/mumble/Messages.cpp
+++ b/src/mumble/Messages.cpp
@@ -522,7 +522,7 @@ void MainWindow::msgUserState(const MumbleProto::UserState &msg) {
 		QString newName = u8(msg.name());
 		pmModel->renameUser(pDst, newName);
 		if (! oldName.isNull() && oldName != newName) {
-			g.l->log(Log::Information, tr("%1 renamed to %2").arg(Log::formatClientUser(pDst, Log::Target, oldName),
+			g.l->log(Log::Information, tr("%1 renamed to %2.").arg(Log::formatClientUser(pDst, Log::Target, oldName),
 				Log::formatClientUser(pDst, Log::Target)));
 		}
 	}


### PR DESCRIPTION
To be consistent with all other log messages, a period is added after the "renamed to" message.