### PR TITLE
Fix #2572: Fix invisible Quickchat bar on startup

### DIFF
--- a/src/mumble/MainWindow.cpp
+++ b/src/mumble/MainWindow.cpp
@@ -333,7 +333,9 @@ void MainWindow::setupGui()  {
 
 	updateTransmitModeComboBox();
 
-#if QT_VERSION < 0x050000 && !defined(Q_OS_MAC)
+// For Qt >= 5, enable this call (only) for Windows.
+// For Qt < 5, enable for anything but macOS.
+#if (QT_VERSION >= 0x050000 && defined(Q_OS_WIN)) || (QT_VERSION < 0x050000 && !defined(Q_OS_MAC))
 	setupView(false);
 #endif
 


### PR DESCRIPTION
Since 4009ea353944fc9cbefcbf95979f0d6d0c0ec3b2 on Windows the quickchat
bar was invisible on startup due to height 0. We keep the new logic
introduced for other OSes, but for Windows, we keep the setupView(false)
call.

@mkrautz You wrote the change was tested on Windows. Did you not notice this problem?
PTAL