### PR TITLE
ConnectDialog, ServerHandler: use HostAddress instead of QHostAddress…

### DIFF
--- a/src/mumble/ConnectDialog.h
+++ b/src/mumble/ConnectDialog.h
@@ -58,7 +58,7 @@
 struct FavoriteServer;
 class QUdpSocket;
 
-typedef QPair<QHostAddress, unsigned short> qpAddress;
+typedef QPair<HostAddress, unsigned short> qpAddress;
 
 struct PublicInfo {
 	QString qsName;

--- a/src/mumble/ServerHandler.cpp
+++ b/src/mumble/ServerHandler.cpp
@@ -160,7 +160,7 @@ void ServerHandler::udpReady() {
 		quint16 senderPort;
 		qusUdp->readDatagram(encrypted, qMin(2048U, buflen), &senderAddr, &senderPort);
 
-		if (!(senderAddr == qhaRemote) || (senderPort != usPort))
+		if (!(HostAddress(senderAddr) == HostAddress(qhaRemote)) || (senderPort != usPort))
 			continue;
 
 		ConnectionPtr connection(cConnection);


### PR DESCRIPTION
… when comparing addresses.

In Qt 5.5.1 (and presumably some earlier versions, too) some
IPv4 addresses are returned to us as IPv6-mapped IPv4 addresses
by QHostAddress.

Unfortunately, QHostAddress's operator== doesn't consider an
IPv4 address equivalent to an IPv6-mapped IPv4 address.

That meant that our pings in the connection dialog were silently
dropped, as well as all received UDP packets in the ServerHandler
class.

This change modifies all places where we compare QHostAddresses
to first convert the addresses into our own HostAddress type. That
type *does* consider 10.0.0.1 == [::ffff:10.0.0.1], and our
comparisons work again.