### PR TITLE
Fix building Mumble on unix with no-dbus

### DIFF
--- a/src/mumble/Log_unix.cpp
+++ b/src/mumble/Log_unix.cpp
@@ -88,6 +88,7 @@ void Log::postNotification(MsgType mt, const QString &console, const QString &pl
 		uiLastId = response.arguments().at(0).toUInt();
 	} else {
 #else
+	Q_UNUSED(console);
 	if (true) {
 #endif
 		postQtNotification(mt, plain);


### PR DESCRIPTION
The `console` parameter to `Log::postNotification` in src/mumble/Log_unix.cpp was unused when the no-dbus option was used. This adds a Q_UNUSED macro call to suppress the unused parameter warning (which prevents building with `-Werror`).

The build error in question:
```
Log_unix.cpp:39:55: error: unused parameter ‘console’ [-Werror=unused-parameter]
 void Log::postNotification(MsgType mt, const QString &console, const QString &plain) {
                                                       ^
```