### PR TITLE
Send clipboard content to chat

### DIFF
--- a/src/mumble/MainWindow.cpp
+++ b/src/mumble/MainWindow.cpp
@@ -231,6 +231,10 @@ void MainWindow::createActions() {
 	gsSendTextMessage=new GlobalShortcut(this, idx++, tr("Send Text Message", "Global Shortcut"), true, QVariant(QString()));
 	gsSendTextMessage->setObjectName(QLatin1String("gsSendTextMessage"));
 
+	gsSendClipboardTextMessage=new GlobalShortcut(this, idx++, tr("Send Clipboard Text Message", "Global Shortcut"));
+	gsSendClipboardTextMessage->setObjectName(QLatin1String("gsSendClipboardTextMessage"));
+	gsSendClipboardTextMessage->qsWhatsThis = tr("This will send your Clipboard content to the channel you are currently in.", "Global Shortcut");
+
 #ifndef Q_OS_MAC
 	qstiIcon->show();
 #endif
@@ -2692,6 +2696,16 @@ void MainWindow::on_gsSendTextMessage_triggered(bool down, QVariant scdata) {
 	Channel *c = ClientUser::get(g.uiSession)->cChannel;
 	g.sh->sendChannelTextMessage(c->iId, qsText, false);
 	g.l->log(Log::TextMessage, tr("To %1: %2").arg(Log::formatChannel(c), qsText), tr("Message to channel %1").arg(c->qsName), true);
+}
+
+void MainWindow::on_gsSendClipboardTextMessage_triggered(bool down, QVariant) {
+	if (!down) {
+		return;
+	}
+
+	// call sendChatbarMessage() instead of on_gsSendTextMessage_triggered() to handle
+	// formatting of the content in the clipboard, i.e., href.  
+	sendChatbarMessage(QApplication::clipboard()->text());
 }
 
 void MainWindow::whisperReleased(QVariant scdata) {

--- a/src/mumble/MainWindow.h
+++ b/src/mumble/MainWindow.h
@@ -77,7 +77,7 @@ class MainWindow : public QMainWindow, public MessageHandler, public Ui::MainWin
 		GlobalShortcut *gsUnlink, *gsPushMute, *gsJoinChannel, *gsToggleOverlay;
 		GlobalShortcut *gsMinimal, *gsVolumeUp, *gsVolumeDown, *gsWhisper, *gsLinkChannel;
 		GlobalShortcut *gsCycleTransmitMode;
-		GlobalShortcut *gsSendTextMessage;
+		GlobalShortcut *gsSendTextMessage, *gsSendClipboardTextMessage;
 		DockTitleBar *dtbLogDockTitle, *dtbChatDockTitle;
 
 		ACLEditor *aclEdit;
@@ -256,6 +256,7 @@ class MainWindow : public QMainWindow, public MessageHandler, public Ui::MainWin
 		void removeTarget(ShortcutTarget *);
 		void on_gsCycleTransmitMode_triggered(bool, QVariant);
 		void on_gsSendTextMessage_triggered(bool, QVariant);
+		void on_gsSendClipboardTextMessage_triggered(bool, QVariant);
 		void on_Reconnect_timeout();
 		void on_Icon_messageClicked();
 		void on_Icon_activated(QSystemTrayIcon::ActivationReason);


### PR DESCRIPTION
Paste and Send from Clipboard Shortcut #2501

Users can now set a shortcut to send the content in their clipboard to the channel they are in. Works when mumble is not in the foreground.

Feature #2501 