### PR TITLE
Move HTML filtering to a separate shared class.

### DIFF
--- a/src/HTMLFilter.cpp
+++ b/src/HTMLFilter.cpp
@@ -1,0 +1,74 @@
+/* Copyright (C) 2005-2011, Thorvald Natvig <thorvald@natvig.com>
+   Copyright (C) 2016, Mikkel Krautz <mikkel@krautz.dk>
+
+   All rights reserved.
+
+   Redistribution and use in source and binary forms, with or without
+   modification, are permitted provided that the following conditions
+   are met:
+
+   - Redistributions of source code must retain the above copyright notice,
+     this list of conditions and the following disclaimer.
+   - Redistributions in binary form must reproduce the above copyright notice,
+     this list of conditions and the following disclaimer in the documentation
+     and/or other materials provided with the distribution.
+   - Neither the name of the Mumble Developers nor the names of its
+     contributors may be used to endorse or promote products derived from this
+     software without specific prior written permission.
+
+   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+   ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+   LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+   A PARTICULAR PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE FOUNDATION OR
+   CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+   EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+   PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+   PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+   LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+   NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+   SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+#include "murmur_pch.h"
+
+#include "HTMLFilter.h"
+
+QString HTMLFilter::escapeTags(const QString &in) {
+	QString out;
+	for (int i = 0; i < in.size(); i++) {
+		if (in.at(i) == QLatin1Char('<')) {
+			out += QLatin1String("&lt;");
+		} else if (in.at(i) == QLatin1Char('>')) {
+			out += QLatin1String("&gt;");
+		} else {
+			out += in.at(i);
+		}
+	}
+	return out;
+}
+
+bool HTMLFilter::filter(const QString &in, QString &out) {
+	if (! in.contains(QLatin1Char('<'))) {
+		out = in.simplified();
+	} else {
+		QXmlStreamReader qxsr(QString::fromLatin1("<document>%1</document>").arg(in));
+		QString qs;
+		while (! qxsr.atEnd()) {
+			switch (qxsr.readNext()) {
+				case QXmlStreamReader::Invalid:
+					return false;
+				case QXmlStreamReader::Characters:
+					qs += qxsr.text();
+					break;
+				case QXmlStreamReader::EndElement:
+					if ((qxsr.name() == QLatin1String("br")) || (qxsr.name() == QLatin1String("p")))
+						qs += QLatin1Char('\n');
+					break;
+				default:
+					break;
+			}
+		}
+		out = escapeTags(qs.simplified());
+	}
+	return true;
+}

--- a/src/HTMLFilter.h
+++ b/src/HTMLFilter.h
@@ -1,0 +1,63 @@
+/* Copyright (C) 2005-2011, Thorvald Natvig <thorvald@natvig.com>
+   Copyright (C) 2016, Mikkel Krautz <mikkel@krautz.dk>
+
+   All rights reserved.
+
+   Redistribution and use in source and binary forms, with or without
+   modification, are permitted provided that the following conditions
+   are met:
+
+   - Redistributions of source code must retain the above copyright notice,
+     this list of conditions and the following disclaimer.
+   - Redistributions in binary form must reproduce the above copyright notice,
+     this list of conditions and the following disclaimer in the documentation
+     and/or other materials provided with the distribution.
+   - Neither the name of the Mumble Developers nor the names of its
+     contributors may be used to endorse or promote products derived from this
+     software without specific prior written permission.
+
+   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+   ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+   LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+   A PARTICULAR PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE FOUNDATION OR
+   CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+   EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+   PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+   PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+   LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+   NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+   SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+#ifndef MUMBLE_HTMLFILTER_H_
+#define MUMBLE_HTMLFILTER_H_
+
+#include <QString>
+
+/// HTMLFilter provides utilitites for
+/// creating a plain text representaton
+/// of a HTML document.
+///
+/// It is used for converting Mumble
+/// text messages, comments, and more
+/// to plain text when a server is
+/// configured to disallow HTML. 
+class HTMLFilter {
+		/// escapeTags returns the in HTML document
+		/// with all occurrences of > and <
+		/// replaced by &lt; and &gt;.
+		static QString escapeTags(const QString &in);
+	public:
+		/// filter does a best-effort conversion of the
+		/// in HTML document to a plain-text representation.
+		///
+		/// If the filtering process succeeded, the function
+		/// writes the filtered document as plain text to
+		/// out, and returns true.
+		///
+		/// If the filtering failed, the function returns false
+		/// and out is left unchanged.	
+		static bool filter(const QString &in, QString &out);
+};
+
+#endif

--- a/src/mumble.pri
+++ b/src/mumble.pri
@@ -8,8 +8,8 @@ CONFIG		+= qt thread debug_and_release warn_on
 DEFINES		*= MUMBLE_VERSION_STRING=$$VERSION
 INCLUDEPATH	+= $$PWD . ../mumble_proto
 VPATH		+= $$PWD
-HEADERS		*= ACL.h Channel.h CryptState.h Connection.h Group.h User.h Net.h OSInfo.h Timer.h SSL.h Version.h SSLCipherInfo.h SSLCipherInfoTable.h
-SOURCES 	*= ACL.cpp Group.cpp Channel.cpp Connection.cpp User.cpp Timer.cpp CryptState.cpp OSInfo.cpp Net.cpp SSL.cpp Version.cpp SSLCipherInfo.cpp
+HEADERS		*= ACL.h Channel.h CryptState.h Connection.h Group.h HTMLFilter.h User.h Net.h OSInfo.h Timer.h SSL.h Version.h SSLCipherInfo.h SSLCipherInfoTable.h
+SOURCES 	*= ACL.cpp Group.cpp Channel.cpp Connection.cpp HTMLFilter.cpp User.cpp Timer.cpp CryptState.cpp OSInfo.cpp Net.cpp SSL.cpp Version.cpp SSLCipherInfo.cpp
 LIBS		*= -lmumble_proto
 # Note: Protobuf generates into its own directory so we can mark it as a
 #       system include folder for unix. Otherwise the generated code creates


### PR DESCRIPTION
Move HTML filtering to a separate shared class.

And touch up some of its code.

LuaMilkshake reports that it is possible to get
Murmur to emit HTML even when allowhtml is false.

For example via "<br />&lt;b&gt;hello world&lt;/&gt;",
which would be translated to "\n<b>hello world</b>"
by the previous HTML filtering code.

Mumble uses QXmlStreamReader to get each token of
an XML document to sanitize it.
Unfortunately, QXmlStreamReader isn't just a tokenizer.
It has a lot of behind-the-scenes XML logic to handle
things such as entities.
Entities definitions are read and handled by the
QXmlStreamReader itself, and are not emitted to a
consumer of QXmlStreamReader. This means that when
QXmlStreamReader gives you a piece of 'text' data,
it will have already translated any entities in the
text and translated them accordingly.
This is why LuaMilkshake's example works.

It is seemingly not possible to get QXmlStreamReader
to avoid handling entities. But I believe we can at
least stop it from allow new entities to be defined.
The original code already did that -- by wrapping
the input XML in a new root tag "<document>". This
ensures that an internal DTD cannot be defined, and
thus that no new entities can be added.

This limits the number of entities we need to
handle, to the small list of default entities
defined by XML: &quot; &amp; &aps; &lt; &gt;.

To ensure that the HTML filter is at least a little
bit effective against these injection attacks, we
ammend the logic of the HTML filter to attmpt to
strip &lt; and &gt; *after* running it through
the original QXmlStreamReader-based filter.
This ensures that no additional HTML elements
can be added via entities.