### PR TITLE
Added a DBus method for getting a list of currently talking users.

### DIFF
--- a/src/mumble/DBus.cpp
+++ b/src/mumble/DBus.cpp
@@ -61,6 +61,18 @@ void MumbleDBus::getCurrentUrl(const QDBusMessage &msg) {
 	QDBusConnection::sessionBus().send(msg.createReply(QString::fromLatin1(u.toEncoded())));
 }
 
+void MumbleDBus::getTalkingUsers(const QDBusMessage &msg) {
+	if (!g.sh || !g.sh->isRunning() || ! g.uiSession) {
+		QDBusConnection::sessionBus().send(msg.createErrorReply(QLatin1String("net.sourceforge.mumble.Error.connection"), QLatin1String("Not connected")));
+		return;
+	}
+	QStringList names;
+	foreach(ClientUser *cu, ClientUser::getTalking()) {
+		names.append(cu->qsName);
+	}
+	QDBusConnection::sessionBus().send(msg.createReply(names));
+}
+
 void MumbleDBus::focus() {
 	g.mw->show();
 	g.mw->raise();

--- a/src/mumble/DBus.h
+++ b/src/mumble/DBus.h
@@ -22,6 +22,7 @@ class MumbleDBus : public QDBusAbstractAdaptor {
 	public slots:
 		void openUrl(const QString &url, const QDBusMessage &);
 		void getCurrentUrl(const QDBusMessage &);
+		void getTalkingUsers(const QDBusMessage &);
 		void focus();
 		void setSelfMuted(bool mute);
 		void setSelfDeaf(bool deafen);


### PR DESCRIPTION
This is useful, for example, when bridging mumble to a two-way radio. A script can query mumble over DBus for when to push the radio's push-to-talk button.