### PR TITLE
Fix relative paths for Murmur -ini switch

### DIFF
--- a/src/murmur/Meta.cpp
+++ b/src/murmur/Meta.cpp
@@ -189,6 +189,7 @@ void MetaParams::read(QString fname) {
 			qFatal("Specified ini file %s could not be opened", qPrintable(fname));
 		}
 		qdBasePath = QFileInfo(f).absoluteDir();
+		fname = QFileInfo(f).absoluteFilePath();
 		f.close();
 	}
 	QDir::setCurrent(qdBasePath.absolutePath());


### PR DESCRIPTION
This ensures that the file passed to QSettings is an absolute path, to avoid issues with changing Murmur's working directory but keeping a relative ini path.

Fixes mumble-voip/mumble#2121