### PR TITLE
Murmur: use aiUdpFlag.load() in comparisons to fix Qt <5.2 build.

### DIFF
--- a/src/murmur/MurmurIce.cpp
+++ b/src/murmur/MurmurIce.cpp
@@ -72,7 +72,7 @@ static void userToUser(const ::User *p, Murmur::User &mp) {
 	mp.udpPing = u->dUDPPingAvg;
 	mp.tcpPing = u->dTCPPingAvg;
 
-	mp.tcponly = u->aiUdpFlag == 0;
+	mp.tcponly = u->aiUdpFlag.load() == 0;
 
 	::Murmur::NetAddress addr(16, 0);
 	const Q_IPV6ADDR &a = u->haAddress.qip6;

--- a/src/murmur/Server.cpp
+++ b/src/murmur/Server.cpp
@@ -894,7 +894,7 @@ bool Server::checkDecrypt(ServerUser *u, const char *encrypt, char *plain, unsig
 }
 
 void Server::sendMessage(ServerUser *u, const char *data, int len, QByteArray &cache, bool force) {
-	if ((u->aiUdpFlag == 1 || force) && (u->sUdpSocket != INVALID_SOCKET)) {
+	if ((u->aiUdpFlag.load() == 1 || force) && (u->sUdpSocket != INVALID_SOCKET)) {
 #if defined(__LP64__)
 		STACKVAR(char, ebuffer, len+4+16);
 		char *buffer = reinterpret_cast<char *>(((reinterpret_cast<quint64>(ebuffer) + 8) & ~7) + 4);


### PR DESCRIPTION
Fixes mumble-voip/mumble#2418