### PR TITLE
Log: do not apply QApplication's stylesheet to the temporary LogDocument used in validHtml().

### DIFF
--- a/src/mumble/Log.cpp
+++ b/src/mumble/Log.cpp
@@ -402,7 +402,11 @@ QString Log::validHtml(const QString &html, bool allowReplacement, QTextCursor *
 
 	QRectF qr = dw.availableGeometry(dw.screenNumber(g.mw));
 	qtd.setTextWidth(qr.width() / 2);
-	qtd.setDefaultStyleSheet(qApp->styleSheet());
+
+	// Ensure we are not using a stylesheet in our LogDocument.
+	// If a stylesheet is set, its styling will leak out into
+	// the HTML returned by the LogDocument's toHtml() method.
+	qtd.setDefaultStyleSheet(QLatin1String(""));
 
 	// Call documentLayout on our LogDocument to ensure
 	// it has a layout backing it. With a layout set on


### PR DESCRIPTION
Do not apply our theme's stylesheet to the LogDocument used in validHtml().

We use the LogDocument to check whether the passed-in HTML is valid
and if it is of a reasonable size. To do that, we insert the HTML we
have to validate into the LogDocument. Then we use use the LogDocument
to check the validity, size, and so on. If everthing is OK, we retrieve
the HTML again via toHtml().

Unfortunately, if our theme's stylesheet is set on the LogDocument, its
styles will leak out in the HTML output by the LogDocument.

This change modifies the validHtml() function to use an empty stylesheet,
to avoid any modifications to the passed-in HTML.

Fixes mumble-voip/mumble#1748