### PR TITLE
Log_unix: always send plain text notifications via org.freedesktop.Notifications.

### DIFF
--- a/src/mumble/Log_unix.cpp
+++ b/src/mumble/Log_unix.cpp
@@ -81,7 +81,7 @@ void Log::postNotification(MsgType mt, const QString &console, const QString &pl
 	if (response.type()!=QDBusMessage::ReplyMessage || response.arguments().at(0).toUInt()==0) {
 		QDBusInterface gnome(QLatin1String("org.freedesktop.Notifications"), QLatin1String("/org/freedesktop/Notifications"), QLatin1String("org.freedesktop.Notifications"));
 		if (gnome.isValid())
-			response = gnome.call(QLatin1String("Notify"), QLatin1String("Mumble"), uiLastId, qsIcon, msgName(mt), console, QStringList(), hints, -1);
+			response = gnome.call(QLatin1String("Notify"), QLatin1String("Mumble"), uiLastId, qsIcon, msgName(mt), plain, QStringList(), hints, -1);
 	}
 
 	if (response.type()==QDBusMessage::ReplyMessage && response.arguments().count() == 1) {


### PR DESCRIPTION
We've gotten reports of this for some years now, but haven't solved it in a good
way, yet.

Some notification daemons and/or desktop environments allow *some* HTML. Some don't.

The latest freedesktop.org notification specification [1] states that supporting
a HTML subset is optional, but servers that do not support the HTML subset should
filter them out.

From the reports we've received on the issue tracker for some time, it doesn't
seem like notification daemons are filtering out HTML in practice.

For example, in mumble-voip/mumble#1535, it is reported that Fedora's
(GNOME 3's?) notification daemon doesn't support the mumble:// URL scheme,
and shows raw HTML instead.

In mumble-voip/mumble#2211, it is reported that elementary OS's notification
daemon doesn't support HTML in notifications either.

So, until something changes, we'll just send plain text notifications
when using org.freedesktop.Notifications.

[1]: https://developer.gnome.org/notification-spec/

Fixes mumble-voip/mumble#2211
Fixes mumble-voip/mumble#1535