### PR TITLE
Improve OSS device closing

### DIFF
--- a/src/mumble/OSS.cpp
+++ b/src/mumble/OSS.cpp
@@ -221,20 +221,23 @@ void OSSInput::run() {
 	ival = AFMT_S16_NE;
 	if ((ioctl(fd, SNDCTL_DSP_SETFMT, &ival) == -1) || (ival != AFMT_S16_NE)) {
 		qWarning("OSSInput: Failed to set sound format");
-		goto out;
+		close(fd);
+		return;
 	}
 
 	ival = 1;
 	if ((ioctl(fd, SNDCTL_DSP_CHANNELS, &ival) == -1)) {
 		qWarning("OSSInput: Failed to set mono mode");
-		goto out;
+		close(fd);
+		return;
 	}
 	iMicChannels = ival;
 
 	ival = SAMPLE_RATE;
 	if (ioctl(fd, SNDCTL_DSP_SPEED, &ival) == -1) {
 		qWarning("OSSInput: Failed to set speed");
-		goto out;
+		close(fd);
+		return;
 	}
 	iMicFreq = ival;
 
@@ -258,8 +261,6 @@ void OSSInput::run() {
 	qWarning("OSSInput: Releasing.");
 	ioctl(fd, SNDCTL_DSP_RESET, NULL);
 
-out:
-	close(fd);
 }
 
 OSSOutput::OSSOutput() {


### PR DESCRIPTION
FreeBSD ports has been carrying this patch for two years now. I can't
locate the specific details and my commit message failed to give details
on this patch, but FreeBSD is probably the primary OSS audio backend
consumer for Mumble. This fix improved interaction with the OSS devices.

I think the original author *really* hated the use of goto because it could have been preserved with just the addition of the return. I can't say I hold a religious stance on it.