### PR TITLE
Enable the Opus music encoder

### DIFF
--- a/src/mumble/AudioInput.cpp
+++ b/src/mumble/AudioInput.cpp
@@ -85,7 +85,14 @@ AudioInput::AudioInput() : opusBuffer(g.s.iFramesPerPacket * (SAMPLE_RATE / 100)
 	iFrameSize = SAMPLE_RATE / 100;
 
 #ifdef USE_OPUS
-	opusState = opus_encoder_create(SAMPLE_RATE, 1, OPUS_APPLICATION_VOIP, NULL);
+	if (!g.s.bUseOpusMusicEncoding) {
+		opusState = opus_encoder_create(SAMPLE_RATE, 1, OPUS_APPLICATION_VOIP, NULL);
+		qWarning("AudioInput: Opus encoder set for VOIP");
+	} else {
+		opusState = opus_encoder_create(SAMPLE_RATE, 1, OPUS_APPLICATION_AUDIO, NULL);
+		qWarning("AudioInput: Opus encoder set for Music");
+	}
+
 	opus_encoder_ctl(opusState, OPUS_SET_VBR(0)); // CBR
 #endif
 

--- a/src/mumble/Settings.cpp
+++ b/src/mumble/Settings.cpp
@@ -249,6 +249,8 @@ Settings::Settings() {
 	fVADmin = 0.80f;
 	fVADmax = 0.98f;
 
+	bUseOpusMusicEncoding = false;
+
 	bTxAudioCue = false;
 	qsTxAudioCueOn = cqsDefaultPushClickOn;
 	qsTxAudioCueOff = cqsDefaultPushClickOff;
@@ -590,6 +592,8 @@ void Settings::load(QSettings* settings_ptr) {
 	SAVELOAD(bWhisperFriends, "audio/whisperfriends");
 	SAVELOAD(bTransmitPosition, "audio/postransmit");
 
+	SAVELOAD(bUseOpusMusicEncoding, "codec/opus/encoder/music");
+
 	SAVELOAD(iJitterBufferSize, "net/jitterbuffer");
 	SAVELOAD(iFramesPerPacket, "net/framesperpacket");
 
@@ -900,6 +904,8 @@ void Settings::save() {
 	SAVELOAD(qsAudioOutput, "audio/output");
 	SAVELOAD(bWhisperFriends, "audio/whisperfriends");
 	SAVELOAD(bTransmitPosition, "audio/postransmit");
+
+	SAVELOAD(bUseOpusMusicEncoding, "codec/opus/encoder/music");
 
 	SAVELOAD(iJitterBufferSize, "net/jitterbuffer");
 	SAVELOAD(iFramesPerPacket, "net/framesperpacket");

--- a/src/mumble/Settings.h
+++ b/src/mumble/Settings.h
@@ -190,6 +190,7 @@ struct Settings {
 	bool bOnlyAttenuateSameOutput;
 	bool bAttenuateLoopbacks;
 	int iOutputDelay;
+	bool bUseOpusMusicEncoding;
 
 	QString qsALSAInput, qsALSAOutput;
 	QString qsPulseAudioInput, qsPulseAudioOutput;


### PR DESCRIPTION
This commit adds the ability to use the AUDIO encoder
instead of the VOIP encoder, that can be used for
bots or broadcaster, who wants to stream in a higher quality.

To enable this feature add this to the Mumble config:
[codec]
opus/encoder/music=true

Fixes mumble-voip/mumble#1630