### PR TITLE
CustomElements: only treat Tab with no modifiers in ChatbarTextEdit as a tabPressed() signal.

### DIFF
--- a/src/mumble/CustomElements.cpp
+++ b/src/mumble/CustomElements.cpp
@@ -160,7 +160,7 @@ bool ChatbarTextEdit::event(QEvent *evt) {
 			}
 			return true;
 		}
-		if (kev->key() == Qt::Key_Tab) {
+		if (kev->key() == Qt::Key_Tab && kev->modifiers() == Qt::NoModifier) {
 			emit tabPressed();
 			return true;
 		} else if (kev->key() == Qt::Key_Space && kev->modifiers() == Qt::ControlModifier) {


### PR DESCRIPTION
The old behavior was overly greedy, and caused Shift-Tab (focus previous)
events to get swallowed by the widget.

This simple change allows Shift-Tab in the ChatbarTextEdit in MainWindow
to work as it should.

Originally, I had implemented this in mumble-voip/mumble#2409, but I
realized that the patch could probably be simplified. This is the result
of that simplification.

Fixes part of mumble-voip/mumble#2291