### PR TITLE
Added an appdata.xml file for Linux software gallery integration

### DIFF
--- a/scripts/mumble.appdata.xml
+++ b/scripts/mumble.appdata.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<application>
+  <id type="desktop">mumble.desktop</id>
+  <metadata_license>CC0-1.0</metadata_license>
+  <project_license>BSD-3-Clause</project_license>
+  <title>Mumble</title>
+  <summary>Voice Chat Software</summary>
+  <description>
+    <p>Mumble is an open source, low-latency, high quality voice chat software primarily intended for use while gaming.</p>
+  </description>
+  <url type="homepage">https://wiki.mumble.info</url>
+  <screenshots>
+    <screenshot type="default">
+      <image>https://screenshots.debian.net/screenshots/000/001/906/large.png</image>
+    </screenshot>
+  </screenshots>
+</application>

--- a/scripts/scripts.pro
+++ b/scripts/scripts.pro
@@ -6,4 +6,4 @@
 DIST *= server/dbus/murmur.pl server/dbus/dbusauth.pl server/dbus/weblist.pl
 DIST *= server/ice/weblist.php server/ice/icedemo.php
 DIST *= murmur.ini murmur.ini.system murmur.init murmur.conf murmur.logrotate murmur-user-wrapper
-DIST *= mumble-overlay mumble.desktop mumble.protocol
+DIST *= mumble-overlay mumble.desktop mumble.protocol mumble.appdata.xml


### PR DESCRIPTION
https://people.freedesktop.org/~hughsient/appdata/ has some more details. The screenshot is pretty poor but https://wiki.mumble.info/wiki/Category:Screenshots_of_Mumble_client had none for Linux.