### PR TITLE
Plugins: lay the groundwork for using Windows PA plugins on Linux with Wine

### DIFF
--- a/plugins/l4d2/l4d2_linux.cpp
+++ b/plugins/l4d2/l4d2_linux.cpp
@@ -144,14 +144,14 @@ static int trylock(const std::multimap<std::wstring, unsigned long long int> &pi
 		return false;
 	}
 
-	procptr32_t steamclient = getModuleAddr("steamclient.so"); // Retrieve "steamclient.so" module's memory address
+	procptr32_t steamclient = getModuleAddr(L"steamclient.so"); // Retrieve "steamclient.so" module's memory address
 	// This prevents the plugin from linking to the game in case something goes wrong during module linking.
 	if (steamclient == 0)
 		return false;
 
 	serverid_steamclient = steamclient + 0x118E965; // Module + Server ID offset
 
-	procptr32_t server = getModuleAddr("server.so"); // Retrieve "server.so" module's memory address
+	procptr32_t server = getModuleAddr(L"server.so"); // Retrieve "server.so" module's memory address
 	// This prevents the plugin from linking to the game in case something goes wrong during module linking.
 	if (server == 0)
 		return false;

--- a/plugins/mumble_plugin.h
+++ b/plugins/mumble_plugin.h
@@ -15,6 +15,14 @@
 # define MUMBLE_PLUGIN_CALLING_CONVENTION
 #endif
 
+#if defined(__GNUC__)
+# define MUMBLE_PLUGIN_EXPORT __attribute__((visibility("default")))
+#elif defined(_MSC_VER)
+# define MUMBLE_PLUGIN_EXPORT __declspec(dllexport)
+#else
+# error No MUMBLE_PLUGIN_EXPORT definition available
+#endif
+
 // Visual Studio 2008 x86
 #if _MSC_VER == 1500 && defined(_M_IX86)
 # define MUMBLE_PLUGIN_MAGIC     0xd63ab7ef

--- a/plugins/mumble_plugin_win32_32bit.h
+++ b/plugins/mumble_plugin_win32_32bit.h
@@ -6,9 +6,15 @@
 #ifndef MUMBLE_MUMBLE_PLUGIN_WIN32_32BIT_H_
 #define MUMBLE_MUMBLE_PLUGIN_WIN32_32BIT_H_
 
+#if defined(__linux__)
+# include "mumble_plugin_linux_32bit.h"
+#else
+
 typedef unsigned long procptr32_t;
 
 #define PTR_TYPE procptr32_t
 #include "mumble_plugin_win32_ptr_type.h"
+
+#endif
 
 #endif

--- a/plugins/mumble_plugin_win32_64bit.h
+++ b/plugins/mumble_plugin_win32_64bit.h
@@ -6,9 +6,15 @@
 #ifndef MUMBLE_MUMBLE_PLUGIN_WIN32_64BIT_H_
 #define MUMBLE_MUMBLE_PLUGIN_WIN32_64BIT_H_
 
+#if defined(__linux__)
+ #include "mumble_plugin_linux_64bit.h"
+#else
+
 typedef unsigned long long procptr64_t;
 
 #define PTR_TYPE procptr64_t
 #include "mumble_plugin_win32_ptr_type.h"
+
+#endif
 
 #endif

--- a/plugins/rl/rl.cpp
+++ b/plugins/rl/rl.cpp
@@ -93,10 +93,10 @@ static MumblePlugin2 rlplug2 = {
 	trylock
 };
 
-extern "C" __declspec(dllexport) MumblePlugin *getMumblePlugin() {
+extern "C" MUMBLE_PLUGIN_EXPORT MumblePlugin *getMumblePlugin() {
 	return &rlplug;
 }
 
-extern "C" __declspec(dllexport) MumblePlugin2 *getMumblePlugin2() {
+extern "C" MUMBLE_PLUGIN_EXPORT MumblePlugin2 *getMumblePlugin2() {
 	return &rlplug2;
 }

--- a/plugins/rl/rl.pro
+++ b/plugins/rl/rl.pro
@@ -5,7 +5,8 @@
 
 include(../plugins.pri)
 
-TARGET		= rl
-SOURCES		= rl.cpp
-LIBS		+= -luser32
+TARGET = rl
+linux:TARGET = mumble_paplugin_win32_rl
 
+SOURCES = rl.cpp
+win32:LIBS = -luser32

--- a/src/mumble/Plugins.cpp
+++ b/src/mumble/Plugins.cpp
@@ -511,6 +511,27 @@ void Plugins::on_Timer_timeout() {
 			baseName = firstPart + QLatin1String(".") + completeSuffix;
 		}
 
+		if (baseName == QLatin1String("wine-preloader") || baseName == QLatin1String("wine64-preloader")) {
+			QFile f(QString(QLatin1String("/proc/%1/cmdline")).arg(entry));
+			if (f.open(QIODevice::ReadOnly)) {
+				QByteArray cmdline = f.readAll();
+				f.close();
+
+				int nul = cmdline.indexOf('\0');
+				if (nul != -1) {
+					cmdline.truncate(nul);
+				}
+
+				QString exe = QString::fromUtf8(cmdline);
+				if (exe.contains(QLatin1String("\\"))) {
+					int lastBackslash = exe.lastIndexOf(QLatin1String("\\"));
+					if (exe.count() > lastBackslash + 1) {
+						baseName = exe.mid(lastBackslash + 1);
+					}
+				}
+			}
+		}
+
 		if (!baseName.isEmpty()) {
 			pids.insert(std::pair<std::wstring, unsigned long long int>(baseName.toStdWString(), pid));
 		}


### PR DESCRIPTION
This PR implements support for running Windows PA plugins on Linux with Wine.

The existing plugins should, in most cases, be usable without many source changes.

The PR also ports the Rocket League PA plugin for Windows to run on Linux/Wine, as a proof of concept.