### PR TITLE
Replace obsolete Qt method with new method

### DIFF
--- a/src/mumble/OverlayConfig.cpp
+++ b/src/mumble/OverlayConfig.cpp
@@ -171,7 +171,12 @@ OverlayConfig::OverlayConfig(Settings &st) :
 
 	// grab a desktop screenshot as background
 	QRect dsg = QApplication::desktop()->screenGeometry();
+
+#if QT_VERSION > 0x050000
+	qpScreen = QGuiApplication::primaryScreen()->grabWindow(QApplication::desktop()->winId());
+#else
 	qpScreen = QPixmap::grabWindow(QApplication::desktop()->winId(), dsg.x(), dsg.y(), dsg.width(), dsg.height());
+#endif
 	if (qpScreen.size().isEmpty()) {
 		qWarning() << __FUNCTION__ << "failed to grab desktop image, trying desktop widget...";
 


### PR DESCRIPTION
* QPixmap::grabWindow has been obsoleted with Qt 5.
Use the new QScreen::grabWindow instead, from primaryScreen.