### PR TITLE
Allow Mumble to be built with MSVC2015

### DIFF
--- a/compiler.pri
+++ b/compiler.pri
@@ -49,34 +49,9 @@ win32 {
 	QMAKE_LIBDIR *= "$$OPENSSL_PATH/lib" "$$LIBSNDFILE_PATH/lib" "$$BOOST_PATH/lib"
 	INCLUDEPATH *= "$$OPENSSL_PATH/include" "$$LIBSNDFILE_PATH/include"
 
-	# Sanity check that DXSDK_DIR, LIB and INCLUDE are properly set up.
-	#
-	# On Windows/x86, we build using the VS2013 v120_xp toolchain, which targets
-	# a slightly modified Win7 SDK that still allows building for Windows XP. In that
-	# environment, we must use the "external" DirectX SDK (June 2010). This SDK is
-	# specified via the SXSDK_DIR.
-	#
-	# On Windows/amd64, we build using the VS2013 v120 platform, and we target the
-	# Windows 8.1 SDK. In this setup, we use the DirectX SDK included with the Windows
-	# 8.1 SDK, but only to a point. The bundled SDK does not include all things that
-	# we depend on for the overlay, such as d3dx{9,10,11}. To overcome this, we use
-	# both SDKs: the one bundled with the Windows 8.1 SDK for most libraries, and the
-	# external June 2010 variant for the things that are not in the Windows 8.1 SDK
-	# variant of the DirectX SDK. This is the approach recommended by Microsoft:
-	# http://msdn.microsoft.com/en-us/library/windows/desktop/ee663275(v=vs.85).aspx
-	# (see step 5).
-	#
-	# Because of these things, the Windows build currently expects the build environment
-	# to properly set up the LIB and INCLUDE environment variables, with correct ordering
-	# of the Windows SDK and DirectX depending on the platform we're targetting.
-	# It's tough to check these things with qmake, we'll have to do with a simple sanity
-	# check for the presence of the variables.
-	DXSDK_DIR_VAR=$$(DXSDK_DIR)
+	# Sanity check that LIB and INCLUDE are properly set up.
 	INCLUDE_VAR=$$(INCLUDE)
 	LIB_VAR=$$(LIB)
-	isEmpty(DXSDK_DIR_VAR) {
-		error("Missing DXSDK_DIR environment variable. Are you missing the DirectX SDK (June 2010)?")
-	}
 	isEmpty(LIB_VAR) {
 		error("The LIB environment variable is not set. Are you not in a build environment?")
 	}

--- a/compiler.pri
+++ b/compiler.pri
@@ -109,6 +109,10 @@ win32 {
 	QMAKE_CXXFLAGS_RELEASE -= -Zc:strictStrings
 	QMAKE_CFLAGS_RELEASE_WITH_DEBUGINFO -= -Zc:strictStrings
 	QMAKE_CXXFLAGS_RELEASE_WITH_DEBUGINFO -= -Zc:strictStrings
+	# The mkspec update for MSVC2015 puts the flag directly in
+	# CFLAGS and CXXFLAGS, so try there, too.
+	QMAKE_CFLAGS -= -Zc:strictStrings
+	QMAKE_CXXFLAGS -= -Zc:strictStrings
 
 	# Explicitly set the subsystem versions to
 	# 5.01 (XP) for x86 and 6.00 (Vista) for x64.

--- a/plugins/mumble_plugin.h
+++ b/plugins/mumble_plugin.h
@@ -43,6 +43,16 @@
 # define MUMBLE_PLUGIN_MAGIC    0x9f3ed4c0
 # define MUMBLE_PLUGIN_MAGIC_2  0x9f3ed4cf
 # define MUMBLE_PLUGIN_MAGIC_QT 0x9f3ed4ca
+// Visual Studio 2015 x86
+#elif _MSC_VER == 1900 && defined(_M_IX86)
+# define MUMBLE_PLUGIN_MAGIC    0xa9b8c7c0
+# define MUMBLE_PLUGIN_MAGIC_2  0xa9b8c7cf
+# define MUMBLE_PLUGIN_MAGIC_QT 0xa9b8c7ca
+// Visual Studio 2015 x64
+#elif _MSC_VER == 1900 && defined(_M_X64)
+# define MUMBLE_PLUGIN_MAGIC    0x1f2e3dc0
+# define MUMBLE_PLUGIN_MAGIC_2  0x1f2e3dcf
+# define MUMBLE_PLUGIN_MAGIC_QT 0x1f2e3dca
 // Generic plugin magic values for platforms
 // where we do not officially plugins other
 // than "link".

--- a/src/mumble/os_win.cpp
+++ b/src/mumble/os_win.cpp
@@ -196,8 +196,9 @@ FARPROC WINAPI delayHook(unsigned dliNotify, PDelayLoadInfo pdli) {
 	return 0;
 }
 
+decltype(__pfnDliNotifyHook2) __pfnDliNotifyHook2 = delayHook;
+
 void os_init() {
-	__pfnDliNotifyHook2 = delayHook;
 	__cpuid(cpuinfo, 1);
 
 #define MMXSSE 0x02800000

--- a/toolchain/win32-msvc2015/x64.toolchain
+++ b/toolchain/win32-msvc2015/x64.toolchain
@@ -1,0 +1,39 @@
+# Copyright 2005-2016 The Mumble Developers. All rights reserved.
+# Use of this source code is governed by a BSD-style license
+# that can be found in the LICENSE file at the root of the
+# Mumble source tree or at <https://www.mumble.info/LICENSE>.
+
+# This file describes the x64 toolchain of
+# MSVC2015 compiler.
+#
+# This file can be included in a .pro file
+# to cause the target in that file to be
+# built for the x64 architecture, regardless
+# of the native architecture of the build
+# environment.
+
+# Use the x86-based amd64 cross compiler by default.
+QMAKE_CC = "\"$$(VCINSTALLDIR)bin\\x86_amd64\\cl.exe\""
+QMAKE_CXX = "\"$$(VCINSTALLDIR)bin\\x86_amd64\\cl.exe\""
+QMAKE_LINK = \""$$(VCINSTALLDIR)\\bin\\x86_amd64\\link.exe\""
+QMAKE_LIB = \""$$(VCINSTALLDIR)\\bin\\x86_amd64\\lib.exe\""
+
+# ...but use the native amd64 compiler if it is available.
+exists($$(VCINSTALLDIR)\\bin\\amd64) {
+	QMAKE_CC = "\"$$(VCINSTALLDIR)bin\\amd64\\cl.exe\""
+	QMAKE_CXX = "\"$$(VCINSTALLDIR)bin\\amd64\\cl.exe\""
+	QMAKE_LINK = \""$$(VCINSTALLDIR)\\bin\\amd64\\link.exe\""
+	QMAKE_LIB = \""$$(VCINSTALLDIR)\\bin\\amd64\\lib.exe\""
+}
+
+QMAKE_RC = \""$$(WindowsSdkDir)\\bin\\x64\\rc.exe\""
+
+INCLUDEPATH *= "$$(VCINSTALLDIR)\\include"
+INCLUDEPATH *= "$$(VCINSTALLDIR)\\atlmfc\\include"
+INCLUDEPATH *= "$$(WindowsSdkDir)\\include\\shared"
+INCLUDEPATH *= "$$(WindowsSdkDir)\\include\\um"
+INCLUDEPATH *= "$$(WindowsSdkDir)\\include\\winrt"
+
+QMAKE_LFLAGS *= "/LIBPATH:\"$$(VCINSTALLDIR)\\lib\\amd64\""
+QMAKE_LFLAGS *= "/LIBPATH:\"$$(VCINSTALLDIR)\\atlmfc\\lib\\amd64\""
+QMAKE_LFLAGS *= "/LIBPATH:\"$$(WindowsSdkDir)\\lib\\$$(WindowsSDKLibVersion)um\\x64\""

--- a/toolchain/win32-msvc2015/x86-xp.toolchain
+++ b/toolchain/win32-msvc2015/x86-xp.toolchain
@@ -1,0 +1,37 @@
+# Copyright 2005-2016 The Mumble Developers. All rights reserved.
+# Use of this source code is governed by a BSD-style license
+# that can be found in the LICENSE file at the root of the
+# Mumble source tree or at <https://www.mumble.info/LICENSE>.
+
+# This file describes the x86-xp toolchain of
+# MSVC2015 compiler. This is a special toolchain
+# that is designed to be backwards compatible
+# with Windows XP.
+#
+# This file can be included in a .pro file
+# to cause the target in that file to be
+# built for the x86 architecture targetting
+# Windows XP, regardless of the native
+# architecture of the build environment.
+
+WIN7_XP_SDK_DIR="C:\\Program Files (x86)\\Microsoft SDKs\\Windows\\v7.1A"
+
+QMAKE_CC = "\"$$(VCINSTALLDIR)bin\\cl.exe\" /D_USING_V110_SDK71_"
+QMAKE_CXX = "\"$$(VCINSTALLDIR)bin\\cl.exe\" /D_USING_V110_SDK71_"
+QMAKE_LINK = \""$$(VCINSTALLDIR)\\bin\\link.exe\""
+QMAKE_LIB = \""$$(VCINSTALLDIR)\\bin\\lib.exe\""
+QMAKE_RC = \""$${WIN7_XP_SDK_DIR}\\bin\\rc.exe\" /D_USING_V110_SDK71_"
+
+INCLUDEPATH *= "$$(DXSDK_DIR)\\include"
+INCLUDEPATH *= "$${WIN7_XP_SDK_DIR}\\include"
+INCLUDEPATH *= "$$(VCINSTALLDIR)\\include"
+INCLUDEPATH *= "$$(VCINSTALLDIR)\\atlmfc\\include"
+INCLUDEPATH *= "$$(WindowsSdkDir)\\include\\shared"
+INCLUDEPATH *= "$$(WindowsSdkDir)\\include\\um"
+INCLUDEPATH *= "$$(WindowsSdkDir)\\include\\winrt"
+
+QMAKE_LFLAGS *= "/LIBPATH:\"$$(DXSDK_DIR)\\lib\\x86\""
+QMAKE_LFLAGS *= "/LIBPATH:\"$$(VCINSTALLDIR)\\lib\""
+QMAKE_LFLAGS *= "/LIBPATH:\"$$(VCINSTALLDIR)\\atlmfc\\lib\""
+QMAKE_LFLAGS *= "/LIBPATH:\"$$(WindowsSdkDir)\\lib\\$$(WindowsSDKLibVersion)um\\x86\""
+QMAKE_LFLAGS *= "/LIBPATH:\"$$(WindowsSdkDir)\\lib\\$$(WindowsSDKLibVersion)ucrt\\x86\""

--- a/toolchain/win32-msvc2015/x86.toolchain
+++ b/toolchain/win32-msvc2015/x86.toolchain
@@ -1,0 +1,29 @@
+# Copyright 2005-2016 The Mumble Developers. All rights reserved.
+# Use of this source code is governed by a BSD-style license
+# that can be found in the LICENSE file at the root of the
+# Mumble source tree or at <https://www.mumble.info/LICENSE>.
+
+# This file describes the x86 toolchain of
+# MSVC2015 compiler.
+#
+# This file can be included in a .pro file
+# to cause the target in that file to be
+# built for the x86 architecture, regardless
+# of the native architecture of the build
+# environment.
+
+QMAKE_CC = "\"$$(VCINSTALLDIR)bin\\cl.exe\""
+QMAKE_CXX = "\"$$(VCINSTALLDIR)bin\\cl.exe\""
+QMAKE_LINK = \""$$(VCINSTALLDIR)\\bin\\link.exe\""
+QMAKE_LIB = \""$$(VCINSTALLDIR)\\bin\\lib.exe\""
+QMAKE_RC = \""$$(WindowsSdkDir)\\bin\\x86\\rc.exe\""
+
+INCLUDEPATH *= "$$(VCINSTALLDIR)\\include"
+INCLUDEPATH *= "$$(VCINSTALLDIR)\\atlmfc\\include"
+INCLUDEPATH *= "$$(WindowsSdkDir)\\include\\shared"
+INCLUDEPATH *= "$$(WindowsSdkDir)\\include\\um"
+INCLUDEPATH *= "$$(WindowsSdkDir)\\include\\winrt"
+
+QMAKE_LFLAGS *= "/LIBPATH:\"$$(VCINSTALLDIR)\\lib\""
+QMAKE_LFLAGS *= "/LIBPATH:\"$$(VCINSTALLDIR)\\atlmfc\\lib\""
+QMAKE_LFLAGS *= "/LIBPATH:\"$$(WindowsSdkDir)\\lib\\$$(WindowsSDKLibVersion)um\\x86\""


### PR DESCRIPTION
This PR adds a toolchain file, and includes various small fixups that are needed to make Mumble build on MSVC2015.

This PR, by itself, allows both Mumble and Murmur to build, but the x64 overlay and some plugins do not build without extra PRs. These are:

https://github.com/mumble-voip/mumble/pull/2522
https://github.com/mumble-voip/mumble/pull/2523

MSVC2015 also shows a few new warnings. These are fixed in the following PRs:
https://github.com/mumble-voip/mumble/pull/2525
https://github.com/mumble-voip/mumble/pull/2524

And, to finish off, PR https://github.com/mumble-voip/mumble/pull/2526 enables warnings by default on Windows when in a buildenv. I used this when fixing the tree.

