### PR TITLE
Fix warnings in code shared between mumble and murmur

### DIFF
--- a/src/Connection.cpp
+++ b/src/Connection.cpp
@@ -91,17 +91,17 @@ void Connection::setToS() {
 		qWarning("Connection: Failed to add flow to QOS");
 #elif defined(Q_OS_UNIX)
 	int val = 0xa0;
-	if (setsockopt(qtsSocket->socketDescriptor(), IPPROTO_IP, IP_TOS, &val, sizeof(val))) {
+	if (setsockopt(static_cast<int>(qtsSocket->socketDescriptor()), IPPROTO_IP, IP_TOS, &val, sizeof(val))) {
 		val = 0x60;
-		if (setsockopt(qtsSocket->socketDescriptor(), IPPROTO_IP, IP_TOS, &val, sizeof(val)))
+		if (setsockopt(static_cast<int>(qtsSocket->socketDescriptor()), IPPROTO_IP, IP_TOS, &val, sizeof(val)))
 			qWarning("Connection: Failed to set TOS for TCP Socket");
 	}
 #if defined(SO_PRIORITY)
 	socklen_t optlen = sizeof(val);
-	if (getsockopt(qtsSocket->socketDescriptor(), SOL_SOCKET, SO_PRIORITY, &val, &optlen) == 0) {
+	if (getsockopt(static_cast<int>(qtsSocket->socketDescriptor()), SOL_SOCKET, SO_PRIORITY, &val, &optlen) == 0) {
 		if (val == 0) {
 			val = 6;
-			setsockopt(qtsSocket->socketDescriptor(), SOL_SOCKET, SO_PRIORITY, &val, sizeof(val));
+			setsockopt(static_cast<int>(qtsSocket->socketDescriptor()), SOL_SOCKET, SO_PRIORITY, &val, sizeof(val));
 		}
 	}
 #endif
@@ -109,7 +109,7 @@ void Connection::setToS() {
 #endif
 }
 
-int Connection::activityTime() const {
+qint64 Connection::activityTime() const {
 	return qtLastPacket.elapsed();
 }
 
@@ -182,7 +182,7 @@ void Connection::messageToNetwork(const ::google::protobuf::Message &msg, unsign
 		return;
 	cache.resize(len + 6);
 	unsigned char *uc = reinterpret_cast<unsigned char *>(cache.data());
-	qToBigEndian<quint16>(msgType, & uc[0]);
+	qToBigEndian<quint16>(static_cast<quint16>(msgType), & uc[0]);
 	qToBigEndian<quint32>(len, & uc[2]);
 
 	msg.SerializeToArray(uc + 6, len);
@@ -213,9 +213,9 @@ void Connection::forceFlush() {
 	qtsSocket->flush();
 
 	nodelay = 1;
-	setsockopt(qtsSocket->socketDescriptor(), IPPROTO_TCP, TCP_NODELAY, reinterpret_cast<char *>(&nodelay), sizeof(nodelay));
+	setsockopt(static_cast<int>(qtsSocket->socketDescriptor()), IPPROTO_TCP, TCP_NODELAY, reinterpret_cast<char *>(&nodelay), static_cast<socklen_t>(sizeof(nodelay)));
 	nodelay = 0;
-	setsockopt(qtsSocket->socketDescriptor(), IPPROTO_TCP, TCP_NODELAY, reinterpret_cast<char *>(&nodelay), sizeof(nodelay));
+	setsockopt(static_cast<int>(qtsSocket->socketDescriptor()), IPPROTO_TCP, TCP_NODELAY, reinterpret_cast<char *>(&nodelay), static_cast<socklen_t>(sizeof(nodelay)));
 }
 
 void Connection::disconnectSocket(bool force) {

--- a/src/Connection.h
+++ b/src/Connection.h
@@ -89,7 +89,7 @@ class Connection : public QObject {
 		void sendMessage(const QByteArray &qbaMsg);
 		void disconnectSocket(bool force=false);
 		void forceFlush();
-		int activityTime() const;
+		qint64 activityTime() const;
 		void resetActivityTime();
 
 		CryptState csCrypt;

--- a/src/Net.h
+++ b/src/Net.h
@@ -92,7 +92,7 @@ struct Ban {
 #define SWAP64(x) (x)
 #else
 #ifdef __x86_64__
-#define SWAP64(x) ({register quint64 __out, __in = (x); __asm__("bswap %q0" : "=r"(__out) : "0"(__in)); __out;})
+#define SWAP64(x) __builtin_bswap64(x)
 #else
 #define SWAP64(x) qbswap<quint64>(x)
 #endif

--- a/src/SSL.cpp
+++ b/src/SSL.cpp
@@ -267,6 +267,7 @@ QString MumbleSSL::protocolToString(QSsl::SslProtocol protocol) {
 		case QSsl::TlsV1SslV3: return QLatin1String("TlsV1SslV3");
 		case QSsl::SecureProtocols: return QLatin1String("SecureProtocols");
 #endif
+		default:
 		case QSsl::UnknownProtocol: return QLatin1String("UnknownProtocol");
 	}
 }

--- a/src/SignalCurry.h
+++ b/src/SignalCurry.h
@@ -46,10 +46,10 @@ private:
 	bool bDeleteAfterFirstUse;
 	QVariant qvData;
 public:
-	SignalCurry(QVariant data, bool deleteAfterFirstUse = false, QObject *parent = 0) :
-		QObject(parent),
-		bDeleteAfterFirstUse(deleteAfterFirstUse),
-		qvData(data) {}
+	SignalCurry(QVariant data, bool deleteAfterFirstUse = false, QObject *p = 0)
+	    : QObject(p)
+		, bDeleteAfterFirstUse(deleteAfterFirstUse)
+		, qvData(data) {}
 
 	static void curry(QObject *sender, const char *signal, QObject *receiver, const char *slot, QVariant data) {
 		SignalCurry *c = new SignalCurry(data);

--- a/src/bonjour/BonjourServiceBrowser.cpp
+++ b/src/bonjour/BonjourServiceBrowser.cpp
@@ -30,8 +30,8 @@ ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include "BonjourServiceBrowser.h"
 
-BonjourServiceBrowser::BonjourServiceBrowser(QObject *parent)
-		: QObject(parent), dnssref(0), bonjourSocket(0) {
+BonjourServiceBrowser::BonjourServiceBrowser(QObject *p)
+		: QObject(p), dnssref(0), bonjourSocket(0) {
 }
 
 BonjourServiceBrowser::~BonjourServiceBrowser() {

--- a/src/bonjour/BonjourServiceBrowser.h
+++ b/src/bonjour/BonjourServiceBrowser.h
@@ -47,9 +47,6 @@ class BonjourServiceBrowser : public QObject {
 		inline QList<BonjourRecord> currentRecords() const {
 			return bonjourRecords;
 		}
-		inline QString serviceType() const {
-			return browsingType;
-		}
 
 	signals:
 		void currentBonjourRecordsChanged(const QList<BonjourRecord> &list);
@@ -65,7 +62,6 @@ class BonjourServiceBrowser : public QObject {
 		DNSServiceRef dnssref;
 		QSocketNotifier *bonjourSocket;
 		QList<BonjourRecord> bonjourRecords;
-		QString browsingType;
 };
 
 #endif

--- a/src/bonjour/BonjourServiceRegister.cpp
+++ b/src/bonjour/BonjourServiceRegister.cpp
@@ -31,8 +31,8 @@ ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include "BonjourServiceRegister.h"
 
-BonjourServiceRegister::BonjourServiceRegister(QObject *parent)
-		: QObject(parent), dnssref(0), bonjourSocket(0) {
+BonjourServiceRegister::BonjourServiceRegister(QObject *p)
+		: QObject(p), dnssref(0), bonjourSocket(0) {
 }
 
 BonjourServiceRegister::~BonjourServiceRegister() {
@@ -50,7 +50,7 @@ void BonjourServiceRegister::registerService(const BonjourRecord &record, quint1
 	quint16 bigEndianPort = servicePort;
 #if Q_BYTE_ORDER == Q_LITTLE_ENDIAN
 	{
-		bigEndianPort =  0 | ((servicePort & 0x00ff) << 8) | ((servicePort & 0xff00) >> 8);
+		bigEndianPort =  static_cast<quint16>(((servicePort & 0x00ff) << 8) | ((servicePort & 0xff00) >> 8));
 	}
 #endif
 

--- a/src/bonjour/BonjourServiceRegister.h
+++ b/src/bonjour/BonjourServiceRegister.h
@@ -41,7 +41,7 @@ class QSocketNotifier;
 class BonjourServiceRegister : public QObject {
 		Q_OBJECT
 	public:
-		BonjourServiceRegister(QObject *parent = 0);
+		BonjourServiceRegister(QObject *p = 0);
 		~BonjourServiceRegister();
 
 		void registerService(const BonjourRecord &record, quint16 servicePort);

--- a/src/bonjour/BonjourServiceResolver.cpp
+++ b/src/bonjour/BonjourServiceResolver.cpp
@@ -55,7 +55,7 @@ void BonjourServiceResolver::resolveBonjourRecord(const BonjourRecord &record) {
 	                          record.serviceName.toUtf8().constData(),
 	                          record.registeredType.toUtf8().constData(),
 	                          record.replyDomain.toUtf8().constData(),
-	                          (DNSServiceResolveReply)bonjourResolveReply, rr);
+	                          static_cast<DNSServiceResolveReply>(bonjourResolveReply), rr);
 
 	if (err == kDNSServiceErr_NoError) {
 		int sockfd = DNSServiceRefSockFD(rr->dnssref);
@@ -89,7 +89,7 @@ void BonjourServiceResolver::bonjourSocketReadyRead(int sockfd) {
 void BonjourServiceResolver::bonjourResolveReply(DNSServiceRef, DNSServiceFlags ,
         quint32 , DNSServiceErrorType errorCode,
         const char *, const char *hosttarget, quint16 port,
-        quint16 , const char *, void *context) {
+        quint16 , const unsigned char *, void *context) {
 	ResolveRecord *rr = static_cast<ResolveRecord *>(context);
 	rr->bsr->qmResolvers.remove(DNSServiceRefSockFD(rr->dnssref));
 

--- a/src/bonjour/BonjourServiceResolver.h
+++ b/src/bonjour/BonjourServiceResolver.h
@@ -68,7 +68,7 @@ class BonjourServiceResolver : public QObject {
 		static void DNSSD_API bonjourResolveReply(DNSServiceRef sdRef, DNSServiceFlags flags,
 		        quint32 interfaceIndex, DNSServiceErrorType errorCode,
 		        const char *fullName, const char *hosttarget, quint16 port,
-		        quint16 txtLen, const char *txtRecord, void *context);
+		        quint16 txtLen, const unsigned char *txtRecord, void *context);
 };
 
 #endif

--- a/src/mumble.pri
+++ b/src/mumble.pri
@@ -43,8 +43,8 @@ unix {
 		PKG_CONFIG = pkg-config --static
 	}
 
-	QMAKE_CFLAGS *= -isystem ../mumble_proto
-	QMAKE_CXXFLAGS *= -isystem ../mumble_proto
+	QMAKE_CFLAGS *= "-isystem ../mumble_proto"
+	QMAKE_CXXFLAGS *= "-isystem ../mumble_proto"
 
 	CONFIG *= link_pkgconfig
 	LIBS *= -lprotobuf


### PR DESCRIPTION
This PR fixes the warnings produced in code we share between mumble and murmur.

On windows the ```static_cast<int> ``` casts for the socket in Connection.cpp are not 100% cosher on Win64. However I'm pretty sure while in theory windows could return bigger handles according to the type there it's safe the assume they never will. On Linux the fd is defined to be int.