### PR TITLE
overlay_gl: unmask framebuffer color components in drawContext().

### DIFF
--- a/overlay_gl/overlay.c
+++ b/overlay_gl/overlay.c
@@ -523,6 +523,8 @@ static void drawContext(Context * ctx, int width, int height) {
 	glPushMatrix();
 	glLoadIdentity();
 
+	glColorMask(GL_TRUE, GL_TRUE, GL_TRUE, GL_TRUE);
+
 	glDisable(GL_ALPHA_TEST);
 	glDisable(GL_AUTO_NORMAL);
 	// Skip clip planes, there are thousands of them.


### PR DESCRIPTION
World of Warcraft masks all colors via glColorMaskIndexedEXT(0, 0, 0, 0, 0)
before we draw our overlay.

This broke overlay rendering on OS X when shadow quality was set
to anything greater than low.

This commit ensures that we allow drawing of colors to the main
framebuffer -- so we can draw the overlay properly.

Fixes mumble-voip/mumble#1010
Fixes mumble-voip/mumble#1561