### PR TITLE
Fix various warnings when building on GCC 5.2.1 on i386 (Ubuntu 15.10)

### DIFF
--- a/overlay_gl/overlay.c
+++ b/overlay_gl/overlay.c
@@ -345,7 +345,7 @@ static void drawOverlay(Context *ctx, unsigned int width, unsigned int height) {
 				disconnect(ctx);
 				return;
 			} else if (length != ctx->omMsg.omh.iLength) {
-				ods("Short overlay message read %x %ld/%d", ctx->omMsg.omh.uiType, length, ctx->omMsg.omh.iLength);
+				ods("Short overlay message read %x %zd/%d", ctx->omMsg.omh.uiType, length, ctx->omMsg.omh.iLength);
 				disconnect(ctx);
 				return;
 			}
@@ -363,10 +363,11 @@ static void drawOverlay(Context *ctx, unsigned int width, unsigned int height) {
 							struct stat buf;
 							
 							if (fstat(fd, &buf) != -1) {
-								if (buf.st_size >= ctx->uiWidth * ctx->uiHeight * 4
-								        && buf.st_size < 512 * 1024 * 1024) {
-									ctx->uiMappedLength = (unsigned int)buf.st_size;
-									ctx->a_ucTexture = mmap(NULL, (size_t)buf.st_size, PROT_READ, MAP_SHARED, fd, 0);
+								unsigned int buflen = buf.st_size;
+								if (buflen >= ctx->uiWidth * ctx->uiHeight * 4
+								        && buflen < 512 * 1024 * 1024) {
+									ctx->uiMappedLength = buflen;
+									ctx->a_ucTexture = mmap(NULL, (size_t)buflen, PROT_READ, MAP_SHARED, fd, 0);
 									if (ctx->a_ucTexture != MAP_FAILED) {
 										// mmap successfull; send a new bodyless sharedmemory overlay message and regenerate the overlay texture
 										struct OverlayMsg om;

--- a/src/mumble/OSS.cpp
+++ b/src/mumble/OSS.cpp
@@ -249,7 +249,7 @@ void OSSInput::run() {
 		int len = static_cast<int>(iMicLength * iMicChannels * sizeof(short));
 		ssize_t l = read(fd, buffer, len);
 		if (l != len) {
-			qWarning("OSSInput: Read %ld", l);
+			qWarning("OSSInput: Read %zd", l);
 			break;
 		}
 		addMic(buffer, iMicLength);
@@ -355,7 +355,7 @@ void OSSOutput::run() {
 		if (stillRun) {
 			ssize_t l = write(fd, mbuffer, blocklen);
 			if (l != blocklen) {
-				qWarning("OSSOutput: Write %ld != %ld", l, blocklen);
+				qWarning("OSSOutput: Write %zd != %zd", l, blocklen);
 				break;
 			}
 		} else {
@@ -363,7 +363,7 @@ void OSSOutput::run() {
 				this->msleep(20);
 			ssize_t l = write(fd, mbuffer, blocklen);
 			if (l != blocklen) {
-				qWarning("OSSOutput: Write %ld != %ld", l, blocklen);
+				qWarning("OSSOutput: Write %zd != %zd", l, blocklen);
 				break;
 			}
 		}

--- a/src/mumble/SharedMemory_unix.cpp
+++ b/src/mumble/SharedMemory_unix.cpp
@@ -77,7 +77,7 @@ SharedMemory2::SharedMemory2(QObject *p, unsigned int minsize, const QString &me
 	}
 	struct stat buf;
 	fstat(d->iShmemFD, &buf);
-	off_t memsize = buf.st_size;
+	unsigned int memsize = static_cast<unsigned int>(buf.st_size);
 	if (memsize < minsize) {
 		qWarning() << "SharedMemory2: Segment too small" << memsize << minsize;
 	} else if (memsize > std::numeric_limits<unsigned int>::max()) {
@@ -85,7 +85,7 @@ SharedMemory2::SharedMemory2(QObject *p, unsigned int minsize, const QString &me
 	} else {
 		a_ucData = reinterpret_cast<unsigned char *>(mmap(NULL, minsize, prot, MAP_SHARED, d->iShmemFD, 0));
 		if (a_ucData != reinterpret_cast<unsigned char *>(-1)) {
-			uiSize = static_cast<unsigned int>(memsize);
+			uiSize = memsize;
 			return;
 		}
 		qWarning() << "SharedMemory2: Failed to map shared memory segment" << qsName;


### PR DESCRIPTION
Fixes #1866