### PR TITLE
Add the ACL to Remove the Comment or Avatar

### DIFF
--- a/src/ACL.cpp
+++ b/src/ACL.cpp
@@ -97,15 +97,17 @@ QFlags<ChanACL::Perm> ChanACL::effectivePermissions(ServerUser *p, Channel *chan
 						granted |= Kick;
 					if (acl->pAllow & Ban)
 						granted |= Ban;
-					if (acl->pAllow & ResetCommentTexture)
-						granted |= ResetCommentTexture;
+					if (acl->pAllow & ResetComment)
+						granted |= ResetComment;
+                                        if (acl->pAllow & ResetTexture)
+                                                granted |= ResetTexture;
 					if (acl->pAllow & Register)
 						granted |= Register;
 					if (acl->pAllow & SelfRegister)
 						granted |= SelfRegister;
 				}
 				if ((ch==chan && acl->bApplyHere) || (ch!=chan && acl->bApplySubs)) {
-					granted |= (acl->pAllow & ~(Kick|Ban|ResetCommentTexture|Register|SelfRegister|Cached));
+					granted |= (acl->pAllow & ~(Kick|Ban|ResetComment|ResetTexture|Register|SelfRegister|Cached));
 					granted &= ~acl->pDeny;
 				}
 			}
@@ -119,7 +121,7 @@ QFlags<ChanACL::Perm> ChanACL::effectivePermissions(ServerUser *p, Channel *chan
 	if (granted & Write) {
 		granted |= Traverse|Enter|MuteDeafen|Move|MakeChannel|LinkChannel|TextMessage|MakeTempChannel;
 		if (chan->iId == 0)
-			granted |= Kick|Ban|ResetCommentTexture|Register|SelfRegister;
+			granted |= Kick|Ban|ResetComment|ResetTexture|Register|SelfRegister;
 	}
 
 	if (cache) {
@@ -180,8 +182,10 @@ QString ChanACL::whatsThis(Perm p) {
 			return tr("This represents the permission to forcibly remove users from the server.");
 		case Ban:
 			return tr("This represents the permission to permanently remove users from the server.");
-		case ResetCommentTexture:
-			return tr("This represents the permission to reset the avatar or the comment from a user.");
+		case ResetComment:
+			return tr("This represents the permission to reset the comment from a user.");
+		case ResetTexture:
+			return tr("This represents the permission to reset the profil picture of a user.");
 		case Register:
 			return tr("This represents the permission to register and unregister users on the server.");
 		case SelfRegister:
@@ -233,8 +237,10 @@ QString ChanACL::permName(Perm p) {
 			return tr("Kick");
 		case Ban:
 			return tr("Ban");
-		case ResetCommentTexture:
-			return tr("Reset Comment and Avatar");
+		case ResetComment:
+			return tr("Reset Comment");
+		case ResetTexture:
+			return tr("Reset Avatar");
 		case Register:
 			return tr("Register User");
 		case SelfRegister:

--- a/src/ACL.cpp
+++ b/src/ACL.cpp
@@ -97,13 +97,15 @@ QFlags<ChanACL::Perm> ChanACL::effectivePermissions(ServerUser *p, Channel *chan
 						granted |= Kick;
 					if (acl->pAllow & Ban)
 						granted |= Ban;
+					if (acl->pAllow & ResetCommentTexture)
+						granted |= ResetCommentTexture;
 					if (acl->pAllow & Register)
 						granted |= Register;
 					if (acl->pAllow & SelfRegister)
 						granted |= SelfRegister;
 				}
 				if ((ch==chan && acl->bApplyHere) || (ch!=chan && acl->bApplySubs)) {
-					granted |= (acl->pAllow & ~(Kick|Ban|Register|SelfRegister|Cached));
+					granted |= (acl->pAllow & ~(Kick|Ban|ResetCommentTexture|Register|SelfRegister|Cached));
 					granted &= ~acl->pDeny;
 				}
 			}
@@ -117,7 +119,7 @@ QFlags<ChanACL::Perm> ChanACL::effectivePermissions(ServerUser *p, Channel *chan
 	if (granted & Write) {
 		granted |= Traverse|Enter|MuteDeafen|Move|MakeChannel|LinkChannel|TextMessage|MakeTempChannel;
 		if (chan->iId == 0)
-			granted |= Kick|Ban|Register|SelfRegister;
+			granted |= Kick|Ban|ResetCommentTexture|Register|SelfRegister;
 	}
 
 	if (cache) {
@@ -178,6 +180,8 @@ QString ChanACL::whatsThis(Perm p) {
 			return tr("This represents the permission to forcibly remove users from the server.");
 		case Ban:
 			return tr("This represents the permission to permanently remove users from the server.");
+		case ResetCommentTexture:
+			return tr("This represents the permission to reset the avatar or the comment from a user.");
 		case Register:
 			return tr("This represents the permission to register and unregister users on the server.");
 		case SelfRegister:
@@ -229,6 +233,8 @@ QString ChanACL::permName(Perm p) {
 			return tr("Kick");
 		case Ban:
 			return tr("Ban");
+		case ResetCommentTexture:
+			return tr("Reset Comment and Avatar");
 		case Register:
 			return tr("Register User");
 		case SelfRegister:

--- a/src/ACL.h
+++ b/src/ACL.h
@@ -35,12 +35,13 @@ class ChanACL : public QObject {
 			// Root channel only
 			Kick = 0x10000,
 			Ban = 0x20000,
-			ResetCommentTexture = 0x40000,
-			Register = 0x80000,
-			SelfRegister = 0x100000,
+			Register = 0x40000,
+			SelfRegister = 0x80000,
+			ResetComment = 0x100000,
+			ResetTexture = 0x200000,
 
 			Cached = 0x8000000,
-			All = 0x1F07FF
+			All = 0x3f07ff
 		};
 
 		Q_DECLARE_FLAGS(Permissions, Perm)

--- a/src/ACL.h
+++ b/src/ACL.h
@@ -35,11 +35,12 @@ class ChanACL : public QObject {
 			// Root channel only
 			Kick = 0x10000,
 			Ban = 0x20000,
-			Register = 0x40000,
-			SelfRegister = 0x80000,
+			ResetCommentTexture = 0x40000,
+			Register = 0x80000,
+			SelfRegister = 0x100000,
 
 			Cached = 0x8000000,
-			All = 0xf07ff
+			All = 0x1F07FF
 		};
 
 		Q_DECLARE_FLAGS(Permissions, Perm)

--- a/src/mumble/MainWindow.cpp
+++ b/src/mumble/MainWindow.cpp
@@ -1453,8 +1453,8 @@ void MainWindow::qmUser_aboutToShow() {
 		qaUserLocalMute->setEnabled(! self);
 		qaUserLocalVolume->setEnabled(! self);
 		qaUserLocalIgnore->setEnabled(! self);
-		qaUserCommentReset->setEnabled(! p->qbaCommentHash.isEmpty() && (g.pPermissions & (ChanACL::Move | ChanACL::Write)));
-		qaUserTextureReset->setEnabled(! p->qbaTextureHash.isEmpty() && (g.pPermissions & (ChanACL::Move | ChanACL::Write)));
+		qaUserCommentReset->setEnabled(! p->qbaCommentHash.isEmpty() && (g.pPermissions & (ChanACL::ResetCommentTexture | ChanACL::Write)));
+		qaUserTextureReset->setEnabled(! p->qbaTextureHash.isEmpty() && (g.pPermissions & (ChanACL::ResetCommentTexture | ChanACL::Write)));
 		qaUserCommentView->setEnabled(! p->qbaCommentHash.isEmpty());
 
 		qaUserMute->setChecked(p->bMute || p->bSuppress);

--- a/src/mumble/MainWindow.cpp
+++ b/src/mumble/MainWindow.cpp
@@ -1453,8 +1453,8 @@ void MainWindow::qmUser_aboutToShow() {
 		qaUserLocalMute->setEnabled(! self);
 		qaUserLocalVolume->setEnabled(! self);
 		qaUserLocalIgnore->setEnabled(! self);
-		qaUserCommentReset->setEnabled(! p->qbaCommentHash.isEmpty() && (g.pPermissions & (ChanACL::ResetCommentTexture | ChanACL::Write)));
-		qaUserTextureReset->setEnabled(! p->qbaTextureHash.isEmpty() && (g.pPermissions & (ChanACL::ResetCommentTexture | ChanACL::Write)));
+		qaUserCommentReset->setEnabled(! p->qbaCommentHash.isEmpty() && (g.pPermissions & (ChanACL::ResetComment | ChanACL::Write)));
+		qaUserTextureReset->setEnabled(! p->qbaTextureHash.isEmpty() && (g.pPermissions & (ChanACL::ResetTexture | ChanACL::Write)));
 		qaUserCommentView->setEnabled(! p->qbaCommentHash.isEmpty());
 
 		qaUserMute->setChecked(p->bMute || p->bSuppress);

--- a/src/murmur/Messages.cpp
+++ b/src/murmur/Messages.cpp
@@ -547,8 +547,8 @@ void Server::msgUserState(ServerUser *uSource, MumbleProto::UserState &msg) {
 		bool changed = false;
 		comment = u8(msg.comment());
 		if (uSource != pDstServerUser) {
-			if (! hasPermission(uSource, root, ChanACL::Move)) {
-				PERM_DENIED(uSource, root, ChanACL::Move);
+			if (! hasPermission(uSource, root, ChanACL::ResetCommentTexture)) {
+				PERM_DENIED(uSource, root, ChanACL::ResetCommentTexture);
 				return;
 			}
 			if (comment.length() > 0) {

--- a/src/murmur/Messages.cpp
+++ b/src/murmur/Messages.cpp
@@ -547,8 +547,8 @@ void Server::msgUserState(ServerUser *uSource, MumbleProto::UserState &msg) {
 		bool changed = false;
 		comment = u8(msg.comment());
 		if (uSource != pDstServerUser) {
-			if (! hasPermission(uSource, root, ChanACL::ResetCommentTexture)) {
-				PERM_DENIED(uSource, root, ChanACL::ResetCommentTexture);
+			if (! hasPermission(uSource, root, ChanACL::ResetComment)) {
+				PERM_DENIED(uSource, root, ChanACL::ResetComment);
 				return;
 			}
 			if (comment.length() > 0) {
@@ -572,8 +572,8 @@ void Server::msgUserState(ServerUser *uSource, MumbleProto::UserState &msg) {
 			return;
 		}
 		if (uSource != pDstServerUser) {
-			if (! hasPermission(uSource, root, ChanACL::Move)) {
-				PERM_DENIED(uSource, root, ChanACL::Move);
+			if (! hasPermission(uSource, root, ChanACL::ResetTexture)) {
+				PERM_DENIED(uSource, root, ChanACL::ResetTexture);
 				return;
 			}
 			if (msg.texture().length() > 0) {


### PR DESCRIPTION
An ACL split that Users, who has the right to move can no longer reset the Avatar or the Comment of a User.
