### PR TITLE
MumbleSSL: add a sanity check for QSsl loading a different version of OpenSSL than we're linked against.

### DIFF
--- a/src/SSL.cpp
+++ b/src/SSL.cpp
@@ -5,6 +5,12 @@
 
 #include "murmur_pch.h"
 
+// Needed for MumbleSSL::qsslSanityCheck()
+#ifdef Q_OS_LINUX
+# include <dlfcn.h>
+# include <link.h>
+#endif
+
 #include "SSL.h"
 
 #include "Version.h"
@@ -12,6 +18,79 @@
 void MumbleSSL::initialize() {
 	// Let Qt initialize OpenSSL...
 	QSslSocket::supportsSsl();
+
+	// Check that we aren't in a situation where
+	// Qt has dynamically loaded *another*
+	// version/soname of libssl and/or libcrypto
+	// alongside the copy we link against ourselves.
+	//
+	// This can happen when Qt is built without the
+	// -openssl-linked configure option. When Qt is
+	// built without -openssl-linked, it will try
+	// to dynamically load the OpenSSL libraries.
+	// When Qt dynamically loads OpenSSL and there
+	// are multiple version of libcrypto and libssl
+	// available on the system, it is possible for
+	// Qt to load another version of OpenSSL in
+	// addition to the one our binary is linked
+	// against. Typically, this will happen if
+	// Mumble or Murmur are linked against
+	// an older version, and a newer version is
+	// available on the system as well.
+	//
+	// If we're in a situation where two version of
+	// OpenSSL's libraries are loaded into our process,
+	// we abort immediately. Things WILL go wrong.
+	MumbleSSL::qsslSanityCheck();
+}
+
+// Check that we haven't loaded multiple copies of OpenSSL
+// into our process by accident.
+void MumbleSSL::qsslSanityCheck() {
+#ifdef Q_OS_LINUX
+	struct link_map *lm = NULL;
+	void *self = dlopen(NULL, RTLD_NOW);
+	if (self == NULL) {
+		qFatal("SSL: could not dlopen program binary");
+	}
+
+	if (dlinfo(self, RTLD_DI_LINKMAP, &lm) == -1) {
+		qFatal("SSL: unable to acquire link_map: %s", dlerror());
+	}
+	if (lm == NULL) {
+		qFatal("SSL: link_map is NULL");
+	}
+
+	QStringList libssl;
+	QStringList libcrypto;
+
+	while (lm != NULL) {
+		QString name = QString::fromLocal8Bit(lm->l_name);
+		if (name.contains(QLatin1String("libssl"))) {
+			libssl << name;
+		} else if (name.contains(QLatin1String("libcrypto"))) {
+			libcrypto << name;
+		}
+		lm = lm->l_next;
+	}
+
+	bool ok = true;
+	if (libcrypto.size() == 0 || libssl.size() == 0) {
+		qFatal("SSL library query failed: %i libcrypto's and %i libssl's found.", libcrypto.size(), libssl.size());
+	}
+	if (libssl.size() > 1) {
+		qCritical("Found multiple libssl.so copies in binary: %s", qPrintable(libssl.join(QLatin1String(", "))));
+		ok = false;
+	}
+	if (libcrypto.size() > 1) {
+		qCritical("Found multiple libcrypto.so copies in binary: %s", qPrintable(libcrypto.join(QLatin1String(", "))));
+		ok = false;
+	}
+
+	if (!ok) {
+		qFatal("Aborting due to previous errors");
+	}
+#endif
 }
 
 QString MumbleSSL::defaultOpenSSLCipherString() {

--- a/src/SSL.h
+++ b/src/SSL.h
@@ -13,6 +13,7 @@
 class MumbleSSL {
 	public:
 		static void initialize();
+		static void qsslSanityCheck();
 		static QString defaultOpenSSLCipherString();
 		static QList<QSslCipher> ciphersFromOpenSSLCipherString(QString cipherString);
 		static void addSystemCA();

--- a/src/mumble/mumble.pro
+++ b/src/mumble/mumble.pro
@@ -493,6 +493,11 @@ unix {
     PKGCONFIG *= x11
     LIBS *= -lrt -lXi
 
+    # For MumbleSSL::qsslSanityCheck()
+    contains(UNAME, Linux) {
+      LIBS *= -ldl
+    }
+
     !CONFIG(no-oss) {
       CONFIG  *= oss
     }

--- a/src/murmur/murmur.pro
+++ b/src/murmur/murmur.pro
@@ -50,6 +50,9 @@ win32 {
 unix {
   contains(UNAME, Linux) {
     LIBS *= -lcap
+
+    # For MumbleSSL::qsslSanityCheck()
+    LIBS *= -ldl
   }
 
   CONFIG(static):!macx {


### PR DESCRIPTION
/cc @crknadle 