### PR TITLE
Split up of chat and server log Dockwidgets

### DIFF
--- a/src/mumble/CustomElements.cpp
+++ b/src/mumble/CustomElements.cpp
@@ -69,7 +69,6 @@ void LogTextBrowser::scrollLogToBottom() {
 	verticalScrollBar()->setValue(verticalScrollBar()->maximum());
 }
 
-
 void ChatbarTextEdit::focusInEvent(QFocusEvent *qfe) {
 	inFocus(true);
 	QTextEdit::focusInEvent(qfe);

--- a/src/mumble/Log.cpp
+++ b/src/mumble/Log.cpp
@@ -482,9 +482,14 @@ void Log::log(MsgType mt, const QString &console, const QString &terse, bool own
 
 	// Message output on console
 	if ((flags & Settings::LogConsole)) {
-		QTextCursor tc = g.mw->qteLog->textCursor();
+		LogTextBrowser *tlog;
+		if(mt == TextMessage)
+			tlog = g.mw->qteMsg;
+		else
+			tlog = g.mw->qteLog;
 
-		LogTextBrowser *tlog = g.mw->qteLog;
+		QTextCursor tc = tlog->textCursor();
+
 		const int oldscrollvalue = tlog->getLogScroll();
 		const bool scroll = (oldscrollvalue == tlog->getLogScrollMaximum());
 
@@ -503,13 +508,13 @@ void Log::log(MsgType mt, const QString &console, const QString &terse, bool own
 			qttf.setPadding(2);
 			qttf.setBorderStyle(QTextFrameFormat::BorderStyle_Solid);
 			tc.insertFrame(qttf);
-		} else if (! g.mw->qteLog->document()->isEmpty()) {
+		} else if (! tlog->document()->isEmpty()) {
 			tc.insertBlock();
 		}
 		tc.insertHtml(Log::msgColor(QString::fromLatin1("[%1] ").arg(Qt::escape(dt.time().toString())), Log::Time));
 		validHtml(console, true, &tc);
 		tc.movePosition(QTextCursor::End);
-		g.mw->qteLog->setTextCursor(tc);
+		tlog->setTextCursor(tc);
 
 		if (scroll || ownMessage)
 			tlog->scrollLogToBottom();

--- a/src/mumble/LookConfig.cpp
+++ b/src/mumble/LookConfig.cpp
@@ -202,6 +202,7 @@ void LookConfig::accept() const {
 		if (qApp->styleSheet() != MainWindow::defaultStyleSheet) {
 			qApp->setStyleSheet(MainWindow::defaultStyleSheet);
 			g.mw->qteLog->document()->setDefaultStyleSheet(qApp->styleSheet());
+			g.mw->qteMsg->document()->setDefaultStyleSheet(qApp->styleSheet());
 		}
 	} else {
 		QFile file(s.qsSkin);
@@ -212,6 +213,7 @@ void LookConfig::accept() const {
 			QDir::addSearchPath(QLatin1String("skin"), fi.path());
 			qApp->setStyleSheet(sheet);
 			g.mw->qteLog->document()->setDefaultStyleSheet(sheet);
+			g.mw->qteMsg->document()->setDefaultStyleSheet(sheet);
 		}
 	}
 	g.mw->setShowDockTitleBars(g.s.wlWindowLayout == Settings::LayoutCustom);

--- a/src/mumble/MainWindow.cpp
+++ b/src/mumble/MainWindow.cpp
@@ -904,8 +904,8 @@ void MainWindow::setupView(bool toggle_minimize) {
 			removeDockWidget(qdwLog);
 			removeDockWidget(qdwMsg);
 			addDockWidget(Qt::RightDockWidgetArea, qdwMsg);
-			addDockWidget(Qt::LeftDockWidgetArea, qdwLog);
 			qdwMsg->show();
+			addDockWidget(Qt::LeftDockWidgetArea, qdwLog);
 			qdwLog->show();
 			splitDockWidget(qdwMsg, qdwChat, Qt::Vertical);
 			qdwChat->show();
@@ -914,8 +914,8 @@ void MainWindow::setupView(bool toggle_minimize) {
 			removeDockWidget(qdwLog);
 			removeDockWidget(qdwMsg);
 			addDockWidget(Qt::BottomDockWidgetArea, qdwMsg);
-			addDockWidget(Qt::LeftDockWidgetArea, qdwLog);
 			qdwMsg->show();
+			addDockWidget(Qt::LeftDockWidgetArea, qdwLog);
 			qdwLog->show();
 			splitDockWidget(qdwMsg, qdwChat, Qt::Vertical);
 			qdwChat->show();
@@ -936,7 +936,6 @@ void MainWindow::setupView(bool toggle_minimize) {
 			break;
 	}
 	qteChat->updateGeometry();
-	g.s.wlWindowLayout = wlTmp;
 
 	QRect geom = frameGeometry();
 
@@ -1024,6 +1023,9 @@ void MainWindow::setupView(bool toggle_minimize) {
 
 	show();
 	activateWindow();
+
+	// The view is properly set up now(after adjusting sizes etc) so we can update g.s.wlWindowLayout safely
+	g.s.wlWindowLayout = wlTmp;
 
 	// If activated show the PTT window
 	if (g.s.bShowPTTButtonWindow && g.s.atTransmit == Settings::PushToTalk) {
@@ -2972,7 +2974,7 @@ void MainWindow::on_qdwLog_dockLocationChanged(Qt::DockWidgetArea) {
 	g.s.wlWindowLayout = Settings::LayoutCustom;
 }
 
-void MainWindow::on_qdwMsg_dockLocationChanged(const Qt::DockWidgetArea)
+void MainWindow::on_qdwMsg_dockLocationChanged(Qt::DockWidgetArea)
 {
 	g.s.wlWindowLayout = Settings::LayoutCustom;
 }

--- a/src/mumble/MainWindow.cpp
+++ b/src/mumble/MainWindow.cpp
@@ -903,33 +903,31 @@ void MainWindow::setupView(bool toggle_minimize) {
 		case Settings::LayoutClassic:
 			removeDockWidget(qdwLog);
 			removeDockWidget(qdwMsg);
-			addDockWidget(Qt::LeftDockWidgetArea, qdwMsg);
+			addDockWidget(Qt::RightDockWidgetArea, qdwMsg);
 			addDockWidget(Qt::LeftDockWidgetArea, qdwLog);
 			qdwMsg->show();
 			qdwLog->show();
-			splitDockWidget(qdwMsg, qdwLog, Qt::Vertical);
-			splitDockWidget(qdwLog, qdwChat, Qt::Vertical);
+			splitDockWidget(qdwMsg, qdwChat, Qt::Vertical);
 			qdwChat->show();
 			break;
 		case Settings::LayoutStacked:
 			removeDockWidget(qdwLog);
 			removeDockWidget(qdwMsg);
-			addDockWidget(Qt::LeftDockWidgetArea, qdwMsg);
+			addDockWidget(Qt::BottomDockWidgetArea, qdwMsg);
 			addDockWidget(Qt::LeftDockWidgetArea, qdwLog);
 			qdwMsg->show();
 			qdwLog->show();
-			splitDockWidget(qdwMsg, qdwLog, Qt::Vertical);
-			splitDockWidget(qdwLog, qdwChat, Qt::Vertical);
+			splitDockWidget(qdwMsg, qdwChat, Qt::Vertical);
 			qdwChat->show();
 			break;
 		case Settings::LayoutHybrid:
 			removeDockWidget(qdwMsg);
 			removeDockWidget(qdwLog);
 			removeDockWidget(qdwChat);
-			addDockWidget(Qt::LeftDockWidgetArea, qdwMsg);
-			qdwMsg->show();
 			addDockWidget(Qt::LeftDockWidgetArea, qdwLog);
 			qdwLog->show();
+			addDockWidget(Qt::LeftDockWidgetArea, qdwMsg);
+			qdwMsg->show();
 			addDockWidget(Qt::BottomDockWidgetArea, qdwChat);
 			qdwChat->show();
 			break;

--- a/src/mumble/MainWindow.cpp
+++ b/src/mumble/MainWindow.cpp
@@ -270,6 +270,7 @@ void MainWindow::setupGui()  {
 	qteChat->setAttribute(Qt::WA_MacShowFocusRect, false);
 	qteChat->setFrameShape(QFrame::NoFrame);
 	qteLog->setFrameStyle(QFrame::NoFrame);
+	qteMsg->setFrameStyle(QFrame::NoFrame);
 #endif
 
 	LogDocument *ld = new LogDocument(qteLog);
@@ -277,6 +278,12 @@ void MainWindow::setupGui()  {
 
 	qteLog->document()->setMaximumBlockCount(g.s.iMaxLogBlocks);
 	qteLog->document()->setDefaultStyleSheet(qApp->styleSheet());
+
+	LogDocument *md = new LogDocument(qteMsg);
+	qteMsg->setDocument(md);
+
+	qteMsg->document()->setMaximumBlockCount(g.s.iMaxLogBlocks);
+	qteMsg->document()->setDefaultStyleSheet(qApp->styleSheet());
 
 	pmModel = new UserModel(qtvUsers);
 	qtvUsers->setModel(pmModel);
@@ -307,6 +314,14 @@ void MainWindow::setupGui()  {
 
 	foreach(QWidget *w, qdwLog->findChildren<QWidget *>()) {
 		w->installEventFilter(dtbLogDockTitle);
+		w->setMouseTracking(true);
+	}
+
+	dtbMsgDockTitle = new DockTitleBar();
+	qdwMsg->setTitleBarWidget(dtbMsgDockTitle);
+
+	foreach(QWidget *w, qdwMsg->findChildren<QWidget *>()) {
+		w->installEventFilter(dtbMsgDockTitle);
 		w->setMouseTracking(true);
 	}
 
@@ -389,11 +404,13 @@ void MainWindow::setupGui()  {
 // dock widgets.
 void MainWindow::setShowDockTitleBars(bool doShow) {
 	dtbLogDockTitle->setEnabled(doShow);
+	dtbMsgDockTitle->setEnabled(doShow);
 	dtbChatDockTitle->setEnabled(doShow);
 }
 
 MainWindow::~MainWindow() {
 	delete qwPTTButtonWidget;
+	delete qdwMsg->titleBarWidget();
 	delete qdwLog->titleBarWidget();
 	delete pmModel;
 	delete qtvUsers;
@@ -648,6 +665,57 @@ void MainWindow::on_qteLog_customContextMenuRequested(const QPoint &mpos) {
 	delete menu;
 }
 
+void MainWindow::on_qteMsg_anchorClicked(const QUrl &url)
+{
+	if (!handleSpecialContextMenu(url, QCursor::pos(), true)) {
+#ifdef Q_OS_MAC
+		// Clicking a link can cause the user's default browser to pop up while
+		// we're intercepting all events. This can be very confusing (because
+		// the user can't click on anything before they dismiss the overlay
+		// by hitting their toggle hotkey), so let's disallow clicking links
+		// when embedded into the overlay for now.
+		if (g.ocIntercept)
+			return;
+#endif
+		if (url.scheme() != QLatin1String("file")
+				&& url.scheme() != QLatin1String("qrc")
+				&& !url.isRelative())
+			QDesktopServices::openUrl(url);
+	}
+}
+
+void MainWindow::on_qteMsg_highlighted(const QUrl &url)
+{
+	if (url.scheme() == QString::fromLatin1("clientid") || url.scheme() == QString::fromLatin1("channelid"))
+		return;
+
+	if (! url.isValid())
+		QToolTip::hideText();
+	else {
+		if (qApp->activeWindow() != NULL) {
+			QToolTip::showText(QCursor::pos(), url.toString(), qteMsg, QRect());
+		}
+	}
+}
+
+void MainWindow::on_qteMsg_customContextMenuRequested(const QPoint &mpos)
+{
+	QString link = qteMsg->anchorAt(mpos);
+	if (! link.isEmpty()) {
+		QUrl l(link);
+
+		if (handleSpecialContextMenu(l, qteMsg->mapToGlobal(mpos)))
+			return;
+	}
+
+	QPoint contentPosition = QPoint(QApplication::isRightToLeft() ? (qteMsg->horizontalScrollBar()->maximum() - qteMsg->horizontalScrollBar()->value()) : qteMsg->horizontalScrollBar()->value(), qteMsg->verticalScrollBar()->value());
+	QMenu *menu = qteMsg->createStandardContextMenu(mpos + contentPosition);
+	menu->addSeparator();
+	menu->addAction(tr("Clear"), qteMsg, SLOT(clear(void)));
+	menu->exec(qteMsg->mapToGlobal(mpos));
+	delete menu;
+}
+
 static void recreateServerHandler() {
 	ServerHandlerPtr sh = g.sh;
 	if (sh && sh->isRunning()) {
@@ -834,21 +902,32 @@ void MainWindow::setupView(bool toggle_minimize) {
 	switch (wlTmp) {
 		case Settings::LayoutClassic:
 			removeDockWidget(qdwLog);
+			removeDockWidget(qdwMsg);
+			addDockWidget(Qt::LeftDockWidgetArea, qdwMsg);
 			addDockWidget(Qt::LeftDockWidgetArea, qdwLog);
+			qdwMsg->show();
 			qdwLog->show();
+			splitDockWidget(qdwMsg, qdwLog, Qt::Vertical);
 			splitDockWidget(qdwLog, qdwChat, Qt::Vertical);
 			qdwChat->show();
 			break;
 		case Settings::LayoutStacked:
 			removeDockWidget(qdwLog);
-			addDockWidget(Qt::BottomDockWidgetArea, qdwLog);
+			removeDockWidget(qdwMsg);
+			addDockWidget(Qt::LeftDockWidgetArea, qdwMsg);
+			addDockWidget(Qt::LeftDockWidgetArea, qdwLog);
+			qdwMsg->show();
 			qdwLog->show();
+			splitDockWidget(qdwMsg, qdwLog, Qt::Vertical);
 			splitDockWidget(qdwLog, qdwChat, Qt::Vertical);
 			qdwChat->show();
 			break;
 		case Settings::LayoutHybrid:
+			removeDockWidget(qdwMsg);
 			removeDockWidget(qdwLog);
 			removeDockWidget(qdwChat);
+			addDockWidget(Qt::LeftDockWidgetArea, qdwMsg);
+			qdwMsg->show();
 			addDockWidget(Qt::LeftDockWidgetArea, qdwLog);
 			qdwLog->show();
 			addDockWidget(Qt::BottomDockWidgetArea, qdwChat);
@@ -909,6 +988,7 @@ void MainWindow::setupView(bool toggle_minimize) {
 	}
 
 	if (! showit) {
+		qdwMsg->setVisible(showit);
 		qdwLog->setVisible(showit);
 		qdwChat->setVisible(showit);
 		qtIconToolbar->setVisible(showit);
@@ -2894,11 +2974,21 @@ void MainWindow::on_qdwLog_dockLocationChanged(Qt::DockWidgetArea) {
 	g.s.wlWindowLayout = Settings::LayoutCustom;
 }
 
+void MainWindow::on_qdwMsg_dockLocationChanged(const Qt::DockWidgetArea)
+{
+	g.s.wlWindowLayout = Settings::LayoutCustom;
+}
+
 void MainWindow::on_qdwChat_visibilityChanged(bool) {
 	g.s.wlWindowLayout = Settings::LayoutCustom;
 }
 
 void MainWindow::on_qdwLog_visibilityChanged(bool) {
+	g.s.wlWindowLayout = Settings::LayoutCustom;
+}
+
+void MainWindow::on_qdwMsg_visibilityChanged(bool)
+{
 	g.s.wlWindowLayout = Settings::LayoutCustom;
 }
 
@@ -2986,4 +3076,3 @@ void MainWindow::destroyUserInformation() {
 		}
 	}
 }
-

--- a/src/mumble/MainWindow.h
+++ b/src/mumble/MainWindow.h
@@ -103,7 +103,7 @@ class MainWindow : public QMainWindow, public MessageHandler, public Ui::MainWin
 		GlobalShortcut *gsMinimal, *gsVolumeUp, *gsVolumeDown, *gsWhisper, *gsLinkChannel;
 		GlobalShortcut *gsCycleTransmitMode;
 		GlobalShortcut *gsSendTextMessage;
-		DockTitleBar *dtbLogDockTitle, *dtbChatDockTitle;
+		DockTitleBar *dtbLogDockTitle, *dtbMsgDockTitle, *dtbChatDockTitle;
 
 		ACLEditor *aclEdit;
 		BanEditor *banEdit;
@@ -248,13 +248,18 @@ class MainWindow : public QMainWindow, public MessageHandler, public Ui::MainWin
 		void on_qteChat_tabPressed();
 		void on_qteChat_ctrlSpacePressed();
 		void on_qtvUsers_customContextMenuRequested(const QPoint &mpos);
-		void on_qteLog_customContextMenuRequested(const QPoint &pos);
+		void on_qteLog_customContextMenuRequested(const QPoint &mpos);
 		void on_qteLog_anchorClicked(const QUrl &);
 		void on_qteLog_highlighted(const QUrl & link);
+		void on_qteMsg_anchorClicked(const QUrl &url);
+		void on_qteMsg_highlighted(const QUrl &url);
+		void on_qteMsg_customContextMenuRequested(const QPoint &mpos);
 		void on_qdwChat_dockLocationChanged(Qt::DockWidgetArea);
 		void on_qdwLog_dockLocationChanged(Qt::DockWidgetArea);
+		void on_qdwMsg_dockLocationChanged(const Qt::DockWidgetArea);
 		void on_qdwChat_visibilityChanged(bool);
 		void on_qdwLog_visibilityChanged(bool);
+		void on_qdwMsg_visibilityChanged(bool);
 		void on_PushToTalk_triggered(bool, QVariant);
 		void on_PushToMute_triggered(bool, QVariant);
 		void on_VolumeUp_triggered(bool, QVariant);

--- a/src/mumble/MainWindow.h
+++ b/src/mumble/MainWindow.h
@@ -256,7 +256,7 @@ class MainWindow : public QMainWindow, public MessageHandler, public Ui::MainWin
 		void on_qteMsg_customContextMenuRequested(const QPoint &mpos);
 		void on_qdwChat_dockLocationChanged(Qt::DockWidgetArea);
 		void on_qdwLog_dockLocationChanged(Qt::DockWidgetArea);
-		void on_qdwMsg_dockLocationChanged(const Qt::DockWidgetArea);
+		void on_qdwMsg_dockLocationChanged(Qt::DockWidgetArea);
 		void on_qdwChat_visibilityChanged(bool);
 		void on_qdwLog_visibilityChanged(bool);
 		void on_qdwMsg_visibilityChanged(bool);

--- a/src/mumble/MainWindow.ui
+++ b/src/mumble/MainWindow.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>671</width>
-    <height>457</height>
+    <height>435</height>
    </rect>
   </property>
   <property name="windowTitle">

--- a/src/mumble/MainWindow.ui
+++ b/src/mumble/MainWindow.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>671</width>
-    <height>435</height>
+    <height>457</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -117,6 +117,34 @@
     </property>
     <property name="whatsThis">
      <string>This shows all recent activity. Connecting to servers, errors and information messages all show up here.&lt;br /&gt;To configure exactly which messages show up here, use the &lt;b&gt;Settings&lt;/b&gt; command from the menu.</string>
+    </property>
+    <property name="openLinks">
+     <bool>false</bool>
+    </property>
+   </widget>
+  </widget>
+  <widget class="QDockWidget" name="qdwMsg">
+   <property name="minimumSize">
+    <size>
+     <width>250</width>
+     <height>93</height>
+    </size>
+   </property>
+   <property name="features">
+    <set>QDockWidget::DockWidgetClosable|QDockWidget::DockWidgetMovable</set>
+   </property>
+   <property name="windowTitle">
+    <string>Messages</string>
+   </property>
+   <attribute name="dockWidgetArea">
+    <number>1</number>
+   </attribute>
+   <widget class="LogTextBrowser" name="qteMsg">
+    <property name="contextMenuPolicy">
+     <enum>Qt::CustomContextMenu</enum>
+    </property>
+    <property name="whatsThis">
+     <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;This shows all chat messages.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
     </property>
     <property name="openLinks">
      <bool>false</bool>

--- a/src/mumble/MainWindow.ui
+++ b/src/mumble/MainWindow.ui
@@ -137,7 +137,7 @@
     <string>Messages</string>
    </property>
    <attribute name="dockWidgetArea">
-    <number>1</number>
+    <number>2</number>
    </attribute>
    <widget class="LogTextBrowser" name="qteMsg">
     <property name="contextMenuPolicy">
@@ -171,7 +171,7 @@
     <string>Chatbar</string>
    </property>
    <attribute name="dockWidgetArea">
-    <number>1</number>
+    <number>2</number>
    </attribute>
    <widget class="ChatbarTextEdit" name="qteChat">
     <property name="sizePolicy">


### PR DESCRIPTION
This patch is in preparation of enabling a backlog for chat messages(between sessions, stored locally, paging @amki), basically I have split the old log window up so that server messages(switching channels etc.) are separate from user to user/channel chat.

Since I am royally incapable of updating the layout.svg thumbnails I am putting this pull request out there with hope that Santa sends kittens(the French kind, with paintbrushes and cute berets) to fix this issue.
