### PR TITLE
compiler.pri: enable warnings-as-errors by default on Windows.

### DIFF
--- a/compiler.pri
+++ b/compiler.pri
@@ -91,6 +91,14 @@ win32 {
 		QMAKE_CXXFLAGS_RELEASE *= /analyze
 	}
 
+	# Always enable warnings-as-errors
+	# if we're inside a Mumble build environment.
+	# Can be disabled with CONFIG+=no-warnings-as-errors.
+	MUMBLE_PREFIX=$$(MUMBLE_PREFIX)
+	!isEmpty(MUMBLE_PREFIX):!CONFIG(no-warnings-as-errors) {
+		CONFIG += warnings-as-errors
+	}
+
 	CONFIG(warnings-as-errors) {
 		QMAKE_CFLAGS *= -WX
 		QMAKE_CXXFLAGS *= -WX


### PR DESCRIPTION
Apparently, I missed this the first time around.