### PR TITLE
Add Joeliam to .mailmap and sync AUTHORS.

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -102,3 +102,6 @@ John Marion <john@lmsn.net> <LuaMilkshake@users.noreply.github.com>
 
 # Alias of Derrick Dymock <actown@gmail.com
 Derrick Dymock <actown@gmail.com> Derrick Dymock <derrick@puppetlabs.com>
+
+# Alias of Joel Kees <joelkees@gmail.com>
+Joel Kees <joelkees@gmail.com> Joeliam <joelkees@gmail.com>

--- a/AUTHORS
+++ b/AUTHORS
@@ -101,6 +101,7 @@ javitonino <javitonino@users.sourceforge.net>
 Jérôme "buggerone" <buggerone@users.sourceforge.net>
 Jerome Vidal <jerhum@users.sourceforge.net>
 jgeboski <jgeboski@gmail.com>
+Joel Kees <joelkees@gmail.com>
 Joël Troch <joel.troch62@gmail.com>
 John Marion <john@lmsn.net>
 John P <johnhatestrash@gmail.com>


### PR DESCRIPTION
In PR #2248, I promised to change the commit's
author before landing. I didn't.

This adds an entry to the .mailmap to make up
for that.