### PR TITLE
GlobalShortcut_win: fix XboxInput button mask in buttonName().

### DIFF
--- a/src/mumble/GlobalShortcut_win.cpp
+++ b/src/mumble/GlobalShortcut_win.cpp
@@ -779,7 +779,7 @@ QString GlobalShortcutWin::buttonName(const QVariant &v) {
 #ifdef USE_XBOXINPUT
 	if (g.s.bEnableXboxInput && xboxinput->isValid() && guid == XboxInput::s_XboxInputGuid) {
 		uint32_t idx = (type >> 24) & 0xff;
-		uint32_t button = (type & 0x00ffffffff);
+		uint32_t button = (type & 0x00ffffff);
 
 		// Translate from our own button index mapping to
 		// the actual Xbox controller button names.


### PR DESCRIPTION
The controller ID is shifted 24 bits, so the correct mask is
0x00ffffff.

Also, 0x00ffffffff (40 bits) should have been a red flag, since
we're working with uint32_t types here.

This fixes button names for Xbox controllers that are at indexes > 0.