### PR TITLE
MainWindow, CustomElements: implement proper Backtab/Shift-Tab behavior for MainWindow::qteChat.

### DIFF
--- a/src/mumble/CustomElements.cpp
+++ b/src/mumble/CustomElements.cpp
@@ -163,6 +163,9 @@ bool ChatbarTextEdit::event(QEvent *evt) {
 		if (kev->key() == Qt::Key_Tab) {
 			emit tabPressed();
 			return true;
+		} else if (kev->key() == Qt::Key_Backtab) {
+			emit backtabPressed();
+			return true;
 		} else if (kev->key() == Qt::Key_Space && kev->modifiers() == Qt::ControlModifier) {
 			emit ctrlSpacePressed();
 			return true;

--- a/src/mumble/CustomElements.h
+++ b/src/mumble/CustomElements.h
@@ -59,6 +59,7 @@ class ChatbarTextEdit : public QTextEdit {
 		unsigned int completeAtCursor();
 	signals:
 		void tabPressed(void);
+		void backtabPressed(void);
 		void ctrlSpacePressed(void);
 		void entered(QString);
 	public slots:

--- a/src/mumble/MainWindow.cpp
+++ b/src/mumble/MainWindow.cpp
@@ -1776,6 +1776,13 @@ void MainWindow::on_qteChat_tabPressed() {
 	qteChat->completeAtCursor();
 }
 
+/// Handles Backtab/Shift-Tab for qteChat, which allows
+/// users to move focus to the previous widget in
+/// MainWindow.
+void MainWindow::on_qteChat_backtabPressed() {
+	focusPreviousChild();
+}
+
 /**
  * Controlls ctrl space username completion and selection for the chatbar.
  * @see ChatbarLineEdit::completeAtCursor()

--- a/src/mumble/MainWindow.h
+++ b/src/mumble/MainWindow.h
@@ -238,6 +238,7 @@ class MainWindow : public QMainWindow, public MessageHandler, public Ui::MainWin
 		void on_qaHelpVersionCheck_triggered();
 		void on_qaQuit_triggered();
 		void on_qteChat_tabPressed();
+		void on_qteChat_backtabPressed();
 		void on_qteChat_ctrlSpacePressed();
 		void on_qtvUsers_customContextMenuRequested(const QPoint &mpos);
 		void on_qteLog_customContextMenuRequested(const QPoint &pos);


### PR DESCRIPTION
This seemingly already works on macOS and Linux, but not on Windows.

Implements part of mumble-voip/mumble#2291