### PR TITLE
Mumble: remove expert mode.

### DIFF
--- a/src/mumble/ASIOInput.cpp
+++ b/src/mumble/ASIOInput.cpp
@@ -393,10 +393,6 @@ void ASIOConfig::load(const Settings &r) {
 	qlwSpeaker->clear();
 }
 
-bool ASIOConfig::expert(bool) {
-	return false;
-}
-
 void ASIOConfig::clearQuery() {
 	bOk = false;
 	qlName->setText(QString());

--- a/src/mumble/ASIOInput.h
+++ b/src/mumble/ASIOInput.h
@@ -58,7 +58,6 @@ class ASIOConfig : public ConfigWidget, public Ui::ASIOConfig {
 	public slots:
 		void save() const Q_DECL_OVERRIDE;
 		void load(const Settings &r) Q_DECL_OVERRIDE;
-		bool expert(bool) Q_DECL_OVERRIDE;
 		void clearQuery();
 		void on_qcbDevice_activated(int index);
 		void on_qpbQuery_clicked();

--- a/src/mumble/AudioConfigDialog.cpp
+++ b/src/mumble/AudioConfigDialog.cpp
@@ -183,21 +183,6 @@ void AudioInputDialog::save() const {
 	}
 }
 
-bool AudioInputDialog::expert(bool b) {
-	qgbInterfaces->setVisible(b);
-	qgbAudio->setVisible(b);
-	qliFrames->setVisible(b);
-	qsFrames->setVisible(b);
-	qlFrames->setVisible(b);
-	qswTransmit->setVisible(b);
-	qliIdle->setVisible(b);
-	qsbIdle->setVisible(b);
-	qcbIdleAction->setVisible(b);
-	qlIdle->setVisible(b);
-	qlIdle2->setVisible(b);
-	return true;
-}
-
 void AudioInputDialog::on_qsFrames_valueChanged(int v) {
 	qlFrames->setText(tr("%1 ms").arg((v==1) ? 10 : (v-1)*20));
 	updateBitrate();
@@ -507,10 +492,6 @@ void AudioOutputDialog::save() const {
 			aor->setDeviceChoice(qcbDevice->itemData(idx), s);
 		}
 	}
-}
-
-bool AudioOutputDialog::expert(bool b) {
-	return b;
 }
 
 void AudioOutputDialog::on_qcbSystem_currentIndexChanged(int) {

--- a/src/mumble/AudioConfigDialog.h
+++ b/src/mumble/AudioConfigDialog.h
@@ -53,7 +53,6 @@ class AudioInputDialog : public ConfigWidget, public Ui::AudioInput {
 	public slots:
 		void save() const Q_DECL_OVERRIDE;
 		void load(const Settings &r) Q_DECL_OVERRIDE;
-		bool expert(bool) Q_DECL_OVERRIDE;
 		void updateBitrate();
 		void continuePlayback();
 
@@ -87,7 +86,6 @@ class AudioOutputDialog : public ConfigWidget, public Ui::AudioOutput {
 	public slots:
 		void save() const Q_DECL_OVERRIDE;
 		void load(const Settings &r) Q_DECL_OVERRIDE;
-		bool expert(bool) Q_DECL_OVERRIDE;
 		void on_qsDelay_valueChanged(int v);
 		void on_qsJitter_valueChanged(int v);
 		void on_qsVolume_valueChanged(int v);

--- a/src/mumble/ConfigDialog.cpp
+++ b/src/mumble/ConfigDialog.cpp
@@ -48,8 +48,7 @@ ConfigDialog::ConfigDialog(QWidget *p) : QDialog(p) {
 		addPage(cwn(s), ++idx);
 	}
 
-	qcbExpert->setChecked(g.s.bExpert);
-	on_qcbExpert_clicked(g.s.bExpert);
+	updateListView();
 
 	QPushButton *okButton = dialogButtonBox->button(QDialogButtonBox::Ok);
 	okButton->setToolTip(tr("Accept changes"));
@@ -132,7 +131,6 @@ void ConfigDialog::on_pageButtonBox_clicked(QAbstractButton *b) {
 	switch (pageButtonBox->standardButton(b)) {
 		case QDialogButtonBox::RestoreDefaults: {
 				Settings def;
-				def.bExpert = g.s.bExpert;
 				conf->load(def);
 				break;
 			}
@@ -167,7 +165,7 @@ void ConfigDialog::on_qlwIcons_currentItemChanged(QListWidgetItem *current, QLis
 	}
 }
 
-void ConfigDialog::on_qcbExpert_clicked(bool b) {
+void ConfigDialog::updateListView() {
 	QWidget *ccw = qmIconWidgets.value(qlwIcons->currentItem());
 	QListWidgetItem *sel = NULL;
 
@@ -178,19 +176,16 @@ void ConfigDialog::on_qcbExpert_clicked(bool b) {
 	int configNavbarWidth = 0;
 
 	foreach(ConfigWidget *cw, qmWidgets) {
-		bool showit = cw->expert(b);
 		configNavbarWidth = qMax(configNavbarWidth, qfm.width(cw->title()));
-		if (showit || b)  {
-			QListWidgetItem *i = new QListWidgetItem(qlwIcons);
-			i->setIcon(cw->icon());
-			i->setText(cw->title());
-			i->setFlags(Qt::ItemIsSelectable | Qt::ItemIsEnabled);
 
+		QListWidgetItem *i = new QListWidgetItem(qlwIcons);
+		i->setIcon(cw->icon());
+		i->setText(cw->title());
+		i->setFlags(Qt::ItemIsSelectable | Qt::ItemIsEnabled);
 
-			qmIconWidgets.insert(i, cw);
-			if (cw == ccw)
-				sel = i;
-		}
+		qmIconWidgets.insert(i, cw);
+		if (cw == ccw)
+			sel = i;
 	}
 
 	// Add space for icon and some padding.
@@ -221,7 +216,6 @@ void ConfigDialog::apply() {
 
 	// They might have changed their keys.
 	g.iPushToTalk = 0;
-	g.s.bExpert = qcbExpert->isChecked();
 
 	Audio::start();
 }

--- a/src/mumble/ConfigDialog.h
+++ b/src/mumble/ConfigDialog.h
@@ -44,6 +44,7 @@ class ConfigDialog : public QDialog, public Ui::ConfigDialog {
 		QHash<ConfigWidget *, QWidget *> qhPages;
 		QMap<unsigned int, ConfigWidget *> qmWidgets;
 		QMap<QListWidgetItem *, ConfigWidget *> qmIconWidgets;
+		void updateListView();
 		void addPage(ConfigWidget *aw, unsigned int idx);
 		Settings s;
 
@@ -52,17 +53,15 @@ class ConfigDialog : public QDialog, public Ui::ConfigDialog {
 		~ConfigDialog() Q_DECL_OVERRIDE;
 #ifdef Q_OS_MAC
 	protected:
-		void setupMacToolbar(bool expert);
+		void setupMacToolbar();
 		void removeMacToolbar();
 	public:
-		void updateExpert(bool expert);
 		void on_widgetSelected(ConfigWidget *);
 #endif
 	public slots:
 		void on_pageButtonBox_clicked(QAbstractButton *);
 		void on_dialogButtonBox_clicked(QAbstractButton *);
 		void on_qlwIcons_currentItemChanged(QListWidgetItem *current, QListWidgetItem *previous);
-		void on_qcbExpert_clicked(bool);
 		void apply();
 		void accept() Q_DECL_OVERRIDE;
 };

--- a/src/mumble/ConfigDialog.ui
+++ b/src/mumble/ConfigDialog.ui
@@ -42,19 +42,6 @@
      </property>
     </widget>
    </item>
-   <item row="1" column="0">
-    <widget class="QCheckBox" name="qcbExpert">
-     <property name="sizePolicy">
-      <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
-       <horstretch>0</horstretch>
-       <verstretch>0</verstretch>
-      </sizepolicy>
-     </property>
-     <property name="text">
-      <string>Advanced</string>
-     </property>
-    </widget>
-   </item>
    <item row="2" column="0" colspan="3">
     <layout class="QHBoxLayout" name="horizontalLayout">
      <item>

--- a/src/mumble/ConfigDialogDelegate.h
+++ b/src/mumble/ConfigDialogDelegate.h
@@ -41,9 +41,8 @@
 #if MAC_OS_X_VERSION_MIN_REQUIRED >= 1060
 <NSToolbarDelegate>
 #endif
-- (id) initWithConfigDialog:(ConfigDialogMac *)dialog andToolbar:(NSToolbar *)toolbar andWidgetMap:(QMap<unsigned int, ConfigWidget *> *)map inExpertMode:(BOOL)isExpertMode;
+- (id) initWithConfigDialog:(ConfigDialogMac *)dialog andToolbar:(NSToolbar *)toolbar andWidgetMap:(QMap<unsigned int, ConfigWidget *> *)map;
 - (void) selectItem:(ConfigWidget *)cw;
-- (BOOL) expertMode;
 @end
 
 #endif

--- a/src/mumble/ConfigDialogDelegate.mm
+++ b/src/mumble/ConfigDialogDelegate.mm
@@ -55,24 +55,21 @@ static NSImage *ConfigDialogDelegate_QIcon_to_AutoreleasedNSImage(const QIcon &i
 	ConfigDialogMac                      *_configDialog;
 	NSToolbar                            *_toolbar;
 	QMap<unsigned int, ConfigWidget *>   *_widgetMap;
-	BOOL                                 _expertMode;
 
    	NSMutableDictionary                  *_nameWidgetMapping;
 	NSMutableArray                       *_identifiers;
 }
 - (NSToolbarItem *) toolbar:(NSToolbar *)toolbar itemForItemIdentifier:(NSString *)identifier willBeInsertedIntoToolbar:(BOOL)flag;
 - (void) itemSelected:(NSToolbarItem *)toolbarItem;
-- (void) expertSelected:(NSButton *)button;
 @end
 
 @implementation ConfigDialogDelegate
 
-- (id) initWithConfigDialog:(ConfigDialogMac *)dialog andToolbar:(NSToolbar *)toolbar andWidgetMap:(QMap<unsigned int, ConfigWidget *> *)map inExpertMode:(BOOL)isExpertMode {
+- (id) initWithConfigDialog:(ConfigDialogMac *)dialog andToolbar:(NSToolbar *)toolbar andWidgetMap:(QMap<unsigned int, ConfigWidget *> *)map {
 	if ((self = [super init])) {
 		_configDialog = dialog;
 		_toolbar = toolbar;
 		_widgetMap = map;
-		_expertMode = isExpertMode;
 
 		NSUInteger numItems = _widgetMap->count() + 2;
 
@@ -80,16 +77,13 @@ static NSImage *ConfigDialogDelegate_QIcon_to_AutoreleasedNSImage(const QIcon &i
 		_identifiers = [[NSMutableArray alloc] initWithCapacity:numItems];
 
 		foreach (ConfigWidget *cw, *_widgetMap) {
-			if (cw->expert(_expertMode) || _expertMode) {
-				NSString *str = ConfigDialogDelegate_QString_to_AutoreleasedNSString(cw->title());
-				NSValue *ptr = [NSValue valueWithPointer:cw];
-				[_nameWidgetMapping setObject:ptr forKey:str];
-				[_identifiers addObject:str];
-			}
+			NSString *str = ConfigDialogDelegate_QString_to_AutoreleasedNSString(cw->title());
+			NSValue *ptr = [NSValue valueWithPointer:cw];
+			[_nameWidgetMapping setObject:ptr forKey:str];
+			[_identifiers addObject:str];
 		}
 
 		[_identifiers addObject:NSToolbarFlexibleSpaceItemIdentifier];
-		[_identifiers addObject:@"expertModeCheckbox"];
 	}
 	return self;
 }
@@ -119,26 +113,6 @@ static NSImage *ConfigDialogDelegate_QIcon_to_AutoreleasedNSImage(const QIcon &i
 	(void) toolbar;
 	(void) willBeInserted;
 
-	// Special-case for the 'Expert Mode' checkbox.
-	if ([identifier isEqualTo:@"expertModeCheckbox"]) {
-		NSToolbarItem *item = [[[NSToolbarItem alloc] initWithItemIdentifier:identifier] autorelease];
-
-		NSString *advanced = ConfigDialogDelegate_QString_to_AutoreleasedNSString(qApp->translate("ConfigDialog", "Advanced"));
-		[item setLabel:advanced];
-
-		NSButton *button = [[[NSButton alloc] init] autorelease];
-		NSSize buttonSize = NSMakeSize(OSX_TOOLBAR_ICON_SIZE/2, OSX_TOOLBAR_ICON_SIZE);
-		[button setButtonType:NSSwitchButton];
-		[button setState:(_expertMode ? NSOnState : NSOffState)];
-		[item setView:button];
-		[item setMinSize:buttonSize];
-		[item setMaxSize:buttonSize];
-		[item setTarget:self];
-		[item setAction:@selector(expertSelected:)];
-
-		return item;
-	}
-
 	ConfigWidget *cw = reinterpret_cast<ConfigWidget *>([[_nameWidgetMapping valueForKey:identifier] pointerValue]);
 	NSToolbarItem *item = [[[NSToolbarItem alloc] initWithItemIdentifier:identifier] autorelease];
 	[item setLabel:identifier];
@@ -162,14 +136,6 @@ static NSImage *ConfigDialogDelegate_QIcon_to_AutoreleasedNSImage(const QIcon &i
 	if (cw != NULL) {
 		_configDialog->on_widgetSelected(cw);
 	}
-}
-
-- (void) expertSelected:(NSButton *)button {
-	_configDialog->updateExpert([button state] == NSOnState);
-}
-
-- (BOOL) expertMode {
-	return _expertMode;
 }
 
 @end

--- a/src/mumble/ConfigDialog_macx.h
+++ b/src/mumble/ConfigDialog_macx.h
@@ -51,17 +51,15 @@ class ConfigDialogMac : public QDialog, public Ui::ConfigDialog {
 		ConfigDialogMac(QWidget *p = NULL);
 		~ConfigDialogMac() Q_DECL_OVERRIDE;
 	protected:
-		void setupMacToolbar(bool expert);
+		void setupMacToolbar();
 		void removeMacToolbar();
 	public:
-		void updateExpert(bool expert);
 		void on_widgetSelected(ConfigWidget *);
 	public slots:
 		void delayedInit();
 		void on_pageButtonBox_clicked(QAbstractButton *);
 		void on_dialogButtonBox_clicked(QAbstractButton *);
 		void on_qlwIcons_currentItemChanged(QListWidgetItem *current, QListWidgetItem *previous);
-		void on_qcbExpert_clicked(bool);
 		void apply();
 		void accept() Q_DECL_OVERRIDE;
 };

--- a/src/mumble/ConfigWidget.h
+++ b/src/mumble/ConfigWidget.h
@@ -65,7 +65,6 @@ class ConfigWidget : public QWidget {
 		virtual void accept() const;
 		virtual void save() const = 0;
 		virtual void load(const Settings &r) = 0;
-		virtual bool expert(bool) = 0;
 };
 
 typedef ConfigWidget *(*ConfigWidgetNew)(Settings &st);

--- a/src/mumble/GlobalShortcut.cpp
+++ b/src/mumble/GlobalShortcut.cpp
@@ -141,27 +141,14 @@ ShortcutActionWidget::ShortcutActionWidget(QWidget *p) : QComboBox(p) {
 
 	idx++;
 
-	bool expert = true;
-	// Try to traverse to GlobalShortcutConfig to get expert state (default: true)
-	while (p) {
-		GlobalShortcutConfig *gsc = qobject_cast<GlobalShortcutConfig *>(p);
-		if (gsc) {
-			expert = gsc->bExpert;
-			break;
-		}
-		p = p->parentWidget();
-	}
 	foreach(GlobalShortcut *gs, GlobalShortcutEngine::engine->qmShortcuts) {
-		// Hide all expert actions if we are not in expert mode
-		if (expert || ! gs->bExpert) {
-			insertItem(idx, gs->name);
-			setItemData(idx, gs->idx);
-			if (! gs->qsToolTip.isEmpty())
-				setItemData(idx, gs->qsToolTip, Qt::ToolTipRole);
-			if (! gs->qsWhatsThis.isEmpty())
-				setItemData(idx, gs->qsWhatsThis, Qt::WhatsThisRole);
-			idx++;
-		}
+		insertItem(idx, gs->name);
+		setItemData(idx, gs->idx);
+		if (! gs->qsToolTip.isEmpty())
+			setItemData(idx, gs->qsToolTip, Qt::ToolTipRole);
+		if (! gs->qsWhatsThis.isEmpty())
+			setItemData(idx, gs->qsWhatsThis, Qt::WhatsThisRole);
+		idx++;
 	}
 }
 
@@ -212,7 +199,7 @@ ShortcutTargetDialog::ShortcutTargetDialog(const ShortcutTarget &st, QWidget *pw
 
 	// Load current shortcut configuration
 	qcbForceCenter->setChecked(st.bForceCenter);
-	qgbModifiers->setVisible(g.s.bExpert);
+	qgbModifiers->setVisible(true);
 
 	if (st.bUsers) {
 		qrbUsers->setChecked(true);
@@ -686,7 +673,6 @@ QIcon GlobalShortcutConfig::icon() const {
 
 void GlobalShortcutConfig::load(const Settings &r) {
 	qlShortcuts = r.qlShortcuts;
-	bExpert = r.bExpert;
 
 	// The 'Skip' button is supposed to be live, meaning users do not need to click Apply for
 	// their choice of skipping to apply.
@@ -747,10 +733,7 @@ void GlobalShortcutConfig::reload() {
 	qtwShortcuts->clear();
 	foreach(const Shortcut &sc, qlShortcuts) {
 		QTreeWidgetItem *item = itemForShortcut(sc);
-		::GlobalShortcut *gs = GlobalShortcutEngine::engine->qmShortcuts.value(sc.iIndex);
 		qtwShortcuts->addTopLevelItem(item);
-		if (gs && gs->bExpert && ! bExpert)
-			item->setHidden(true);
 	}
 #ifdef Q_OS_MAC
 	if (! g.s.bSuppressMacEventTapWarning) {
@@ -765,12 +748,6 @@ void GlobalShortcutConfig::accept() const {
 	GlobalShortcutEngine::engine->bNeedRemap = true;
 	GlobalShortcutEngine::engine->needRemap();
 	GlobalShortcutEngine::engine->setEnabled(g.s.bShortcutEnable);
-}
-
-bool GlobalShortcutConfig::expert(bool exp) {
-	bExpert = exp;
-	reload();
-	return true;
 }
 
 
@@ -956,10 +933,9 @@ QString GlobalShortcutEngine::buttonText(const QList<QVariant> &list) {
 void GlobalShortcutEngine::prepareInput() {
 }
 
-GlobalShortcut::GlobalShortcut(QObject *p, int index, QString qsName, bool expert, QVariant def) : QObject(p) {
+GlobalShortcut::GlobalShortcut(QObject *p, int index, QString qsName, QVariant def) : QObject(p) {
 	idx = index;
 	name=qsName;
-	bExpert = expert;
 	qvDefault = def;
 	GlobalShortcutEngine::add(this);
 }

--- a/src/mumble/GlobalShortcut.h
+++ b/src/mumble/GlobalShortcut.h
@@ -64,10 +64,9 @@ class GlobalShortcut : public QObject {
 		QString qsWhatsThis;
 		QString name;
 		QVariant qvDefault;
-		bool bExpert;
 		int idx;
 
-		GlobalShortcut(QObject *parent, int index, QString qsName, bool expert = true, QVariant def = QVariant());
+		GlobalShortcut(QObject *parent, int index, QString qsName, QVariant def = QVariant());
 		~GlobalShortcut() Q_DECL_OVERRIDE;
 
 		bool active() const {
@@ -212,7 +211,6 @@ class GlobalShortcutConfig : public ConfigWidget, public Ui::GlobalShortcut {
 	protected:
 		QList<Shortcut> qlShortcuts;
 		QTreeWidgetItem *itemForShortcut(const Shortcut &) const;
-		bool bExpert;
 		bool showWarning() const;
 		bool eventFilter(QObject *, QEvent *) Q_DECL_OVERRIDE;
 	public:
@@ -224,7 +222,6 @@ class GlobalShortcutConfig : public ConfigWidget, public Ui::GlobalShortcut {
 		void save() const Q_DECL_OVERRIDE;
 		void load(const Settings &r) Q_DECL_OVERRIDE;
 		void reload();
-		bool expert(bool) Q_DECL_OVERRIDE;
 		void commit();
 		void on_qcbEnableGlobalShortcuts_stateChanged(int);
 		void on_qpbAdd_clicked(bool);

--- a/src/mumble/LCD.cpp
+++ b/src/mumble/LCD.cpp
@@ -123,10 +123,6 @@ LCDConfig::LCDConfig(Settings &st) : ConfigWidget(st) {
 	}
 }
 
-bool LCDConfig::expert(bool) {
-	return false;
-}
-
 QString LCDConfig::title() const {
 	return tr("LCD");
 }

--- a/src/mumble/LCD.h
+++ b/src/mumble/LCD.h
@@ -54,7 +54,6 @@ class LCDConfig : public ConfigWidget, public Ui::LCDConfig {
 		void accept() const Q_DECL_OVERRIDE;
 		void save() const Q_DECL_OVERRIDE;
 		void load(const Settings &r) Q_DECL_OVERRIDE;
-		bool expert(bool) Q_DECL_OVERRIDE;
 };
 
 class LCDEngine : public QObject {

--- a/src/mumble/Log.cpp
+++ b/src/mumble/Log.cpp
@@ -169,10 +169,6 @@ void LogConfig::accept() const {
 	g.mw->qteLog->document()->setMaximumBlockCount(s.iMaxLogBlocks);
 }
 
-bool LogConfig::expert(bool) {
-	return false;
-}
-
 void LogConfig::on_qtwMessages_itemChanged(QTreeWidgetItem* i, int column) {
 	if (! i->isSelected()) return;
 	switch (column) {

--- a/src/mumble/Log.h
+++ b/src/mumble/Log.h
@@ -54,7 +54,6 @@ class LogConfig : public ConfigWidget, public Ui::LogConfig {
 		void accept() const Q_DECL_OVERRIDE;
 		void save() const Q_DECL_OVERRIDE;
 		void load(const Settings &) Q_DECL_OVERRIDE;
-		bool expert(bool) Q_DECL_OVERRIDE;
 
 		void on_qtwMessages_itemChanged(QTreeWidgetItem*, int);
 		void on_qtwMessages_itemClicked(QTreeWidgetItem*, int);

--- a/src/mumble/LookConfig.cpp
+++ b/src/mumble/LookConfig.cpp
@@ -243,15 +243,6 @@ void LookConfig::accept() const {
 	g.mw->setShowDockTitleBars(g.s.wlWindowLayout == Settings::LayoutCustom);
 }
 
-bool LookConfig::expert(bool b) {
-	qcbExpand->setVisible(b);
-	qliExpand->setVisible(b);
-	qcbUsersTop->setVisible(b);
-	qcbStateInTray->setVisible(b);
-	qcbShowContextMenuInMenuBar->setVisible(b);
-	return true;
-}
-
 void LookConfig::themeDirectoryChanged() {
 	qWarning() << "Theme directory changed";
 	QVariant themeData = qcbTheme->itemData(qcbTheme->currentIndex());

--- a/src/mumble/LookConfig.h
+++ b/src/mumble/LookConfig.h
@@ -52,7 +52,6 @@ class LookConfig : public ConfigWidget, Ui::LookConfig {
 		void accept() const Q_DECL_OVERRIDE;
 		void save() const Q_DECL_OVERRIDE;
 		void load(const Settings &r) Q_DECL_OVERRIDE;
-		bool expert(bool) Q_DECL_OVERRIDE;
 		void themeDirectoryChanged();
 	private:
 		/// Reload themes combobox and select given configuredStyle in it

--- a/src/mumble/MainWindow.cpp
+++ b/src/mumble/MainWindow.cpp
@@ -192,7 +192,7 @@ MainWindow::MainWindow(QWidget *p) : QMainWindow(p) {
 
 void MainWindow::createActions() {
 	int idx = 1;
-	gsPushTalk=new GlobalShortcut(this, idx++, tr("Push-to-Talk", "Global Shortcut"), false);
+	gsPushTalk=new GlobalShortcut(this, idx++, tr("Push-to-Talk", "Global Shortcut"));
 	gsPushTalk->setObjectName(QLatin1String("PushToTalk"));
 	gsPushTalk->qsToolTip = tr("Push and hold this button to send voice.", "Global Shortcut");
 	gsPushTalk->qsWhatsThis = tr("This configures the push-to-talk button, and as long as you hold this button down, you will transmit voice.", "Global Shortcut");
@@ -201,12 +201,12 @@ void MainWindow::createActions() {
 	gsResetAudio=new GlobalShortcut(this, idx++, tr("Reset Audio Processor", "Global Shortcut"));
 	gsResetAudio->setObjectName(QLatin1String("ResetAudio"));
 
-	gsMuteSelf=new GlobalShortcut(this, idx++, tr("Mute Self", "Global Shortcut"), false, 0);
+	gsMuteSelf=new GlobalShortcut(this, idx++, tr("Mute Self", "Global Shortcut"), 0);
 	gsMuteSelf->setObjectName(QLatin1String("gsMuteSelf"));
 	gsMuteSelf->qsToolTip = tr("Set self-mute status.", "Global Shortcut");
 	gsMuteSelf->qsWhatsThis = tr("This will set or toggle your muted status. If you turn this off, you will also disable self-deafen.", "Global Shortcut");
 
-	gsDeafSelf=new GlobalShortcut(this, idx++, tr("Deafen Self", "Global Shortcut"), false, 0);
+	gsDeafSelf=new GlobalShortcut(this, idx++, tr("Deafen Self", "Global Shortcut"), 0);
 	gsDeafSelf->setObjectName(QLatin1String("gsDeafSelf"));
 	gsDeafSelf->qsToolTip = tr("Set self-deafen status.", "Global Shortcut");
 	gsDeafSelf->qsWhatsThis = tr("This will set or toggle your deafened status. If you turn this on, you will also enable self-mute.", "Global Shortcut");
@@ -221,7 +221,7 @@ void MainWindow::createActions() {
 	gsJoinChannel->setObjectName(QLatin1String("MetaChannel"));
 	gsJoinChannel->qsToolTip = tr("Use in conjunction with Whisper to.", "Global Shortcut");
 
-	gsToggleOverlay=new GlobalShortcut(this, idx++, tr("Toggle Overlay", "Global Shortcut"), false);
+	gsToggleOverlay=new GlobalShortcut(this, idx++, tr("Toggle Overlay", "Global Shortcut"));
 	gsToggleOverlay->setObjectName(QLatin1String("ToggleOverlay"));
 	gsToggleOverlay->qsToolTip = tr("Toggle state of in-game overlay.", "Global Shortcut");
 	gsToggleOverlay->qsWhatsThis = tr("This will switch the states of the in-game overlay.", "Global Shortcut");
@@ -240,7 +240,7 @@ void MainWindow::createActions() {
 	qstiIcon->setToolTip(tr("Mumble -- %1").arg(QLatin1String(MUMBLE_RELEASE)));
 	qstiIcon->setObjectName(QLatin1String("Icon"));
 
-	gsWhisper = new GlobalShortcut(this, idx++, tr("Whisper/Shout"), false, QVariant::fromValue(ShortcutTarget()));
+	gsWhisper = new GlobalShortcut(this, idx++, tr("Whisper/Shout"), QVariant::fromValue(ShortcutTarget()));
 	gsWhisper->setObjectName(QLatin1String("gsWhisper"));
 
 	gsLinkChannel=new GlobalShortcut(this, idx++, tr("Link Channel", "Global Shortcut"));
@@ -250,7 +250,7 @@ void MainWindow::createActions() {
 	gsCycleTransmitMode=new GlobalShortcut(this, idx++, tr("Cycle Transmit Mode", "Global Shortcut"));
 	gsCycleTransmitMode->setObjectName(QLatin1String("gsCycleTransmitMode"));
 
-	gsSendTextMessage=new GlobalShortcut(this, idx++, tr("Send Text Message", "Global Shortcut"), true, QVariant(QString()));
+	gsSendTextMessage=new GlobalShortcut(this, idx++, tr("Send Text Message", "Global Shortcut"), QVariant(QString()));
 	gsSendTextMessage->setObjectName(QLatin1String("gsSendTextMessage"));
 
 #ifndef Q_OS_MAC

--- a/src/mumble/NetworkConfig.cpp
+++ b/src/mumble/NetworkConfig.cpp
@@ -163,19 +163,6 @@ void NetworkConfig::accept() const {
 	NetworkConfig::SetupProxy();
 }
 
-bool NetworkConfig::expert(bool b) {
-	qcbTcpMode->setVisible(b);
-	qcbQoS->setVisible(b);
-	qgbProxy->setVisible(b);
-	qcbUsage->setVisible(b);
-
-	qgbMisc->setVisible(b); // For now Misc only contains elements visible in expert mode
-	qcbImageDownload->setVisible(b);
-	qcbSuppressIdentity->setVisible(b);
-
-	return true;
-}
-
 void NetworkConfig::on_qcbType_currentIndexChanged(int v) {
 	Settings::ProxyType pt = static_cast<Settings::ProxyType>(v);
 

--- a/src/mumble/NetworkConfig.h
+++ b/src/mumble/NetworkConfig.h
@@ -53,7 +53,6 @@ class NetworkConfig : public ConfigWidget, Ui::NetworkConfig {
 		void accept() const Q_DECL_OVERRIDE;
 		void save() const Q_DECL_OVERRIDE;
 		void load(const Settings &r) Q_DECL_OVERRIDE;
-		bool expert(bool) Q_DECL_OVERRIDE;
 
 		void on_qcbType_currentIndexChanged(int v);
 };

--- a/src/mumble/OverlayConfig.cpp
+++ b/src/mumble/OverlayConfig.cpp
@@ -351,18 +351,6 @@ void OverlayConfig::load(const Settings &r) {
 	update();
 }
 
-bool OverlayConfig::expert(bool show_expert) {
-	int idx = qtwSetup->indexOf(qwExceptions);
-
-#ifdef Q_OS_LINUX
-	Q_UNUSED(show_expert);
-	qtwSetup->setTabEnabled(idx, false);
-#else
-	qtwSetup->setTabEnabled(idx, show_expert);
-#endif
-	return true;
-}
-
 QString OverlayConfig::title() const {
 	return tr("Overlay");
 }

--- a/src/mumble/OverlayConfig.h
+++ b/src/mumble/OverlayConfig.h
@@ -101,7 +101,6 @@ class OverlayConfig : public ConfigWidget, public Ui::OverlayConfig {
 		void accept() const Q_DECL_OVERRIDE;
 		void save() const Q_DECL_OVERRIDE;
 		void load(const Settings &r) Q_DECL_OVERRIDE;
-		bool expert(bool) Q_DECL_OVERRIDE;
 };
 
 #endif

--- a/src/mumble/Plugins.cpp
+++ b/src/mumble/Plugins.cpp
@@ -125,10 +125,6 @@ void PluginConfig::save() const {
 	}
 }
 
-bool PluginConfig::expert(bool) {
-	return false;
-}
-
 PluginInfo *PluginConfig::pluginForItem(QTreeWidgetItem *i) const {
 	if (i) {
 		foreach(PluginInfo *pi, g.p->qlPlugins) {

--- a/src/mumble/Plugins.h
+++ b/src/mumble/Plugins.h
@@ -59,7 +59,6 @@ class PluginConfig : public ConfigWidget, public Ui::PluginConfig {
 	public slots:
 		void save() const Q_DECL_OVERRIDE;
 		void load(const Settings &r) Q_DECL_OVERRIDE;
-		bool expert(bool) Q_DECL_OVERRIDE;
 		void on_qpbConfig_clicked();
 		void on_qpbAbout_clicked();
 		void on_qpbReload_clicked();

--- a/src/mumble/Settings.cpp
+++ b/src/mumble/Settings.cpp
@@ -284,7 +284,6 @@ Settings::Settings() {
 
 	uiDoublePush = 0;
 	pttHold = 0;
-	bExpert = true;
 
 #ifdef NO_UPDATE_CHECK
 	bUpdateCheck = false;
@@ -666,7 +665,6 @@ void Settings::load(QSettings* settings_ptr) {
 	// Network settings - SSL
 	SAVELOAD(qsSslCiphers, "net/sslciphers");
 
-	SAVELOAD(bExpert, "ui/expert");
 	SAVELOAD(qsLanguage, "ui/language");
 	SAVELOAD(themeName, "ui/theme");
 	SAVELOAD(themeStyleName, "ui/themestyle");
@@ -973,7 +971,6 @@ void Settings::save() {
 	// Network settings - SSL
 	SAVELOAD(qsSslCiphers, "net/sslciphers");
 
-	SAVELOAD(bExpert, "ui/expert");
 	SAVELOAD(qsLanguage, "ui/language");
 	SAVELOAD(themeName, "ui/theme");
 	SAVELOAD(themeStyleName, "ui/themestyle");

--- a/src/mumble/Settings.h
+++ b/src/mumble/Settings.h
@@ -173,8 +173,6 @@ struct Settings {
 	quint64 uiDoublePush;
 	quint64 pttHold;
 
-	bool bExpert;
-
 	bool bTxAudioCue;
 	static const QString cqsDefaultPushClickOn;
 	static const QString cqsDefaultPushClickOff;


### PR DESCRIPTION
@hacst feels there is too much documentation mentioning expert mode for it to be sensible for us to drop it in 1.3.0.

This commit is just here to give us a feel for the amount of code we could drop.
