### PR TITLE
plugins/: Update memory addresses retrieval

### DIFF
--- a/plugins/aoc/aoc.cpp
+++ b/plugins/aoc/aoc.cpp
@@ -38,10 +38,7 @@
 
 using namespace std;
 
-BYTE *posptr;
-BYTE *rotptr;
-BYTE *stateptr;
-BYTE *hostptr;
+procptr32_t posptr, rotptr, stateptr, hostptr;
 
 static bool calcout(float *pos, float *rot, float *opos, float *front, float *top) {
 	float h = rot[0];
@@ -147,14 +144,14 @@ static int trylock(const std::multimap<std::wstring, unsigned long long int> &pi
 	*/
 
 	// Remember addresses for later
-	posptr = pModule + 0x748e14;
-	rotptr = pModule + 0x73dc9c;
-	stateptr = pModule + 0x6d4334;
+	posptr = pModule32 + 0x748e14;
+	rotptr = pModule32 + 0x73dc9c;
+	stateptr = pModule32 + 0x6d4334;
 	hostptr = mod_engine + 0x3C2A84;
 
 	//Gamecheck
 	char sMagic[13];
-	if (!peekProc(pModule + 0x7071e8, sMagic, 13) || strncmp("ageofchivalry", sMagic, 13)!=0)
+	if (!peekProc(pModule32 + 0x7071e8, sMagic, 13) || strncmp("ageofchivalry", sMagic, 13)!=0)
 		return false;
 
 	// Check if we can get meaningful data from it

--- a/plugins/aoc/aoc.cpp
+++ b/plugins/aoc/aoc.cpp
@@ -128,7 +128,7 @@ static int trylock(const std::multimap<std::wstring, unsigned long long int> &pi
 	if (! initialize(pids, L"hl2.exe", L"client.dll"))
 		return false;
 
-	BYTE *mod_engine=getModuleAddr(L"engine.dll");
+	procptr32_t mod_engine=getModuleAddr(L"engine.dll");
 	if (!mod_engine)
 		return false;
 

--- a/plugins/arma2/arma2.cpp
+++ b/plugins/arma2/arma2.cpp
@@ -123,11 +123,11 @@ static int trylock(const std::multimap<std::wstring, unsigned long long int> &pi
 	   if (!pModule)
 	*/
 
-	procptr32_t *ptr1 = peekProc<procptr32_t>(0x00C500FC);
+	procptr32_t ptr1 = peekProc<procptr32_t>((procptr32_t) 0x00C500FC);
 
-	procptr32_t *ptr2 = peekProc<procptr32_t>(ptr1 + 0x88);
+	procptr32_t ptr2 = peekProc<procptr32_t>(ptr1 + 0x88);
 
-	procptr32_t *base = ptr2 + 0x10;
+	procptr32_t base = ptr2 + 0x10;
 
 	posptr = base + 0x18;
 	frontptr = base;

--- a/plugins/arma2/arma2.cpp
+++ b/plugins/arma2/arma2.cpp
@@ -36,9 +36,7 @@
 
 #include "../mumble_plugin_win32.h"
 
-BYTE *posptr;
-BYTE *frontptr;
-BYTE *topptr;
+procptr32_t posptr, frontptr, topptr;
 
 static int fetch(float *avatar_pos, float *avatar_front, float *avatar_top, float *camera_pos, float *camera_front, float *camera_top, std::string &, std::wstring &) {
 	for (int i=0;i<3;i++)
@@ -125,11 +123,11 @@ static int trylock(const std::multimap<std::wstring, unsigned long long int> &pi
 	   if (!pModule)
 	*/
 
-	BYTE *ptr1 = peekProc<BYTE *>((BYTE *) 0x00C500FC);
+	procptr32_t *ptr1 = peekProc<procptr32_t>(0x00C500FC);
 
-	BYTE *ptr2 = peekProc<BYTE *>(ptr1 + 0x88);
+	procptr32_t *ptr2 = peekProc<procptr32_t>(ptr1 + 0x88);
 
-	BYTE *base = ptr2 + 0x10;
+	procptr32_t *base = ptr2 + 0x10;
 
 	posptr = base + 0x18;
 	frontptr = base;

--- a/plugins/bf1942/bf1942.cpp
+++ b/plugins/bf1942/bf1942.cpp
@@ -36,8 +36,7 @@
 
 #include "../mumble_plugin_win32.h"
 
-BYTE *faceptr;
-BYTE *topptr;
+procptr32_t faceptr, topptr;
 //BYTE *stateptr;
 //BYTE *contextptr;
 
@@ -59,7 +58,7 @@ static int fetch(float *avatar_pos, float *avatar_front, float *avatar_top, floa
 
 	//peekProc(contextptr, ccontext, 128);
 
-	ok = peekProc((BYTE *) 0x00976274, avatar_pos, 12) &&
+	ok = peekProc((procptr32_t) 0x00976274, avatar_pos, 12) &&
 	     peekProc(faceptr, avatar_front, 12) &&
 	     peekProc(topptr, avatar_top, 12);
 
@@ -88,8 +87,8 @@ static int trylock(const std::multimap<std::wstring, unsigned long long int> &pi
 	if (! initialize(pids, L"BF1942.exe"))
 		return false;
 
-	BYTE *ptr1 = peekProc<BYTE *>((BYTE *) 0x009A9468);
-	BYTE *ptr2 = peekProc<BYTE *>(ptr1 + 0x98);
+	procptr32_t ptr1 = peekProc<procptr32_t>((procptr32_t) 0x009A9468);
+	procptr32_t ptr2 = peekProc<procptr32_t>(ptr1 + 0x98);
 
 	faceptr = ptr2 + 0x5C;
 	topptr = ptr2 + 0x4C;

--- a/plugins/bf2/bf2.cpp
+++ b/plugins/bf2/bf2.cpp
@@ -10,26 +10,20 @@ using namespace std;
 bool ptr_chain_valid = false;
 
 // Modules
-BYTE *pmodule_bf2;
-BYTE *pmodule_renddx9;
+procptr32_t pmodule_bf2, pmodule_renddx9;
 
 // Magic ptrs
-BYTE* const login_ptr = (BYTE*)0x30058642;
-BYTE* const state_ptr = (BYTE*)0x00A1D0A8;
+procptr32_t const login_ptr = (procptr32_t) 0x30058642;
+procptr32_t const state_ptr = (procptr32_t) 0x00A1D0A8;
 
 // Vector ptrs
-BYTE *pos_ptr;
-BYTE *face_ptr;
-BYTE *top_ptr;
+procptr32_t pos_ptr, face_ptr, top_ptr;
 
 // Context ptrs
-BYTE* const ipport_ptr = (BYTE*)0x009A80B8;
+procptr32_t const ipport_ptr = (procptr32_t) 0x009A80B8;
 
 // Identity ptrs
-BYTE *commander_ptr;
-BYTE *squad_leader_ptr;
-BYTE *squad_state_ptr;
-BYTE *team_state_ptr;
+procptr32_t commander_ptr, squad_leader_ptr, squad_state_ptr, team_state_ptr;
 
 inline bool resolve_ptrs() {
 	pos_ptr = face_ptr = top_ptr = commander_ptr = squad_leader_ptr = squad_state_ptr = team_state_ptr = NULL;
@@ -37,13 +31,13 @@ inline bool resolve_ptrs() {
 	// Resolve all pointer chains to the values we want to fetch
 	//
 
-	BYTE *base_bf2audio = pModule + 0x4645c;
-	BYTE *base_bf2audio_2 = peekProc<BYTE *>(base_bf2audio);
+	procptr32_t base_bf2audio = pModule32 + 0x4645c;
+	procptr32_t base_bf2audio_2 = peekProc<procptr32_t>(base_bf2audio);
 	if (!base_bf2audio_2) return false;
 
-	pos_ptr = peekProc<BYTE *>(base_bf2audio_2 + 0xb4);
-	face_ptr = peekProc<BYTE *>(base_bf2audio_2 + 0xb8);
-	top_ptr = peekProc<BYTE *>(base_bf2audio_2 + 0xbc);
+	pos_ptr = peekProc<procptr32_t>(base_bf2audio_2 + 0xb4);
+	face_ptr = peekProc<procptr32_t>(base_bf2audio_2 + 0xb8);
+	top_ptr = peekProc<procptr32_t>(base_bf2audio_2 + 0xbc);
 	if (!pos_ptr || !face_ptr || !top_ptr) return false;
 
 	/*
@@ -62,17 +56,17 @@ inline bool resolve_ptrs() {
 		Squad state: RendDX9.dll+00244AE0 + 0x60 -> 10C				BYTE		0 is not in squad; 1 is in Alpha squad, 2 Bravo, ... , 9 India
 		Team state: BF2.exe+0058734C + 0x239						BYTE		0 is blufor (US team, for example), 1 is opfor (Insurgents)
 	*/
-	BYTE *base_renddx9 = peekProc<BYTE *>(pmodule_renddx9 + 0x00244AE0);
+	procptr32_t base_renddx9 = peekProc<procptr32_t>(pmodule_renddx9 + 0x00244AE0);
 	if (!base_renddx9) return false;
 
-	BYTE *base_renddx9_2 = peekProc<BYTE *>(base_renddx9 + 0x60);
+	procptr32_t base_renddx9_2 = peekProc<procptr32_t>(base_renddx9 + 0x60);
 	if (!base_renddx9_2) return false;
 
 	commander_ptr = base_renddx9_2 + 0x110;
 	squad_leader_ptr = base_renddx9_2 + 0x111;
 	squad_state_ptr = base_renddx9_2 + 0x10C;
 
-	BYTE *base_bf2 = peekProc<BYTE *>(pmodule_bf2 + 0x0058734C);
+	procptr32_t base_bf2 = peekProc<procptr32_t>(pmodule_bf2 + 0x0058734C);
 	if (!base_bf2) return false;
 
 	team_state_ptr = base_bf2 + 0x239;
@@ -84,7 +78,7 @@ static int fetch(float *avatar_pos, float *avatar_front, float *avatar_top, floa
 		avatar_pos[i] = avatar_front[i] = avatar_top[i] = camera_pos[i] = camera_front[i] = camera_top[i] = 0.0f;
 
 	bool ok;
-	BYTE logincheck;
+	procptr32_t logincheck;
 	ok = peekProc(login_ptr, &logincheck, 1);
 	if (! ok)
 		return false;
@@ -92,7 +86,7 @@ static int fetch(float *avatar_pos, float *avatar_front, float *avatar_top, floa
 	if (logincheck == 0)
 		return false;
 
-	BYTE state;
+	procptr32_t state;
 	ok = peekProc(state_ptr , &state, 1); // Magical state value
 	if (! ok)
 		return false;

--- a/plugins/bf2142/bf2142.cpp
+++ b/plugins/bf2142/bf2142.cpp
@@ -5,9 +5,7 @@
 
 #include "../mumble_plugin_win32.h"
 
-BYTE *posptr;
-BYTE *faceptr;
-BYTE *topptr;
+procptr32_t posptr, faceptr, topptr;
 
 static int fetch(float *avatar_pos, float *avatar_front, float *avatar_top, float *camera_pos, float *camera_front, float *camera_top, std::string &context, std::wstring &) {
 	for (int i=0;i<3;i++)
@@ -18,7 +16,7 @@ static int fetch(float *avatar_pos, float *avatar_front, float *avatar_top, floa
 	char logincheck;
 	bool ok;
 
-	ok = peekProc((BYTE *) 0x00A1D908, &logincheck, 1);
+	ok = peekProc((procptr32_t) 0x00A1D908, &logincheck, 1);
 	if (! ok)
 		return false;
 
@@ -31,14 +29,14 @@ static int fetch(float *avatar_pos, float *avatar_front, float *avatar_top, floa
 		usually 1, never 0		if you create your own server ingame; this value will switch to 1 the instant you click "Join Game"
 		usually 3, never 0		if you load into a server; this value will switch to 3 the instant you click "Join Game"
 	*/
-	ok = peekProc((BYTE *) 0x00B47968, &state, 1); // Magical state value
+	ok = peekProc((procptr32_t) 0x00B47968, &state, 1); // Magical state value
 	if (! ok)
 		return false;
 
 	ok = peekProc(posptr, avatar_pos, 12) &&
 	     peekProc(faceptr, avatar_front, 12) &&
 	     peekProc(topptr, avatar_top, 12) &&
-	     peekProc((BYTE *) 0x00B527B8, ccontext, 128);
+	     peekProc((procptr32_t) 0x00B527B8, ccontext, 128);
 
 	if (! ok)
 		return false;
@@ -68,12 +66,12 @@ static int trylock(const std::multimap<std::wstring, unsigned long long int> &pi
 	if (! initialize(pids, L"BF2142.exe", L"BF2142Audio.dll"))
 		return false;
 
-	BYTE *cacheaddr = pModule + 0x4745c;
-	BYTE *cache = peekProc<BYTE *>(cacheaddr);
+	procptr32_t cacheaddr = pModule32 + 0x4745c;
+	procptr32_t cache = peekProc<procptr32_t>(cacheaddr);
 
-	posptr = peekProc<BYTE *>(cache + 0xc0);
-	faceptr = peekProc<BYTE *>(cache + 0xc4);
-	topptr = peekProc<BYTE *>(cache + 0xc8);
+	posptr = peekProc<procptr32_t>(cache + 0xc0);
+	faceptr = peekProc<procptr32_t>(cache + 0xc4);
+	topptr = peekProc<procptr32_t>(cache + 0xc8);
 
 	float apos[3], afront[3], atop[3], cpos[3], cfront[3], ctop[3];
 	std::string context;

--- a/plugins/bf3/bf3.cpp
+++ b/plugins/bf3/bf3.cpp
@@ -40,20 +40,18 @@
 static bool ptr_chain_valid = false;
 
 // Magic ptrs
-static BYTE* const state_ptr = (BYTE *) 0x238ABDC;
+static procptr32_t const state_ptr = (procptr32_t) 0x238ABDC;
 
 // Vector ptrs
-static BYTE* const avatar_pos_ptr = (BYTE *) 0x0238AB70;
-static BYTE* const avatar_front_ptr = (BYTE *) 0x0238ABA0;
-static BYTE* const avatar_top_ptr = (BYTE *) 0x0238AB90;
+static procptr32_t const avatar_pos_ptr = (procptr32_t) 0x0238AB70;
+static procptr32_t const avatar_front_ptr = (procptr32_t) 0x0238ABA0;
+static procptr32_t const avatar_top_ptr = (procptr32_t) 0x0238AB90;
 
 // Context ptrs
-static BYTE* const ipport_ptr = (BYTE *) 0x0235DB90;
+static procptr32_t const ipport_ptr = (procptr32_t) 0x0235DB90;
 
 // Identity ptrs
-static BYTE *team_state_ptr;
-static BYTE *squad_state_ptr;
-static BYTE *squad_lead_state_ptr;
+static procptr32_t team_state_ptr, squad_state_ptr, squad_lead_state_ptr;
 
 // Offsets
 static const int base_offset = 0x01EF25C4;
@@ -102,17 +100,17 @@ inline bool resolve_ptrs() {
         Team state:  BF3.exe+0x01EF25C4 + 0x1C + 0xBC + 0x31C                    BYTE        1 is blufor (US team, for example), 2 is opfor (RU), 0 is probably upcoming spec mode
     */
 
-    BYTE *base_bf3 = peekProc<BYTE *>(pModule + base_offset);
+    procptr32_t base_bf3 = peekProc<procptr32_t>(pModule32 + base_offset);
     if (!base_bf3)
         return false;
 
-    BYTE *offset_ptr1 = peekProc<BYTE *>(base_bf3 + identity_offset1);
+    procptr32_t offset_ptr1 = peekProc<procptr32_t>(base_bf3 + identity_offset1);
     if (!offset_ptr1) return false;
-    BYTE *offset_ptr2 = peekProc<BYTE *>(offset_ptr1 + identity_offset2);
+    procptr32_t offset_ptr2 = peekProc<procptr32_t>(offset_ptr1 + identity_offset2);
     if (!offset_ptr2) return false;
-    BYTE *offset_ptr3 = peekProc<BYTE *>(offset_ptr2 + identity_offset3);
+    procptr32_t offset_ptr3 = peekProc<procptr32_t>(offset_ptr2 + identity_offset3);
     if (!offset_ptr3) return false;
-    BYTE *offset_ptr4 = peekProc<BYTE *>(offset_ptr3 + identity_offset4);
+    procptr32_t offset_ptr4 = peekProc<procptr32_t>(offset_ptr3 + identity_offset4);
     if (!offset_ptr4) return false;
 
     squad_state_ptr = offset_ptr4 + squad_state_offset;

--- a/plugins/bf4/bf4.cpp
+++ b/plugins/bf4/bf4.cpp
@@ -44,7 +44,7 @@ static int fetch(float *avatar_pos, float *avatar_front, float *avatar_top, floa
             peekProc(serverid_offset, serverid, 37) && // Server ID (36 characters).
             peekProc(pModule64 + 0x21B80C0, host, 22) && // Host value: "IP:Port" when in a server, "bot" when loading and empty when it's hidden.
             peekProc(pModule64 + 0x24AFAE5, team, 3) && // Team value: US (United States); RU (Russia); CH (China).
-            peekProc(squad_offset_2 + 0x230, squad, 1) && // Squad value: 0 (not in a squad); 1 (Alpha); 2 (Bravo); 3 (Charlie)... 26 (Zulu).
+            peekProc(squad_offset_2 + 0x230, squad, 2) && // Squad value: 0 (not in a squad); 1 (Alpha); 2 (Bravo); 3 (Charlie)... 26 (Zulu).
             peekProc(squad_offset_2 + 0x234, squad_leader, 1) && // Squad leader value: 0 (False); 1 (True).
             peekProc(squad_offset_2 + 0x235, squad_state, 1); // Squad state value: 0 (Public); 1 (Private).
 

--- a/plugins/bf4/bf4.cpp
+++ b/plugins/bf4/bf4.cpp
@@ -16,37 +16,37 @@ static int fetch(float *avatar_pos, float *avatar_front, float *avatar_top, floa
     BYTE squad, squad_leader, squad_state;
 
     // Server ID pointers
-    BYTE *serverid_base = peekProc<BYTE *>(pModule + 0x02210658);
+    procptr64_t serverid_base = peekProc<procptr64_t>(pModule64 + 0x02210658);
     if (!serverid_base) return false;
-    BYTE *serverid_offset_0 = peekProc<BYTE *>(serverid_base + 0x18);
+    procptr64_t serverid_offset_0 = peekProc<procptr64_t>(serverid_base + 0x18);
     if (!serverid_offset_0) return false;
-    BYTE *serverid_offset_1 = peekProc<BYTE *>(serverid_offset_0 + 0x28);
+    procptr64_t serverid_offset_1 = peekProc<procptr64_t>(serverid_offset_0 + 0x28);
     if (!serverid_offset_1) return false;
-    BYTE *serverid_offset = peekProc<BYTE *>(serverid_offset_1 + 0x350);
+    procptr64_t serverid_offset = peekProc<procptr64_t>(serverid_offset_1 + 0x350);
     if (!serverid_offset) return false;
 
     // Squad pointers
-    BYTE *squad_base = peekProc<BYTE *>(pModule + 0x02210718);
+    procptr64_t squad_base = peekProc<procptr64_t>(pModule64 + 0x02210718);
     if (!squad_base) return false;
-    BYTE *squad_offset_0 = peekProc<BYTE *>(squad_base + 0xD8);
+    procptr64_t squad_offset_0 = peekProc<procptr64_t>(squad_base + 0xD8);
     if (!squad_offset_0) return false;
-    BYTE *squad_offset_1 = peekProc<BYTE *>(squad_offset_0 + 0x100);
+    procptr64_t squad_offset_1 = peekProc<procptr64_t>(squad_offset_0 + 0x100);
     if (!squad_offset_1) return false;
-    BYTE *squad_offset_2 = peekProc<BYTE *>(squad_offset_1 + 0x58);
+    procptr64_t squad_offset_2 = peekProc<procptr64_t>(squad_offset_1 + 0x58);
     if (!squad_offset_2) return false;
 
     // Peekproc and assign game addresses to our containers, so we can retrieve positional data
-    ok = peekProc((BYTE *) pModule + 0x21CAFF0, &state, 1) && // Magical state value: 0 when in-game and 1 when in menu/dead.
-            peekProc((BYTE *) pModule + 0x21C6D40, avatar_pos, 12) && // Avatar Position values (X, Y and Z).
-            peekProc((BYTE *) pModule + 0x21CAF80, camera_pos, 12) && // Camera Position values (X, Y and Z).
-            peekProc((BYTE *) pModule + 0x21CAF60, avatar_top, 12) && // Avatar Top Vector values (X, Y and Z).
-            peekProc((BYTE *) pModule + 0x21CAF70, avatar_front, 12) && // Avatar Front Vector values (X, Y and Z).
-            peekProc((BYTE *) serverid_offset, serverid) && // Server ID (36 characters).
-            peekProc((BYTE *) pModule + 0x21B80C0, host) && // Host value: "IP:Port" when in a server, "bot" when loading and empty when it's hidden.
-            peekProc((BYTE *) pModule + 0x24AFAE5, team) && // Team value: US (United States); RU (Russia); CH (China).
-            peekProc((BYTE *) squad_offset_2 + 0x230, squad) && // Squad value: 0 (not in a squad); 1 (Alpha); 2 (Bravo); 3 (Charlie)... 26 (Zulu).
-            peekProc((BYTE *) squad_offset_2 + 0x234, squad_leader) && // Squad leader value: 0 (False); 1 (True).
-            peekProc((BYTE *) squad_offset_2 + 0x235, squad_state); // Squad state value: 0 (Public); 1 (Private).
+    ok = peekProc(pModule64 + 0x21CAFF0, &state, 1) && // Magical state value: 0 when in-game and 1 when in menu/dead.
+            peekProc(pModule64 + 0x21C6D40, avatar_pos, 12) && // Avatar Position values (X, Y and Z).
+            peekProc(pModule64 + 0x21CAF80, camera_pos, 12) && // Camera Position values (X, Y and Z).
+            peekProc(pModule64 + 0x21CAF60, avatar_top, 12) && // Avatar Top Vector values (X, Y and Z).
+            peekProc(pModule64 + 0x21CAF70, avatar_front, 12) && // Avatar Front Vector values (X, Y and Z).
+            peekProc(serverid_offset, serverid, 1) && // Server ID (36 characters).
+            peekProc(pModule64 + 0x21B80C0, host, 1) && // Host value: "IP:Port" when in a server, "bot" when loading and empty when it's hidden.
+            peekProc(pModule64 + 0x24AFAE5, team, 1) && // Team value: US (United States); RU (Russia); CH (China).
+            peekProc(squad_offset_2 + 0x230, squad, 1) && // Squad value: 0 (not in a squad); 1 (Alpha); 2 (Bravo); 3 (Charlie)... 26 (Zulu).
+            peekProc(squad_offset_2 + 0x234, squad_leader, 1) && // Squad leader value: 0 (False); 1 (True).
+            peekProc(squad_offset_2 + 0x235, squad_state, 1); // Squad state value: 0 (Public); 1 (Private).
 
     // This prevents the plugin from linking to the game in case something goes wrong during values retrieval from memory addresses.
     if (! ok) {

--- a/plugins/bf4/bf4.cpp
+++ b/plugins/bf4/bf4.cpp
@@ -41,9 +41,9 @@ static int fetch(float *avatar_pos, float *avatar_front, float *avatar_top, floa
             peekProc(pModule64 + 0x21CAF80, camera_pos, 12) && // Camera Position values (X, Y and Z).
             peekProc(pModule64 + 0x21CAF60, avatar_top, 12) && // Avatar Top Vector values (X, Y and Z).
             peekProc(pModule64 + 0x21CAF70, avatar_front, 12) && // Avatar Front Vector values (X, Y and Z).
-            peekProc(serverid_offset, serverid, 1) && // Server ID (36 characters).
-            peekProc(pModule64 + 0x21B80C0, host, 1) && // Host value: "IP:Port" when in a server, "bot" when loading and empty when it's hidden.
-            peekProc(pModule64 + 0x24AFAE5, team, 1) && // Team value: US (United States); RU (Russia); CH (China).
+            peekProc(serverid_offset, serverid, 37) && // Server ID (36 characters).
+            peekProc(pModule64 + 0x21B80C0, host, 22) && // Host value: "IP:Port" when in a server, "bot" when loading and empty when it's hidden.
+            peekProc(pModule64 + 0x24AFAE5, team, 3) && // Team value: US (United States); RU (Russia); CH (China).
             peekProc(squad_offset_2 + 0x230, squad, 1) && // Squad value: 0 (not in a squad); 1 (Alpha); 2 (Bravo); 3 (Charlie)... 26 (Zulu).
             peekProc(squad_offset_2 + 0x234, squad_leader, 1) && // Squad leader value: 0 (False); 1 (True).
             peekProc(squad_offset_2 + 0x235, squad_state, 1); // Squad state value: 0 (Public); 1 (Private).

--- a/plugins/bf4_x86/bf4_x86.cpp
+++ b/plugins/bf4_x86/bf4_x86.cpp
@@ -42,7 +42,7 @@ static int fetch(float *avatar_pos, float *avatar_front, float *avatar_top, floa
             peekProc(serverid_offset, serverid, 37) && // Server ID (36 characters).
             peekProc(pModule32 + 0x1BA8A10, host, 22) && // Host value: "IP:Port" when in a server, "bot" when loading and empty when it's hidden.
             peekProc(pModule32 + 0x1C814B5, team, 3) && // Team value: US (United States); RU (Russia); CH (China).
-            peekProc(squad_offset_1 + 0x15C, squad, 1) && // Squad value: 0 (not in a squad); 1 (Alpha); 2 (Bravo); 3 (Charlie)... 26 (Zulu).
+            peekProc(squad_offset_1 + 0x15C, squad, 2) && // Squad value: 0 (not in a squad); 1 (Alpha); 2 (Bravo); 3 (Charlie)... 26 (Zulu).
             peekProc(squad_offset_1 + 0x160, squad_leader, 1) && // Squad leader value: 0 (False); 1 (True).
             peekProc(squad_offset_1 + 0x161, squad_state, 1); // Squad state value: 0 (Public); 1 (Private).
 

--- a/plugins/bf4_x86/bf4_x86.cpp
+++ b/plugins/bf4_x86/bf4_x86.cpp
@@ -39,9 +39,9 @@ static int fetch(float *avatar_pos, float *avatar_front, float *avatar_top, floa
             peekProc(pModule32 + 0x1BB6A90, camera_pos, 12) && // Camera Position values (X, Y and Z).
             peekProc(pModule32 + 0x1BB6A70, avatar_top, 12) && // Avatar Top Vector values (X, Y and Z).
             peekProc(pModule32 + 0x1BB6A80, avatar_front, 12) && // Avatar Front Vector values (X, Y and Z).
-            peekProc(serverid_offset, serverid, 1) && // Server ID (36 characters).
-            peekProc(pModule32 + 0x1BA8A10, host, 1) && // Host value: "IP:Port" when in a server, "bot" when loading and empty when it's hidden.
-            peekProc(pModule32 + 0x1C814B5, team, 1) && // Team value: US (United States); RU (Russia); CH (China).
+            peekProc(serverid_offset, serverid, 37) && // Server ID (36 characters).
+            peekProc(pModule32 + 0x1BA8A10, host, 22) && // Host value: "IP:Port" when in a server, "bot" when loading and empty when it's hidden.
+            peekProc(pModule32 + 0x1C814B5, team, 3) && // Team value: US (United States); RU (Russia); CH (China).
             peekProc(squad_offset_1 + 0x15C, squad, 1) && // Squad value: 0 (not in a squad); 1 (Alpha); 2 (Bravo); 3 (Charlie)... 26 (Zulu).
             peekProc(squad_offset_1 + 0x160, squad_leader, 1) && // Squad leader value: 0 (False); 1 (True).
             peekProc(squad_offset_1 + 0x161, squad_state, 1); // Squad state value: 0 (Public); 1 (Private).

--- a/plugins/bf4_x86/bf4_x86.cpp
+++ b/plugins/bf4_x86/bf4_x86.cpp
@@ -16,35 +16,35 @@ static int fetch(float *avatar_pos, float *avatar_front, float *avatar_top, floa
     BYTE squad, squad_leader, squad_state;
 
     // Server ID pointers
-    BYTE *serverid_base = peekProc<BYTE *>(pModule + 0x01BEBC04);
+    procptr32_t serverid_base = peekProc<procptr32_t>(pModule32 + 0x01BEBC04);
     if (!serverid_base) return false;
-    BYTE *serverid_offset_0 = peekProc<BYTE *>(serverid_base + 0xC);
+    procptr32_t serverid_offset_0 = peekProc<procptr32_t>(serverid_base + 0xC);
     if (!serverid_offset_0) return false;
-    BYTE *serverid_offset_1 = peekProc<BYTE *>(serverid_offset_0 + 0x14);
+    procptr32_t serverid_offset_1 = peekProc<procptr32_t>(serverid_offset_0 + 0x14);
     if (!serverid_offset_1) return false;
-    BYTE *serverid_offset = peekProc<BYTE *>(serverid_offset_1 + 0x1D0);
+    procptr32_t serverid_offset = peekProc<procptr32_t>(serverid_offset_1 + 0x1D0);
     if (!serverid_offset) return false;
 
     // Squad pointers
-    BYTE *squad_base = peekProc<BYTE *>(pModule + 0x01BEBC90);
+    procptr32_t squad_base = peekProc<procptr32_t>(pModule32 + 0x01BEBC90);
     if (!squad_base) return false;
-    BYTE *squad_offset_0 = peekProc<BYTE *>(squad_base + 0x7C);
+    procptr32_t squad_offset_0 = peekProc<procptr32_t>(squad_base + 0x7C);
     if (!squad_offset_0) return false;
-    BYTE *squad_offset_1 = peekProc<BYTE *>(squad_offset_0 + 0x728);
+    procptr32_t squad_offset_1 = peekProc<procptr32_t>(squad_offset_0 + 0x728);
     if (!squad_offset_1) return false;
 
     // Peekproc and assign game addresses to our containers, so we can retrieve positional data
-    ok = peekProc((BYTE *) pModule + 0x1BB6AC2, &state, 1) && // Magical state value: 0 when in-game and 1 when in menu/dead.
-            peekProc((BYTE *) pModule + 0x1BB3C30, avatar_pos, 12) && // Avatar Position values (X, Y and Z).
-            peekProc((BYTE *) pModule + 0x1BB6A90, camera_pos, 12) && // Camera Position values (X, Y and Z).
-            peekProc((BYTE *) pModule + 0x1BB6A70, avatar_top, 12) && // Avatar Top Vector values (X, Y and Z).
-            peekProc((BYTE *) pModule + 0x1BB6A80, avatar_front, 12) && // Avatar Front Vector values (X, Y and Z).
-            peekProc((BYTE *) serverid_offset, serverid) && // Server ID (36 characters).
-            peekProc((BYTE *) pModule + 0x1BA8A10, host) && // Host value: "IP:Port" when in a server, "bot" when loading and empty when it's hidden.
-            peekProc((BYTE *) pModule + 0x1C814B5, team) && // Team value: US (United States); RU (Russia); CH (China).
-            peekProc((BYTE *) squad_offset_1 + 0x15C, squad) && // Squad value: 0 (not in a squad); 1 (Alpha); 2 (Bravo); 3 (Charlie)... 26 (Zulu).
-            peekProc((BYTE *) squad_offset_1 + 0x160, squad_leader) && // Squad leader value: 0 (False); 1 (True).
-            peekProc((BYTE *) squad_offset_1 + 0x161, squad_state); // Squad state value: 0 (Public); 1 (Private).
+    ok = peekProc(pModule32 + 0x1BB6AC2, &state, 1) && // Magical state value: 0 when in-game and 1 when in menu/dead.
+            peekProc(pModule32 + 0x1BB3C30, avatar_pos, 12) && // Avatar Position values (X, Y and Z).
+            peekProc(pModule32 + 0x1BB6A90, camera_pos, 12) && // Camera Position values (X, Y and Z).
+            peekProc(pModule32 + 0x1BB6A70, avatar_top, 12) && // Avatar Top Vector values (X, Y and Z).
+            peekProc(pModule32 + 0x1BB6A80, avatar_front, 12) && // Avatar Front Vector values (X, Y and Z).
+            peekProc(serverid_offset, serverid, 1) && // Server ID (36 characters).
+            peekProc(pModule32 + 0x1BA8A10, host, 1) && // Host value: "IP:Port" when in a server, "bot" when loading and empty when it's hidden.
+            peekProc(pModule32 + 0x1C814B5, team, 1) && // Team value: US (United States); RU (Russia); CH (China).
+            peekProc(squad_offset_1 + 0x15C, squad, 1) && // Squad value: 0 (not in a squad); 1 (Alpha); 2 (Bravo); 3 (Charlie)... 26 (Zulu).
+            peekProc(squad_offset_1 + 0x160, squad_leader, 1) && // Squad leader value: 0 (False); 1 (True).
+            peekProc(squad_offset_1 + 0x161, squad_state, 1); // Squad state value: 0 (Public); 1 (Private).
 
     // This prevents the plugin from linking to the game in case something goes wrong during values retrieval from memory addresses.
     if (! ok) {

--- a/plugins/bfbc2/bfbc2.cpp
+++ b/plugins/bfbc2/bfbc2.cpp
@@ -54,7 +54,7 @@ static int fetch(float *avatar_pos, float *avatar_front, float *avatar_top, floa
 
 	// Find out whether this is the steam version
 	char sMagic[6];
-	if (!peekProc((BYTE *) 0x015715b4, sMagic, 6)) {
+	if (!peekProc((procptr32_t) 0x015715b4, sMagic, 6)) {
 		generic_unlock();
 		return false;
 	}
@@ -62,13 +62,13 @@ static int fetch(float *avatar_pos, float *avatar_front, float *avatar_top, floa
 	is_steam = (strncmp("Score:", sMagic, 6) == 0);
 
 	if (is_steam) {
-		ok = peekProc((BYTE *) 0x01571E90, avatar_pos, 12) &&
-		     peekProc((BYTE *) 0x01571E80, avatar_front, 12) &&
-		     peekProc((BYTE *) 0x01571E70, avatar_top, 12);
+		ok = peekProc((procptr32_t) 0x01571E90, avatar_pos, 12) &&
+		     peekProc((procptr32_t) 0x01571E80, avatar_front, 12) &&
+		     peekProc((procptr32_t) 0x01571E70, avatar_top, 12);
 	} else {
-		ok = peekProc((BYTE *) 0x01579600, avatar_pos, 12) &&
-		     peekProc((BYTE *) 0x015795F0, avatar_front, 12) &&
-		     peekProc((BYTE *) 0x015795E0, avatar_top, 12);
+		ok = peekProc((procptr32_t) 0x01579600, avatar_pos, 12) &&
+		     peekProc((procptr32_t) 0x015795F0, avatar_front, 12) &&
+		     peekProc((procptr32_t) 0x015795E0, avatar_top, 12);
 	}
 
 	if (! ok)

--- a/plugins/bfheroes/bfheroes.cpp
+++ b/plugins/bfheroes/bfheroes.cpp
@@ -5,10 +5,7 @@
 
 #include "../mumble_plugin_win32.h"
 
-BYTE *posptr;
-BYTE *faceptr;
-BYTE *topptr;
-BYTE *stateptr;
+procptr32_t posptr, faceptr, topptr, stateptr;
 
 static int fetch(float *avatar_pos, float *avatar_front, float *avatar_top, float *camera_pos, float *camera_front, float *camera_top, std::string &, std::wstring &) {
 	for (int i=0;i<3;i++)
@@ -18,7 +15,7 @@ static int fetch(float *avatar_pos, float *avatar_front, float *avatar_top, floa
 	char logincheck;
 	bool ok;
 
-	ok = peekProc((BYTE *) 0x00A24D6C, &logincheck, 1);
+	ok = peekProc((procptr32_t) 0x00A24D6C, &logincheck, 1);
 	if (! ok)
 		return false;
 
@@ -54,13 +51,13 @@ static int trylock(const std::multimap<std::wstring, unsigned long long int> &pi
 	if (! initialize(pids, L"BFHeroes.exe", L"BFAudio.dll"))
 		return false;
 
-	BYTE *cacheaddr = pModule + 0x4745c;
-	BYTE *cache = peekProc<BYTE *>(cacheaddr);
+	procptr32_t cacheaddr = pModule32 + 0x4745c;
+	procptr32_t cache = peekProc<procptr32_t>(cacheaddr);
 
-	posptr = peekProc<BYTE *>(cache + 0xc0);
-	faceptr = peekProc<BYTE *>(cache + 0xc4);
-	topptr = peekProc<BYTE *>(cache + 0xc8);
-	stateptr = peekProc<BYTE *>(cache + 0xc0);
+	posptr = peekProc<procptr32_t>(cache + 0xc0);
+	faceptr = peekProc<procptr32_t>(cache + 0xc4);
+	topptr = peekProc<procptr32_t>(cache + 0xc8);
+	stateptr = peekProc<procptr32_t>(cache + 0xc0);
 
 	float apos[3], afront[3], atop[3], cpos[3], cfront[3], ctop[3];
 	std::string context;

--- a/plugins/blacklight/blacklight.cpp
+++ b/plugins/blacklight/blacklight.cpp
@@ -54,10 +54,10 @@
 	TODO: Find Avatar position, front, top vectors, protect against version change (find a random pointer to check), distinguish spectator and normal mode
 */
 
-static BYTE *camfrontptr = (BYTE *)0x141bc20;
-static BYTE *camtopptr = camfrontptr + 0xC;
-static BYTE *camptr = camfrontptr + 0x18;
-static BYTE *hostipportptr;
+static procptr32_t camfrontptr = (procptr32_t) 0x141bc20;
+static procptr32_t camtopptr = camfrontptr + 0xC;
+static procptr32_t camptr = camfrontptr + 0x18;
+static procptr32_t hostipportptr;
 
 static char prev_hostipport[22];
 
@@ -77,7 +77,7 @@ static bool calcout(float *cam, float *camfront, float *camtop, float *ocam, flo
 static bool refreshPointers(void) {
 	hostipportptr = NULL;
 
-	hostipportptr = pModule + 0xB8C57;
+	hostipportptr = pModule32 + 0xB8C57;
 
 	return true;
 }
@@ -92,8 +92,8 @@ static int fetch(float *avatar_pos, float *avatar_front, float *avatar_top, floa
 
 	ok = peekProc(camfrontptr, camfront, 12) &&
 		 peekProc(camtopptr, camtop, 12) &&
-		 peekProc(hostipportptr, hostipport) &&
-		 peekProc(camptr, cam);
+		 peekProc(hostipportptr, hostipport, 1) &&
+		 peekProc(camptr, cam, 1);
 
 	if (!ok) 
 		return false;

--- a/plugins/blacklight/blacklight.cpp
+++ b/plugins/blacklight/blacklight.cpp
@@ -92,8 +92,8 @@ static int fetch(float *avatar_pos, float *avatar_front, float *avatar_top, floa
 
 	ok = peekProc(camfrontptr, camfront, 12) &&
 		 peekProc(camtopptr, camtop, 12) &&
-		 peekProc(hostipportptr, hostipport, 1) &&
-		 peekProc(camptr, cam, 1);
+		 peekProc(hostipportptr, hostipport, 22) &&
+		 peekProc(camptr, cam, 12);
 
 	if (!ok) 
 		return false;

--- a/plugins/borderlands/borderlands.cpp
+++ b/plugins/borderlands/borderlands.cpp
@@ -36,16 +36,11 @@
 
 #include "../mumble_plugin_win32.h"
 
-BYTE *posptr;
-BYTE *frontptr;
-BYTE *topptr;
-BYTE *contextptraddress;
-BYTE *stateaddress;
-BYTE *loginaddress;
+procptr32_t posptr, frontptr, topptr, contextptraddress, stateaddress, loginaddress;
 
 static int fetch(float *avatar_pos, float *avatar_front, float *avatar_top, float *camera_pos, float *camera_front, float *camera_top, std::string &context, std::wstring &) {
 	static bool loggedin = false;
-	static BYTE *contextptr;
+	static procptr32_t contextptr;
 	bool ok;
 
 	// Zeroing the floats
@@ -61,9 +56,9 @@ static int fetch(float *avatar_pos, float *avatar_front, float *avatar_top, floa
 	if (login == 0) {
 		loggedin = false;
 	} else if (!loggedin) {
-		BYTE *ptr1 = peekProc<BYTE *>(contextptraddress);
-		BYTE *ptr2 = peekProc<BYTE *>(ptr1 + 0x28c);
-		BYTE *ptr3 = peekProc<BYTE *>(ptr2 + 0x210);
+		procptr32_t ptr1 = peekProc<procptr32_t >(contextptraddress);
+		procptr32_t ptr2 = peekProc<procptr32_t >(ptr1 + 0x28c);
+		procptr32_t ptr3 = peekProc<procptr32_t >(ptr2 + 0x210);
 		if (ptr3 != 0) loggedin = true; //pointer set
 		contextptr = ptr3 + 0x2c;
 	}
@@ -139,33 +134,33 @@ static int trylock(const std::multimap<std::wstring, unsigned long long int> &pi
 
 	// Trying to assess which version of Borderlands is running.
 	char version[6];
-	if (!peekProc((BYTE *) 0x01f16ce8, &version, sizeof(version))) {
+	if (!peekProc((procptr32_t) 0x01f16ce8, &version, sizeof(version))) {
 		generic_unlock();
 		return false;
 	}
 
-	BYTE *ptraddress;
+	procptr32_t ptraddress;
 	if (strncmp("the cl", version, sizeof(version)) == 0) { // retail version
-		ptraddress = (BYTE *) 0x01f73744;
-		stateaddress = (BYTE *) 0x01f9bb18;
-		contextptraddress = (BYTE *) 0x01fd7398;
-		loginaddress = (BYTE *) 0x01fd83a8;
+		ptraddress = (procptr32_t) 0x01f73744;
+		stateaddress = (procptr32_t) 0x01f9bb18;
+		contextptraddress = (procptr32_t) 0x01fd7398;
+		loginaddress = (procptr32_t) 0x01fd83a8;
 	} else if (strncmp("Tir-ku", version, sizeof(version)) == 0) { // steam version
-		ptraddress = (BYTE *) 0x01f705c4;
-		stateaddress = (BYTE *) 0x01f98998;
-		contextptraddress = (BYTE *) 0x01fd4218;
-		loginaddress = (BYTE *) 0x01fd5220;
+		ptraddress = (procptr32_t) 0x01f705c4;
+		stateaddress = (procptr32_t) 0x01f98998;
+		contextptraddress = (procptr32_t) 0x01fd4218;
+		loginaddress = (procptr32_t) 0x01fd5220;
 	} else if (strncmp("german", version, sizeof(version)) == 0) { // german version
-		ptraddress = (BYTE *) 0x01f72744;
-		stateaddress = (BYTE *) 0x01f9ab18;
-		contextptraddress = (BYTE *) 0x01fd6398;
-		loginaddress = (BYTE *) 0x01fd73a8;
+		ptraddress = (procptr32_t) 0x01f72744;
+		stateaddress = (procptr32_t) 0x01f9ab18;
+		contextptraddress = (procptr32_t) 0x01fd6398;
+		loginaddress = (procptr32_t) 0x01fd73a8;
 	} else { // unknown version
 		generic_unlock();
 		return false;
 	}
 
-	BYTE *ptr1 = peekProc<BYTE *>(ptraddress);
+	procptr32_t ptr1 = peekProc<procptr32_t>(ptraddress);
 	if (ptr1 == 0) {
 		generic_unlock();
 		return false;

--- a/plugins/borderlands2/borderlands2.cpp
+++ b/plugins/borderlands2/borderlands2.cpp
@@ -85,7 +85,7 @@ static int fetch(float *avatar_pos, float *avatar_front, float *avatar_top, floa
 	procptr32_t character_name_ptr = ptr2 + 0x80;
 
 	char character_name[16]; // The game limits us to 15 char names
-	ok = peekProc(character_name_ptr, character_name, 1);
+	ok = peekProc(character_name_ptr, character_name, 16);
 	if (ok)
 	{
 		// character_name is zero terminated, but using strnlen for double-plus safety
@@ -136,7 +136,7 @@ static int trylock(const std::multimap<std::wstring, unsigned long long int> &pi
 	memcmp(buf, strlit, std::min(sizeof(buf), sizeof(strlit)-1)) == 0
 
 	// 1.3.1
-	if (peekProc(pModule32 + 0x1E6D048, detected_version, 1)
+	if (peekProc(pModule32 + 0x1E6D048, detected_version, 32)
 		&& VERSION_EQ(detected_version, "WILLOW2-PCSAGE-28-CL697606"))
 	{
 		vects_ptr = pModule32 + 0x1E792B0;
@@ -144,7 +144,7 @@ static int trylock(const std::multimap<std::wstring, unsigned long long int> &pi
 		character_name_ptr_loc = pModule32 + 0x1E7302C;
 	}
 	// 1.4.0
-	else if (peekProc(pModule32 + 0x1E8D1D8, detected_version, 1)
+	else if (peekProc(pModule32 + 0x1E8D1D8, detected_version, 32)
 		&& VERSION_EQ(detected_version, "WILLOW2-PCSAGE-77-CL711033"))
 	{
 		vects_ptr = pModule32 + 0x1E993F0;
@@ -152,7 +152,7 @@ static int trylock(const std::multimap<std::wstring, unsigned long long int> &pi
 		character_name_ptr_loc = pModule32 + 0x1E93194;
 	}
 	// 1.5.0
-	else if (peekProc(pModule32 + 0x01E9F338, detected_version, 1)
+	else if (peekProc(pModule32 + 0x01E9F338, detected_version, 32)
 		&& VERSION_EQ(detected_version, "WILLOW2-PCLILAC-60-CL721220"))
 	{
 		vects_ptr = pModule32 + 0x1EAB650;
@@ -160,7 +160,7 @@ static int trylock(const std::multimap<std::wstring, unsigned long long int> &pi
 		character_name_ptr_loc = pModule32 + 0x01EA5384;
 	}
 	// 1.7.0
-	else if (peekProc(pModule32 + 0x01ED53A8, detected_version, 1)
+	else if (peekProc(pModule32 + 0x01ED53A8, detected_version, 32)
 		&& VERSION_EQ(detected_version, "WILLOW2-PCALLIUM-55-CL770068"))
 	{
 		vects_ptr = pModule32 + 0x1EE18E0;
@@ -168,7 +168,7 @@ static int trylock(const std::multimap<std::wstring, unsigned long long int> &pi
 		character_name_ptr_loc = pModule32 + 0x01EDB5B4;
 	}
 	// 1.8.3
-	else if (peekProc(pModule32 + 0x1EE63C8, detected_version, 1)
+	else if (peekProc(pModule32 + 0x1EE63C8, detected_version, 32)
 		&& VERSION_EQ(detected_version, "WILLOW2-PCCHINA-29-CL827556"))
 	{
 		vects_ptr = pModule32 + 0x1EF2930;

--- a/plugins/borderlands2/borderlands2.cpp
+++ b/plugins/borderlands2/borderlands2.cpp
@@ -38,9 +38,9 @@
 #include "../mumble_plugin_win32.h"
 #include <algorithm>
 
-VOID *vects_ptr;
-VOID *state_ptr;
-VOID *character_name_ptr_loc;
+procptr32_t vects_ptr;
+procptr32_t state_ptr;
+procptr32_t character_name_ptr_loc;
 
 static int fetch(float *avatar_pos, float *avatar_front, float *avatar_top, float *camera_pos, float *camera_front, float *camera_top, std::string &, std::wstring &identity)
 {
@@ -53,7 +53,7 @@ static int fetch(float *avatar_pos, float *avatar_front, float *avatar_top, floa
 	char state;
 
 	// State 1 == in-game, 0 == in-menu
-	ok = peekProc(state_ptr, state);
+	ok = peekProc(state_ptr, state, 1);
 	if (!ok) return false;
 
 	if (state == 0)
@@ -67,7 +67,7 @@ static int fetch(float *avatar_pos, float *avatar_front, float *avatar_top, floa
 	} game_vects;
 
 
-	ok = peekProc(vects_ptr, game_vects);
+	ok = peekProc(vects_ptr, game_vects, 1);
 	if (!ok) return false;
 
 	// Copy game vectors into return values
@@ -80,12 +80,12 @@ static int fetch(float *avatar_pos, float *avatar_front, float *avatar_top, floa
 
 
 	// Extract the character name
-	BYTE *ptr1 = peekProc<BYTE*>(character_name_ptr_loc);
-	BYTE *ptr2 = peekProc<BYTE*>(ptr1 + 0xC);
-	BYTE *character_name_ptr = ptr2 + 0x80;
+	procptr32_t ptr1 = peekProc<procptr32_t>(character_name_ptr_loc);
+	procptr32_t ptr2 = peekProc<procptr32_t>(ptr1 + 0xC);
+	procptr32_t character_name_ptr = ptr2 + 0x80;
 
 	char character_name[16]; // The game limits us to 15 char names
-	ok = peekProc(character_name_ptr, character_name);
+	ok = peekProc(character_name_ptr, character_name, 1);
 	if (ok)
 	{
 		// character_name is zero terminated, but using strnlen for double-plus safety
@@ -136,44 +136,44 @@ static int trylock(const std::multimap<std::wstring, unsigned long long int> &pi
 	memcmp(buf, strlit, std::min(sizeof(buf), sizeof(strlit)-1)) == 0
 
 	// 1.3.1
-	if (peekProc(pModule + 0x1E6D048, detected_version)
+	if (peekProc(pModule32 + 0x1E6D048, detected_version, 1)
 		&& VERSION_EQ(detected_version, "WILLOW2-PCSAGE-28-CL697606"))
 	{
-		vects_ptr = pModule + 0x1E792B0;
-		state_ptr = pModule + 0x1E79BC8;
-		character_name_ptr_loc = pModule + 0x1E7302C;
+		vects_ptr = pModule32 + 0x1E792B0;
+		state_ptr = pModule32 + 0x1E79BC8;
+		character_name_ptr_loc = pModule32 + 0x1E7302C;
 	}
 	// 1.4.0
-	else if (peekProc(pModule + 0x1E8D1D8, detected_version)
+	else if (peekProc(pModule32 + 0x1E8D1D8, detected_version, 1)
 		&& VERSION_EQ(detected_version, "WILLOW2-PCSAGE-77-CL711033"))
 	{
-		vects_ptr = pModule + 0x1E993F0;
-		state_ptr = pModule + 0x1E99D08;
-		character_name_ptr_loc = pModule + 0x1E93194;
+		vects_ptr = pModule32 + 0x1E993F0;
+		state_ptr = pModule32 + 0x1E99D08;
+		character_name_ptr_loc = pModule32 + 0x1E93194;
 	}
 	// 1.5.0
-	else if (peekProc(pModule + 0x01E9F338, detected_version)
+	else if (peekProc(pModule32 + 0x01E9F338, detected_version, 1)
 		&& VERSION_EQ(detected_version, "WILLOW2-PCLILAC-60-CL721220"))
 	{
-		vects_ptr = pModule + 0x1EAB650;
-		state_ptr = pModule + 0x1EABF68;
-		character_name_ptr_loc = pModule + 0x01EA5384;
+		vects_ptr = pModule32 + 0x1EAB650;
+		state_ptr = pModule32 + 0x1EABF68;
+		character_name_ptr_loc = pModule32 + 0x01EA5384;
 	}
 	// 1.7.0
-	else if (peekProc(pModule + 0x01ED53A8, detected_version)
+	else if (peekProc(pModule32 + 0x01ED53A8, detected_version, 1)
 		&& VERSION_EQ(detected_version, "WILLOW2-PCALLIUM-55-CL770068"))
 	{
-		vects_ptr = pModule + 0x1EE18E0;
-		state_ptr = pModule + 0x1EE21F8;
-		character_name_ptr_loc = pModule + 0x01EDB5B4;
+		vects_ptr = pModule32 + 0x1EE18E0;
+		state_ptr = pModule32 + 0x1EE21F8;
+		character_name_ptr_loc = pModule32 + 0x01EDB5B4;
 	}
 	// 1.8.3
-	else if (peekProc(pModule + 0x1EE63C8, detected_version)
+	else if (peekProc(pModule32 + 0x1EE63C8, detected_version, 1)
 		&& VERSION_EQ(detected_version, "WILLOW2-PCCHINA-29-CL827556"))
 	{
-		vects_ptr = pModule + 0x1EF2930;
-		state_ptr = pModule + 0x1EF3248;
-		character_name_ptr_loc = pModule + 0x01EEC5D4;
+		vects_ptr = pModule32 + 0x1EF2930;
+		state_ptr = pModule32 + 0x1EF3248;
+		character_name_ptr_loc = pModule32 + 0x01EEC5D4;
 	}
 	else
 	{

--- a/plugins/breach/breach.cpp
+++ b/plugins/breach/breach.cpp
@@ -36,9 +36,7 @@
 
 #include "../mumble_plugin_win32.h"
 
-BYTE *posptr;
-BYTE *frontptr;
-BYTE *topptr;
+procptr32_t posptr, frontptr, topptr;
 
 static int fetch(float *avatar_pos, float *avatar_front, float *avatar_top, float *camera_pos, float *camera_front, float *camera_top, std::string &, std::wstring &) {
 	bool ok;
@@ -48,7 +46,7 @@ static int fetch(float *avatar_pos, float *avatar_front, float *avatar_top, floa
 
 	// State value is working most of the time
 	unsigned char state;
-	ok = peekProc((BYTE *) 0x11146bb, &state, sizeof(state));
+	ok = peekProc((procptr32_t) 0x11146bb, &state, sizeof(state));
 	if (! ok)
 		return false;
 	// State is 255 when you are in a menu
@@ -84,13 +82,13 @@ static int trylock(const std::multimap<std::wstring, unsigned long long int> &pi
 
 	// Checking the version of Breach
 	char version[12];
-	if ((! peekProc((BYTE *) 0x1118f98, &version, sizeof(version))) || (strncmp("breach 1.1.0", version, sizeof(version)) != 0)) {
+	if ((! peekProc((procptr32_t) 0x1118f98, &version, sizeof(version))) || (strncmp("breach 1.1.0", version, sizeof(version)) != 0)) {
 		generic_unlock();
 		return false;
 	}
 
 	// Setting the pointers for the avatar information
-	BYTE *ptr1 = peekProc<BYTE *>(pModule + 0x177980);
+	procptr32_t ptr1 = peekProc<procptr32_t>(pModule32 + 0x177980);
 	if (ptr1 == 0) {
 		generic_unlock();
 		return false;

--- a/plugins/cod2/cod2.cpp
+++ b/plugins/cod2/cod2.cpp
@@ -26,18 +26,18 @@ static int fetch(float *avatar_pos, float *avatar_front, float *avatar_top, floa
 			0x0151A110		float	Vertical view (degrees) (=0 out-of-game)
 			0x0096B688		byte	Magic value (0=ingame/out-of-game, 4=spectator)
 	*/
-	ok = peekProc((BYTE *) 0x0096B688, &state, 1);
+	ok = peekProc((procptr32_t) 0x0096B688, &state, 1);
 	if (! ok)
 		return false;
 
 	if (state == 4)
 		return true; // If this magic value is 4 we are spectating, so switch of PA
 
-	ok = peekProc((BYTE *) 0x01516608, avatar_pos+2, 4) &&	//Z
-	     peekProc((BYTE *) 0x0151660C, avatar_pos, 4) &&	//X
-	     peekProc((BYTE *) 0x01516610, avatar_pos+1, 4) && //Y
-	     peekProc((BYTE *) 0x0151A114, &viewHor, 4) && //Hor
-	     peekProc((BYTE *) 0x0151A110, &viewVer, 4); //Ver
+	ok = peekProc((procptr32_t) 0x01516608, avatar_pos+2, 4) &&	//Z
+	     peekProc((procptr32_t) 0x0151660C, avatar_pos, 4) &&	//X
+	     peekProc((procptr32_t) 0x01516610, avatar_pos+1, 4) && //Y
+	     peekProc((procptr32_t) 0x0151A114, &viewHor, 4) && //Hor
+	     peekProc((procptr32_t) 0x0151A110, &viewVer, 4); //Ver
 
 	if (! ok)
 		return false;

--- a/plugins/cod4/cod4.cpp
+++ b/plugins/cod4/cod4.cpp
@@ -30,7 +30,7 @@ static int fetch(float *avatar_pos, float *avatar_front, float *avatar_top, floa
 
 			0x0074E380		byte	Magical state value
 	*/
-	ok = peekProc((BYTE *) 0x0074E380, &state, 1); // Magical state value
+	ok = peekProc((procptr32_t) 0x0074E380, &state, 1); // Magical state value
 	if (! ok)
 		return false;
 	/*
@@ -45,12 +45,12 @@ static int fetch(float *avatar_pos, float *avatar_front, float *avatar_top, floa
 	if (state != 4)
 		return true; // This results in all vectors beeing zero which tells mumble to ignore them.
 
-	ok = peekProc((BYTE *) 0x0072AFD0, avatar_pos+2, 4) &&	//Z
-	     peekProc((BYTE *) 0x0072AFE0, avatar_pos, 4) &&	//X
-	     peekProc((BYTE *) 0x0072AFF0, avatar_pos+1, 4) && //Y
-	     peekProc((BYTE *) 0x0072AF3C, &viewHor, 4) && //Hor
-	     peekProc((BYTE *) 0x0072AF38, &viewVer, 4) && //Ver
-	     peekProc((BYTE *) 0x00956D88, ccontext, 128);
+	ok = peekProc((procptr32_t) 0x0072AFD0, avatar_pos+2, 4) &&	//Z
+	     peekProc((procptr32_t) 0x0072AFE0, avatar_pos, 4) &&	//X
+	     peekProc((procptr32_t) 0x0072AFF0, avatar_pos+1, 4) && //Y
+	     peekProc((procptr32_t) 0x0072AF3C, &viewHor, 4) && //Hor
+	     peekProc((procptr32_t) 0x0072AF38, &viewVer, 4) && //Ver
+	     peekProc((procptr32_t) 0x00956D88, ccontext, 128);
 
 	if (! ok)
 		return false;
@@ -84,15 +84,15 @@ static int fetch(float *avatar_pos, float *avatar_front, float *avatar_top, floa
 
 	// Calculate view unit vector
 	/*
-	   Vertical view 0° when centered
-					85°	when looking down
-				   275° when looking up
+	   Vertical view 0Â° when centered
+					85Â°	when looking down
+				   275Â° when looking up
 	   Decreasing when looking up.
 
-	   Horizontal is 0° when facing North
-					90° when facing West
-				   180° when facing South
-				   270° when facing East
+	   Horizontal is 0Â° when facing North
+					90Â° when facing West
+				   180Â° when facing South
+				   270Â° when facing East
 	   Increasing when turning left.
 	*/
 	viewVer *= static_cast<float>(M_PI / 180.0f);

--- a/plugins/cod5/cod5.cpp
+++ b/plugins/cod5/cod5.cpp
@@ -27,7 +27,7 @@ static int fetch(float *avatar_pos, float *avatar_front, float *avatar_top, floa
 
 			0x0098FD2C		byte	Magical state value
 	*/
-	ok = peekProc((BYTE *) 0x0098FD2C, &state, 1); // Magical state value
+	ok = peekProc((procptr32_t) 0x0098FD2C, &state, 1); // Magical state value
 	if (! ok)
 		return false;
 	/*
@@ -42,11 +42,11 @@ static int fetch(float *avatar_pos, float *avatar_front, float *avatar_top, floa
 	if (state != 4)
 		return true; // This results in all vectors beeing zero which tells mumble to ignore them.
 
-	ok = peekProc((BYTE *) 0x008DE23C, avatar_pos+2, 4) &&	//Z
-	     peekProc((BYTE *) 0x008DE234, avatar_pos, 4) &&	//X
-	     peekProc((BYTE *) 0x008DE238, avatar_pos+1, 4) && //Y
-	     peekProc((BYTE *) 0x008DE244, &viewHor, 4) && //Hor
-	     peekProc((BYTE *) 0x008DE240, &viewVer, 4); //Ver
+	ok = peekProc((procptr32_t) 0x008DE23C, avatar_pos+2, 4) &&	//Z
+	     peekProc((procptr32_t) 0x008DE234, avatar_pos, 4) &&	//X
+	     peekProc((procptr32_t) 0x008DE238, avatar_pos+1, 4) && //Y
+	     peekProc((procptr32_t) 0x008DE244, &viewHor, 4) && //Hor
+	     peekProc((procptr32_t) 0x008DE240, &viewVer, 4); //Ver
 
 	if (! ok)
 		return false;
@@ -69,15 +69,15 @@ static int fetch(float *avatar_pos, float *avatar_front, float *avatar_top, floa
 
 	// Calculate view unit vector
 	/*
-	   Vertical view 0° when centered
-					85°	when looking down
-				   275° when looking up
+	   Vertical view 0Â° when centered
+					85Â°	when looking down
+				   275Â° when looking up
 	   Decreasing when looking up.
 
-	   Horizontal is 0° when facing North
-					90° when facing West
-				   180° when facing South
-				   270° when facing East
+	   Horizontal is 0Â° when facing North
+					90Â° when facing West
+				   180Â° when facing South
+				   270Â° when facing East
 	   Increasing when turning left.
 	*/
 	viewVer *= static_cast<float>(M_PI / 180.0f);

--- a/plugins/codmw2/codmw2.cpp
+++ b/plugins/codmw2/codmw2.cpp
@@ -59,7 +59,7 @@ static int fetch(float *avatar_pos, float *avatar_front, float *avatar_top, floa
 
 			0x007F7A34		byte	Magical state value
 	*/
-	ok = peekProc((BYTE *) 0x007F8AB4, &state, 1); // Magical state value
+	ok = peekProc((procptr32_t) 0x007F8AB4, &state, 1); // Magical state value
 	if (! ok)
 		return false;
 	/*
@@ -74,11 +74,11 @@ static int fetch(float *avatar_pos, float *avatar_front, float *avatar_top, floa
 	if (state != 1)
 		return true; // This results in all vectors beeing zero which tells mumble to ignore them.
 
-	ok = peekProc((BYTE *) 0x008F1FF8, avatar_pos+2, 4) &&	//Z
-	     peekProc((BYTE *) 0x008F1FFC, avatar_pos, 4) &&	//X
-	     peekProc((BYTE *) 0x008F2000, avatar_pos+1, 4) && //Y
-	     peekProc((BYTE *) 0x008F2008, &viewHor, 4) && //Hor
-	     peekProc((BYTE *) 0x008F2004, &viewVer, 4); //Ver
+	ok = peekProc((procptr32_t) 0x008F1FF8, avatar_pos+2, 4) &&	//Z
+	     peekProc((procptr32_t) 0x008F1FFC, avatar_pos, 4) &&	//X
+	     peekProc((procptr32_t) 0x008F2000, avatar_pos+1, 4) && //Y
+	     peekProc((procptr32_t) 0x008F2008, &viewHor, 4) && //Hor
+	     peekProc((procptr32_t) 0x008F2004, &viewVer, 4); //Ver
 
 	if (! ok)
 		return false;
@@ -101,15 +101,15 @@ static int fetch(float *avatar_pos, float *avatar_front, float *avatar_top, floa
 
 	// Calculate view unit vector
 	/*
-	   Vertical view 0° when centered
-					85°	when looking down
-				   275° when looking up
+	   Vertical view 0Â° when centered
+					85Â°	when looking down
+				   275Â° when looking up
 	   Decreasing when looking up.
 
-	   Horizontal is 0° when facing North
-					90° when facing West
-				   180° when facing South
-				   270° when facing East
+	   Horizontal is 0Â° when facing North
+					90Â° when facing West
+				   180Â° when facing South
+				   270Â° when facing East
 	   Increasing when turning left.
 	*/
 	viewVer *= static_cast<float>(M_PI / 180.0f);

--- a/plugins/codmw2so/codmw2so.cpp
+++ b/plugins/codmw2so/codmw2so.cpp
@@ -62,14 +62,14 @@ static int fetch(float *avatar_pos, float *avatar_front, float *avatar_top, floa
 			0x009270F0		byte	Magical state value
 	*/
 
-	ok = peekProc((BYTE *) 0x019713F0, &specops, 1); // Magical state value
+	ok = peekProc((procptr32_t) 0x019713F0, &specops, 1); // Magical state value
 	if (! ok)
 		return false;
 
 	if (specops != 2)
 		return false; // 2 value indicates you are playing Special Ops, 1 indicates SP, 0 indicates at three-way selection menu
 
-	ok = peekProc((BYTE *) 0x009270F0, &state, 1); // Magical state value
+	ok = peekProc((procptr32_t) 0x009270F0, &state, 1); // Magical state value
 	if (! ok)
 		return false;
 
@@ -85,11 +85,11 @@ static int fetch(float *avatar_pos, float *avatar_front, float *avatar_top, floa
 	if (state == 0)
 		return true; // This results in all vectors beeing zero which tells mumble to ignore them.
 
-	ok = peekProc((BYTE *) 0x00783A64, avatar_pos+2, 4) &&	//Z
-	     peekProc((BYTE *) 0x00783A68, avatar_pos, 4) &&	//X
-	     peekProc((BYTE *) 0x00783A6C, avatar_pos+1, 4) && //Y
-	     peekProc((BYTE *) 0x00783A34, &viewHor, 4) && //Hor
-	     peekProc((BYTE *) 0x00783A30, &viewVer, 4); //Ver
+	ok = peekProc((procptr32_t) 0x00783A64, avatar_pos+2, 4) &&	//Z
+	     peekProc((procptr32_t) 0x00783A68, avatar_pos, 4) &&	//X
+	     peekProc((procptr32_t) 0x00783A6C, avatar_pos+1, 4) && //Y
+	     peekProc((procptr32_t) 0x00783A34, &viewHor, 4) && //Hor
+	     peekProc((procptr32_t) 0x00783A30, &viewVer, 4); //Ver
 
 	if (! ok)
 		return false;
@@ -112,15 +112,15 @@ static int fetch(float *avatar_pos, float *avatar_front, float *avatar_top, floa
 
 	// Calculate view unit vector
 	/*
-	   Vertical view 0° when centered
-					85°	when looking down
-				   275° when looking up
+	   Vertical view 0Â° when centered
+					85Â°	when looking down
+				   275Â° when looking up
 	   Decreasing when looking up.
 
-	   Horizontal is 0° when facing North
-					90° when facing West
-				   180° when facing South
-				   270° when facing East
+	   Horizontal is 0Â° when facing North
+					90Â° when facing West
+				   180Â° when facing South
+				   270Â° when facing East
 	   Increasing when turning left.
 	*/
 	viewVer *= static_cast<float>(M_PI / 180.0f);

--- a/plugins/cs/cs.cpp
+++ b/plugins/cs/cs.cpp
@@ -39,7 +39,7 @@
 
 using namespace std;
 
-BYTE *pEngine;
+procptr32_t pEngine;
 
 /*  DESCRIPTION             ADDRESS             TYPE    VALUE
 
@@ -76,12 +76,12 @@ static int fetch(float *avatar_pos, float *avatar_front, float *avatar_top, floa
 	                        |                   270     T spawn
 	*/
 
-	ok = peekProc((BYTE*) pModule + 0x11D470, avatar_pos, 12) &&
-	     peekProc((BYTE*) pModule + 0x11D47C, &fViewHor, 4) &&
-	     peekProc((BYTE*) pModule + 0x11D480, &fViewVer, 4) &&
-	     peekProc((BYTE*) pModule + 0xFC228, &bConnected, 1) &&
-	     peekProc((BYTE*) pModule + 0xFBC2C, &cPlayerState, 1) &&
-	     peekProc((BYTE*) pEngine + 0x697E60, cHostAddr, 40);
+	ok = peekProc(pModule32 + 0x11D470, avatar_pos, 12) &&
+	     peekProc(pModule32 + 0x11D47C, &fViewHor, 4) &&
+	     peekProc(pModule32 + 0x11D480, &fViewVer, 4) &&
+	     peekProc(pModule32 + 0xFC228, &bConnected, 1) &&
+	     peekProc(pModule32 + 0xFBC2C, &cPlayerState, 1) &&
+	     peekProc(pEngine + 0x697E60, cHostAddr, 40);
 	if (!ok)
 		return false;
 
@@ -141,7 +141,7 @@ static int trylock(const std::multimap<std::wstring, unsigned long long int> &pi
 
 	// Gamecheck
 	char sMagic[16];
-	if (!peekProc(pModule + 0xE46F5, sMagic, 16) || strncmp("CSSpectatorGUI@@", sMagic, 16)!=0)
+	if (!peekProc(pModule32 + 0xE46F5, sMagic, 16) || strncmp("CSSpectatorGUI@@", sMagic, 16)!=0)
 		return false;
 
 	float apos[3], afront[3], atop[3], cpos[3], cfront[3], ctop[3];

--- a/plugins/dys/dys.cpp
+++ b/plugins/dys/dys.cpp
@@ -38,10 +38,7 @@
 
 using namespace std;
 
-BYTE *posptr;
-BYTE *rotptr;
-BYTE *stateptr;
-BYTE *hostptr;
+procptr32_t posptr, rotptr, stateptr, hostptr;
 
 static bool calcout(float *pos, float *rot, float *opos, float *front, float *top) {
 	float h = rot[0];
@@ -131,7 +128,7 @@ static int trylock(const std::multimap<std::wstring, unsigned long long int> &pi
 	if (! initialize(pids, L"hl2.exe", L"client.dll"))
 		return false;
 
-	BYTE *mod_engine=getModuleAddr(L"engine.dll");
+	procptr32_t mod_engine=getModuleAddr(L"engine.dll");
 	if (!mod_engine)
 		return false;
 
@@ -145,14 +142,14 @@ static int trylock(const std::multimap<std::wstring, unsigned long long int> &pi
 	*/
 
 	// Remember addresses for later
-	posptr = pModule + 0x4A3330;
-	rotptr = pModule + 0x454E04;
-	stateptr = pModule + 0x4518A0;
+	posptr = pModule32 + 0x4A3330;
+	rotptr = pModule32 + 0x454E04;
+	stateptr = pModule32 + 0x4518A0;
 	hostptr = mod_engine + 0x3C2A84;
 
 	//Gamecheck
 	char sMagic[14];
-	if (!peekProc(pModule + 0x463726, sMagic, 14) || strncmp("DysObjective@@", sMagic, 14)!=0)
+	if (!peekProc(pModule32 + 0x463726, sMagic, 14) || strncmp("DysObjective@@", sMagic, 14)!=0)
 		return false;
 
 	// Check if we can get meaningful data from it

--- a/plugins/etqw/etqw.cpp
+++ b/plugins/etqw/etqw.cpp
@@ -40,11 +40,7 @@
 
 using namespace std;
 
-BYTE *pos1ptr;
-BYTE *pos2ptr;
-BYTE *pos3ptr;
-BYTE *rot1ptr;
-BYTE *rot2ptr;
+procptr32_t pos1ptr, pos2ptr, pos3ptr, rot1ptr, rot2ptr;
 
 static int fetch(float *avatar_pos, float *avatar_front, float *avatar_top, float *camera_pos, float *camera_front, float *camera_top, std::string &context, std::wstring &) {
 	char menustate;
@@ -68,7 +64,7 @@ static int fetch(float *avatar_pos, float *avatar_front, float *avatar_top, floa
 			0x013F9E1C		float	Vertical view
 			0x013E8D18		byte	Magic value (32 ingame / 0 spectating)
 	*/
-	ok = peekProc((BYTE *) 0x00801BA4, &menustate, 1);
+	ok = peekProc((procptr32_t) 0x00801BA4, &menustate, 1);
 	if (! ok)
 		return false;
 	if (menustate == 0)
@@ -79,7 +75,7 @@ static int fetch(float *avatar_pos, float *avatar_front, float *avatar_top, floa
 	     peekProc(pos3ptr, avatar_pos+2, 4) && //Z
 	     peekProc(rot1ptr, &viewHor, 4) && //Hor
 	     peekProc(rot2ptr, &viewVer, 4) && //Ver
-	     peekProc((BYTE *) 0x0122E0B8, ccontext, 128);
+	     peekProc((procptr32_t) 0x0122E0B8, ccontext, 128);
 
 	if (! ok)
 		return false;
@@ -137,11 +133,11 @@ static int trylock(const std::multimap<std::wstring, unsigned long long int> &pi
 	if (! initialize(pids, L"etqw.exe", L"gamex86.dll"))
 		return false;
 
-	pos1ptr = pModule + 0x74EABC;
-	pos2ptr = pModule + 0x74EAB4;
-	pos3ptr = pModule + 0x74EAB8;
-	rot1ptr = pModule + 0x75D2B4;
-	rot2ptr = pModule + 0x75D30C;
+	pos1ptr = pModule32 + 0x74EABC;
+	pos2ptr = pModule32 + 0x74EAB4;
+	pos3ptr = pModule32 + 0x74EAB8;
+	rot1ptr = pModule32 + 0x75D2B4;
+	rot2ptr = pModule32 + 0x75D30C;
 
 	float apos[3], afront[3], atop[3], cpos[3], cfront[3], ctop[3];
 	std::string context;

--- a/plugins/gmod/gmod.cpp
+++ b/plugins/gmod/gmod.cpp
@@ -38,10 +38,7 @@
 
 using namespace std;
 
-BYTE *posptr;
-BYTE *rotptr;
-BYTE *stateptr;
-BYTE *hostptr;
+procptr32_t posptr, rotptr, stateptr, hostptr;
 
 static bool calcout(float *pos, float *rot, float *opos, float *front, float *top) {
 	float v = rot[0];
@@ -125,24 +122,24 @@ static int trylock(const std::multimap<std::wstring, unsigned long long int> &pi
 	if (! initialize(pids, L"hl2.exe", L"client.dll"))
 		return false;
 
-	BYTE *mod_engine=getModuleAddr(L"engine.dll");
+	procptr32_t mod_engine=getModuleAddr(L"engine.dll");
 	if (!mod_engine)
 		return false;
 
 	// Remember addresses for later
 	// position tuple: x,y,z, float
 	// client.dll+0x6856B8
-	posptr = pModule + 0x6856B8;
+	posptr = pModule32 + 0x6856B8;
 	// orientation tuple: v,h,? float
 	// v: up = -90°, down = 90°; h (rotation): -180 - 180°
 	// client.dll+0x5B5914
-	rotptr = pModule + 0x5B5914;
+	rotptr = pModule32 + 0x5B5914;
 	// spawn state: client.dll+0x?????? - 0 when at main menu, 2 when not spawned, 15 to 14 when spawned, byte
 	// This could not be verified/found by Kissaki
 	stateptr = mod_engine + 0x375565;
 	// ID string; Game name "garrysmod"
 	// engine.dll+0x6622DC
-	BYTE *idptr = mod_engine + 0x6622DC;
+	procptr32_t idptr = mod_engine + 0x6622DC;
 	// host string: String in form "ip:port".
 	// engine.dll+0x49176C
 	hostptr = mod_engine + 0x49176C;

--- a/plugins/gtaiv/gtaiv.cpp
+++ b/plugins/gtaiv/gtaiv.cpp
@@ -45,7 +45,7 @@ static int setuppointers() {
 	procptr32_t playerptr, charptr;
 
 	// Player stuff
-	if (!peekProc(base_address + 0xF1CC68, playerid))
+	if (!peekProc(base_address + 0xF1CC68, playerid, 255))
 		return false;
 
 	if (!peekProc(base_address + 0x11A7008 + (playerid * 4), &playerptr, 4) || !playerptr)
@@ -63,7 +63,7 @@ static int setuppointers() {
 static int fetch(float *avatar_pos, float *avatar_front, float *avatar_top, float *camera_pos, float *camera_front, float *camera_top,
                  std::string &, std::wstring &) {
 	unsigned int playerid_check;
-	if (!peekProc(base_address + 0xF1CC68, playerid_check))
+	if (!peekProc(base_address + 0xF1CC68, playerid_check, 255))
 		return false;
 	if (playerid_check != playerid) {
 		if (!setuppointers())

--- a/plugins/gtaiv/gtaiv.cpp
+++ b/plugins/gtaiv/gtaiv.cpp
@@ -37,13 +37,12 @@
 #include "../mumble_plugin_win32.h"
 
 static unsigned int playerid;
-static BYTE *base_address;
-static BYTE *cvecptr;
-static BYTE *displayptr;
+static procptr32_t base_address;
+static procptr32_t cvecptr;
+static procptr32_t displayptr;
 
 static int setuppointers() {
-	BYTE *playerptr;
-	BYTE *charptr;
+	procptr32_t playerptr, charptr;
 
 	// Player stuff
 	if (!peekProc(base_address + 0xF1CC68, playerid))
@@ -132,9 +131,9 @@ static int trylock(const std::multimap<std::wstring, unsigned long long int> &pi
 	float cpos[3], cfront[3], ctop[3];
 	std::wstring sidentity;
 	std::string scontext;
-	BYTE *viewportptr;
+	procptr32_t viewportptr;
 
-	base_address = pModule - 0x400000;
+	base_address = pModule32 - 0x400000;
 
 	if (!peekProc(base_address + 0x10F47F0, &viewportptr, 4) || !viewportptr)
 		return false;
@@ -185,4 +184,3 @@ extern "C" __declspec(dllexport) MumblePlugin *getMumblePlugin() {
 extern "C" __declspec(dllexport) MumblePlugin2 *getMumblePlugin2() {
 	return &gtaivplug2;
 }
-

--- a/plugins/gtav/gtav.cpp
+++ b/plugins/gtav/gtav.cpp
@@ -19,22 +19,22 @@ static int fetch(float *avatar_pos, float *avatar_front, float *avatar_top, floa
 	char state, in_game, player[50], vehicle[50], location[50], street[50];
 
 	// Avatar pointer
-	BYTE *avatar_base = peekProc<BYTE *>(pModule + 0x01B3D3F0);
+	procptr64_t avatar_base = peekProc<procptr64_t>(pModule64 + 0x01B3D3F0);
 	if (!avatar_base) return false;
 
 	// Peekproc and assign game addresses to our containers, so we can retrieve positional data
-	ok = peekProc((BYTE *) pModule + 0x267FD50, &state, 1) && // Magical state value: 0 when in single player, 2 when online and 3 when in a lobby.
-			peekProc((BYTE *) pModule + 0x1B6D757, &in_game, 1) && // 0 when loading or not in-game, 1 when in-game.
-			peekProc((BYTE *) pModule + 0x1EC2830, avatar_pos_corrector, 12) && // Avatar Position values (X, Z and Y).
-			peekProc((BYTE *) pModule + 0x1BFEDA0, camera_pos_corrector, 12) && // Camera Position values (X, Z and Y).
-			peekProc((BYTE *) avatar_base + 0x70, avatar_front_corrector, 12) && // Avatar Front Vector values (X, Z and Y).
-			peekProc((BYTE *) avatar_base + 0x80, avatar_top_corrector, 12) && // Avatar Top Vector values (X, Z and Y).
-			peekProc((BYTE *) pModule + 0x1C00860, camera_front_corrector, 12) && // Camera Front Vector values (X, Z and Y).
-			peekProc((BYTE *) pModule + 0x1ED0E30, camera_top_corrector, 12) && // Camera Top Vector values (X, Z and Y).
-			peekProc((BYTE *) pModule + 0x268A4EC, player) && // Player nickname.
-			peekProc((BYTE *) pModule + 0x2282400, vehicle) && // Vehicle name if in a vehicle, empty if not.
-			peekProc((BYTE *) pModule + 0x2281DDB, location) && // Location name.
-			peekProc((BYTE *) pModule + 0x227EBA0, street); // Street name if on a street, empty if not.
+	ok = peekProc(pModule64 + 0x267FD50, &state, 1) && // Magical state value: 0 when in single player, 2 when online and 3 when in a lobby.
+			peekProc(pModule64 + 0x1B6D757, &in_game, 1) && // 0 when loading or not in-game, 1 when in-game.
+			peekProc(pModule64 + 0x1EC2830, avatar_pos_corrector, 12) && // Avatar Position values (X, Z and Y).
+			peekProc(pModule64 + 0x1BFEDA0, camera_pos_corrector, 12) && // Camera Position values (X, Z and Y).
+			peekProc(avatar_base + 0x70, avatar_front_corrector, 12) && // Avatar Front Vector values (X, Z and Y).
+			peekProc(avatar_base + 0x80, avatar_top_corrector, 12) && // Avatar Top Vector values (X, Z and Y).
+			peekProc(pModule64 + 0x1C00860, camera_front_corrector, 12) && // Camera Front Vector values (X, Z and Y).
+			peekProc(pModule64 + 0x1ED0E30, camera_top_corrector, 12) && // Camera Top Vector values (X, Z and Y).
+			peekProc(pModule64 + 0x268A4EC, player, 50) && // Player nickname.
+			peekProc(pModule64 + 0x2282400, vehicle, 50) && // Vehicle name if in a vehicle, empty if not.
+			peekProc(pModule64 + 0x2281DDB, location, 50) && // Location name.
+			peekProc(pModule64 + 0x227EBA0, street, 50); // Street name if on a street, empty if not.
 
 	// This prevents the plugin from linking to the game in case something goes wrong during values retrieval from memory addresses.
 	if (! ok)

--- a/plugins/gw/gw.cpp
+++ b/plugins/gw/gw.cpp
@@ -73,17 +73,17 @@
 
 */
 
-static BYTE *camptr = (BYTE *) 0xa30274;
-static BYTE *posptr = (BYTE *) 0xa302a4;
-static BYTE *camfrontptr = (BYTE *) 0xbf46b8;
-static BYTE *frontptr_ = (BYTE *) 0xd55610;
-static BYTE *frontptr;
+static procptr32_t camptr = (procptr32_t) 0xa30274;
+static procptr32_t posptr = (procptr32_t) 0xa302a4;
+static procptr32_t camfrontptr = (procptr32_t) 0xbf46b8;
+static procptr32_t frontptr_ = (procptr32_t) 0xd55610;
+static procptr32_t frontptr;
 
-static BYTE *locationptr = (BYTE *) 0xa3fa08;
-static BYTE *areaptr = (BYTE *) 0xa31158;
+static procptr32_t locationptr = (procptr32_t) 0xa3fa08;
+static procptr32_t areaptr = (procptr32_t) 0xa31158;
 
 static char prev_location;
-static int  prev_areaid;
+static int prev_areaid;
 
 static bool calcout(float *pos, float *front, float *cam, float *camfront, float *opos, float *ofront, float *ocam, float *ocamfront) {
 
@@ -114,13 +114,13 @@ static bool refreshPointers(void)
 {
 	frontptr = NULL;
 
-	frontptr = peekProc<BYTE *>(frontptr_);
+	frontptr = peekProc<procptr32_t>(frontptr_);
 	if (!frontptr)
 		return false;
-	frontptr = peekProc<BYTE *>(frontptr + 0x8);
+	frontptr = peekProc<procptr32_t>(frontptr + 0x8);
 	if (!frontptr)
 		return false;
-	frontptr = peekProc<BYTE *>(frontptr);
+	frontptr = peekProc<procptr32_t>(frontptr);
 	if (!frontptr)
 		return false;
 	frontptr = frontptr + 0x1c;
@@ -137,22 +137,22 @@ static int fetch(float *avatar_pos, float *avatar_front, float *avatar_top, floa
 	char location;
 	int areaid;
 
-	ok = peekProc(camptr, cam) &&
-		 peekProc(posptr, pos) &&
-		 peekProc(camfrontptr, camfront) &&
+	ok = peekProc(camptr, cam, 12) &&
+		 peekProc(posptr, pos, 12) &&
+		 peekProc(camfrontptr, camfront, 12) &&
 		 peekProc(locationptr, &location, 1) &&
-		 peekProc(areaptr, &areaid, 4);
+		 peekProc(areaptr, &areaid, 1);
 
 	if (!ok) // First we check, if the game is even running or if we should unlink because it's not / it's broken
 		return false;
-	
+
 	ok = refreshPointers(); // yes, we need to do this pretty often since the pointer gets wiped and changed evey time you leave a world instance (that means on loading screens etc)
 	if (!ok) { // Next we check, if we're inside the game or in menus/in a loading screen
 		context.clear();
 		return true; // don't report positional data but stay linked to avoid unnecessary unlinking on loading screens
 	}
 	else { // If we're inside the game, try to peekProc the last value we need or unlink (again, in case something went wrong)
-		if (!peekProc(frontptr, front))
+		if (!peekProc(frontptr, front, 12))
 			return false;
 	}
 

--- a/plugins/insurgency/insurgency.cpp
+++ b/plugins/insurgency/insurgency.cpp
@@ -38,10 +38,7 @@
 
 using namespace std;
 
-BYTE *posptr;
-BYTE *rotptr;
-BYTE *stateptr;
-BYTE *hostptr;
+procptr32_t posptr, rotptr, stateptr, hostptr;
 
 static bool calcout(float *pos, float *rot, float *opos, float *front, float *top) {
 	float h = rot[0];
@@ -131,7 +128,7 @@ static int trylock(const std::multimap<std::wstring, unsigned long long int> &pi
 	if (! initialize(pids, L"hl2.exe", L"client.dll"))
 		return false;
 
-	BYTE *mod_engine=getModuleAddr(L"engine.dll");
+	procptr32_t mod_engine=getModuleAddr(L"engine.dll");
 	if (!mod_engine)
 		return false;
 
@@ -145,14 +142,14 @@ static int trylock(const std::multimap<std::wstring, unsigned long long int> &pi
 	*/
 
 	// Remember addresses for later
-	posptr = pModule + 0x4F1EE0;
-	rotptr = pModule + 0x4F247C;
-	stateptr = pModule + 0x4AFEB8;
+	posptr = pModule32 + 0x4F1EE0;
+	rotptr = pModule32 + 0x4F247C;
+	stateptr = pModule32 + 0x4AFEB8;
 	hostptr = mod_engine + 0x3909A4;
 
 	//Gamecheck
 	char sMagic[14];
-	if (!peekProc(pModule + 0x46B512, sMagic, 14) || strncmp("CombatWeapon@@", sMagic, 14)!=0)
+	if (!peekProc(pModule32 + 0x46B512, sMagic, 14) || strncmp("CombatWeapon@@", sMagic, 14)!=0)
 		return false;
 
 	// Check if we can get meaningful data from it
@@ -170,7 +167,7 @@ static int trylock(const std::multimap<std::wstring, unsigned long long int> &pi
 }
 
 static const std::wstring longdesc() {
-	return std::wstring(L"Supports Insurgency pModule build 4044. No identity support yet.");
+	return std::wstring(L"Supports Insurgency: Modern Infantry Combat build 4044. No identity support yet.");
 }
 
 static std::wstring description(L"Insurgency: Modern Infantry Combat (Build 4044)");

--- a/plugins/jc2/jc2.cpp
+++ b/plugins/jc2/jc2.cpp
@@ -45,8 +45,8 @@ const unsigned int off_char_matrix = 0x15C;
 const unsigned int off_camera_manager = 0xD919F4;
 const unsigned int off_cam_matrix = 0x2FC;
 
-static BYTE *char_matrix_ptr = 0;
-static BYTE *cam_matrix_ptr = 0;
+static procptr32_t char_matrix_ptr = 0;
+static procptr32_t cam_matrix_ptr = 0;
 
 typedef struct {
 	float x;
@@ -63,13 +63,9 @@ typedef struct {
 } Matrix4;
 
 static int setuppointers() {
-	BYTE *character_manager;
-	BYTE *local_player;
-	BYTE *character;
+	procptr32_t character_manager, local_player, character, camera_manager;
 
-	BYTE *camera_manager;
-
-	if (!peekProc(pModule + off_character_manager, &character_manager, 4) || !character_manager)
+	if (!peekProc(pModule32 + off_character_manager, &character_manager, 4) || !character_manager)
 		return false;
 
 	if (!peekProc(character_manager + off_local_player, &local_player, 4) || !local_player)
@@ -80,7 +76,7 @@ static int setuppointers() {
 
 	char_matrix_ptr = character + off_char_matrix;
 
-	if (!peekProc(pModule + off_camera_manager, &camera_manager, 4) || !camera_manager)
+	if (!peekProc(pModule32 + off_camera_manager, &camera_manager, 4) || !camera_manager)
 		return false;
 
 	cam_matrix_ptr = camera_manager + off_cam_matrix;
@@ -189,4 +185,3 @@ extern "C" __declspec(dllexport) MumblePlugin *getMumblePlugin() {
 extern "C" __declspec(dllexport) MumblePlugin2 *getMumblePlugin2() {
 	return &jc2plug2;
 }
-

--- a/plugins/l4d/l4d.cpp
+++ b/plugins/l4d/l4d.cpp
@@ -5,8 +5,7 @@
 
 #include "../mumble_plugin_win32.h"
 
-BYTE *posptr;
-BYTE *rotptr;
+procptr32_t posptr, rotptr;
 
 static bool calcout(float *pos, float *rot, float *opos, float *front, float *top) {
 	float h = rot[0];
@@ -46,8 +45,8 @@ static int trylock(const std::multimap<std::wstring, unsigned long long int> &pi
 	if (! initialize(pids, L"left4dead.exe", L"client.dll"))
 		return false;
 
-	posptr = pModule + 0x596E30;
-	rotptr = pModule + 0x596E3C;
+	posptr = pModule32 + 0x596E30;
+	rotptr = pModule32 + 0x596E3C;
 
 	float pos[3];
 	float rot[3];

--- a/plugins/l4d2/l4d2.cpp
+++ b/plugins/l4d2/l4d2.cpp
@@ -6,7 +6,7 @@
 #include "../mumble_plugin_win32.h" // Include standard plugin header.
 #include "../mumble_plugin_utils.h" // Include plugin header for special functions, like "escape".
 
-BYTE *serverid_steamclient, *player_engine; // BYTE values to contain modules addresses
+procptr32_t serverid_steamclient, player_engine; // BYTE values to contain modules addresses
 
 static int fetch(float *avatar_pos, float *avatar_front, float *avatar_top, float *camera_pos, float *camera_front, float *camera_top, std::string &context, std::wstring &identity) {
 	for (int i=0;i<3;i++) {
@@ -23,16 +23,16 @@ static int fetch(float *avatar_pos, float *avatar_front, float *avatar_top, floa
 	BYTE state;
 
 	// Peekproc and assign game addresses to our containers, so we can retrieve positional data
-	ok = peekProc((BYTE *) pModule + 0x06ACBD5, &state, 1) && // Magical state value: 0 or 255 when in main menu and 1 when in-game.
-			peekProc((BYTE *) pModule + 0x06B9E1C, avatar_pos_corrector, 12) && // Avatar Position values (X, Z and Y).
-			peekProc((BYTE *) pModule + 0x0774B98, camera_pos_corrector, 12) && // Camera Position values (X, Z and Y).
-			peekProc((BYTE *) pModule + 0x0774BF8, avatar_front_corrector, 12) && // Front vector values (X, Z and Y).
-			peekProc((BYTE *) pModule + 0x0774C28, avatar_top_corrector, 12) && // Top vector values (Z, X and Y).
-			peekProc((BYTE *) serverid_steamclient, serverid) && // Unique server Steam ID.
-			peekProc((BYTE *) pModule + 0x0772B24, host) && // Server value: "IP:Port" (xxx.xxx.xxx.xxx:yyyyy) when in a remote server, "loopback:0" when on a local server and empty when not playing.
-			peekProc((BYTE *) pModule + 0x0772D2C, servername) && // Server name.
-			peekProc((BYTE *) pModule + 0x0772C28, map) && // Map name.
-			peekProc((BYTE *) player_engine, player); // Player nickname.
+	ok = peekProc(pModule32 + 0x06ACBD5, &state, 1) && // Magical state value: 0 or 255 when in main menu and 1 when in-game.
+			peekProc(pModule32 + 0x06B9E1C, avatar_pos_corrector, 12) && // Avatar Position values (X, Z and Y).
+			peekProc(pModule32 + 0x0774B98, camera_pos_corrector, 12) && // Camera Position values (X, Z and Y).
+			peekProc(pModule32 + 0x0774BF8, avatar_front_corrector, 12) && // Front vector values (X, Z and Y).
+			peekProc(pModule32 + 0x0774C28, avatar_top_corrector, 12) && // Top vector values (Z, X and Y).
+			peekProc(serverid_steamclient, serverid, 22) && // Unique server Steam ID.
+			peekProc(pModule32 + 0x0772B24, host, 22) && // Server value: "IP:Port" (xxx.xxx.xxx.xxx:yyyyy) when in a remote server, "loopback:0" when on a local server and empty when not playing.
+			peekProc(pModule32 + 0x0772D2C, servername, 50) && // Server name.
+			peekProc(pModule32 + 0x0772C28, map, 30) && // Map name.
+			peekProc(player_engine, player, 33); // Player nickname.
 
 	// This prevents the plugin from linking to the game in case something goes wrong during values retrieval from memory addresses.
 	if (! ok)
@@ -148,14 +148,14 @@ static int trylock(const std::multimap<std::wstring, unsigned long long int> &pi
 		return false;
 	}
 
-	BYTE *steamclient=getModuleAddr(L"steamclient.dll"); // Link "steamclient.dll" module
+	procptr32_t steamclient=getModuleAddr(L"steamclient.dll"); // Link "steamclient.dll" module
 	// This prevents the plugin from linking to the game in case something goes wrong during module linking.
 	if (!steamclient)
 		return false;
 
 	serverid_steamclient = steamclient + 0x09888ED; // Module + Server ID offset
 
-	BYTE *engine=getModuleAddr(L"engine.dll"); // // Link "engine.dll" module
+	procptr32_t engine=getModuleAddr(L"engine.dll"); // // Link "engine.dll" module
 	// This prevents the plugin from linking to the game in case something goes wrong during module linking.
 	if (!engine)
 		return false;

--- a/plugins/lol/lol.cpp
+++ b/plugins/lol/lol.cpp
@@ -57,17 +57,15 @@
 	PORT:					+0x1C (offset, not pointer!)
 */
 
-static BYTE *posptr;
-static BYTE *afrontptr;
-static BYTE *tmpptr;
+static procptr32_t posptr, afrontptr, tmpptr;
 
-static BYTE *posptr_ = (BYTE *)0x2F5E5F8;
-static BYTE *camptr = (BYTE *)0xB738E8;
-static BYTE *camfrontptr = camptr + 0x14;
-static BYTE *gameptr = (BYTE *)0xE22E90;
+static procptr32_t posptr_ = (procptr32_t) 0x2F5E5F8;
+static procptr32_t camptr = (procptr32_t) 0xB738E8;
+static procptr32_t camfrontptr = camptr + 0x14;
+static procptr32_t gameptr = (procptr32_t) 0xE22E90;
 
-static BYTE *hostipptr = (BYTE *)0xAF69D18;
-static BYTE *hostportptr = hostipptr + 0x1C;
+static procptr32_t hostipptr = (procptr32_t) 0xAF69D18;
+static procptr32_t hostportptr = hostipptr + 0x1C;
 
 static char prev_hostip[16]; // These should never change while the game is running, but just in case...
 static int prev_hostport;
@@ -86,14 +84,14 @@ static bool refreshPointers(void) {
 	posptr = afrontptr = tmpptr = NULL;
 	
 	// Avatar front vector pointer
-	tmpptr = peekProc<BYTE *>(gameptr);
+	tmpptr = peekProc<procptr32_t>(gameptr);
 	if (!tmpptr)
 		return false; // Something went wrong, unlink
 
 	afrontptr = tmpptr + 0x2acc;
 	
 	// Avatar position vector
-	tmpptr = peekProc<BYTE *>(posptr_);
+	tmpptr = peekProc<procptr32_t>(posptr_);
 	if (!tmpptr)
 		return false; // Something went wrong, unlink
 
@@ -112,14 +110,14 @@ static int fetch(float *avatar_pos, float *avatar_front, float *avatar_top, floa
 	bool ok;
 
 	// Player not in game (or something broke), unlink
-	if (!peekProc<BYTE *>(gameptr))
+	if (!peekProc<procptr32_t>(gameptr))
 		return false;
 
 	ok = peekProc(camfrontptr, camera_front, 12) &&
 		 peekProc(camptr, cam, 12) &&
 		 peekProc(posptr, ipos, 12) &&
 		 peekProc(afrontptr, avatar_front, 12) &&
-		 peekProc(hostipptr, hostip) &&
+		 peekProc(hostipptr, hostip, 16) &&
 		 peekProc(hostportptr, &hostport, 4);
 
 	if (!ok) 

--- a/plugins/lotro/lotro.cpp
+++ b/plugins/lotro/lotro.cpp
@@ -45,7 +45,7 @@ static int fetch(float *avatar_pos, float *avatar_front, float *avatar_top, floa
 	byte l[2];
 	byte r,i;
 	float o[3];
-	BYTE *hPtr;
+	procptr32_t hPtr;
 	float h;
 
 	/*
@@ -66,16 +66,16 @@ static int fetch(float *avatar_pos, float *avatar_front, float *avatar_top, floa
 		nPtr = pointer to character name (unique on a server)
 	*/
 
-	ok = peekProc((BYTE *) 0x01272D34, o, 12) &&
-	     peekProc((BYTE *) 0x01272D2C, l, 2) &&
-	     peekProc((BYTE *) 0x01272D28, &r, 1) &&
-	     peekProc((BYTE *) 0x01272D20, &i, 1) &&
-	     peekProc((BYTE *)(pModule + 0x00A138A4), &hPtr, 4);
+	ok = peekProc((procptr32_t) 0x01272D34, o, 12) &&
+	     peekProc((procptr32_t) 0x01272D2C, l, 2) &&
+	     peekProc((procptr32_t) 0x01272D28, &r, 1) &&
+	     peekProc((procptr32_t) 0x01272D20, &i, 1) &&
+	     peekProc((procptr32_t)(pModule32 + 0x00A138A4), &hPtr, 4);
 
 	if (! ok)
 		return false;
 
-	ok = peekProc((BYTE *)(hPtr  + 0x0000046F), &h, 4);
+	ok = peekProc((procptr32_t)(hPtr  + 0x0000046F), &h, 4);
 
 	if (! ok)
 		return false;

--- a/plugins/ql/ql.cpp
+++ b/plugins/ql/ql.cpp
@@ -21,15 +21,15 @@ static int fetch(float *avatar_pos, float *avatar_front, float *avatar_top, floa
 	BYTE team;
 
 	// Peekproc and assign game addresses to our containers, so we can retrieve positional data
-	ok = peekProc((BYTE *) pModule + 0x0188248, &state, 1) && // Magical state value: 1 when in-game and 0 when in main menu.
-			peekProc((BYTE *) pModule + 0x1041C68, &spec, 1) && // Spectator state value: 1 when spectating and 0 when playing.
-			peekProc((BYTE *) pModule + 0x0EB8950, avatar_pos_corrector, 12) && // Avatar Position values (Z, X and Y, respectively).
-			peekProc((BYTE *) pModule + 0x0E6093C, camera_pos_corrector, 12) && // Camera Position values (Z, X and Y, respectively).
-			peekProc((BYTE *) pModule + 0x106CE04, &viewHor, 4) && // Changes in a range from 180 to -180 when moving the view to left/right.
-			peekProc((BYTE *) pModule + 0x106CE00, &viewVer, 4) && // Changes in a range from 87.890625 (looking down) to -87.890625 (looking up).
-			peekProc((BYTE *) pModule + 0x0E4A638, host) && // Server value: "IP:Port" when in a remote server, "loopback" when on a local server.
-			peekProc((BYTE *) pModule + 0x12DE8D8, map) && // Map name.
-			peekProc((BYTE *) pModule + 0x106CE6C, team); // Team value: 0 when in a FFA game (no team); 1 when in Red team; 2 when in Blue team; 3 when in Spectators.
+	ok = peekProc(pModule32 + 0x0188248, &state, 1) && // Magical state value: 1 when in-game and 0 when in main menu.
+			peekProc(pModule32 + 0x1041C68, &spec, 1) && // Spectator state value: 1 when spectating and 0 when playing.
+			peekProc(pModule32 + 0x0EB8950, avatar_pos_corrector, 12) && // Avatar Position values (Z, X and Y, respectively).
+			peekProc(pModule32 + 0x0E6093C, camera_pos_corrector, 12) && // Camera Position values (Z, X and Y, respectively).
+			peekProc(pModule32 + 0x106CE04, &viewHor, 4) && // Changes in a range from 180 to -180 when moving the view to left/right.
+			peekProc(pModule32 + 0x106CE00, &viewVer, 4) && // Changes in a range from 87.890625 (looking down) to -87.890625 (looking up).
+			peekProc(pModule32 + 0x0E4A638, host, 22) && // Server value: "IP:Port" when in a remote server, "loopback" when on a local server.
+			peekProc(pModule32 + 0x12DE8D8, map, 30) && // Map name.
+			peekProc(pModule32 + 0x106CE6C, team, 1); // Team value: 0 when in a FFA game (no team); 1 when in Red team; 2 when in Blue team; 3 when in Spectators.
 
 	if (! ok) {
 		return false;

--- a/plugins/sr/sr.cpp
+++ b/plugins/sr/sr.cpp
@@ -3,7 +3,7 @@
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.
 
-/* Copyright (C) 2012, Lukas Orsv‰rn <lucas.orsv@gmail.com>
+/* Copyright (C) 2012, Lukas Orsv√§rn <lucas.orsv@gmail.com>
    Copyright (C) 2005-2010, Thorvald Natvig <thorvald@natvig.com> 
 
    All rights reserved.
@@ -51,7 +51,7 @@ static int fetch(float *avatar_pos, float *avatar_front, float *avatar_top, floa
 	/*
 		value is <     >
 	*/
-	ok = peekProc((BYTE *) 0xB378564, &state, 1); // Magical state value
+	ok = peekProc((procptr32_t) 0xB378564, &state, 1); // Magical state value
 	if (! ok)
 		return false;
 	
@@ -59,9 +59,9 @@ static int fetch(float *avatar_pos, float *avatar_front, float *avatar_top, floa
 		return true; // This results in all vectors beeing zero which tells Mumble to ignore them.
 	
 	// Peekproc and assign game addresses to our containers, so we can retrieve positional data
-	ok = peekProc((BYTE *) 0x1243BE84, &pos_corrector, 12) &&
-	        peekProc((BYTE *) 0x1243BEA8, &front_corrector, 12) &&
-	        peekProc((BYTE *) 0x1243BE9C, &top_corrector, 12);
+	ok = peekProc((procptr32_t) 0x1243BE84, &pos_corrector, 12) &&
+	        peekProc((procptr32_t) 0x1243BEA8, &front_corrector, 12) &&
+	        peekProc((procptr32_t) 0x1243BE9C, &top_corrector, 12);
 	
 	if (! ok)
 		return false;

--- a/plugins/sto/sto.cpp
+++ b/plugins/sto/sto.cpp
@@ -5,9 +5,7 @@
 
 #include "../mumble_plugin_win32.h"
 
-static BYTE *identptr;
-static BYTE *contextptr;
-static BYTE *posptr;
+static procptr32_t identptr, contextptr, posptr;
 
 static void inline u8(std::wstring &dst, const std::string &src) {
 	if (src.length() > static_cast<size_t>(std::numeric_limits<int>::max())) {
@@ -28,9 +26,9 @@ static int fetch(float *avatar_pos, float *avatar_front, float *avatar_top, floa
 	char contextblock[0x80];
 	float posblock[64];
 
-	if (! peekProc(identptr, identblock) ||
-	        ! peekProc(contextptr, contextblock) ||
-	        ! peekProc(posptr, posblock))
+	if (! peekProc(identptr, identblock, 0x200) ||
+	        ! peekProc(contextptr, contextblock, 0x80) ||
+	        ! peekProc(posptr, posblock, 64))
 		return false;
 
 	std::string ident = std::string(identblock+0x188, strnlen(identblock + 0x188, 0x78)) + std::string("@") + std::string(identblock, strnlen(identblock, 0x80));
@@ -78,16 +76,16 @@ static int trylock(const std::multimap<std::wstring, unsigned long long int> &pi
 		return false;
 
 	char version[17];
-	peekProc(pModule + 0x1616080, version);
+	peekProc(pModule32 + 0x1616080, version, 17);
 	version[16]=0;
 
 	if (memcmp(version, "ST.0.20100217c.3", sizeof(version)) == 0) {
 #ifdef PLUGIN_DEBUG
 		printf("STO: WANTLINK %s\n", version);
 #endif
-		contextptr = pModule + 0x16b2cd4;
+		contextptr = pModule32 + 0x16b2cd4;
 		identptr = contextptr + 0x444;
-		posptr = pModule + 0x18c2340;
+		posptr = pModule32 + 0x18c2340;
 
 		return true;
 	} else {

--- a/plugins/ut2004/ut2004.cpp
+++ b/plugins/ut2004/ut2004.cpp
@@ -39,11 +39,7 @@
 
 using namespace std;
 
-BYTE *pos0ptr;
-BYTE *pos1ptr;
-BYTE *pos2ptr;
-BYTE *faceptr;
-BYTE *topptr;
+procptr32_t pos0ptr, pos1ptr, pos2ptr, faceptr, topptr;
 
 static int fetch(float *avatar_pos, float *avatar_front, float *avatar_top, float *camera_pos, float *camera_front, float *camera_top, std::string &, std::wstring &) {
 	//char ccontext[128];
@@ -103,10 +99,10 @@ static int trylock(const std::multimap<std::wstring, unsigned long long int> &pi
 	if (! initialize(pids, L"UT2004.exe", L"Engine.dll"))
 		return false;
 
-	BYTE *ptraddress = pModule + 0x4A44FC;
-	BYTE *ptr2 = peekProc<BYTE *>(ptraddress);
-	BYTE *ptr3 = peekProc<BYTE *>(ptr2 + 0xCC);
-	BYTE *baseptr = ptr3 + 0x1C8;
+	procptr32_t ptraddress = pModule32 + 0x4A44FC;
+	procptr32_t ptr2 = peekProc<procptr32_t>(ptraddress);
+	procptr32_t ptr3 = peekProc<procptr32_t>(ptr2 + 0xCC);
+	procptr32_t baseptr = ptr3 + 0x1C8;
 
 	pos0ptr = baseptr;
 	pos1ptr = baseptr + 0x4;

--- a/plugins/ut3/ut3.cpp
+++ b/plugins/ut3/ut3.cpp
@@ -41,11 +41,7 @@
 
 using namespace std;
 
-BYTE *pos0ptr;
-BYTE *pos1ptr;
-BYTE *pos2ptr;
-BYTE *faceptr;
-BYTE *topptr;
+procptr32_t pos0ptr, pos1ptr, pos2ptr, faceptr, topptr;
 //BYTE *stateptr;
 
 static int fetch(float *avatar_pos, float *avatar_front, float *avatar_top, float *camera_pos, float *camera_front, float *camera_top, std::string &, std::wstring &) {
@@ -59,7 +55,7 @@ static int fetch(float *avatar_pos, float *avatar_front, float *avatar_top, floa
 	for (int i=0;i<3;i++)
 		avatar_pos[i] = avatar_front[i] = avatar_top[i] = camera_pos[i] = camera_front[i] = camera_top[i] = 0.0f;
 
-	ok = peekProc((BYTE *) 0x01DEAFD9, &state, 1);
+	ok = peekProc((procptr32_t) 0x01DEAFD9, &state, 1);
 	if (! ok)
 		return false;
 
@@ -128,8 +124,8 @@ static int trylock(const std::multimap<std::wstring, unsigned long long int> &pi
 	if (! initialize(pids, L"UT3.exe", L"wrap_oal.dll"))
 		return false;
 
-	BYTE *ptraddress = pModule + 0x8A740;
-	BYTE *baseptr = peekProc<BYTE *>(ptraddress);
+	BYTE *ptraddress = pModule32 + 0x8A740;
+	BYTE *baseptr = peekProc<procptr32_t>(ptraddress);
 
 	pos0ptr = baseptr;
 	pos1ptr = baseptr + 0x4;

--- a/plugins/ut3/ut3.cpp
+++ b/plugins/ut3/ut3.cpp
@@ -124,8 +124,8 @@ static int trylock(const std::multimap<std::wstring, unsigned long long int> &pi
 	if (! initialize(pids, L"UT3.exe", L"wrap_oal.dll"))
 		return false;
 
-	BYTE *ptraddress = pModule32 + 0x8A740;
-	BYTE *baseptr = peekProc<procptr32_t>(ptraddress);
+	BYTE ptraddress = pModule32 + 0x8A740;
+	BYTE baseptr = peekProc<procptr32_t>(ptraddress);
 
 	pos0ptr = baseptr;
 	pos1ptr = baseptr + 0x4;

--- a/plugins/ut99/ut99.cpp
+++ b/plugins/ut99/ut99.cpp
@@ -162,7 +162,7 @@ static int fetch(float *avatar_pos, float *avatar_front, float *avatar_top, floa
 	wservername[sizeof(wservername)/sizeof(wservername[0]) - 1] = '\0';
 
 	std::string servername;
-	wcsToMultibyteStdString(wservername, servername, 60);
+	wcsToMultibyteStdString(wservername, servername);
 
 	std::ostringstream contextss;
 	contextss << "{"

--- a/plugins/wolfet/wolfet.cpp
+++ b/plugins/wolfet/wolfet.cpp
@@ -57,7 +57,7 @@ static int fetch(float *avatar_pos, float *avatar_front, float *avatar_top, floa
 		avatar_pos[i] = avatar_front[i] = avatar_top[i] = camera_pos[i] = camera_front[i] = camera_top[i] = 0.0f;
 
 	bool ok;
-	ok = peekProc((BYTE *) 0x013E8DFC, &team, 1);
+	ok = peekProc((procptr32_t) 0x013E8DFC, &team, 1);
 	if (!ok)
 		return false;
 
@@ -65,9 +65,9 @@ static int fetch(float *avatar_pos, float *avatar_front, float *avatar_top, floa
 	if (team == 0 || team == 3)
 		return true;
 
-	ok = peekProc((BYTE *) 0x013E8CF4, avatar_pos, 12) &&   // X, Y, Z
-		peekProc((BYTE *) 0x013F9E20, &viewHor, 4) &&      // Hor-Angle
-		peekProc((BYTE *) 0x013F9E1C, &viewVer, 4);        // Ver-Angle
+	ok = peekProc((procptr32_t) 0x013E8CF4, avatar_pos, 12) &&   // X, Y, Z
+		peekProc((procptr32_t) 0x013F9E20, &viewHor, 4) &&      // Hor-Angle
+		peekProc((procptr32_t) 0x013F9E1C, &viewVer, 4);        // Ver-Angle
 
 	if (!ok)
 		return false;
@@ -91,8 +91,8 @@ static int fetch(float *avatar_pos, float *avatar_front, float *avatar_top, floa
 	// Context - concatenated server-ip, mapname and team value
 	char hostip[32];
 	char mapname[40];
-	ok = peekProc((BYTE *) 0x009FFD30, hostip, sizeof(hostip)) &&
-		peekProc((BYTE *) 0x010B4908, mapname, sizeof(hostip));
+	ok = peekProc((procptr32_t) 0x009FFD30, hostip, sizeof(hostip)) &&
+		peekProc((procptr32_t) 0x010B4908, mapname, sizeof(hostip));
 	hostip[sizeof(hostip)-1] = '\0';
 	mapname[sizeof(mapname)-1] = '\0';
 	// Context in JSON format, {} with fields ipport (server hostname), map, and team (: int)


### PR DESCRIPTION
Update to almost all plugins to fit the new changes done to memory addresses retrieval system (https://github.com/mumble-voip/mumble/pull/2347).

Compile errors:

**AOC** at line 131:
> error: C2440: 'initializing' : cannot convert from 'BYTE *' to 'procptr32_t'
> There is no context in which this conversion is possible

**BF2** at lines 165 and 168:
> error: C2440: '=' : cannot convert from 'BYTE *' to 'procptr32_t'
> There is no context in which this conversion is possible

**BF4** at lines 47, 48 and 49 and **BF4_x86** at lines 45, 46 and 47:
> error: C2665: 'peekProc' : none of the 2 overloads could convert all the argument types
> ../mumble_plugin_win32.h(99): could be 'bool peekProc(procptr64_t,void *,SIZE_T)'
> ../mumble_plugin_win32.h(93): or       'bool peekProc(procptr32_t,void *,SIZE_T)'
> while trying to match the argument list '(procptr64_t, BYTE, int)'

**Borderlands 2** at lines 56 and 70:
> error: C2665: 'peekProc' : none of the 2 overloads could convert all the argument types
> ../mumble_plugin_win32.h(99): could be 'bool peekProc(procptr64_t,void *,SIZE_T)'
> ../mumble_plugin_win32.h(93): or       'bool peekProc(procptr32_t,void *,SIZE_T)'
> while trying to match the argument list '(procptr32_t, fetch::<unnamed-type-game_vects>, int)'

**CS** at line 138:
> error: C2440: '=' : cannot convert from 'BYTE *' to 'procptr32_t'
> There is no context in which this conversion is possible

**DYS** at line 131:
> error: C2440: 'initializing' : cannot convert from 'BYTE *' to 'procptr32_t'
> There is no context in which this conversion is possible

**GMod** at line 125:
> error: C2440: 'initializing' : cannot convert from 'BYTE *' to 'procptr32_t'
> There is no context in which this conversion is possible

**GTAIV** at lines 48 and 66:
> error: C2665: 'peekProc' : none of the 2 overloads could convert all the argument types
> ../mumble_plugin_win32.h(99): could be 'bool peekProc(procptr64_t,void *,SIZE_T)'
> ../mumble_plugin_win32.h(93): or       'bool peekProc(procptr32_t,void *,SIZE_T)'
> while trying to match the argument list '(procptr32_t, unsigned int, int)'

**GTAV** at line 22:
> error: C2665: 'peekProc' : none of the 2 overloads could convert all the argument types
> ../mumble_plugin_win32.h(99): could be 'bool peekProc(procptr64_t,void *,SIZE_T)'
> ../mumble_plugin_win32.h(93): or       'bool peekProc(procptr32_t,void *,SIZE_T)'

**Insurgency** at line 131:
> error: C2440: 'initializing' : cannot convert from 'BYTE *' to 'procptr32_t'
> There is no context in which this conversion is possible

**L4D2** at lines 151 and 158:
> error: C2440: 'initializing' : cannot convert from 'BYTE *' to 'procptr32_t'
> There is no context in which this conversion is possible

**QL** at line 32:
> error: C2665: 'peekProc' : none of the 2 overloads could convert all the argument types
> ../mumble_plugin_win32.h(99): could be 'bool peekProc(procptr64_t,void *,SIZE_T)'
> ../mumble_plugin_win32.h(93): or       'bool peekProc(procptr32_t,void *,SIZE_T)'
> while trying to match the argument list '(procptr32_t, BYTE, int)'

**Unreal Tournament 3** at line 128:
> error: C2668: 'peekProc' : ambiguous call to overloaded function
> ../mumble_plugin_win32.h(129): could be 'T peekProc<procptr32_t>(procptr64_t)'
> with
> [
>     T=procptr32_t
> ]
> ../mumble_plugin_win32.h(122): or       'T peekProc<procptr32_t>(procptr32_t)'
> with
> [
>     T=procptr32_t
> ]
> while trying to match the argument list '(BYTE)'

**Unreal Tournament 99** at line 102:
> error: C2665: 'peekProc' : none of the 2 overloads could convert all the argument types
> ../mumble_plugin_win32.h(99): could be 'bool peekProc(procptr64_t,void *,SIZE_T)'
> ../mumble_plugin_win32.h(93): or       'bool peekProc(procptr32_t,void *,SIZE_T)'
> while trying to match the argument list '(procptr32_t, char, int)'
At line 158:
> error: C2661: 'peekProc' : no overloaded function takes 2 arguments