### PR TITLE
Fix must_pkgconfig and misspelling in mumble.pro

### DIFF
--- a/pkgconfig.pri
+++ b/pkgconfig.pri
@@ -19,6 +19,7 @@ defineTest(must_pkgconfig) {
 	pkg = $$1
 	system(pkg-config --exists $$pkg) {
 		PKGCONFIG *= $$pkg
+		export(PKGCONFIG)
 	} else {
 		error(pkg-config could not find package $$pkg)
 	}

--- a/src/mumble/mumble.pro
+++ b/src/mumble/mumble.pro
@@ -303,7 +303,7 @@ CONFIG(no-xinput2) {
 
 CONFIG(no-bundled-speex) {
   must_pkgconfig(speex)
-  must_pkgconfnig(speexdsp)
+  must_pkgconfig(speexdsp)
 }
 
 !CONFIG(no-bundled-speex) {
@@ -569,7 +569,7 @@ bonjour {
 	}
 	unix:!macx {
 		system(pkg-config --exists avahi-compat-libdns_sd avahi-client) {
-			must_pkgconfig(avahai-compat-libdns_sd)
+			must_pkgconfig(avahi-compat-libdns_sd)
 			must_pkgconfig(avahi-client)
 		} else {
 			LIBS *= -ldns_sd


### PR DESCRIPTION
A fix to https://github.com/mumble-voip/mumble/commit/4dc497e6f2693b943b57045ad163f72b8a87c03e («build: add pkgconfig.pri and must_pkgconfig qmake function.») because there are some mistakes in the function names and PKGCONFIG will be empty after the use of the must_pkgconfig function.