### PR TITLE
Messages, Murmur.ice: make username checking case insensitive throughout Murmur.

### DIFF
--- a/src/murmur/Messages.cpp
+++ b/src/murmur/Messages.cpp
@@ -149,7 +149,7 @@ void Server::msgAuthenticate(ServerUser *uSource, MumbleProto::Authenticate &msg
 		if (u == uSource)
 			continue;
 		if (((u->iId>=0) && (u->iId == uSource->iId)) ||
-		        (u->qsName == uSource->qsName)) {
+		        (u->qsName.toLower() == uSource->qsName.toLower())) {
 			uOld = u;
 			break;
 		}

--- a/src/murmur/Murmur.ice
+++ b/src/murmur/Murmur.ice
@@ -345,6 +345,12 @@ module Murmur
 		 *  The data in the certificate (name, email addresses etc), as well as the list of signing certificates,
 		 *  should only be trusted if certstrong is true.
 		 *
+		 *  Internally, Murmur treats usernames as case-insensitive. It is recommended
+		 *  that authenticators do the same. Murmur checks if a username is in use when
+		 *  a user connects. If the connecting user is registered, the other username is
+		 *  kicked. If the connecting user is not registered, the connecting user is not
+		 *  allowed to join the server.
+		 *
 		 *  @param name Username to authenticate.
 		 *  @param pw Password to authenticate with.
 		 *  @param certificates List of der encoded certificates the user connected with.


### PR DESCRIPTION
The database query for looking up users in ServerDB has always been
case insensitive.

This commit makes the "duplicate user"-check in Messages.cpp case
insensitive as well.

Furthermore, this commit updates the documentation for the authenticate()
callback in Murmur.ice to document that authenticators should strive to
make usernames case insensitive.

Fixes mumble-voip/mumble#1078