### PR TITLE
ALSA: Handle input device suspend/recovery gracefully

### DIFF
--- a/src/mumble/ALSAAudio.cpp
+++ b/src/mumble/ALSAAudio.cpp
@@ -382,8 +382,11 @@ void ALSAAudioInput::run() {
 #endif
 		readblapp = snd_pcm_readi(capture_handle, inbuff, static_cast<int>(wantPeriod));
 		if (readblapp == -ESTRPIPE) {
-			// suspend event - what to do?
-			qWarning("ALSAAudioInput: %s", snd_strerror(static_cast<int>(readblapp)));
+			qWarning("ALSAAudioInput: PCM suspended, trying to resume");
+			while (bRunning && snd_pcm_resume(capture_handle) == -EAGAIN)
+				msleep(1000);
+			if ((err = snd_pcm_prepare(capture_handle)) < 0)
+				qWarning("ALSAAudioInput: %s: %s", snd_strerror(static_cast<int>(readblapp)), snd_strerror(err));
 		} else if (readblapp == -EPIPE) {
 			err = snd_pcm_prepare(capture_handle);
 			qWarning("ALSAAudioInput: %s: %s", snd_strerror(static_cast<int>(readblapp)), snd_strerror(err));


### PR DESCRIPTION
Currently if the PCM device is suspended, the input thread will run forever, spamming `ALSAAudioInput: Streams pipe error` on stderr.

The solution is to periodically call `snd_pcm_resume` until the device is ready to receive, after which the thread can continue as normal.