### PR TITLE
Revert 72038f6, add -lssl for FreeBSD

### DIFF
--- a/src/mumble.pri
+++ b/src/mumble.pri
@@ -48,7 +48,12 @@ unix {
 
 	CONFIG *= link_pkgconfig
 	LIBS *= -lprotobuf
-	PKGCONFIG *= openssl
+
+	contains(UNAME, FreeBSD) {
+		LIBS *= -lcrypto -lssl
+	} else {
+		PKGCONFIG *= openssl
+	}
 }
 
 # Make Q_DECL_OVERRIDE and Q_DECL_FINAL no-ops


### PR DESCRIPTION
Until we kill off a base-system OpenSSL in FreeBSD (11.0 hopefully) we
are stuck with treating FreeBSD as a special snowflake. Trying to use
the packaged OpenSSL doesn't work nicely because QT packages on FreeBSD
use the base system OpenSSL and then they conflict...