### PR TITLE
ViewCert: only include 'QStringList processQSslCertificateInfo(QString in)' when built against Qt 4.

### DIFF
--- a/src/mumble/ViewCert.cpp
+++ b/src/mumble/ViewCert.cpp
@@ -20,13 +20,13 @@ static QStringList processQSslCertificateInfo(QStringList in) {
 	}
 	return list;
 }
-#endif
-
+#else
 static QStringList processQSslCertificateInfo(QString in) {
 	QStringList out;
 	out << decode_utf8_qssl_string(in);
 	return out;
 }
+#endif
 
 static void addQSslCertificateInfo(QStringList &l, const QString &label, const QStringList &items) {
 	foreach (const QString &item, items) {


### PR DESCRIPTION
When building the tree with Qt 5, the processQSslCertificateInfo overload
that takes a QString is unused.

This commit ensures that this overload is only available in Qt 4 builds.

Fixes mumble-voip/mumble#2394