### PR TITLE
MainWindow: only allow toolbar dragging in the 'custom' layout.

### DIFF
--- a/src/mumble/MainWindow.cpp
+++ b/src/mumble/MainWindow.cpp
@@ -886,6 +886,8 @@ void MainWindow::setupView(bool toggle_minimize) {
 	Settings::WindowLayout wlTmp = g.s.wlWindowLayout;
 	switch (wlTmp) {
 		case Settings::LayoutClassic:
+			qtIconToolbar->setMovable(false);
+			addToolBar(Qt::TopToolBarArea, qtIconToolbar);
 			removeDockWidget(qdwLog);
 			addDockWidget(Qt::LeftDockWidgetArea, qdwLog);
 			qdwLog->show();
@@ -893,6 +895,8 @@ void MainWindow::setupView(bool toggle_minimize) {
 			qdwChat->show();
 			break;
 		case Settings::LayoutStacked:
+			qtIconToolbar->setMovable(false);
+			addToolBar(Qt::TopToolBarArea, qtIconToolbar);
 			removeDockWidget(qdwLog);
 			addDockWidget(Qt::BottomDockWidgetArea, qdwLog);
 			qdwLog->show();
@@ -900,6 +904,8 @@ void MainWindow::setupView(bool toggle_minimize) {
 			qdwChat->show();
 			break;
 		case Settings::LayoutHybrid:
+			qtIconToolbar->setMovable(false);
+			addToolBar(Qt::TopToolBarArea, qtIconToolbar);
 			removeDockWidget(qdwLog);
 			removeDockWidget(qdwChat);
 			addDockWidget(Qt::LeftDockWidgetArea, qdwLog);
@@ -907,8 +913,9 @@ void MainWindow::setupView(bool toggle_minimize) {
 			addDockWidget(Qt::BottomDockWidgetArea, qdwChat);
 			qdwChat->show();
 			break;
-		default:
-			wlTmp = Settings::LayoutCustom;
+		case Settings::LayoutCustom:
+			qtIconToolbar->setMovable(true);
+			addToolBar(qtIconToolbar);
 			break;
 	}
 	qteChat->updateGeometry();


### PR DESCRIPTION
Now that we only allow customizing the UI when using the 'custom'
layout, it makes sense to only allow moving the toolbar when in the
'custom layout.

For all our pre-defined layouts, the toolbar is forced to be on top
of the window.