### PR TITLE
Fix Timer class's system-header Boost problems

### DIFF
--- a/src/Timer.cpp
+++ b/src/Timer.cpp
@@ -5,6 +5,23 @@
 
 #include "murmur_pch.h"
 
+#include <boost/version.hpp>
+
+// Not all Boost versions can use a header-only
+// boost_system without build failures.
+//
+// See mumble-voip/mumble#2366.
+//
+// This was fixed in Boost 1.56.0.
+//
+// See:
+//  https://github.com/boostorg/system/blob/boost-1.56.0/include/boost/system/error_code.hpp#L514-L516
+// vs.
+//  https://github.com/boostorg/system/blob/boost-1.55.0/include/boost/system/error_code.hpp#L515-L517
+#if BOOST_VERSION >= 105600
+# define USE_BOOST_CHRONO
+#endif
+
 #include "Timer.h"
 
 Timer::Timer(bool start) {
@@ -44,7 +61,23 @@ bool Timer::operator>(const Timer &other) const {
 	return uiStart < other.uiStart;
 }
 
-#if defined(Q_OS_WIN)
+#ifdef USE_BOOST_CHRONO
+// Ensure boost_system is header only.
+#define BOOST_ERROR_CODE_HEADER_ONLY
+// Ensure boost_chrono is header only.
+#define BOOST_CHRONO_DONT_PROVIDE_HYBRID_ERROR_HANDLING
+#define BOOST_CHRONO_HEADER_ONLY
+
+#include <boost/chrono.hpp>
+
+quint64 Timer::now() {
+	using namespace boost::chrono;
+	time_point<steady_clock> now = steady_clock::now();
+	time_point<steady_clock>::duration epochDuration = now.time_since_epoch();
+	microseconds epochDurationUsec = duration_cast<microseconds>(epochDuration);
+	return static_cast<quint64>(epochDurationUsec.count());
+}
+#elif defined(Q_OS_WIN)
 #include <windows.h>
 
 quint64 Timer::now() {


### PR DESCRIPTION
These commits fix https://github.com/mumble-voip/mumble/issues/2366

We:

1. Revert the Boost patch.
2. Commit my earlier PR to use clock_gettime with CLOCK_MONOTONIC so we have a proper fallback  for POSIX systems that use old-ish Boost versions.
3. Re-introduce the Boost patch, guarded by BOOST_VERSION >= 1.56.0

Not pretty, but at least once we can go C++11 only, we can drop the whole mess and just use std::chrono.