### PR TITLE
ManualPlugin: use same mumble_plugin.h preamble in both ManualPlugin.cpp and ManualPlugin.h.

### DIFF
--- a/src/mumble/ManualPlugin.cpp
+++ b/src/mumble/ManualPlugin.cpp
@@ -22,9 +22,6 @@
 #ifdef Q_OS_UNIX
 #define __cdecl
 typedef WId HWND;
-#define DLL_PUBLIC __attribute__((visibility("default")))
-#else
-#define DLL_PUBLIC __declspec(dllexport)
 #endif
 
 #include "../../plugins/mumble_plugin.h"

--- a/src/mumble/ManualPlugin.h
+++ b/src/mumble/ManualPlugin.h
@@ -19,11 +19,9 @@
 
 #include "ui_ManualPlugin.h"
 
-#ifdef Q_OS_UNIX
-typedef WId HWND;
-#endif
 
-#include "../../plugins/mumble_plugin.h"
+typedef struct _MumblePlugin MumblePlugin;
+typedef struct _MumblePluginQt MumblePluginQt;
 
 class Manual : public QDialog, public Ui::Manual {
 		Q_OBJECT


### PR DESCRIPTION
Clang knows about __cdecl (and ignores it), but GCC 4.2 as used on the OS X Universal
builder does not.

Fix that by using the exact same preamble as we use in ManualPlugin.cpp

Fixes mumble-voip/mumble#2439