### PR TITLE
Remove unused jitter reporting code

### DIFF
--- a/src/mumble/ClientUser.cpp
+++ b/src/mumble/ClientUser.cpp
@@ -311,10 +311,3 @@ void Channel::addClientUser(ClientUser *p) {
 	addUser(p);
 	p->setParent(this);
 }
-
-QDataStream &operator<<(QDataStream &qds, const ClientUser::JitterRecord &jr) {
-	qds << static_cast<qint8>(qBound(-128, jr.iSequence, 127));
-	qds << static_cast<qint8>(qBound(-128, jr.iFrames, 127));
-	qds << static_cast<quint32>(qMin(4294967295ULL, jr.uiElapsed));
-	return qds;
-}

--- a/src/mumble/ClientUser.h
+++ b/src/mumble/ClientUser.h
@@ -42,12 +42,6 @@ class ClientUser : public QObject, public User {
 		Q_OBJECT
 		Q_DISABLE_COPY(ClientUser)
 	public:
-		struct JitterRecord {
-			int iSequence;
-			int iFrames;
-			quint64 uiElapsed;
-		};
-
 		Settings::TalkState tsState;
 		Timer tLastTalkStateChange;
 		bool bLocalIgnore;
@@ -108,7 +102,5 @@ class ClientUser : public QObject, public User {
 		void prioritySpeakerStateChanged();
 		void recordingStateChanged();
 };
-
-QDataStream &operator<<(QDataStream &, const ClientUser::JitterRecord &);
 
 #endif


### PR DESCRIPTION
As far as I can tell, this is left over from the already-removed jitter reporting feature. This is the last of the code that matches a grep for "jitter" in the tree that isn't related to the jitter buffer. It was originally added in d042b70.

Passed a smoke-test build on Arch Linux with `CONFIG+="bundled-celt no-g15 no-ice packaged release"`.