### PR TITLE
Idle action improvements

### DIFF
--- a/icons/publicdomain/Zzz_sleep.svg
+++ b/icons/publicdomain/Zzz_sleep.svg
@@ -1,0 +1,235 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   version="1.1"
+   width="49.388714"
+   height="54.500465"
+   id="svg3168"
+   inkscape:version="0.48.4 r9939"
+   sodipodi:docname="Zzz_sleep.svg">
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="2560"
+     inkscape:window-height="1385"
+     id="namedview5023"
+     showgrid="false"
+     inkscape:zoom="12.836708"
+     inkscape:cx="4.0778311"
+     inkscape:cy="24.565592"
+     inkscape:window-x="-2"
+     inkscape:window-y="-3"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg3168"
+     fit-margin-top="0"
+     fit-margin-left="0"
+     fit-margin-right="0"
+     fit-margin-bottom="0" />
+  <metadata
+     id="metadata3205">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs3170">
+    <linearGradient
+       x1="20.27"
+       y1="30.870001"
+       x2="17.440001"
+       y2="14.54"
+       id="linearGradient4668"
+       gradientUnits="userSpaceOnUse">
+      <stop
+         id="stop4670"
+         style="stop-color:#a0a0a0;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop4672"
+         style="stop-color:#9bff9b;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       x1="22.200001"
+       y1="30.530001"
+       x2="19.360001"
+       y2="14.2"
+       id="e"
+       xlink:href="#a"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       x1="9"
+       y1="44.299999"
+       x2="5.0999999"
+       y2="30.76"
+       id="d"
+       xlink:href="#a"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       x1="40.400002"
+       y1="1.91"
+       x2="46.400002"
+       y2="9.29"
+       id="b"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.25,0,0,2.11,-56,1.76)">
+      <stop
+         id="stop3175"
+         style="stop-color:#005c00;stop-opacity:1;"
+         offset="0" />
+      <stop
+         id="stop3177"
+         style="stop-color:#009400;stop-opacity:1;"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       x1="20.27"
+       y1="30.870001"
+       x2="17.440001"
+       y2="14.54"
+       id="a"
+       gradientUnits="userSpaceOnUse">
+      <stop
+         id="stop3180"
+         style="stop-color:#49ac49;stop-opacity:1;"
+         offset="0" />
+      <stop
+         id="stop3182"
+         style="stop-color:#007e00;stop-opacity:1;"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       x1="9"
+       y1="44.299999"
+       x2="5.0999999"
+       y2="30.76"
+       id="linearGradient3771"
+       xlink:href="#linearGradient4668"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       x1="22.200001"
+       y1="30.530001"
+       x2="19.360001"
+       y2="14.2"
+       id="linearGradient3775"
+       xlink:href="#a"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.2853546,0,0,1.2853546,-10.31492,-4.9290956)" />
+    <linearGradient
+       x1="40.400002"
+       y1="1.91"
+       x2="46.400002"
+       y2="9.29"
+       id="linearGradient3779"
+       xlink:href="#b"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.7218267,0,0,2.5524686,-76.433808,-0.45714763)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#a"
+       id="linearGradient5054"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.5012367,0,0,1.5012367,-14.51748,-11.494071)"
+       x1="22.200001"
+       y1="30.530001"
+       x2="19.360001"
+       y2="14.2" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#a-4"
+       id="linearGradient5054-8"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.5012367,0,0,1.5012367,-15.398943,-10.407974)"
+       x1="22.200001"
+       y1="30.530001"
+       x2="19.360001"
+       y2="14.2" />
+    <linearGradient
+       x1="20.27"
+       y1="30.870001"
+       x2="17.440001"
+       y2="14.54"
+       id="a-4"
+       gradientUnits="userSpaceOnUse">
+      <stop
+         id="stop3180-7"
+         style="stop-color:#429c42;stop-opacity:1;"
+         offset="0" />
+      <stop
+         id="stop3182-2"
+         style="stop-color:#007e00;stop-opacity:1;"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       y2="14.2"
+       x2="19.360001"
+       y1="30.530001"
+       x1="22.200001"
+       gradientTransform="matrix(1.1535477,0,0,1.1535477,-20.879215,14.760744)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient5071"
+       xlink:href="#a-4"
+       inkscape:collect="always" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#b"
+       id="linearGradient5090"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.9527206,0,0,2.7689958,-85.124114,-2.8575773)"
+       x1="40.400002"
+       y1="1.91"
+       x2="46.400002"
+       y2="9.29" />
+  </defs>
+  <path
+     d="m 29.018387,20.572348 v 3.452845 L 18.52474,36.95084 h 10.493647 v 3.272697 H 12.654906 V 36.770692 L 23.163563,23.845045 H 12.654906 v -3.272697 z"
+     id="g"
+     style="fill:url(#linearGradient5054);stroke:none"
+     inkscape:connector-curvature="0" />
+  <path
+     d="M 49.388713,0.00328102 V 5.9349685 L 37.919034,17.181553 H 49.375589 V 22.90327 H 29.29709 V 16.971582 L 40.753645,5.7249973 H 29.323337 l -0.0065,-5.72171628 z"
+     id="f"
+     style="fill:url(#linearGradient5090);stroke:none"
+     inkscape:connector-curvature="0" />
+  <g
+     transform="matrix(1.3123202,0,0,1.3123202,-11.634179,-5.1672608)"
+     id="g3197"
+     style="opacity:0.5">
+    <path
+       d="M 32.3,7.21 V 5.03 h 13.1"
+       id="path3199"
+       style="fill:none;stroke:#ffffff;stroke-width:2.18000007;stroke-linecap:square"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 31.2,21.4 h 2.18 v -3.61 l 7.77,-7.64 C 41.5,9.81 41.58,9.27 41.34,8.84 41.1,8.41 40.6,8.19 40.12,8.31 39.94,8.37 39.76,8.47 39.62,8.61 L 31.2,16.9 z m 5.64,-3.15 c 0.06,0.6 0.59,1.05 1.19,0.99 h 8.39 v -2.18 h -8.56 c -0.63,0.06 -1.08,0.59 -1.02,1.19 z"
+       id="path3201"
+       style="fill:#ffffff"
+       inkscape:connector-curvature="0" />
+  </g>
+  <path
+     d="m 12.57367,39.400525 v 2.65316 l -8.0633,9.932045 h 8.0633 v 2.514735 H 0 v -2.65316 L 8.0748336,41.91526 H 0 v -2.514735 z"
+     id="g-5"
+     style="fill:url(#linearGradient5071);stroke:none"
+     inkscape:connector-curvature="0" />
+</svg>

--- a/icons/publicdomain/readme.txt
+++ b/icons/publicdomain/readme.txt
@@ -1,4 +1,5 @@
 Information_icon.svg came from http://en.wikipedia.org/wiki/File:Information_icon.svg.
+Zzz_sleep.svg is based on http://commons.wikimedia.org/wiki/File:Zzz_sleep.svg
 
 Licensing
 The copyright holder of this work, hereby release it into the public domain. This applies worldwide.

--- a/src/Channel.cpp
+++ b/src/Channel.cpp
@@ -79,6 +79,25 @@ Channel *Channel::get(int id) {
 	return c_qhChannels.value(id);
 }
 
+Channel *Channel::get(const QString &path) {
+	Channel *cur = get(0);
+	QStringList channelsInPath = path.split(QString::fromUtf8("/"), QString::SkipEmptyParts);
+	int depth = channelsInPath.length();
+	int traversed = 0;
+
+	while (traversed < depth) {
+		foreach (Channel *child, cur->qlChannels) {
+			if (child->qsName == channelsInPath.value(traversed)) {
+				cur = child;
+				traversed++;
+				break;
+			}
+			return NULL;
+		}
+	}
+	return cur;
+}
+
 Channel *Channel::add(int id, const QString &name) {
 	QWriteLocker lock(&c_qrwlChannels);
 

--- a/src/Channel.cpp
+++ b/src/Channel.cpp
@@ -85,6 +85,10 @@ Channel *Channel::get(const QString &path) {
 	int depth = channelsInPath.length();
 	int traversed = 0;
 
+	if (cur->qlChannels.length() < 1) {
+		return NULL;
+	}
+
 	while (traversed < depth) {
 		foreach (Channel *child, cur->qlChannels) {
 			if (child->qsName == channelsInPath.value(traversed)) {

--- a/src/Channel.cpp
+++ b/src/Channel.cpp
@@ -91,7 +91,7 @@ Channel *Channel::get(const QString &path) {
 	int depth = channelsInPath.length();
 	int traversed = 0;
 
-	if (cur->qlChannels.length() < 1) {
+	if (cur->qlChannels.length() < 1 || path.isEmpty()) {
 		return NULL;
 	}
 

--- a/src/Channel.h
+++ b/src/Channel.h
@@ -78,6 +78,10 @@ class Channel : public QObject {
 		static QHash<int, Channel *> c_qhChannels;
 		static QReadWriteLock c_qrwlChannels;
 
+		static QString qsIdleChannel;
+		static Channel *cIdleChannel;
+
+		static Channel *getIdleChannel();
 		static Channel *get(int);
 		static Channel *get(const QString &);
 		static Channel *add(int, const QString &);
@@ -99,6 +103,8 @@ class Channel : public QObject {
 		bool isLinked(Channel *c) const;
 		void link(Channel *c);
 		void unlink(Channel *c = NULL);
+
+		bool isIdleChannel() const;
 
 		QSet<Channel *> allLinks();
 		QSet<Channel *> allChildren();

--- a/src/Channel.h
+++ b/src/Channel.h
@@ -79,6 +79,7 @@ class Channel : public QObject {
 		static QReadWriteLock c_qrwlChannels;
 
 		static Channel *get(int);
+		static Channel *get(const QString &);
 		static Channel *add(int, const QString &);
 		static void remove(Channel *);
 

--- a/src/mumble/AudioInput.cpp
+++ b/src/mumble/AudioInput.cpp
@@ -44,6 +44,7 @@
 #include "System.h"
 #include "NetworkConfig.h"
 #include "VoiceRecorder.h"
+#include "Channel.h"
 
 #ifdef USE_OPUS
 #include "opus.h"
@@ -828,6 +829,10 @@ void AudioInput::encodeAudioFrame() {
 				emit doDeaf();
 			} else if (g.s.iaeIdleAction == Settings::Mute && !g.s.bMute) {
 				emit doMute();
+			} else if (g.s.iaeIdleAction == Settings::IdleMove){
+				Channel *ic = Channel::getIdleChannel();
+				if (ic && ClientUser::get(g.uiSession)->cChannel != ic)
+					g.sh->joinChannel(g.uiSession, ic->iId);
 			}
 		}
 

--- a/src/mumble/AudioInput.cpp
+++ b/src/mumble/AudioInput.cpp
@@ -39,6 +39,7 @@
 #include "User.h"
 #include "PacketDataStream.h"
 #include "Plugins.h"
+#include "System.h"
 #include "Message.h"
 #include "Global.h"
 #include "NetworkConfig.h"
@@ -821,13 +822,11 @@ void AudioInput::encodeAudioFrame() {
 	if (! bIsSpeech && ! bPreviousVoice) {
 		iBitrate = 0;
 
-		if (g.s.iaeIdleAction != Settings::Nothing && ((tIdle.elapsed() / 1000000ULL) > g.s.iIdleTime)) {
+		if (g.s.iaeIdleAction != Settings::Nothing && (System::getIdleSeconds() > g.s.iIdleTime)) {
 
 			if (g.s.iaeIdleAction == Settings::Deafen && !g.s.bDeaf) {
-				tIdle.restart();
 				emit doDeaf();
 			} else if (g.s.iaeIdleAction == Settings::Mute && !g.s.bMute) {
-				tIdle.restart();
 				emit doMute();
 			}
 		}
@@ -839,8 +838,6 @@ void AudioInput::encodeAudioFrame() {
 		spx_int32_t increment = 12;
 		speex_preprocess_ctl(sppPreprocess, SPEEX_PREPROCESS_SET_AGC_INCREMENT, &increment);
 	}
-
-	tIdle.restart();
 
 	EncodingOutputBuffer buffer;
 	Q_ASSERT(buffer.size() >= static_cast<size_t>(iAudioQuality / 100 * iAudioFrames / 8));

--- a/src/mumble/AudioInput.cpp
+++ b/src/mumble/AudioInput.cpp
@@ -39,9 +39,9 @@
 #include "User.h"
 #include "PacketDataStream.h"
 #include "Plugins.h"
-#include "System.h"
 #include "Message.h"
 #include "Global.h"
+#include "System.h"
 #include "NetworkConfig.h"
 #include "VoiceRecorder.h"
 
@@ -822,7 +822,7 @@ void AudioInput::encodeAudioFrame() {
 	if (! bIsSpeech && ! bPreviousVoice) {
 		iBitrate = 0;
 
-		if (g.s.iaeIdleAction != Settings::Nothing && (System::getIdleSeconds() > g.s.iIdleTime)) {
+		if (g.s.iaeIdleAction != Settings::Nothing && (g.sys->getIdleSeconds() > g.s.iIdleTime)) {
 
 			if (g.s.iaeIdleAction == Settings::Deafen && !g.s.bDeaf) {
 				emit doDeaf();

--- a/src/mumble/AudioInput.h
+++ b/src/mumble/AudioInput.h
@@ -164,8 +164,6 @@ class AudioInput : public QThread {
 	public:
 		bool bResetProcessor;
 
-		Timer tIdle;
-
 		int iBitrate;
 		float dPeakSpeaker, dPeakSignal, dMaxMic, dPeakMic, dPeakCleanMic;
 		float fSpeechProb;

--- a/src/mumble/AudioInput.h
+++ b/src/mumble/AudioInput.h
@@ -99,11 +99,17 @@ class AudioInput : public QThread {
 
 		OpusEncoder *opusState;
 		bool selectCodec();
-		
+
 		typedef boost::array<unsigned char, 960> EncodingOutputBuffer;
 		
 		int encodeOpusFrame(short *source, int size, EncodingOutputBuffer& buffer);
 		int encodeCELTFrame(short *pSource, EncodingOutputBuffer& buffer);
+
+		//Idle tracking variables. These should probably be moved eventually
+		unsigned int uiLastIdleTime;
+		Channel *cLastChannel;
+		Settings::IdleAction iaeLastIdleAction;
+
 	protected:
 		MessageHandler::UDPMessageType umtType;
 		SampleFormat eMicFormat, eEchoFormat;

--- a/src/mumble/AudioInput.ui
+++ b/src/mumble/AudioInput.ui
@@ -823,6 +823,11 @@
           </item>
           <item>
            <property name="text">
+            <string>move to idle channel</string>
+           </property>
+          </item>
+          <item>
+           <property name="text">
             <string>deafen</string>
            </property>
           </item>

--- a/src/mumble/ConnectDialog.h
+++ b/src/mumble/ConnectDialog.h
@@ -152,6 +152,8 @@ class ServerItem : public QTreeWidgetItem, public PingStats {
 
 		QString qsUrl;
 
+		QString qsIdleChannel;
+
 		QString qsBonjourHost;
 		BonjourRecord brRecord;
 
@@ -161,7 +163,7 @@ class ServerItem : public QTreeWidgetItem, public PingStats {
 
 		ServerItem(const FavoriteServer &fs);
 		ServerItem(const PublicInfo &pi);
-		ServerItem(const QString &name, const QString &host, unsigned short port, const QString &uname, const QString &password = QString());
+		ServerItem(const QString &name, const QString &host, unsigned short port, const QString &uname, const QString &password = QString(), const QString &qsIdleChannel = QString());
 		ServerItem(const BonjourRecord &br);
 		ServerItem(const QString &name, ItemType itype, const QString &continent = QString(), const QString &country = QString());
 		ServerItem(const ServerItem *si);
@@ -215,7 +217,7 @@ class ConnectDialogEdit : public QDialog, protected Ui::ConnectDialogEdit {
 		void on_qleName_textEdited(const QString&);
 		void on_qleServer_textEdited(const QString&);
 	public:
-		QString qsName, qsHostname, qsUsername, qsPassword;
+		QString qsName, qsHostname, qsUsername, qsPassword, qsIdleChannel;
 		unsigned short usPort;
 		ConnectDialogEdit(QWidget *parent,
 		                  const QString &name = QString(),
@@ -223,6 +225,7 @@ class ConnectDialogEdit : public QDialog, protected Ui::ConnectDialogEdit {
 		                  const QString &user = QString(),
 		                  unsigned short port = DEFAULT_MUMBLE_PORT,
 		                  const QString &password = QString(),
+				  const QString &idleChannel = QString(),
 		                  bool add = false);
 };
 

--- a/src/mumble/ConnectDialogEdit.ui
+++ b/src/mumble/ConnectDialogEdit.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>265</width>
-    <height>197</height>
+    <height>213</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -99,7 +99,7 @@ Username to send to the server. Be aware that the server can impose restrictions
      </property>
     </widget>
    </item>
-   <item row="8" column="1">
+   <item row="9" column="1">
     <widget class="QDialogButtonBox" name="qdbbButtonBox">
      <property name="standardButtons">
       <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
@@ -120,7 +120,7 @@ Password to be sent to the server on connect. This password is needed when conne
      </property>
     </widget>
    </item>
-   <item row="7" column="1">
+   <item row="8" column="1">
     <widget class="QCheckBox" name="qcbShowPassword">
      <property name="toolTip">
       <string/>
@@ -151,6 +151,27 @@ Label of the server. This is what the server will be named like in your server l
      </property>
      <property name="placeholderText">
       <string>Local server label</string>
+     </property>
+    </widget>
+   </item>
+   <item row="7" column="1">
+    <widget class="QLineEdit" name="qleIdleChannel">
+     <property name="toolTip">
+      <string>Channel to move to when idle, if enabled</string>
+     </property>
+     <property name="whatsThis">
+      <string>&lt;b&gt;Idle Channel&lt;/b&gt;&lt;br /&gt;
+Path to channel to move to when Mumble detects that your system is idle. Formatted like this: &quot;/MySubChannel/&quot;</string>
+     </property>
+     <property name="placeholderText">
+      <string>Path to idle channel</string>
+     </property>
+    </widget>
+   </item>
+   <item row="7" column="0">
+    <widget class="QLabel" name="label">
+     <property name="text">
+      <string>Idle Channel</string>
      </property>
     </widget>
    </item>

--- a/src/mumble/Database.h
+++ b/src/mumble/Database.h
@@ -39,6 +39,7 @@ struct FavoriteServer {
 	QString qsPassword;
 	QString qsHostname;
 	QString qsUrl;
+	QString qsIdleChannel;
 	unsigned short usPort;
 };
 

--- a/src/mumble/Global.h
+++ b/src/mumble/Global.h
@@ -55,6 +55,7 @@ class LCD;
 class BonjourClient;
 class OverlayClient;
 class CELTCodec;
+class System;
 
 class QNetworkAccessManager;
 
@@ -68,6 +69,7 @@ public:
 	boost::shared_ptr<ServerHandler> sh;
 	boost::shared_ptr<AudioInput> ai;
 	boost::shared_ptr<AudioOutput> ao;
+	System *sys;
 	Database *db;
 	Log *l;
 	Plugins *p;

--- a/src/mumble/GlobalShortcut.cpp
+++ b/src/mumble/GlobalShortcut.cpp
@@ -846,12 +846,6 @@ bool GlobalShortcutEngine::handleButton(const QVariant &button, bool down) {
 		emit buttonPressed(! down);
 	}
 
-	if (down) {
-		AudioInputPtr ai = g.ai;
-		if (ai.get())
-			ai->tIdle.restart();
-	}
-
 	int idx = qlButtonList.indexOf(button);
 	if (idx == -1)
 		return false;

--- a/src/mumble/MainWindow.cpp
+++ b/src/mumble/MainWindow.cpp
@@ -2050,10 +2050,6 @@ void MainWindow::on_qaAudioMute_triggered() {
 		return;
 	}
 
-	AudioInputPtr ai = g.ai;
-	if (ai)
-		ai->tIdle.restart();
-
 	g.s.bMute = qaAudioMute->isChecked();
 
 	if (! g.s.bMute && g.s.bDeaf) {
@@ -2085,9 +2081,6 @@ void MainWindow::on_qaAudioDeaf_triggered() {
 		on_qaAudioMute_triggered();
 		return;
 	}
-	AudioInputPtr ai = g.ai;
-	if (ai)
-		ai->tIdle.restart();
 
 	g.s.bDeaf = qaAudioDeaf->isChecked();
 	if (g.s.bDeaf && ! g.s.bMute) {

--- a/src/mumble/Settings.h
+++ b/src/mumble/Settings.h
@@ -166,7 +166,7 @@ struct Settings {
 	enum ChannelDrag { Ask, DoNothing, Move };
 	enum ServerShow { ShowPopulated, ShowReachable, ShowAll };
 	enum TalkState { Passive, Talking, Whispering, Shouting };
-	enum IdleAction { Nothing, Deafen, Mute };
+	enum IdleAction { Nothing, IdleMove, Deafen, Mute };
 	typedef QPair<QList<QSslCertificate>, QSslKey> KeyPair;
 
 	AudioTransmit atTransmit;

--- a/src/mumble/System.cpp
+++ b/src/mumble/System.cpp
@@ -31,13 +31,28 @@
 #include "System.h"
 
 #if defined(Q_OS_LINUX)
-#include <X11/Xlib.h>
 #include <X11/extensions/scrnsaver.h>
 #elif defined(Q_OS_WIN)
 #include "windows.h"
 #endif
 
 #include <limits>
+
+System::System() {
+#if defined(Q_OS_LINUX)
+	display = XOpenDisplay("");
+
+	if (display == NULL) {
+		qCritical("System: XOpenDisplay() Failed!!");
+	}
+#endif
+}
+
+System::~System() {
+#if defined(Q_OS_LINUX)
+	XCloseDisplay(display);
+#endif
+}
 
 unsigned int System::getIdleSeconds() {
 #if defined(Q_OS_WIN)
@@ -47,14 +62,11 @@ unsigned int System::getIdleSeconds() {
 		return static_cast<unsigned int>((GetTickCount() - info.dwTime) / 1000);
 	}
 #elif defined(Q_OS_LINUX)
-	Display *display;
 	int event_base, error_base;
 	XScreenSaverInfo info;
 	float seconds;
 
-	display = XOpenDisplay("");
-
-	if (XScreenSaverQueryExtension(display, &event_base, &error_base)) {
+	if (display != NULL && XScreenSaverQueryExtension(display, &event_base, &error_base)) {
 		XScreenSaverQueryInfo(display, DefaultRootWindow(display), &info);
 		return static_cast<unsigned int>(info.idle / 1000);
 	}

--- a/src/mumble/System.cpp
+++ b/src/mumble/System.cpp
@@ -1,0 +1,63 @@
+/* Copyright (C) 2011, Stefan Hacker <dd0t@users.sourceforge.net>
+
+   All rights reserved.
+
+   Redistribution and use in source and binary forms, with or without
+   modification, are permitted provided that the following conditions
+   are met:
+
+   - Redistributions of source code must retain the above copyright notice,
+	 this list of conditions and the following disclaimer.
+   - Redistributions in binary form must reproduce the above copyright notice,
+	 this list of conditions and the following disclaimer in the documentation
+	 and/or other materials provided with the distribution.
+   - Neither the name of the Mumble Developers nor the names of its
+	 contributors may be used to endorse or promote products derived from this
+	 software without specific prior written permission.
+
+   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+   ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+   LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+   A PARTICULAR PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE FOUNDATION OR
+   CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+   EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+   PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+   PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+   LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+   NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+   SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+#include "System.h"
+
+#if defined(Q_WS_X11)
+#include <X11/Xlib.h>
+#include <X11/extensions/scrnsaver.h>
+#elif defined(Q_OS_WIN)
+#include "windows.h"
+#endif
+
+#include <limits>
+
+unsigned int System::getIdleSeconds() {
+#if defined(Q_WS_WIN)
+	LASTINPUTINFO info;
+	info.cbSize = sizeof(LASTINPUTINFO);
+	if (GetLastInputInfo(&info)) {
+		return static_cast<unsigned int>((GetTickCount() - info.dwTime) / 1000);
+	}
+#elif defined(Q_WS_X11)
+	Display *display;
+	int event_base, error_base;
+	XScreenSaverInfo info;
+	float seconds;
+
+	display = XOpenDisplay("");
+
+	if (XScreenSaverQueryExtension(display, &event_base, &error_base)) {
+		XScreenSaverQueryInfo(display, DefaultRootWindow(display), &info);
+		return static_cast<unsigned int>(info.idle / 1000);
+	}
+#endif
+	return std::numeric_limits<unsigned int>::max();
+}

--- a/src/mumble/System.cpp
+++ b/src/mumble/System.cpp
@@ -30,7 +30,7 @@
 
 #include "System.h"
 
-#if defined(Q_WS_X11)
+#if defined(Q_OS_LINUX)
 #include <X11/Xlib.h>
 #include <X11/extensions/scrnsaver.h>
 #elif defined(Q_OS_WIN)
@@ -40,13 +40,13 @@
 #include <limits>
 
 unsigned int System::getIdleSeconds() {
-#if defined(Q_WS_WIN)
+#if defined(Q_OS_WIN)
 	LASTINPUTINFO info;
 	info.cbSize = sizeof(LASTINPUTINFO);
 	if (GetLastInputInfo(&info)) {
 		return static_cast<unsigned int>((GetTickCount() - info.dwTime) / 1000);
 	}
-#elif defined(Q_WS_X11)
+#elif defined(Q_OS_LINUX)
 	Display *display;
 	int event_base, error_base;
 	XScreenSaverInfo info;
@@ -59,5 +59,5 @@ unsigned int System::getIdleSeconds() {
 		return static_cast<unsigned int>(info.idle / 1000);
 	}
 #endif
-	return std::numeric_limits<unsigned int>::max();
+	return std::numeric_limits<unsigned int>::min();
 }

--- a/src/mumble/System.h
+++ b/src/mumble/System.h
@@ -1,0 +1,41 @@
+/* Copyright (C) 2011, Stefan Hacker <dd0t@users.sourceforge.net>
+
+   All rights reserved.
+
+   Redistribution and use in source and binary forms, with or without
+   modification, are permitted provided that the following conditions
+   are met:
+
+   - Redistributions of source code must retain the above copyright notice,
+	 this list of conditions and the following disclaimer.
+   - Redistributions in binary form must reproduce the above copyright notice,
+	 this list of conditions and the following disclaimer in the documentation
+	 and/or other materials provided with the distribution.
+   - Neither the name of the Mumble Developers nor the names of its
+	 contributors may be used to endorse or promote products derived from this
+	 software without specific prior written permission.
+
+   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+   ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+   LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+   A PARTICULAR PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE FOUNDATION OR
+   CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+   EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+   PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+   PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+   LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+   NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+   SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+#ifndef SYSTEM_H
+#define SYSTEM_H
+
+class System {
+	System() {};
+	~System() {};
+public:
+	static unsigned int getIdleSeconds();
+};
+
+#endif // SYSTEM_H

--- a/src/mumble/System.h
+++ b/src/mumble/System.h
@@ -31,11 +31,20 @@
 #ifndef SYSTEM_H
 #define SYSTEM_H
 
+#if defined(Q_OS_LINUX)
+#include <X11/Xlib.h>
+#endif
+
 class System {
-	System() {};
-	~System() {};
+#if defined(Q_OS_LINUX)
+private:
+	Display *display;
+#endif
+
 public:
-	static unsigned int getIdleSeconds();
+	unsigned int getIdleSeconds();
+	System();
+	~System();
 };
 
 #endif // SYSTEM_H

--- a/src/mumble/UserModel.cpp
+++ b/src/mumble/UserModel.cpp
@@ -232,6 +232,7 @@ UserModel::UserModel(QObject *p) : QAbstractItemModel(p) {
 	qiChannel=QIcon(QLatin1String("skin:channel.svg"));
 	qiActiveChannel=QIcon(QLatin1String("skin:channel_active.svg"));
 	qiLinkedChannel=QIcon(QLatin1String("skin:channel_linked.svg"));
+	qiIdleChannel=QIcon(QLatin1String("skin:Zzz_sleep.svg"));
 	qiFriend=QIcon(QLatin1String("skin:emblems/emblem-favorite.svg"));
 	qiComment=QIcon(QLatin1String("skin:comment.svg"));
 	qiCommentSeen=QIcon(QLatin1String("skin:comment_seen.svg"));
@@ -453,6 +454,9 @@ QVariant UserModel::data(const QModelIndex &idx, int role) const {
 
 				if (c->bFiltered)
 					l << (qiFilter);
+
+				if (c == Channel::getIdleChannel())
+					l << (qiIdleChannel);
 
 				return l;
 			case Qt::FontRole:
@@ -1259,6 +1263,7 @@ void UserModel::removeAll() {
 	}
 
 	qsLinked.clear();
+	Channel::cIdleChannel = NULL;
 
 	updateOverlay();
 }

--- a/src/mumble/UserModel.h
+++ b/src/mumble/UserModel.h
@@ -93,7 +93,7 @@ class UserModel : public QAbstractItemModel {
 		QIcon qiPrioritySpeaker;
 		QIcon qiRecording;
 		QIcon qiDeafenedSelf, qiDeafenedServer;
-		QIcon qiAuthenticated, qiChannel, qiLinkedChannel, qiActiveChannel;
+		QIcon qiAuthenticated, qiChannel, qiLinkedChannel, qiActiveChannel, qiIdleChannel;
 		QIcon qiFriend;
 		QIcon qiComment, qiCommentSeen, qiFilter;
 		ModelItem *miRoot;

--- a/src/mumble/main.cpp
+++ b/src/mumble/main.cpp
@@ -57,6 +57,7 @@
 #include "SocketRPC.h"
 #include "MumbleApplication.h"
 #include "ApplicationPalette.h"
+#include "System.h"
 
 #if defined(USE_STATIC_QT_PLUGINS) && QT_VERSION < 0x050000
 Q_IMPORT_PLUGIN(qtaccessiblewidgets)
@@ -381,6 +382,9 @@ int main(int argc, char **argv) {
 	// Initialize database
 	g.db = new Database();
 
+	//Initialize System
+	g.sys = new System();
+
 #ifdef USE_BONJOUR
 	// Initialize bonjour
 	g.bc = new BonjourClient();
@@ -538,6 +542,7 @@ int main(int argc, char **argv) {
 	delete g.db;
 	delete g.p;
 	delete g.l;
+	delete g.sys;
 
 #ifdef USE_BONJOUR
 	delete g.bc;

--- a/src/mumble/mumble.pro
+++ b/src/mumble/mumble.pro
@@ -145,7 +145,8 @@ HEADERS *= BanEditor.h \
     OverlayEditor.h \
     OverlayEditorScene.h \
     MumbleApplication.h \
-    ApplicationPalette.h
+    ApplicationPalette.h \
+    System.h
 
 SOURCES *= BanEditor.cpp \
     ACLEditor.cpp \
@@ -205,7 +206,8 @@ SOURCES *= BanEditor.cpp \
     VoiceRecorderDialog.cpp \
     WebFetch.cpp \
     MumbleApplication.cpp \
-    smallft.cpp
+    smallft.cpp \
+    System.cpp
 
 DIST		*= ../../icons/mumble.ico licenses.h smallft.h ../../icons/mumble.xpm murmur_pch.h mumble.plist
 RESOURCES	*= mumble.qrc mumble_translations.qrc mumble_flags.qrc
@@ -450,7 +452,7 @@ unix {
     HEADERS *= GlobalShortcut_unix.h
     SOURCES *= GlobalShortcut_unix.cpp TextToSpeech_unix.cpp Overlay_unix.cpp SharedMemory_unix.cpp Log_unix.cpp
     PKGCONFIG *= x11
-    LIBS *= -lrt -lXi
+    LIBS *= -lrt -lXi -lXss
 
     !CONFIG(no-oss) {
       CONFIG  *= oss

--- a/src/mumble/mumble.qrc
+++ b/src/mumble/mumble.qrc
@@ -1,6 +1,7 @@
 <RCC>
     <qresource prefix="/">
         <file alias="Information_icon.svg">../../icons/publicdomain/Information_icon.svg</file>
+	<file alias="Zzz_sleep.svg">../../icons/publicdomain/Zzz_sleep.svg</file>
         <file alias="self_undeafened.svg">../../icons/self_undeafened.svg</file>
         <file alias="mumble.svg">../../icons/mumble.svg</file>
         <file alias="mumble.icns">../../icons/mumble.icns</file>


### PR DESCRIPTION
The following improvements to idle actions in the Mumble client are included in this PR:
- Use system idle time to trigger idle actions
- Add ability to move to a specified channel when idle

I've added a new field to the favourite server dialog, a new drop-down option in the perferences as well as an icon to indicate the idle channel, as seen here:

![Screenshot](http://www.fastquake.com/images/screen-mumbleidle1-20150616-221916_c.png)

When the user returns to their computer, the idle action is reversed (they are moved out of the idle channel or unmuted/undeafened).

This does not work on Mac as I have no Macintosh machine to develop or test on. To make it work on Mac, implement the necessary code into System.cpp's getIdleSeconds(). Until then, the idle action fails gracefully by simply not occurring.

Please review this change and give me your thoughts and suggestions :)
