### PR TITLE
3rdparty/xinputcheck-src: add Xbox One S wireless (non-Bluetooth) and Xbox One Elite wireless.

### DIFF
--- a/3rdparty/xinputcheck-src/xinputcheck.cpp
+++ b/3rdparty/xinputcheck-src/xinputcheck.cpp
@@ -78,15 +78,19 @@ SDL_IsXInputDevice(const GUID* pGuidProductFromDirectInput)
     static GUID IID_X360WirelessGamepad = { MAKELONG(0x045E, 0x028E), 0x0000, 0x0000, { 0x00, 0x00, 0x50, 0x49, 0x44, 0x56, 0x49, 0x44 } };
     static GUID IID_XOneWiredGamepad = { MAKELONG(0x045E, 0x02FF), 0x0000, 0x0000, { 0x00, 0x00, 0x50, 0x49, 0x44, 0x56, 0x49, 0x44 } };
     static GUID IID_XOneWirelessGamepad = { MAKELONG(0x045E, 0x02DD), 0x0000, 0x0000, { 0x00, 0x00, 0x50, 0x49, 0x44, 0x56, 0x49, 0x44 } };
-    static GUID IID_XOneBluetoothGamepad = { MAKELONG(0x045E, 0x02E0), 0x0000, 0x0000, { 0x00, 0x00, 0x50, 0x49, 0x44, 0x56, 0x49, 0x44 } };
+    static GUID IID_XOneSWirelessGamepad = { MAKELONG(0x045E, 0x02EA), 0x0000, 0x0000, { 0x00, 0x00, 0x50, 0x49, 0x44, 0x56, 0x49, 0x44 } };
+    static GUID IID_XOneSBluetoothGamepad = { MAKELONG(0x045E, 0x02E0), 0x0000, 0x0000, { 0x00, 0x00, 0x50, 0x49, 0x44, 0x56, 0x49, 0x44 } };
+    static GUID IID_XOneEliteWirelessGamepad = { MAKELONG(0x045E, 0x02E3), 0x0000, 0x0000, { 0x00, 0x00, 0x50, 0x49, 0x44, 0x56, 0x49, 0x44 } };
 
     static const GUID *s_XInputProductGUID[] = {
         &IID_ValveStreamingGamepad,
-        &IID_X360WiredGamepad,     /* Microsoft's wired X360 controller for Windows. */
-        &IID_X360WirelessGamepad,  /* Microsoft's wireless X360 controller for Windows. */
-        &IID_XOneWiredGamepad,     /* Microsoft's wired Xbox One controller for Windows. */
-        &IID_XOneWirelessGamepad,  /* Microsoft's wireless Xbox One controller for Windows. */
-        &IID_XOneBluetoothGamepad  /* Microsoft's Bluetooth Xbox One controller for Windows. */
+        &IID_X360WiredGamepad,         /* Microsoft's wired X360 controller for Windows. */
+        &IID_X360WirelessGamepad,      /* Microsoft's wireless X360 controller for Windows. */
+        &IID_XOneWiredGamepad,         /* Microsoft's wired Xbox One controller for Windows. */
+        &IID_XOneWirelessGamepad,      /* Microsoft's wireless Xbox One controller for Windows. */
+        &IID_XOneSWirelessGamepad,     /* Microsoft's wireless Xbox One S controller for Windows. */
+        &IID_XOneSBluetoothGamepad,    /* Microsoft's Bluetooth Xbox One S controller for Windows. */
+        &IID_XOneEliteWirelessGamepad  /* Microsoft's wireless Xbox One Elite controller for Windows. */
     };
 
     size_t iDevice;


### PR DESCRIPTION
In my initial testing, I apparently missed that the Xbox One S wireless
controller has a different GUID than a regular Xbox One wireless
controller when used with the Xbox wireless dongle for Windows.

Also, add the GUID for the Xbox One Elite wireless controller, which
also has a different GUID than the regular Xbox One wireless when
used in wireless mode.