### PR TITLE
Introduce MUComboBox subclass and use it throughout the tree.

### DIFF
--- a/src/mumble/ACLEditor.ui
+++ b/src/mumble/ACLEditor.ui
@@ -171,7 +171,7 @@ When checked the channel created will be marked as temporary. This means when th
          </property>
          <layout class="QHBoxLayout">
           <item>
-           <widget class="QComboBox" name="qcbGroupList">
+           <widget class="MUComboBox" name="qcbGroupList">
             <property name="sizePolicy">
              <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
               <horstretch>0</horstretch>
@@ -337,7 +337,7 @@ Contains the list of members inherited by the current channel. Uncheck &lt;i&gt;
            </widget>
           </item>
           <item row="2" column="0" colspan="2">
-           <widget class="QComboBox" name="qcbGroupAdd">
+           <widget class="MUComboBox" name="qcbGroupAdd">
             <property name="sizePolicy">
              <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
               <horstretch>0</horstretch>
@@ -354,10 +354,10 @@ Contains the list of members inherited by the current channel. Uncheck &lt;i&gt;
              <bool>true</bool>
             </property>
             <property name="insertPolicy">
-             <enum>QComboBox::NoInsert</enum>
+             <enum>MUComboBox::NoInsert</enum>
             </property>
             <property name="sizeAdjustPolicy">
-             <enum>QComboBox::AdjustToMinimumContentsLength</enum>
+             <enum>MUComboBox::AdjustToMinimumContentsLength</enum>
             </property>
            </widget>
           </item>
@@ -369,7 +369,7 @@ Contains the list of members inherited by the current channel. Uncheck &lt;i&gt;
            </widget>
           </item>
           <item row="2" column="3" colspan="2">
-           <widget class="QComboBox" name="qcbGroupRemove">
+           <widget class="MUComboBox" name="qcbGroupRemove">
             <property name="sizePolicy">
              <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
               <horstretch>0</horstretch>
@@ -386,10 +386,10 @@ Contains the list of members inherited by the current channel. Uncheck &lt;i&gt;
              <bool>true</bool>
             </property>
             <property name="insertPolicy">
-             <enum>QComboBox::NoInsert</enum>
+             <enum>MUComboBox::NoInsert</enum>
             </property>
             <property name="sizeAdjustPolicy">
-             <enum>QComboBox::AdjustToMinimumContentsLength</enum>
+             <enum>MUComboBox::AdjustToMinimumContentsLength</enum>
             </property>
            </widget>
           </item>
@@ -603,7 +603,7 @@ Contains the list of members inherited by the current channel. Uncheck &lt;i&gt;
              </widget>
             </item>
             <item row="0" column="1">
-             <widget class="QComboBox" name="qcbACLGroup">
+             <widget class="MUComboBox" name="qcbACLGroup">
               <property name="sizePolicy">
                <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
                 <horstretch>0</horstretch>
@@ -632,7 +632,7 @@ Contains the list of members inherited by the current channel. Uncheck &lt;i&gt;
              </widget>
             </item>
             <item row="1" column="1">
-             <widget class="QComboBox" name="qcbACLUser">
+             <widget class="MUComboBox" name="qcbACLUser">
               <property name="sizePolicy">
                <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
                 <horstretch>0</horstretch>
@@ -649,7 +649,7 @@ Contains the list of members inherited by the current channel. Uncheck &lt;i&gt;
                <bool>true</bool>
               </property>
               <property name="sizeAdjustPolicy">
-               <enum>QComboBox::AdjustToMinimumContentsLength</enum>
+               <enum>MUComboBox::AdjustToMinimumContentsLength</enum>
               </property>
              </widget>
             </item>
@@ -687,6 +687,11 @@ Contains the list of members inherited by the current channel. Uncheck &lt;i&gt;
    <extends>QWidget</extends>
    <header>RichTextEditor.h</header>
    <container>1</container>
+  </customwidget>
+  <customwidget>
+   <class>MUComboBox</class>
+   <extends>QComboBox</extends>
+   <header>widgets/MUComboBox.h</header>
   </customwidget>
  </customwidgets>
  <tabstops>

--- a/src/mumble/ASIOInput.ui
+++ b/src/mumble/ASIOInput.ui
@@ -31,7 +31,7 @@
        </widget>
       </item>
       <item>
-       <widget class="QComboBox" name="qcbDevice">
+       <widget class="MUComboBox" name="qcbDevice">
         <property name="sizePolicy">
          <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
           <horstretch>1</horstretch>
@@ -375,6 +375,13 @@
    </item>
   </layout>
  </widget>
+ <customwidgets>
+  <customwidget>
+   <class>MUComboBox</class>
+   <extends>QComboBox</extends>
+   <header>widgets/MUComboBox.h</header>
+  </customwidget>
+ </customwidgets>
  <resources/>
  <connections/>
 </ui>

--- a/src/mumble/AudioInput.ui
+++ b/src/mumble/AudioInput.ui
@@ -31,7 +31,7 @@
        </widget>
       </item>
       <item row="0" column="1">
-       <widget class="QComboBox" name="qcbSystem">
+       <widget class="MUComboBox" name="qcbSystem">
         <property name="sizePolicy">
          <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
           <horstretch>0</horstretch>
@@ -73,7 +73,7 @@
        </widget>
       </item>
       <item row="0" column="4">
-       <widget class="QComboBox" name="qcbDevice">
+       <widget class="MUComboBox" name="qcbDevice">
         <property name="sizePolicy">
          <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
           <horstretch>1</horstretch>
@@ -87,7 +87,7 @@
          <string>&lt;b&gt;This is the input device to use for audio.&lt;/b&gt;</string>
         </property>
         <property name="sizeAdjustPolicy">
-         <enum>QComboBox::AdjustToMinimumContentsLength</enum>
+         <enum>MUComboBox::AdjustToMinimumContentsLength</enum>
         </property>
         <property name="minimumContentsLength">
          <number>16</number>
@@ -121,7 +121,7 @@
        </widget>
       </item>
       <item row="1" column="4">
-       <widget class="QComboBox" name="qcbEcho">
+       <widget class="MUComboBox" name="qcbEcho">
         <property name="toolTip">
          <string>Cancel echo from speakers</string>
         </property>
@@ -171,7 +171,7 @@
        </widget>
       </item>
       <item row="0" column="1" colspan="2">
-       <widget class="QComboBox" name="qcbTransmit">
+       <widget class="MUComboBox" name="qcbTransmit">
         <property name="toolTip">
          <string>When to transmit your speech</string>
         </property>
@@ -815,7 +815,7 @@
          </widget>
         </item>
         <item>
-         <widget class="QComboBox" name="qcbIdleAction">
+         <widget class="MUComboBox" name="qcbIdleAction">
           <item>
            <property name="text">
             <string>nothing</string>
@@ -879,6 +879,11 @@
    <extends>QWidget</extends>
    <header>AudioStats.h</header>
    <container>1</container>
+  </customwidget>
+  <customwidget>
+   <class>MUComboBox</class>
+   <extends>QComboBox</extends>
+   <header>widgets/MUComboBox.h</header>
   </customwidget>
  </customwidgets>
  <tabstops>

--- a/src/mumble/AudioOutput.ui
+++ b/src/mumble/AudioOutput.ui
@@ -31,7 +31,7 @@
        </widget>
       </item>
       <item row="0" column="1">
-       <widget class="QComboBox" name="qcbSystem">
+       <widget class="MUComboBox" name="qcbSystem">
         <property name="sizePolicy">
          <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
           <horstretch>0</horstretch>
@@ -73,7 +73,7 @@
        </widget>
       </item>
       <item row="0" column="4">
-       <widget class="QComboBox" name="qcbDevice">
+       <widget class="MUComboBox" name="qcbDevice">
         <property name="sizePolicy">
          <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
           <horstretch>1</horstretch>
@@ -87,7 +87,7 @@
          <string>&lt;b&gt;This is the output device to use for audio.&lt;/b&gt;</string>
         </property>
         <property name="sizeAdjustPolicy">
-         <enum>QComboBox::AdjustToMinimumContentsLength</enum>
+         <enum>MUComboBox::AdjustToMinimumContentsLength</enum>
         </property>
         <property name="minimumContentsLength">
          <number>16</number>
@@ -687,7 +687,7 @@
        </widget>
       </item>
       <item row="0" column="1" colspan="2">
-       <widget class="QComboBox" name="qcbLoopback">
+       <widget class="MUComboBox" name="qcbLoopback">
         <property name="toolTip">
          <string>Desired loopback mode</string>
         </property>
@@ -730,6 +730,13 @@
   <tabstop>qsPacketDelay</tabstop>
   <tabstop>qsPacketLoss</tabstop>
  </tabstops>
+ <customwidgets>
+  <customwidget>
+   <class>MUComboBox</class>
+   <extends>QComboBox</extends>
+   <header>widgets/MUComboBox.h</header>
+  </customwidget>
+ </customwidgets>
  <resources/>
  <connections/>
 </ui>

--- a/src/mumble/AudioWizard.ui
+++ b/src/mumble/AudioWizard.ui
@@ -89,7 +89,7 @@ Please be aware that as long as this wizard is active, audio will be looped loca
         </widget>
        </item>
        <item row="1" column="1">
-        <widget class="QComboBox" name="qcbInput">
+        <widget class="MUComboBox" name="qcbInput">
          <property name="toolTip">
           <string>Input method for audio</string>
          </property>
@@ -109,7 +109,7 @@ Please be aware that as long as this wizard is active, audio will be looped loca
         </widget>
        </item>
        <item row="2" column="1">
-        <widget class="QComboBox" name="qcbInputDevice">
+        <widget class="MUComboBox" name="qcbInputDevice">
          <property name="toolTip">
           <string>Input device to use</string>
          </property>
@@ -161,7 +161,7 @@ Please be aware that as long as this wizard is active, audio will be looped loca
         </widget>
        </item>
        <item row="1" column="1">
-        <widget class="QComboBox" name="qcbOutput">
+        <widget class="MUComboBox" name="qcbOutput">
          <property name="toolTip">
           <string>Output method for audio</string>
          </property>
@@ -181,7 +181,7 @@ Please be aware that as long as this wizard is active, audio will be looped loca
         </widget>
        </item>
        <item row="2" column="1">
-        <widget class="QComboBox" name="qcbOutputDevice">
+        <widget class="MUComboBox" name="qcbOutputDevice">
          <property name="toolTip">
           <string>Output device to use</string>
          </property>
@@ -862,6 +862,11 @@ Mumble is under continuous development, and the development team wants to focus 
    <class>ShortcutKeyWidget</class>
    <extends>QLineEdit</extends>
    <header>GlobalShortcut.h</header>
+  </customwidget>
+  <customwidget>
+   <class>MUComboBox</class>
+   <extends>QComboBox</extends>
+   <header>widgets/MUComboBox.h</header>
   </customwidget>
  </customwidgets>
  <resources/>

--- a/src/mumble/GlobalShortcut.cpp
+++ b/src/mumble/GlobalShortcut.cpp
@@ -105,7 +105,7 @@ void ShortcutKeyWidget::displayKeys(bool last) {
 	emit keySet(keys.count() > 0, last);
 }
 
-ShortcutActionWidget::ShortcutActionWidget(QWidget *p) : QComboBox(p) {
+ShortcutActionWidget::ShortcutActionWidget(QWidget *p) : MUComboBox(p) {
 	int idx = 0;
 
 	insertItem(idx, tr("Unassigned"));
@@ -148,7 +148,7 @@ unsigned int ShortcutActionWidget::index() const {
 	return itemData(currentIndex()).toUInt();
 }
 
-ShortcutToggleWidget::ShortcutToggleWidget(QWidget *p) : QComboBox(p) {
+ShortcutToggleWidget::ShortcutToggleWidget(QWidget *p) : MUComboBox(p) {
 	int idx = 0;
 
 	insertItem(idx, tr("Off"));

--- a/src/mumble/GlobalShortcut.h
+++ b/src/mumble/GlobalShortcut.h
@@ -18,6 +18,7 @@
 
 #include "ConfigDialog.h"
 #include "Timer.h"
+#include "MUComboBox.h"
 
 #include "ui_GlobalShortcut.h"
 #include "ui_GlobalShortcutTarget.h"
@@ -82,7 +83,7 @@ class ShortcutKeyWidget : public QLineEdit {
  *
  * @see GlobalShortcutEngine
  */
-class ShortcutActionWidget : public QComboBox {
+class ShortcutActionWidget : public MUComboBox {
 	private:
 		Q_OBJECT
 		Q_DISABLE_COPY(ShortcutActionWidget)
@@ -93,7 +94,7 @@ class ShortcutActionWidget : public QComboBox {
 		void setIndex(int);
 };
 
-class ShortcutToggleWidget : public QComboBox {
+class ShortcutToggleWidget : public MUComboBox {
 	private:
 		Q_OBJECT
 		Q_DISABLE_COPY(ShortcutToggleWidget)

--- a/src/mumble/GlobalShortcutTarget.ui
+++ b/src/mumble/GlobalShortcutTarget.ui
@@ -114,7 +114,7 @@
            <widget class="QListWidget" name="qlwUsers"/>
           </item>
           <item row="0" column="1">
-           <widget class="QComboBox" name="qcbUser"/>
+           <widget class="MUComboBox" name="qcbUser"/>
           </item>
           <item row="1" column="1">
            <widget class="QPushButton" name="qpbAdd">
@@ -237,4 +237,11 @@
    </hints>
   </connection>
  </connections>
+ <customwidgets>
+  <customwidget>
+   <class>MUComboBox</class>
+   <extends>QComboBox</extends>
+   <header>widgets/MUComboBox.h</header>
+  </customwidget>
+ </customwidgets>
 </ui>

--- a/src/mumble/LookConfig.ui
+++ b/src/mumble/LookConfig.ui
@@ -21,7 +21,7 @@
      </property>
      <layout class="QGridLayout" name="gridLayout">
       <item row="3" column="0" colspan="2">
-       <widget class="QComboBox" name="qcbLanguage">
+       <widget class="MUComboBox" name="qcbLanguage">
         <property name="toolTip">
          <string>Language to use (requires restart)</string>
         </property>
@@ -38,7 +38,7 @@
        </widget>
       </item>
       <item row="1" column="0" colspan="2">
-       <widget class="QComboBox" name="qcbTheme">
+       <widget class="MUComboBox" name="qcbTheme">
         <property name="sizePolicy">
          <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
           <horstretch>0</horstretch>
@@ -181,7 +181,7 @@
        </widget>
       </item>
       <item row="0" column="1">
-       <widget class="QComboBox" name="qcbAlwaysOnTop">
+       <widget class="MUComboBox" name="qcbAlwaysOnTop">
         <property name="toolTip">
          <string>This setting controls when the application will be always on top.</string>
         </property>
@@ -250,7 +250,7 @@
        </widget>
       </item>
       <item row="0" column="1">
-       <widget class="QComboBox" name="qcbChannelDrag">
+       <widget class="MUComboBox" name="qcbChannelDrag">
         <property name="toolTip">
          <string>This changes the behavior when moving channels.</string>
         </property>
@@ -267,7 +267,7 @@
        </widget>
       </item>
       <item row="1" column="1">
-       <widget class="QComboBox" name="qcbExpand">
+       <widget class="MUComboBox" name="qcbExpand">
         <property name="toolTip">
          <string>When to automatically expand channels</string>
         </property>
@@ -520,6 +520,13 @@
    </item>
   </layout>
  </widget>
+ <customwidgets>
+  <customwidget>
+   <class>MUComboBox</class>
+   <extends>QComboBox</extends>
+   <header>widgets/MUComboBox.h</header>
+  </customwidget>
+ </customwidgets>
  <resources/>
  <connections/>
 </ui>

--- a/src/mumble/MainWindow.cpp
+++ b/src/mumble/MainWindow.cpp
@@ -314,8 +314,8 @@ void MainWindow::setupGui()  {
 	        SLOT(qtvUserCurrentChanged(const QModelIndex &, const QModelIndex &)));
 
 	// QtCreator and uic.exe do not allow adding arbitrary widgets
-	// such as a QComboBox to a QToolbar, even though they are supported.
-	qcbTransmitMode = new QComboBox(qtIconToolbar);
+	// such as a MUComboBox to a QToolbar, even though they are supported.
+	qcbTransmitMode = new MUComboBox(qtIconToolbar);
 	qcbTransmitMode->setObjectName(QLatin1String("qcbTransmitMode"));
 	qcbTransmitMode->addItem(tr("Continuous"));
 	qcbTransmitMode->addItem(tr("Voice Activity"));

--- a/src/mumble/MainWindow.h
+++ b/src/mumble/MainWindow.h
@@ -11,12 +11,10 @@
 # include <QtCore/QPointer>
 # include <QtWidgets/QMainWindow>
 # include <QtWidgets/QSystemTrayIcon>
-# include <QtWidgets/QComboBox>
 #else
 # include <QtCore/QWeakPointer>
 # include <QtGui/QMainWindow>
 # include <QtGui/QSystemTrayIcon>
-# include <QtGui/QComboBox>
 #endif
 
 #include <QtNetwork/QAbstractSocket>
@@ -26,6 +24,7 @@
 #include "Mumble.pb.h"
 #include "Usage.h"
 #include "UserLocalVolumeDialog.h"
+#include "MUComboBox.h"
 
 #include "ui_MainWindow.h"
 
@@ -149,7 +148,7 @@ class MainWindow : public QMainWindow, public MessageHandler, public Ui::MainWin
 
 		PTTButtonWidget *qwPTTButtonWidget;
 
-		QComboBox *qcbTransmitMode;
+		MUComboBox *qcbTransmitMode;
 		QAction *qaTransmitMode;
 		QAction *qaTransmitModeSeparator;
 

--- a/src/mumble/NetworkConfig.ui
+++ b/src/mumble/NetworkConfig.ui
@@ -111,7 +111,7 @@
        </widget>
       </item>
       <item row="0" column="1" colspan="3">
-       <widget class="QComboBox" name="qcbType">
+       <widget class="MUComboBox" name="qcbType">
         <property name="sizePolicy">
          <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
           <horstretch>0</horstretch>
@@ -361,6 +361,13 @@ Prevents the client from downloading images embedded into chat messages with the
    </item>
   </layout>
  </widget>
+ <customwidgets>
+  <customwidget>
+   <class>MUComboBox</class>
+   <extends>QComboBox</extends>
+   <header>widgets/MUComboBox.h</header>
+  </customwidget>
+ </customwidgets>
  <resources/>
  <connections/>
 </ui>

--- a/src/mumble/UserEdit.ui
+++ b/src/mumble/UserEdit.ui
@@ -90,7 +90,7 @@
        </widget>
       </item>
       <item row="2" column="5">
-       <widget class="QComboBox" name="qcbInactive">
+       <widget class="MUComboBox" name="qcbInactive">
         <property name="sizePolicy">
          <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
           <horstretch>0</horstretch>
@@ -226,4 +226,11 @@
    </hints>
   </connection>
  </connections>
+ <customwidgets>
+  <customwidget>
+   <class>MUComboBox</class>
+   <extends>QComboBox</extends>
+   <header>widgets/MUComboBox.h</header>
+  </customwidget>
+ </customwidgets>
 </ui>

--- a/src/mumble/VoiceRecorderDialog.ui
+++ b/src/mumble/VoiceRecorderDialog.ui
@@ -149,7 +149,7 @@
        </widget>
       </item>
       <item row="0" column="1">
-       <widget class="QComboBox" name="qcbFormat"/>
+       <widget class="MUComboBox" name="qcbFormat"/>
       </item>
       <item row="2" column="0">
        <widget class="QLabel" name="qlTargetDirectory">
@@ -189,6 +189,13 @@
    </item>
   </layout>
  </widget>
+ <customwidgets>
+  <customwidget>
+   <class>MUComboBox</class>
+   <extends>QComboBox</extends>
+   <header>widgets/MUComboBox.h</header>
+  </customwidget>
+ </customwidgets>
  <resources>
   <include location="mumble_tango.qrc"/>
  </resources>

--- a/src/mumble/mumble.pro
+++ b/src/mumble/mumble.pro
@@ -130,7 +130,8 @@ HEADERS *= BanEditor.h \
     ApplicationPalette.h \
     ThemeInfo.h \
     Themes.h \
-    OverlayPositionableItem.h
+    OverlayPositionableItem.h \
+    widgets/MUComboBox.h
 
 SOURCES *= BanEditor.cpp \
     ACLEditor.cpp \
@@ -194,7 +195,8 @@ SOURCES *= BanEditor.cpp \
     ../../3rdparty/smallft-src/smallft.cpp \
     ThemeInfo.cpp \
     Themes.cpp \
-    OverlayPositionableItem.cpp
+    OverlayPositionableItem.cpp \
+    widgets/MUComboBox.cpp
 
 DIST		*= ../../icons/mumble.ico licenses.h ../../icons/mumble.xpm murmur_pch.h mumble.plist
 RESOURCES	*= mumble.qrc mumble_translations.qrc mumble_flags.qrc ../../themes/MumbleTheme.qrc
@@ -234,6 +236,7 @@ include(translations.pri)
 PRECOMPILED_HEADER = mumble_pch.hpp
 INCLUDEPATH *= ../../3rdparty/qqbonjour-src
 INCLUDEPATH *= ../../3rdparty/smallft-src
+INCLUDEPATH *= widgets
 
 CONFIG(static) {
   # Ensure that static Mumble.app on Mac OS X

--- a/src/mumble/widgets/MUComboBox.cpp
+++ b/src/mumble/widgets/MUComboBox.cpp
@@ -1,0 +1,38 @@
+// Copyright 2005-2016 The Mumble Developers. All rights reserved.
+// Use of this source code is governed by a BSD-style license
+// that can be found in the LICENSE file at the root of the
+// Mumble source tree or at <https://www.mumble.info/LICENSE>.
+
+#include "mumble_pch.hpp"
+
+#include "MUComboBox.h"
+
+MUComboBox::MUComboBox(QWidget *parent)
+	: QComboBox(parent) {
+
+	// Set the QComboBox to be backed by a QListView.
+	// By default on macOS, QComboBoxes are backed by
+	// something that tries to emulate a native macOS
+	// menu.
+	//
+	// However, that QAbstractItemView behaves
+	// inconsistently when styled. For example, it does
+	// not seem possible to set the size of individual
+	// items, because they're restricted to the height
+	// of a normal macOS menu item.
+	// Also, at least for this QComboBox (which lives
+	// inside a QToolbar), the height of the QAbstractItemView
+	// was also wrong when styled. This caused the combo box
+	// to always scroll, even though it seemingly was sized
+	// correctly.
+	//
+	// To get consistent behavior, we use QListView instead.
+	QListView *lv = new QListView();
+	// Don't show ellipses. In this combo box, the
+	// text does fit -- and is resized automatically to fit.
+	// But ellipses are added anyway.
+	// So, forcefully disable them.
+	lv->setTextElideMode(Qt::ElideNone);
+
+	this->setView(lv);
+}

--- a/src/mumble/widgets/MUComboBox.h
+++ b/src/mumble/widgets/MUComboBox.h
@@ -1,0 +1,17 @@
+// Copyright 2005-2016 The Mumble Developers. All rights reserved.
+// Use of this source code is governed by a BSD-style license
+// that can be found in the LICENSE file at the root of the
+// Mumble source tree or at <https://www.mumble.info/LICENSE>.
+
+#ifndef MUMBLE_MUMBLE_WIDGETS_MUCOMBOBOX_H_
+#define MUMBLE_MUMBLE_WIDGETS_MUCOMBOBOX_H_
+
+#include <QComboBox>
+
+class MUComboBox : public QComboBox {
+	Q_OBJECT
+public:
+	MUComboBox(QWidget *parent = NULL);
+};
+
+#endif


### PR DESCRIPTION
This PR introduces MUComboBox and uses it throughout the tree.

Per the commit introducing MUComboBox:

> Add MUComboBox.
>
> This adds a new QComboBox subclass called MUComboBox
> to widgets/MUComboBox.{cpp,h}.
>
> This QComboBox subclass explicitly uses a QListView
> as the backing view for the QComboBox.
>
> This fixes various styling issues for QComboBox
> on macOS.
>
> By default on macOS, QComboBoxes are backed by
> something that tries to emulate a native macOS
> menu. However, that QAbstractItemView behaves
> inconsistently when styled. For example, it does
> not seem possible to set the size of individual
> items, because they're restricted to the height
> of a normal macOS menu item.
> Also, in some cases (such as the QComboBox used
> for the transmission picker in MainWindow's
> QToolbar),  the height of the QAbstractItemView
> was also wrong when styled. This caused the combo
> box to always scroll, even though it seemingly
> was sized correctly.
>
> To get consistent behavior, we use QListView as
> the QComboBox's view in MUComboBox.
>
> Also, at least for the default Mumble themes,
> I've observed some weird eliding behavior for
> the text of added items in the transmission picker
> QComboBox in MainWindow's toolbar. Because of that,
> for MUComboBox, we don't show ellipses by default.
> This fixes the display of the combo box in the
> MainWindow's toolbar.

Before:

![image](https://cloud.githubusercontent.com/assets/36527/17464414/7194813c-5cde-11e6-86fb-2db7a9e18bb8.png)

After:

![image](https://cloud.githubusercontent.com/assets/36527/17464416/74e4791e-5cde-11e6-81f2-3f09a61d4785.png)

Before (with Mumble Dark, in ConfigDialog):

![image](https://cloud.githubusercontent.com/assets/36527/17464422/81c59b2c-5cde-11e6-8189-7ef84ee00960.png)

After (with Mumble Dark, in ConfigDialog):

![image](https://cloud.githubusercontent.com/assets/36527/17464423/8c2154e4-5cde-11e6-9c02-3bc3054167a6.png)

Before (No theme, in ConfigDialog):

![image](https://cloud.githubusercontent.com/assets/36527/17464424/9a784642-5cde-11e6-8802-937b38fe82e6.png)

After (No theme, in ConfigDialog):

![image](https://cloud.githubusercontent.com/assets/36527/17464426/a3b7541e-5cde-11e6-9051-2416c4bfe0b4.png)


