### PR TITLE
TextToSpeech_unix: use Mumble's language setting, or the system locale for TTS language.

### DIFF
--- a/src/mumble/Settings.cpp
+++ b/src/mumble/Settings.cpp
@@ -252,6 +252,7 @@ Settings::Settings() {
 	bTTSMessageReadBack = false;
 	iTTSVolume = 75;
 	iTTSThreshold = 250;
+	qsTTSLanguage = QString();
 	iQuality = 40000;
 	fVolume = 1.0f;
 	fOtherVolume = 0.5f;
@@ -647,6 +648,7 @@ void Settings::load(QSettings* settings_ptr) {
 	SAVELOAD(iTTSVolume, "tts/volume");
 	SAVELOAD(iTTSThreshold, "tts/threshold");
 	SAVELOAD(bTTSMessageReadBack, "tts/readback");
+	SAVELOAD(qsTTSLanguage, "tts/language");
 
 	// Network settings
 	SAVELOAD(bTCPCompat, "net/tcponly");
@@ -956,6 +958,7 @@ void Settings::save() {
 	SAVELOAD(iTTSVolume, "tts/volume");
 	SAVELOAD(iTTSThreshold, "tts/threshold");
 	SAVELOAD(bTTSMessageReadBack, "tts/readback");
+	SAVELOAD(qsTTSLanguage, "tts/language");
 
 	// Network settings
 	SAVELOAD(bTCPCompat, "net/tcponly");

--- a/src/mumble/Settings.h
+++ b/src/mumble/Settings.h
@@ -188,6 +188,15 @@ struct Settings {
 	bool bWhisperFriends;
 	bool bTTSMessageReadBack;
 	int iTTSVolume, iTTSThreshold;
+	/// The Text-to-Speech language to use. This setting overrides
+	/// the default language for the Text-to-Speech engine, which
+	/// is usually inferred from the current locale.
+	///
+	/// The language is expected to be in BCP47 form.
+	///
+	/// The setting is currently only supported by the speech-dispatcher
+	///backend.
+	QString qsTTSLanguage;
 	int iQuality, iMinLoudness, iVoiceHold, iJitterBufferSize;
 	int iNoiseSuppress;
 

--- a/src/mumble/TextToSpeech_unix.cpp
+++ b/src/mumble/TextToSpeech_unix.cpp
@@ -60,6 +60,22 @@ TextToSpeechPrivate::TextToSpeechPrivate() {
 	if (! spd) {
 		qWarning("TextToSpeech: Failed to contact speech dispatcher.");
 	} else {
+		QString lang;
+		if (!g.s.qsTTSLanguage.isEmpty()) {
+			lang = g.s.qsTTSLanguage;
+		} else if (!g.s.qsLanguage.isEmpty()) {
+			QLocale locale(g.s.qsLanguage);
+			lang = locale.bcp47Name();
+		} else {
+			QLocale systemLocale;
+			lang = systemLocale.bcp47Name();
+		}
+		if (!lang.isEmpty()) {
+			if (spd_set_language(spd, lang.toLocal8Bit().constData()) != 0) {
+				qWarning("TextToSpeech: Failed to set language.");
+			}
+		}
+
 		if (spd_set_punctuation(spd, SPD_PUNCT_NONE) != 0)
 			qWarning("TextToSpech: Failed to set punctuation mode.");
 		if (spd_set_spelling(spd, SPD_SPELL_ON) != 0)


### PR DESCRIPTION
This commit adds code to TextToSpeech_unix to set
the desired TextToSpeech language that speech-dispatcher
should use.

In addition, this commit also adds a new setting,
"tts/language". This is a BCP 47-style language code
that TTS engines will attemp to adhere to.

I put it in, to allow users to still be able to use
an English TTS engine, while using Mumble in another
language.

For now, "tts/language" is a hidden setting -- it has
no UI to configure it.

Fixes mumble-voip/mumble#2066