### PR TITLE
ConnectDialog: disable ping and host lookups when using a proxy.

### DIFF
--- a/src/mumble/ConnectDialog.cpp
+++ b/src/mumble/ConnectDialog.cpp
@@ -834,6 +834,11 @@ ConnectDialog::ConnectDialog(QWidget *p, bool autoconnect) : QDialog(p), bAutoCo
 
 	siAutoConnect = NULL;
 
+	bAllowPing = g.s.ptProxyType == Settings::NoProxy;
+	bAllowHostLookup = g.s.ptProxyType == Settings::NoProxy;
+	bAllowBonjour = g.s.ptProxyType == Settings::NoProxy;
+	bAllowFilters = g.s.ptProxyType == Settings::NoProxy;
+
 	if (tPublicServers.elapsed() >= 60 * 24 * 1000000ULL) {
 		qlPublicServers.clear();
 	}
@@ -857,17 +862,30 @@ ConnectDialog::ConnectDialog(QWidget *p, bool autoconnect) : QDialog(p), bAutoCo
 	
 	qpbAdd->setHidden(g.s.disableConnectDialogEditing);
 	qpbEdit->setHidden(g.s.disableConnectDialogEditing);
-	
+
+	// Hide ping and user count if we are not allowed to ping.
+	if (!bAllowPing) {
+		qtwServers->setColumnCount(1);
+	}
+
 	qtwServers->sortItems(1, Qt::AscendingOrder);
 
 #if QT_VERSION >= 0x050000
 	qtwServers->header()->setSectionResizeMode(0, QHeaderView::Stretch);
-	qtwServers->header()->setSectionResizeMode(1, QHeaderView::ResizeToContents);
-	qtwServers->header()->setSectionResizeMode(2, QHeaderView::ResizeToContents);
+	if (qtwServers->columnCount() >= 2) {
+		qtwServers->header()->setSectionResizeMode(1, QHeaderView::ResizeToContents);
+	}
+	if (qtwServers->columnCount() >= 3) {
+		qtwServers->header()->setSectionResizeMode(2, QHeaderView::ResizeToContents);
+	}
 #else
 	qtwServers->header()->setResizeMode(0, QHeaderView::Stretch);
-	qtwServers->header()->setResizeMode(1, QHeaderView::ResizeToContents);
-	qtwServers->header()->setResizeMode(2, QHeaderView::ResizeToContents);
+	if (qtwServers->columnCount() >= 2) {
+		qtwServers->header()->setResizeMode(1, QHeaderView::ResizeToContents);
+	}
+	if (qtwServers->columnCount() >= 3) {
+		qtwServers->header()->setResizeMode(2, QHeaderView::ResizeToContents);
+	}
 #endif
 
 	connect(qtwServers->header(), SIGNAL(sortIndicatorChanged(int, Qt::SortOrder)), this, SLOT(OnSortChanged(int, Qt::SortOrder)));
@@ -876,16 +894,20 @@ ConnectDialog::ConnectDialog(QWidget *p, bool autoconnect) : QDialog(p), bAutoCo
 	qaShowReachable->setChecked(false);
 	qaShowPopulated->setChecked(false);
 
-	switch (g.s.ssFilter) {
-		case Settings::ShowPopulated:
-			qaShowPopulated->setChecked(true);
-			break;
-		case Settings::ShowReachable:
-			qaShowReachable->setChecked(true);
-			break;
-		default:
-			qaShowAll->setChecked(true);
-			break;
+	if (bAllowFilters) {
+		switch (g.s.ssFilter) {
+			case Settings::ShowPopulated:
+				qaShowPopulated->setChecked(true);
+				break;
+			case Settings::ShowReachable:
+				qaShowReachable->setChecked(true);
+				break;
+			default:
+				qaShowAll->setChecked(true);
+				break;
+		}
+	} else {
+		qaShowAll->setChecked(true);
 	}
 
 	qagFilters = new QActionGroup(this);
@@ -901,6 +923,10 @@ ConnectDialog::ConnectDialog(QWidget *p, bool autoconnect) : QDialog(p), bAutoCo
 	qmFilters->addAction(qaShowReachable);
 	qmFilters->addAction(qaShowPopulated);
 
+	if (!bAllowFilters) {
+		qmFilters->setEnabled(false);
+	}
+
 	QList<QTreeWidgetItem *> ql;
 	QList<FavoriteServer> favorites = Database::getFavorites();
 
@@ -913,7 +939,7 @@ ConnectDialog::ConnectDialog(QWidget *p, bool autoconnect) : QDialog(p), bAutoCo
 
 #ifdef USE_BONJOUR
 	// Make sure the we got the objects we need, then wire them up
-	if (g.bc->bsbBrowser && g.bc->bsrResolver) {
+	if (bAllowBonjour && g.bc->bsbBrowser && g.bc->bsrResolver) {
 		connect(g.bc->bsbBrowser, SIGNAL(error(DNSServiceErrorType)),
 		        this, SLOT(onLanBrowseError(DNSServiceErrorType)));
 		connect(g.bc->bsbBrowser, SIGNAL(currentBonjourRecordsChanged(const QList<BonjourRecord> &)),
@@ -982,7 +1008,7 @@ ConnectDialog::~ConnectDialog() {
 
 void ConnectDialog::accept() {
 	ServerItem *si = static_cast<ServerItem *>(qtwServers->currentItem());
-	if (! si || si->qlAddresses.isEmpty() || si->qsHostname.isEmpty()) {
+	if (! si || (bAllowHostLookup && si->qlAddresses.isEmpty()) || si->qsHostname.isEmpty()) {
 		qWarning() << "Invalid server";
 		return;
 	}
@@ -1212,6 +1238,9 @@ void ConnectDialog::on_qtwServers_currentItemChanged(QTreeWidgetItem *item, QTre
 	}
 	
 	bool bOk = !si->qlAddresses.isEmpty();
+	if (!bAllowHostLookup) {
+		bOk = true;
+	}
 	qdbbButtonBox->button(QDialogButtonBox::Ok)->setEnabled(bOk);
 
 	bLastFound = true;
@@ -1353,22 +1382,27 @@ void ConnectDialog::timeTick() {
 				if (! siAutoConnect->qlAddresses.isEmpty()) {
 					accept();
 					return;
+				} else if (!bAllowHostLookup) {
+					accept();
+					return;
 				}
 			}
 		}
 	}
 
-	// Start DNS Lookup of first unknown hostname
-	foreach(const QString &host, qlDNSLookup) {
-		if (qsDNSActive.contains(host))
-			continue;
+	if (bAllowHostLookup) {
+		// Start DNS Lookup of first unknown hostname
+		foreach(const QString &host, qlDNSLookup) {
+			if (qsDNSActive.contains(host))
+				continue;
 
-		qlDNSLookup.removeAll(host);
-		qlDNSLookup.append(host);
+			qlDNSLookup.removeAll(host);
+			qlDNSLookup.append(host);
 
-		qsDNSActive.insert(host);
-		QHostInfo::lookupHost(host, this, SLOT(lookedUp(QHostInfo)));
-		break;
+			qsDNSActive.insert(host);
+			QHostInfo::lookupHost(host, this, SLOT(lookedUp(QHostInfo)));
+			break;
+		}
 	}
 
 	ServerItem *current = static_cast<ServerItem *>(qtwServers->currentItem());
@@ -1429,6 +1463,10 @@ void ConnectDialog::timeTick() {
 
 
 void ConnectDialog::startDns(ServerItem *si) {
+	if (!bAllowHostLookup) {
+		return;
+	}
+
 	QString host = si->qsHostname.toLower();
 
 	if (si->qlAddresses.isEmpty()) {
@@ -1450,7 +1488,7 @@ void ConnectDialog::startDns(ServerItem *si) {
 	}
 
 #ifdef USE_BONJOUR
-	if (si->qsHostname.isEmpty() && ! si->brRecord.serviceName.isEmpty()) {
+	if (bAllowBonjour && si->qsHostname.isEmpty() && ! si->brRecord.serviceName.isEmpty()) {
 		if (! qlBonjourActive.contains(si->brRecord)) {
 			g.bc->bsrResolver->resolveBonjourRecord(si->brRecord);
 			qlBonjourActive.append(si->brRecord);
@@ -1469,6 +1507,10 @@ void ConnectDialog::startDns(ServerItem *si) {
 }
 
 void ConnectDialog::stopDns(ServerItem *si) {
+	if (!bAllowHostLookup) {
+		return;
+	}
+
 	foreach(const QHostAddress &qha, si->qlAddresses) {
 		qpAddress addr(HostAddress(qha), si->usPort);
 		if (qhPings.contains(addr)) {
@@ -1520,8 +1562,10 @@ void ConnectDialog::lookedUp(QHostInfo info) {
 
 	qhDNSWait.remove(host);
 
-	foreach(const qpAddress &addr, qs) {
-		sendPing(addr.first.toAddress(), addr.second);
+	if (bAllowPing) {
+		foreach(const qpAddress &addr, qs) {
+			sendPing(addr.first.toAddress(), addr.second);
+		}
 	}
 }
 

--- a/src/mumble/ConnectDialog.h
+++ b/src/mumble/ConnectDialog.h
@@ -268,6 +268,22 @@ class ConnectDialog : public QDialog, public Ui::ConnectDialog {
 
 		bool bLastFound;
 
+		/// bAllowPing determines whether ConnectDialog can use
+		/// UDP packets to ping remote hosts to be able to show a
+		/// ping latency and user count.
+		bool bAllowPing;
+		/// bAllowHostLookup determines whether ConnectDialog can
+		/// resolve hosts via DNS, Bonjour, and so on.
+		bool bAllowHostLookup;
+		/// bAllowBonjour determines whether ConfigDialog can use
+		/// Bonjour to find nearby servers on the local network.
+		bool bAllowBonjour;
+		/// bAllowFilters determines whether filters are available
+		/// in the ConfigDialog. If this option is diabled, the
+		/// 'Show All' filter is forced, and no other filter can
+		/// be chosen.
+		bool bAllowFilters;
+
 		QMap<QString, QIcon> qmIcons;
 
 		void sendPing(const QHostAddress &, unsigned short port);


### PR DESCRIPTION
ConnectDialog: disable ping and host lookups when using a proxy.

This commit adds four flags to the ConnectDialog. One that allows
pings, one that allows system hostname lookups, one that allows
Bonjour host lookups, and one that allows the use of filters in
the ConnectDialog.

By default, they are all enabled.

However, if you're using a proxy, all will be disabled.

The commit also updates the ConnectDialog UI to hide
the user count and ping columns when pings are not enabled.
This is because it is generally not possible to ping via the
usual UDP mechanism when using Mumble through a proxy.

Also, since it is not possible to ping servers, the filters
that are usually available for the ConnectDialog are also
disabled. When using a proxy, all servers are shown.

As a consequence of this commit, Mumble will now allow you to
connect to a server for which a hostname has not yet been
resolved if you are using a proxy.

Previously, for hosts that could not be resolved via the regular
resolvers in Mumble (system resolver, Bonjour, ...), Mumble
would not be able to connect. This is because Mumble would disable
the Connect button if no hostname(s) could be resolved -- or were
not yet resolved.

With this commit, Mumble will now allow connections to those
hosts, and let the proxy will do the hostname resolving. This
allows, among other things, Mumble to connect to Tor .onion
hosts when using Tor as a proxy.

Fixes mumble-voip/mumble#1033
Fixes mumble-voip/mumble#1812