### PR TITLE
Show the SSL cert's SHA1 digest in the "SSL Verification failed" prompt.

### DIFF
--- a/src/mumble/MainWindow.cpp
+++ b/src/mumble/MainWindow.cpp
@@ -2799,8 +2799,12 @@ void MainWindow::serverDisconnected(QAbstractSocket::SocketError err, QString re
 		if (! g.sh->qscCert.isEmpty()) {
 			QSslCertificate c = g.sh->qscCert.at(0);
 			QString basereason;
-			if (! Database::getDigest(host, port).isNull()) {
+			QString actual_digest = QString::fromLatin1(c.digest(QCryptographicHash::Sha1).toHex());
+			QString digests_section = tr("<li>Server certificate digest (SHA-1):\t%1</li>").arg(ViewCert::prettifyDigest(actual_digest));
+			QString expected_digest = Database::getDigest(host, port);
+			if (! expected_digest.isNull()) {
 				basereason = tr("<b>WARNING:</b> The server presented a certificate that was different from the stored one.");
+				digests_section.append(tr("<li>Expected certificate digest (SHA-1):\t%1</li>").arg(ViewCert::prettifyDigest(expected_digest)));
 			} else {
 				basereason = tr("Server presented a certificate which failed verification.");
 			}
@@ -2809,9 +2813,9 @@ void MainWindow::serverDisconnected(QAbstractSocket::SocketError err, QString re
 				qsl << QString::fromLatin1("<li>%1</li>").arg(Qt::escape(e.errorString()));
 
 			QMessageBox qmb(QMessageBox::Warning, QLatin1String("Mumble"),
-			                tr("<p>%1.<br />The specific errors with this certificate are: </p><ol>%2</ol>"
+			                tr("<p>%1</p><ul>%2</ul><p>The specific errors with this certificate are:</p><ol>%3</ol>"
 			                   "<p>Do you wish to accept this certificate anyway?<br />(It will also be stored so you won't be asked this again.)</p>"
-			                  ).arg(basereason).arg(qsl.join(QString())), QMessageBox::Yes | QMessageBox::No, this);
+			                  ).arg(basereason).arg(digests_section).arg(qsl.join(QString())), QMessageBox::Yes | QMessageBox::No, this);
 
 			qmb.setDefaultButton(QMessageBox::No);
 			qmb.setEscapeButton(QMessageBox::No);

--- a/src/mumble/ViewCert.cpp
+++ b/src/mumble/ViewCert.cpp
@@ -57,6 +57,16 @@ ViewCert::ViewCert(QList<QSslCertificate> cl, QWidget *p) : QDialog(p) {
 	resize(510,300);
 }
 
+QString ViewCert::prettifyDigest(QString digest) {
+	QString pretty_digest = digest.toUpper();
+	int step = 2;
+	QChar separator = QChar::fromAscii(':');
+	for (int i = step; i < pretty_digest.size(); i += step + 1) {
+		pretty_digest.insert(i, separator);
+	}
+	return pretty_digest;
+}
+
 void ViewCert::on_Chain_currentRowChanged(int idx) {
 	qlwCert->clear();
 	if ((idx < 0) || (idx >= qlCerts.size()))
@@ -75,7 +85,7 @@ void ViewCert::on_Chain_currentRowChanged(int idx) {
 	l << tr("Valid to: %1").arg(c.expiryDate().toString());
 	l << tr("Serial: %1").arg(QString::fromLatin1(c.serialNumber().toHex()));
 	l << tr("Public Key: %1 bits %2").arg(c.publicKey().length()).arg((c.publicKey().algorithm() == QSsl::Rsa) ? tr("RSA") : tr("DSA"));
-	l << tr("Digest (SHA-1): %1").arg(QString::fromLatin1(c.digest(QCryptographicHash::Sha1).toHex()));
+	l << tr("Digest (SHA-1): %1").arg(prettifyDigest(QString::fromLatin1(c.digest(QCryptographicHash::Sha1).toHex())));
 
 #if QT_VERSION >= 0x050000
 	const QMultiMap<QSsl::AlternativeNameEntryType, QString> &alts = c.subjectAlternativeNames();

--- a/src/mumble/ViewCert.h
+++ b/src/mumble/ViewCert.h
@@ -30,6 +30,7 @@ class ViewCert : public QDialog {
 		void on_Chain_currentRowChanged(int);
 	public:
 		ViewCert(QList<QSslCertificate> c, QWidget *p);
+		static QString prettifyDigest(QString);
 };
 
 #endif


### PR DESCRIPTION
It's pretty awkward to find this information easily which is a problem
when self-signed certificates are used. So, let's show the digest of
the certificate immediately on the "SSL Verification failed"
prompt. Furthermore, if we already have a digest recorded for the
address (from a previous run) and it has changed, we *also* show the
old (expected) digest.