### PR TITLE
scripts/generate-AUTHORS.py: use icu for sorting to get deterministic output on all platforms.

### DIFF
--- a/scripts/generate-AUTHORS.py
+++ b/scripts/generate-AUTHORS.py
@@ -11,7 +11,7 @@ from __future__ import (unicode_literals, print_function, division)
 import sys
 import subprocess
 import codecs
-import locale
+import pyuca
 
 blacklist = (
 	# Unknown
@@ -124,8 +124,6 @@ def gitAuthorsOutput():
 	return stdout
 
 def main():
-	locale.setlocale(locale.LC_ALL, "")
-
 	authorsSet = set()
 	authorsText = gitAuthorsOutput()
 	for line in authorsText.split("\n"):
@@ -186,10 +184,8 @@ def main():
 
 	# Sort alphabetically
 	authors = list(authorsSet)
-	if sys.version[0] == '2': # Python 2
-		authors.sort(cmp=locale.strcoll)
-	else:
-		authors.sort(key=locale.strxfrm)
+	collator = pyuca.Collator()
+	authors.sort(key=collator.sort_key)
 
 	for author in authors:
 		f.write(author)


### PR DESCRIPTION
My own rule of thumb for scripts in our repo is to keep the
number dependencies down. In practice, this means I always
strive to only use the standard library.

In this case, it's not that easy.

The existing code sorted sufficiently on Windows.

However, when run on Unix-like systems, it produces odd, and
to my mind, unexpected sorting behavior. (Such as ignoring spaces,
and sorting 'Hey You' after 'Heyh You'.)

I suppose the sort order is a matter of preference.

But the non-determinism of the script's output isn't.
If we don't fix this, we'll get noisy diffs once in a while,
which isn't very nice.

This commit changes the script to use PyICU to
do the sorting. On Windows, I propose we simply
include PyICU in the buildenv, which makes things
Just Work on there.