### PR TITLE
Murmur: add support for EDH cipher suites, and for specifying Diffie-Hellman parmeters.

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -160,3 +160,9 @@ CONFIG+=no-gkey (Mumble, Win32)
  time dependencies, and requires Logitech Gaming
  Software to be installed to have any effect at
  runtime.
+
+CONFIG+=no-qssldiffiehellmanparameters
+ Don't build in support for custom Diffie-Hellman
+ parameters, even if the QSslDiffieHellmanParameters
+ class is available in the version of Qt you are
+ building against.

--- a/scripts/murmur.ini
+++ b/scripts/murmur.ini
@@ -160,6 +160,13 @@ users=100
 ;sslCert=
 ;sslKey=
 
+; The sslDHParams option allows you to specify a PEM-encoded file with
+; Diffie-Hellman parameters, which will be used as the default Diffie-
+; Hellman parameters for all virtual servers.
+; If a file is not specified, each Murmur virtual server will auto-generate
+; its own unique set of 2048-bit Diffie-Hellman parameters on first launch.
+;sslDHParams=
+
 ; The sslCiphers option chooses the cipher suites to make available for use
 ; in SSL/TLS. This option is server-wide, and cannot be set on a
 ; per-virtual-server basis.
@@ -176,7 +183,7 @@ users=100
 ; Note: Changing this option may impact the backwards compatibility of your
 ; Murmur server, and can remove the ability for older Mumble clients to be able
 ; to connect to it.
-;sslCiphers=EECDH+AESGCM:AES256-SHA:AES128-SHA
+;sslCiphers=EECDH+AESGCM:EDH+aRSA+AESGCM:DHE-RSA-AES256-SHA:DHE-RSA-AES128-SHA:AES256-SHA:AES128-SHA
 
 ; If Murmur is started as root, which user should it switch to?
 ; This option is ignored if Murmur isn't started with root privileges.

--- a/src/SSL.cpp
+++ b/src/SSL.cpp
@@ -35,7 +35,7 @@
 #include "Version.h"
 
 QString MumbleSSL::defaultOpenSSLCipherString() {
-	return QLatin1String("EECDH+AESGCM:AES256-SHA:AES128-SHA");
+	return QLatin1String("EECDH+AESGCM:EDH+aRSA+AESGCM:DHE-RSA-AES256-SHA:DHE-RSA-AES128-SHA:AES256-SHA:AES128-SHA");
 }
 
 QList<QSslCipher> MumbleSSL::ciphersFromOpenSSLCipherString(QString cipherString) {

--- a/src/murmur/Meta.h
+++ b/src/murmur/Meta.h
@@ -114,6 +114,7 @@ public:
 
 	QSslCertificate qscCert;
 	QSslKey qskKey;
+	QByteArray qbaDHParams;
 	QByteArray qbaPassPhrase;
 	QString qsCiphers;
 

--- a/src/murmur/Server.cpp
+++ b/src/murmur/Server.cpp
@@ -1173,6 +1173,12 @@ void Server::newClient() {
 		sock->addCaCertificate(qscCert);
 		sock->addCaCertificates(qlCA);
 
+#if defined(USE_QSSLDIFFIEHELLMANPARAMETERS)
+		QSslConfiguration cfg = sock->sslConfiguration();
+		cfg.setDiffieHellmanParameters(qsdhpDHParams);
+		sock->setSslConfiguration(cfg);
+#endif
+
 		if (qqIds.isEmpty()) {
 			log(QString("Session ID pool (%1) empty, rejecting connection").arg(iMaxUsers));
 			sock->disconnectFromHost();

--- a/src/murmur/Server.h
+++ b/src/murmur/Server.h
@@ -49,6 +49,9 @@
 #include <QtNetwork/QSslKey>
 #include <QtNetwork/QSslSocket>
 #include <QtNetwork/QTcpServer>
+#if defined(USE_QSSLDIFFIEHELLMANPARAMETERS)
+# include <QtNetwork/QSslDiffieHellmanParameters>
+#endif
 #ifdef Q_OS_WIN
 #include <windows.h>
 #endif
@@ -168,6 +171,9 @@ class Server : public QThread {
 		QList<QSslCertificate> qlCA;
 		QSslCertificate qscCert;
 		QSslKey qskKey;
+#if defined(USE_QSSLDIFFIEHELLMANPARAMETERS)
+		QSslDiffieHellmanParameters qsdhpDHParams;
+#endif
 
 		Timer tUptime;
 

--- a/src/murmur/main.cpp
+++ b/src/murmur/main.cpp
@@ -419,6 +419,7 @@ int main(int argc, char **argv) {
 			ServerDB::setConf(sid, "key");
 			ServerDB::setConf(sid, "certificate");
 			ServerDB::setConf(sid, "passphrase");
+			ServerDB::setConf(sid, "sslDHParams");
 		}
 	}
 

--- a/src/murmur/murmur.pro
+++ b/src/murmur/murmur.pro
@@ -168,4 +168,20 @@ bonjour {
 	}
 }
 
+# Check for QSslDiffieHellmanParameters availability, and define
+# USE_QSSLDIFFIEHELLMANPARAMETERS preprocessor if available.
+#
+# Can be disabled with no-qssldiffiehellmanparameters.
+!CONFIG(no-qssldiffiehellmanparameters):exists($$[QT_INSTALL_HEADERS]/QtNetwork/QSslDiffieHellmanParameters) {
+	# ...but only if we're inside a Mumble build environment for now.
+	# If someone decides to put a Mumble snapshot into a distro, this
+	# could break the build in the future, with newer versions of Qt,
+	# if the API of QSslDiffieHellmanParameters changes when it is
+	# upstreamed.
+	MUMBLE_PREFIX=$$(MUMBLE_PREFIX)
+	!isEmpty(MUMBLE_PREFIX) {
+		DEFINES += USE_QSSLDIFFIEHELLMANPARAMETERS
+	}
+}
+
 include(../../symbols.pri)


### PR DESCRIPTION
This change allows server admins to specify Diffie-Hellman
parameters for Murmur to use. This is done using the sslDHParams
option in the config file. Diffie-Hellman parameters can also be
set on a per-server basis using the sslDHParams option.

Note: the functionality implemented in this change requires the
QSslDiffieHellmanParameters class in Qt, which has not yet landed
upstream in the Qt 5 'dev' branch. This means that the functionality
discussed in this change will, for now, only work in binaries provided
by the Mumble project, or binaries that are built using our build
environments, and not binaries that link against any released versions
of Qt at present.

This change modifies the default TLS cipher suite string to add
EDH+aRSA+AESGCM, DHE-RSA-AES256-SHA and DHE-RSA-AES128-SHA.

This yields the following ciphers, in TLS/RFC notation:

    TLS_DHE_RSA_WITH_AES_256_GCM_SHA384
    TLS_DHE_RSA_WITH_AES_128_GCM_SHA256
    TLS_DHE_RSA_WITH_AES_256_CBC_SHA
    TLS_DHE_RSA_WITH_AES_128_CBC_SHA

This change also allows Murmur servers to provide forward secrecy
to older clients, such as our own pre-built binaries before 1.2.9.

It also provides forward secrecy for users that use Mumble 1.2.x
versions on Linux distros, and other Unix-like systems. This is
because Mumble 1.2.x on Unix-like systems builds against Qt 4, which
limits the connection to TLS 1.0.

Before this change, Murmur was not able to negotiate an ephemeral
Diffie-Hellman key exchange for those clients. This is now possible.