### PR TITLE
Mark text as not to be translated

### DIFF
--- a/src/mumble/ACLEditor.ui
+++ b/src/mumble/ACLEditor.ui
@@ -120,7 +120,7 @@ When checked the channel created will be marked as temporary. This means when th
             <string>ID of the channel.</string>
            </property>
            <property name="text">
-            <string>ChannelID</string>
+            <string notr="true">ChannelID</string>
            </property>
           </widget>
          </item>


### PR DESCRIPTION
The default label text "ChannelID" is never displayed on the client.
ACLEditor.cpp will always set the text with a placeholder for the ID.

As such, mark this default text as not to be translated.

This issue (unknown text) was raised on transifex kingu.

If someone could build and try this? :D