### PR TITLE
Update Opus to 1.1.1.

### DIFF
--- a/3rdparty/opus-build/Win32/config.h
+++ b/3rdparty/opus-build/Win32/config.h
@@ -28,8 +28,6 @@ POSSIBILITY OF SUCH DAMAGE.
 #ifndef CONFIG_H
 #define CONFIG_H
 
-#define inline __inline
-
 #define USE_ALLOCA            1
 
 /* Comment out the next line for floating-point code */
@@ -37,14 +35,28 @@ POSSIBILITY OF SUCH DAMAGE.
 
 #define OPUS_BUILD            1
 
-/* Get rid of the CELT VS compile warnings */
-#if 1
-#pragma warning(disable : 4996)/* This function or variable may be unsafe. Consider using fopen_s instead. To disable deprecation, use _CRT_SECURE_NO_WARNINGS. See online help for details. */
+#if defined(_M_IX86) || defined(_M_X64)
+/* Can always compile SSE intrinsics (no special compiler flags necessary) */
+#define OPUS_X86_MAY_HAVE_SSE
+#define OPUS_X86_MAY_HAVE_SSE2
+#define OPUS_X86_MAY_HAVE_SSE4_1
+
+/* Presume SSE functions, if compiled to use SSE/SSE2/AVX (note that AMD64 implies SSE2, and AVX
+   implies SSE4.1) */
+#if defined(_M_X64) || (defined(_M_IX86_FP) && (_M_IX86_FP >= 1)) || defined(__AVX__)
+#define OPUS_X86_PRESUME_SSE 1
+#endif
+#if defined(_M_X64) || (defined(_M_IX86_FP) && (_M_IX86_FP >= 2)) || defined(__AVX__)
+#define OPUS_X86_PRESUME_SSE2 1
+#endif
+#if defined(__AVX__)
+#define OPUS_X86_PRESUME_SSE4_1 1
 #endif
 
-/* Enable SSE functions, if compiled with SSE/SSE2 (note that AMD64 implies SSE2) */
-#if defined(_M_X64) || (defined(_M_IX86_FP) && (_M_IX86_FP >= 1))
-#define __SSE__               1
+#if !defined(OPUS_X86_PRESUME_SSE4_1) || !defined(OPUS_X86_PRESUME_SSE2) || !defined(OPUS_X86_PRESUME_SSE)
+#define OPUS_HAVE_RTCD 1
+#endif
+
 #endif
 
 #include "version.h"

--- a/3rdparty/opus-build/Win32/version.h
+++ b/3rdparty/opus-build/Win32/version.h
@@ -1,1 +1,1 @@
-#define PACKAGE_VERSION "v1.1-beta"
+#define PACKAGE_VERSION "v1.1.1"

--- a/3rdparty/opus-build/config.h
+++ b/3rdparty/opus-build/config.h
@@ -93,7 +93,7 @@
 #define PACKAGE_NAME "opus"
 
 /* Define to the full name and version of this package. */
-#define PACKAGE_STRING "opus 1.1-beta"
+#define PACKAGE_STRING "opus 1.1.1"
 
 /* Define to the one symbol short name of this package. */
 #define PACKAGE_TARNAME "opus"
@@ -102,7 +102,7 @@
 #define PACKAGE_URL ""
 
 /* Define to the version of this package. */
-#define PACKAGE_VERSION "1.1-beta"
+#define PACKAGE_VERSION "1.1.1"
 
 /* Define to 1 if you have the ANSI C header files. */
 #define STDC_HEADERS 1

--- a/3rdparty/opus-build/opus-build.pro
+++ b/3rdparty/opus-build/opus-build.pro
@@ -68,9 +68,12 @@ unix {
 DIST = config.h
 
 INCLUDEPATH *= \
+../$$SOURCEDIR \
 ../$$SOURCEDIR/celt \
+../$$SOURCEDIR/celt/x86 \
 ../$$SOURCEDIR/include \
 ../$$SOURCEDIR/silk \
+../$$SOURCEDIR/silk/x86 \
 ../$$SOURCEDIR/silk/float
 
 # celt_sources.mk: CELT_SOURCES
@@ -93,6 +96,23 @@ celt/celt_lpc.c \
 celt/quant_bands.c \
 celt/rate.c \
 celt/vq.c
+
+win32 {
+  # celt_sources.mk: CELT_SOURCES_SSE
+  SOURCES *= \
+  celt/x86/x86cpu.c \
+  celt/x86/x86_celt_map.c \
+  celt/x86/pitch_sse.c
+
+  # celt_sources.mk: CELT_SOURCES_SSE2
+  SOURCES *= \
+  celt/x86/pitch_sse2.c
+
+  # celt_sources.mk: CELT_SOURCES_SSE4_1
+  SOURCES *= \
+  celt/x86/celt_lpc_sse.c \
+  celt/x86/pitch_sse4_1.c
+}
 
 # silk_sources.mk: SILK_SOURCES + SILK_SOURCES_FLOAT
 SOURCES *= \
@@ -204,6 +224,15 @@ silk/float/scale_vector_FLP.c \
 silk/float/schur_FLP.c \
 silk/float/sort_FLP.c
 
+win32 {
+  # silk_sources.mk: SILK_SOURCES_SSE4_1
+  SOURCES *= \
+  silk/x86/NSQ_sse.c \
+  silk/x86/NSQ_del_dec_sse.c \
+  silk/x86/x86_silk_map.c \
+  silk/x86/VAD_sse.c \
+  silk/x86/VQ_WMat_EC_sse.c
+}
 
 # opus_sources.mk: OPUS_SOURCES + OPUS_SOURCES_FLOAT
 SOURCES *= \
@@ -217,6 +246,7 @@ src/repacketizer.c \
 src/analysis.c \
 src/mlp.c \
 src/mlp_data.c
+
 
 CONFIG(debug, debug|release) {
 	CONFIG += console


### PR DESCRIPTION
This commit updates Opus to 1.1.1 as per mumble-voip/mumble#1979.

For now, it only enables the new x86 intrinsics on Windows.

We should be able to enable them safely on Windows and OS X.

Linux is tougher, because we would need to be able to get the target architecture in qmake.
I am not sure it is worth the hassle -- distros will use non-bundled Opus anyway.