### PR TITLE
Fix for ban reason context menu overlap.

### DIFF
--- a/src/mumble/BanEditor.ui
+++ b/src/mumble/BanEditor.ui
@@ -151,9 +151,6 @@
         <property name="toolTip">
          <string>Reason for the ban</string>
         </property>
-        <property name="layoutDirection">
-         <enum>Qt::RightToLeft</enum>
-        </property>
         <property name="placeholderText">
          <string>No reason</string>
         </property>


### PR DESCRIPTION
This commit removes the `Qt::RightToLeft` property from `qleReason`. This fixes issue #2474.