### PR TITLE
make image inserting consistent between clipboard and file selection

### DIFF
--- a/src/mumble/Log.cpp
+++ b/src/mumble/Log.cpp
@@ -333,7 +333,13 @@ void Log::clearIgnore() {
 	qmIgnore.clear();
 }
 
-unsigned int Log::estimatedDataURLImageSize(const QByteArray &buf) {
+/// Estimate the size of buf when encoded as an HTML image tag
+/// with the src attribute set to a base64-encoded data URL, such
+/// as:
+///
+///    <img src="image/jpeg;base64,[base64-of-buf-goes-here]" />
+///
+static unsigned int estimatedDataURLImageSize(const QByteArray &buf) {
     // We estimate the extra characters (HTML) in the encoded
     // message to be around 64.
     const unsigned int htmlExtras = 64U;

--- a/src/mumble/Log.cpp
+++ b/src/mumble/Log.cpp
@@ -370,8 +370,9 @@ QString Log::imageToImg(QImage img) {
 		imgwrite.write(img);
 	}
 
-	const int safety = 1024;
-	while ((static_cast<unsigned int>(qba.length() * 2 + safety) >= g.uiImageLength) && (quality > 0)) {
+	QString encoded = imageToImg(format, qba);
+
+	while ((encoded.length() > static_cast<int>(g.uiImageLength)) && (quality > 0)) {
 		qba.clear();
 		QBuffer qb(&qba);
 		qb.open(QIODevice::WriteOnly);
@@ -382,9 +383,11 @@ QString Log::imageToImg(QImage img) {
 		imgwrite.setQuality(quality);
 		imgwrite.write(img);
 		quality -= 10;
+
+		encoded = imageToImg(format, qba);
 	}
-	if (static_cast<unsigned int>(qba.length() * 2 + safety) < g.uiImageLength) {
-		return imageToImg(format, qba);
+	if (encoded.length() <= static_cast<int>(g.uiImageLength)) {
+		return encoded;
 	}
 	return QString();
 }

--- a/src/mumble/Log.cpp
+++ b/src/mumble/Log.cpp
@@ -358,10 +358,6 @@ QString Log::imageToImg(const QByteArray &format, const QByteArray &image) {
 }
 
 QString Log::imageToImg(QImage img) {
-	if ((img.width() > 480) || (img.height() > 270)) {
-		img = img.scaled(480, 270, Qt::KeepAspectRatio, Qt::SmoothTransformation);
-	}
-
 	int quality = 100;
 	QByteArray format = "PNG";
 
@@ -374,7 +370,8 @@ QString Log::imageToImg(QImage img) {
 		imgwrite.write(img);
 	}
 
-	while ((qba.length() >= 65536) && (quality > 0)) {
+	const int safety = 1024;
+	while ((static_cast<unsigned int>(qba.length() * 2 + safety) >= g.uiImageLength) && (quality > 0)) {
 		qba.clear();
 		QBuffer qb(&qba);
 		qb.open(QIODevice::WriteOnly);
@@ -386,7 +383,7 @@ QString Log::imageToImg(QImage img) {
 		imgwrite.write(img);
 		quality -= 10;
 	}
-	if (qba.length() < 65536) {
+	if (static_cast<unsigned int>(qba.length() * 2 + safety) < g.uiImageLength) {
 		return imageToImg(format, qba);
 	}
 	return QString();

--- a/src/mumble/Log.cpp
+++ b/src/mumble/Log.cpp
@@ -333,34 +333,6 @@ void Log::clearIgnore() {
 	qmIgnore.clear();
 }
 
-unsigned int Log::estimatedDataURLImageSize(const QByteArray &buf) {
-	// We estimate the extra characters (HTML) in the encoded
-	// message to be around 32.
-	const unsigned int htmlExtras = 32U;
-
-	// Count the number of characters that will be percent encoded by
-	// Log::imageToImg(const QByteArray &, const QByteArray &)
-	unsigned int percentEncodedCount = 0;
-	for (int i = 0; i < buf.length(); i++) {
-		switch (buf[i]) {
-		case '+':
-		case '/':
-		case '=':
-			percentEncodedCount++;
-		}
-	}
-
-	// Calculate the base64 length.
-	// Note that the value of len will be <= INT_MAX, so this
-	// calculation will not cause overflow.
-	//
-	// Percent encoding characters require an additional two bytes each
-	unsigned int len = static_cast<unsigned int>(buf.length());
-	unsigned int b64len = ((len + 2U) / 3U) * 4U + percentEncodedCount * 2;
-
-	return b64len + htmlExtras;
-}
-
 QString Log::imageToImg(const QByteArray &format, const QByteArray &image) {
 	QString fmt = QLatin1String(format);
 
@@ -386,7 +358,9 @@ QString Log::imageToImg(QImage img) {
 		imgwrite.write(img);
 	}
 
-	while ((estimatedDataURLImageSize(qba) > g.uiImageLength) && (quality > 0)) {
+	QString encoded = imageToImg(format, qba);
+
+	while ((static_cast<unsigned int>(encoded.length()) > g.uiImageLength) && (quality > 0)) {
 		qba.clear();
 		QBuffer qb(&qba);
 		qb.open(QIODevice::WriteOnly);
@@ -397,9 +371,11 @@ QString Log::imageToImg(QImage img) {
 		imgwrite.setQuality(quality);
 		imgwrite.write(img);
 		quality -= 10;
+
+		encoded = imageToImg(format, qba);
 	}
-	if (estimatedDataURLImageSize(qba) <= g.uiImageLength) {
-		return imageToImg(format, qba);
+	if (static_cast<unsigned int>(encoded.length()) <= g.uiImageLength) {
+		return encoded;
 	}
 	return QString();
 }

--- a/src/mumble/Log.cpp
+++ b/src/mumble/Log.cpp
@@ -340,17 +340,18 @@ void Log::clearIgnore() {
 ///    <img src="image/jpeg;base64,[base64-of-buf-goes-here]" />
 ///
 static unsigned int estimatedDataURLImageSize(const QByteArray &buf) {
-    // We estimate the extra characters (HTML) in the encoded
-    // message to be around 64.
-    const unsigned int htmlExtras = 64U;
+	// We estimate the extra characters (HTML) in the encoded message to be
+	// around 64. This accounts for the image tag itself, but also a bit of
+	// extra HTML from the user.
+	const unsigned int htmlExtras = 64U;
 
-    // Calculate the base64 length.
-    // Note that the value of len will be <= INT_MAX, so this
-    // calculation will not cause overflow.
-    unsigned int len = static_cast<unsigned int>(buf.length());
-    unsigned int b64len = ((len + 2U) / 3U) * 4U;
+	// Calculate the base64 length.
+	// Note that the value of len will be <= INT_MAX, so this
+	// calculation will not cause overflow.
+	unsigned int len = static_cast<unsigned int>(buf.length());
+	unsigned int b64len = ((len + 2U) / 3U) * 4U;
 
-    return b64len + htmlExtras;
+	return b64len + htmlExtras;
 }
 
 QString Log::imageToImg(const QByteArray &format, const QByteArray &image) {

--- a/src/mumble/Log.cpp
+++ b/src/mumble/Log.cpp
@@ -368,17 +368,7 @@ QString Log::imageToImg(const QByteArray &format, const QByteArray &image) {
 		fmt = QLatin1String("qt");
 
 	QByteArray rawbase = image.toBase64();
-	QByteArray encoded;
-	int i = 0;
-	int begin = 0, end = 0;
-	do {
-		begin = i*72;
-		end = begin+72;
-
-		encoded.append(QUrl::toPercentEncoding(QLatin1String(rawbase.mid(begin,72))));
-
-		++i;
-	} while (end < rawbase.length());
+	QByteArray encoded = QUrl::toPercentEncoding(QLatin1String(rawbase));
 
 	return QString::fromLatin1("<img src=\"data:image/%1;base64,%2\" />").arg(fmt).arg(QLatin1String(encoded));
 }

--- a/src/mumble/Log.h
+++ b/src/mumble/Log.h
@@ -95,6 +95,13 @@ class Log : public QObject {
 		void setIgnore(MsgType t, int ignore = 1 << 30);
 		void clearIgnore();
 		static QString validHtml(const QString &html, bool allowReplacement = false, QTextCursor *tc = NULL);
+		/// Estimate the size of buf when encoded as an HTML image tag
+		/// with the src attribute set to a base64-encoded data URL, such
+		/// as:
+		///
+		///    <img src="image/jpeg;base64,[base64-of-buf-goes-here]" />
+		///
+		static unsigned int estimatedDataURLImageSize(const QByteArray &buf);
 		static QString imageToImg(const QByteArray &format, const QByteArray &image);
 		static QString imageToImg(QImage img);
 		static QString msgColor(const QString &text, LogColorType t);

--- a/src/mumble/Log.h
+++ b/src/mumble/Log.h
@@ -95,12 +95,6 @@ class Log : public QObject {
 		void setIgnore(MsgType t, int ignore = 1 << 30);
 		void clearIgnore();
 		static QString validHtml(const QString &html, bool allowReplacement = false, QTextCursor *tc = NULL);
-		/// Estimate the size of buf when encoded as an HTML image tag
-		/// with the src attribute set to a base64-encoded data URL, such
-		/// as:
-		///
-		///    <img src="image/jpeg;base64,[base64-of-buf-goes-here]" />
-		static unsigned int estimatedDataURLImageSize(const QByteArray &buf);
 		static QString imageToImg(const QByteArray &format, const QByteArray &image);
 		static QString imageToImg(QImage img);
 		static QString msgColor(const QString &text, LogColorType t);

--- a/src/mumble/Log.h
+++ b/src/mumble/Log.h
@@ -95,13 +95,6 @@ class Log : public QObject {
 		void setIgnore(MsgType t, int ignore = 1 << 30);
 		void clearIgnore();
 		static QString validHtml(const QString &html, bool allowReplacement = false, QTextCursor *tc = NULL);
-		/// Estimate the size of buf when encoded as an HTML image tag
-		/// with the src attribute set to a base64-encoded data URL, such
-		/// as:
-		///
-		///    <img src="image/jpeg;base64,[base64-of-buf-goes-here]" />
-		///
-		static unsigned int estimatedDataURLImageSize(const QByteArray &buf);
 		static QString imageToImg(const QByteArray &format, const QByteArray &image);
 		static QString imageToImg(QImage img);
 		static QString msgColor(const QString &text, LogColorType t);

--- a/src/mumble/Log.h
+++ b/src/mumble/Log.h
@@ -95,6 +95,12 @@ class Log : public QObject {
 		void setIgnore(MsgType t, int ignore = 1 << 30);
 		void clearIgnore();
 		static QString validHtml(const QString &html, bool allowReplacement = false, QTextCursor *tc = NULL);
+		/// Estimate the size of buf when encoded as an HTML image tag
+		/// with the src attribute set to a base64-encoded data URL, such
+		/// as:
+		///
+		///    <img src="image/jpeg;base64,[base64-of-buf-goes-here]" />
+		static unsigned int estimatedDataURLImageSize(const QByteArray &buf);
 		static QString imageToImg(const QByteArray &format, const QByteArray &image);
 		static QString imageToImg(QImage img);
 		static QString msgColor(const QString &text, LogColorType t);

--- a/src/mumble/RichTextEditor.cpp
+++ b/src/mumble/RichTextEditor.cpp
@@ -252,18 +252,7 @@ void RichTextEditor::on_qaImage_triggered() {
 	if (qba.isEmpty())
 		return;
 
-	if ((g.uiImageLength > 0) && (static_cast<unsigned int>(qba.length()) > g.uiImageLength)) {
-		QMessageBox::warning(this, tr("Failed to load image"), tr("Image file too large to embed in document. Please use images smaller than %1 kB.").arg(g.uiImageLength /1024));
-		return;
-	}
-
-	QBuffer qb(&qba);
-	qb.open(QIODevice::ReadOnly);
-
-	QByteArray format = QImageReader::imageFormat(&qb);
-	qb.close();
-
-	qteRichText->insertHtml(Log::imageToImg(format, qba));
+	qteRichText->insertHtml(Log::imageToImg(choice.second));
 }
 
 void RichTextEditor::onCurrentChanged(int index) {


### PR DESCRIPTION
Previously, images inserted from the clipboard would follow a different
path than images inserted via the file selection. Clipboard images were
restricted to a maximum dimensions of 480x270, where file selection images
were restricted based on their their size in bytes (comparing to the
server's limit). Additionally, only images from the clipboard would have
their quality reduced in order to reduce image size.

Images now posted from either source will not have a dimension restriction,
and will have their quality reduced, as necessary, to fit into the
server's limit.
