### PR TITLE
Positional Audio support for Rocket League and Left 4 Dead 2 plugin update

### DIFF
--- a/plugins/l4d2/l4d2.cpp
+++ b/plugins/l4d2/l4d2.cpp
@@ -88,10 +88,10 @@ static int trylock(const std::multimap<std::wstring, unsigned long long int> &pi
 	context: same as state appearantly
 
 	*/
-	posptr = pModule + 0x818950;
-	rotptr = pModule + 0x7D0D18;
-	stateptr = pModule + 0x8169BC;
-	contextptr = pModule + 0x8169BC;
+	posptr = pModule + 0x8217D0;
+	rotptr = pModule + 0x762E04;
+	stateptr = pModule + 0x81CB4C;
+	contextptr = pModule + 0x81CB4C;
 	
 	float pos[3];
 	float rot[3];
@@ -165,10 +165,10 @@ static int fetch(float *avatar_pos, float *avatar_front, float *avatar_top, floa
 }
 
 static const std::wstring longdesc() {
-	return std::wstring(L"Supports L4D2 version 2.1.3.5 with context support. No identity support yet.");
+	return std::wstring(L"Supports L4D2 version 2.1.4.4 with context support. No identity support yet.");
 }
 
-static std::wstring description(L"Left 4 Dead 2 (version 2.1.3.5)");
+static std::wstring description(L"Left 4 Dead 2 (version 2.1.4.4)");
 static std::wstring shortname(L"Left 4 Dead 2");
 
 static int trylock1() {

--- a/plugins/rl/rl.cpp
+++ b/plugins/rl/rl.cpp
@@ -1,33 +1,7 @@
-/* Copyright (C) 2005-2010, Thorvald Natvig <thorvald@natvig.com>
-   Copyright (C) 2016, Davide Beatrici (davidebeatrici) <davidebeatrici@gmail.com>
-
-   All rights reserved.
-
-   Redistribution and use in source and binary forms, with or without
-   modification, are permitted provided that the following conditions
-   are met:
-
-   - Redistributions of source code must retain the above copyright notice,
-     this list of conditions and the following disclaimer.
-   - Redistributions in binary form must reproduce the above copyright notice,
-     this list of conditions and the following disclaimer in the documentation
-     and/or other materials provided with the distribution.
-   - Neither the name of the Mumble Developers nor the names of its
-     contributors may be used to endorse or promote products derived from this
-     software without specific prior written permission.
-
-   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
-   ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
-   LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
-   A PARTICULAR PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE FOUNDATION OR
-   CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
-   EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
-   PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
-   PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
-   LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
-   NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
-   SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*/
+// Copyright 2016 The Mumble Developers. All rights reserved.
+// Use of this source code is governed by a BSD-style license
+// that can be found in the LICENSE file at the root of the
+// Mumble source tree or at <https://www.mumble.info/LICENSE>.
 
 #include "../mumble_plugin_win32.h"
 

--- a/plugins/rl/rl.cpp
+++ b/plugins/rl/rl.cpp
@@ -1,0 +1,144 @@
+/* Copyright (C) 2005-2010, Thorvald Natvig <thorvald@natvig.com>
+   Copyright (C) 2016, Davide Beatrici (davidebeatrici) <davidebeatrici@gmail.com>
+
+   All rights reserved.
+
+   Redistribution and use in source and binary forms, with or without
+   modification, are permitted provided that the following conditions
+   are met:
+
+   - Redistributions of source code must retain the above copyright notice,
+     this list of conditions and the following disclaimer.
+   - Redistributions in binary form must reproduce the above copyright notice,
+     this list of conditions and the following disclaimer in the documentation
+     and/or other materials provided with the distribution.
+   - Neither the name of the Mumble Developers nor the names of its
+     contributors may be used to endorse or promote products derived from this
+     software without specific prior written permission.
+
+   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+   ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+   LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+   A PARTICULAR PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE FOUNDATION OR
+   CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+   EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+   PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+   PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+   LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+   NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+   SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+#include "../mumble_plugin_win32.h"
+
+static int fetch(float *avatar_pos, float *avatar_front, float *avatar_top, float *camera_pos, float *camera_front, float *camera_top, std::string &context, std::wstring &identity) {
+	for (int i=0;i<3;i++)
+		avatar_pos[i]=avatar_front[i]=avatar_top[i]=0.0f;
+
+        // char state;
+	bool ok;
+        // Create containers to stuff our raw data into, so we can convert it to Mumble's coordinate system
+	float pos_corrector[3];
+	float front_corrector[3];
+	float top_corrector[3];
+
+	/*
+		value is <     >
+	*/
+	// ok = peekProc((BYTE *) 0x<offset>, &state, 1); // Magical state value
+	// if (! ok)
+	//	return false;
+
+	// if (state == 0)
+	//  return true; // This results in all vectors beeing zero which tells Mumble to ignore them.
+
+        // Peekproc and assign game addresses to our containers, so we can retrieve positional data
+	ok = peekProc((BYTE *) pModule + 0x015E5EB0, &pos_corrector, 12) &&
+	     peekProc((BYTE *) pModule + 0x015E5EB0, &front_corrector, 12) &&
+	     peekProc((BYTE *) pModule + 0x015E5EB0, &top_corrector, 12);
+
+	if (! ok)
+		return false;
+
+        // X = pModule + 0x015E5EB8
+        // Y = pModule + 0x015E5EB4
+        // Z = pModule + 0x015E5EB0
+	avatar_pos[0] = pos_corrector[2];
+	avatar_pos[1] = pos_corrector[1];
+	avatar_pos[2] = pos_corrector[0];
+
+	for (int i=0;i<3;i++)
+		avatar_pos[i]/=32.0f; // Scale to meters
+
+	avatar_front[0] = front_corrector[2];
+	avatar_front[1] = front_corrector[1];
+	avatar_front[2] = front_corrector[0];
+
+	avatar_top[0] = top_corrector[2];
+	avatar_top[1] = top_corrector[1];
+	avatar_top[2] = top_corrector[0];
+
+	for (int i=0;i<3;i++) {
+		camera_pos[i] = avatar_pos[i];
+		camera_front[i] = avatar_front[i];
+		camera_top[i] = avatar_top[i];
+	}
+
+	return true;
+}
+
+static int trylock(const std::multimap<std::wstring, unsigned long long int> &pids) {
+
+	if (! initialize(pids, L"RocketLeague.exe"))
+		return false;
+
+	// Check if we can get meaningful data from it
+	float apos[3], afront[3], atop[3];
+	float cpos[3], cfront[3], ctop[3];
+	std::wstring sidentity;
+	std::string scontext;
+
+	if (fetch(apos, afront, atop, cpos, cfront, ctop, scontext, sidentity)) {
+		return true;
+	} else {
+		generic_unlock();
+		return false;
+	}
+}
+
+static const std::wstring longdesc() {
+	return std::wstring(L"Supports Rocket League. No identity support yet.");
+}
+
+static std::wstring description(L"Rocket League");
+static std::wstring shortname(L"Rocket League");
+
+static int trylock1() {
+	return trylock(std::multimap<std::wstring, unsigned long long int>());
+}
+
+static MumblePlugin rlplug = {
+	MUMBLE_PLUGIN_MAGIC,
+	description,
+	shortname,
+	NULL,
+	NULL,
+	trylock1,
+	generic_unlock,
+	longdesc,
+	fetch
+};
+
+static MumblePlugin2 rlplug2 = {
+	MUMBLE_PLUGIN_MAGIC_2,
+	MUMBLE_PLUGIN_VERSION,
+	trylock
+};
+
+extern "C" __declspec(dllexport) MumblePlugin *getMumblePlugin() {
+	return &rlplug;
+}
+
+extern "C" __declspec(dllexport) MumblePlugin2 *getMumblePlugin2() {
+	return &rlplug2;
+}

--- a/plugins/rl/rl.cpp
+++ b/plugins/rl/rl.cpp
@@ -107,10 +107,10 @@ static int trylock(const std::multimap<std::wstring, unsigned long long int> &pi
 }
 
 static const std::wstring longdesc() {
-	return std::wstring(L"Supports Rocket League. No identity nor context support yet.");
+	return std::wstring(L"Supports Rocket League version 1.0.10897.0 without identity nor context support yet.");
 }
 
-static std::wstring description(L"Rocket League");
+static std::wstring description(L"Rocket League (version 1.0.10897.0)");
 static std::wstring shortname(L"Rocket League");
 
 static int trylock1() {

--- a/plugins/rl/rl.cpp
+++ b/plugins/rl/rl.cpp
@@ -107,7 +107,7 @@ static int trylock(const std::multimap<std::wstring, unsigned long long int> &pi
 }
 
 static const std::wstring longdesc() {
-	return std::wstring(L"Supports Rocket League. No identity support yet.");
+	return std::wstring(L"Supports Rocket League. No identity nor context support yet.");
 }
 
 static std::wstring description(L"Rocket League");

--- a/plugins/rl/rl.pro
+++ b/plugins/rl/rl.pro
@@ -1,0 +1,6 @@
+include(../plugins.pri)
+
+TARGET		= rl
+SOURCES		= rl.cpp
+LIBS		+= -luser32
+


### PR DESCRIPTION
No context nor identity support available yet.

Thanks to **@mkrautz** on Mumble IRC Chat for the compile fix (https://github.com/mumble-voip/mumble/pull/2195) and for helping me about memory addresses (pModule).
This probably would not have been possible without his help.
Thanks also to **@hacst**: he tried to troubleshoot my compile problem.