### PR TITLE
scripts/generate-AUTHORS.py: use 'origin/branch' instead of just 'branch' in git log call.

### DIFF
--- a/scripts/generate-AUTHORS.py
+++ b/scripts/generate-AUTHORS.py
@@ -113,7 +113,7 @@ patchAuthors = (
 )
 
 def gitAuthorsOutput():
-	p = subprocess.Popen(["git", "log", "--use-mailmap", "--format=%aN <%aE>", "master", "1.2.x"], stdout=subprocess.PIPE)
+	p = subprocess.Popen(["git", "log", "--use-mailmap", "--format=%aN <%aE>", "origin/master", "origin/1.2.x"], stdout=subprocess.PIPE)
 	stdout, stderr = p.communicate()
 	if stdout is not None:
 		stdout = stdout.decode('utf-8')


### PR DESCRIPTION
This allows the script to work even if, say, origin/1.2.x is not checked
out locally as '1.2.x'.