### PR TITLE
Various mumble_plugin.h and ManualPlugin fixes

### DIFF
--- a/plugins/link/link-posix.cpp
+++ b/plugins/link/link-posix.cpp
@@ -3,9 +3,6 @@
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.
 
-#define __cdecl
-typedef unsigned long HWND;
-
 #include "../mumble_plugin.h"
 
 #include <stdio.h>

--- a/plugins/link/link.cpp
+++ b/plugins/link/link.cpp
@@ -31,8 +31,8 @@ struct LinkedMem {
 	wchar_t description[2048];
 };
 
-static void about(HWND h) {
-	::MessageBox(h, L"Reads audio position information from linked game", L"Mumble Link Plugin", MB_OK);
+static void about(void *h) {
+	::MessageBox(reinterpret_cast<HWND>(h), L"Reads audio position information from linked game", L"Mumble Link Plugin", MB_OK);
 }
 
 static HANDLE hMapObject = NULL;

--- a/plugins/mumble_plugin.h
+++ b/plugins/mumble_plugin.h
@@ -24,7 +24,7 @@
 #elif _MSC_VER == 1600 && defined(_M_IX86)
 # define MUMBLE_PLUGIN_MAGIC    0xd63ab7f0
 # define MUMBLE_PLUGIN_MAGIC_2  0xd63ab7ff
-# define MMUBLE_PLUGIN_MAGIC_QT 0xd63ab70f
+# define MUMBLE_PLUGIN_MAGIC_QT 0xd63ab70f
 // Visual Studio 2013 x86
 #elif _MSC_VER == 1800 && defined(_M_IX86)
 # define MUMBLE_PLUGIN_MAGIC    0xd63ab7c0

--- a/plugins/mumble_plugin.h
+++ b/plugins/mumble_plugin.h
@@ -9,6 +9,12 @@
 #include <string>
 #include <map>
 
+#if defined(_MSC_VER)
+# define MUMBLE_PLUGIN_CALLING_CONVENTION __cdecl
+#else
+# define MUMBLE_PLUGIN_CALLING_CONVENTION
+#endif
+
 // Visual Studio 2008 x86
 #if _MSC_VER == 1500 && defined(_M_IX86)
 # define MUMBLE_PLUGIN_MAGIC     0xd63ab7ef
@@ -44,18 +50,18 @@ typedef struct _MumblePlugin {
 	unsigned int magic;
 	const std::wstring &description;
 	const std::wstring &shortname;
-	void (__cdecl *about)(HWND);
-	void (__cdecl *config)(HWND);
-	int (__cdecl *trylock)();
-	void (__cdecl *unlock)();
-	const std::wstring(__cdecl *longdesc)();
-	int (__cdecl *fetch)(float *avatar_pos, float *avatar_front, float *avatar_top, float *camera_pos, float *camera_front, float *camera_top, std::string &context, std::wstring &identity);
+	void (MUMBLE_PLUGIN_CALLING_CONVENTION *about)(HWND);
+	void (MUMBLE_PLUGIN_CALLING_CONVENTION *config)(HWND);
+	int (MUMBLE_PLUGIN_CALLING_CONVENTION *trylock)();
+	void (MUMBLE_PLUGIN_CALLING_CONVENTION *unlock)();
+	const std::wstring(MUMBLE_PLUGIN_CALLING_CONVENTION *longdesc)();
+	int (MUMBLE_PLUGIN_CALLING_CONVENTION *fetch)(float *avatar_pos, float *avatar_front, float *avatar_top, float *camera_pos, float *camera_front, float *camera_top, std::string &context, std::wstring &identity);
 } MumblePlugin;
 
 typedef struct _MumblePlugin2 {
 	unsigned int magic;
 	unsigned int version;
-	int (__cdecl *trylock)(const std::multimap<std::wstring, unsigned long long int> &);
+	int (MUMBLE_PLUGIN_CALLING_CONVENTION *trylock)(const std::multimap<std::wstring, unsigned long long int> &);
 } MumblePlugin2;
 
 /// MumblePluginQt provides an extra set of functions that will
@@ -78,7 +84,7 @@ typedef struct _MumblePluginQt {
 	/// The ptr argument is a pointer to a QWidget that
 	/// should be used as the parent for a Qt-based
 	/// about dialog.
-	void (__cdecl *about)(void *ptr);
+	void (MUMBLE_PLUGIN_CALLING_CONVENTION *about)(void *ptr);
 
 	/// config is called when Mumble requests the plugin
 	/// to show its configuration dialog.
@@ -86,12 +92,12 @@ typedef struct _MumblePluginQt {
 	/// The ptr argument is a pointer to a QWidget that
 	/// should be used as the parent for a Qt-based
 	/// configuration dialog.
-	void (__cdecl *config)(void *ptr);
+	void (MUMBLE_PLUGIN_CALLING_CONVENTION *config)(void *ptr);
 } MumblePluginQt;
 
-typedef MumblePlugin *(__cdecl *mumblePluginFunc)();
-typedef MumblePlugin2 *(__cdecl *mumblePlugin2Func)();
-typedef MumblePluginQt *(__cdecl *mumblePluginQtFunc)();
+typedef MumblePlugin *(MUMBLE_PLUGIN_CALLING_CONVENTION *mumblePluginFunc)();
+typedef MumblePlugin2 *(MUMBLE_PLUGIN_CALLING_CONVENTION *mumblePlugin2Func)();
+typedef MumblePluginQt *(MUMBLE_PLUGIN_CALLING_CONVENTION *mumblePluginQtFunc)();
 
 /*
  * All plugins must implement one function called mumbleGetPlugin(), which

--- a/plugins/mumble_plugin.h
+++ b/plugins/mumble_plugin.h
@@ -50,8 +50,8 @@ typedef struct _MumblePlugin {
 	unsigned int magic;
 	const std::wstring &description;
 	const std::wstring &shortname;
-	void (MUMBLE_PLUGIN_CALLING_CONVENTION *about)(HWND);
-	void (MUMBLE_PLUGIN_CALLING_CONVENTION *config)(HWND);
+	void (MUMBLE_PLUGIN_CALLING_CONVENTION *about)(void *);
+	void (MUMBLE_PLUGIN_CALLING_CONVENTION *config)(void *);
 	int (MUMBLE_PLUGIN_CALLING_CONVENTION *trylock)();
 	void (MUMBLE_PLUGIN_CALLING_CONVENTION *unlock)();
 	const std::wstring(MUMBLE_PLUGIN_CALLING_CONVENTION *longdesc)();
@@ -107,8 +107,8 @@ typedef MumblePluginQt *(MUMBLE_PLUGIN_CALLING_CONVENTION *mumblePluginQtFunc)()
  * name of the plugin shown in the GUI, while shortname is used for TTS.
  *
  * The individual functions are:
- * about(HWND parent) - Player clicked the about button over plugin
- * config(HWND parent) - Player clicked the config button
+ * about(void *parent) - Player clicked the about button over plugin
+ * config(void *parent) - Player clicked the config button
  * trylock() - Search system for likely process and try to lock on.
  *      The parameter is a set of process names and associated PIDs.
  *		Return 1 if succeeded, else 0. Note that once a plugin is locked on,

--- a/src/mumble/ManualPlugin.cpp
+++ b/src/mumble/ManualPlugin.cpp
@@ -19,14 +19,6 @@
 
 #include <float.h>
 
-#ifdef Q_OS_UNIX
-#define __cdecl
-typedef WId HWND;
-#define DLL_PUBLIC __attribute__((visibility("default")))
-#else
-#define DLL_PUBLIC __declspec(dllexport)
-#endif
-
 #include "../../plugins/mumble_plugin.h"
 
 static QPointer<Manual> mDlg = NULL;

--- a/src/mumble/ManualPlugin.h
+++ b/src/mumble/ManualPlugin.h
@@ -19,10 +19,6 @@
 
 #include "ui_ManualPlugin.h"
 
-#ifdef Q_OS_UNIX
-typedef WId HWND;
-#endif
-
 #include "../../plugins/mumble_plugin.h"
 
 class Manual : public QDialog, public Ui::Manual {


### PR DESCRIPTION
This PR contains commits to fix the following:

 - Replace hard-coded __cdecl with MUMBLE_PLUGIN_CALLING_CONVENTION
 - Replace HWND with unsigned long
 - Fix typo in MUMBLE_PLUGIN_MAGIC_QT for _MSC_VER == 1600, _M_IX86.
 - Remove __cdecl/HWND preamble from ManualPlugin.