### PR TITLE
GlobalShortcut_win: add additional diagnostic logging to the DirectInput backend

### DIFF
--- a/src/mumble/GlobalShortcut_win.cpp
+++ b/src/mumble/GlobalShortcut_win.cpp
@@ -400,6 +400,14 @@ BOOL CALLBACK GlobalShortcutWin::EnumDeviceObjectsCallback(LPCDIDEVICEOBJECTINST
 	QString name = QString::fromUtf16(reinterpret_cast<const ushort *>(lpddoi->tszName));
 	id->qhNames[lpddoi->dwType] = name;
 
+	if (g.s.bDirectInputVerboseLogging) {
+		qWarning("GlobalShortcutWin: EnumObjects: device %s %s object 0x%.8x %s",
+		         qPrintable(QUuid(id->guid).toString()),
+		         qPrintable(id->name),
+		         lpddoi->dwType,
+		         qPrintable(name));
+	}
+
 	return DIENUM_CONTINUE;
 }
 

--- a/src/mumble/GlobalShortcut_win.cpp
+++ b/src/mumble/GlobalShortcut_win.cpp
@@ -481,9 +481,13 @@ BOOL GlobalShortcutWin::EnumDevicesCB(LPCDIDEVICEINSTANCE pdidi, LPVOID pContext
 	// blacklist, we need a more structured aproach.
 	{
 		if (id->vendor_id == 0x262A) {
-			qWarning("GlobalShortcutWin: rejected blacklisted device %s (GUID: %s, PGUID: %s, VID: 0x%.4x, PID: 0x%.4x)",
-			         qPrintable(id->name), qPrintable(id->vguid.toString()), qPrintable(id->vguidproduct.toString()),
-			         id->vendor_id, id->product_id);
+			qWarning("GlobalShortcutWin: rejected blacklisted device %s (GUID: %s, PGUID: %s, VID: 0x%.4x, PID: 0x%.4x, TYPE: 0x%.8x)",
+			         qPrintable(id->name),
+			         qPrintable(id->vguid.toString()),
+			         qPrintable(id->vguidproduct.toString()),
+			         id->vendor_id,
+			         id->product_id,
+			         pdidi->dwDevType);
 			delete id;
 			return DIENUM_CONTINUE;
 		}

--- a/src/mumble/GlobalShortcut_win.cpp
+++ b/src/mumble/GlobalShortcut_win.cpp
@@ -543,7 +543,13 @@ BOOL GlobalShortcutWin::EnumDevicesCB(LPCDIDEVICEINSTANCE pdidi, LPVOID pContext
 		if (FAILED(hr = id->pDID->SetProperty(DIPROP_BUFFERSIZE, &dipdw.diph)))
 			qFatal("GlobalShortcutWin: SetProperty: %lx", hr);
 
-		qWarning("Adding device %s %s %s:%d", qPrintable(QUuid(id->guid).toString()),qPrintable(name),qPrintable(sname),id->qhNames.count());
+		qWarning("Adding device %s %s %s:%d type 0x%.8x",
+		         qPrintable(QUuid(id->guid).toString()),
+		         qPrintable(name),
+		         qPrintable(sname),
+		         id->qhNames.count(),
+		         pdidi->dwDevType);
+
 		cbgsw->qhInputDevices[id->guid] = id;
 	} else {
 		id->pDID->Release();

--- a/src/mumble/Settings.cpp
+++ b/src/mumble/Settings.cpp
@@ -390,6 +390,7 @@ Settings::Settings() {
 	bEnableXInput2 = true;
 	bEnableGKey = true;
 	bEnableXboxInput = true;
+	bDirectInputVerboseLogging = false;
 
 	for (int i=Log::firstMsgType; i<=Log::lastMsgType; ++i) {
 		qmMessages.insert(i, Settings::LogConsole | Settings::LogBalloon | Settings::LogTTS);
@@ -718,6 +719,7 @@ void Settings::load(QSettings* settings_ptr) {
 	SAVELOAD(bEnableXInput2, "shortcut/x11/xinput2/enable");
 	SAVELOAD(bEnableGKey, "shortcut/gkey");
 	SAVELOAD(bEnableXboxInput, "shortcut/windows/xbox/enable");
+	SAVELOAD(bDirectInputVerboseLogging, "shortcut/windows/directinput/verboselogging");
 
 	int nshorts = settings_ptr->beginReadArray(QLatin1String("shortcuts"));
 	for (int i=0; i<nshorts; i++) {
@@ -1023,6 +1025,7 @@ void Settings::save() {
 	SAVELOAD(bEnableEvdev, "shortcut/linux/evdev/enable");
 	SAVELOAD(bEnableXInput2, "shortcut/x11/xinput2/enable");
 	SAVELOAD(bEnableXboxInput, "shortcut/windows/xbox/enable");
+	SAVELOAD(bDirectInputVerboseLogging, "shortcut/windows/directinput/verboselogging");
 
 	settings_ptr->beginWriteArray(QLatin1String("shortcuts"));
 	int idx = 0;

--- a/src/mumble/Settings.h
+++ b/src/mumble/Settings.h
@@ -229,6 +229,8 @@ struct Settings {
 	bool bEnableXInput2;
 	bool bEnableGKey;
 	bool bEnableXboxInput;
+	/// Enable verbose logging in GlobalShortcutWin's DirectInput backend.
+	bool bDirectInputVerboseLogging;
 	QList<Shortcut> qlShortcuts;
 
 	enum MessageLog { LogNone = 0x00, LogConsole = 0x01, LogTTS = 0x02, LogBalloon = 0x04, LogSoundfile = 0x08};


### PR DESCRIPTION
This PR adds

 - A verbose logging mode in which all objects (buttons, axes, etc.) of a DirectInput device are logged.
 - Logging of dwDevType when adding or rejecting a device. This is to help troubleshooting in the future. For example, it might turn out that devices that misbehave for us share a device type, or similar.