### PR TITLE
Show Minimal View status in title

### DIFF
--- a/src/mumble/MainWindow.cpp
+++ b/src/mumble/MainWindow.cpp
@@ -259,7 +259,7 @@ void MainWindow::createActions() {
 }
 
 void MainWindow::setupGui()  {
-	setWindowTitle(tr("Mumble -- %1").arg(QLatin1String(MUMBLE_RELEASE)));
+	updateWindowTitle();
 	setCentralWidget(qtvUsers);
 	setAcceptDrops(true);
 
@@ -385,6 +385,10 @@ void MainWindow::setupGui()  {
 	qApp->processEvents();
 #endif
 #endif
+}
+
+void MainWindow::updateWindowTitle() {
+	setWindowTitle((g.s.bMinimalView ? tr("Mumble - Minimal View -- %1") : tr("Mumble -- %1")).arg(QLatin1String(MUMBLE_RELEASE)));
 }
 
 // Sets whether or not to show the title bars on the MainWindow's
@@ -2247,6 +2251,7 @@ void MainWindow::on_qaConfigDialog_triggered() {
 
 void MainWindow::on_qaConfigMinimal_triggered() {
 	g.s.bMinimalView = qaConfigMinimal->isChecked();
+	updateWindowTitle();
 	setupView();
 }
 

--- a/src/mumble/MainWindow.h
+++ b/src/mumble/MainWindow.h
@@ -174,6 +174,7 @@ class MainWindow : public QMainWindow, public MessageHandler, public Ui::MainWin
 
 		void createActions();
 		void setupGui();
+		void updateWindowTitle();
 		void customEvent(QEvent *evt) Q_DECL_OVERRIDE;
 		void findDesiredChannel();
 		void setupView(bool toggle_minimize = true);


### PR DESCRIPTION
In the window title, indicate when Mumble is in Minimal View.

This should make it more clear,
especially if not connected to a server when there is *no* content in
the window, that it is not stuck/missing data.
This may also give the user a hint what to search for, if he is
unfamiliar with Minimal Mode.

This was suggested by the contributed usability suggestions from earlier this year.

Normal and in minimal view
![normal](https://cloud.githubusercontent.com/assets/93181/10866883/c590c0be-8045-11e5-852a-2c18fcaaeea6.png) ![minview](https://cloud.githubusercontent.com/assets/93181/10866884/c6b0f02c-8045-11e5-953c-8f4a1d9242c2.png)
