### PR TITLE
Unbundled celt mumble.pro fix on Linux

### DIFF
--- a/src/mumble/mumble.pro
+++ b/src/mumble/mumble.pro
@@ -315,6 +315,10 @@ CONFIG(sbcelt) {
   }
   CONFIG(no-bundled-celt) {
     INCLUDEPATH	*= /usr/include/celt
+    unix {
+      QMAKE_CFLAGS *= "-isystem /usr/include/celt"
+      QMAKE_CXXFLAGS *= "-isystem /usr/include/celt"
+    }
   }
   !CONFIG(no-bundled-celt) {
     INCLUDEPATH *= ../../3rdparty/celt-0.7.0-src/libcelt


### PR DESCRIPTION
Hi

The build is broken for me on master without this fix.  Seems like these few lines made it to the bundled portion but not the unbundled.   I am using system celt 0.7.1 which was forked on Fedora to remain compatible with Mumble.

This fix should be relevant to Debian and any other distro with unbundling policies.  


