### PR TITLE
[Positional Audio] Battlefield 4: Fixed Squad/Squad Leader pointers

### DIFF
--- a/plugins/bf4/bf4.cpp
+++ b/plugins/bf4/bf4.cpp
@@ -1,4 +1,4 @@
-// Copyright 2016 The Mumble Developers. All rights reserved.
+// Copyright 2005-2016 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.
@@ -32,9 +32,9 @@ static int fetch(float *avatar_pos, float *avatar_front, float *avatar_top, floa
     if (!serverid_offset) return false;
 
     // Squad pointers
-    BYTE *squad_base = peekProc<BYTE *>(pModule + 0x02210D68);
+    BYTE *squad_base = peekProc<BYTE *>(pModule + 0x02210718);
     if (!squad_base) return false;
-    BYTE *squad_offset_0 = peekProc<BYTE *>(squad_base + 0x570);
+    BYTE *squad_offset_0 = peekProc<BYTE *>(squad_base + 0xD8);
     if (!squad_offset_0) return false;
     BYTE *squad_offset_1 = peekProc<BYTE *>(squad_offset_0 + 0x100);
     if (!squad_offset_1) return false;


### PR DESCRIPTION
- The pointers were not working on some servers, or pointing to random memory addresses. The new ones seem to work fine.
- Updated the license header.