### PR TITLE
Murmur: fix MurmurDBus::addChannel that was broken by Murmur's new locking.

### DIFF
--- a/src/murmur/DBus.cpp
+++ b/src/murmur/DBus.cpp
@@ -378,7 +378,7 @@ void MurmurDBus::addChannel(const QString &name, int chanparent, const QDBusMess
 
 	{
 		QWriteLocker wl(&server->qrwlVoiceThread);
-		server->addChannel(cChannel, name);
+		nc = server->addChannel(cChannel, name);
 	}
 
 	server->updateChannel(nc);


### PR DESCRIPTION
This method was broken by commit f260bd19133086b993a4a0cd027293153b4a15f0.

In particular, the line:

    Channel *nc = server->addChannel(cChannel, name);

was removed by a locked block:

    {
        QWriteLocker wl(&server->qrwlVoiceThread);
        server->addChannel(cChannel, name);
    }

Note that nc is never assigned in the locked block.

See
https://github.com/mumble-voip/mumble/commit/f260bd19133086b993a4a0cd027293153b4a15f0#diff-a6537e937b1df62a77d014d7a8c3008bL377
for the full diff.

Fixes mumble-voip/mumble#2392