### PR TITLE
Fix OpenSSL intialization.

### DIFF
--- a/src/SSL.cpp
+++ b/src/SSL.cpp
@@ -34,6 +34,11 @@
 
 #include "Version.h"
 
+void MmubleSSL::initialize() {
+	// Let Qt initialize OpenSSL...
+	QSslSocket::supportsSsl();
+}
+
 QString MumbleSSL::defaultOpenSSLCipherString() {
 	return QLatin1String("EECDH+AESGCM:EDH+aRSA+AESGCM:DHE-RSA-AES256-SHA:DHE-RSA-AES128-SHA:AES256-SHA:AES128-SHA");
 }

--- a/src/SSL.h
+++ b/src/SSL.h
@@ -37,6 +37,7 @@
 
 class MumbleSSL {
 	public:
+		static void initialize();
 		static QString defaultOpenSSLCipherString();
 		static QList<QSslCipher> ciphersFromOpenSSLCipherString(QString cipherString);
 		static void addSystemCA();

--- a/src/mumble/ServerHandler.cpp
+++ b/src/mumble/ServerHandler.cpp
@@ -95,7 +95,14 @@ ServerHandler::ServerHandler() {
 	tConnectionTimeoutTimer = NULL;
 	uiVersion = 0;
 
-	// For some strange reason, on Win32, we have to call supportsSsl before the cipher list is ready.
+	// Historically, this initialized OpenSSL for us:
+	//
+	//     "For some strange reason, on Win32, we have to call
+	//      supportsSsl before the cipher list is ready."
+	//
+	// Now, OpenSSL is initialized in main() via MumbleSSL::initialize(),
+	// but since it's handy to have the OpenSSL version available, we
+	// keep this one around as well.
 	qWarning("OpenSSL Support: %d (%s)", QSslSocket::supportsSsl(), SSLeay_version(SSLEAY_VERSION));
 
 	MumbleSSL::addSystemCA();

--- a/src/mumble/main.cpp
+++ b/src/mumble/main.cpp
@@ -98,6 +98,8 @@ int main(int argc, char **argv) {
 #endif
 #endif
 
+	MumbleSSL::initialize();
+
 	// Initialize application object.
 	MumbleApplication a(argc, argv);
 	a.setApplicationName(QLatin1String("Mumble"));

--- a/src/murmur/main.cpp
+++ b/src/murmur/main.cpp
@@ -183,6 +183,9 @@ int main(int argc, char **argv) {
 	}
 
 	SetDllDirectory(L"");
+
+	MumbleSSL::initialize();
+
 #endif
 	int res;
 


### PR DESCRIPTION
Add a MumbleSSL::initialize() method and call it
in Mumble's and Murmur's main functions, just before
construction of QApplication.

This ensures OpenSSL is initialized before we use it.

Our new cipher suite selection support apparently broke
Mumble and Murmur on Linux, at least for some systems.

This commit remedies that by ensuring that we initialize
OpenSSL early.

For Debian's patch, see
http://sources.debian.net/patches/patch/mumble/1.2.12-1/43-initialize-SSL.diff/

Fixes https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=804363
Fixes mumble-voip/mumble#1876