### PR TITLE
WASAPI: remove unnecessary Timer.h and User.h includes in WASAPI.cpp.

### DIFF
--- a/src/mumble/WASAPI.cpp
+++ b/src/mumble/WASAPI.cpp
@@ -8,8 +8,6 @@
 #include "WASAPI.h"
 #include "WASAPINotificationClient.h"
 #include "Global.h"
-#include "Timer.h"
-#include "User.h"
 
 
 // Now that Win7 is published, which includes public versions of these


### PR DESCRIPTION
Fixes mumble-voip/mumble#2299