### PR TITLE
Fix OpenSSL build error on FreeBSD 9

### DIFF
--- a/src/SSL.cpp
+++ b/src/SSL.cpp
@@ -43,7 +43,7 @@ QList<QSslCipher> MumbleSSL::ciphersFromOpenSSLCipherString(QString cipherString
 
 	SSL_CTX *ctx = NULL;
 	SSL *ssl = NULL;
-	const SSL_METHOD *meth = NULL;
+	SSL_METHOD *meth = NULL;
 	int i = 0;
 
 	QByteArray csbuf = cipherString.toLatin1();


### PR DESCRIPTION
Can confirm this builds and runs on a FreeBSD test jail, but it's in a
galaxy far far away and I can't connect clients to do further testing at
the moment.

These are the build errors this resolves.

GCC 4.2
```
../SSL.cpp: In static member function 'static QList<QSslCipher> MumbleSSL::ciphersFromOpenSSLCipherString(QString)':
../SSL.cpp:58: error: invalid conversion from 'const SSL_METHOD*' to 'SSL_METHOD*'
compilation terminated due to -Wfatal-errors.
*** [release/SSL.o] Error code 1
```

Clang
```
../SSL.cpp:58:8: fatal error: no matching function for call to 'SSL_CTX_new'
        ctx = SSL_CTX_new(meth);
              ^~~~~~~~~~~
/usr/include/openssl/ssl.h:1356:10: note: candidate function not viable: 1st argument ('const SSL_METHOD *' (aka 'const ssl_method_st *')) would lose const qualifier
SSL_CTX *SSL_CTX_new(SSL_METHOD *meth);
         ^
41 warnings and 1 error generated.
```