### PR TITLE
Fix updatecheck result logging

### DIFF
--- a/src/mumble/VersionCheck.cpp
+++ b/src/mumble/VersionCheck.cpp
@@ -12,8 +12,6 @@
 #include "WebFetch.h"
 
 VersionCheck::VersionCheck(bool autocheck, QObject *p, bool focus) : QObject(p) {
-	bSilent = autocheck;
-
 	QUrl url;
 	url.setPath(focus ? QLatin1String("/v1/banner") : QLatin1String("/v1/version-check"));
 
@@ -184,7 +182,7 @@ void VersionCheck::fetched(QByteArray a, QUrl url) {
 			g.mw->msgBox(QString::fromUtf8(a));
 #endif
 		}
-	} else if (bSilent) {
+	} else {
 		g.mw->msgBox(tr("Mumble failed to retrieve version information from the central server."));
 	}
 

--- a/src/mumble/VersionCheck.h
+++ b/src/mumble/VersionCheck.h
@@ -14,8 +14,6 @@ class VersionCheck : public QObject {
 	private:
 		Q_OBJECT
 		Q_DISABLE_COPY(VersionCheck)
-	protected:
-		bool bSilent;
 	public slots:
 		void fetched(QByteArray data, QUrl url);
 	public:


### PR DESCRIPTION
Entirely drop the separate autoupdate logic, and no longer use the `auto` parameter of the update check service. Always log success/failure on any update check.

Fixes unintended backwards logic of when to log result (by always logging as mentioned).

Three commits you may want to check individually. They also contain further info about the individual changes.