### PR TITLE
Replace all comments using hash (#) w/ semicolons (;)

### DIFF
--- a/scripts/murmur.ini
+++ b/scripts/murmur.ini
@@ -1,208 +1,208 @@
-# Murmur configuration file.
-#
-# General notes:
-# * Settings in this file are default settings and many of them can be overridden
-#   with virtual server specific configuration via the Ice or DBus interface.
-# * Due to the way this configuration file is read some rules have to be
-#   followed when specifying variable values (as in variable = value):
-#     * Make sure to quote the value when using commas in strings or passwords.
-#        NOT variable = super,secret BUT variable = "super,secret"
-#     * Make sure to escape special characters like '\' or '"' correctly
-#        NOT variable = """ BUT variable = "\""
-#        NOT regex = \w* BUT regex = \\w*
+; Murmur configuration file.
+;
+; General notes:
+; * Settings in this file are default settings and many of them can be overridden
+;   with virtual server specific configuration via the Ice or DBus interface.
+; * Due to the way this configuration file is read some rules have to be
+;   followed when specifying variable values (as in variable = value):
+;     * Make sure to quote the value when using commas in strings or passwords.
+;        NOT variable = super,secret BUT variable = "super,secret"
+;     * Make sure to escape special characters like '\' or '"' correctly
+;        NOT variable = """ BUT variable = "\""
+;        NOT regex = \w* BUT regex = \\w*
 
-# Path to database. If blank, will search for
-# murmur.sqlite in default locations or create it if not found.
+; Path to database. If blank, will search for
+; murmur.sqlite in default locations or create it if not found.
 database=
 
-# If you wish to use something other than SQLite, you'll need to set the name
-# of the database above, and also uncomment the below.
-# Sticking with SQLite is strongly recommended, as it's the most well tested
-# and by far the fastest solution.
-#
-#dbDriver=QMYSQL
-#dbUsername=
-#dbPassword=
-#dbHost=
-#dbPort=
-#dbPrefix=murmur_
-#dbOpts=
+; If you wish to use something other than SQLite, you'll need to set the name
+; of the database above, and also uncomment the below.
+; Sticking with SQLite is strongly recommended, as it's the most well tested
+; and by far the fastest solution.
+;
+;dbDriver=QMYSQL
+;dbUsername=
+;dbPassword=
+;dbHost=
+;dbPort=
+;dbPrefix=murmur_
+;dbOpts=
 
-# Murmur defaults to not using D-Bus. If you wish to use dbus, which is one of the
-# RPC methods available in Murmur, please specify so here.
-#
-#dbus=session
+; Murmur defaults to not using D-Bus. If you wish to use dbus, which is one of the
+; RPC methods available in Murmur, please specify so here.
+;
+;dbus=session
 
-# Alternate D-Bus service name. Only use if you are running distinct
-# murmurd processes connected to the same D-Bus daemon.
-#dbusservice=net.sourceforge.mumble.murmur
+; Alternate D-Bus service name. Only use if you are running distinct
+; murmurd processes connected to the same D-Bus daemon.
+;dbusservice=net.sourceforge.mumble.murmur
 
-# If you want to use ZeroC Ice to communicate with Murmur, you need
-# to specify the endpoint to use. Since there is no authentication
-# with ICE, you should only use it if you trust all the users who have
-# shell access to your machine.
-# Please see the ICE documentation on how to specify endpoints.
+; If you want to use ZeroC Ice to communicate with Murmur, you need
+; to specify the endpoint to use. Since there is no authentication
+; with ICE, you should only use it if you trust all the users who have
+; shell access to your machine.
+; Please see the ICE documentation on how to specify endpoints.
 ice="tcp -h 127.0.0.1 -p 6502"
 
-# Ice primarily uses local sockets. This means anyone who has a
-# user account on your machine can connect to the Ice services.
-# You can set a plaintext "secret" on the Ice connection, and
-# any script attempting to access must then have this secret
-# (as context with name "secret").
-# Access is split in read (look only) and write (modify) 
-# operations. Write access always includes read access,
-# unless read is explicitly denied (see note below).
-#
-# Note that if this is uncommented and with empty content,
-# access will be denied.
+; Ice primarily uses local sockets. This means anyone who has a
+; user account on your machine can connect to the Ice services.
+; You can set a plaintext "secret" on the Ice connection, and
+; any script attempting to access must then have this secret
+; (as context with name "secret").
+; Access is split in read (look only) and write (modify) 
+; operations. Write access always includes read access,
+; unless read is explicitly denied (see note below).
+;
+; Note that if this is uncommented and with empty content,
+; access will be denied.
 
-#icesecretread=
+;icesecretread=
 icesecretwrite=
 
-# How many login attempts do we tolerate from one IP
-# inside a given timeframe before we ban the connection?
-# Note that this is global (shared between all virtual servers), and that
-# it counts both successfull and unsuccessfull connection attempts.
-# Set either Attempts or Timeframe to 0 to disable.
-#autobanAttempts = 10
-#autobanTimeframe = 120
-#autobanTime = 300
+; How many login attempts do we tolerate from one IP
+; inside a given timeframe before we ban the connection?
+; Note that this is global (shared between all virtual servers), and that
+; it counts both successfull and unsuccessfull connection attempts.
+; Set either Attempts or Timeframe to 0 to disable.
+;autobanAttempts = 10
+;autobanTimeframe = 120
+;autobanTime = 300
 
-# Specifies the file Murmur should log to. By default, Murmur
-# logs to the file 'murmur.log'. If you leave this field blank
-# on Unix-like systems, Murmur will force itself into foreground
-# mode which logs to the console.
-#logfile=murmur.log
+; Specifies the file Murmur should log to. By default, Murmur
+; logs to the file 'murmur.log'. If you leave this field blank
+; on Unix-like systems, Murmur will force itself into foreground
+; mode which logs to the console.
+;logfile=murmur.log
 
-# If set, Murmur will write its process ID to this file
-# when running in daemon mode (when the -fg flag is not
-# specified on the command line). Only available on
-# Unix-like systems.
-#pidfile=
+; If set, Murmur will write its process ID to this file
+; when running in daemon mode (when the -fg flag is not
+; specified on the command line). Only available on
+; Unix-like systems.
+;pidfile=
 
-# The below will be used as defaults for new configured servers.
-# If you're just running one server (the default), it's easier to
-# configure it here than through D-Bus or Ice.
-#
-# Welcome message sent to clients when they connect.
+; The below will be used as defaults for new configured servers.
+; If you're just running one server (the default), it's easier to
+; configure it here than through D-Bus or Ice.
+;
+; Welcome message sent to clients when they connect.
 welcometext="<br />Welcome to this server running <b>Murmur</b>.<br />Enjoy your stay!<br />"
 
-# Port to bind TCP and UDP sockets to.
+; Port to bind TCP and UDP sockets to.
 port=64738
 
-# Specific IP or hostname to bind to.
-# If this is left blank (default), Murmur will bind to all available addresses.
-#host=
+; Specific IP or hostname to bind to.
+; If this is left blank (default), Murmur will bind to all available addresses.
+;host=
 
-# Password to join server.
+; Password to join server.
 serverpassword=
 
-# Maximum bandwidth (in bits per second) clients are allowed
-# to send speech at.
+; Maximum bandwidth (in bits per second) clients are allowed
+; to send speech at.
 bandwidth=72000
 
-# Maximum number of concurrent clients allowed.
+; Maximum number of concurrent clients allowed.
 users=100
 
-# Amount of users with Opus support needed to force Opus usage, in percent.
-# 0 = Always enable Opus, 100 = enable Opus if it's supported by all clients.
-#opusthreshold=100
+; Amount of users with Opus support needed to force Opus usage, in percent.
+; 0 = Always enable Opus, 100 = enable Opus if it's supported by all clients.
+;opusthreshold=100
 
-# Maximum depth of channel nesting. Note that some databases like MySQL using
-# InnoDB will fail when operating on deeply nested channels.
-#channelnestinglimit=10
+; Maximum depth of channel nesting. Note that some databases like MySQL using
+; InnoDB will fail when operating on deeply nested channels.
+;channelnestinglimit=10
 
-# Regular expression used to validate channel names.
-# (Note that you have to escape backslashes with \ )
-#channelname=[ \\-=\\w\\#\\[\\]\\{\\}\\(\\)\\@\\|]+
+; Regular expression used to validate channel names.
+; (Note that you have to escape backslashes with \ )
+;channelname=[ \\-=\\w\\#\\[\\]\\{\\}\\(\\)\\@\\|]+
 
-# Regular expression used to validate user names.
-# (Note that you have to escape backslashes with \ )
-#username=[-=\\w\\[\\]\\{\\}\\(\\)\\@\\|\\.]+
+; Regular expression used to validate user names.
+; (Note that you have to escape backslashes with \ )
+;username=[-=\\w\\[\\]\\{\\}\\(\\)\\@\\|\\.]+
 
-# Maximum length of text messages in characters. 0 for no limit.
-#textmessagelength=5000
+; Maximum length of text messages in characters. 0 for no limit.
+;textmessagelength=5000
 
-# Maximum length of text messages in characters, with image data. 0 for no limit.
-#imagemessagelength=131072
+; Maximum length of text messages in characters, with image data. 0 for no limit.
+;imagemessagelength=131072
 
-# Allow clients to use HTML in messages, user comments and channel descriptions?
-#allowhtml=true
+; Allow clients to use HTML in messages, user comments and channel descriptions?
+;allowhtml=true
 
-# Murmur retains the per-server log entries in an internal database which
-# allows it to be accessed over D-Bus/ICE.
-# How many days should such entries be kept?
-# Set to 0 to keep forever, or -1 to disable logging to the DB.
-#logdays=31
+; Murmur retains the per-server log entries in an internal database which
+; allows it to be accessed over D-Bus/ICE.
+; How many days should such entries be kept?
+; Set to 0 to keep forever, or -1 to disable logging to the DB.
+;logdays=31
 
-# To enable public server registration, the serverpassword must be blank, and
-# this must all be filled out.
-# The password here is used to create a registry for the server name; subsequent
-# updates will need the same password. Don't lose your password.
-# The URL is your own website, and only set the registerHostname for static IP
-# addresses.
-# Only uncomment the 'registerName' parameter if you wish to give your "Root" channel a custom name.
-#
-#registerName=Mumble Server
-#registerPassword=secret
-#registerUrl=http://www.mumble.info/
-#registerHostname=
+; To enable public server registration, the serverpassword must be blank, and
+; this must all be filled out.
+; The password here is used to create a registry for the server name; subsequent
+; updates will need the same password. Don't lose your password.
+; The URL is your own website, and only set the registerHostname for static IP
+; addresses.
+; Only uncomment the 'registerName' parameter if you wish to give your "Root" channel a custom name.
+;
+;registerName=Mumble Server
+;registerPassword=secret
+;registerUrl=http://www.mumble.info/
+;registerHostname=
 
-# If this option is enabled, the server will announce its presence via the 
-# bonjour service discovery protocol. To change the name announced by bonjour
-# adjust the registerName variable.
-# See http://developer.apple.com/networking/bonjour/index.html for more information
-# about bonjour.
-#bonjour=True
+; If this option is enabled, the server will announce its presence via the 
+; bonjour service discovery protocol. To change the name announced by bonjour
+; adjust the registerName variable.
+; See http://developer.apple.com/networking/bonjour/index.html for more information
+; about bonjour.
+;bonjour=True
 
-# If you have a proper SSL certificate, you can provide the filenames here.
-# Otherwise, Murmur will create its own certificate automatically.
-#sslCert=
-#sslKey=
+; If you have a proper SSL certificate, you can provide the filenames here.
+; Otherwise, Murmur will create its own certificate automatically.
+;sslCert=
+;sslKey=
 
-# The sslCiphers option chooses the cipher suites to make available for use
-# in SSL/TLS. This option is server-wide, and cannot be set on a
-# per-virtual-server basis.
-#
-# This option is specified using OpenSSL cipher list notation (see
-# https://www.openssl.org/docs/apps/ciphers.html#CIPHER-LIST-FORMAT).
-#
-# It is recommended that you try your cipher string using 'openssl ciphers <string>'
-# before setting it here, to get a feel for which cipher suites you will get.
-#
-# After setting this option, it is recommend that you inspect your Murmur log
-# to ensure that Murmur is using the cipher suites that you expected it to.
-#
-# Note: Changing this option may impact the backwards compatibility of your
-# Murmur server, and can remove the ability for older Mumble clients to be able
-# to connect to it.
-#sslCiphers=EECDH+AESGCM:AES256-SHA:AES128-SHA
+; The sslCiphers option chooses the cipher suites to make available for use
+; in SSL/TLS. This option is server-wide, and cannot be set on a
+; per-virtual-server basis.
+;
+; This option is specified using OpenSSL cipher list notation (see
+; https://www.openssl.org/docs/apps/ciphers.html#CIPHER-LIST-FORMAT).
+;
+; It is recommended that you try your cipher string using 'openssl ciphers <string>'
+; before setting it here, to get a feel for which cipher suites you will get.
+;
+; After setting this option, it is recommend that you inspect your Murmur log
+; to ensure that Murmur is using the cipher suites that you expected it to.
+;
+; Note: Changing this option may impact the backwards compatibility of your
+; Murmur server, and can remove the ability for older Mumble clients to be able
+; to connect to it.
+;sslCiphers=EECDH+AESGCM:AES256-SHA:AES128-SHA
 
-# If Murmur is started as root, which user should it switch to?
-# This option is ignored if Murmur isn't started with root privileges.
-#uname=
+; If Murmur is started as root, which user should it switch to?
+; This option is ignored if Murmur isn't started with root privileges.
+;uname=
 
-# If this options is enabled, only clients which have a certificate are allowed
-# to connect.
-#certrequired=False
+; If this options is enabled, only clients which have a certificate are allowed
+; to connect.
+;certrequired=False
 
-# If enabled, clients are sent information about the servers version and operating
-# system.
-#sendversion=True
+; If enabled, clients are sent information about the servers version and operating
+; system.
+;sendversion=True
 
-# This sets password hash storage to legacy mode (1.2.4 and before)
-# (Note that setting this to true is insecure and should not be used unless absolutely necessary)
-#legacyPasswordHash=false
+; This sets password hash storage to legacy mode (1.2.4 and before)
+; (Note that setting this to true is insecure and should not be used unless absolutely necessary)
+;legacyPasswordHash=false
 
-# By default a strong amount of PBKDF2 iterations are chosen automatically. If >0 this setting
-# overrides the automatic benchmark and forces a specific number of iterations.
-# (Note that you should only change this value if you know what you are doing)
-#kdfIterations=-1
+; By default a strong amount of PBKDF2 iterations are chosen automatically. If >0 this setting
+; overrides the automatic benchmark and forces a specific number of iterations.
+; (Note that you should only change this value if you know what you are doing)
+;kdfIterations=-1
 
-# You can configure any of the configuration options for Ice here. We recommend
-# leave the defaults as they are.
-# Please note that this section has to be last in the configuration file.
-#
+; You can configure any of the configuration options for Ice here. We recommend
+; leave the defaults as they are.
+; Please note that this section has to be last in the configuration file.
+;
 [Ice]
 Ice.Warn.UnknownProperties=1
 Ice.MessageSizeMax=65536


### PR DESCRIPTION
**Lines starting with a hash are not considered to be comments!!**

The `QSettings()` class has no formal support for comments. In fact,
there's no mention of comments at all in the class documentation:
http://doc.qt.io/qt-5/qsettings.html

There is some limited support for comments by denoting a line with a
semicolon. You can confirm this via the associated source code:
https://github.com/qtproject/qtbase/blob/5.6/src/corelib/io/qsettings.cpp

However, if saving the file via the Qt interfaces, comments will
generally be stripped out. This isn't to my knowledge a problem for
Murmur as there's no case where the server itself will update its
configuration and save the changes back to its INI file automatically.

***The existing sample INI file prior to this commit only ever worked as
there's an even number of unescaped special characters in the header!***