### PR TITLE
OverlayClient: hide QGraphicsPixmapItems when FPS and time are disabled instead of setting an empty QPixmap.

### DIFF
--- a/src/mumble/OverlayClient.cpp
+++ b/src/mumble/OverlayClient.cpp
@@ -103,24 +103,26 @@ void OverlayClient::updateFPS() {
 		const BasepointPixmap &pm = OverlayTextLine(
 		            QString(QLatin1String("%1")).arg(iroundf(framesPerSecond + 0.5f)),
 		            g.s.os.qfFps).createPixmap(g.s.os.qcFps);
+		qgpiFPS->setVisible(true);
 		qgpiFPS->setPixmap(pm);
 		// offset to use basepoint
 		//TODO: settings are providing a top left anchor, so shift down by ascent
 		qgpiFPS->setOffset(-pm.qpBasePoint + QPoint(0, pm.iAscent));
 		qgpiFPS->updateRender();
 	} else {
-		qgpiFPS->setPixmap(QPixmap());
+		qgpiFPS->setVisible(false);
 	}
 }
 
 void OverlayClient::updateTime() {
 	if (g.s.os.bTime) {
 		const BasepointPixmap &pm = OverlayTextLine(QString(QLatin1String("%1")).arg(QTime::currentTime().toString()), g.s.os.qfFps).createPixmap(g.s.os.qcFps);
+		qgpiTime->setVisible(true);
 		qgpiTime->setPixmap(pm);
 		qgpiTime->setOffset(-pm.qpBasePoint + QPoint(0, pm.iAscent));
 		qgpiTime->updateRender();
 	} else {
-		qgpiTime->setPixmap(QPixmap());
+		qgpiTime->setVisible(false);
 	}
 }
 


### PR DESCRIPTION
Setting an empty QPixmap, at least in Qt 5, causes a great deal of
redraws. The QGraphicsScene triggers a changed() call, and
OverlayClient sends a blit request to the overlay library.

Before, any update to the invisible FPS counter or time view
would cause a full screen blit.

Now, when the overlay is truly empty (no FPS, time or users), no
messages are sent over the wire to the overlay library.