### PR TITLE
Allow only one instance from UserLocalVolumeDialog per User

### DIFF
--- a/src/mumble/MainWindow.cpp
+++ b/src/mumble/MainWindow.cpp
@@ -1518,13 +1518,7 @@ void MainWindow::on_qaUserLocalVolume_triggered() {
 
 void MainWindow::openUserLocalVolumeDialog(ClientUser *p) {
 	unsigned int session = p->uiSession;
-	if (qmUserVolTracker.contains(session)) {
-		qmUserVolTracker.value(session)->raise();
-	} else {
-		UserLocalVolumeDialog *uservol = new UserLocalVolumeDialog(session, &qmUserVolTracker);
-		uservol->show();
-		qmUserVolTracker.insert(session, uservol);
-	}
+	UserLocalVolumeDialog::present(session, &qmUserVolTracker);
 }
 
 void MainWindow::on_qaUserDeaf_triggered() {

--- a/src/mumble/MainWindow.cpp
+++ b/src/mumble/MainWindow.cpp
@@ -1518,8 +1518,13 @@ void MainWindow::on_qaUserLocalVolume_triggered() {
 
 void MainWindow::openUserLocalVolumeDialog(ClientUser *p) {
 	unsigned int session = p->uiSession;
-	UserLocalVolumeDialog *uservol = new UserLocalVolumeDialog(session);
-	uservol->show();
+	if (qmuservolTracker.contains(session)) {
+		qmuservolTracker.value(session)->raise();
+	} else {
+		UserLocalVolumeDialog *uservol = new UserLocalVolumeDialog(session, &qmuservolTracker);
+		uservol->show();
+		qmuservolTracker.insert(session, uservol);
+	}
 }
 
 void MainWindow::on_qaUserDeaf_triggered() {

--- a/src/mumble/MainWindow.cpp
+++ b/src/mumble/MainWindow.cpp
@@ -1518,12 +1518,12 @@ void MainWindow::on_qaUserLocalVolume_triggered() {
 
 void MainWindow::openUserLocalVolumeDialog(ClientUser *p) {
 	unsigned int session = p->uiSession;
-	if (qmuservolTracker.contains(session)) {
-		qmuservolTracker.value(session)->raise();
+	if (qmUserVolTracker.contains(session)) {
+		qmUserVolTracker.value(session)->raise();
 	} else {
-		UserLocalVolumeDialog *uservol = new UserLocalVolumeDialog(session, &qmuservolTracker);
+		UserLocalVolumeDialog *uservol = new UserLocalVolumeDialog(session, &qmUserVolTracker);
 		uservol->show();
-		qmuservolTracker.insert(session, uservol);
+		qmUserVolTracker.insert(session, uservol);
 	}
 }
 

--- a/src/mumble/MainWindow.h
+++ b/src/mumble/MainWindow.h
@@ -25,6 +25,7 @@
 #include "Message.h"
 #include "Mumble.pb.h"
 #include "Usage.h"
+#include "UserLocalVolumeDialog.h"
 
 #include "ui_MainWindow.h"
 
@@ -71,6 +72,7 @@ class MainWindow : public QMainWindow, public MessageHandler, public Ui::MainWin
 		QMenu *qmTray;
 		QIcon qiIcon, qiIconMuteSelf, qiIconMuteServer, qiIconDeafSelf, qiIconDeafServer, qiIconMuteSuppressed;
 		QIcon qiTalkingOn, qiTalkingWhisper, qiTalkingShout, qiTalkingOff;
+		QMap<unsigned int, UserLocalVolumeDialog*> qmuservolTracker;
 
 		GlobalShortcut *gsPushTalk, *gsResetAudio, *gsMuteSelf, *gsDeafSelf;
 		GlobalShortcut *gsUnlink, *gsPushMute, *gsJoinChannel, *gsToggleOverlay;

--- a/src/mumble/MainWindow.h
+++ b/src/mumble/MainWindow.h
@@ -72,7 +72,7 @@ class MainWindow : public QMainWindow, public MessageHandler, public Ui::MainWin
 		QMenu *qmTray;
 		QIcon qiIcon, qiIconMuteSelf, qiIconMuteServer, qiIconDeafSelf, qiIconDeafServer, qiIconMuteSuppressed;
 		QIcon qiTalkingOn, qiTalkingWhisper, qiTalkingShout, qiTalkingOff;
-		QMap<unsigned int, UserLocalVolumeDialog*> qmuservolTracker;
+		QMap<unsigned int, UserLocalVolumeDialog *> qmUserVolTracker;
 
 		GlobalShortcut *gsPushTalk, *gsResetAudio, *gsMuteSelf, *gsDeafSelf;
 		GlobalShortcut *gsUnlink, *gsPushMute, *gsJoinChannel, *gsToggleOverlay;

--- a/src/mumble/UserLocalVolumeDialog.cpp
+++ b/src/mumble/UserLocalVolumeDialog.cpp
@@ -62,6 +62,17 @@ void UserLocalVolumeDialog::closeEvent(QCloseEvent *event) {
 	event->accept();
 }
 
+void UserLocalVolumeDialog::present(unsigned int sessionId,
+                                    QMap<unsigned int, UserLocalVolumeDialog *> *qmUserVolTracker) {
+	if (qmUserVolTracker->contains(sessionId)) {
+		qmUserVolTracker->value(sessionId)->raise();
+	} else {
+		UserLocalVolumeDialog *uservol = new UserLocalVolumeDialog(sessionId, qmUserVolTracker);
+		uservol->show();
+		qmUserVolTracker->insert(sessionId, uservol);
+	}
+}
+
 void UserLocalVolumeDialog::on_qsUserLocalVolume_valueChanged(int value) {
 	qsbUserLocalVolume->setValue(value);
 	ClientUser *user = ClientUser::get(m_clientSession);

--- a/src/mumble/UserLocalVolumeDialog.cpp
+++ b/src/mumble/UserLocalVolumeDialog.cpp
@@ -42,10 +42,10 @@
 #include "Database.h"
 
 UserLocalVolumeDialog::UserLocalVolumeDialog(unsigned int sessionId,
-                                             QMap<unsigned int, UserLocalVolumeDialog*> *qmuservolTracker)
+                                             QMap<unsigned int, UserLocalVolumeDialog *> *qmUserVolTracker)
 	: QDialog(NULL)
 	, m_clientSession(sessionId)
-	, m_qmuservolTracker(qmuservolTracker){
+	, m_qmUserVolTracker(qmUserVolTracker){
 	setupUi(this);
 
 	ClientUser *user = ClientUser::get(sessionId);
@@ -58,7 +58,7 @@ UserLocalVolumeDialog::UserLocalVolumeDialog(unsigned int sessionId,
 }
 
 void UserLocalVolumeDialog::closeEvent(QCloseEvent *event) {
-	m_qmuservolTracker->remove(m_clientSession);
+	m_qmUserVolTracker->remove(m_clientSession);
 	event->accept();
 }
 
@@ -93,6 +93,6 @@ void UserLocalVolumeDialog::on_qbbUserLocalVolume_clicked(QAbstractButton *butto
 }
 
 void UserLocalVolumeDialog::reject() {
-	m_qmuservolTracker->remove(m_clientSession);
+	m_qmUserVolTracker->remove(m_clientSession);
 	UserLocalVolumeDialog::close();
 }

--- a/src/mumble/UserLocalVolumeDialog.cpp
+++ b/src/mumble/UserLocalVolumeDialog.cpp
@@ -84,7 +84,7 @@ void UserLocalVolumeDialog::on_qbbUserLocalVolume_clicked(QAbstractButton *butto
 		if (user && !user->qsHash.isEmpty()) {
 			Database::setUserLocalVolume(user->qsHash, user->fLocalVolume);
 		}
-        UserLocalVolumeDialog::close();
+		UserLocalVolumeDialog::close();
 	}
 	if (button == qbbUserLocalVolume->button(QDialogButtonBox::Cancel)) {
 		qsUserLocalVolume->setValue(m_originalVolumeAdjustmentDecibel);

--- a/src/mumble/UserLocalVolumeDialog.h
+++ b/src/mumble/UserLocalVolumeDialog.h
@@ -50,7 +50,7 @@ class UserLocalVolumeDialog : public QDialog, private Ui::UserLocalVolumeDialog 
 
 		/// The user's original adjustment (in dB) when entering the dialog.
 		int m_originalVolumeAdjustmentDecibel;
-		QMap<unsigned int, UserLocalVolumeDialog*> *m_qmuservolTracker;
+		QMap<unsigned int, UserLocalVolumeDialog *> *m_qmUserVolTracker;
 
 	public slots:
 		void closeEvent(QCloseEvent *event);
@@ -60,8 +60,8 @@ class UserLocalVolumeDialog : public QDialog, private Ui::UserLocalVolumeDialog 
 		void reject();
 
 	public:
-		UserLocalVolumeDialog(unsigned int sessionId = 0,
-                                      QMap<unsigned int, UserLocalVolumeDialog*> *qmuservolTracker = NULL);
+		UserLocalVolumeDialog(unsigned int sessionId,
+                                      QMap<unsigned int, UserLocalVolumeDialog *> *qmUserVolTracker);
 };
 
 #endif

--- a/src/mumble/UserLocalVolumeDialog.h
+++ b/src/mumble/UserLocalVolumeDialog.h
@@ -60,6 +60,8 @@ class UserLocalVolumeDialog : public QDialog, private Ui::UserLocalVolumeDialog 
 		void reject();
 
 	public:
+		static void present(unsigned int sessionId,
+                                    QMap<unsigned int, UserLocalVolumeDialog *> *qmUserVolTracker);
 		UserLocalVolumeDialog(unsigned int sessionId,
                                       QMap<unsigned int, UserLocalVolumeDialog *> *qmUserVolTracker);
 };

--- a/src/mumble/UserLocalVolumeDialog.h
+++ b/src/mumble/UserLocalVolumeDialog.h
@@ -36,6 +36,8 @@
 #ifndef MUMBLE_MUMBLE_USERVOLUME_H_
 #define MUMBLE_MUMBLE_USERVOLUME_H_
 
+#include <QMap>
+
 #include "ui_UserLocalVolumeDialog.h"
 #include "ClientUser.h"
 
@@ -45,16 +47,21 @@ class UserLocalVolumeDialog : public QDialog, private Ui::UserLocalVolumeDialog 
 
 		/// The session ID for the user that the dialog is changing the volume for.
 		unsigned int m_clientSession;
+
 		/// The user's original adjustment (in dB) when entering the dialog.
 		int m_originalVolumeAdjustmentDecibel;
+		QMap<unsigned int, UserLocalVolumeDialog*> *m_qmuservolTracker;
 
 	public slots:
+		void closeEvent(QCloseEvent *event);
 		void on_qsUserLocalVolume_valueChanged(int value);
 		void on_qsbUserLocalVolume_valueChanged(int value);
 		void on_qbbUserLocalVolume_clicked(QAbstractButton *b);
+		void reject();
 
 	public:
-		UserLocalVolumeDialog(unsigned int sessionId = 0);
+		UserLocalVolumeDialog(unsigned int sessionId = 0,
+                                      QMap<unsigned int, UserLocalVolumeDialog*> *qmuservolTracker = NULL);
 };
 
 #endif


### PR DESCRIPTION
An extension for #1903 (Improve Volume adjust per user) because it is possible to open more than one volume dialog per user.

If the user tries now to open a dialog for a user that is already open, Mumble will show the dialog instead of open a new one.