### PR TITLE
UserLocalVolumeDialog: subclass QDialog instead of QWidget.

### DIFF
--- a/src/mumble/MainWindow.cpp
+++ b/src/mumble/MainWindow.cpp
@@ -1499,7 +1499,6 @@ void MainWindow::on_qaUserLocalVolume_triggered() {
 void MainWindow::openUserLocalVolumeDialog(ClientUser *p) {
 	unsigned int session = p->uiSession;
 	UserLocalVolumeDialog *uservol = new UserLocalVolumeDialog(session);
-	uservol->setWindowFlags(Qt::Dialog);
 	uservol->show();
 }
 

--- a/src/mumble/UserLocalVolumeDialog.cpp
+++ b/src/mumble/UserLocalVolumeDialog.cpp
@@ -37,7 +37,7 @@
 #include "Database.h"
 
 UserLocalVolumeDialog::UserLocalVolumeDialog(unsigned int sessionId)
-	: QWidget(NULL)
+	: QDialog(NULL)
 	, m_clientSession(sessionId) {
 	setupUi(this);
 

--- a/src/mumble/UserLocalVolumeDialog.h
+++ b/src/mumble/UserLocalVolumeDialog.h
@@ -34,7 +34,7 @@
 #include "ui_UserLocalVolumeDialog.h"
 #include "ClientUser.h"
 
-class UserLocalVolumeDialog : public QWidget, private Ui::UserLocalVolumeDialog {
+class UserLocalVolumeDialog : public QDialog, private Ui::UserLocalVolumeDialog {
 		Q_OBJECT
 		Q_DISABLE_COPY(UserLocalVolumeDialog);
 

--- a/src/mumble/UserLocalVolumeDialog.ui
+++ b/src/mumble/UserLocalVolumeDialog.ui
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ui version="4.0">
  <class>UserLocalVolumeDialog</class>
- <widget class="QWidget" name="UserLocalVolumeDialog">
+ <widget class="QDialog" name="UserLocalVolumeDialog">
   <property name="geometry">
    <rect>
     <x>0</x>


### PR DESCRIPTION
This automatically gives us the ability to close the dialog
with the escape key.

Fixes mumble-voip/mumble#1938