### PR TITLE
Show "self mute/deaf", "global mute/deaf", "prio speaker", "user left channe…

### DIFF
--- a/src/mumble/Messages.cpp
+++ b/src/mumble/Messages.cpp
@@ -319,7 +319,7 @@ void MainWindow::msgUserState(const MumbleProto::UserState &msg) {
 		if (msg.has_self_deaf())
 			pDst->setSelfDeaf(msg.self_deaf());
 
-		if ((pSelf && pDst != pSelf && (pDst->cChannel == pSelf->cChannel)) || (pSelf && pDst != pSelf && ((pDst->cChannel->allLinks().contains(pSelf->cChannel))))) {
+		if (pSelf && pDst != pSelf && ((pDst->cChannel == pSelf->cChannel) || pDst->cChannel->allLinks().contains(pSelf->cChannel))) {
 			QString name = pDst->qsName;
 			if (pDst->bSelfMute && pDst->bSelfDeaf)
 				g.l->log(Log::OtherSelfMute, tr("%1 is now muted and deafened.").arg(Log::formatClientUser(pDst, Log::Target)));

--- a/src/mumble/Messages.cpp
+++ b/src/mumble/Messages.cpp
@@ -319,7 +319,7 @@ void MainWindow::msgUserState(const MumbleProto::UserState &msg) {
 		if (msg.has_self_deaf())
 			pDst->setSelfDeaf(msg.self_deaf());
 
-		if (pSelf && pDst != pSelf && (pDst->cChannel == pSelf->cChannel)) {
+		if ((pSelf && pDst != pSelf && (pDst->cChannel == pSelf->cChannel)) || (pSelf && pDst != pSelf && ((pDst->cChannel->allLinks().contains(pSelf->cChannel))))) {
 			QString name = pDst->qsName;
 			if (pDst->bSelfMute && pDst->bSelfDeaf)
 				g.l->log(Log::OtherSelfMute, tr("%1 is now muted and deafened.").arg(Log::formatClientUser(pDst, Log::Target)));
@@ -352,7 +352,7 @@ void MainWindow::msgUserState(const MumbleProto::UserState &msg) {
 	}
 
 	if (msg.has_priority_speaker()) {
-		if (pSelf && ((pDst->cChannel == pSelf->cChannel) || (pSrc == pSelf))) {
+		if (pSelf && ((pDst->cChannel == pSelf->cChannel) || (pDst->cChannel->allLinks().contains(pSelf->cChannel)) || (pSrc == pSelf))) {
 			if ((pSrc == pDst) && (pSrc == pSelf)) {
 				if (pDst->bPrioritySpeaker) {
 					g.l->log(Log::YouMuted, tr("You revoked your priority speaker status."));
@@ -397,7 +397,7 @@ void MainWindow::msgUserState(const MumbleProto::UserState &msg) {
 		if (msg.has_suppress())
 			pDst->setSuppress(msg.suppress());
 
-		if (pSelf && ((pDst->cChannel == pSelf->cChannel) || (pSrc == pSelf))) {
+		if (pSelf && ((pDst->cChannel == pSelf->cChannel) || (pDst->cChannel->allLinks().contains(pSelf->cChannel)) || (pSrc == pSelf))) {
 			if (pDst == pSelf) {
 				if (msg.has_mute() && msg.has_deaf() && pDst->bMute && pDst->bDeaf) {
 					g.l->log(Log::YouMuted, tr("You were muted and deafened by %1.").arg(Log::formatClientUser(pSrc, Log::Source)));
@@ -583,7 +583,7 @@ void MainWindow::msgUserRemove(const MumbleProto::UserRemove &msg) {
 		else
 			g.l->log((pSrc == pSelf) ? Log::YouKicked : Log::UserKicked, tr("%3 was kicked from the server by %1: %2.").arg(Log::formatClientUser(pSrc, Log::Source)).arg(reason).arg(Log::formatClientUser(pDst, Log::Target)));
 	} else {
-		if (pDst->cChannel == pSelf->cChannel) {
+		if (pDst->cChannel == pSelf->cChannel || pDst->cChannel->allLinks().contains(pSelf->cChannel)) {
 			g.l->log(Log::ChannelLeave, tr("%1 left channel and disconnected.").arg(Log::formatClientUser(pDst, Log::Source)));
 		} else {
 			g.l->log(Log::UserLeave, tr("%1 disconnected.").arg(Log::formatClientUser(pDst, Log::Source)));


### PR DESCRIPTION
…l and disconnected" states in linked channels.