### PR TITLE
Change sourceforge links to mumble.info links

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -2,9 +2,9 @@ Binary versions
 ===============
 
 Binary versions for Win32 of the most recent version of mumble are provided
-on mumble.info, see http://mumble.info/
+at http://www.mumble.info/
 
-The only legitimate releases of Mumble will be on mumble.info, any other
+The only legitimate releases of Mumble will be on www.mumble.info, any other
 place offering Mumble is likely to contain trojans or viruses.
 
 Windows pre-requisites

--- a/INSTALL
+++ b/INSTALL
@@ -2,9 +2,9 @@ Binary versions
 ===============
 
 Binary versions for Win32 of the most recent version of mumble are provided
-on sourceforge.net, see http://www.sourceforge.net/projects/mumble/
+on mumble.info, see http://mumble.info/
 
-The only legitimate releases of Mumble will be on sourceforge, any other
+The only legitimate releases of Mumble will be on mumble.info, any other
 place offering Mumble is likely to contain trojans or viruses.
 
 Windows pre-requisites

--- a/INSTALL
+++ b/INSTALL
@@ -11,21 +11,21 @@ Windows pre-requisites
 ======================
 
 Detailed build instructions are available at
-http://mumble.sourceforge.net/BuildingWindows and it is highly recommended
+http://wiki.mumble.info/wiki/BuildingWindows and it is highly recommended
 to follow them to the letter.
 
 Mac OS X pre-requisites
 =======================
 
 Detailed build instructions are available at
-http://mumble.sourceforge.net/BuildingMacOSX and it is highly recommended
+http://wiki.mumble.info/wiki/BuildingMacOSX and it is highly recommended
 to follow them to the letter.
 
 Linux pre-requisites
 ====================
 
 Detailed build instructions are available at
-http://mumble.sourceforge.net/BuildingLinux and it is highly recommended
+http://wiki.mumble.info/wiki/BuildingLinux and it is highly recommended
 to follow them to the letter.
 
 Please note that in addition to the depending libraries, you also need

--- a/README.static.linux
+++ b/README.static.linux
@@ -88,9 +88,9 @@ is usually set up as a first step.  To do this, follow the steps below:
 For more advanced setup and usage of Murmur, please visit the Mumble Wiki,
 at http://mumble.info/. Some pages of interest are available at:
 
-   http://mumble.sourceforge.net/Running_Murmur
-   http://mumble.sourceforge.net/ACL_and_Groups
-   http://mumble.sourceforge.net/Murmurguide
+   http://wiki.mumble.info/wiki/Running_Murmur
+   http://wiki.mumble.info/wiki/ACL_and_Groups
+   http://wiki.mumble.info/wiki/Murmurguide
 
 Additional Murmur Options
 =========================

--- a/README.static.osx
+++ b/README.static.osx
@@ -86,9 +86,9 @@ is usually set up as a first step.  To do this, follow the steps below:
 For more advanced setup and usage of Murmur, please visit the Mumble Wiki,
 at http://mumble.info/. Some pages of interest are available at:
 
-   http://mumble.sourceforge.net/Running_Murmur
-   http://mumble.sourceforge.net/ACL_and_Groups
-   http://mumble.sourceforge.net/Murmurguide
+   http://wiki.mumble.info/wiki/Running_Murmur
+   http://wiki.mumble.info/wiki/ACL_and_Groups
+   http://wiki.mumble.info/wiki/Murmurguide
 
 Additional Murmur Options
 =========================

--- a/scripts/murmur.ini
+++ b/scripts/murmur.ini
@@ -145,7 +145,7 @@ users=100
 #
 #registerName=Mumble Server
 #registerPassword=secret
-#registerUrl=http://mumble.sourceforge.net/
+#registerUrl=http://mumble.info/
 #registerHostname=
 
 # If this option is enabled, the server will announce its presence via the 

--- a/scripts/murmur.ini
+++ b/scripts/murmur.ini
@@ -145,7 +145,7 @@ users=100
 #
 #registerName=Mumble Server
 #registerPassword=secret
-#registerUrl=http://mumble.info/
+#registerUrl=http://www.mumble.info/
 #registerHostname=
 
 # If this option is enabled, the server will announce its presence via the 

--- a/scripts/server/ice/simpleregister.php
+++ b/scripts/server/ice/simpleregister.php
@@ -4,7 +4,7 @@
 $serverId = 1;
 
 // Requires a correctly set up PHP-ICE Module and mumble server running with ICE.
-//  For instructions see http://mumble.sourceforge.net/ICE
+//  For instructions see http://wiki.mumble.info/wiki/Ice
 
 // Credits
 //  This script was created by Kissaki


### PR DESCRIPTION
Updated sourceforge links to point to the correct mumble.info equivalent links. in response to https://github.com/mumble-voip/mumble/issues/1727
