### PR TITLE
3rdparty/opus-build: enable use of SSE and SSE2 intrinsics in Opus on…

### DIFF
--- a/3rdparty/opus-build/config.h
+++ b/3rdparty/opus-build/config.h
@@ -135,3 +135,29 @@
 # define _Restrict
 # define __restrict__
 #endif
+
+// For now, only enable for OS X. We're sure
+// that OS X is x86, but we can't make the
+// same assumption for other Unix-like OSes.
+#ifdef __APPLE__
+/* Use run-time CPU capabilities detection */
+/* #undef OPUS_HAVE_RTCD */
+
+/* Compiler supports X86 SSE Intrinsics */
+#define OPUS_X86_MAY_HAVE_SSE 1
+
+/* Compiler supports X86 SSE2 Intrinsics */
+#define OPUS_X86_MAY_HAVE_SSE2 1
+
+/* Compiler supports X86 SSE4.1 Intrinsics */
+/* #undef OPUS_X86_MAY_HAVE_SSE4_1 */
+
+/* Define if binary requires SSE intrinsics support */
+#define OPUS_X86_PRESUME_SSE 1
+
+/* Define if binary requires SSE2 intrinsics support */
+#define OPUS_X86_PRESUME_SSE2 1
+
+/* Define if binary requires SSE4.1 intrinsics support */
+/* #undef OPUS_X86_PRESUME_SSE4_1 */
+#endif

--- a/3rdparty/opus-build/opus-build.pro
+++ b/3rdparty/opus-build/opus-build.pro
@@ -97,7 +97,7 @@ celt/quant_bands.c \
 celt/rate.c \
 celt/vq.c
 
-win32 {
+win32|macx {
   # celt_sources.mk: CELT_SOURCES_SSE
   SOURCES *= \
   celt/x86/x86cpu.c \
@@ -107,7 +107,9 @@ win32 {
   # celt_sources.mk: CELT_SOURCES_SSE2
   SOURCES *= \
   celt/x86/pitch_sse2.c
+}
 
+win32 {
   # celt_sources.mk: CELT_SOURCES_SSE4_1
   SOURCES *= \
   celt/x86/celt_lpc_sse.c \


### PR DESCRIPTION
… OS X.

We cannot yet use SSE4.1, because that requires us to pass -msse4.1 to the
files that require SSE4.1 intrinsics. That is not very practical with the
current structure of opus-build and our use of qmake.

Updates mumble-voip/mumble#2000