### PR TITLE
GlobalShortuct_win: warn if a device takes more than 1 second to poll via DirectInput.

### DIFF
--- a/src/mumble/GlobalShortcut_win.cpp
+++ b/src/mumble/GlobalShortcut_win.cpp
@@ -550,7 +550,20 @@ void GlobalShortcutWin::timeTicked() {
 			default:
 				break;
 		}
-		id->pDID->Poll();
+
+		{
+			QElapsedTimer timer;
+			timer.start();
+
+			id->pDID->Poll();
+
+			// If a call to Poll takes more than
+			// a second, warn the user that they
+			// might have a misbehaving device.
+			if (timer.elapsed() > 1000) {
+				qWarning("GlobalShortcut_win: Poll() for device %s took %li msec. This is abnormal, the device is possibly misbehaving...", qPrintable(QUuid(id->guid).toString()), static_cast<long>(timer.elapsed()));
+			}
+		}
 
 		hr = id->pDID->GetDeviceData(sizeof(DIDEVICEOBJECTDATA), rgdod, &dwItems, 0);
 		if (FAILED(hr))


### PR DESCRIPTION
We've had reports of various DACs misbehaving, causing Mumble to freeze
for a long time when they use global shortcuts.

See for example mumble-voip/mumble#1880 and mumble-voip/mumble#1977.

This is not a fix, but it gives users who face this problem a hint if they
look in their Mumble log.