### PR TITLE
About: change 'The Mumble team' to 'The Mumble Developers', as used in our license.

### DIFF
--- a/src/mumble/About.cpp
+++ b/src/mumble/About.cpp
@@ -68,11 +68,13 @@ AboutDialog::AboutDialog(QWidget *p) : QDialog(p) {
 	QLabel *text=new QLabel(about);
 	text->setOpenExternalLinks(true);
 	text->setText(tr(
-	                  "<h3>Mumble (%1)</h3>"
-	                  "<p>Copyright %3 The Mumble team</p>"
-	                  "<p><b>A voice-chat utility for gamers</b></p>"
-	                  "<p><tt><a href=\"%2\">%2</a></tt></p>"
-	              ).arg(QLatin1String(MUMBLE_RELEASE)).arg(QLatin1String("http://www.mumble.info/")).arg(QLatin1String("2005-2014")));
+		"<h3>Mumble (%1)</h3>"
+		"<p>%3</p>"
+		"<p><b>A voice-chat utility for gamers</b></p>"
+		"<p><tt><a href=\"%2\">%2</a></tt></p>"
+	).arg(QLatin1String(MUMBLE_RELEASE))
+	 .arg(QLatin1String("http://www.mumble.info/"))
+	 .arg(QLatin1String("Copyright 2005-2015 The Mumble Developers")));
 	QHBoxLayout *qhbl=new QHBoxLayout(about);
 	qhbl->addWidget(icon);
 	qhbl->addWidget(text);


### PR DESCRIPTION
Our LICENSE file references:

    "[...] Neither the name of the Mumble Developers nor
     the names of its contributors [...]"

As discussed in mumble-voip/mumble#1513, we should use that when
referencing the authors of Mumble.

This commit also makes the string untranslatable. This is
intentional, as "The Mumble Developers" identifies the name
we use for the project in a copyright context.

In fact, the whole Copyright string in the About dialog is now
marked as untranslatable. I think this is sensible, as our license
text itself is in English, and the meaning of the word "Copyright"
should be widely recognized even by non-English speakers. Referencing
local equivalents of Copyright law could cause confusion regarding
the legal status of Mumble.

Updates mumble-voip/mumble#1513