### PR TITLE
Remove hardcoded IP whitelist for master server

### DIFF
--- a/src/murmur/Meta.cpp
+++ b/src/murmur/Meta.cpp
@@ -673,9 +673,6 @@ bool Meta::banCheck(const QHostAddress &addr) {
 	if ((mp.iBanTries == 0) || (mp.iBanTimeframe == 0))
 		return false;
 
-	if (addr.toIPv4Address() == ((128U << 24) | (39U << 16) | (114U << 8) | 1U))
-		return false;
-
 	if (qhBans.contains(addr)) {
 		Timer t = qhBans.value(addr);
 		if (t.elapsed() < (1000000ULL * mp.iBanTime))


### PR DESCRIPTION
I brought this up in IRC and it looks like this isn't a valid IP anymore. I'm not sure if it would be preferred to implement a replacement whitelist solution, but hardcoded IPs leave a bad taste anyway.

This was originally added here: https://github.com/mumble-voip/mumble/commit/63cca58b7e7cf2676538f2190d27b8bc22dc8781