### PR TITLE
Fix unused-parameter error

### DIFF
--- a/src/mumble/GlobalShortcut_unix.cpp
+++ b/src/mumble/GlobalShortcut_unix.cpp
@@ -300,7 +300,7 @@ void GlobalShortcutX::inputReadyRead(int) {
 #define test_bit(bit, array)    (array[bit/8] & (1<<(bit%8)))
 
 // The /dev/input directory changed
-void GlobalShortcutX::directoryChanged(const QString &dir) {
+void GlobalShortcutX::directoryChanged(const QString &) {
 #ifdef Q_OS_LINUX
 	if (!g.s.bEnableEvdev) {
 		return;


### PR DESCRIPTION
Clang on FreeBSD picked this up. References issue #1896 