### PR TITLE
build: add pkgconfig.pri and must_pkgconfig qmake function.

### DIFF
--- a/pkgconfig.pri
+++ b/pkgconfig.pri
@@ -1,0 +1,25 @@
+# Copyright 2005-2016 The Mumble Developers. All rights reserved.
+# Use of this source code is governed by a BSD-style license
+# that can be found in the LICENSE file at the root of the
+# Mumble source tree or at <https://www.mumble.info/LICENSE>.
+
+# must_pkgconfig(pkg)
+#
+# This function checks if the passed-in package
+# name is available on the system. If it is,
+# it is added to the PKGCONFIG variable.
+# If not, exit qmake with a fatal error stating
+# that the package could not be found.
+#
+# Example usage:
+#
+#     must_pkgconfig(openssl)
+#
+defineTest(must_pkgconfig) {
+	pkg = $$1
+	system(pkg-config --exists $$pkg) {
+		PKGCONFIG *= $$pkg
+	} else {
+		error(pkg-config could not find package $$pkg)
+	}
+}

--- a/src/mumble.pri
+++ b/src/mumble.pri
@@ -6,6 +6,7 @@
 include(../compiler.pri)
 include(../qt.pri)
 include(../rcc.pri)
+include(../pkgconfig.pri)
 
 VERSION		= 1.3.0
 DIST		= mumble.pri Message.h PacketDataStream.h CryptState.h Timer.h Version.h OSInfo.h SSL.h
@@ -51,12 +52,12 @@ unix {
 
 	CONFIG *= link_pkgconfig
 
-	PKGCONFIG *= protobuf
+	must_pkgconfig(protobuf)
 
 	contains(UNAME, FreeBSD) {
 		LIBS *= -lcrypto -lssl
 	} else {
-		PKGCONFIG *= openssl
+		must_pkgconfig(openssl)
 	}
 }
 

--- a/src/mumble/mumble.pro
+++ b/src/mumble/mumble.pro
@@ -302,7 +302,8 @@ CONFIG(no-xinput2) {
 }
 
 CONFIG(no-bundled-speex) {
-  PKGCONFIG	*= speex speexdsp
+  must_pkgconfig(speex)
+  must_pkgconfnig(speexdsp)
 }
 
 !CONFIG(no-bundled-speex) {
@@ -352,7 +353,7 @@ CONFIG(no-vorbis-recording) {
 }
 
 unix:!CONFIG(bundled-opus):system(pkg-config --exists opus) {
-  PKGCONFIG *= opus
+  must_pkgconfig(opus)
   DEFINES *= USE_OPUS
 } else {
   !CONFIG(no-opus) {
@@ -447,7 +448,7 @@ unix {
 
   CONFIG *= link_pkgconfig
 
-  PKGCONFIG *= sndfile
+  must_pkgconfig(sndfile)
 
   macx {
     TARGET = Mumble
@@ -489,7 +490,7 @@ unix {
   } else {
     HEADERS *= GlobalShortcut_unix.h
     SOURCES *= GlobalShortcut_unix.cpp TextToSpeech_unix.cpp Overlay_unix.cpp SharedMemory_unix.cpp Log_unix.cpp
-    PKGCONFIG *= x11
+    must_pkgconfig(x11)
     LIBS *= -lrt -lXi
 
     # For MumbleSSL::qsslSanityCheck()
@@ -515,7 +516,7 @@ unix {
 
 alsa {
 	DEFINES *= USE_ALSA
-	PKGCONFIG *= alsa
+	must_pkgconfig(alsa)
 	HEADERS *= ALSAAudio.h
 	SOURCES *= ALSAAudio.cpp
 }
@@ -529,14 +530,14 @@ oss {
 
 pulseaudio {
 	DEFINES *= USE_PULSEAUDIO
-	PKGCONFIG *= libpulse
+	must_pkgconfig(libpulse)
 	HEADERS *= PulseAudio.h
 	SOURCES *= PulseAudio.cpp
 }
 
 portaudio {
 	DEFINES *= USE_PORTAUDIO
-	PKGCONFIG *= portaudio-2.0
+	must_pkgconfig(portaudio-2.0)
 	HEADERS *= PAAudio.h
 	SOURCES *= PAAudio.cpp
 }
@@ -568,7 +569,8 @@ bonjour {
 	}
 	unix:!macx {
 		system(pkg-config --exists avahi-compat-libdns_sd avahi-client) {
-			PKGCONFIG *= avahi-compat-libdns_sd avahi-client
+			must_pkgconfig(avahai-compat-libdns_sd)
+			must_pkgconfig(avahi-client)
 		} else {
 			LIBS *= -ldns_sd
 		}
@@ -586,7 +588,7 @@ speechd {
 	DEFINES *= USE_SPEECHD
 	system(pkg-config --atleast-version=0.8 speech-dispatcher) {
 		DEFINES *= USE_SPEECHD_PKGCONFIG
-		PKGCONFIG *= speech-dispatcher
+		must_pkgconfig(speech-dispatcher)
 	} else {
 		LIBS *= -lspeechd
 		INCLUDEPATH	*= /usr/include/speech-dispatcher

--- a/src/murmur/murmur.pro
+++ b/src/murmur/murmur.pro
@@ -163,7 +163,8 @@ grpc {
 
 	unix {
 		QMAKE_CXXFLAGS *= -std=c++11
-		PKGCONFIG += grpc grpc++
+		must_pkgconfig(grpc)
+		must_pkgconfig(grpc++)
 	}
 }
 
@@ -185,7 +186,8 @@ bonjour {
 	}
 	unix:!macx {
 		system(pkg-config --exists avahi-compat-libdns_sd avahi-client) {
-			PKGCONFIG *= avahi-compat-libdns_sd avahi-client
+			must_pkgconfig(avahi-compat-libdns_sd)
+			must_pkgconfig(avahi-client)
 		} else {
 			LIBS *= -ldns_sd
 		}

--- a/src/murmur_grpcwrapper_protoc_plugin/murmur_grpcwrapper_protoc_plugin.pro
+++ b/src/murmur_grpcwrapper_protoc_plugin/murmur_grpcwrapper_protoc_plugin.pro
@@ -12,6 +12,6 @@ SOURCES = main.cpp
 LIBS = -lprotoc
 CONFIG -= qt
 CONFIG += c++11
-PKGCONFIG += protobuf
+must_pkgconfig(protobuf)
 
 include(../../symbols.pri)


### PR DESCRIPTION
This commit adds a new helper function, must_pkgconfig.

It is intended as a replacement for:

    PKGCONFIG *= openssl

The must_pkgconfig function performs error checking,
and fails if the package is not available.

This is to avoid situations mumble-voip/mumble#2309
where the build environment is not set up correctly
in some way.

When using must_pkgconfig, we fail early with a
clear error message, instead of failing with
a cryptic build-time error later on.