### PR TITLE
Convert all remaining uses of LIBPATH in qmake files to use QMAKE_LIBDIR instead.

### DIFF
--- a/3rdparty/speex-build/AGC.pro
+++ b/3rdparty/speex-build/AGC.pro
@@ -8,4 +8,4 @@ SOURCES = AGC.cpp
 HEADERS = Timer.h
 INCLUDEPATH = ../src ../speex-src/include
 LIBS += -lspeex
-LIBPATH += ../../release
+QMAKE_LIBDIR += ../../release

--- a/3rdparty/speex-build/ResampMark.pro
+++ b/3rdparty/speex-build/ResampMark.pro
@@ -8,4 +8,4 @@ SOURCES = ResampMark.cpp
 HEADERS = Timer.h
 INCLUDEPATH = ../../src ../speex-src/include
 LIBS += -lspeex
-LIBPATH += ../../release
+QMAKE_LIBDIR += ../../release

--- a/3rdparty/speex-build/SpeexMark.pro
+++ b/3rdparty/speex-build/SpeexMark.pro
@@ -8,4 +8,4 @@ SOURCES = SpeexMark.cpp
 HEADERS = Timer.h
 INCLUDEPATH = ../src ../speex-src/include
 LIBS += -lspeex
-LIBPATH += ../../release
+QMAKE_LIBDIR += ../../release

--- a/plugins/manual/manual.pro
+++ b/plugins/manual/manual.pro
@@ -23,11 +23,11 @@ FORMS		+= manual.ui
 # building for win32-static.
 win32:CONFIG(qt_dynamic_lookup) {
     CONFIG(debug, debug|release) {
-        LIBPATH *= ../../debug
+        QMAKE_LIBDIR *= ../../debug
     }
 
     CONFIG(release, debug|release) {
-        LIBPATH *= ../../release
+        QMAKE_LIBDIR *= ../../release
     }
 
     LIBS *= -lmumble_app

--- a/src/tests/Resample.pro
+++ b/src/tests/Resample.pro
@@ -21,11 +21,11 @@ win32 {
 }
 
 CONFIG(debug, debug|release) {
-  LIBPATH	+= ../../debug
+  QMAKE_LIBDIR += ../../debug
   DESTDIR	= ../../debug
 }
 
 CONFIG(release, debug|release) {
-  LIBPATH	+= ../../release
+  QMAKE_LIBDIR += ../../release
   DESTDIR	= ../../release
 }


### PR DESCRIPTION
LIBPATH is deprecated in favor of QMAKE_LIBDIR.