### PR TITLE
TextMessage, RichTextEditor: accept TextMessage dialog when Ctrl-Enter is pressed.

### DIFF
--- a/src/mumble/RichTextEditor.cpp
+++ b/src/mumble/RichTextEditor.cpp
@@ -184,6 +184,9 @@ RichTextEditor::RichTextEditor(QWidget *p) : QTabWidget(p) {
 	updateActions();
 
 	qteRichText->setFocus();
+
+	qteRichText->installEventFilter(this);
+	qptePlainText->installEventFilter(this);
 }
 
 bool RichTextEditor::isModified() const {
@@ -613,6 +616,20 @@ QString RichTextEditor::text() {
 
 	bChanged = false;
 	return qptePlainText->toPlainText();
+}
+
+bool RichTextEditor::eventFilter(QObject *obj, QEvent *evt) {
+	if (obj != qptePlainText && obj != qteRichText)
+		return false;
+	if (evt->type() == QEvent::KeyPress) {
+		QKeyEvent *keyEvent = static_cast<QKeyEvent *>(evt);
+		if (((keyEvent->key() == Qt::Key_Enter) || (keyEvent->key() == Qt::Key_Return)) &&
+		        (keyEvent->modifiers() == Qt::ControlModifier)) {
+			emit accept();
+			return true;
+		}
+	}
+	return false;
 }
 
 bool RichTextImage::isValidImage(const QByteArray &ba, QByteArray &fmt) {

--- a/src/mumble/RichTextEditor.h
+++ b/src/mumble/RichTextEditor.h
@@ -50,10 +50,14 @@ class RichTextEditor : public QTabWidget, Ui::RichTextEditor {
 		bool bReadOnly;
 		void richToPlain();
 		QColor qcColor;
+		bool eventFilter(QObject *obj, QEvent *event) Q_DECL_OVERRIDE;
 	public:
 		RichTextEditor(QWidget *p = NULL);
 		QString text();
 		bool isModified() const;
+	signals:
+		/// The accept signal is emitted when Ctrl-Enter is pressed inside the RichTextEditor.
+		void accept();
 	public slots:
 		void setText(const QString &text, bool readonly = false);
 		void updateColor(const QColor &);

--- a/src/mumble/TextMessage.cpp
+++ b/src/mumble/TextMessage.cpp
@@ -12,8 +12,9 @@ TextMessage::TextMessage(QWidget *p, QString title, bool bChannel) : QDialog(p) 
 	if (!bChannel)
 		qcbTreeMessage->setHidden(true);
 	setWindowTitle(title);
-	rteMessage->installEventFilter(this);
 	bTreeMessage = false;
+
+	QObject::connect(rteMessage, SIGNAL(accept()), this, SLOT(accept()));
 }
 
 void TextMessage::on_qcbTreeMessage_stateChanged(int s) {
@@ -60,18 +61,3 @@ QString TextMessage::autoFormat(QString qsPlain) {
 QString TextMessage::message() {
 	return rteMessage->text();
 }
-
-bool TextMessage::eventFilter(QObject *obj, QEvent *evt) {
-	if (obj != rteMessage)
-		return false;
-	if (evt->type() == QEvent::KeyPress) {
-		QKeyEvent *keyEvent = static_cast<QKeyEvent *>(evt);
-		if (((keyEvent->key() == Qt::Key_Enter) || (keyEvent->key() == Qt::Key_Return)) &&
-		        (keyEvent->modifiers() == Qt::NoModifier)) {
-			accept();
-			return true;
-		}
-	}
-	return false;
-}
-

--- a/src/mumble/TextMessage.h
+++ b/src/mumble/TextMessage.h
@@ -19,7 +19,6 @@ class TextMessage : public QDialog, public Ui::TextMessage {
 	public:
 		TextMessage(QWidget *parent = NULL, QString title = tr("Enter text"), bool bChannel = false);
 		QString message();
-		bool eventFilter(QObject *obj, QEvent *event) Q_DECL_OVERRIDE;
 		static QString autoFormat(QString qsPlain);
 		bool bTreeMessage;
 };


### PR DESCRIPTION
A new signal, accept(), is added on RichTextEditor.
This signal is emitted when Ctrl-Enter is pressed in a RichTextEditor.

This commit rips out an old non-working event filter TextMessage
that was supposed to accept the dialog when the user pressed
Enter. However, this code didn't work anymore because the
QTextEditor widgets of RichTextEditor swallowed all the KeyPress
events.

Finally, in the TextMessage class, the accept() signal from RichTextEditor
is connected to the accept() of TextMessage's QDialog, allowing
users to accept the dialog with Ctrl-Enter.

Fixes mumble-voip/mumble#2294