### PR TITLE
Normalize submodule URLs as https

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,21 +1,21 @@
 [submodule "speex"]
 	path = 3rdparty/speex-src
-	url = git://git.xiph.org/speex.git/
+	url = https://git.xiph.org/speex.git/
 [submodule "celt-0.7.0-src"]
 	path = 3rdparty/celt-0.7.0-src
 	url = https://github.com/mumble-voip/celt-0.7.0.git
 [submodule "celt-0.11.0-src"]
 	path = 3rdparty/celt-0.11.0-src
-	url = git://git.xiph.org/celt.git/
+	url = https://git.xiph.org/celt.git/
 [submodule "opus-src"]
 	path = 3rdparty/opus-src
 	url = https://github.com/mumble-voip/opus.git
 [submodule "sbcelt-src"]
 	path = 3rdparty/sbcelt-src
-	url = git://github.com/mumble-voip/sbcelt.git
+	url = https://github.com/mumble-voip/sbcelt.git
 [submodule "3rdparty/fx11-src"]
 	path = 3rdparty/fx11-src
-	url = git://github.com/mumble-voip/fx11.git
+	url = https://github.com/mumble-voip/fx11.git
 [submodule "3rdparty/minhook-src"]
 	path = 3rdparty/minhook-src
 	url = https://github.com/mumble-voip/minhook.git


### PR DESCRIPTION
Those of us behind corporate firewalls have trouble cloning repos with
the git protocol. Change all submodule URLs to use https instead of git.