### PR TITLE
Various OpenBSD fixes

### DIFF
--- a/python.pri
+++ b/python.pri
@@ -1,0 +1,72 @@
+# Copyright 2005-2016 The Mumble Developers. All rights reserved.
+# Use of this source code is governed by a BSD-style license
+# that can be found in the LICENSE file at the root of the
+# Mumble source tree or at <https://www.mumble.info/LICENSE>.
+
+# This .pri files finds a suitable Python binary on the system.
+#
+# It exposes the found Python binary as the 'PYTHON' qmake variable.
+# This variable contains the absolute path to a working Python binary.
+#
+# Why do we need to do this?
+#
+# Some systems (for example, OpenBSD's Python port), are not
+# PEP 394 (https://www.python.org/dev/peps/pep-0394/) compliant.
+#
+# This means that there is no 'python', 'python2' or 'python3'
+# binaries in the $PATH.
+#
+# On those systems, we can't rely on a '#!/usr/bin/env python2'
+# or similar shebang. We have to query the system for versioned
+# Python binaries like "python2.7" instead.
+#
+# This file does that, by searching in $PATH using the 'which'
+# tool.
+#
+# If no binary is found, an error is shown to the user.
+#
+# This script also supports setting a MUMBLE_PYTHON environment
+# variable to specify an absolute path to a Python binary to use.
+# Setting this environment variable overrides any querying.
+
+win32 {
+	PYTHON = $$(MUMBLE_PYTHON)
+	isEmpty(PYTHON) {
+		PYTHON=python
+	}
+} else {
+	PYTHON = $$(MUMBLE_PYTHON)
+	isEmpty(PYTHON) {
+		PYTHON=$$system(which python 2>/dev/null)
+	}
+	isEmpty(PYTHON) {
+		PYTHON=$$system(which python2 2>/dev/null)
+	}
+	isEmpty(PYTHON) {
+		PYTHON=$$system(which python2.7 2>/dev/null)
+	}
+	isEmpty(PYTHON) {
+		PYTHON=$$system(which python3 2>/dev/null)
+	}
+	isEmpty(PYTHON) {
+		PYTHON=$$system(which python3.0 2>/dev/null)
+	}
+	isEmpty(PYTHON) {
+		PYTHON=$$system(which python3.1 2>/dev/null)
+	}
+	isEmpty(PYTHON) {
+		PYTHON=$$system(which python3.2 2>/dev/null)
+	}
+	isEmpty(PYTHON) {
+		PYTHON=$$system(which python3.3 2>/dev/null)
+	}
+	isEmpty(PYTHON) {
+		PYTHON=$$system(which python3.4 2>/dev/null)
+	}
+	isEmpty(PYTHON) {
+		PYTHON=$$system(which python3.5 2>/dev/null)
+	}
+	isEmpty(PYTHON) {
+		error("Unable to find the system's Python binary. Some scripts invoked during the Mumble build use Python. You can manually specify it via the MUMBLE_PYTHON environment variable (either 2 or 3).")
+	}
+}

--- a/src/mumble/PulseAudio.cpp
+++ b/src/mumble/PulseAudio.cpp
@@ -32,11 +32,6 @@
 
 #include "PulseAudio.h"
 
-#include <sys/soundcard.h>
-#include <fcntl.h>
-#include <errno.h>
-#include <sys/ioctl.h>
-
 #include "Global.h"
 #include "MainWindow.h"
 #include "Timer.h"

--- a/src/mumble/mumble.pro
+++ b/src/mumble/mumble.pro
@@ -1,4 +1,5 @@
 include(../mumble.pri)
+include(../../python.pri)
 
 DEFINES		*= MUMBLE
 TEMPLATE	= app
@@ -69,7 +70,7 @@ CONFIG(static) {
       DEF_KIND = release
     }
 
-    gendef.commands = python ../../scripts/gen-mumble_app-qt-def.py $${DEF_KIND} $$[QT_INSTALL_LIBS] $${DEF_FILE}
+    gendef.commands = $$PYTHON ../../scripts/gen-mumble_app-qt-def.py $${DEF_KIND} $$[QT_INSTALL_LIBS] $${DEF_FILE}
     QMAKE_EXTRA_TARGETS *= gendef
     PRE_TARGETDEPS *= gendef
     QMAKE_DISTCLEAN *= $${DEF_FILE}
@@ -645,9 +646,9 @@ CONFIG(no-update) {
 			error(Failed to run lrelease for $$fn)
 		}
 	}
-	GENQRC = ../../scripts/generate-mumble_qt-qrc.py
+	GENQRC = $$PYTHON ../../scripts/generate-mumble_qt-qrc.py
 	win32 {
-		GENQRC = python ..\\..\\scripts\\generate-mumble_qt-qrc.py
+		GENQRC = $$PYTHON ..\\..\\scripts\\generate-mumble_qt-qrc.py
 	}
 	!system($$GENQRC mumble_qt_auto.qrc $$[QT_INSTALL_TRANSLATIONS] $$QT_TRANSLATIONS_FALLBACK_DIR) {
 		error(Failed to run generate-mumble_qt-qrc.py script)

--- a/src/mumble/mumble_pch.hpp
+++ b/src/mumble/mumble_pch.hpp
@@ -106,7 +106,7 @@ typedef WId HWND;
 #include <netinet/tcp.h>
 #endif
 
-#if defined(__MMX__) || defined(Q_OS_WIN)
+#if !defined(Q_OS_OPENBSD) && (defined(__MMX__) || defined(Q_OS_WIN))
 #include <mmintrin.h>
 #endif
 


### PR DESCRIPTION
This allows Mumble to build on OpenBSD OOTB, with dependencies from the OpenBSD ports tree.