### PR TITLE
scripts/generate-CHANGES.py: fix capture group in gitMailmapLookup's contact regexp.

### DIFF
--- a/scripts/generate-CHANGES.py
+++ b/scripts/generate-CHANGES.py
@@ -194,7 +194,7 @@ def gitMailmapLookup(author, email):
 	if p.returncode != 0:
 		raise Exception('"git check-mailmap" failed: %s', stderr)
 
-	match = re.match('^(.*)\ (\<.*\>)$', stdout)
+	match = re.match('^(.*)\ \<(.*)\>$', stdout)
 	if match is None:
 		raise Exception("unable to parse contact output from 'git check-mailmap'")
 


### PR DESCRIPTION
The email capture group accidently captured
the whole email part of the contact, including
angle brackets.

Update the capture group to only capture the
actual email address.