### PR TITLE
Touch up Mumble and Murmur manpages

### DIFF
--- a/man/mumble.1
+++ b/man/mumble.1
@@ -1,14 +1,54 @@
-.TH MUMBLE 1 "2015 December 27"
+.TH MUMBLE 1 "2016 May 9"
 .SH NAME
-mumble \- a low\-latency, high quality voice chat program for gaming.
+mumble - a low-latency, high quality voice chat program
 .SH SYNOPSIS
 .B mumble
+[\fB\-m\fR|\fB\-\-multiple\fR] [\fB\-n\fR|\fB\-\-noidentity\fR] [\fBURL\fR]
+.br
+.B mumble
+\fB\-h\fR|\fB\-\-help
 .SH DESCRIPTION
-Mumble is a low\-latency, high quality voice chat utility for
-gaming that runs under X11.
+Mumble is an open source, low-latency, high quality voice chat software
+primarily intended for use while gaming.
+.SH OPTIONS
+.TP
+.B \-h, \-\-help
+Display help and exit.
+.TP
+.B \-m, \-\-multiple
+Allow multiple instances of the client to be started.
+.TP
+.B \-n, \-\-noidentity
+Suppress loading of identity files (i.e., certificates.)
+.P
+.B URL
+specifies a URL to connect to after startup instead of showing the connection
+window.
+.SH RPC CONTROL
+.P
+It is possible to remote control a running instance of Mumble using the
+following command:
+.P
+.B mumble rpc
+[\fBACTION\fR]
+.P
+Where \fBACTION\fR is one of the following:
+.RS
+.TP
+.B mute
+Mute self
+.TP
+.B unmute
+Unmute self
+.TP
+.B deaf
+Deafen self
+.TP
+.B undeaf
+Undeafen self
+.RE
 .SH SEE ALSO
 .BR mumble\-overlay (1),
 .BR murmurd (1).
-.br
 .SH AUTHORS
 mumble and murmurd were written by The Mumble Developers.

--- a/man/murmurd.1
+++ b/man/murmurd.1
@@ -1,41 +1,55 @@
-.TH murmurd 1 "2015 December 27"
+.TH murmurd 1 "2016 May 9"
 .SH NAME
-murmurd \- VoIP server.
+murmurd - VoIP server.
 .SH SYNOPSIS
 .B murmurd
-.RI [ options ]
+[\fB-ini \fIinifile\fR] [\fB-fg\fR] [\fB-v\fR]
+.br
+.B murmurd \-supw \fIpassword\fR \fIserverid\fR
+.br
+.B murmurd \-readsupw \fIserverid\fR
+.br
+.B murmurd \-limits
+.br
+.B murmurd \-wipessl
+.br
+.B murmurd \-wipelogs
+.br
+.B murmurd \-version\fR|\fB\-\-version
+.br
+.B murmurd \-h\fR|\fB\-help\fR|\fB\-\-help
 .SH DESCRIPTION
-Murmur is the server component of Mumble, a low\-latency, high quality VoIP
+Murmur is the server component of Mumble, a low-latency, high quality VoIP
 application.
 .SH OPTIONS
 .TP
 .B \-h, \-help, \-\-help
 Show a summary of the options.
 .TP
-.BI \-ini \ "inifile"
-Specify which inifile to use. Without this option, murmur will search for
+.B \-ini \fIinifile
+Specify which ini file to use. Without this option, murmur will search for
 a murmur.ini file and will fall back to builtin defaults if one isn't found.
 .TP
 .B \-fg
 Run in the foreground (do not fork).
-.br
-This is very useful for debugging.
 .TP
 .B \-v
 Verbose mode, slightly more information is logged.
 .TP
-.BI \-supw \ "password" \ [ "serverid" ]
-This will forcefully set the SuperUser password for a server. SuperUser is
-a special account (similar to
-.RI root
-) which bypasses all access controls. This command may be used while the
-server is running.
+.B \-supw \fIpassword\fR [\fIserverid\fR]
+This sets the SuperUser password for a server. SuperUser is a special account
+(similar to root) which bypasses all access controls. This command may be used
+while the server is running. Optionally takes a \fIserverid\fR representing the
+virtual server to set the password for.
 .TP
-.BI \-readsupw \ [srv]
-Reads password for server srv from standard input.
+.BI \-readsupw\fR\ [\fIserverid\fR]
+Reads SuperUser password from stdin. Optionally takes a \fIserverid\fR
+representing the virtual server to set the password for.
 .TP
 .B \-limits
-Tests and shows how many file descriptors and threads can be created. The purpose of this option is to test how many clients Murmur can handle. Murmur will exit after this test.
+Tests and shows how many file descriptors and threads can be created. The
+purpose of this option is to test how many clients Murmur can handle. Murmur
+will exit after this test.
 .TP
 .B \-wipessl
 Remove SSL certificates from database.
@@ -47,7 +61,7 @@ Remove all log entries from database.
 Show version information.
 .SH SEE ALSO
 .BR mumble (1),
-.BR murmur\-wrapper (1).
+.BR murmur\-user\-wrapper (1).
 .br
 .SH AUTHORS
 mumble and murmurd were written by The Mumble Developers.


### PR DESCRIPTION
This fills out the mostly desolate mumble manpage (using information from --help), and touches up on details in both the mumble and murmur manpages.