### PR TITLE
Fix various warnings in the Windows overlay found by upgrading to MSVC2015

### DIFF
--- a/overlay/lib.cpp
+++ b/overlay/lib.cpp
@@ -276,7 +276,12 @@ void Pipe::checkMessage(unsigned int width, unsigned int height) {
 				}
 				break;
 			case OVERLAY_MSGTYPE_BLIT: {
-					RECT r = {omMsg.omb.x, omMsg.omb.y, omMsg.omb.x + omMsg.omb.w, omMsg.omb.y + omMsg.omb.h};
+					RECT r = {
+						static_cast<LONG>(omMsg.omb.x),
+						static_cast<LONG>(omMsg.omb.y),
+						static_cast<LONG>(omMsg.omb.x + omMsg.omb.w),
+						static_cast<LONG>(omMsg.omb.y + omMsg.omb.h)
+					};
 
 					std::vector<RECT>::iterator i = blits.begin();
 					while (i != blits.end()) {

--- a/overlay/lib.h
+++ b/overlay/lib.h
@@ -7,6 +7,9 @@
 #define MUMBLE_LIB_H_
 
 #define _UNICODE
+#ifdef _WIN32_WINNT
+# undef _WIN32_WINNT
+#endif
 #define  _WIN32_WINNT 0x0501
 #include <stdio.h>
 #include <stdarg.h>

--- a/overlay/overlay_exe/overlay_exe.cpp
+++ b/overlay/overlay_exe/overlay_exe.cpp
@@ -150,8 +150,8 @@ int main(int argc, char **argv) {
 		}
 
 		try {
-			unsigned long passedInHandle = std::stoul(handleStr);
-			parent = reinterpret_cast<HANDLE>(passedInHandle & 0xFFFFFFFFUL);
+			unsigned long long passedInHandle = std::stoull(handleStr);
+			parent = reinterpret_cast<HANDLE>(passedInHandle & 0xFFFFFFFFULL);
 		} catch(std::exception &) {
 			return OVERLAY_HELPER_ERROR_EXE_INVALID_HANDLE_ARGUMENT;
 		}


### PR DESCRIPTION
Add LONG cast when creating RECT.

Before re-defining _WIN32_WINNT, undef it first, if it's already set.

Use unsigned long long in HANDLE conversion code in overlay_exe to avoid casting from a pointer to a smaller-than-pointer-sized integer.