### PR TITLE
FreeBSD needs unistd.h or the __int64 typedef fails

### DIFF
--- a/src/mumble/mumble_pch.hpp
+++ b/src/mumble/mumble_pch.hpp
@@ -39,6 +39,9 @@
 #ifdef Q_OS_WIN
 #define ENABLE_SNDFILE_WINDOWS_PROTOTYPES 1
 #endif
+#ifdef __FreeBSD__
+#include <unistd.h>
+#endif
 #define __int64_t __int64
 #include <sndfile.h>
 #undef __int64_t


### PR DESCRIPTION
Example of failure:

    In file included from mumble_pch.hpp:46:
    In file included from /usr/local/include/sndfile.h:33:
    /usr/include/sys/types.h:71:9: fatal error: unknown type name '__int64'
    typedef __int64_t       quad_t;
            ^
    mumble_pch.hpp:45:19: note: expanded from macro '__int64_t'
    #define __int64_t __int64
                      ^
    92 warnings and 1 error generated.