### PR TITLE
Reorder server menu

### DIFF
--- a/src/mumble/MainWindow.cpp
+++ b/src/mumble/MainWindow.cpp
@@ -1083,11 +1083,12 @@ void MainWindow::qcbTransmitMode_activated(int index) {
 void MainWindow::on_qmServer_aboutToShow() {
 	qmServer->clear();
 	qmServer->addAction(qaServerConnect);
+	qmServer->addSeparator();
 	qmServer->addAction(qaServerDisconnect);
-	qmServer->addAction(qaServerBanList);
-	qmServer->addAction(qaServerUserList);
 	qmServer->addAction(qaServerInformation);
 	qmServer->addAction(qaServerTokens);
+	qmServer->addAction(qaServerUserList);
+	qmServer->addAction(qaServerBanList);
 	qmServer->addSeparator();
 	qmServer->addAction(qaQuit);
 


### PR DESCRIPTION
I would like to suggest mainly categorizing our menu items with separators, but taking a look at it, also reordering of the items.

Before:
![before](https://cloud.githubusercontent.com/assets/93181/10866309/e636dd7a-8028-11e5-977b-b10256d675b0.png)

After:
![after](https://cloud.githubusercontent.com/assets/93181/10866310/e7ece2fe-8028-11e5-90cc-a40189025566.png)


Reorder menu to a more hierarchical, logical order.
General server action "connect", which is not server specific, separated
from the server specific items. IItems from those that everyone can use to those
used (only) by server admins.


What do you think?
@mkrautz @hacst 