### PR TITLE
scripts/mkini.sh: consider semicolons as comments to fix .ini generation.

### DIFF
--- a/scripts/mkini.sh
+++ b/scripts/mkini.sh
@@ -9,10 +9,10 @@ cp murmur.ini murmur.ini.win32
 cp murmur.ini murmur.ini.osx
 cp murmur.ini murmur.ini.system
 
-perl -pi.bak -e 's/^(#|)dbus=.*$/\1dbus=system/' murmur.ini.system
-perl -pi.bak -e 's/^(#|)logfile=.*$/logfile=\/var\/log\/mumble-server\/mumble-server.log/' murmur.ini.system
-perl -pi.bak -e 's/^(#|)pidfile=.*$/pidfile=\/var\/run\/mumble-server\/mumble-server.pid/' murmur.ini.system
-perl -pi.bak -e 's/^(#|)database=.*$/database=\/var\/lib\/mumble-server\/mumble-server.sqlite/' murmur.ini.system
-perl -pi.bak -e 's/^(#|)uname=.*$/uname=mumble-server/' murmur.ini.system
+perl -pi.bak -e 's/^(#|;|)dbus=.*$/\1dbus=system/' murmur.ini.system
+perl -pi.bak -e 's/^(#|;|)logfile=.*$/logfile=\/var\/log\/mumble-server\/mumble-server.log/' murmur.ini.system
+perl -pi.bak -e 's/^(#|;|)pidfile=.*$/pidfile=\/var\/run\/mumble-server\/mumble-server.pid/' murmur.ini.system
+perl -pi.bak -e 's/^(#|;|)database=.*$/database=\/var\/lib\/mumble-server\/mumble-server.sqlite/' murmur.ini.system
+perl -pi.bak -e 's/^(#|;|)uname=.*$/uname=mumble-server/' murmur.ini.system
 
 perl -pi.bak -e 'BEGIN{undef $/;} s/\n/\r\n/smg' murmur.ini.win32


### PR DESCRIPTION
As-is, the murmur.ini.system used by our PPA builds
(and Debian-based distros) are broken because the
script doesn't set the "logfile" and "pidfile"
options.