### PR TITLE
fix crash caused by decoding all MIME data formats in RichTextHtmlEdit

### DIFF
--- a/src/mumble/RichTextEditor.cpp
+++ b/src/mumble/RichTextEditor.cpp
@@ -85,8 +85,6 @@ void RichTextHtmlEdit::insertFromMimeData(const QMimeData *source) {
 
 #ifndef QT_NO_DEBUG
 	qWarning() << "RichTextHtmlEdit::insertFromMimeData" << source->formats();
-	foreach(const QString &format, source->formats())
-		qWarning() << format << decodeMimeString(source->data(format));
 #endif
 
 	if (source->hasImage()) {


### PR DESCRIPTION
Under Qt 5.6.0 on Linux, if a program had a large image in its clipboard
that we tried to paste into Mumble's rich text editor, that program would
crash.

The problem code was only enabled in debug mode, so most users would
never have experienced this.