### PR TITLE
MainWindow: only allow layout to be changed via settings.

### DIFF
--- a/src/mumble/MainWindow.cpp
+++ b/src/mumble/MainWindow.cpp
@@ -364,12 +364,10 @@ void MainWindow::setupGui()  {
 	else if (! g.s.bMinimalView && ! g.s.qbaMainWindowGeometry.isNull())
 		restoreGeometry(g.s.qbaMainWindowGeometry);
 
-	Settings::WindowLayout wlTmp = g.s.wlWindowLayout;
 	if (g.s.bMinimalView && ! g.s.qbaMinimalViewState.isNull())
 		restoreState(g.s.qbaMinimalViewState);
 	else if (! g.s.bMinimalView && ! g.s.qbaMainWindowState.isNull())
 		restoreState(g.s.qbaMainWindowState);
-	g.s.wlWindowLayout = wlTmp;
 
 	setupView(false);
 
@@ -562,6 +560,14 @@ void MainWindow::updateTransmitModeComboBox() {
 			qcbTransmitMode->setCurrentIndex(2);
 			return;
 	}
+}
+
+QMenu *MainWindow::createPopupMenu() {
+	if (g.s.wlWindowLayout == Settings::LayoutCustom) {
+		return QMainWindow::createPopupMenu();
+	}
+
+	return new QMenu();
 }
 
 Channel *MainWindow::getContextMenuChannel() {
@@ -882,9 +888,7 @@ void MainWindow::setOnTop(bool top) {
 void MainWindow::setupView(bool toggle_minimize) {
 	bool showit = ! g.s.bMinimalView;
 
-	// Update window layout
-	Settings::WindowLayout wlTmp = g.s.wlWindowLayout;
-	switch (wlTmp) {
+	switch (g.s.wlWindowLayout) {
 		case Settings::LayoutClassic:
 			removeDockWidget(qdwLog);
 			addDockWidget(Qt::LeftDockWidgetArea, qdwLog);
@@ -908,11 +912,9 @@ void MainWindow::setupView(bool toggle_minimize) {
 			qdwChat->show();
 			break;
 		default:
-			wlTmp = Settings::LayoutCustom;
 			break;
 	}
 	qteChat->updateGeometry();
-	g.s.wlWindowLayout = wlTmp;
 
 	QRect geom = frameGeometry();
 
@@ -3030,22 +3032,6 @@ void MainWindow::on_qteLog_highlighted(const QUrl &url) {
 			QToolTip::showText(QCursor::pos(), url.toString(), qteLog, QRect());
 		}
 	}
-}
-
-void MainWindow::on_qdwChat_dockLocationChanged(Qt::DockWidgetArea) {
-	g.s.wlWindowLayout = Settings::LayoutCustom;
-}
-
-void MainWindow::on_qdwLog_dockLocationChanged(Qt::DockWidgetArea) {
-	g.s.wlWindowLayout = Settings::LayoutCustom;
-}
-
-void MainWindow::on_qdwChat_visibilityChanged(bool) {
-	g.s.wlWindowLayout = Settings::LayoutCustom;
-}
-
-void MainWindow::on_qdwLog_visibilityChanged(bool) {
-	g.s.wlWindowLayout = Settings::LayoutCustom;
 }
 
 void MainWindow::context_triggered() {

--- a/src/mumble/MainWindow.h
+++ b/src/mumble/MainWindow.h
@@ -187,6 +187,8 @@ class MainWindow : public QMainWindow, public MessageHandler, public Ui::MainWin
 		void showEvent(QShowEvent *e) Q_DECL_OVERRIDE;
 		void changeEvent(QEvent* e) Q_DECL_OVERRIDE;
 
+		QMenu *createPopupMenu() Q_DECL_OVERRIDE;
+
 		bool handleSpecialContextMenu(const QUrl &url, const QPoint &pos_, bool focus = false);
 		Channel* getContextMenuChannel();
 		ClientUser* getContextMenuUser();
@@ -259,10 +261,6 @@ class MainWindow : public QMainWindow, public MessageHandler, public Ui::MainWin
 		void on_qteLog_customContextMenuRequested(const QPoint &pos);
 		void on_qteLog_anchorClicked(const QUrl &);
 		void on_qteLog_highlighted(const QUrl & link);
-		void on_qdwChat_dockLocationChanged(Qt::DockWidgetArea);
-		void on_qdwLog_dockLocationChanged(Qt::DockWidgetArea);
-		void on_qdwChat_visibilityChanged(bool);
-		void on_qdwLog_visibilityChanged(bool);
 		void on_PushToTalk_triggered(bool, QVariant);
 		void on_PushToMute_triggered(bool, QVariant);
 		void on_VolumeUp_triggered(bool, QVariant);


### PR DESCRIPTION
This simplifies our handling of our UI layout setting in
MainWindow.

Previously, we had slots that detected visibility and position
changes for dock elements. And if any of them fired, we would
revert back to the 'custom' layout.

However, changing the layout behind the user's back meant we
had to keep track of the original layout setting when we
performed a re-layout of the MainWindow, such as when we apply
new settings from the ConfigDialog.

In Qt 5 (we think!), things changed, and the slots are called
more frequently.

Currently, that means that Mumble *always* resets to the 'custom'
layout when applying settings. That's no good.

This commit removes the slots that listen for layout and visibility
changes for dock elements. It also removes MainWindow's 'dock widget'
context menu when not in the 'custom' layout. The result is that you
are now locked into the layout that you choose in the ConfigDialog.

We already have code in Mumble that I wrote a while back that disables
dragging of dock elements when you are not in the 'custom' layout.

This is a natural extension of that: you can no longer modify the
layout of the UI unless you choose 'custom'.

Fixes mumble-voip/mumble#2003