### PR TITLE
Plugins, VersionCheck: don't pass WTD_LIFETIME_SIGNING_FLAG to WinTrust APIs.

### DIFF
--- a/src/mumble/Plugins.cpp
+++ b/src/mumble/Plugins.cpp
@@ -653,7 +653,7 @@ void Plugins::fetchedPAPluginDL(QByteArray data, QUrl url) {
 				data.fdwRevocationChecks = WTD_REVOKE_NONE;
 				data.dwUnionChoice = WTD_CHOICE_FILE;
 				data.pFile = &file;
-				data.dwProvFlags = WTD_SAFER_FLAG | WTD_USE_DEFAULT_OSVER_CHECK | WTD_LIFETIME_SIGNING_FLAG;
+				data.dwProvFlags = WTD_SAFER_FLAG | WTD_USE_DEFAULT_OSVER_CHECK;
 				data.dwUIContext = WTD_UICONTEXT_INSTALL;
 
 				static GUID guid = WINTRUST_ACTION_GENERIC_VERIFY_V2;

--- a/src/mumble/VersionCheck.cpp
+++ b/src/mumble/VersionCheck.cpp
@@ -108,7 +108,7 @@ void VersionCheck::fetched(QByteArray a, QUrl url) {
 						data.fdwRevocationChecks = WTD_REVOKE_NONE;
 						data.dwUnionChoice = WTD_CHOICE_FILE;
 						data.pFile = &file;
-						data.dwProvFlags = WTD_SAFER_FLAG | WTD_USE_DEFAULT_OSVER_CHECK | WTD_LIFETIME_SIGNING_FLAG;
+						data.dwProvFlags = WTD_SAFER_FLAG | WTD_USE_DEFAULT_OSVER_CHECK;
 						data.dwUIContext = WTD_UICONTEXT_INSTALL;
 
 						static GUID guid = WINTRUST_ACTION_GENERIC_VERIFY_V2;


### PR DESCRIPTION
Our binaries are timestamped, and we expect them to be deemed
valid by Windows even after the certificate expires. And they
are.

However, our own code explicitly passes WTD_LIFETIME_SIGNING
to the WinTrust APIs, overriding Windows's default of treating
timestamped binaries as valid even after certificate expiry.
(As long as the certificate doesn't have the lifetime signing bit
set!)

Now, this of course begs the question: What if our binaries
*did* have the lifetime signing bit set? Would *not* passing
this flag to the WinTrust APIs override that -- and trick
Mumble into thinking that a code signature that Windows
deems invalid is actually still valid?

I don't know yet. But I would assume that *not* including
the flag makes Windows use the lifetime signing bit of
the certificate to determine the strategy to use in validating
the binary.