### PR TITLE
Changes the behavior for oversized messages.

### DIFF
--- a/src/mumble/Log.cpp
+++ b/src/mumble/Log.cpp
@@ -133,6 +133,7 @@ void LogConfig::load(const Settings &r) {
 	qcbReadBackOwn->setChecked(r.bTTSMessageReadBack);
 #endif
 	qcbWhisperFriends->setChecked(r.bWhisperFriends);
+  qcbBigMessages->setChecked(r.bBigMessages);
 }
 
 void LogConfig::save() const {
@@ -162,6 +163,7 @@ void LogConfig::save() const {
 	s.bTTSMessageReadBack = qcbReadBackOwn->isChecked();
 #endif
 	s.bWhisperFriends = qcbWhisperFriends->isChecked();
+  s.bBigMessages = qcbBigMessages->isChecked();
 }
 
 void LogConfig::accept() const {
@@ -443,19 +445,27 @@ QString Log::validHtml(const QString &html, bool allowReplacement, QTextCursor *
 	QSizeF s = qtd.size();
 
 	if (!valid || (s.width() > qr.width()) || (s.height() > qr.height())) {
-		qtd.setPlainText(html);
-		qtd.adjustSize();
-		s = qtd.size();
+		//qtd.setPlainText(html);
+		//qtd.adjustSize();
+		//s = qtd.size();
 
-		if ((s.width() > qr.width()) || (s.height() > qr.height())) {
-			QString errorMessage = tr("[[ Text object too large to display ]]");
+		//if ((s.width() > qr.width()) || (s.height() > qr.height())) {
+		QString errorMessage = tr("[[ Text object too large to display ]]");
+		//}
+ 		QString sSound = g.s.qmMessageSounds.value(Log::MsgType(Warning));
+		AudioOutputPtr ao = g.ao;
+		if (!ao || !ao->playSample(sSound, false)) {
+			qWarning() << "Sound file" << sSound << "is not a valid audio file, fallback to TTS.";
+		}
+    if (!g.s.bBigMessages) {
 			if (tc) {
 				tc->insertText(errorMessage);
 				return QString();
 			} else {
 				return errorMessage;
 			}
-		}
+    }
+
 	}
 
 	if (tc) {
@@ -498,7 +508,6 @@ void Log::log(MsgType mt, const QString &console, const QString &terse, bool own
 			tc.insertHtml(tr("[Date changed to %1]\n").arg(Qt::escape(qdDate.toString(Qt::DefaultLocaleShortDate))));
 			tc.movePosition(QTextCursor::End);
 		}
-
 		if (plain.contains(QRegExp(QLatin1String("[\\r\\n]")))) {
 			QTextFrameFormat qttf;
 			qttf.setBorder(1);

--- a/src/mumble/Log.cpp
+++ b/src/mumble/Log.cpp
@@ -445,19 +445,13 @@ QString Log::validHtml(const QString &html, bool allowReplacement, QTextCursor *
 	QSizeF s = qtd.size();
 
 	if (!valid || (s.width() > qr.width()) || (s.height() > qr.height())) {
-		//qtd.setPlainText(html);
-		//qtd.adjustSize();
-		//s = qtd.size();
-
-		//if ((s.width() > qr.width()) || (s.height() > qr.height())) {
-		QString errorMessage = tr("[[ Text object too large to display ]]");
-		//}
  		QString sSound = g.s.qmMessageSounds.value(Log::MsgType(Warning));
 		AudioOutputPtr ao = g.ao;
 		if (!ao || !ao->playSample(sSound, false)) {
 			qWarning() << "Sound file" << sSound << "is not a valid audio file, fallback to TTS.";
 		}
     if (!g.s.bBigMessages) {
+      QString errorMessage = tr("[[ Text object too large to display ]]");
 			if (tc) {
 				tc->insertText(errorMessage);
 				return QString();
@@ -465,7 +459,6 @@ QString Log::validHtml(const QString &html, bool allowReplacement, QTextCursor *
 				return errorMessage;
 			}
     }
-
 	}
 
 	if (tc) {

--- a/src/mumble/Log.ui
+++ b/src/mumble/Log.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>446</width>
-    <height>334</height>
+    <width>517</width>
+    <height>389</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -165,6 +165,25 @@
         </property>
         <property name="text">
          <string>Only accept whispers from friends</string>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item>
+    <widget class="QGroupBox" name="qgbBigMessages">
+     <property name="title">
+      <string>Oversized Text Messages</string>
+     </property>
+     <layout class="QVBoxLayout" name="verticalLayout">
+      <item>
+       <widget class="QCheckBox" name="qcbBigMessages">
+        <property name="toolTip">
+         <string>If checked mumble will display messages witch won't fit on your screen, else you get only a warning.</string>
+        </property>
+        <property name="text">
+         <string>Show oversized messages</string>
         </property>
        </widget>
       </item>

--- a/src/mumble/Settings.cpp
+++ b/src/mumble/Settings.cpp
@@ -38,7 +38,6 @@
 #include "Log.h"
 #include "Global.h"
 #include "SSL.h"
-
 #include "../../overlay/overlay.h"
 
 bool Shortcut::isServerSpecific() const {
@@ -281,6 +280,7 @@ Settings::Settings() {
 	bUserTop = true;
 
 	bWhisperFriends = false;
+  bBigMessages = true;
 
 	uiDoublePush = 0;
 	pttHold = 0;
@@ -612,6 +612,8 @@ void Settings::load(QSettings* settings_ptr) {
 	SAVELOAD(qsAudioInput, "audio/input");
 	SAVELOAD(qsAudioOutput, "audio/output");
 	SAVELOAD(bWhisperFriends, "audio/whisperfriends");
+  
+ 
 	SAVELOAD(bTransmitPosition, "audio/postransmit");
 
 	SAVELOAD(iJitterBufferSize, "net/jitterbuffer");
@@ -765,6 +767,8 @@ void Settings::load(QSettings* settings_ptr) {
 		SAVELOAD(qmMessages[it.key()], "log");
 	}
 	settings_ptr->endArray();
+	// or on a other position in source and/or category
+  SAVELOAD(bBigMessages, "chat/bigmessage");
 
 	settings_ptr->beginReadArray(QLatin1String("messagesounds"));
 	for (QMap<int, QString>::const_iterator it = qmMessageSounds.constBegin(); it != qmMessageSounds.constEnd(); ++it) {
@@ -1065,7 +1069,10 @@ void Settings::save() {
 		settings_ptr->setArrayIndex(it.key());
 		SAVELOAD(qmMessages[it.key()], "log");
 	}
+  
 	settings_ptr->endArray();
+	// or on a other position in source and/or category
+  SAVELOAD(bBigMessages, "chat/bigmessage");
 
 	settings_ptr->beginWriteArray(QLatin1String("messagesounds"));
 	for (QMap<int, QString>::const_iterator it = qmMessageSounds.constBegin(); it != qmMessageSounds.constEnd(); ++it) {

--- a/src/mumble/Settings.cpp
+++ b/src/mumble/Settings.cpp
@@ -612,8 +612,6 @@ void Settings::load(QSettings* settings_ptr) {
 	SAVELOAD(qsAudioInput, "audio/input");
 	SAVELOAD(qsAudioOutput, "audio/output");
 	SAVELOAD(bWhisperFriends, "audio/whisperfriends");
-  
- 
 	SAVELOAD(bTransmitPosition, "audio/postransmit");
 
 	SAVELOAD(iJitterBufferSize, "net/jitterbuffer");
@@ -1069,7 +1067,6 @@ void Settings::save() {
 		settings_ptr->setArrayIndex(it.key());
 		SAVELOAD(qmMessages[it.key()], "log");
 	}
-  
 	settings_ptr->endArray();
 	// or on a other position in source and/or category
   SAVELOAD(bBigMessages, "chat/bigmessage");

--- a/src/mumble/Settings.h
+++ b/src/mumble/Settings.h
@@ -186,6 +186,7 @@ struct Settings {
 	bool bTTS;
 	bool bUserTop;
 	bool bWhisperFriends;
+  bool bBigMessages;
 	bool bTTSMessageReadBack;
 	int iTTSVolume, iTTSThreshold;
 	int iQuality, iMinLoudness, iVoiceHold, iJitterBufferSize;


### PR DESCRIPTION
Oversized messages don't convert in plaintext anymore. The user can decide if the message renderd or not.
As addition an accoustic warning signal will played if in user settings the warning audio file is set.

**This are my first lines of code in c/cpp. I'm started to lern it yesterday. So the changes may look wired or have side effects I've not noticed yet.**
