### PR TITLE
scripts/qt.conf: remove.

### DIFF
--- a/scripts/qt.conf
+++ b/scripts/qt.conf
@@ -1,2 +1,0 @@
-[Paths]
-Plugins = QtPlugins


### PR DESCRIPTION
Previously, qt.conf was used to sepecify the runtime
plugin path for Qt in our dynamic Windows and OS X
builds.

Now that those builds use static Qt, the file is
unused.

Delete it.