### PR TITLE
AudioWizard: always use ClassicStyle.

### DIFF
--- a/src/mumble/AudioWizard.ui
+++ b/src/mumble/AudioWizard.ui
@@ -13,6 +13,9 @@
   <property name="windowTitle">
    <string>Audio Tuning Wizard</string>
   </property>
+  <property name="wizardStyle">
+   <enum>QWizard::ClassicStyle</enum>
+  </property>
   <widget class="CompletablePage" name="qwpIntro">
    <property name="title">
     <string>Introduction</string>


### PR DESCRIPTION
This is a sensible default, because it looks good using all themes.
Previously, we used Qt's default style, which is platform-specific.
On Windows, we got an Aero-like style.

This change also fixes our issue with some parts of the wizard not
being styled correctly.

Fixes mumble-voip/mumble#2436