### PR TITLE
Add Finnish translations to the wix project

### DIFF
--- a/installer/MumbleInstall.wixproj
+++ b/installer/MumbleInstall.wixproj
@@ -56,6 +56,7 @@
     <EmbeddedResource Include="Translations\Danish.wxl" />
     <EmbeddedResource Include="Translations\Dutch.wxl" />
     <EmbeddedResource Include="Translations\English.wxl" />
+    <EmbeddedResource Include="Translations\Finnish.wxl" />
     <EmbeddedResource Include="Translations\French.wxl" />
     <EmbeddedResource Include="Translations\German.wxl" />
     <EmbeddedResource Include="Translations\Italian.wxl" />


### PR DESCRIPTION
Attempt to fix #1757 

Couldn't build the wix installer due to a pile of dependencies that weren't taken care of by the mumble-releng (Windows debugging tools and ZeroC in \Program Files mainly) so this change is untested.

But this seemed like a likely cause. All the other language translations were included in the wix project save for the Finnish translations.