### PR TITLE
mumble: add various Q_DECL_OVERRIDE declarations to fix the macOS build.

### DIFF
--- a/src/mumble/AudioInput.h
+++ b/src/mumble/AudioInput.h
@@ -155,7 +155,7 @@ class AudioInput : public QThread {
 
 		AudioInput();
 		~AudioInput() Q_DECL_OVERRIDE;
-		void run() = 0;
+		void run() Q_DECL_OVERRIDE = 0;
 		virtual bool isAlive() const;
 		bool isTransmitting() const;
 };

--- a/src/mumble/AudioOutput.h
+++ b/src/mumble/AudioOutput.h
@@ -98,7 +98,7 @@ class AudioOutput : public QThread {
 		void addFrameToBuffer(ClientUser *, const QByteArray &, unsigned int iSeq, MessageHandler::UDPMessageType type);
 		void removeBuffer(const ClientUser *);
 		AudioOutputSample *playSample(const QString &filename, bool loop = false);
-		void run() = 0;
+		void run() Q_DECL_OVERRIDE = 0;
 		virtual bool isAlive() const;
 		const float *getSpeakerPos(unsigned int &nspeakers);
 		static float calcGain(float dotproduct, float distance);

--- a/src/mumble/GlobalShortcut.h
+++ b/src/mumble/GlobalShortcut.h
@@ -248,7 +248,7 @@ class GlobalShortcutEngine : public QThread {
 		void resetMap();
 		void remap();
 		virtual void needRemap();
-		void run();
+		void run() Q_DECL_OVERRIDE;
 
 		bool handleButton(const QVariant &, bool);
 		static void add(GlobalShortcut *);

--- a/src/mumble/UserListModel.h
+++ b/src/mumble/UserListModel.h
@@ -42,7 +42,7 @@ class UserListModel : public QAbstractTableModel {
 		bool setData(const QModelIndex &dataIndex, const QVariant &value, int role) Q_DECL_OVERRIDE;
 		Qt::ItemFlags flags(const QModelIndex &flagIndex) const Q_DECL_OVERRIDE;
 	
-		bool removeRows(int row, int count, const QModelIndex &parentIndex = QModelIndex());
+		bool removeRows(int row, int count, const QModelIndex &parentIndex = QModelIndex()) Q_DECL_OVERRIDE;
 	
 		/// Function for removing all rows in a selection
 		void removeRowsInSelection(const QItemSelection &selection);

--- a/src/mumble/UserModel.h
+++ b/src/mumble/UserModel.h
@@ -89,9 +89,9 @@ class UserModel : public QAbstractItemModel {
 		QModelIndex index(Channel *, int column = 0) const;
 		QModelIndex index(ModelItem *) const;
 
-		QVariant data(const QModelIndex &index, int role) const;
-		Qt::ItemFlags flags(const QModelIndex &index) const;
-		QVariant headerData(int section, Qt::Orientation orientation, int role = Qt::DisplayRole) const;
+		QVariant data(const QModelIndex &index, int role) const Q_DECL_OVERRIDE;
+		Qt::ItemFlags flags(const QModelIndex &index) const Q_DECL_OVERRIDE;
+		QVariant headerData(int section, Qt::Orientation orientation, int role = Qt::DisplayRole) const Q_DECL_OVERRIDE;
 		QModelIndex index(int row, int column, const QModelIndex &parent = QModelIndex()) const Q_DECL_OVERRIDE;
 		QModelIndex parent(const QModelIndex &index) const Q_DECL_OVERRIDE;
 		int rowCount(const QModelIndex &parent = QModelIndex()) const Q_DECL_OVERRIDE;


### PR DESCRIPTION
Clang on macOS warns about the lack of the override keyword
for these method declarations.

Add Q_DECL_OVERRIDE to them, to fix the -Werror build on macOS.