### PR TITLE
Themes: add support for user styles.

### DIFF
--- a/src/mumble/Themes.h
+++ b/src/mumble/Themes.h
@@ -50,6 +50,16 @@ private:
 	
 	/// Returns default style-sheet used for fall-backs
 	static QString getDefaultStylesheet();
+
+	/// userStylesheetPath returns the absolute path to the
+	/// user.qss file.
+	static QString userStylesheetPath();
+
+	/// readStylesheet fills stylesheetContent with the content
+	/// of the file at stylesheetFn, if available.
+	/// If a the file is is available, the function returns true.
+	/// If no file is available, it returns false.
+	static bool readStylesheet(const QString &stylesheetFn, QString &stylesheetContent);
 };
 
 #endif // MUMBLE_MUMBLE_THEMES_H_


### PR DESCRIPTION
Mumble will now read and use a user.qss
file from the base path.

The content of the user.qss will
be added after the actual theme's stylesheet.

This allows users to make small tweaks to
the themes we ship.

It also allows developers to test small tweaks
without rebuilding Mumble.

Locations where Mumble will look for user.qss:
Windows:    %APPDATA%\Mumble\user.qss
macOS:      $HOME/Library/Application Support/Mumble/Mumble/user.qss
Unix-like:  $HOME/.local/share/Mumble/Mumble/user.qss
