### PR TITLE
[Linux] Migrate old Qt4 data directory to new Qt5 location

### DIFF
--- a/src/mumble/Global.cpp
+++ b/src/mumble/Global.cpp
@@ -63,6 +63,8 @@ static void migrateDataDir() {
 	qWarning("Application data migration failed.");
 #endif
 
+// Qt4 used another data directory on Unix-like systems, to ensure a seamless
+// transition we must first move the users data to the new directory.
 #if defined(Q_OS_UNIX) && ! defined(Q_OS_MAC)
 #if QT_VERSION >= 0x050000
 	QString olddir = QStandardPaths::writableLocation(QStandardPaths::GenericDataLocation) + QLatin1String("/data/Mumble");

--- a/src/mumble/Global.cpp
+++ b/src/mumble/Global.cpp
@@ -62,6 +62,28 @@ static void migrateDataDir() {
 
 	qWarning("Application data migration failed.");
 #endif
+
+#if defined(Q_OS_UNIX) && ! defined(Q_OS_MAC)
+#if QT_VERSION >= 0x050000
+	QString olddir = QStandardPaths::writableLocation(QStandardPaths::GenericDataLocation) + QLatin1String("/data/Mumble");
+	QString newdir = QStandardPaths::writableLocation(QStandardPaths::GenericDataLocation) + QLatin1String("/Mumble");
+
+	if (!QFile::exists(newdir) && QFile::exists(olddir)) {
+		QDir d;
+		d.mkpath(newdir + QLatin1String("/.."));
+		if (d.rename(olddir, newdir)) {
+			qWarning("Migrated application data directory from '%s' to '%s'",
+			         qPrintable(olddir), qPrintable(newdir));
+			return;
+		}
+	} else {
+		/* Data dir has already been migrated. */
+		return;
+	}
+
+	qWarning("Application data migration failed.");
+#endif
+#endif
 }
 
 Global::Global() {


### PR DESCRIPTION
This migration moves the directory ~/.local/share/data/Mumble/Mumble to ~/.local/share/Mumble/Mumble. This is to my knowledge only an issue on Linux, and only when the user migrates from a Qt4 to Qt5 build.

This fixes my previous issue #1702.
