### PR TITLE
Document -disablesu on murmur manpage

### DIFF
--- a/man/murmurd.1
+++ b/man/murmurd.1
@@ -9,6 +9,8 @@ murmurd - VoIP server.
 .br
 .B murmurd \-readsupw \fIserverid\fR
 .br
+.B murmurd \-disablesu \fIserverid\fR
+.br
 .B murmurd \-limits
 .br
 .B murmurd \-wipessl
@@ -45,6 +47,10 @@ virtual server to set the password for.
 .BI \-readsupw\fR\ [\fIserverid\fR]
 Reads SuperUser password from stdin. Optionally takes a \fIserverid\fR
 representing the virtual server to set the password for.
+.TP
+.B \-disablesu\fR\ [\fIserverid\fR]
+Disables the SuperUser account. Optionally takes a \fIserverid\fR representing
+the virtual server to disable the SuperUser account on.
 .TP
 .B \-limits
 Tests and shows how many file descriptors and threads can be created. The

--- a/man/murmurd.1
+++ b/man/murmurd.1
@@ -5,11 +5,11 @@ murmurd - VoIP server.
 .B murmurd
 [\fB-ini \fIinifile\fR] [\fB-fg\fR] [\fB-v\fR]
 .br
-.B murmurd \-supw \fIpassword\fR \fIserverid\fR
+.B murmurd \-supw\fR \fIpassword\fR [\fIserverid\fR]
 .br
-.B murmurd \-readsupw \fIserverid\fR
+.B murmurd \-readsupw\fR [\fIserverid\fR]
 .br
-.B murmurd \-disablesu \fIserverid\fR
+.B murmurd \-disablesu\fR [\fIserverid\fR]
 .br
 .B murmurd \-limits
 .br

--- a/man/murmurd.1
+++ b/man/murmurd.1
@@ -44,7 +44,7 @@ This sets the SuperUser password for a server. SuperUser is a special account
 while the server is running. Optionally takes a \fIserverid\fR representing the
 virtual server to set the password for.
 .TP
-.BI \-readsupw\fR\ [\fIserverid\fR]
+.B \-readsupw\fR\ [\fIserverid\fR]
 Reads SuperUser password from stdin. Optionally takes a \fIserverid\fR
 representing the virtual server to set the password for.
 .TP


### PR DESCRIPTION
I added documentation for `-disablesu` to the murmur manpage.

This also includes a couple other nitpicky fixes to the manpage as separate commits.