### PR TITLE
Add GIF support

### DIFF
--- a/src/mumble/CustomElements.cpp
+++ b/src/mumble/CustomElements.cpp
@@ -97,6 +97,10 @@ void LogTextBrowser::mouseMoveEvent(QMouseEvent *e) {
 		if (movie == qmActiveAnimation) {
 			break;
 		}
+		if (qmActiveAnimation) {
+			qmActiveAnimation->setPaused(true);
+			qmActiveAnimation = 0;
+		}
 		movie->setPaused(false);
 		qmActiveAnimation = movie;
 	} while(false);

--- a/src/mumble/CustomElements.cpp
+++ b/src/mumble/CustomElements.cpp
@@ -39,7 +39,7 @@
 #include "Log.h"
 
 
-LogTextBrowser::LogTextBrowser(QWidget *p) : QTextBrowser(p) {}
+LogTextBrowser::LogTextBrowser(QWidget *p) : QTextBrowser(p), qmActiveAnimation(0) {}
 
 void LogTextBrowser::resizeEvent(QResizeEvent *e) {
 	scrollLogToBottom();
@@ -67,6 +67,53 @@ void LogTextBrowser::setLogScroll(int scroll_pos) {
 
 void LogTextBrowser::scrollLogToBottom() {
 	verticalScrollBar()->setValue(verticalScrollBar()->maximum());
+}
+
+void LogTextBrowser::mouseMoveEvent(QMouseEvent *e) {
+	do {
+		QTextCursor cursor = cursorForPosition(e->pos());
+		QTextCharFormat fmt = cursor.charFormat();
+		if (fmt.objectType() == QTextFormat::NoObject) {
+			cursor.movePosition(QTextCursor::NextCharacter);
+			fmt = cursor.charFormat();
+		}
+		if (!fmt.isImageFormat()) {
+			if (qmActiveAnimation) {
+				qmActiveAnimation->setPaused(true);
+				qmActiveAnimation = 0;
+			}
+			break;
+		}
+		QString name = fmt.toImageFormat().name();
+		LogDocument *doc = qobject_cast<LogDocument *>(document());
+		QMovie *movie = doc->qhAnimations.value(name);
+		if (!movie) {
+			if (qmActiveAnimation) {
+				qmActiveAnimation->setPaused(true);
+				qmActiveAnimation = 0;
+			}
+			break;
+		}
+		if (movie == qmActiveAnimation) {
+			break;
+		}
+		movie->setPaused(false);
+		qmActiveAnimation = movie;
+	} while(false);
+
+	QTextBrowser::mouseMoveEvent(e);
+}
+
+void LogTextBrowser::animationFrameUpdated(const QRect &) {
+	LogDocument *doc = qobject_cast<LogDocument *>(document());
+
+	QMovie *movie = qobject_cast<QMovie *>(sender());
+	QUrl name = QUrl(doc->qhAnimations.key(movie), QUrl::TolerantMode);
+	doc->addResource(QTextDocument::ImageResource, name, movie->currentImage());
+
+	// Need to send event or else the image will not be redrawn.
+	QEvent *e = new QEvent(QEvent::FontChange);
+	QApplication::postEvent(this, e);
 }
 
 

--- a/src/mumble/CustomElements.h
+++ b/src/mumble/CustomElements.h
@@ -44,13 +44,18 @@
 # include <QtGui/QTextEdit>
 #endif
 
+#include <QMovie>
+
 class LogTextBrowser : public QTextBrowser {
 	private:
 		Q_OBJECT
 		Q_DISABLE_COPY(LogTextBrowser)
+
+		QMovie *qmActiveAnimation;
 	protected:
 		void resizeEvent(QResizeEvent *e) Q_DECL_OVERRIDE;
 		bool event(QEvent *e) Q_DECL_OVERRIDE;
+		void mouseMoveEvent(QMouseEvent *e) Q_DECL_OVERRIDE;
 	public:
 		LogTextBrowser(QWidget *p = NULL);
 
@@ -58,6 +63,8 @@ class LogTextBrowser : public QTextBrowser {
 		int getLogScrollMaximum();
 		void setLogScroll(int scroll_pos);
 		void scrollLogToBottom();
+	public slots:
+		void animationFrameUpdated(const QRect &);
 };
 
 class ChatbarTextEdit : public QTextEdit {

--- a/src/mumble/Log.cpp
+++ b/src/mumble/Log.cpp
@@ -717,7 +717,6 @@ void LogDocument::finished() {
 						buffer->setData(ba);
 						buffer->open(QIODevice::ReadOnly);
 						animation->setDevice(buffer);
-						animation->setPaused(true);
 
 						qhAnimations[name.toString()] = animation;
 						connect(animation, SIGNAL(updated(const QRect&)), ltb, SLOT(animationFrameUpdated(const QRect&)));

--- a/src/mumble/Log.cpp
+++ b/src/mumble/Log.cpp
@@ -705,7 +705,23 @@ void LogDocument::finished() {
 					ok = (qi.width() <= g.s.iMaxImageWidth && qi.height() <= g.s.iMaxImageHeight);
 				}
 				if (ok) {
-					addResource(QTextDocument::ImageResource, rep->request().url(), qi);
+					const QUrl &name = rep->request().url();
+					addResource(QTextDocument::ImageResource, name, qi);
+
+					LogTextBrowser *ltb = qobject_cast<LogTextBrowser *>(this->parent());
+					if (ltb && fmt == QByteArray("gif")) {
+						// Currently, only animations inside of a LogTextBrowser is
+						// supported.
+						QMovie *animation = new QMovie(this);
+						QBuffer *buffer = new QBuffer(animation);
+						buffer->setData(ba);
+						buffer->open(QIODevice::ReadOnly);
+						animation->setDevice(buffer);
+						animation->setPaused(true);
+
+						qhAnimations[name.toString()] = animation;
+						connect(animation, SIGNAL(updated(const QRect&)), ltb, SLOT(animationFrameUpdated(const QRect&)));
+					}
 
 					// Force a re-layout of the QTextEdit the next
 					// time we enter the event loop.

--- a/src/mumble/Log.h
+++ b/src/mumble/Log.h
@@ -35,6 +35,7 @@
 #include <QtCore/QDate>
 #include <QtGui/QTextCursor>
 #include <QtGui/QTextDocument>
+#include <QMovie>
 
 #include "ConfigDialog.h"
 #include "ui_Log.h"
@@ -114,6 +115,7 @@ class LogDocument : public QTextDocument {
 		void setAllowHTTPResources(bool allowHttpResources);
 		void setOnlyLoadDataURLs(bool onlyLoadDataURLs);
 		bool isValid();
+		QHash<QString, QMovie *> qhAnimations;
 	public slots:
 		void receivedHead();
 		void finished();

--- a/src/mumble/MainWindow.cpp
+++ b/src/mumble/MainWindow.cpp
@@ -3064,7 +3064,7 @@ QPair<QByteArray, QImage> MainWindow::openImageFile() {
 #endif
 	}
 
-	QString fname = QFileDialog::getOpenFileName(this, tr("Choose image file"), g.s.qsImagePath, tr("Images (*.png *.jpg *.jpeg)"));
+	QString fname = QFileDialog::getOpenFileName(this, tr("Choose image file"), g.s.qsImagePath, tr("Images (*.png *.jpg *.jpeg *.gif)"));
 
 	if (fname.isNull())
 		return retval;


### PR DESCRIPTION
- Only the chat log (`LogTextBrowser`) supports them in this patch
- GIFs only play when they are hovered over

Updates #1698

Edit: Right now, "Save Image As..." only saves the current frame.
