### PR TITLE
overlay: remove Far Cry 4 from the default blacklist.

### DIFF
--- a/overlay/overlay_blacklist.h
+++ b/overlay/overlay_blacklist.h
@@ -67,7 +67,6 @@ static const char *overlayBlacklist[] = {
 	"HydraSysTray.exe", // Razer Hydra system tray
 	"devenv.exe", // Microsoft Visual Studio
 	"spotify.exe", // Spotify
-	"FarCry4.exe", // Far Cry 4 x64 overlay crash: https://github.com/mumble-voip/mumble/issues/1514
 	"EpicGamesLauncher.exe", // Epic, Unreal Tournament launcher
 	"dwm.exe", // Windows Desktop Window Manager
 	"MouseKeyboardCenter.exe",


### PR DESCRIPTION
The interplay between Mumble/Steam/Uplay overlays seems
to have been fixed by one of the parties (not us!).

Far Cry 4 now runs with the Mumble overlay.

Fixes mumble-voip/mumble#1514