### PR TITLE
compiler.pri: explicitly default to C++03 on Unix-like systems.

### DIFF
--- a/compiler.pri
+++ b/compiler.pri
@@ -105,6 +105,31 @@ unix {
 		QMAKE_CFLAGS *= -O3 -march=native -ffast-math -ftree-vectorize -fprofile-use
 		QMAKE_CXXFLAGS *= -O3 -march=native -ffast-math -ftree-vectorize -fprofile-use
 	}
+
+	# Note: Mumble and Murmur 1.2.x wasn't developed in C++11 mode,
+	# and has not seen sufficient testing. Use this CONFIG option at
+	# your own risk.
+	CONFIG(c++11) {
+		QMAKE_CXXFLAGS *= -std=c++11
+
+		# Debian seems to put C++11 variants of shared libraries
+		# in /usr/lib/$triple/c++11.
+		#
+		# At least, that is the case for ZeroC Ice.
+		#
+		# The expectation is that this is a general convention,
+		# so add it to our library search path in C++11 mode.
+		MULTIARCH_TRIPLE = $$system($${QMAKE_CXX} -print-multiarch)
+		!isEmpty(MULTIARCH_TRIPLE) {
+			QMAKE_LIBDIR *= /usr/lib/$${MULTIARCH_TRIPLE}/c++11
+		}
+	} else {
+		# If C++11 support hasn't been explicitly enabled,
+		# force C++03 mode. If we don't do this, newer
+		# compilers (such as G++ 6) will default to C++11
+		# without us being aware.
+		QMAKE_CXXFLAGS *= -std=c++03
+	}
 }
 
 unix:!macx {


### PR DESCRIPTION
This is an offshoot of Debian bug #831184.
(See https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=831184)

Basically, G++6 now defaults to C++11 (or greater) mode.
We haven't explicitly passed a C++ standard C(XX)FLAG, so
until now, we've built against the g++/clang's default, which
until now was C++98 or C++03.

Now, Mumble itself doesn't really care what C++ mode it's built in.
We build fine in C++11 mode.

However, on Debian/Ubuntu, libraries such as ZeroC Ice
provide separate C++11 and C++03 .so's with different ABIs.
The default version in system's lib dir is the C++03 version,
but the ABI that is targeted when building with "g++ -lIce [...]"
(that is, without explicitly specifying a default C++ mode)
is the C++11 variant -- because G++6 defaults to C++11 mode.

This puts us in a situation where we have to *know* which C++
version we're built against, to be able to select the correct
Ice libraries on Debian/Ubuntu.

Debian's C++11 Ice libraries live in `/usr/lib/$TRIPLE/c++11`,
and the C++03 versions live in `/usr/lib/$TRIPLE/`.

(Actually, the C+11 libraries in `/usr/lib/$TRIPLE/c++11` are
symlinks to .so files in /usr/lib/$TRIPLE with a '++11'
suffix. Which makes sense: this way, /usr/lib/$TRIPLE/c++11 is
only a developer detail, and not part of the default library
search path of the system.)

This commit does a few things to patch things up:

 - We now explicitly pass a `-std=` flag to the compiler.
 - By default, we build with `-std=c++03`, but if
   CONFIG(c++11) is specified (either by being the default
   in modern Qt 5 versions, or explicitly via user action),
   we use `-std=c++11`.
 - When CONFIG(c++11) is specified, we ensure QMAKE_LIBDIR
   includes `/usr/lib/$TRIPLE/c++11` such that we link against
   the correct libraries.

Fixes mumble-voip/mumble#2494

[Backported from master e99b0c9093]