### PR TITLE
plugins/link: Initialize wsPluginName to fix the empty shortname problem

### DIFF
--- a/plugins/link/link-posix.cpp
+++ b/plugins/link/link-posix.cpp
@@ -18,7 +18,7 @@
 #include <fcntl.h>
 #include <time.h>
 
-static std::wstring wsPluginName;
+static std::wstring wsPluginName(L"Link");
 static std::wstring wsDescription;
 static char memname[256];
 


### PR DESCRIPTION
This fixes #2482.