### PR TITLE
GlobalShortcut_win: NULL-initialize xboxinput and gkey member variables.

### DIFF
--- a/src/mumble/GlobalShortcut_win.cpp
+++ b/src/mumble/GlobalShortcut_win.cpp
@@ -96,9 +96,15 @@ GlobalShortcutEngine *GlobalShortcutEngine::platformInit() {
 }
 
 
-GlobalShortcutWin::GlobalShortcutWin() {
-	pDI = NULL;
-	uiHardwareDevices = 0;
+GlobalShortcutWin::GlobalShortcutWin()
+	: pDI(NULL)
+#ifdef USE_GKEY
+	, gkey(NULL)
+#endif
+#ifdef USE_XBOXINPUT
+	, xboxinput(NULL)
+#endif
+	, uiHardwareDevices(0) {
 
 	// Hidden setting to disable hooking
 	bHook = g.qs->value(QLatin1String("winhooks"), true).toBool();


### PR DESCRIPTION
If XboxInput or GKey support is disabled via 'shortcut/gkey/enable' or
'shortcut/windows/xbox/enable', GlobalShortcut_win will attempt to delete
the xboxinput and gkey member variables, which may contain garbage.
If they contain garbage, this will cause the Mumble process to crash.

This commit ensures the xboxinput and gkey member variables are
initialized to NULL on GlobalShortcut_win construction.