### PR TITLE
Simplify LICENSE file, add LICENSE.header and add AUTHORS.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -1,0 +1,176 @@
+// This is the official list of people who have contributed
+// to, and hold the copyright to Mumble.
+//
+// The use of Mumble source code is governed by a BSD-style
+// license that can be found in the LICENSE file at the root
+// of the Mumble source tree or at <http://www.mumble.info/LICENSE>.
+//
+// Contributions made on behalf of another entity, such as a
+// company are indicated with the following suffix:
+//
+//     John Doe <jd@mumble.info> (on behalf of $COMPANY)
+//
+// It is possible to mix individual contributions with company
+// contributions. For example, if a contributor, over time,
+// has contributed code copyrighted by the contributor, as well
+// as various companies:
+//
+//     John Doe <jd@mumble.info> (individually, on behalf of
+//                                $COMPANY1, on behalf of
+//                                $COMPANY2, [...]).
+
+Alex Krishnan <akrishnan@twilio.com>
+Alex Maclean <monkeh@monkeh.net>
+Álvaro Manuel Recio Pérez <naproxeno@users.sourceforge.net>
+Andreas Bibok <biboka@users.sourceforge.net>
+Andreas Sinz <andreas.sinz@aon.at>
+Antoine Bertin <diaoulael@users.sourceforge.net>
+Anton Romanov <theli.ua@gmail.com>
+Arcenciel <arcenciel@users.sourceforge.net>
+Arie <allochtoon@zonnet.nl>
+arrai <array.of.intellect@gmail.com>
+Artem Vorotnikov <skybon@gmail.com>
+asmolero <alsamolero@gmail.com>
+Asura Lee <ashurta@gmail.com>
+Austin Liou <https://github.com/austinliou>
+B0nuse <mumble@mumble.ru>
+Bartek "stranded" Sumowski <sumowski@gmail.com>
+Bas Wijnen <wijnen@debian.org>
+BAYSSE Laurent <lolo_32@users.sourceforge.net>
+bendem <online@bendem.be>
+Benjamin Jemlich <pcgod@users.sourceforge.net>
+Benjamin Neff <benjamin@coding4coffee.ch>
+Bernhard M. Wiedemann <bernhardout@lsmod.de>
+bogie <priivet@gmail.com>
+Bojan <bogie@b02.a01.ca>
+BuddyButterfly <buddy.butterfly@web.de>
+Charles Ricketts <githlar@gmail.com>
+Chosi <chosi@choseh.de>
+Christian Krause <chkr@plauener.de>
+Christoph Hofmann <christoph.hofmann@vfc2.eu>
+Christopher Knadle <Chris.Knadle@coredump.us>
+Cristian Gattamelati <cristian.gattamelati@gmail.com>
+d-rez <dark.skeleton@gmail.com>
+dc6jgk <github.filter@gkware.com>
+dennisschagt <dennisschagt@gmail.com>
+Derrick Dymock <derrick@puppetlabs.com>
+DK <davidk@mail.org>
+DNW <dnw.ftw@gmail.com>
+doggone <rolf@metadata.be>
+DWM|G <gallaghermumble@gmail.com>
+EarlOfWenc <lorenz.schwittmann@gmail.com>
+Erik Bouvin Pedersen <erikbp@users.sourceforge.net>
+Evan Purkhiser <evanpurkhiser@gmail.com>
+Ferdinand Thiessen <rpm@fthiessen.de>
+Filip Hedman <hedman.filip@gmail.com>
+Finessi Manuel <fino.manu@gmail.com>
+Frank Engler <https://github.com/9x6>
+Frank Mueller <frmimue@gmail.com>
+Fredrik Nordin <freedick@ludd.ltu.se>
+freedick <freddan007@gmail.com>
+Generator <american.jesus.pt@gmail.com>
+GoD-Tony <noreply@gmail.com>
+Gregor A <gdur.mugen@gmail.com>
+Harry Gabriel <h.gabriel@nodefab.de>
+haru_arc <arcenciel@users.sf.net>
+He Tal <hetao29@users.sourceforge.net>
+Hengqing Hu <esrms@users.sourceforge.net>
+Henry Fallon <hjf288@gmail.com>
+Iain Georgeson <debbugs@iain.georgeson.me.uk>
+Ilmar Kruis <seaeagle1@users.sourceforge.net>
+Imre Botos <zokny@users.sourceforge.net>
+Jacob Peddicord <jacob@peddicord.net>
+Jamie Fraser <fwagglechop@gmail.com>
+Jan Klass <kissaki@gmx.de>
+jgeboski <jgeboski@gmail.com>
+Joël Troch <joel.troch62@gmail.com>
+John P <johnhatestrash@gmail.com>
+Jonathan E. Hansen <zentriple@users.sourceforge.net>
+Jordan Cristiano <https://github.com/SizzlingCalamari>
+Jordan Klassen <jordan@klassen.me.uk>
+Joshua Kocinski <git@cl0secall.net>
+Julien Pardons <j.pardons@redline-hosting.eu>
+Justin M <justin.m.mcgrath@gmail.com>
+Justin McGrath <justin.m.mcgrath@gmail.com>
+Karl Dietz <dekarl@users.sourceforge.net>
+karokatona <karokatona@users.sourceforge.net>
+Kevin Rohland <kevin@nascher.org>
+Kevin Strasser <kevstras@gmail.com>
+Kissaki <kissaki@gmx.de>
+Kjetil Jørgensen <kjetijor@users.sourceforge.net>
+Kyle Smith <askreet@gmail.com>
+Lartza <https://github.com/Lartza>
+Lekensteyn <lekensteyn@users.sourceforge.net>
+Ludwig Nussel <ludwig.nussel@suse.de>
+Lukas Orsvärn <lucas.orsv@gmail.com>
+main() <main@ehvag.eu.org>
+Marius Grannæs <grannas@users.sourceforge.net>
+Mark-Willem Jansen <rawnar@users.sourceforge.net>
+Mark Felder <feld@feld.me>
+Markus S <Reaper@gmx.at>
+Martijn Stolk <github@netripper.nl>
+Martin Skilnand <cybknight@users.sourceforge.net>
+Martin von Gagern <Martin.vGagern@gmx.net>
+Matt Hamilton <m@tthamilton.com>
+Matt Lewandowsky <matt@greenviolet.net>
+Matthias Salzeder <mail@MatthiasSalzeder.de>
+Matthias Vogelgesang <matthias.vogelgesang@gmail.com>
+meanracoon <racoon@meanclan.org>
+Mew <Giratina493@mew151.net>
+Micah Caldwell <micah@zoltu.net>
+Michael Pavlyshko <me@mixaill.tk>
+Michael Ziegler <diese-addy@funzt-halt.net>
+Michał "Zuko" Żukowski <zuczeq@gmail.com>
+Mike <mike@flomp.net>
+Mikkel Krautz <mikkel@krautz.dk>
+Mikko Rantanen <jubjub@jubjubnest.net>
+Natenom <natenom@natenom.com>
+Necromancer <necro3@users.sourceforge.net>
+Nicos Gollan <gtdev@spearhead.de>
+Nik Johnson <nik@jnstw.us>
+Nikita Puzyryov <https://github.com/NikitaPuzyryov>
+Nikolaj Dombrow <nikolaj.dombrow@dombrow.de>
+nomad <gmc_holle@users.sourceforge.net>
+Opalium <opalium@users.sourceforge.net>
+Otto Allmendinger <oallmendinger@users.sourceforge.net>
+Patrick Matthäi <pmatthaei@debian.org>
+Peter Vágner <pvdeejay@gmail.com>
+Phil <synapse84@gmail.com>
+Philip Cass <frymaster@127001.org>
+Phrag <info@clanwars.cz>
+Piotr Chodań <dark.skeleton@gmail.com>
+Piratonym <piratonym@piratonym.cc>
+QuirB <quirb@gmx.net>
+qwestduck <gsreceiver2@yahoo.com>
+Rafael Correia <rafaeljpc@gmail.com>
+Rafael Lopez <rafael@case.edu>
+rdb <git@rdb.name>
+Roman Priesol <roman@priesol.net>
+ronoc <conor@forwind.net>
+Ryan Austin <ryan.e.austin@gmail.com>
+Sami Laine <sami.v.laine@gmail.com>
+Samuel D. Leslie <sdl@nexiom.net>
+scapula <rasmus.ry@gmail.com>
+Semion Tsinman <Necromancer3333@gmail.com>
+Sergey Ivanov <randomei@users.sourceforge.net>
+Spaccaossi <spaccaossi@gmail.com>
+Stefan Hacker <dd0t@users.sourceforge.net>
+Steve Hill <github@cheesy.sackheads.org>
+stevenh <steven.hartland@multiplay.co.uk>
+SuperNascher <kevin@nascher.org>
+Sven-Hendrik Haase <sh@lutzhaase.com>
+Svenne33 <svenne33@users.sourceforge.net>
+Tim Burke <tim.burke@gmail.com>
+Tim Cooper <tim.cooper@layeh.com>
+Timo Gurr <timo.gurr@gmail.com>
+Timo K <timer@dbclan.de>
+tkmorris <mauricioarozi@gmail.com>
+Tristan Matthews <tristan.matthews@savoirfairelinux.com>
+Tsbook <tsbook@users.sourceforge.net>
+Tuck Therebelos <snares@users.sourceforge.net>
+Wesley W. Terpstra <terpstra@users.sourceforge.net>
+Will Tange <bh34rt@gmail.com>
+withgod <withgod@users.sourceforge.net>
+x89 <napalm10@gmail.com>
+zapman
+Zorg <zorgiepoo@gmail.com>

--- a/LICENSE
+++ b/LICENSE
@@ -1,14 +1,8 @@
-Copyright (C) 2005-2013, Thorvald Natvig <thorvald@natvig.com>
-Copyright (C) 2007, Stefan Gehn <mETz AT gehn DOT net>
-Copyright (C) 2007, Sebastian Schlingmann <mit_service@users.sourceforge.net>
-Copyright (C) 2007, Trenton Schulz
-Copyright (C) 2008-2016, Mikkel Krautz <mikkel@krautz.dk>
-Copyright (C) 2008, Andreas Messer <andi@bupfen.de>
-Copyright (C) 2008-2016, Stefan Hacker <dd0t@users.sourceforge.net>
-Copyright (C) 2008-2011, Snares <snares@users.sourceforge.net>
-Copyright (C) 2009-2013, Benjamin Jemlich <pcgod@users.sourceforge.net>
-Copyright (C) 2009-2016, Kissaki <kissaki@gmx.de>
-Copyright (C) 2010-2016, Jamie Fraser <jamie.f@mumbledog.com>
+Copyright (C) 2005-2016 The Mumble Developers
+
+A list of The Mumble Developers can be found in the
+AUTHORS file at the root of the Mumble source tree
+or at <http://www.mumble.info/AUTHORS>.
 
 All rights reserved.
 
@@ -21,7 +15,7 @@ are met:
 - Redistributions in binary form must reproduce the above copyright notice,
   this list of conditions and the following disclaimer in the documentation
   and/or other materials provided with the distribution.
-- Neither the name of the Mumble Developers nor the names of its
+- Neither the name of The Mumble Developers nor the names of its
   contributors may be used to endorse or promote products derived from this
   software without specific prior written permission.
 

--- a/LICENSE.header
+++ b/LICENSE.header
@@ -1,0 +1,4 @@
+// Copyright 2016 The Mumble Developers. All rights reserved.
+// Use of this source code is governed by a BSD-style license
+// that can be found in the LICENSE file at the root of the
+// Mumble source tree or at <http://www.mumble.info/LICENSE>.

--- a/scripts/generate-AUTHORS.py
+++ b/scripts/generate-AUTHORS.py
@@ -1,0 +1,199 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+#
+# Copyright 2016 The Mumble Developers. All rights reserved.
+# Use of this source code is governed by a BSD-style license
+# that can be found in the LICENSE file at the root of the
+# Mumble source tree or at <http://www.mumble.info/LICENSE>.
+
+from __future__ import (unicode_literals, print_function, division)
+
+import sys
+import subprocess
+import codecs
+import locale
+
+blacklist = (
+	# Unknown
+	"(no author) <(no author)@05730e5d-ab1b-0410-a4ac-84af385074fa>",
+	"root <root@DiskStation.(none)>",
+	"unknown <LoL@.(none)>",
+	"unknown <d0t@.(none)>",
+
+	# Bots
+	"MumbleTransifexBot <mumbletransifexbot@mumble.info>",
+
+	# Aliases of Bartek "stranded" Sumowski <sumowski@gmail.com>
+	"Bartek <sumowski@users.sourceforge.net>",
+	"Bartek Sumowksi <sumowski@gmail.com>",
+
+	# Alias of Benjamin Jemlich <pcgod@users.sourceforge.net>
+	"Benjamin Jemlich <pcgod@gmx.net>",
+
+	# Alias of EarlOfWenc <lorenz.schwittmann@gmail.com>
+	"EarlOfWenc <user@localhost>",
+
+	# Aliases of Jamie Fraser <fwagglechop@gmail.com> -- latest commit uses this email.a
+	"Jamie Fraser <jamie.f@mumbledog.com>",
+	"Jamie Fraser <jamie.f@sabrienix.com>",
+
+	# Aliases of Álvaro Manuel Recio Pérez <naproxeno@users.sourceforge.net>
+	"Álvaro M. Recio Pérez <naproxeno@users.sourceforge.net>",
+	"Álvaro Manuel Recio Pérez <naproxeno@kepis.(none)>",
+
+	# Aliases of Thorvald Natvig <slicer@users.sourceforge.net>
+	"Thorvald Natvig <github@natvig.com>",
+	"Thorvald Natvig <slicer@users.sourceforge.net>",
+	"Thorvald Natvig <thorvald@-e false.(none)>",
+	"Thorvald Natvig <thorvald@debian.localdomain>",
+	"Thorvald Natvig <thorvald@natvig.com>",
+
+	# Alias of Spaccaossi <spaccaossi@gmail.com>
+	"Spaccaossi <spaccaossi@users.sourceforge.net>",
+
+	# Aliases of Stefan Hacker <dd0t@users.sourceforge.net>
+	"Stefan H <dd0t@users.sourceforge.net>",
+	"Stefan Hacker <hacker.stefan@googlemail.com>",
+	"Stefan Hacker <hast@hast-desktop.(none)>",
+
+	# Aliases of Michał "Zuko" Żukowski <zuczeq@gmail.com>
+	"Michał Żukowski <zuczeq@gmail.com>",
+	"Zukowski Michal <zuczeq@gmail.com>",
+	"Żukowski Michał <zuczeq@gmail.com>",
+	"zuczeq <zuczeq@users.sourceforge.net>",
+	"Zuko <zuczeq@gmail.com>",
+
+	# Two authors?! Both are listed elsewhere, so drop.
+	"Michael Ziegler and Natenom <natenom@googlemail.com>",
+
+	# ...What?
+	"Netbios Domain Administrator <admin@gameserver2.(none)>",
+
+	# Aliases of Mikkel Krautz <mikkel@krautz.dk>
+	"Mikkel <mikkel@krautz.dk>",
+	"Mikkel Krautz <mkrautz@users.sourceforge.net>",
+
+	# Alias of tkmorris <mauricioarozi@gmail.com>
+	"morris <tkmorris@users.sourceforge.net>",
+
+	# Alias of bendem <online@bendem.be>
+	"bendem <bendembd@gmail.com>",
+
+	# Alias of arrai <array.of.intellect@gmail.com>
+	"Arrai <arrai@users.sourceforge.net>",
+
+	# Alias of Joël Troch <joel.troch62@gmail.com>
+	"Joël Troch <https://github.com/JoelTroch>",
+
+	# Matthias Vogelgesang <matthias.vogelgesang@gmail.com>
+	"Matthias Vogelgesang <m0ta@users.sourceforge.net>",
+
+	# Alias of Tuck Therebelos <snares@users.sourceforge.net>
+	"Snares <snares@users.sourceforge.net>",
+
+	# Aliases of Natenom <natenom@natenom.com>
+	"Natenom <natenom@googlemail.com>",
+	"Natenom <natenom@natenom.name>",
+
+	# Alias of Arcenciel <arcenciel@users.sourceforge.net>
+	"arcenciel <arcenciel@users.sourceforge.net>",
+
+	# Alias of Jonathan E. Hansen <zentriple@users.sourceforge.net>
+	"Jonathan <zentriple@users.sourceforge.net>",
+	"zentriple <zentriple@users.sourceforge.net>",
+	"Zentriple <zentriple@users.sourceforge.net>",
+
+
+	# Alias of Patrick Matthäi <pmatthaei@debian.org>
+	"Patrick Matthäi <the-me88@users.sourceforge.net>",
+
+	# Alias of Jan Klass <kissaki@gmx.de>
+	"Jan Klass <kissaki0@gmail.com>",
+
+	# Alias of Necromancer <necro3@users.sourceforge.net>
+	"Necromancer <necromancer3@users.sourceforge.net>",
+
+	# Alias of Svenne33 <svenne33@users.sourceforge.net>
+	"svenne33 <svenne33@users.sourceforge.net>",
+
+	# Potentially an alias of BAYSSE Laurent <lolo_32@users.sourceforge.net>
+	"lolo_32 <Alex@.(none)>",
+)
+
+def gitAuthorsOutput():
+	p = subprocess.Popen(["git", "log", "--all", "--format=%aN <%aE>"], stdout=subprocess.PIPE)
+	stdout, stderr = p.communicate()
+	if stdout is not None:
+		stdout = stdout.decode('utf-8')
+	if stderr is not None:
+		stderr = stderr.decode('utf-8')
+	if p.returncode != 0:
+		raise Exception('"git log" failed: %s', stderr)
+	return stdout
+
+def main():
+	locale.setlocale(locale.LC_ALL, "")
+
+	authorsSet = set()
+	authorsText = gitAuthorsOutput()
+	for line in authorsText.split("\n"):
+		if line == '':
+			continue
+
+		if line == "zapman <unknown>":
+			line = "zapman"
+
+		# Fix "=?UTF-8 Michał Żukowski?=" and possibly others like it.
+		if line.startswith("=?UTF-8 "):
+			line = line.replace("=?UTF-8 ", "")
+			line = line.replace("?=", "")
+
+		# Use GitHub URL instead of $user@users.noreply.github.com
+		if '@users.noreply.github.com' in line:
+			line = line.replace('@users.noreply.github.com', '')
+			line = line.replace('<', '<https://github.com/')
+
+		if line in blacklist:
+			continue
+
+		authorsSet.add(line)
+
+	f = codecs.open("AUTHORS", "w", "utf-8")
+	f.write('''// This is the official list of people who have contributed
+// to, and hold the copyright to Mumble.
+//
+// The use of Mumble source code is governed by a BSD-style
+// license that can be found in the LICENSE file at the root
+// of the Mumble source tree or at <http://www.mumble.info/LICENSE>.
+//
+// Contributions made on behalf of another entity, such as a
+// company are indicated with the following suffix:
+//
+//     John Doe <jd@mumble.info> (on behalf of $COMPANY)
+//
+// It is possible to mix individual contributions with company
+// contributions. For example, if a contributor, over time,
+// has contributed code copyrighted by the contributor, as well
+// as various companies:
+//
+//     John Doe <jd@mumble.info> (individually, on behalf of
+//                                $COMPANY1, on behalf of
+//                                $COMPANY2, [...]).
+
+''')
+
+	# Sort alphabetically
+	authors = list(authorsSet)
+	if sys.version[0] == '2': # Python 2
+		authors.sort(cmp=locale.strcoll)
+	else:
+		authors.sort(key=locale.strxfrm)
+
+	for author in authors:
+		f.write(author)
+		f.write("\n")
+
+	f.close()
+
+if __name__ == '__main__':
+	main()


### PR DESCRIPTION
This simplifies the LICENSE file refer to the copyright
holders of Mumble as "The Mumble Developers". The client
already does this in the About dialog.

The entity "The Mumble Developers" is the name we use for
the copyright holders of Mumble. These are listed in the
AUTHORS file.

The AUTHORS file is generated via scripts/generate-AUTHORS.py.
The script looks at the Git history and removes duplicates and
other mistakes made through the years.

All new files in the repo should use the license header found
in LICENSE.header.

The AUTHORS and LICENSE files are permalinked to

    https://www.mumble.info/LICENSE
    https://www.mumble.info/AUTHORS

These locations are used in the files themselves,
as well as the license header.