### PR TITLE
include actor when performing a user rename

### DIFF
--- a/src/mumble/Messages.cpp
+++ b/src/mumble/Messages.cpp
@@ -534,12 +534,12 @@ void MainWindow::msgUserState(const MumbleProto::UserState &msg) {
 		QString newName = u8(msg.name());
 		pmModel->renameUser(pDst, newName);
 		if (! oldName.isNull() && oldName != newName) {
-			if (pSrc != pDst) {
-				g.l->log(Log::UserRenamed, tr("%1 renamed to %2 by %3.").arg(Log::formatClientUser(pDst, Log::Target, oldName))
-					.arg(Log::formatClientUser(pDst, Log::Target)).arg(Log::formatClientUser(pSrc, Log::Source)));
-			} else {
+			if (pSrc == NULL || pSrc == pDst) {
 				g.l->log(Log::UserRenamed, tr("%1 renamed to %2.").arg(Log::formatClientUser(pDst, Log::Target, oldName),
 					Log::formatClientUser(pDst, Log::Target)));
+			} else {
+				g.l->log(Log::UserRenamed, tr("%1 renamed to %2 by %3.").arg(Log::formatClientUser(pDst, Log::Target, oldName))
+					.arg(Log::formatClientUser(pDst, Log::Target)).arg(Log::formatClientUser(pSrc, Log::Source)));
 			}
 		}
 	}

--- a/src/mumble/Messages.cpp
+++ b/src/mumble/Messages.cpp
@@ -534,8 +534,13 @@ void MainWindow::msgUserState(const MumbleProto::UserState &msg) {
 		QString newName = u8(msg.name());
 		pmModel->renameUser(pDst, newName);
 		if (! oldName.isNull() && oldName != newName) {
-			g.l->log(Log::UserRenamed, tr("%1 renamed to %2.").arg(Log::formatClientUser(pDst, Log::Target, oldName),
-				Log::formatClientUser(pDst, Log::Target)));
+			if (pSrc != pDst) {
+				g.l->log(Log::UserRenamed, tr("%1 renamed to %2 by %3.").arg(Log::formatClientUser(pDst, Log::Target, oldName))
+					.arg(Log::formatClientUser(pDst, Log::Target)).arg(Log::formatClientUser(pSrc, Log::Source)));
+			} else {
+				g.l->log(Log::UserRenamed, tr("%1 renamed to %2.").arg(Log::formatClientUser(pDst, Log::Target, oldName),
+					Log::formatClientUser(pDst, Log::Target)));
+			}
 		}
 	}
 	if (msg.has_texture_hash()) {

--- a/src/murmur/Messages.cpp
+++ b/src/murmur/Messages.cpp
@@ -1512,6 +1512,7 @@ void Server::msgUserList(ServerUser *uSource, MumbleProto::UserList &msg) {
 						}
 					}
 					if (mpus.has_session()) {
+						mpus.set_actor(uSource->uiSession);
 						mpus.set_name(u8(name));
 						sendAll(mpus);
 					}


### PR DESCRIPTION
The actor is included when doing mutes, bans, etc., so it might as well be included here too.