### PR TITLE
Log: check for QSizeF::isValid() in Log::validHtml()

### DIFF
--- a/src/mumble/Log.cpp
+++ b/src/mumble/Log.cpp
@@ -416,12 +416,12 @@ QString Log::validHtml(const QString &html, bool allowReplacement, QTextCursor *
 	qtd.adjustSize();
 	QSizeF s = qtd.size();
 
-	if (!valid || (s.width() > qr.width()) || (s.height() > qr.height())) {
+	if (!valid || !s.isValid() || (s.width() > qr.width()) || (s.height() > qr.height())) {
 		qtd.setPlainText(html);
 		qtd.adjustSize();
 		s = qtd.size();
 
-		if ((s.width() > qr.width()) || (s.height() > qr.height())) {
+		if (!s.isValid() || (s.width() > qr.width()) || (s.height() > qr.height())) {
 			QString errorMessage = tr("[[ Text object too large to display ]]");
 			if (tc) {
 				tc->insertText(errorMessage);


### PR DESCRIPTION
A fix to #2477 because it is possible to create an element with width and height that is to long for [qreal](http://doc.qt.io/qt-5/qtglobal.html#qreal-typedef).