### PR TITLE
Murmur postgresql support

### DIFF
--- a/src/murmur/ServerDB.cpp
+++ b/src/murmur/ServerDB.cpp
@@ -473,7 +473,7 @@ ServerDB::ServerDB() {
 		} else {
 			qWarning("Importing old data...");
 
-			if (Meta::mp.qsDBDriver != "QSQLITE" && Meta::mp.qsDBDriver != "QPSQL")
+			if (Meta::mp.qsDBDriver == "QMYSQL")
 				SQLDO("SET FOREIGN_KEY_CHECKS = 0;");
 			SQLDO("INSERT INTO `%1servers` (`server_id`) SELECT `server_id` FROM `%1servers%2`");
 			SQLDO("INSERT INTO `%1slog` (`server_id`, `msg`, `msgtime`) SELECT `server_id`, `msg`, `msgtime` FROM `%1slog%2`");
@@ -549,7 +549,7 @@ ServerDB::ServerDB() {
 				SQLDO("INSERT INTO `%1channel_info` SELECT * FROM `%1channel_info%2`");
 			}
 
-			if (Meta::mp.qsDBDriver != "QSQLITE" && Meta::mp.qsDBDriver != "QPSQL")
+			if (Meta::mp.qsDBDriver == "QMYSQL")
 				SQLDO("SET FOREIGN_KEY_CHECKS = 1;");
 
 			qWarning("Removing old tables...");

--- a/src/murmur/ServerDB.cpp
+++ b/src/murmur/ServerDB.cpp
@@ -644,16 +644,6 @@ bool ServerDB::query(QSqlQuery &query, const QString &str, bool fatal, bool warn
 		if (query.exec(q)) {
 			return true;
 		} else {
-			db->close();
-			if (! db->open()) {
-				qFatal("Lost connection to SQL Database: Reconnect: %s", qPrintable(db->lastError().text()));
-			}
-			query = QSqlQuery();
-			if (query.exec(q)) {
-				qWarning("SQL Connection lost, reconnection OK");
-				return true;
-			}	
-			
 			if (fatal) {
 				*db = QSqlDatabase();
 				qFatal("SQL Error [%s]: %s", qPrintable(query.lastQuery()), qPrintable(query.lastError().text()));

--- a/src/murmur/ServerDB.cpp
+++ b/src/murmur/ServerDB.cpp
@@ -28,22 +28,22 @@
 
 
 class TransactionHolder {
-public:
-	QSqlQuery *qsqQuery;
-	TransactionHolder() {
-		ServerDB::db->transaction();
-		qsqQuery = new QSqlQuery();
-	}
+	public:
+		QSqlQuery *qsqQuery;
+		TransactionHolder() {
+			ServerDB::db->transaction();
+			qsqQuery = new QSqlQuery();
+		}
 
-	~TransactionHolder() {
-		qsqQuery->clear();
-		delete qsqQuery;
-		ServerDB::db->commit();
-	}
-	TransactionHolder(const TransactionHolder & other) {
-		ServerDB::db->transaction();
-		qsqQuery = other.qsqQuery ? new QSqlQuery(*other.qsqQuery) : 0;
-	}
+		~TransactionHolder() {
+			qsqQuery->clear();
+			delete qsqQuery;
+			ServerDB::db->commit();
+		}
+		TransactionHolder(const TransactionHolder & other) {
+			ServerDB::db->transaction();
+			qsqQuery = other.qsqQuery ? new QSqlQuery(*other.qsqQuery) : 0;
+		}
 };
 
 QSqlDatabase *ServerDB::db = NULL;
@@ -54,32 +54,32 @@ void ServerDB::loadOrSetupMetaPKBDF2IterationsCount(QSqlQuery &query) {
 	if (!Meta::mp.legacyPasswordHash) {
 		if (Meta::mp.kdfIterations <= 0) {
 			// Configuration doesn't specify an override, load from db
-
+			
 			SQLDO("SELECT `value` FROM `%1meta` WHERE `keystring` = 'pbkdf2_iterations'");
 			if (query.next()) {
 				Meta::mp.kdfIterations = query.value(0).toInt();
 			}
-
+			
 			if (Meta::mp.kdfIterations <= 0) {
 				// Didn't get a valid iteration count from DB, overwrite
 				Meta::mp.kdfIterations = PBKDF2::benchmark();
-
+				
 				qWarning() << "Performed initial PBKDF2 benchmark. Will use " << Meta::mp.kdfIterations << " iterations as default";
-
+				
 				SQLPREP("INSERT INTO `%1meta` (`keystring`, `value`) VALUES('pbkdf2_iterations',?)");
 				query.addBindValue(Meta::mp.kdfIterations);
 				SQLEXEC();
 			}
 		}
-
+		
 		if (Meta::mp.kdfIterations < PBKDF2::BENCHMARK_MINIMUM_ITERATION_COUNT) {
 			qWarning() << "Configured default PBKDF2 iteration count of " << Meta::mp.kdfIterations << " is below minimum recommended value of " << PBKDF2::BENCHMARK_MINIMUM_ITERATION_COUNT << " and could be insecure.";
 		}
-	}
+	}	
 }
 
 ServerDB::ServerDB() {
-	if (!QSqlDatabase::isDriverAvailable(Meta::mp.qsDBDriver)) {
+	if (! QSqlDatabase::isDriverAvailable(Meta::mp.qsDBDriver)) {
 		qFatal("ServerDB: Database driver %s not available", qPrintable(Meta::mp.qsDBDriver));
 	}
 	if (db) {

--- a/src/murmur/ServerDB.cpp
+++ b/src/murmur/ServerDB.cpp
@@ -326,7 +326,7 @@ ServerDB::ServerDB() {
 			}
 			SQLQUERY("CREATE TABLE `%1servers`(`server_id` SERIAL PRIMARY KEY)");
 
-			SQLQUERY("CREATE TABLE `%1slog`(`server_id` INTEGER NOT NULL, `msg` TEXT, `msgtime` TIMESTAMP)");
+			SQLQUERY("CREATE TABLE `%1slog`(`server_id` INTEGER NOT NULL, `msg` TEXT, `msgtime` TIMESTAMP DEFAULT now())");
 			SQLQUERY("CREATE INDEX `%1slog_time` ON `%1slog`(`msgtime`)");
 			SQLQUERY("ALTER TABLE `%1slog` ADD CONSTRAINT `%1slog_server_del` FOREIGN KEY (`server_id`) REFERENCES `%1servers`(`server_id`) ON DELETE CASCADE");
 
@@ -343,7 +343,7 @@ ServerDB::ServerDB() {
 			SQLQUERY("CREATE UNIQUE INDEX `%1channel_info_id` ON `%1channel_info`(`server_id`, `channel_id`, `key`)");
 			SQLQUERY("ALTER TABLE `%1channel_info` ADD CONSTRAINT `%1channel_info_del_channel` FOREIGN KEY (`server_id`, `channel_id`) REFERENCES `%1channels`(`server_id`,`channel_id`) ON DELETE CASCADE");
 
-			SQLQUERY("CREATE TABLE `%1users` (`server_id` INTEGER NOT NULL, `user_id` INTEGER NOT NULL, `name` varchar(255), `pw` varchar(128), `lastchannel` INTEGER, `texture` BYTEA, `last_active` TIMESTAMP)");
+			SQLQUERY("CREATE TABLE `%1users` (`server_id` INTEGER NOT NULL, `user_id` INTEGER NOT NULL, `name` varchar(255), `pw` varchar(128), `salt` varchar(128), `kdfiterations` INTEGER, `lastchannel` INTEGER, `texture` BYTEA, `last_active` TIMESTAMP)");
 			SQLQUERY("CREATE INDEX `%1users_channel` ON `%1users`(`server_id`, `lastchannel`)");
 			SQLQUERY("CREATE UNIQUE INDEX `%1users_name` ON `%1users` (`server_id`,`name`)");
 			SQLQUERY("CREATE UNIQUE INDEX `%1users_id` ON `%1users` (`server_id`, `user_id`)");
@@ -2068,7 +2068,7 @@ void Server::dblog(const QString &str) const {
 		}
 	}
 
-	SQLPREP("INSERT INTO `%1slog` (`server_id`, `msg`, `msgtime`) VALUES(?,?, now())");
+	SQLPREP("INSERT INTO `%1slog` (`server_id`, `msg`) VALUES(?,?)");
 	query.addBindValue(iServerNum);
 	query.addBindValue(str);
 	SQLEXEC();

--- a/src/murmur/ServerDB.h
+++ b/src/murmur/ServerDB.h
@@ -41,6 +41,7 @@ class ServerDB {
 		static int getLogLen(int server_id);
 		static void wipeLogs();
 		static bool prepare(QSqlQuery &, const QString &, bool fatal = true, bool warn = true);
+		static bool query(QSqlQuery &, const QString &, bool fatal = true, bool warn = true);
 		static bool exec(QSqlQuery &, const QString &str = QString(), bool fatal= true, bool warn = true);
 		static bool execBatch(QSqlQuery &, const QString &str = QString(), bool fatal= true);
 		// No copy; private declaration without implementation


### PR DESCRIPTION
This is the new and improved version of https://github.com/mumble-voip/mumble/pull/2383 and addresses issue https://github.com/mumble-voip/mumble/issues/2187

This pull request uses the UPSERT functionality of PostgreSQL. If QPSQL is chosen as the database engine in mumble-server.ini then the **version of PostgreSQL used needs to be 9.5 or higher**.

Key changes this pull request makes:
- It adds the patch from https://sourceforge.net/p/mumble/patches/368/
- It updates the create user table function to include salt and kdfiterations since they weren't used when the patch was made.
- It fixes the dblog function so it works for both PostgreSQL and other database types.
- The patch used the same method to insert or update rows for all database engines. This has been changed so that PostgreSQL uses UPSERT (INSERT ... ON CONFLICT (...) DO UPDATE ...) and all other engines use the same REPLACE INTO statement as they currently do.
- The reconnection logic from the patch has been removed as there were issues with it.
- There are some white space fixes too.

Example settings for mumble-server.ini to use PostgerSQL:
database=localdb
dbDriver=QPSQL
dbUsername=murmur
dbPassword=murmurpass
dbHost=localhost
dbPort=5432
dbPrefix=murmur_

These settings will cause murmur to try and connect to a PostgreSQL database called "localdb" on the server with the address "localhost" and port 5432.
It will connect using the username "murmur" and the password "murmurpass". All the tables and sequences automatically created used will have the prefix "murmur_".
If there is a schema with the same name as the user name then the murmur tables and sequences will be created in that schema (this is the default PostgreSQL behavior).