### PR TITLE
AudioInput: ensure our encoders are reset correctly when using > 1 frame per packet.

### DIFF
--- a/src/mumble/AudioInput.h
+++ b/src/mumble/AudioInput.h
@@ -125,6 +125,11 @@ class AudioInput : public QThread {
 		CELTCodec *cCodec;
 		CELTEncoder *ceEncoder;
 
+		/// bResetEncoder is a flag that notifies
+		/// our encoder functions that the encoder
+		/// needs to be reset.
+		bool bResetEncoder;
+
 		/// Encoded audio rate in bit/s
 		int iAudioQuality;
 		/// Number of 10ms audio "frames" per packet (!= frames in packet)


### PR DESCRIPTION
When AudioInput is configured to use more than a single frame per
packet, the "!bPreviousVoice"-check in encodeOpusFrame() and
encodeCELTFrame() is not sufficient in determining when to reset
the encoder.

This is because bPreviousVoice refers to the previous *frame*.

But when AudioInput is configured to use multiple frames per
packet, we won't enter encodeOpusFrame() at the initial frame
where bPreviousVoice would be false.

The result is that we never reset the current encoder
when using more than one frame per packet.

This change adds a flag, bResetEncoder, to the AudioInput class.

Now, When AudioInput encounters a frame that is speech, and the
previous frame was not (bIsSpeech && !bPreviousVoice), it will
set the bResetEncoder flag.

The encoder is now reset correctly when a new voice stream begins,
just like it is for the single frame-per-packet case.