### PR TITLE
Add support for moving multiple users/channels

### DIFF
--- a/src/mumble/MainWindow.cpp
+++ b/src/mumble/MainWindow.cpp
@@ -335,6 +335,10 @@ void MainWindow::setupGui()  {
 	        SIGNAL(currentChanged(const QModelIndex &, const QModelIndex &)),
 	        SLOT(qtvUserCurrentChanged(const QModelIndex &, const QModelIndex &)));
 
+	// Deselect channels in multiselection
+	connect(qtvUsers->selectionModel(), SIGNAL(selectionChanged(const QItemSelection&, const QItemSelection&)),
+	        qtvUsers, SLOT(modifySelections(const QItemSelection&, const QItemSelection&)));
+
 	// QtCreator and uic.exe do not allow adding arbitrary widgets
 	// such as a QComboBox to a QToolbar, even though they are supported.
 	qcbTransmitMode = new QComboBox(qtIconToolbar);

--- a/src/mumble/MainWindow.ui
+++ b/src/mumble/MainWindow.ui
@@ -23,6 +23,9 @@
    <property name="contextMenuPolicy">
     <enum>Qt::CustomContextMenu</enum>
    </property>
+   <property name="selectionMode">
+    <enum>QAbstractItemView::ExtendedSelection</enum>
+   </property>
    <property name="acceptDrops">
     <bool>true</bool>
    </property>

--- a/src/mumble/MainWindow.ui
+++ b/src/mumble/MainWindow.ui
@@ -26,6 +26,9 @@
    <property name="selectionMode">
     <enum>QAbstractItemView::ExtendedSelection</enum>
    </property>
+   <property name="selectionBehavior">
+    <enum>QAbstractItemView::SelectRows</enum>
+   </property>
    <property name="acceptDrops">
     <bool>true</bool>
    </property>

--- a/src/mumble/UserModel.cpp
+++ b/src/mumble/UserModel.cpp
@@ -1370,164 +1370,165 @@ bool UserModel::dropMimeData(const QMimeData *md, Qt::DropAction, int row, int c
 
 	QByteArray qba = md->data(mimeTypes().at(0));
 	QDataStream ds(qba);
+	while (! ds.atEnd()) {
+		bool isChannel;
+		int iId = -1;
+		unsigned int uiSession = 0;
+		ds >> isChannel;
 
-	bool isChannel;
-	int iId = -1;
-	unsigned int uiSession = 0;
-	ds >> isChannel;
+		if (isChannel)
+			ds >> iId;
+		else
+			ds >> uiSession;
 
-	if (isChannel)
-		ds >> iId;
-	else
-		ds >> uiSession;
-
-	Channel *c;
-	if (! p.isValid()) {
-		c = Channel::get(0);
-	} else {
-		c = getChannel(p);
-	}
-
-	if (! c)
-		return false;
-
-	expandAll(c);
-
-	if (! isChannel) {
-		// User dropped somewhere
-		MumbleProto::UserState mpus;
-		mpus.set_session(uiSession);
-		mpus.set_channel_id(c->iId);
-		g.sh->sendMessage(mpus);
-	} else if (c->iId != iId) {
-		// Channel dropped somewhere (not on itself)
-		int ret;
-		switch (g.s.ceChannelDrag) {
-			case Settings::Ask:
-				ret=QMessageBox::question(g.mw, QLatin1String("Mumble"), tr("Are you sure you want to drag this channel?"), QMessageBox::Yes, QMessageBox::No);
-
-				if (ret == QMessageBox::No)
-					return false;
-				break;
-			case Settings::DoNothing:
-				g.l->log(Log::Information, MainWindow::tr("You have Channel Dragging set to \"Do Nothing\" so the channel wasn't moved."));
-				return false;
-				break;
-			case Settings::Move:
-				break;
-			default:
-				g.l->log(Log::CriticalError, MainWindow::tr("Unknown Channel Drag mode in UserModel::dropMimeData."));
-				return false;
-				break;
+		Channel *c;
+		if (! p.isValid()) {
+			c = Channel::get(0);
+		} else {
+			c = getChannel(p);
 		}
 
-		long long inewpos = 0;
-		Channel *dropped = Channel::c_qhChannels.value(iId);
-
-		if (! dropped)
+		if (! c)
 			return false;
 
-		if (p.isValid()) {
-			ModelItem *pi = static_cast<ModelItem *>(p.internalPointer());
-			if (pi->pUser)
-				pi = pi->parent;
+		expandAll(c);
 
-			int ifirst = 0;
-			int ilast = pi->rows() - 1;
+		if (! isChannel) {
+			// User dropped somewhere
+			MumbleProto::UserState mpus;
+			mpus.set_session(uiSession);
+			mpus.set_channel_id(c->iId);
+			g.sh->sendMessage(mpus);
+		} else if (c->iId != iId) {
+			// Channel dropped somewhere (not on itself)
+			int ret;
+			switch (g.s.ceChannelDrag) {
+				case Settings::Ask:
+					ret=QMessageBox::question(g.mw, QLatin1String("Mumble"), tr("Are you sure you want to drag this channel?"), QMessageBox::Yes, QMessageBox::No);
 
-			if (ilast > 0) {
-				while (pi->userAt(ifirst) && ifirst < ilast) ifirst++;
-				while (pi->userAt(ilast) && ilast > 0) ilast--;
+					if (ret == QMessageBox::No)
+						return false;
+					break;
+				case Settings::DoNothing:
+					g.l->log(Log::Information, MainWindow::tr("You have Channel Dragging set to \"Do Nothing\" so the channel wasn't moved."));
+					return false;
+					break;
+				case Settings::Move:
+					break;
+				default:
+					g.l->log(Log::CriticalError, MainWindow::tr("Unknown Channel Drag mode in UserModel::dropMimeData."));
+					return false;
+					break;
 			}
 
-			if (row == -1 && column == -1) {
-				// Dropped on item
-				if (getUser(p)) {
-					// Dropped on player
-					if (ilast > 0) {
-						if (pi->bUsersTop) {
-							if (pi->channelAt(ifirst) == dropped || NAMECMPCHANNEL(pi->channelAt(ifirst), dropped)) {
-								if (dropped->iPosition ==  pi->channelAt(ifirst)->iPosition) return true;
-								inewpos = pi->channelAt(ifirst)->iPosition;
+			long long inewpos = 0;
+			Channel *dropped = Channel::c_qhChannels.value(iId);
+
+			if (! dropped)
+				return false;
+
+			if (p.isValid()) {
+				ModelItem *pi = static_cast<ModelItem *>(p.internalPointer());
+				if (pi->pUser)
+					pi = pi->parent;
+
+				int ifirst = 0;
+				int ilast = pi->rows() - 1;
+
+				if (ilast > 0) {
+					while (pi->userAt(ifirst) && ifirst < ilast) ifirst++;
+					while (pi->userAt(ilast) && ilast > 0) ilast--;
+				}
+
+				if (row == -1 && column == -1) {
+					// Dropped on item
+					if (getUser(p)) {
+						// Dropped on player
+						if (ilast > 0) {
+							if (pi->bUsersTop) {
+								if (pi->channelAt(ifirst) == dropped || NAMECMPCHANNEL(pi->channelAt(ifirst), dropped)) {
+									if (dropped->iPosition ==  pi->channelAt(ifirst)->iPosition) return true;
+									inewpos = pi->channelAt(ifirst)->iPosition;
+								} else {
+									inewpos = static_cast<long long>(pi->channelAt(ifirst)->iPosition) - 20;
+								}
 							} else {
-								inewpos = static_cast<long long>(pi->channelAt(ifirst)->iPosition) - 20;
-							}
-						} else {
-							if (dropped == pi->channelAt(ilast) || NAMECMPCHANNEL(dropped, pi->channelAt(ilast))) {
-								if (pi->channelAt(ilast)->iPosition == dropped->iPosition) return true;
-								inewpos = pi->channelAt(ilast)->iPosition;
-							} else {
-								inewpos = static_cast<long long>(pi->channelAt(ilast)->iPosition) + 20;
+								if (dropped == pi->channelAt(ilast) || NAMECMPCHANNEL(dropped, pi->channelAt(ilast))) {
+									if (pi->channelAt(ilast)->iPosition == dropped->iPosition) return true;
+									inewpos = pi->channelAt(ilast)->iPosition;
+								} else {
+									inewpos = static_cast<long long>(pi->channelAt(ilast)->iPosition) + 20;
+								}
 							}
 						}
-					}
-				}
-			} else {
-				// Dropped between items
-				if (ilast == 0) {
-					// No channels in there yet
-				} else if (row <= ifirst) {
-					if (pi->channelAt(ifirst) == dropped || NAMECMPCHANNEL(pi->channelAt(ifirst), dropped)) {
-						if (dropped->iPosition ==  pi->channelAt(ifirst)->iPosition) return true;
-						inewpos = pi->channelAt(ifirst)->iPosition;
-					} else {
-						inewpos = static_cast<long long>(pi->channelAt(ifirst)->iPosition) - 20;
-					}
-				} else if (row > ilast) {
-					if (dropped == pi->channelAt(ilast) || NAMECMPCHANNEL(dropped, pi->channelAt(ilast))) {
-						if (pi->channelAt(ilast)->iPosition == dropped->iPosition) return true;
-						inewpos = pi->channelAt(ilast)->iPosition;
-					} else {
-						inewpos = static_cast<long long>(pi->channelAt(ilast)->iPosition) + 20;
 					}
 				} else {
-					// Dropped between channels
-					Channel *lower = pi->channelAt(row);
-					Channel *upper = pi->channelAt(row - 1);
-
-					if (lower->iPosition == upper->iPosition && NAMECMPCHANNEL(lower, dropped) && NAMECMPCHANNEL(dropped, upper)) {
-						inewpos = upper->iPosition;
-					} else if (lower->iPosition > upper->iPosition && NAMECMPCHANNEL(lower, dropped)) {
-						inewpos = lower->iPosition;
-					} else if (lower->iPosition > upper->iPosition && NAMECMPCHANNEL(dropped, upper)) {
-						inewpos = upper->iPosition;
-					} else if (lower == dropped || upper == dropped) {
-						return true;
-					} else if (abs(lower->iPosition) - abs(upper->iPosition) > 1) {
-						inewpos = upper->iPosition + (abs(lower->iPosition) - abs(upper->iPosition))/2;
+					// Dropped between items
+					if (ilast == 0) {
+						// No channels in there yet
+					} else if (row <= ifirst) {
+						if (pi->channelAt(ifirst) == dropped || NAMECMPCHANNEL(pi->channelAt(ifirst), dropped)) {
+							if (dropped->iPosition ==  pi->channelAt(ifirst)->iPosition) return true;
+							inewpos = pi->channelAt(ifirst)->iPosition;
+						} else {
+							inewpos = static_cast<long long>(pi->channelAt(ifirst)->iPosition) - 20;
+						}
+					} else if (row > ilast) {
+						if (dropped == pi->channelAt(ilast) || NAMECMPCHANNEL(dropped, pi->channelAt(ilast))) {
+							if (pi->channelAt(ilast)->iPosition == dropped->iPosition) return true;
+							inewpos = pi->channelAt(ilast)->iPosition;
+						} else {
+							inewpos = static_cast<long long>(pi->channelAt(ilast)->iPosition) + 20;
+						}
 					} else {
-						// Not enough space, other channels have to be moved
-						if (static_cast<long long>(pi->channelAt(ilast)->iPosition) + 40 > INT_MAX) {
-							QMessageBox::critical(g.mw, QLatin1String("Mumble"), tr("Cannot perform this movement automatically, please reset the numeric sorting indicators or adjust it manually."));
-							return false;
-						}
-						for (int i = row; i <= ilast; i++) {
-							Channel *tmp = pi->channelAt(i);
-							if (tmp != dropped) {
-								MumbleProto::ChannelState mpcs;
-								mpcs.set_channel_id(tmp->iId);
-								mpcs.set_position(tmp->iPosition + 40);
-								g.sh->sendMessage(mpcs);
+						// Dropped between channels
+						Channel *lower = pi->channelAt(row);
+						Channel *upper = pi->channelAt(row - 1);
 
+						if (lower->iPosition == upper->iPosition && NAMECMPCHANNEL(lower, dropped) && NAMECMPCHANNEL(dropped, upper)) {
+							inewpos = upper->iPosition;
+						} else if (lower->iPosition > upper->iPosition && NAMECMPCHANNEL(lower, dropped)) {
+							inewpos = lower->iPosition;
+						} else if (lower->iPosition > upper->iPosition && NAMECMPCHANNEL(dropped, upper)) {
+							inewpos = upper->iPosition;
+						} else if (lower == dropped || upper == dropped) {
+							return true;
+						} else if (abs(lower->iPosition) - abs(upper->iPosition) > 1) {
+							inewpos = upper->iPosition + (abs(lower->iPosition) - abs(upper->iPosition))/2;
+						} else {
+							// Not enough space, other channels have to be moved
+							if (static_cast<long long>(pi->channelAt(ilast)->iPosition) + 40 > INT_MAX) {
+								QMessageBox::critical(g.mw, QLatin1String("Mumble"), tr("Cannot perform this movement automatically, please reset the numeric sorting indicators or adjust it manually."));
+								return false;
 							}
+							for (int i = row; i <= ilast; i++) {
+								Channel *tmp = pi->channelAt(i);
+								if (tmp != dropped) {
+									MumbleProto::ChannelState mpcs;
+									mpcs.set_channel_id(tmp->iId);
+									mpcs.set_position(tmp->iPosition + 40);
+									g.sh->sendMessage(mpcs);
+
+								}
+							}
+							inewpos = upper->iPosition + 20;
 						}
-						inewpos = upper->iPosition + 20;
 					}
 				}
 			}
-		}
 
-		if (inewpos > INT_MAX || inewpos < INT_MIN) {
-			QMessageBox::critical(g.mw, QLatin1String("Mumble"), tr("Cannot perform this movement automatically, please reset the numeric sorting indicators or adjust it manually."));
-			return false;
-		}
+			if (inewpos > INT_MAX || inewpos < INT_MIN) {
+				QMessageBox::critical(g.mw, QLatin1String("Mumble"), tr("Cannot perform this movement automatically, please reset the numeric sorting indicators or adjust it manually."));
+				return false;
+			}
 
-		MumbleProto::ChannelState mpcs;
-		mpcs.set_channel_id(iId);
-		if (dropped->parent() != c)
-			mpcs.set_parent(c->iId);
-		mpcs.set_position(static_cast<int>(inewpos));
-		g.sh->sendMessage(mpcs);
+			MumbleProto::ChannelState mpcs;
+			mpcs.set_channel_id(iId);
+			if (dropped->parent() != c)
+				mpcs.set_parent(c->iId);
+			mpcs.set_position(static_cast<int>(inewpos));
+			g.sh->sendMessage(mpcs);
+		}
 	}
 
 	return true;

--- a/src/mumble/UserModel.cpp
+++ b/src/mumble/UserModel.cpp
@@ -1372,7 +1372,7 @@ bool UserModel::dropMimeData(const QMimeData *md, Qt::DropAction, int row, int c
 	QDataStream ds(qba);
 
 	// Check if there's more than one entry.  Assume uiSession and iId are same size.
-	bool isMultiSelect = qba.size() > (sizeof(bool) + sizeof( ((ClientUser*)0)->uiSession) );
+	bool isMultiSelect = static_cast<unsigned int>(qba.size()) > (sizeof(bool) + sizeof( ((ClientUser*)0)->uiSession) );
 
 	while (! ds.atEnd()) {
 		bool isChannel;

--- a/src/mumble/UserModel.cpp
+++ b/src/mumble/UserModel.cpp
@@ -1370,6 +1370,10 @@ bool UserModel::dropMimeData(const QMimeData *md, Qt::DropAction, int row, int c
 
 	QByteArray qba = md->data(mimeTypes().at(0));
 	QDataStream ds(qba);
+
+	// Check if there's more than one entry.  Assume uiSession and iId are same size.
+	bool isMultiSelect = qba.size() > (sizeof(bool) + sizeof( ((ClientUser*)0)->uiSession) );
+
 	while (! ds.atEnd()) {
 		bool isChannel;
 		int iId = -1;
@@ -1399,6 +1403,9 @@ bool UserModel::dropMimeData(const QMimeData *md, Qt::DropAction, int row, int c
 			mpus.set_session(uiSession);
 			mpus.set_channel_id(c->iId);
 			g.sh->sendMessage(mpus);
+		} else if (isMultiSelect) {
+			// Ignore channels in multiselection (only move users)
+			continue;
 		} else if (c->iId != iId) {
 			// Channel dropped somewhere (not on itself)
 			int ret;

--- a/src/mumble/UserView.cpp
+++ b/src/mumble/UserView.cpp
@@ -385,6 +385,29 @@ void UserView::updateChannel(const QModelIndex &idx) {
 	}
 }
 
+void UserView::modifySelections(const QItemSelection &selected, const QItemSelection &deselected) {
+	// These args are selection deltas instead of entire selections, so ignore them
+	(void) selected;
+	(void) deselected;
+
+	QModelIndexList indices = selectionModel()->selectedIndexes();
+
+	// Ignore single selections
+	if (indices.size() <= 1) {
+		return;
+	}
+
+	// Block selection model signals to prevent infinite recursion.
+	selectionModel()->blockSignals(true);
+	foreach (const QModelIndex& idx, indices) {
+		bool isChannel = static_cast<ModelItem *>(idx.internalPointer())->cChan != NULL;
+		if (isChannel) {
+			selectionModel()->select(idx, QItemSelectionModel::Deselect);
+		}
+	}
+	selectionModel()->blockSignals(false);
+}
+
 #if QT_VERSION >= 0x050000
 void UserView::dataChanged ( const QModelIndex & topLeft, const QModelIndex & bottomRight, const QVector<int> &)
 #else

--- a/src/mumble/UserView.h
+++ b/src/mumble/UserView.h
@@ -87,6 +87,7 @@ class UserView : public QTreeView {
 		void nodeActivated(const QModelIndex &idx);
 		void selectSearchResult();
 		void updateChannel(const QModelIndex &index);
+		void modifySelections(const QItemSelection &selected, const QItemSelection &deselected);
 };
 
 #endif


### PR DESCRIPTION
The ability to move multiple users/channels at once has been a requested feature for several years now (e.g. https://github.com/mumble-voip/mumble/issues/1829).  This is a simple 5-line change that extends the drag-and-drop movement by allowing multiple selections (using ctrl, shift, or mouse drag).

This will NOT do other bulk actions (mute, PM, kick/ban, etc), because I think that's a whole different can of worms based on how controls are implemented.

I've tested this in private builds for personal use for about a year now, and the basic functionality works fine, but there may be some undefined or unwanted behaviors:
- Right-click context menu after a multi-select will clear selections
- Log will still show one message per user/channel moved, which can kind of clutter up the log window
- Multiple channel movement will show a prompt for every channel in selection (which can get annoying), and will not show channel name in prompt ("Are you sure you want to drag this channel?")
- User and Channel context menus do not support multiple selections.  In fact, I think they reflect the user/channel most recently added to selection (or most recently serialized to QDataStream)
- Technically allows both users and channels to be selected and moved together, but who knows what spooky things might happen because of that?

I'm not particularly well versed in QT, so if there's something that I've broken or implemented poorly with this change, please let me know.

This is not meant to be a comprehensive feature addition, but hopefully it's a start and will better allow channel operators to better deal with large groups of users.

Fixes #1829