### PR TITLE
Murmur: allow certificates without full chain, but do not deem such certificates 'strong'.

### DIFF
--- a/src/murmur/Server.cpp
+++ b/src/murmur/Server.cpp
@@ -1306,6 +1306,7 @@ void Server::sslError(const QList<QSslError> &errors) {
 			case QSslError::SelfSignedCertificate:
 			case QSslError::SelfSignedCertificateInChain:
 			case QSslError::UnableToGetLocalIssuerCertificate:
+			case QSslError::UnableToVerifyFirstCertificate:
 			case QSslError::HostNameMismatch:
 			case QSslError::CertificateNotYetValid:
 			case QSslError::CertificateExpired:


### PR DESCRIPTION
This allows users to connect to Murmur with CA-signed certificates
without a complete certificate chain.

Such cases will be treated as non-strong, juts like self-signed
certificates.

Before this, if a client attempted to connect to Murmur with a
client certificate from a OS-trusted CA, but forgot to include
the correct intermediate certificates, the client would not be
allowed in -- and got no proper warning.

With this change, the user is let in. However, because Murmur
can't verify the certificate against the CA store, it is deemed
non-strong.

Ideally, the certificate wizard should warn about cases where
an incomplete certificate chain is used, but I believe this is
a good first step.

Fixes #993