### PR TITLE
GlobalShortcut_win: log product guid when adding a new DirectInput device.

### DIFF
--- a/src/mumble/GlobalShortcut_win.cpp
+++ b/src/mumble/GlobalShortcut_win.cpp
@@ -547,12 +547,13 @@ BOOL GlobalShortcutWin::EnumDevicesCB(LPCDIDEVICEINSTANCE pdidi, LPVOID pContext
 		if (FAILED(hr = id->pDID->SetProperty(DIPROP_BUFFERSIZE, &dipdw.diph)))
 			qFatal("GlobalShortcutWin: SetProperty: %lx", hr);
 
-		qWarning("Adding device %s %s %s:%d type 0x%.8x",
+		qWarning("Adding device %s %s %s:%d type 0x%.8x guid product %s",
 		         qPrintable(QUuid(id->guid).toString()),
 		         qPrintable(name),
 		         qPrintable(sname),
 		         id->qhNames.count(),
-		         pdidi->dwDevType);
+		         pdidi->dwDevType,
+		         qPrintable(id->vguidproduct.toString()));
 
 		cbgsw->qhInputDevices[id->guid] = id;
 	} else {


### PR DESCRIPTION
Previously, we only logged the instance GUID, not the product GUID.

With this change, the log line when adding a new device contains both.