### PR TITLE
Remove additional word character channel name restriction

### DIFF
--- a/src/murmur/Messages.cpp
+++ b/src/murmur/Messages.cpp
@@ -863,8 +863,7 @@ void Server::msgChannelState(ServerUser *uSource, MumbleProto::ChannelState &msg
 			return;
 		}
 
-		QRegExp re2("\\w");
-		if (re2.indexIn(qsName) == -1) {
+		if (qsName.length() == 0) {
 			PERM_DENIED_TYPE(ChannelName);
 			return;
 		}


### PR DESCRIPTION
The server has a regular expression setting for channel names.
The additional restriction of having a word character is probably
reasonable for most users.
However, it is an arbitrary limitation that users may want to circumvent.
For example: A channel could not be named with hyphens only "---".

As this is an arbitrary and invisible limitation, whichs use case is covered
by the channelname setting (with a default and adjustable by the user)
remove it.
