### PR TITLE
mumble.pro: use separate libsndfile libs on Windows.

### DIFF
--- a/src/mumble/mumble.pro
+++ b/src/mumble/mumble.pro
@@ -372,7 +372,8 @@ win32 {
   }
   HEADERS	*= GlobalShortcut_win.h Overlay_win.h TaskList.h UserLockFile.h
   SOURCES	*= GlobalShortcut_win.cpp TextToSpeech_win.cpp Overlay_win.cpp SharedMemory_win.cpp Log_win.cpp os_win.cpp TaskList.cpp ../../overlay/ods.cpp UserLockFile_win.cpp
-  LIBS		*= -ldxguid -ldinput8 -lsapi -lole32 -lws2_32 -ladvapi32 -lwintrust -ldbghelp -llibsndfile-1 -lshell32 -lshlwapi -luser32 -lgdi32 -lpsapi
+  LIBS		*= -ldxguid -ldinput8 -lsapi -lole32 -lws2_32 -ladvapi32 -lwintrust -ldbghelp -lshell32 -lshlwapi -luser32 -lgdi32 -lpsapi
+  LIBS		*= -logg -lvorbis -lvorbisfile -lFLAC -lsndfile
   LIBS		*= -ldelayimp -delayload:shell32.dll
 
   DEFINES	*= WIN32


### PR DESCRIPTION
Previously, we combined all libsndfile dependencies into
a big libsndfile static library. This included Ogg, FLAC,
Vorbis and Vorbisfile.

However, the MSVC linker complains about the combined
library because there are object files in the combined
library that have the same names. This is lpc.obj and
window.obj, which are both present in both Vorbis and
FLAC.

In order to remove this warning from the linker, this
commit links each libsndfile dependency separately,
and moves away from the combined static library.