### PR TITLE
GlobalShortcut_win: log product GUID when excluding an XInput device from DirectInput processing.

### DIFF
--- a/src/mumble/GlobalShortcut_win.cpp
+++ b/src/mumble/GlobalShortcut_win.cpp
@@ -441,7 +441,10 @@ BOOL GlobalShortcutWin::EnumDevicesCB(LPCDIDEVICEINSTANCE pdidi, LPVOID pContext
 	if (XInputCheck_IsGuidProductXInputDevice(&id->guidproduct)) {
 		cbgsw->nxboxinput += 1;
 
-		qWarning("GlobalShortcutWin: excluded XInput device '%s' (%s) from DirectInput", qPrintable(id->name), qPrintable(id->vguid.toString()));
+		qWarning("GlobalShortcutWin: excluded XInput device '%s' (guid %s guid product %s) from DirectInput",
+		         qPrintable(id->name),
+		         qPrintable(id->vguid.toString()),
+		         qPrintable(id->vguidproduct.toString()));
 		delete id;
 		return DIENUM_CONTINUE;
 	}


### PR DESCRIPTION
3rdparty/xinputcheck-src uses the product GUID in its list of well-known
devices.

For debugging purposes, it makes sense for us to log this here.