### PR TITLE
add per-channel user limit

### DIFF
--- a/src/Channel.cpp
+++ b/src/Channel.cpp
@@ -45,6 +45,7 @@ Channel::Channel(int id, const QString &name, QObject *p) : QObject(p) {
 	iPosition = 0;
 	qsName = name;
 	bInheritACL = true;
+	uiMaxUsers = 0;
 	bTemporary = false;
 	cParent = qobject_cast<Channel *>(p);
 	if (cParent)

--- a/src/Channel.h
+++ b/src/Channel.h
@@ -68,6 +68,10 @@ class Channel : public QObject {
 
 		bool bInheritACL;
 
+		/// Maximum number of users allowed in the channel. If this
+		/// value is zero, the maximum number of users allowed in the
+		/// channel is given by the server's "usersperchannel"
+		/// setting.
 		unsigned int uiMaxUsers;
 
 		Channel(int id, const QString &name, QObject *p = NULL);

--- a/src/Channel.h
+++ b/src/Channel.h
@@ -68,6 +68,8 @@ class Channel : public QObject {
 
 		bool bInheritACL;
 
+		unsigned int uiMaxUsers;
+
 		Channel(int id, const QString &name, QObject *p = NULL);
 		~Channel();
 

--- a/src/Mumble.proto
+++ b/src/Mumble.proto
@@ -134,7 +134,9 @@ message ChannelState {
 	optional int32 position = 9 [default = 0];
 	// SHA1 hash of the description if the description is 128 bytes or more.
 	optional bytes description_hash = 10;
-	// Maximum number of users allowed in the channel.
+	// Maximum number of users allowed in the channel. If this value is zero,
+	// the maximum number of users allowed in the channel is given by the
+	// server's "usersperchannel" setting.
 	optional uint32 max_users = 11;
 }
 

--- a/src/Mumble.proto
+++ b/src/Mumble.proto
@@ -134,6 +134,8 @@ message ChannelState {
 	optional int32 position = 9 [default = 0];
 	// SHA1 hash of the description if the description is 128 bytes or more.
 	optional bytes description_hash = 10;
+	// Maximum number of users allowed in the channel.
+	optional uint32 max_users = 11;
 }
 
 // Used to communicate user leaving or being kicked. May be sent by the client

--- a/src/mumble/ACLEditor.cpp
+++ b/src/mumble/ACLEditor.cpp
@@ -63,6 +63,9 @@ ACLEditor::ACLEditor(int channelparentid, QWidget *p) : QDialog(p) {
 	qleChannelPassword->hide();
 	qlChannelPassword->hide();
 
+	qlChannelMaxUsers->hide();
+	qsbChannelMaxUsers->hide();
+
 	qlChannelID->hide();
 
 	qleChannelName->setFocus();
@@ -103,6 +106,9 @@ ACLEditor::ACLEditor(int channelid, const MumbleProto::ACL &mea, QWidget *p) : Q
 
 	qsbChannelPosition->setRange(INT_MIN, INT_MAX);
 	qsbChannelPosition->setValue(pChannel->iPosition);
+
+	qsbChannelMaxUsers->setRange(0, INT_MAX);
+	qsbChannelMaxUsers->setValue(pChannel->uiMaxUsers);
 
 	QGridLayout *grid = new QGridLayout(qgbACLpermissions);
 
@@ -280,6 +286,10 @@ void ACLEditor::accept() {
 		}
 		if (pChannel->iPosition != qsbChannelPosition->value()) {
 			mpcs.set_position(qsbChannelPosition->value());
+			needs_update = true;
+		}
+		if (pChannel->uiMaxUsers != (unsigned int)qsbChannelMaxUsers->value()) {
+			mpcs.set_max_users(qsbChannelMaxUsers->value());
 			needs_update = true;
 		}
 		if (needs_update)

--- a/src/mumble/ACLEditor.cpp
+++ b/src/mumble/ACLEditor.cpp
@@ -107,9 +107,14 @@ ACLEditor::ACLEditor(int channelid, const MumbleProto::ACL &mea, QWidget *p) : Q
 	qsbChannelPosition->setRange(INT_MIN, INT_MAX);
 	qsbChannelPosition->setValue(pChannel->iPosition);
 
-	qsbChannelMaxUsers->setRange(0, INT_MAX);
-	qsbChannelMaxUsers->setValue(pChannel->uiMaxUsers);
-	qsbChannelMaxUsers->setSpecialValueText(tr("Default server value"));
+	if (g.sh->uiVersion >= 0x010300) {
+		qsbChannelMaxUsers->setRange(0, INT_MAX);
+		qsbChannelMaxUsers->setValue(pChannel->uiMaxUsers);
+		qsbChannelMaxUsers->setSpecialValueText(tr("Default server value"));
+	} else {
+		qlChannelMaxUsers->hide();
+		qsbChannelMaxUsers->hide();
+	}
 
 	QGridLayout *grid = new QGridLayout(qgbACLpermissions);
 

--- a/src/mumble/ACLEditor.cpp
+++ b/src/mumble/ACLEditor.cpp
@@ -288,7 +288,7 @@ void ACLEditor::accept() {
 			mpcs.set_position(qsbChannelPosition->value());
 			needs_update = true;
 		}
-		if (pChannel->uiMaxUsers != (unsigned int)qsbChannelMaxUsers->value()) {
+		if (pChannel->uiMaxUsers != static_cast<unsigned int>(qsbChannelMaxUsers->value())) {
 			mpcs.set_max_users(qsbChannelMaxUsers->value());
 			needs_update = true;
 		}

--- a/src/mumble/ACLEditor.cpp
+++ b/src/mumble/ACLEditor.cpp
@@ -109,6 +109,7 @@ ACLEditor::ACLEditor(int channelid, const MumbleProto::ACL &mea, QWidget *p) : Q
 
 	qsbChannelMaxUsers->setRange(0, INT_MAX);
 	qsbChannelMaxUsers->setValue(pChannel->uiMaxUsers);
+	qsbChannelMaxUsers->setSpecialValueText(tr("Default server value"));
 
 	QGridLayout *grid = new QGridLayout(qgbACLpermissions);
 

--- a/src/mumble/ACLEditor.ui
+++ b/src/mumble/ACLEditor.ui
@@ -88,6 +88,30 @@ This value enables you to change the way Mumble arranges the channels in the tre
          </property>
         </widget>
        </item>
+       <item row="8" column="0">
+        <widget class="QLabel" name="qlChannelMaxUsers">
+         <property name="text">
+          <string>Maximum Users</string>
+         </property>
+        </widget>
+       </item>
+       <item row="8" column="1">
+        <widget class="QSpinBox" name="qsbChannelMaxUsers">
+         <property name="maximumSize">
+          <size>
+           <width>16777215</width>
+           <height>16777215</height>
+          </size>
+         </property>
+         <property name="toolTip">
+          <string>Maximum number of users allowed in the channel</string>
+         </property>
+         <property name="whatsThis">
+          <string>&lt;b&gt;Maximum Users&lt;/b&gt;&lt;br /&gt;
+This value allows you to set the maximum number of users allowed in the channel. If the value is above zero, only that number of users will be allowed to enter the channel. If the value is zero, the maximum number of users in the channel is given by the server's default limit.</string>
+         </property>
+        </widget>
+       </item>
        <item row="10" column="1">
         <widget class="QCheckBox" name="qcbChannelTemporary">
          <property name="toolTip">
@@ -668,6 +692,7 @@ Contains the list of members inherited by the current channel. Uncheck &lt;i&gt;
  <tabstops>
   <tabstop>qleChannelPassword</tabstop>
   <tabstop>qsbChannelPosition</tabstop>
+  <tabstop>qsbChannelMaxUsers</tabstop>
   <tabstop>qcbChannelTemporary</tabstop>
   <tabstop>qcbGroupList</tabstop>
   <tabstop>qpbGroupAdd</tabstop>

--- a/src/mumble/Messages.cpp
+++ b/src/mumble/Messages.cpp
@@ -669,6 +669,10 @@ void MainWindow::msgChannelState(const MumbleProto::ChannelState &msg) {
 		if (! ql.isEmpty())
 			pmModel->linkChannels(c, ql);
 	}
+
+	if (msg.has_max_users()) {
+		c->uiMaxUsers = msg.max_users();
+	}
 }
 
 void MainWindow::msgChannelRemove(const MumbleProto::ChannelRemove &msg) {

--- a/src/murmur/Messages.cpp
+++ b/src/murmur/Messages.cpp
@@ -257,6 +257,8 @@ void Server::msgAuthenticate(ServerUser *uSource, MumbleProto::Authenticate &msg
 		else if (! c->qsDesc.isEmpty())
 			mpcs.set_description(u8(c->qsDesc));
 
+		mpcs.set_max_users(c->uiMaxUsers);
+
 		sendMessage(uSource, mpcs);
 
 		foreach(c, c->qlChannels)
@@ -518,7 +520,12 @@ void Server::msgUserState(ServerUser *uSource, MumbleProto::UserState &msg) {
 			PERM_DENIED(pDstServerUser, c, ChanACL::Enter);
 			return;
 		}
-		if (iMaxUsersPerChannel && (c->qlUsers.count() >= iMaxUsersPerChannel)) {
+		if (c->uiMaxUsers) {
+			if ((unsigned int)c->qlUsers.count() >= c->uiMaxUsers) {
+				PERM_DENIED_FALLBACK(ChannelFull, 0x010201, QLatin1String("Channel is full"));
+				return;
+			}
+		} else if (iMaxUsersPerChannel && (c->qlUsers.count() >= iMaxUsersPerChannel)) {
 			PERM_DENIED_FALLBACK(ChannelFull, 0x010201, QLatin1String("Channel is full"));
 			return;
 		}
@@ -1060,6 +1067,9 @@ void Server::msgChannelState(ServerUser *uSource, MumbleProto::ChannelState &msg
 		foreach(Channel *l, qlRemove) {
 			removeLink(c, l);
 		}
+
+		if (msg.has_max_users())
+			c->uiMaxUsers = msg.max_users();
 
 		updateChannel(c);
 		emit channelStateChanged(c);

--- a/src/murmur/Messages.cpp
+++ b/src/murmur/Messages.cpp
@@ -521,7 +521,7 @@ void Server::msgUserState(ServerUser *uSource, MumbleProto::UserState &msg) {
 			return;
 		}
 		if (c->uiMaxUsers) {
-			if ((unsigned int)c->qlUsers.count() >= c->uiMaxUsers) {
+			if (static_cast<unsigned int>(c->qlUsers.count()) >= c->uiMaxUsers) {
 				PERM_DENIED_FALLBACK(ChannelFull, 0x010201, QLatin1String("Channel is full"));
 				return;
 			}

--- a/src/murmur/ServerDB.cpp
+++ b/src/murmur/ServerDB.cpp
@@ -1401,6 +1401,13 @@ void Server::updateChannel(const Channel *c) {
 	query.addBindValue(QVariant(c->iPosition).toString());
 	SQLEXEC();
 
+	// Update channel maximum users
+	query.addBindValue(iServerNum);
+	query.addBindValue(c->iId);
+	query.addBindValue(ServerDB::Channel_Max_Users);
+	query.addBindValue(QVariant(c->uiMaxUsers).toString());
+	SQLEXEC();
+
 	SQLPREP("DELETE FROM `%1groups` WHERE `server_id` = ? AND `channel_id` = ?");
 	query.addBindValue(iServerNum);
 	query.addBindValue(c->iId);
@@ -1480,6 +1487,8 @@ void Server::readChannelPrivs(Channel *c) {
 			hashAssign(c->qsDesc, c->qbaDescHash, value);
 		} else if (key == ServerDB::Channel_Position) {
 			c->iPosition = QVariant(value).toInt(); // If the conversion fails it'll return the default value 0
+		} else if (key == ServerDB::Channel_Max_Users) {
+			c->uiMaxUsers = QVariant(value).toUInt(); // If the conversion fails it'll return the default value 0
 		}
 	}
 

--- a/src/murmur/ServerDB.h
+++ b/src/murmur/ServerDB.h
@@ -43,7 +43,7 @@ class QSqlQuery;
 
 class ServerDB {
 	public:
-		enum ChannelInfo { Channel_Description, Channel_Position };
+		enum ChannelInfo { Channel_Description, Channel_Position, Channel_Max_Users };
 		enum UserInfo { User_Name, User_Email, User_Comment, User_Hash, User_Password, User_LastActive, User_KDFIterations };
 		ServerDB();
 		~ServerDB();


### PR DESCRIPTION
Adds ability to set per-channel user limit from the Mumble client.

Fixes #1619, #1882