### PR TITLE
Fix xboxinput calls crashing on x86

### DIFF
--- a/src/mumble/Settings.cpp
+++ b/src/mumble/Settings.cpp
@@ -414,7 +414,7 @@ Settings::Settings() {
 	bEnableEvdev = false;
 	bEnableXInput2 = true;
 	bEnableGKey = true;
-	bEnableXboxInput = false;
+	bEnableXboxInput = true;
 
 	for (int i=Log::firstMsgType; i<=Log::lastMsgType; ++i) {
 		qmMessages.insert(i, Settings::LogConsole | Settings::LogBalloon | Settings::LogTTS);

--- a/src/mumble/XboxInput.h
+++ b/src/mumble/XboxInput.h
@@ -31,6 +31,10 @@
 #ifndef MUMBLE_MUMBLE_XBOXINPUT_H_
 #define MUMBLE_MUMBLE_XBOXINPUT_H_
 
+#include <windows.h>
+#include <stdint.h>
+#include <QUuid>
+
 /// XBOXINPUT_MAX_DEVICES defines the maximum
 /// number of devices that can be connected
 /// to the system at once.
@@ -79,15 +83,15 @@ class XboxInput {
 		/// Query the state of the Xbox controller at deviceIndex.
 		/// If the function succeeds, it returns 0 (Windows's ERROR_SUCCESS).
 		/// If no device is connected, it returns 0x48F (Windows's ERROR_DEVICE_NOT_CONNECTED).
-		uint32_t (*GetState)(uint32_t deviceIndex, XboxInputState *state);
+		uint32_t (WINAPI *GetState)(uint32_t deviceIndex, XboxInputState *state);
 
 	protected:
 		/// m_getStateFunc represents XInputGetState from the XInput DLL.
-		uint32_t (*m_getStateFunc)(uint32_t deviceIndex, XboxInputState *state);
+		uint32_t (WINAPI *m_getStateFunc)(uint32_t deviceIndex, XboxInputState *state);
 
 		/// m_getStateFuncEx represents XInputGetStateEx, which is optionally
 		/// available in the XInput DLL.
-		uint32_t (*m_getStateExFunc)(uint32_t deviceIndex, XboxInputState *state);
+		uint32_t (WINAPI *m_getStateExFunc)(uint32_t deviceIndex, XboxInputState *state);
 
 		/// m_xinputlib is the handle to the XInput DLL as returned by
 		/// LoadLibrary.


### PR DESCRIPTION
The XboxInputState structure we used was only compatible
to the XInputGetState function. The undocumented
XboxInputStateEx function we prefer requires additional
padding at the end of the structure.

Fixes #2018
Fixes #2016

This PR also reverts disabling xboxinput by default.