### PR TITLE
Do not use _FORTIFY_SOURCE for debug builds since they're not built with optimizations.

### DIFF
--- a/compiler.pri
+++ b/compiler.pri
@@ -260,8 +260,31 @@ unix:!macx {
 		QMAKE_LFLAGS *= -Wl,--no-add-needed
 	}
 
-	QMAKE_CFLAGS *= -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=2
-	QMAKE_CXXFLAGS *= -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=2
+	# Ensure _FORTIFY_SOURCE is not used in debug builds.
+	#
+	# First, ensure _FORTIFY_SOURCE is undefined.
+	# Then -- and, only for release builds -- set
+	# _FORTIFY_SOURCE=2.
+	#
+	# We can't use _FORTIFY_SOURCE in debug builds (which are
+	# built with -O0) because _FORTIFY_SOURCE=1 requires -O1
+	# and _FORTIFY_SOURCE=2 requires -O2.
+	# Modern GLIBCs warn about this since
+	# https://sourceware.org/bugzilla/show_bug.cgi?id=13979.
+	# In Mumble builds with warnings-as-errors, this will
+	# cause build failures.
+	#
+	# We use the += operator because we care about the
+	# ordering of unsetting versus setting the preprocessor
+	# define. If they're in the wrong order, this will not
+	# work as intended.
+	QMAKE_CFLAGS += -U_FORTIFY_SOURCE
+	QMAKE_CXXFLAGS += -U_FORTIFY_SOURCE
+	CONFIG(release, debug|release) {
+		QMAKE_CFLAGS += -D_FORTIFY_SOURCE=2
+		QMAKE_CXXFLAGS += -D_FORTIFY_SOURCE=2
+	}
+
 	QMAKE_LFLAGS *= -Wl,-z,relro -Wl,-z,now
 
 	CONFIG(symbols) {


### PR DESCRIPTION
The _FORTIFY_SOURCE preprocessor define only works when the binary
is built with optimization (-O1 for _FORTIFY_SOURCE=1, -O2 for
_FORTIFY_SOURCE=2).