### PR TITLE
compiler.pri: undefine _FORTIFY_SOURCE before defiining it.

### DIFF
--- a/compiler.pri
+++ b/compiler.pri
@@ -220,7 +220,8 @@ unix:!macx {
 		QMAKE_LFLAGS = -Wl,--no-add-needed
 	}
 
-	DEFINES *= _FORTIFY_SOURCE=2
+	QMAKE_CFLAGS *= -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=2
+	QMAKE_CXXFLAGS *= -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=2
 	QMAKE_LFLAGS *= -Wl,-z,relro -Wl,-z,now
 
 	CONFIG(symbols) {


### PR DESCRIPTION
One some OSes, the system compiler will predefine _FORTIFY_SOURCE.
This previously caused a redefinition error.

This change avoids that error by undefining _FORTIFY_SOURCE before
setting it.

Fixes mumble-voip/mumble#1905