### PR TITLE
overlay_gl: use Elf_Sym instead of Elf64_Sym in FreeBSD specific-code.

### DIFF
--- a/overlay_gl/init_unix.c
+++ b/overlay_gl/init_unix.c
@@ -219,7 +219,7 @@ static int find_odlsym() {
 				strtab = (const char *)((uintptr_t)lm->l_addr + (uintptr_t)dyn->d_un.d_ptr);
 				break;
 			case DT_SYMTAB:
-				symtab = (Elf64_Sym *)((uintptr_t)lm->l_addr + (uintptr_t)dyn->d_un.d_ptr);
+				symtab = (Elf_Sym *)((uintptr_t)lm->l_addr + (uintptr_t)dyn->d_un.d_ptr);
 				break;
 		}
 		dyn++;


### PR DESCRIPTION
This ensures we use the Elf_Sym type instead of Elf64_Sym.

This makes the FreeBSD-specific code work on both 32-bit
and 64-bit targets.

Fixes mumble-voip/mumble#2122