### PR TITLE
Revert PR #2531: installer: use MSVC2015 runtime.

### DIFF
--- a/installer/Files.wxs
+++ b/installer/Files.wxs
@@ -66,12 +66,12 @@
         </Component>
       <?endif ?>
 
-      <?ifdef RedistDirVC14 ?>
-      <Component Id="msvcp140.dll">
-        <File Source="$(var.RedistDirVC14)\msvcp140.dll" KeyPath="yes" />
+      <?ifdef RedistDirVC12 ?>
+      <Component Id="msvcp120.dll">
+        <File Source="$(var.RedistDirVC12)\msvcp120.dll" KeyPath="yes" />
       </Component>
-      <Component Id="vcruntime140.dll">
-        <File Source="$(var.RedistDirVC14)\vcruntime140.dll" KeyPath="yes" />
+      <Component Id="msvcr120.dll">
+        <File Source="$(var.RedistDirVC12)\msvcr120.dll" KeyPath="yes" />
       </Component>
       <?endif ?>
 
@@ -135,12 +135,12 @@
       </Component>
 
       <?ifdef VersionSubDir ?>
-        <?ifdef RedistDirVC14 ?>
-        <Component Id="Murmur_msvcp140.dll">
-          <File Id="Murmur_msvcp140.dll" Source="$(var.RedistDirVC14)\msvcp140.dll" KeyPath="yes" />
+        <?ifdef RedistDirVC12 ?>
+        <Component Id="Murmur_msvcp120.dll">
+          <File Id="Murmur_msvcp120.dll" Source="$(var.RedistDirVC12)\msvcp120.dll" KeyPath="yes" />
         </Component>
-        <Component Id="Murmur_vcruntime140.dll">
-          <File Id="Murmur_vcruntime140.dll" Source="$(var.RedistDirVC14)\vcruntime140.dll" KeyPath="yes" />
+        <Component Id="Murmur_msvcr120.dll">
+          <File Id="Murmur_msvcr120.dll" Source="$(var.RedistDirVC12)\msvcr120.dll" KeyPath="yes" />
         </Component>
         <?endif ?>
         <Component Id="Murmur_dbghelp.dll">

--- a/installer/Product.wxs
+++ b/installer/Product.wxs
@@ -132,9 +132,9 @@
         <ComponentRef Id="mumble_g15_helper.exe" />
       <?endif ?>
 
-      <?ifdef RedistDirVC14 ?>
-        <ComponentRef Id="msvcp140.dll" />
-        <ComponentRef Id="vcruntime140.dll" />
+      <?ifdef RedistDirVC12 ?>
+        <ComponentRef Id="msvcp120.dll" />
+        <ComponentRef Id="msvcr120.dll" />
       <?endif ?>
 
       <ComponentRef Id="dbghelp.dll" />
@@ -150,9 +150,9 @@
       <ComponentRef Id="Murmur.ice" />
 
       <?ifdef VersionSubDir ?>
-        <?ifdef RedistDirVC14 ?>
-          <ComponentRef Id="Murmur_msvcp140.dll" />
-          <ComponentRef Id="Murmur_vcruntime140.dll" />
+        <?ifdef RedistDirVC12 ?>
+          <ComponentRef Id="Murmur_msvcp120.dll" />
+          <ComponentRef Id="Murmur_msvcr120.dll" />
         <?endif ?>
         <ComponentRef Id="Murmur_dbghelp.dll" />
       <?endif ?>

--- a/installer/Settings.wxi
+++ b/installer/Settings.wxi
@@ -92,14 +92,14 @@
   
   <!-- Don't embed VCRedist files if MumbleNoEmbedVCRedist env var is set. -->
   <?ifndef env.MumbleNoEmbedVCRedist ?>
-     <?ifndef env.MumbleRedistDirVC14 ?>
+     <?ifndef env.MumbleRedistDirVC12 ?>
        <?if $(sys.BUILDARCH) = "x86" ?>
-         <?define RedistDirVC14 = "C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\redist\x86\Microsoft.VC140.CRT" ?>
+         <?define RedistDirVC12 = "C:\Program Files (x86)\Microsoft Visual Studio 12.0\VC\redist\x86\Microsoft.VC120.CRT" ?>
        <?elseif $(sys.BUILDARCH) = "x64" ?>
-         <?define RedistDirVC14 = "C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\redist\x64\Microsoft.VC140.CRT" ?>
+         <?define RedistDirVC12 = "C:\Program Files (x86)\Microsoft Visual Studio 12.0\VC\redist\x64\Microsoft.VC120.CRT" ?>
        <?endif ?>
      <?else ?>
-       <?define RedistDirVC14 = "$(env.MumbleRedistDirVC14)" ?>
+       <?define RedistDirVC12 = "$(env.MumbleRedistDirVC12)" ?>
      <?endif ?>
   <?endif ?>
 


### PR DESCRIPTION
There's a conflict with MSVC2015 and LTCG with Mumble's codebase.
Revert to MSVC2013 so we can keep snapshots rolling for now.