### PR TITLE
Murmur: add no-op userTextMessage signal for DBus to silence connect()'s error log output.

### DIFF
--- a/src/murmur/DBus.cpp
+++ b/src/murmur/DBus.cpp
@@ -745,6 +745,10 @@ void MurmurDBus::userStateChanged(const User *p) {
 	emit playerStateChanged(PlayerInfo(p));
 }
 
+void MurmurDBus::userTextMessage(const User *, const TextMessage &) {
+	// Not implemented for DBus.
+}
+
 void MurmurDBus::userConnected(const User *p) {
 	emit playerConnected(PlayerInfo(p));
 }

--- a/src/murmur/DBus.h
+++ b/src/murmur/DBus.h
@@ -134,6 +134,7 @@ class MurmurDBus : public QDBusAbstractAdaptor {
 
 		// These use private types, so won't be converted to DBus
 		void userStateChanged(const User *p);
+		void userTextMessage(const User *, const TextMessage &);
 		void userConnected(const User *p);
 		void userDisconnected(const User *p);
 


### PR DESCRIPTION
This gets rid of the following (harmless, but worrying) error in Murmur's log:

    <W>2016-06-04 00:17:39.229 QObject::connect: No such slot MurmurDBus::userTextMessage(const User *, const TextMessage &)