### PR TITLE
add "maximum users" to control channel protocol

### DIFF
--- a/src/Mumble.proto
+++ b/src/Mumble.proto
@@ -529,6 +529,8 @@ message ServerConfig {
 	optional uint32 message_length = 4;
 	// Maximum image message length.
 	optional uint32 image_message_length = 5;
+	// The maximum number of users allowed on the server.
+	optional uint32 max_users = 6;
 }
 
 // Sent by the server to inform the clients of suggested client configuration

--- a/src/mumble/Global.cpp
+++ b/src/mumble/Global.cpp
@@ -97,6 +97,7 @@ Global::Global() {
 	bAllowHTML = true;
 	uiMessageLength = 5000;
 	uiImageLength = 131072;
+	uiMaxUsers = 0;
 
 	qs = NULL;
 

--- a/src/mumble/Global.h
+++ b/src/mumble/Global.h
@@ -103,6 +103,7 @@ public:
 	bool bAllowHTML;
 	unsigned int uiMessageLength;
 	unsigned int uiImageLength;
+	unsigned int uiMaxUsers;
 	bool bQuit;
 
 	bool bHappyEaster;

--- a/src/mumble/MainWindow.cpp
+++ b/src/mumble/MainWindow.cpp
@@ -1229,6 +1229,9 @@ void MainWindow::on_qaServerInformation_triggered() {
 	                  QString::fromLatin1("%1").arg(sqrt(boost::accumulators::variance(g.sh->accTCP)),0,'f',2),
 	                  Qt::escape(host),
 	                  QString::number(port));
+	if (g.uiMaxUsers) {
+		qsControl += tr("<p>Connected users: %1/%2</p>").arg(ModelItem::c_qhUsers.count()).arg(g.uiMaxUsers);
+	}
 
 	QString qsVoice, qsCrypt, qsAudio;
 
@@ -2649,6 +2652,7 @@ void MainWindow::serverConnected() {
 	g.bAllowHTML = true;
 	g.uiMessageLength = 5000;
 	g.uiImageLength = 131072;
+	g.uiMaxUsers = 0;
 
 	if (g.s.bMute || g.s.bDeaf) {
 		g.sh->setSelfMuteDeafState(g.s.bMute, g.s.bDeaf);

--- a/src/mumble/Messages.cpp
+++ b/src/mumble/Messages.cpp
@@ -190,6 +190,8 @@ void MainWindow::msgServerConfig(const MumbleProto::ServerConfig &msg) {
 		g.uiMessageLength = msg.message_length();
 	if (msg.has_image_message_length())
 		g.uiImageLength = msg.image_message_length();
+	if (msg.has_max_users())
+		g.uiMaxUsers = msg.max_users();
 }
 
 void MainWindow::msgPermissionDenied(const MumbleProto::PermissionDenied &msg) {

--- a/src/murmur/Messages.cpp
+++ b/src/murmur/Messages.cpp
@@ -396,6 +396,7 @@ void Server::msgAuthenticate(ServerUser *uSource, MumbleProto::Authenticate &msg
 	mpsc.set_allow_html(bAllowHTML);
 	mpsc.set_message_length(iMaxTextMessageLength);
 	mpsc.set_image_message_length(iMaxImageMessageLength);
+	mpsc.set_max_users(iMaxUsers);
 	sendMessage(uSource, mpsc);
 
 	MumbleProto::SuggestConfig mpsug;

--- a/src/murmur/Server.cpp
+++ b/src/murmur/Server.cpp
@@ -486,6 +486,10 @@ void Server::setLiveConf(const QString &key, const QString &value) {
 		for (int id = 1; id < iMaxUsers * 2; ++id)
 			if (!qhUsers.contains(id))
 				qqIds.enqueue(id);
+
+		MumbleProto::ServerConfig mpsc;
+		mpsc.set_max_users(iMaxUsers);
+		sendAll(mpsc);
 	} else if (key == "usersperchannel")
 		iMaxUsersPerChannel = i ? i : Meta::mp.iMaxUsersPerChannel;
 	else if (key == "textmessagelength") {


### PR DESCRIPTION
Since this information is provided by the UDP ping protocol, it makes sense to include it to the control protocol too. This is helpful on servers that do not have UDP pings enabled.