### PR TITLE
plugins: allow getModuleAddr() to enumerate 32-bit modules in WoW64 mode.

### DIFF
--- a/plugins/mumble_plugin_win32_ptr_type.h
+++ b/plugins/mumble_plugin_win32_ptr_type.h
@@ -51,7 +51,7 @@ static inline PTR_TYPE_CONCRETE getModuleAddr(DWORD pid, const wchar_t *modname)
 	MODULEENTRY32 me;
 	PTR_TYPE_CONCRETE addr = NULL;
 	me.dwSize = sizeof(me);
-	HANDLE hSnap = CreateToolhelp32Snapshot(TH32CS_SNAPMODULE, pid);
+	HANDLE hSnap = CreateToolhelp32Snapshot(TH32CS_SNAPMODULE|TH32CS_SNAPMODULE32, pid);
 	if (hSnap != INVALID_HANDLE_VALUE) {
 		BOOL ok = Module32First(hSnap, &me);
 


### PR DESCRIPTION
Include TH32CS_SNAPMODULE32 in call to CreateToolhelp32Snapshot.

This fixes module enumeration in getModuleAddr().

Without this flag, if called from a WoW64 process, we'll only see the
64-bit DLLs of the process (i.e., WoW64 specific DLLs) such as:

  ntdll.dll
  wow64.dll
  wow64win.dll
  wow64cpu.dll

and nothing else.

With this flag, we get everything.

Fixes mumble-voip/mumble#2437