### PR TITLE
Fix "RCC Error:" output that appears when running qmake.

### DIFF
--- a/rcc.pri
+++ b/rcc.pri
@@ -1,0 +1,24 @@
+# Use a custom tool to query for RCC dependencies.
+# Qt's regular invocation of "rcc -list" doesn't work with
+# .qrc files that contain references to non-existent files.
+# Our .qrc files do that, because we auto-generate some of
+# the files at make-time.
+
+# Override RCC_DIR to be 'debug' or 'release'.
+# We have to do this because we're loading the
+# 'resources' feature a bit earlier than usual.
+# By default, Qt would have set these itself.
+CONFIG(debug, debug|release) {
+	RCC_DIR = debug
+}
+CONFIG(release, debug|release) {
+	RCC_DIR = release
+}
+
+load(resources)
+
+win32 {
+	rcc.depend_command = python $${PWD}\scripts\rcc-depends.py ${QMAKE_FILE_IN}
+} else {
+	rcc.depend_command = $${PWD}/scripts/rcc-depends.py ${QMAKE_FILE_IN}
+}

--- a/scripts/rcc-depends.py
+++ b/scripts/rcc-depends.py
@@ -1,0 +1,62 @@
+#!/usr/bin/env python
+#
+# Copyright (C) 2015 Mikkel Krautz <mikkel@krautz.dk>
+#
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+# - Redistributions of source code must retain the above copyright notice,
+#   this list of conditions and the following disclaimer.
+# - Redistributions in binary form must reproduce the above copyright notice,
+#   this list of conditions and the following disclaimer in the documentation
+#   and/or other materials provided with the distribution.
+# - Neither the name of the Mumble Developers nor the names of its
+#   contributors may be used to endorse or promote products derived from this
+#   software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE FOUNDATION OR
+# CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+# EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+# PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+# PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+# LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+# NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+# SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+# rcc-depends.py is a small tool that can be used as a drop-in
+# replacement for 'rcc -list' as a command to find dependencies
+# for .qrc files.
+
+from __future__ import (unicode_literals, print_function, division)
+
+import os
+import platform
+import sys
+from xml.dom import minidom
+
+def main():
+	inputs = sys.argv[1:]
+	for fn in inputs:
+		with open(fn, 'r') as f:
+			absFn = os.path.abspath(fn)
+			fnDir = os.path.dirname(absFn)
+			s = f.read()
+			dom = minidom.parseString(s)
+			fileTags = dom.getElementsByTagName('file')
+			for fileTag in fileTags:
+				textNode = fileTag.childNodes[0].wholeText
+				absPath = os.path.normpath(os.path.join(fnDir, textNode))
+				relPath = os.path.relpath(absPath)
+				output = relPath
+				if platform.system() == 'Windows':
+					output = output.replace('\\', '/')
+				print(output)
+
+if __name__ == '__main__':
+	main()

--- a/src/mumble.pri
+++ b/src/mumble.pri
@@ -1,5 +1,6 @@
 include(../compiler.pri)
 include(../qt.pri)
+include(../rcc.pri)
 
 VERSION		= 1.3.0
 DIST		= mumble.pri Message.h PacketDataStream.h CryptState.h Timer.h Version.h OSInfo.h SSL.h


### PR DESCRIPTION
This change removes the "RCC Error:" output that appears
when running "qmake -recursive main.pro".

The qmake tool's resources feature (resources.prf) invokes
"rcc -list <input>.qrc" to determine which files to add as
dependencies for the rcc target (for the given <input>.qrc)
in the generated Makefile.

When invoking "rcc -list [...]" on some of our .qrc files,
we get errors, such as:

    RCC: Error in 'mumble.qrc': Cannot find file 'mumble_cs.qm'
    RCC: Error in 'mumble.qrc': Cannot find file 'mumble_da.qm'
    RCC: Error in 'mumble.qrc': Cannot find file 'mumble_de.qm'
    [...]

This is because our .qrc files include references to files
that are generated when we invoke the Makefile.

Unfortunately, the invocation of "rcc -list [...]" happens
during the qmake invocation, and not when running "make".
So the files simply do not exist yet.

This change replaces the qmake "rcc" extra compiler's
"depend_command" to be a script we wrote ourselves, namely
rcc-depends.py, that lives in the scripts directory.

This script does practically the same thing as invoking
"rcc -list", but it does not care if the files exist yet
or not. It expects that they do.

The result is that all files listed in a .qrc file are now
properly added as dependencies for the Makefile rule that
invokes rcc to process the .qrc file. This did not happen
before.

So, a positive side-effect of this change is that our
Makefile is now able to order things correctly itself,
even for auto-generated files in .qrc files. Before, we
had to give it hints. These hints are still in place,
such as:

    lrel.variable_out = rcc.depends

and

    copytrans.variable_out = rcc.depends

both from mumble.pro.

This change has been tested with both Qt 4 and Qt 5, on
Windows and Linux.