### PR TITLE
Log information about missing target channel

### DIFF
--- a/src/mumble/MainWindow.cpp
+++ b/src/mumble/MainWindow.cpp
@@ -931,8 +931,11 @@ void MainWindow::findDesiredChannel() {
 			g.sh->joinChannel(g.uiSession, chan->iId);
 		}
 		qtvUsers->setCurrentIndex(pmModel->index(chan));
-	} else if (g.uiSession) {
-		qtvUsers->setCurrentIndex(pmModel->index(ClientUser::get(g.uiSession)->cChannel));
+	} else {
+		g.l->log(Log::Information, tr("The targeted channel could not be found."));
+		if (g.uiSession) {
+			qtvUsers->setCurrentIndex(pmModel->index(ClientUser::get(g.uiSession)->cChannel));
+		}
 	}
 	updateMenuPermissions();
 }


### PR DESCRIPTION
For lack of better presentation, I implemented it as a simple log information. A dialog would be more prominent/visible, but equally more annoying. On connectivity issues with (some kind of) dynamic channels this could be pretty annoying as well (server reconnects). A log message is the less intrusive way to inform.

Fixes #2577 E.g. when connecting via Mumble URL and the target channel does not exist
