### PR TITLE
FreeBSD can use pkgconfig too

### DIFF
--- a/src/mumble.pri
+++ b/src/mumble.pri
@@ -37,8 +37,6 @@ win32 {
 }
 
 unix {
-	UNAME=$$system(uname -s)
-
 	CONFIG(static) {
 		PKG_CONFIG = pkg-config --static
 	}
@@ -48,12 +46,7 @@ unix {
 
 	CONFIG *= link_pkgconfig
 	LIBS *= -lprotobuf
-
-	contains(UNAME, FreeBSD) {
-		LIBS *= -lcrypto
-	} else {
-		PKGCONFIG *= openssl
-	}
+	PKGCONFIG *= openssl
 }
 
 # Make Q_DECL_OVERRIDE and Q_DECL_FINAL no-ops


### PR DESCRIPTION
FreeBSD fails to build without also having -lssl passed. I'm not sure
why this is treating FreeBSD as a special snowflake and only passing
-lcrypto. We can use pkgconfig, so just do that.