### PR TITLE
MainWindow: avoid initial setupView(false) call in setupGui() on Qt 5.

### DIFF
--- a/src/mumble/MainWindow.cpp
+++ b/src/mumble/MainWindow.cpp
@@ -333,7 +333,7 @@ void MainWindow::setupGui()  {
 
 	updateTransmitModeComboBox();
 
-#ifndef Q_OS_MAC
+#if QT_VERSION < 0x050000 && !defined(Q_OS_MAC)
 	setupView(false);
 #endif
 


### PR DESCRIPTION
The old behavior causes the MainWindow to not appear on Linux when
using certain Qt 5 versions.

Removing the call to setupView(false) fixes the problem for all
Linux users who have tried it.

I've also tested removing the code path on Windows, and everything
still works as expected.

We'll keep the code path for Qt 4 builds, though!

Fixes mumble-voip/mumble#2192