### PR TITLE
LCD: add workarounds for LCD drawing on Qt 5.6.

### DIFF
--- a/src/mumble/LCD.cpp
+++ b/src/mumble/LCD.cpp
@@ -188,7 +188,14 @@ LCD::LCD() : QObject() {
 		d->setEnabled(enabled);
 	}
 	qiLogo = QIcon(QLatin1String("skin:mumble.svg")).pixmap(48,48).toImage().convertToFormat(QImage::Format_MonoLSB);
+
+#if QT_VERSION >= 0x050600
+	// Don't invert the logo image when using Qt 5.6.
+	// See mumble-voip/mumble#2429
+#else
 	qiLogo.invertPixels();
+#endif
+
 	updateUserView();
 }
 
@@ -242,7 +249,15 @@ void LCD::updateUserView() {
 		QImage *img = qhImages.value(size);
 		QPainter painter(img);
 		painter.setRenderHints(QPainter::Antialiasing | QPainter::TextAntialiasing, false);
+
+#if QT_VERSION >= 0x050600
+		// Use Qt::white instead of Qt::color1 on Qt 5.6.
+		// See mumble-voip/mumble#2429
+		painter.setPen(Qt::white);
+#else
 		painter.setPen(Qt::color1);
+#endif
+
 		painter.setFont(qfNormal);
 
 		img->fill(Qt::color0);


### PR DESCRIPTION
This is a temporary workaround until we can get the issue fixed
upstream.

See mumble-voip/mumble#2429 for more information.