### PR TITLE
Reset to 0 dB on Local Volume Adjustment reset button

### DIFF
--- a/src/mumble/UserLocalVolumeDialog.cpp
+++ b/src/mumble/UserLocalVolumeDialog.cpp
@@ -88,7 +88,7 @@ void UserLocalVolumeDialog::on_qsbUserLocalVolume_valueChanged(int value) {
 
 void UserLocalVolumeDialog::on_qbbUserLocalVolume_clicked(QAbstractButton *button) {
 	if (button == qbbUserLocalVolume->button(QDialogButtonBox::Reset)) {
-		qsUserLocalVolume->setValue(m_originalVolumeAdjustmentDecibel);
+		qsUserLocalVolume->setValue(0);
 	}
 	if (button == qbbUserLocalVolume->button(QDialogButtonBox::Ok)) {
 		ClientUser *user = ClientUser::get(m_clientSession);


### PR DESCRIPTION
When pressing the Reset button in Local Volume Adjustment, it now resets to 0 instead of the modified value.

Feature #2461