### PR TITLE
GlobalShortcut_win: only poll XboxInput if there are XInput devices present.

### DIFF
--- a/src/mumble/GlobalShortcut_win.cpp
+++ b/src/mumble/GlobalShortcut_win.cpp
@@ -73,6 +73,7 @@ GlobalShortcutWin::GlobalShortcutWin()
 #endif
 #ifdef USE_XBOXINPUT
 	, xboxinput(NULL)
+	, nxboxinput(0)
 #endif
 	, uiHardwareDevices(0) {
 
@@ -456,6 +457,8 @@ BOOL GlobalShortcutWin::EnumDevicesCB(LPCDIDEVICEINSTANCE pdidi, LPVOID pContext
 	// See issues mumble-voip/mumble#2104 and mumble-voip/mumble#2147
 	// for more information.
 	if (XInputCheck_IsGuidProductXInputDevice(&id->guidproduct)) {
+		nxboxinput += 1;
+
 		qWarning("GlobalShortcutWin: excluded XInput device '%s' (%s) from DirectInput", qPrintable(id->name), qPrintable(id->vguid.toString()));
 		delete id;
 		return DIENUM_CONTINUE;
@@ -573,6 +576,7 @@ void GlobalShortcutWin::timeTicked() {
 		uiHardwareDevices = g.mw->uiNewHardware;
 
 		XInputCheck_ClearDeviceCache();
+		nxboxinput = 0;
 
 		pDI->EnumDevices(DI8DEVCLASS_ALL, EnumDevicesCB, static_cast<void *>(this), DIEDFL_ATTACHEDONLY);
 	}
@@ -657,7 +661,7 @@ void GlobalShortcutWin::timeTicked() {
 #endif
 
 #ifdef USE_XBOXINPUT
-	if (g.s.bEnableXboxInput && xboxinput->isValid()) {
+	if (g.s.bEnableXboxInput && xboxinput->isValid() && nxboxinput > 0) {
 		XboxInputState state;
 		for (uint32_t i = 0; i < XBOXINPUT_MAX_DEVICES; i++) {
 			if (xboxinput->GetState(i, &state) == 0) {

--- a/src/mumble/GlobalShortcut_win.h
+++ b/src/mumble/GlobalShortcut_win.h
@@ -96,6 +96,10 @@ class GlobalShortcutWin : public GlobalShortcutEngine {
 		/// different than last time we queried it.
 		uint32_t   xboxinputLastPacket[XBOXINPUT_MAX_DEVICES];
 		XboxInput *xboxinput;
+		/// nxboxinput holds the number of XInput devices
+		/// available on the system. It is filled out by
+		/// our EnumDevices callback.
+		int nxboxinput;
 #endif
 
 		static BOOL CALLBACK EnumSuitableDevicesCB(LPCDIDEVICEINSTANCE, LPDIRECTINPUTDEVICE8, DWORD, DWORD, LPVOID);


### PR DESCRIPTION
As reported in mumble-voip/mumble#2166, on some systems, polling
XInput devices when no devices are connected can make Mumble lag.

This patch implements a small optimization: don't try to poll
the XboxInput backend if no XInput devices are attached.

Hopefully this will fix the issue for the affected people.