### PR TITLE
Use proper pkg-config flags for speech-dispatcher and fall back to ma…

### DIFF
--- a/src/mumble/mumble.pro
+++ b/src/mumble/mumble.pro
@@ -545,11 +545,12 @@ dbus {
 
 speechd {
 	DEFINES *= USE_SPEECHD
-	system(pkg-config --atleast-version=0.8 speech-dispatcher) {
+	system(pkg-config --atleast-version=0.8 --cflags --libs speech-dispatcher) {
 		DEFINES *= USE_SPEECHD_PKGCONFIG
 		PKGCONFIG *= speech-dispatcher
 	} else {
 		LIBS *= -lspeechd
+		INCLUDEPATH	*= /usr/include/speech-dispatcher
 	}
 }
 

--- a/src/mumble/mumble.pro
+++ b/src/mumble/mumble.pro
@@ -545,7 +545,7 @@ dbus {
 
 speechd {
 	DEFINES *= USE_SPEECHD
-	system(pkg-config --atleast-version=0.8 --cflags --libs speech-dispatcher) {
+	system(pkg-config --atleast-version=0.8 speech-dispatcher) {
 		DEFINES *= USE_SPEECHD_PKGCONFIG
 		PKGCONFIG *= speech-dispatcher
 	} else {


### PR DESCRIPTION
…nual default path

speech-dispatcher lives in `/usr/include/speech-dispatcher` as per upstream default and mumble should honor that (or at least expect that default to hold true). Also, due to that, it is necessary to use proper pkg-config flags.