### PR TITLE
Disable SuperUser

### DIFF
--- a/src/murmur/ServerDB.cpp
+++ b/src/murmur/ServerDB.cpp
@@ -1153,43 +1153,8 @@ bool Server::setTexture(int id, const QByteArray &texture) {
 	return true;
 }
 
-void ServerDB::setSUPW(int srvnum, const QString &pw) {
-	TransactionHolder th;
-	QString pwHash, saltHash;
-
-	if (!Meta::mp.legacyPasswordHash) {
-		saltHash = PBKDF2::getSalt();
-		pwHash = PBKDF2::getHash(saltHash, pw, Meta::mp.kdfIterations);
-	} else {
-		pwHash = getLegacySHA1Hash(pw);
-	}
-
-	QSqlQuery &query = *th.qsqQuery;
-
-	SQLPREP("SELECT `user_id` FROM `%1users` WHERE `server_id` = ? AND `user_id` = ?");
-	query.addBindValue(srvnum);
-	query.addBindValue(0);
-	SQLEXEC();
-	if (! query.next()) {
-		SQLPREP("INSERT INTO `%1users` (`server_id`, `user_id`, `name`) VALUES (?, ?, ?)");
-		query.addBindValue(srvnum);
-		query.addBindValue(0);
-		query.addBindValue(QLatin1String("SuperUser"));
-		SQLEXEC();
-	}
-
-	SQLPREP("UPDATE `%1users` SET `pw`=?, `salt`=?, `kdfiterations`=? WHERE `server_id` = ? AND `user_id`=?");
-	query.addBindValue(pwHash);
-	query.addBindValue(saltHash);
-	query.addBindValue(Meta::mp.kdfIterations);
-	query.addBindValue(srvnum);
-	query.addBindValue(0);
-	SQLEXEC();
-}
-
-void ServerDB::disableSU(int srvnum) {
+void ServerDB::writeSUPW(int srvnum, const QString &pwHash, const QString &saltHash, const QVariant &kdfIterations) {
         TransactionHolder th;
-
         QSqlQuery &query = *th.qsqQuery;
 
         SQLPREP("SELECT `user_id` FROM `%1users` WHERE `server_id` = ? AND `user_id` = ?");
@@ -1205,12 +1170,30 @@ void ServerDB::disableSU(int srvnum) {
         }
 
         SQLPREP("UPDATE `%1users` SET `pw`=?, `salt`=?, `kdfiterations`=? WHERE `server_id` = ? AND `user_id`=?");
-        query.addBindValue(QVariant()); // NULL
-        query.addBindValue(QVariant()); // NULL
-        query.addBindValue(QVariant()); // NULL
+        query.addBindValue(pwHash);
+        query.addBindValue(saltHash);
+        query.addBindValue(kdfIterations);
         query.addBindValue(srvnum);
         query.addBindValue(0);
         SQLEXEC();
+}
+
+
+void ServerDB::setSUPW(int srvnum, const QString &pw) {
+	QString pwHash, saltHash;
+
+	if (!Meta::mp.legacyPasswordHash) {
+		saltHash = PBKDF2::getSalt();
+		pwHash = PBKDF2::getHash(saltHash, pw, Meta::mp.kdfIterations);
+	} else {
+		pwHash = getLegacySHA1Hash(pw);
+	}
+
+	writeSUPW(srvnum, pwHash, saltHash, Meta::mp.kdfIterations);
+}
+
+void ServerDB::disableSU(int srvnum) {
+        writeSUPW(srvnum, QString(), QString(), QVariant()); // NULL, NULL, NULL
 }
 
 QString ServerDB::getLegacySHA1Hash(const QString &password) {

--- a/src/murmur/ServerDB.cpp
+++ b/src/murmur/ServerDB.cpp
@@ -1187,6 +1187,32 @@ void ServerDB::setSUPW(int srvnum, const QString &pw) {
 	SQLEXEC();
 }
 
+void ServerDB::disableSU(int srvnum) {
+        TransactionHolder th;
+
+        QSqlQuery &query = *th.qsqQuery;
+
+        SQLPREP("SELECT `user_id` FROM `%1users` WHERE `server_id` = ? AND `user_id` = ?");
+        query.addBindValue(srvnum);
+        query.addBindValue(0);
+        SQLEXEC();
+        if (! query.next()) {
+                SQLPREP("INSERT INTO `%1users` (`server_id`, `user_id`, `name`) VALUES (?, ?, ?)");
+                query.addBindValue(srvnum);
+                query.addBindValue(0);
+                query.addBindValue(QLatin1String("SuperUser"));
+                SQLEXEC();
+        }
+
+        SQLPREP("UPDATE `%1users` SET `pw`=?, `salt`=?, `kdfiterations`=? WHERE `server_id` = ? AND `user_id`=?");
+        query.addBindValue(QVariant()); // NULL
+        query.addBindValue(QVariant()); // NULL
+        query.addBindValue(QVariant()); // NULL
+        query.addBindValue(srvnum);
+        query.addBindValue(0);
+        SQLEXEC();
+}
+
 QString ServerDB::getLegacySHA1Hash(const QString &password) {
 	QByteArray hash = QCryptographicHash::hash(password.toUtf8(), QCryptographicHash::Sha1);
 	return QString::fromLatin1(hash.toHex());

--- a/src/murmur/ServerDB.h
+++ b/src/murmur/ServerDB.h
@@ -52,6 +52,7 @@ class ServerDB {
 		static QSqlDatabase *db;
 		static QString qsUpgradeSuffix;
 		static void setSUPW(int iServNum, const QString &pw);
+		static void disableSU(int srvnum);
 		static QList<int> getBootServers();
 		static QList<int> getAllServers();
 		static int addServer();

--- a/src/murmur/ServerDB.h
+++ b/src/murmur/ServerDB.h
@@ -73,6 +73,7 @@ class ServerDB {
 		
 	private:
 		static void loadOrSetupMetaPKBDF2IterationsCount(QSqlQuery &query);
+		static void writeSUPW(int srvnum, const QString &pwHash, const QString &saltHash, const QVariant &kdfIterations);
 };
 
 #endif

--- a/src/murmur/main.cpp
+++ b/src/murmur/main.cpp
@@ -231,6 +231,7 @@ int main(int argc, char **argv) {
 
 	QString inifile;
 	QString supw;
+	bool disableSu = false;
 	bool wipeSsl = false;
 	bool wipeLogs = false;
 	int sunum = 1;
@@ -280,6 +281,14 @@ int main(int argc, char **argv) {
 			}
 			bLast = true;
 #endif
+		} else if ((arg == "-disablesu")) {
+		        detach = false;
+		        disableSu = true;
+		        if (i+1 < args.size()) {
+		                i++;
+		                sunum = args.at(i).toInt();
+		        }
+		        bLast = true;
 		} else if ((arg == "-ini") && (i+1 < args.size())) {
 			i++;
 			inifile = args.at(i);
@@ -301,6 +310,9 @@ int main(int argc, char **argv) {
 			       "  -supw <pw> [srv] Set password for 'SuperUser' account on server srv.\n"
 #ifdef Q_OS_UNIX
 			       "  -readsupw [srv]  Reads password for server srv from standard input.\n"
+#endif
+			       "  -disablesu [srv] Disable password for 'SuperUser' account on server srv.\n"
+#ifdef Q_OS_UNIX
 			       "  -limits          Tests and shows how many file descriptors and threads can be created.\n"
 			       "                   The purpose of this option is to test how many clients Murmur can handle.\n"
 			       "                   Murmur will exit after this test.\n"
@@ -411,6 +423,11 @@ int main(int argc, char **argv) {
 		}
 		ServerDB::setSUPW(sunum, supw);
 		qFatal("Superuser password set on server %d", sunum);
+	}
+
+	if (disableSu) {
+	        ServerDB::disableSU(sunum);
+	        qFatal("SuperUser password disabled on server %d", sunum);
 	}
 
 	if (wipeSsl) {


### PR DESCRIPTION
The account "SuperUser" is known to exist on every server. It is also known this account is secured only by a password. No matter how strong the password is choosen it is only my second choice if I can delegate administration to a cert-authed user and have access to the server process (to re-enable the SuperUser password if it is really necessary). Looking for a way to disable SuperUser account (or at least the password) I got to this feature request: https://sourceforge.net/p/mumble/feature-requests/1130/.
Reading the code doing the authentication I learned it is sufficient to set SuperUser password in the DB to NULL. The attached changes deliver an UI to do that.