### PR TITLE
OSInfo: fix new Windows 10 OSInfo to not include NUL values in the displayable version string.

### DIFF
--- a/src/OSInfo.cpp
+++ b/src/OSInfo.cpp
@@ -23,6 +23,20 @@
 #include "Version.h"
 
 #if defined(Q_OS_WIN)
+// regString converts a wchar_t string of size to a
+// QString. If the string contains a NUL value, that
+// NUL value will terminate the string.
+static QString regString(wchar_t *string, int size) {
+	if (size <= 0) {
+		return QString();
+	}
+	// If string contains a NUL, adjust the size such
+	// that the NUL is not included in the returned
+	// string.
+	const size_t adjustedSize = wcsnlen(string, static_cast<size_t>(size));
+	return QString::fromWCharArray(string, adjustedSize);
+}
+
 /// Query for a Windows 10-style displayable version.
 ///
 /// This returns a string of the kind:
@@ -67,7 +81,7 @@ static QString win10DisplayableVersion() {
 		RegCloseKey(key);
 		return QString();
 	}
-	productName = QString::fromWCharArray(buf, static_cast<int>(len / sizeof(buf[0])));
+	productName = regString(buf, static_cast<int>(len / sizeof(buf[0])));
 
 	len = sizeof(buf);
 	err = RegQueryValueEx(key, L"ReleaseId", NULL, NULL, reinterpret_cast<LPBYTE>(&buf[0]), &len);
@@ -75,7 +89,7 @@ static QString win10DisplayableVersion() {
 		RegCloseKey(key);
 		return QString();
 	}
-	releaseId = QString::fromWCharArray(buf, static_cast<int>(len / sizeof(buf[0])));
+	releaseId = regString(buf, static_cast<int>(len / sizeof(buf[0])));
 
 	len = sizeof(buf);
 	err = RegQueryValueEx(key, L"CurrentBuild", NULL, NULL, reinterpret_cast<LPBYTE>(&buf[0]), &len);
@@ -83,7 +97,7 @@ static QString win10DisplayableVersion() {
 		RegCloseKey(key);
 		return QString();
 	}
-	currentBuild = QString::fromWCharArray(buf, static_cast<int>(len / sizeof(buf[0])));
+	currentBuild = regString(buf, static_cast<int>(len / sizeof(buf[0])));
 
 	len = sizeof(dw);
 	err = RegQueryValueEx(key, L"UBR", NULL, NULL, reinterpret_cast<LPBYTE>(&dw), &len);


### PR DESCRIPTION
These strings from the registry are NUL terminated, but in practice, this
isn't guaranteed.

This means that the displayable version string for Windows 10 currently
contains NUL values.

The Mumble client doesn't care, but it isn't very nice. It breaks things
like CVP providers that don't sanitize Murmur's output.

To fix the problem, this change introduces a regString function that
converts a wchar_t string to QString. Any NUL value in the input
string will terminate the string.

Fixes mumble-voip/mumble#2469