### PR TITLE
overlay: ensure the whole Microsoft Office suite is blacklisted.

### DIFF
--- a/overlay/overlay_blacklist.h
+++ b/overlay/overlay_blacklist.h
@@ -45,7 +45,16 @@ static const char *overlayBlacklist[] = {
 	"EpicGamesLauncher.exe", // Epic, Unreal Tournament launcher
 	"dwm.exe", // Windows Desktop Window Manager
 	"MouseKeyboardCenter.exe",
-	"outlook.exe",
+
+	// Microsoft Office
+	"outlook.exe", // Outlook
+	"winword.exe", // Word
+	"excel.exe", // Excel
+	"powerpnt.exe", // PowerPoint
+	"onenote.exe", // OneNote
+	"mspub.exe", // Publisher
+	"msaccess.exe", // Access
+
 	NULL
 };
 


### PR DESCRIPTION
We might as well...

This is short-term fix until we figure out where to go with
the overlay launcher filter, path filter, etc.

Fixes mumble-voip/mumble#1117