### PR TITLE
GlobalShortcut_win: add PID/VID blacklist for misbehaving devices.

### DIFF
--- a/src/mumble/GlobalShortcut_win.h
+++ b/src/mumble/GlobalShortcut_win.h
@@ -45,9 +45,17 @@ typedef QPair<GUID, DWORD> qpButton;
 
 struct InputDevice {
 	LPDIRECTINPUTDEVICE8 pDID;
+
+	QString name;
+
 	GUID guid;
 	QVariant vguid;
-	QString name;
+
+	GUID guidproduct;
+	QVariant vguidproduct;
+
+	uint16_t vendor_id;
+	uint16_t product_id;
 
 	// dwType to name
 	QHash<DWORD, QString> qhNames;


### PR DESCRIPTION
This commit adds a few new fields to the InputDevice struct found
in GlobalShortcut_win.

We now store the guidProduct in InputDeivce::guidproduct, and
extract the vendor ID and product ID  from that, if possible.
The vendor ID and product ID are stored in InputDevice::product_id
and InputDevice::vendor_id.

Using these new fields, we blacklist devices in EnumDevicesCB, and
reject devices we know to be misbehaving, such as:

 Device Name: ODAC-revB
 Vendor/Product ID: 0x262A, 0x1048
 https://github.com/mumble-voip/mumble/issues/1977

 Device Name: Aune T1 MK2 - HID-compliant consumer control device
 Vendor/Product ID: 0x262A, 0x1168
 https://github.com/mumble-voip/mumble/issues/1880