### PR TITLE
GlobalShortcut_win, XboxInput: implement native XInput support in GlobalShortcut_win.

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -166,3 +166,7 @@ CONFIG+=no-qssldiffiehellmanparameters
  parameters, even if the QSslDiffieHellmanParameters
  class is available in the version of Qt you are
  building against.
+
+CONFIG+=no-xboxinput (Mumble, Win32)
+ Don't build in support for global shortcuts
+ from Xbox controllers via the XInput DLL.

--- a/src/mumble/GlobalShortcut_win.cpp
+++ b/src/mumble/GlobalShortcut_win.cpp
@@ -158,6 +158,15 @@ void GlobalShortcutWin::run() {
 	}
 #endif
 
+#ifdef USE_XBOXINPUT
+	if (g.s.bEnableXboxInput) {
+		xboxinput = new XboxInputLibrary();
+		ZeroMemory(&xinput_last_packet, sizeof(xinput_last_packet));
+		ZeroMemory(&xinput_state, sizeof(xinput_state));
+		qWarning("GlobalShortcutWin: XboxInputLibrary initialized, isValid: %d", xboxinput->isValid());
+	}
+#endif
+
 	QTimer * timer = new QTimer(this);
 	connect(timer, SIGNAL(timeout()), this, SLOT(timeTicked()));
 	timer->start(20);
@@ -168,6 +177,10 @@ void GlobalShortcutWin::run() {
 
 #ifdef USE_GKEY
 	delete gkey;
+#endif
+
+#ifdef USE_XBOXINPUT
+	delete xboxinput;
 #endif
 
 	if (bHook) {
@@ -581,6 +594,7 @@ void GlobalShortcutWin::timeTicked() {
 			handleButton(ql, rgdod[j].dwData & 0x80);
 		}
 	}
+
 #ifdef USE_GKEY
 	if (g.s.bEnableGKey && gkey->isValid()) {
 		for (int button = GKEY_MIN_MOUSE_BUTTON; button <= GKEY_MAX_MOUSE_BUTTON; button++) {
@@ -597,6 +611,58 @@ void GlobalShortcutWin::timeTicked() {
 				ql << (key | (mode << 16));
 				ql << GKeyLibrary::quKeyboard;
 				handleButton(ql, gkey->isKeyboardGkeyPressed(key, mode));
+			}
+		}
+	}
+#endif
+
+#ifdef USE_XBOXINPUT
+	if (g.s.bEnableXboxInput && xboxinput->isValid()) {
+		for (DWORD i = 0; i < XUSER_MAX_COUNT; i++) {
+			if (xboxinput->GetState(i, &xinput_state[i]) == ERROR_SUCCESS) {
+				if (xinput_last_packet[i] != 0 && xinput_state[i].dwPacketNumber <= xinput_last_packet[i]) {
+					continue;
+				}
+
+				// The wButtons DWORD of XINPUT_GAMEPAD contains a bit
+				// for each button on the Xbox controller. The official
+				// headers enumerate the bits via XINPUT_GAMEPAD_*.
+				// The official mapping uses all 16-bits, but leaves
+				// bit 10 and 11 (counting from 0) undocumented.
+				//
+				// It turns out that bit 10 is the guide button,
+				// which can be queried using the non-public
+				// XInputGetStateEx function.
+				//
+				// Our mapping uses the bit number as a button index.
+				// So 0x1 -> 0, 0x2 -> 1, 0x4 -> 2, and so on...
+				//
+				// However, since wButtons is only a 16-bit value, and
+				// we also want to use the left and right triggers as
+				// buttons, we assign them the button indexes 16 and 17.
+				DWORD buttonMask = xinput_state[i].Gamepad.wButtons;
+				for (DWORD j = 0; j < 18; j++) {
+					QList<QVariant> ql;
+
+					bool pressed = false;
+					if (j >= 16) {
+						if (j == 16) { // LeftTrigger
+							pressed = xinput_state[i].Gamepad.bLeftTrigger > XINPUT_GAMEPAD_TRIGGER_THRESHOLD;
+						} else if (j == 17) { // RightTrigger
+							pressed = xinput_state[i].Gamepad.bRightTrigger > XINPUT_GAMEPAD_TRIGGER_THRESHOLD;
+						}
+					} else {
+						DWORD currentButtonMask = (1 << j);
+						pressed = (buttonMask & currentButtonMask) != 0;
+					}
+
+					DWORD type = (i << 24) | j;
+					ql << static_cast<uint>(type);
+					ql << XboxInputLibrary::quXboxInput;
+					handleButton(ql, pressed);
+				}
+
+				xinput_last_packet[i] = xinput_state[i].dwPacketNumber;
 			}
 		}
 	}
@@ -633,6 +699,56 @@ QString GlobalShortcutWin::buttonName(const QVariant &v) {
 		if (isGKey) {
 			device = QLatin1String("GKey:");
 			return device + name; // Example output: "Gkey:G6/M1"
+		}
+	}
+#endif
+
+#ifdef USE_XBOXINPUT
+	if (g.s.bEnableXboxInput && xboxinput->isValid() && guid == XboxInputLibrary::quXboxInput) {
+		DWORD idx = (type >> 24) & 0xff;
+		DWORD button = (type & 0x00ffffffff);
+
+		// Translate from our own button index mapping to
+		// the actual Xbox controller button names.
+		// For a description of the mapping, see the state
+		// querying code in GlobalShortcutWin::timeTicked().
+		switch (button) {
+			case 0:
+				return QString::fromLatin1("Xbox%1:Up").arg(idx + 1);
+			case 1:
+				return QString::fromLatin1("Xbox%1:Down").arg(idx + 1);
+			case 2:
+				return QString::fromLatin1("Xbox%1:Left").arg(idx + 1);
+			case 3:
+				return QString::fromLatin1("Xbox%1:Right").arg(idx + 1);
+			case 4:
+				return QString::fromLatin1("Xbox%1:Start").arg(idx + 1);
+			case 5:
+				return QString::fromLatin1("Xbox%1:Back").arg(idx + 1);
+			case 6:
+				return QString::fromLatin1("Xbox%1:LeftThumb").arg(idx + 1);
+			case 7:
+				return QString::fromLatin1("Xbox%1:RightThumb").arg(idx + 1);
+			case 8:
+				return QString::fromLatin1("Xbox%1:LeftShoulder").arg(idx + 1);
+			case 9:
+				return QString::fromLatin1("Xbox%1:RightShoulder").arg(idx + 1);
+			case 10:
+				return QString::fromLatin1("Xbox%1:Guide").arg(idx + 1);
+			case 11:
+				return QString::fromLatin1("Xbox%1:11").arg(idx + 1);
+			case 12:
+				return QString::fromLatin1("Xbox%1:A").arg(idx + 1);
+			case 13:
+				return QString::fromLatin1("Xbox%1:B").arg(idx + 1);
+			case 14:
+				return QString::fromLatin1("Xbox%1:X").arg(idx + 1);
+			case 15:
+				return QString::fromLatin1("Xbox%1:Y").arg(idx + 1);
+			case 16:
+				return QString::fromLatin1("Xbox%1:LeftTrigger").arg(idx + 1);
+			case 17:
+				return QString::fromLatin1("Xbox%1:RightTrigger").arg(idx + 1);
 		}
 	}
 #endif

--- a/src/mumble/GlobalShortcut_win.h
+++ b/src/mumble/GlobalShortcut_win.h
@@ -38,6 +38,10 @@
 #include "GKey.h"
 #endif
 
+#ifdef USE_XBOXINPUT
+#include "XboxInput.h"
+#endif
+
 #define DIRECTINPUT_VERSION 0x0800
 #include <dinput.h>
 
@@ -77,6 +81,12 @@ class GlobalShortcutWin : public GlobalShortcutEngine {
 #ifdef USE_GKEY
 		GKeyLibrary *gkey;
 #endif
+#ifdef USE_XBOXINPUT
+		DWORD             xinput_last_packet[XUSER_MAX_COUNT];
+		XINPUT_STATE      xinput_state[XUSER_MAX_COUNT];
+		XboxInputLibrary *xboxinput;
+#endif
+
 		static BOOL CALLBACK EnumSuitableDevicesCB(LPCDIDEVICEINSTANCE, LPDIRECTINPUTDEVICE8, DWORD, DWORD, LPVOID);
 		static BOOL CALLBACK EnumDevicesCB(LPCDIDEVICEINSTANCE, LPVOID);
 		static BOOL CALLBACK EnumDeviceObjectsCallback(LPCDIDEVICEOBJECTINSTANCE lpddoi, LPVOID pvRef);

--- a/src/mumble/Settings.cpp
+++ b/src/mumble/Settings.cpp
@@ -414,6 +414,7 @@ Settings::Settings() {
 	bEnableEvdev = false;
 	bEnableXInput2 = true;
 	bEnableGKey = true;
+	bEnableXboxInput = true;
 
 	for (int i=Log::firstMsgType; i<=Log::lastMsgType; ++i) {
 		qmMessages.insert(i, Settings::LogConsole | Settings::LogBalloon | Settings::LogTTS);
@@ -740,6 +741,7 @@ void Settings::load(QSettings* settings_ptr) {
 	SAVELOAD(bEnableEvdev, "shortcut/linux/evdev/enable");
 	SAVELOAD(bEnableXInput2, "shortcut/x11/xinput2/enable");
 	SAVELOAD(bEnableGKey, "shortcut/gkey");
+	SAVELOAD(bEnableXboxInput, "shortcut/windows/xinput/enable");
 
 	int nshorts = settings_ptr->beginReadArray(QLatin1String("shortcuts"));
 	for (int i=0; i<nshorts; i++) {
@@ -1043,6 +1045,7 @@ void Settings::save() {
 	SAVELOAD(bSuppressMacEventTapWarning, "shortcut/mac/suppresswarning");
 	SAVELOAD(bEnableEvdev, "shortcut/linux/evdev/enable");
 	SAVELOAD(bEnableXInput2, "shortcut/x11/xinput2/enable");
+	SAVELOAD(bEnableXboxInput, "shortcut/windows/xinput/enable");
 
 	settings_ptr->beginWriteArray(QLatin1String("shortcuts"));
 	int idx = 0;

--- a/src/mumble/Settings.h
+++ b/src/mumble/Settings.h
@@ -245,6 +245,7 @@ struct Settings {
 	bool bEnableEvdev;
 	bool bEnableXInput2;
 	bool bEnableGKey;
+	bool bEnableXboxInput;
 	QList<Shortcut> qlShortcuts;
 
 	enum MessageLog { LogNone = 0x00, LogConsole = 0x01, LogTTS = 0x02, LogBalloon = 0x04, LogSoundfile = 0x08};

--- a/src/mumble/XboxInput.cpp
+++ b/src/mumble/XboxInput.cpp
@@ -1,0 +1,83 @@
+/* Copyright (C) 2015, Mikkel Krautz <mikkel@krautz.dk>
+
+   All rights reserved.
+
+   Redistribution and use in source and binary forms, with or without
+   modification, are permitted provided that the following conditions
+   are met:
+
+   - Redistributions of source code must retain the above copyright notice,
+     this list of conditions and the following disclaimer.
+   - Redistributions in binary form must reproduce the above copyright notice,
+     this list of conditions and the following disclaimer in the documentation
+     and/or other materials provided with the distribution.
+   - Neither the name of the Mumble Developers nor the names of its
+     contributors may be used to endorse or promote products derived from this
+     software without specific prior written permission.
+
+   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+   ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+   LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+   A PARTICULAR PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE FOUNDATION OR
+   CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+   EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+   PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+   PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+   LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+   NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+   SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+#include "mumble_pch.hpp"
+
+#include "XboxInput.h"
+
+const QUuid XboxInputLibrary::quXboxInput = QUuid(QString::fromLatin1("ca3937e3-640c-4d9e-9ef3-903f8b4fbcab"));
+
+XboxInputLibrary::XboxInputLibrary()
+	: XInputGetState(NULL)
+	, XInputGetStateEx(NULL)
+	, bValid(false) {
+
+	QStringList alternatives;
+	alternatives << QLatin1String("XInput1_4.dll");
+	alternatives << QLatin1String("XInput9_1_0.dll");
+	alternatives << QLatin1String("xinput1_3.dll");
+	alternatives << QLatin1String("xinput1_2.dll");
+	alternatives << QLatin1String("xinput1_1.dll");
+
+	foreach(const QString &lib, alternatives) {
+		hXInput = LoadLibraryW(reinterpret_cast<const wchar_t *>(lib.utf16()));
+		if (hXInput != NULL) {
+			qWarning("XboxInputLibrary: using XInput DLL '%s'", qPrintable(lib));
+			bValid = true;
+			break;
+		}
+	}
+
+	*(reinterpret_cast<void **>(&XInputGetState)) = reinterpret_cast<void *>(GetProcAddress(hXInput, "XInputGetState"));
+	// Undocumented XInputGetStateEx -- ordinal 100. Might not be in the DLL, but if
+	// if is, we want to use it. It provides access to the state of the guide button.
+	*(reinterpret_cast<void **>(&XInputGetStateEx)) = reinterpret_cast<void *>(GetProcAddress(hXInput, (char *)100));
+
+	if (XInputGetStateEx != NULL) {
+		GetState = XInputGetStateEx;
+		qWarning("XboxInputLibrary: using XInputGetStateEx as querying function");
+	} else if (XInputGetState != NULL) {
+		GetState = XInputGetState;
+		qWarning("XboxInputLibrary: using XInputGetState as querying function");
+	} else {
+		bValid = false;
+		qWarning("XboxInputLibrary: no valid querying function found");
+	}
+}
+
+XboxInputLibrary::~XboxInputLibrary() {
+	if (hXInput) {
+		FreeLibrary(hXInput);
+	}
+}
+
+bool XboxInputLibrary::isValid() const {
+	return bValid;
+}

--- a/src/mumble/XboxInput.h
+++ b/src/mumble/XboxInput.h
@@ -1,0 +1,70 @@
+/* Copyright (C) 2015, Mikkel Krautz <mikkel@krautz.dk>
+
+   All rights reserved.
+
+   Redistribution and use in source and binary forms, with or without
+   modification, are permitted provided that the following conditions
+   are met:
+
+   - Redistributions of source code must retain the above copyright notice,
+     this list of conditions and the following disclaimer.
+   - Redistributions in binary form must reproduce the above copyright notice,
+     this list of conditions and the following disclaimer in the documentation
+     and/or other materials provided with the distribution.
+   - Neither the name of the Mumble Developers nor the names of its
+     contributors may be used to endorse or promote products derived from this
+     software without specific prior written permission.
+
+   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+   ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+   LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+   A PARTICULAR PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE FOUNDATION OR
+   CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+   EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+   PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+   PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+   LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+   NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+   SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+#ifndef MUMBLE_MUMBLE_XBOXINPUT_H_
+#define MUMBLE_MUMBLE_XBOXINPUT_H_
+
+#define XUSER_MAX_COUNT                     4
+
+#define XINPUT_GAMEPAD_TRIGGER_THRESHOLD    30
+
+struct XINPUT_GAMEPAD {
+	WORD   wButtons;
+	BYTE   bLeftTrigger;
+	BYTE   bRightTrigger;
+	SHORT  sThumbLX;
+	SHORT  sThumbLY;
+	SHORT  sThumbRX;
+	SHORT  sThumbRY;
+};
+
+struct XINPUT_STATE {
+	DWORD           dwPacketNumber;
+	XINPUT_GAMEPAD  Gamepad;
+};
+
+class XboxInputLibrary {
+	public:
+		XboxInputLibrary();
+		virtual ~XboxInputLibrary();
+
+		static const QUuid quXboxInput;
+
+		bool isValid() const;
+		DWORD (*GetState)(DWORD dwUserIndex, XINPUT_STATE *pState);
+
+	protected:
+		DWORD (*XInputGetState)(DWORD dwUserIndex, XINPUT_STATE *pState);
+		DWORD (*XInputGetStateEx)(DWORD dwUserIndex, XINPUT_STATE *pState);
+		HMODULE hXInput;
+		bool bValid;
+};
+
+#endif

--- a/src/mumble/mumble.pro
+++ b/src/mumble/mumble.pro
@@ -401,6 +401,15 @@ win32 {
     DEFINES *= USE_GKEY
   }
 
+  !CONFIG(no-xboxinput) {
+    CONFIG *= xboxinput
+  }
+  CONFIG(xboxinput) {
+    HEADERS *= XboxInput.h
+    SOURCES *= XboxInput.cpp
+    DEFINES *= USE_XBOXINPUT
+  }
+
   !CONFIG(mumble_dll) {
     !CONFIG(no-elevation) {
       CONFIG(release, debug|release) {


### PR DESCRIPTION
This commit adds native support for XInput to GlobalShortcut on Windows.

Most things XInput-related is named XboxInput in an attempt to reduce
confusion with X11's XInput.

This commit adds a new class, XboxInputLibrary, which is a thin wrapper
class for handling the XInput DLL.

XboxInputLibrary supports various versions of the XInput DLL, as well as
the non-public XInputGetStateEx function (ordinal 100) -- if it is
available in the loaded XInput DLL. XInputGetStateEx makes it possible to
query the state of the guide button, allowing it to be used as a global
shortcut in Mumble.

The most suitable GetState function is chosen by XboxInputLibrary and is
exposed simply via the GetState member variable.

This commit does nothing to prevent DirectInput from *also* getting input
from any connected Xbox controllers. However, no ill effects have been
observed yet.

For now, the result simply is that -- for the buttons that DirectInput
supports -- we get a button click from both engines. For example,
pressing A yields the equivalent of "DirectInput:A + Xbox1:A" as the
shortcut name, because both engines handled the button press.

In the future, we should blacklist the DirectInput device if XboxInput
is enabled to rule out any future incompatibilities.

The current implementation treats a shortcut from the first Xbox
controller as a different shortcut than the same button from a
potential second, third or fourth Xbox controller connected to
the system. As a result, if a button is bound on the first controller
in one session, Mumble will only respond if that button is pressed on
the first controller in future sessions.

Fixes mumble-voip/mumble#1995