### PR TITLE
Do not enable warnings-as-errors by default.

### DIFF
--- a/compiler.pri
+++ b/compiler.pri
@@ -83,14 +83,9 @@ win32 {
 		QMAKE_CXXFLAGS_DEBUG *= /analyze
 		QMAKE_CFLAGS_RELEASE *= /analyze
 		QMAKE_CXXFLAGS_RELEASE *= /analyze
-
-		# Do not treat warnings as errors when
-		# running the static analyzer.
-		# Otherwise, we won't get very far!
-		CONFIG *= no-warnings-as-errors
 	}
 
-	!CONFIG(no-warnings-as-errors) {
+	CONFIG(warnings-as-errors) {
 		QMAKE_CFLAGS *= -WX
 		QMAKE_CXXFLAGS *= -WX
 		QMAKE_LFLAGS *= -WX
@@ -203,7 +198,7 @@ unix {
 	QMAKE_OBJECTIVE_CFLAGS   *= -Wall -Wextra
 	QMAKE_OBJECTIVE_CXXFLAGS *= -Wall -Wextra
 
-	!CONFIG(no-warnings-as-errors) {
+	CONFIG(warnings-as-errors) {
 		QMAKE_CFLAGS	         *= -Werror
 		QMAKE_CXXFLAGS	         *= -Werror
 		QMAKE_OBJECTIVE_CFLAGS   *= -Werror


### PR DESCRIPTION
While we would like to have warnings always be treated
as errors, enabling it will surely cause headaches for
packagers. Different compiler versions behave differently,
and it could potentially turn out top be very annoying for
distro packagers if they try to build an older version of
Mumble using a compiler that we had not anticipated being
used for building Mumble (a newer version of GCC, for
example).

Because of that, we disable warnings-as-errors by default.

Our own binary builds will, of course, enable it
warnings-as-errors to ensure we don't miss anything.

The CI system will also always use it. That should
hopefully also ensure we haven't overlooked anything
on platforms where we don't provide binary builds
ourselves.

Fixes mumble-voip/mumble#2113