### PR TITLE
Messages: add the prefix “Private” in MainWindow::msgTextMessage().

### DIFF
--- a/src/mumble/Messages.cpp
+++ b/src/mumble/Messages.cpp
@@ -682,6 +682,8 @@ void MainWindow::msgTextMessage(const MumbleProto::TextMessage &msg) {
 		target += tr("(Tree) ");
 	} else if (msg.channel_id_size() > 0) {
 		target += tr("(Channel) ");
+	} else if (msg.session_size() > 0) {
+		target += tr("(Private) ");
 	}
 
 	g.l->log(Log::TextMessage, tr("%2%1: %3").arg(name).arg(target).arg(u8(msg.message())),


### PR DESCRIPTION
Users can only detect private messages
if there is no prefix like “Channel” or “Tree”
in the messages.

This commit adds a prefix “Private” to the sender.

Fixes mumble-voip/mumble#2362