### PR TITLE
3rdparty/xinputcheck-src: add Xbox One controller (w/ 3.5 mm jack).

### DIFF
--- a/3rdparty/xinputcheck-src/xinputcheck.cpp
+++ b/3rdparty/xinputcheck-src/xinputcheck.cpp
@@ -78,6 +78,7 @@ SDL_IsXInputDevice(const GUID* pGuidProductFromDirectInput)
     static GUID IID_X360WirelessGamepad = { MAKELONG(0x045E, 0x028E), 0x0000, 0x0000, { 0x00, 0x00, 0x50, 0x49, 0x44, 0x56, 0x49, 0x44 } };
     static GUID IID_XOneWiredGamepad = { MAKELONG(0x045E, 0x02FF), 0x0000, 0x0000, { 0x00, 0x00, 0x50, 0x49, 0x44, 0x56, 0x49, 0x44 } };
     static GUID IID_XOneWirelessGamepad = { MAKELONG(0x045E, 0x02DD), 0x0000, 0x0000, { 0x00, 0x00, 0x50, 0x49, 0x44, 0x56, 0x49, 0x44 } };
+    static GUID IID_XOneNewWirelessGamepad = { MAKELONG(0x045E, 0x02D1), 0x0000, 0x0000, { 0x00, 0x00, 0x50, 0x49, 0x44, 0x56, 0x49, 0x44 } };
     static GUID IID_XOneSWirelessGamepad = { MAKELONG(0x045E, 0x02EA), 0x0000, 0x0000, { 0x00, 0x00, 0x50, 0x49, 0x44, 0x56, 0x49, 0x44 } };
     static GUID IID_XOneSBluetoothGamepad = { MAKELONG(0x045E, 0x02E0), 0x0000, 0x0000, { 0x00, 0x00, 0x50, 0x49, 0x44, 0x56, 0x49, 0x44 } };
     static GUID IID_XOneEliteWirelessGamepad = { MAKELONG(0x045E, 0x02E3), 0x0000, 0x0000, { 0x00, 0x00, 0x50, 0x49, 0x44, 0x56, 0x49, 0x44 } };
@@ -88,6 +89,7 @@ SDL_IsXInputDevice(const GUID* pGuidProductFromDirectInput)
         &IID_X360WirelessGamepad,      /* Microsoft's wireless X360 controller for Windows. */
         &IID_XOneWiredGamepad,         /* Microsoft's wired Xbox One controller for Windows. */
         &IID_XOneWirelessGamepad,      /* Microsoft's wireless Xbox One controller for Windows. */
+        &IID_XOneNewWirelessGamepad,   /* Microsoft's updated wireless Xbox One controller (w/ 3.5 mm jack) for Windows. */
         &IID_XOneSWirelessGamepad,     /* Microsoft's wireless Xbox One S controller for Windows. */
         &IID_XOneSBluetoothGamepad,    /* Microsoft's Bluetooth Xbox One S controller for Windows. */
         &IID_XOneEliteWirelessGamepad  /* Microsoft's wireless Xbox One Elite controller for Windows. */


### PR DESCRIPTION
Apparently, this one has a different GUID as well.