### PR TITLE
mumble_exe: add config option 'shortcut/windows/uiaccess/enable', allowing users to opt-in to disable UIAccess.

### DIFF
--- a/src/mumble/Settings.cpp
+++ b/src/mumble/Settings.cpp
@@ -402,6 +402,7 @@ Settings::Settings() {
 	bEnableXboxInput = true;
 	bEnableWinHooks = true;
 	bDirectInputVerboseLogging = false;
+	bEnableUIAccess = true;
 
 	for (int i=Log::firstMsgType; i<=Log::lastMsgType; ++i) {
 		qmMessages.insert(i, Settings::LogConsole | Settings::LogBalloon | Settings::LogTTS);
@@ -775,6 +776,7 @@ void Settings::load(QSettings* settings_ptr) {
 	SAVELOAD(bEnableXboxInput, "shortcut/windows/xbox/enable");
 	SAVELOAD(bEnableWinHooks, "winhooks");
 	SAVELOAD(bDirectInputVerboseLogging, "shortcut/windows/directinput/verboselogging");
+	SAVELOAD(bEnableUIAccess, "shortcut/windows/uiaccess/enable");
 
 	int nshorts = settings_ptr->beginReadArray(QLatin1String("shortcuts"));
 	for (int i=0; i<nshorts; i++) {
@@ -1104,6 +1106,7 @@ void Settings::save() {
 	SAVELOAD(bEnableXboxInput, "shortcut/windows/xbox/enable");
 	SAVELOAD(bEnableWinHooks, "winhooks");
 	SAVELOAD(bDirectInputVerboseLogging, "shortcut/windows/directinput/verboselogging");
+	SAVELOAD(bEnableUIAccess, "shortcut/windows/uiaccess/enable");
 
 	settings_ptr->beginWriteArray(QLatin1String("shortcuts"));
 	int idx = 0;

--- a/src/mumble/Settings.h
+++ b/src/mumble/Settings.h
@@ -268,6 +268,9 @@ struct Settings {
 	bool bEnableWinHooks;
 	/// Enable verbose logging in GlobalShortcutWin's DirectInput backend.
 	bool bDirectInputVerboseLogging;
+	/// Enable use of UIAccess (Windows's UI automation feature). This allows
+	/// Mumble greater access to global shortcuts.
+	bool bEnableUIAccess;
 	QList<Shortcut> qlShortcuts;
 
 	enum MessageLog { LogNone = 0x00, LogConsole = 0x01, LogTTS = 0x02, LogBalloon = 0x04, LogSoundfile = 0x08};

--- a/src/mumble_exe/mumble_exe.cpp
+++ b/src/mumble_exe/mumble_exe.cpp
@@ -6,6 +6,7 @@
 #include <windows.h>
 #include <shlwapi.h>
 #include <stdio.h>
+#include <sddl.h>
 
 #include <string>
 
@@ -31,6 +32,17 @@ static const std::wstring GetMumbleVersion() {
 #else
 	return std::wstring();
 #endif
+}
+
+// GetExecutablePath returns the path to mumble.exe.
+static const std::wstring GetExecutablePath() {
+	wchar_t path[MAX_PATH];
+
+	if (GetModuleFileNameW(NULL, path, MAX_PATH) == 0)
+		return std::wstring();
+
+	std::wstring exe_path(path);
+	return exe_path;
 }
 
 // GetExecutableDirPath returns the directory that
@@ -134,8 +146,153 @@ static const std::wstring GetAbsoluteMumbleAppDllPath(std::wstring suggested_bas
 	return base_dir + L"\\mumble_app.dll";
 }
 
+// UIAccessDisabledViaConfig queries the configuration store, and returns
+// whether UIAccess has been disabled by the user via the
+// "shortcut/windows/uiaccess/enable" config option.
+static bool UIAccessDisabledViaConfig() {
+	// RegQueryValueEx only zero-terminates if the registry value's type is
+	// one of the Windows registry's string types. Because of this, we have
+	// to use a buffer of 7 elements in order to query for the string "false".
+	//
+	// If the value's type is string, we'll end up with "false\0\0", because we
+	// always zero-pad.
+	//
+	// But that's better than ending up in an infinite loop because we failed
+	// to zero-terminate.
+	wchar_t buf[7];
+	memset(&buf, 0, sizeof(buf));
+	DWORD sz = sizeof(buf) - 1*sizeof(wchar_t);
+
+	HKEY key = NULL;
+	bool success = (RegOpenKeyExW(HKEY_CURRENT_USER, L"Software\\Mumble\\Mumble\\shortcuts\\windows\\uiaccess", NULL, KEY_READ, &key) == ERROR_SUCCESS) &&
+	               (RegQueryValueExW(key, L"enable" , NULL, NULL, (LPBYTE)&buf, &sz) == ERROR_SUCCESS);
+	if (success && _wcsicmp(buf, L"false") == 0) {
+		return true;
+	}
+
+	return false;
+}
+
+// SystemSupportsUIAccess returns true if the
+// operating system supports UIAccess.
+static bool SystemSupportsUIAccess() {
+	OSVERSIONINFOEXW ovi;
+	memset(&ovi, 0, sizeof(ovi));
+
+	ovi.dwOSVersionInfoSize = sizeof(ovi);
+	GetVersionEx(reinterpret_cast<OSVERSIONINFOW *>(&ovi));
+
+	// Windows Vista and later support UIAccess.
+	return ovi.dwMajorVersion > 5;
+}
+
+// ProcessHasUIAccess returns true if the current process has UIAccess enabled.
+static bool ProcessHasUIAccess() {
+	HANDLE token = NULL;
+	if (!OpenProcessToken(GetCurrentProcess(), TOKEN_QUERY, &token)) {
+		return false;
+	}
+
+	DWORD ui_access = 0;
+	DWORD ui_access_size = sizeof(ui_access);
+	if (!GetTokenInformation(token, TokenUIAccess, &ui_access, sizeof(ui_access), &ui_access_size)) {
+		CloseHandle(token);
+		return false;
+	}
+
+	CloseHandle(token);
+	return ui_access != 0;
+}
+
+// RelaunchWithoutUIAccessIfNecessary relaunches the process
+// without UIAccess, if neccs.
+static bool RelaunchWithoutUIAccessIfNecessary() {
+	if (!SystemSupportsUIAccess()) {
+		return true;
+	}
+	if (!ProcessHasUIAccess()) {
+		return true;
+	}
+	if (!UIAccessDisabledViaConfig()) {
+		return true;
+	}
+
+	STARTUPINFO startup_info;
+	memset(&startup_info, 0, sizeof(startup_info));
+
+	GetStartupInfo(&startup_info);
+
+	PROCESS_INFORMATION process_info;
+	memset(&process_info, 0, sizeof(process_info));
+
+	// Store the original value of __COMPAT_LAYER so we can
+	// restore it (which may be equivalent to not setting it all)
+	// once we've been relaunched.
+	wchar_t *compat_layer_env = _wgetenv(L"__COMPAT_LAYER");
+	if (compat_layer_env == NULL) {
+		compat_layer_env = L"mumble_exe_none";
+	}
+	_wputenv_s(L"mumble_exe_prev_compat_layer", compat_layer_env);
+
+	// The only way we have found thus far to ignore the executable's
+	// manifest when calling CreateProcess, is to use the __COMPAT_LAYER
+	// environment variable.
+	//
+	// Setting this to RunAsInvoker seemingly ignores the application's
+	// manifest. RunAsInvoker is the default execution level for Windows
+	// programs.
+	_wputenv_s(L"__COMPAT_LAYER", L"RunAsInvoker");
+
+	std::wstring exe_path = GetExecutablePath();
+	if (exe_path.empty()) {
+		return false;
+	}
+
+	if (!CreateProcessW(exe_path.c_str(),
+	              GetCommandLineW(),
+	              NULL,
+	              NULL,
+	              FALSE,
+	              0,
+	              NULL,
+	              NULL,
+	              &startup_info,
+	              &process_info)) {
+		return false;
+	}
+
+	exit(0);
+}
+
+// CleanupEnvironmentVariables cleans up any
+// unnecessary environment variables.
+//
+// For now, this function cleans up any environment
+// variables set by RelaunchWithoutUIAccessIfNecessary.
+static void CleanupEnvironmentVariables() {
+	wchar_t *prev_compat_layer_env = _wgetenv(L"mumble_exe_prev_compat_layer");
+	if (prev_compat_layer_env != NULL) {
+		if (wcscmp(prev_compat_layer_env, L"mumble_exe_none") == 0) {
+			_wputenv_s(L"__COMPAT_LAYER", L"");
+		} else {
+			_wputenv_s(L"__COMPAT_LAYER", prev_compat_layer_env);
+		}
+	}
+	return true;
+}
+
 #ifdef DEBUG
 int main(int argc, char **argv) {
+	if (!CleanupEnvironmentVariables()) {
+		Alert(L"Mumble Launcher Error -5", L"Unable to clean environment variables");
+		return -5;
+	}
+
+	if (!RelaunchWithoutUIAccessIfNecessary()) {
+		Alert(L"Mumble Launcher Error -6", L"Unable to complete RelaunchWithoutUIAccessIfNecessary");
+		return -6;
+	}
+
 	if (!ConfigureEnvironment()) {
 		Alert(L"Mumble Launcher Error -1", L"Unable to configure environment.");
 		return -1;
@@ -179,6 +336,16 @@ int main(int argc, char **argv) {
 #endif  // DEBUG
 
 int APIENTRY wWinMain(HINSTANCE instance, HINSTANCE prevInstance, wchar_t *cmdArg, int cmdShow) {
+	if (!CleanupEnvironmentVariables()) {
+		Alert(L"Mumble Launcher Error -5", L"Unable to clean environment variables");
+		return -5;
+	}
+
+	if (!RelaunchWithoutUIAccessIfNecessary()) {
+		Alert(L"Mumble Launcher Error -6", L"Unable to complete RelaunchWithoutUIAccessIfNecessary");
+		return -6;
+	}
+
 	if (!ConfigureEnvironment()) {
 		Alert(L"Mumble Launcher Error -1", L"Unable to configure environment.");
 		return -1;

--- a/src/mumble_exe/mumble_exe.pro
+++ b/src/mumble_exe/mumble_exe.pro
@@ -13,7 +13,7 @@ TARGET = mumble
 win32 {
   DEFINES += WIN32 _WIN32
   RC_FILE = ../mumble/mumble.rc
-  LIBS *= -luser32 -lshlwapi
+  LIBS *= -luser32 -lshlwapi -ladvapi32
 
   win32-g++ {
     QMAKE_LFLAGS *= -municode


### PR DESCRIPTION
This adds a new config option, 'shortcut/windows/uiaccess/enable' to
Mumble.

This new config option allows users to configure whether or not Mumble
should use UIAccess.

When UIAccess is disabled via the config option, mumble.exe will ensure
it is launched without UIAccess. It does this by re-launching itself
in such a way that its manifest, which specifies uiAccess=true, is
ignored.

No UI for this config option is implemented yet. It is not clear what
should happen in that regard.

Perhaps Mumble should default to not running with UIAccess, and have an
option in the UI to enable it.
