### PR TITLE
3rdparty/xinputcheck-src: add Xbox One controller GUIDs to avoid device list querying for Xbox One controllers.

### DIFF
--- a/3rdparty/xinputcheck-src/xinputcheck.cpp
+++ b/3rdparty/xinputcheck-src/xinputcheck.cpp
@@ -76,11 +76,17 @@ SDL_IsXInputDevice(const GUID* pGuidProductFromDirectInput)
     static GUID IID_ValveStreamingGamepad = { MAKELONG(0x28DE, 0x11FF), 0x0000, 0x0000, { 0x00, 0x00, 0x50, 0x49, 0x44, 0x56, 0x49, 0x44 } };
     static GUID IID_X360WiredGamepad = { MAKELONG(0x045E, 0x02A1), 0x0000, 0x0000, { 0x00, 0x00, 0x50, 0x49, 0x44, 0x56, 0x49, 0x44 } };
     static GUID IID_X360WirelessGamepad = { MAKELONG(0x045E, 0x028E), 0x0000, 0x0000, { 0x00, 0x00, 0x50, 0x49, 0x44, 0x56, 0x49, 0x44 } };
+    static GUID IID_XOneWiredGamepad = { MAKELONG(0x045E, 0x02FF), 0x0000, 0x0000, { 0x00, 0x00, 0x50, 0x49, 0x44, 0x56, 0x49, 0x44 } };
+    static GUID IID_XOneWirelessGamepad = { MAKELONG(0x045E, 0x02DD), 0x0000, 0x0000, { 0x00, 0x00, 0x50, 0x49, 0x44, 0x56, 0x49, 0x44 } };
+    static GUID IID_XOneBluetoothGamepad = { MAKELONG(0x045E, 0x02E0), 0x0000, 0x0000, { 0x00, 0x00, 0x50, 0x49, 0x44, 0x56, 0x49, 0x44 } };
 
     static const GUID *s_XInputProductGUID[] = {
         &IID_ValveStreamingGamepad,
-        &IID_X360WiredGamepad,   /* Microsoft's wired X360 controller for Windows. */
-        &IID_X360WirelessGamepad /* Microsoft's wireless X360 controller for Windows. */
+        &IID_X360WiredGamepad,     /* Microsoft's wired X360 controller for Windows. */
+        &IID_X360WirelessGamepad,  /* Microsoft's wireless X360 controller for Windows. */
+        &IID_XOneWiredGamepad,     /* Microsoft's wired Xbox One controller for Windows. */
+        &IID_XOneWirelessGamepad,  /* Microsoft's wireless Xbox One controller for Windows. */
+        &IID_XOneBluetoothGamepad  /* Microsoft's Bluetooth Xbox One controller for Windows. */
     };
 
     size_t iDevice;


### PR DESCRIPTION
Querying the device list and checking whether IG_ is in the name does
not work on Windows 10 Anniversary Update (1607).

To work around that, we add the GUIDs for all Xbox One controllers.

This should fix the problem for the most common XInput devices for now.

Presumably, Microsoft will fix this later on. But for now, this will do.

The good thing about doing it this way is that it isn't a workaround per
se -- it's an optimization that already exists in the code.

Fixes mumble-voip/mumble#2483