### PR TITLE
WIP: Rework Mumble URL handling

### DIFF
--- a/src/mumble/ConnectDialog.cpp
+++ b/src/mumble/ConnectDialog.cpp
@@ -585,7 +585,7 @@ QMimeData *ServerItem::toMimeData(const QString &name, const QString &host, unsi
 	url.setHost(host);
 	if (port != DEFAULT_MUMBLE_PORT)
 		url.setPort(port);
-	url.setPath(channel);
+	url.setPath(channel, QUrl::StrictMode);
 
 #if QT_VERSION >= 0x050000
 	QUrlQuery query;

--- a/src/mumble/ConnectDialog.h
+++ b/src/mumble/ConnectDialog.h
@@ -163,7 +163,7 @@ class ServerItem : public QTreeWidgetItem, public PingStats {
 
 		FavoriteServer toFavoriteServer() const;
 		QMimeData *toMimeData() const;
-		static QMimeData *toMimeData(const QString &name, const QString &host, unsigned short port, const QString &channel = QString());
+		static QMimeData *toMimeData(const QString &name, const QString &host, unsigned short port, const QString &channel = QLatin1String("/"));
 
 		static QIcon loadIcon(const QString &name);
 

--- a/src/mumble/URLHandler.cpp
+++ b/src/mumble/URLHandler.cpp
@@ -1,0 +1,138 @@
+// Copyright 2005-2016 The Mumble Developers. All rights reserved.
+// Use of this source code is governed by a BSD-style license
+// that can be found in the LICENSE file at the root of the
+// Mumble source tree or at <https://www.mumble.info/LICENSE>.
+
+
+#include "URLHandler.h"
+
+#include "Log.h"
+
+const QLatin1String ChannelUrlPathHandler::SEP = QLatin1String("/");
+
+QString ChannelUrlPathHandler::getEncodedChannelname(Channel *c) {
+	return QString::fromUtf8(QUrl::toPercentEncoding(c->qsName));
+}
+
+Channel *ChannelUrlPathHandler::searchChannelV1(Channel *parent, QStringList &subPath, const QString &namePrefix, bool &retExactMatch) {
+	// We are out of stuff/path to look for
+	if (subPath.isEmpty()) {
+		// If we have an unidentified channel, we failed to find an exact match
+		retExactMatch = namePrefix.isNull();
+		return parent;
+	}
+
+	// Next channel name to look for
+	QString name = subPath.takeFirst();
+	// If we still have an unidentified channel, construct name with slash
+	if (!namePrefix.isNull()) {
+		name.prepend(SEP);
+		name.prepend(namePrefix);
+	}
+
+	Channel *child = NULL;
+	foreach(Channel *c, parent->qlChannels) {
+		// Compare in lower case for backwards compatibility (can lead to
+		// mistakes with channels where only the case is different)
+		if (c->qsName.toLower() == name.toLower()) {
+			child = c;
+			break;
+		}
+	}
+
+	return searchChannelV1(child ? child : parent, subPath, child ? QString() : name, retExactMatch);
+}
+
+// Depth first search (not searching for alternative exact matches that are
+// possible through ambiguous slashes or case)
+Channel *ChannelUrlPathHandler::searchChannelV1(Channel *root, const QString &path, bool &retExactMatch) {
+	// The hostname-path separator slash is missing for URLs copied from:
+	// * The server (connect dialog)
+	// * The root channel
+	// * Channels with a leading slash that are a child of the root channel
+	//
+	// However, as path was passed through QUrl it always has a leading slash.
+	// It is thus ambiguous whether it is a channel name slash or separator.
+	//
+	// Most/All special characters are escaped, except slashes. Thus, a path
+	// may not be unique (c1/c2 could be a channel or parent and child).
+	//
+	// Channels with a leading slash deeper into the tree have their own
+	// slash (path separator + channel name slash: root/chan1//ChanwithOneLeadingSlash).
+
+	QStringList qlChans = path.split(SEP);
+	Channel *chan = searchChannelV1(root, qlChans, QString(), retExactMatch);
+
+	// We expect a path of "/" to have been an URL without a path slash
+	// in most cases (an URL to the server/root channel). In that case, the
+	// root channel is an exact match. As "/" is a valid channel as well, we
+	// had to look for it, but did not find such a channel.
+	if (!retExactMatch && path == SEP) {
+
+		retExactMatch = true;
+	}
+	return chan;
+}
+
+Channel *ChannelUrlPathHandler::searchChannelV2(Channel *parent, QStringList &chans, bool &retExactMatch) {
+	if (chans.isEmpty()) {
+		retExactMatch = true;
+		return parent;
+	}
+
+	QString name = chans.takeFirst();
+	foreach(Channel *c, parent->qlChannels) {
+		QString cn = getEncodedChannelname(c);
+		if (cn == name) {
+			return searchChannelV2(c, chans, retExactMatch);
+		}
+	}
+	retExactMatch = false;
+	return parent;
+}
+
+Channel *ChannelUrlPathHandler::searchChannelV2(Channel *root, const QString &path, bool &retExactMatch) {
+	QStringList qlChans = path.split(SEP);
+	// The path always begins with a slash - remove the first element
+	qlChans.removeFirst();
+	return searchChannelV2(root, qlChans, retExactMatch);
+}
+
+QString ChannelUrlPathHandler::getUrlPathForChannel(Channel *c) {
+	if (c->cParent == NULL) {
+		return "/";
+	}
+	QString path;
+	while (c->cParent != NULL) {
+		path.prepend(getEncodedChannelname(c));
+		path.prepend(SEP);
+		c = c->cParent;
+	}
+	return path;
+}
+
+Channel *ChannelUrlPathHandler::searchChannelByPath(QString &path, bool &retExactMatch) {
+	Channel *root = Channel::get(0);
+	if (!root) {
+		qFatal("Failed to identify Root channel");
+		return NULL;
+	}
+
+	bool bExactMatchV2 = false;
+	Channel *matchV2 = searchChannelV2(root, path, bExactMatchV2);
+	if (bExactMatchV2) {
+		retExactMatch = true;
+		return matchV2;
+	}
+
+	// Try to parse path in old URL encoding
+	bool bExactMatchV1 = false;
+	Channel *matchV1 = searchChannelV1(root, path, bExactMatchV1);
+	if (bExactMatchV1) {
+		retExactMatch = true;
+		return matchV1;
+	}
+
+	retExactMatch = false;
+	return matchV1;
+}

--- a/src/mumble/URLHandler.h
+++ b/src/mumble/URLHandler.h
@@ -1,0 +1,34 @@
+// Copyright 2005-2016 The Mumble Developers. All rights reserved.
+// Use of this source code is governed by a BSD-style license
+// that can be found in the LICENSE file at the root of the
+// Mumble source tree or at <https://www.mumble.info/LICENSE>.
+
+#ifndef MUMBLE_MUMBLE_URLHANDLER_H_
+#define MUMBLE_MUMBLE_URLHANDLER_H_
+
+#include <QtCore/QtGlobal>
+#include "Channel.h"
+
+class Log;
+
+class ChannelUrlPathHandler {
+private:
+	static const QLatin1String SEP;
+
+	static QString getEncodedChannelname(Channel *c);
+
+	// Depth first search (not searching for alternative exact matches that are
+	// possible through ambiguous slashes or case)
+	static Channel *searchChannelV1(Channel *root, const QString &path, bool &retExactMatch);
+	static Channel *searchChannelV1(Channel *parent, QStringList &subPath, const QString &namePrefix, bool &retExactMatch);
+
+	static Channel *searchChannelV2(Channel *root, const QString &path, bool &retExactMatch);
+	static Channel *searchChannelV2(Channel *parent, QStringList &chans, bool &retExactMatch);
+
+public:
+	static QString getUrlPathForChannel(Channel *c);
+
+	static Channel *searchChannelByPath(QString &path, bool &retExactMatch);
+};
+
+#endif

--- a/src/mumble/mumble.pro
+++ b/src/mumble/mumble.pro
@@ -131,7 +131,8 @@ HEADERS *= BanEditor.h \
     ThemeInfo.h \
     Themes.h \
     OverlayPositionableItem.h \
-    widgets/MUComboBox.h
+    widgets/MUComboBox.h \
+    URLHandler.h
 
 SOURCES *= BanEditor.cpp \
     ACLEditor.cpp \
@@ -196,7 +197,8 @@ SOURCES *= BanEditor.cpp \
     ThemeInfo.cpp \
     Themes.cpp \
     OverlayPositionableItem.cpp \
-    widgets/MUComboBox.cpp
+    widgets/MUComboBox.cpp \
+    URLHandler.cpp
 
 DIST		*= ../../icons/mumble.ico licenses.h ../../icons/mumble.xpm murmur_pch.h mumble.plist
 RESOURCES	*= mumble.qrc mumble_translations.qrc mumble_flags.qrc ../../themes/MumbleTheme.qrc

--- a/src/tests/Channel.cpp
+++ b/src/tests/Channel.cpp
@@ -1,0 +1,108 @@
+#include "Channel.h"
+
+QHash<int, Channel *> Channel::c_qhChannels;
+QReadWriteLock Channel::c_qrwlChannels;
+
+Channel::Channel(int id, const QString &name, QObject *p) : QObject(p) {
+	iId = id;
+	iPosition = 0;
+	qsName = name;
+	bTemporary = false;
+	cParent = qobject_cast<Channel *>(p);
+	if (cParent)
+		cParent->addChannel(this);
+}
+
+Channel::~Channel() {
+	if (cParent)
+		cParent->removeChannel(this);
+
+	foreach(Channel *c, qlChannels)
+		delete c;
+
+	Q_ASSERT(qlChannels.count() == 0);
+	Q_ASSERT(children().count() == 0);
+}
+
+Channel *Channel::get(int id) {
+	QReadLocker lock(&c_qrwlChannels);
+	return c_qhChannels.value(id);
+}
+Channel *Channel::add(int id, const QString &name) {
+	QWriteLocker lock(&c_qrwlChannels);
+
+	if (c_qhChannels.contains(id))
+		return NULL;
+
+	Channel *c = new Channel(id, name, NULL);
+	c_qhChannels.insert(id, c);
+	return c;
+}
+
+void Channel::remove(Channel *c) {
+	QWriteLocker lock(&c_qrwlChannels);
+	c_qhChannels.remove(c->iId);
+}
+
+size_t Channel::getLevel() const {
+	size_t i = 0;
+
+	const Channel *c = this;
+	while (c->cParent) {
+		c = c->cParent;
+		++i;
+	}
+
+	return i;
+}
+
+size_t Channel::getDepth() const {
+	if(qlChannels.empty()) {
+		return 0;
+	}
+
+	size_t result = 0;
+	foreach(Channel *child, qlChannels) {
+		result = qMax(result, child->getDepth() + 1);
+	}
+
+	return result;
+}
+
+QString Channel::getPath() const {
+	QString out;
+
+	const Channel *tmp = this;
+	while (tmp->cParent) {
+		// Skip the root channel.
+		if (tmp->iId == 0) {
+			break;
+		}
+
+		out.prepend(QString::fromLatin1("/"));
+		out.prepend(tmp->qsName);
+
+		tmp = tmp->cParent;
+	}
+
+	return out;
+}
+
+void Channel::addChannel(Channel *c) {
+	c->cParent = this;
+	c->setParent(this);
+	qlChannels << c;
+}
+
+void Channel::removeChannel(Channel *c) {
+	c->cParent = NULL;
+	c->setParent(NULL);
+	qlChannels.removeAll(c);
+}
+
+Channel::operator QString() const {
+	return QString::fromLatin1("%1[%2:%3%4]").arg(qsName,
+	        QString::number(iId),
+	        QString::number(cParent ? cParent->iId : -1),
+	        bTemporary ? QLatin1String("*") : QLatin1String(""));
+}

--- a/src/tests/Channel.h
+++ b/src/tests/Channel.h
@@ -1,0 +1,42 @@
+#ifndef MUMBLE_TESTS_CHANNEL_H_
+#define MUMBLE_TESTS_CHANNEL_H_
+
+#include <QObject>
+#include <QHash>
+#include <QReadWriteLock>
+
+class Channel : public QObject {
+	Q_OBJECT
+	private:
+		Q_DISABLE_COPY(Channel)
+	public:
+		int iId;
+		int iPosition;
+		bool bTemporary;
+		Channel *cParent;
+		QString qsName;
+		QList<Channel *> qlChannels;
+		Channel(int id, const QString &name, QObject *p = NULL);
+		~Channel();
+
+		unsigned int uiPermissions;
+		bool bFiltered;
+
+		static QHash<int, Channel *> c_qhChannels;
+		static QReadWriteLock c_qrwlChannels;
+
+		static Channel *get(int);
+		static Channel *add(int, const QString &);
+		static void remove(Channel *);
+
+		size_t getLevel() const;
+		size_t getDepth() const;
+		QString getPath() const;
+
+		void addChannel(Channel *c);
+		void removeChannel(Channel *c);
+
+		operator QString() const;
+};
+
+#endif

--- a/src/tests/TestURLHandler.cpp
+++ b/src/tests/TestURLHandler.cpp
@@ -1,0 +1,119 @@
+
+#include <QObject>
+#include <QtTest>
+#include <memory>
+
+#include "URLHandler.h"
+
+class TestURLHandler : public QObject {
+	Q_OBJECT
+private:
+	class ChannelBuilder {
+	private:
+		std::shared_ptr<Channel> root;
+		Channel* current;
+	public:
+		ChannelBuilder& operator()(QString name) {
+			if (!root) {
+				root.reset(new Channel(0, name));
+				current = root.get();
+			} else {
+				current = new Channel(current->iPosition, name, current);
+			}
+			return *this;
+		}
+		Channel* ret() {
+			return current;
+		}
+	};
+
+private slots:
+	void rootOnly1() {
+		ChannelBuilder b;
+		b("r");
+		QCOMPARE(ChannelUrlPathHandler::getUrlPathForChannel(b.ret()), QString("/"));
+	}
+	void rootOnly2() {
+		ChannelBuilder b;
+		b("%");
+		QCOMPARE(ChannelUrlPathHandler::getUrlPathForChannel(b.ret()), QString("/"));
+	}
+	void rootOnlyEmpty() {
+		ChannelBuilder b;
+		b("");
+		QCOMPARE(ChannelUrlPathHandler::getUrlPathForChannel(b.ret()), QString("/"));
+	}
+	void pathOneSimple1() {
+		ChannelBuilder b;
+		b("")("a");
+		QCOMPARE(ChannelUrlPathHandler::getUrlPathForChannel(b.ret()), QString("/a"));
+	}
+	void pathOneSimple1Uppercase() {
+		ChannelBuilder b;
+		b("")("A");
+		QCOMPARE(ChannelUrlPathHandler::getUrlPathForChannel(b.ret()), QString("/A"));
+	}
+	void pathOneSimple2() {
+		ChannelBuilder b;
+		b("")("fewdSAfvcs");
+		QCOMPARE(ChannelUrlPathHandler::getUrlPathForChannel(b.ret()), QString("/fewdSAfvcs"));
+	}
+	void pathOneSimple3() {
+		ChannelBuilder b;
+		b("")("r78365t65743287w4z7rf687s6df657865678das8");
+		QCOMPARE(ChannelUrlPathHandler::getUrlPathForChannel(b.ret()), QString("/r78365t65743287w4z7rf687s6df657865678das8"));
+	}
+	void pathOneSpecial1() {
+		ChannelBuilder b;
+		b("")("ß");
+		QCOMPARE(ChannelUrlPathHandler::getUrlPathForChannel(b.ret()), QString("/%C3%9F"));
+	}
+	void pathOneSpecial2() {
+		ChannelBuilder b;
+		b("")("öäÖÄüÜ");
+		QCOMPARE(ChannelUrlPathHandler::getUrlPathForChannel(b.ret()), QString("/%C3%B6%C3%A4%C3%96%C3%84%C3%BC%C3%9C"));
+	}
+	void pathOneEncodedPercent1() {
+		ChannelBuilder b;
+		b("")("%");
+		QCOMPARE(ChannelUrlPathHandler::getUrlPathForChannel(b.ret()), QString("/%25"));
+	}
+	void pathOneEncodedPercent2() {
+		ChannelBuilder b;
+		b("")("%25");
+		QCOMPARE(ChannelUrlPathHandler::getUrlPathForChannel(b.ret()), QString("/%2525"));
+	}
+	void pathOneEncodedSlash() {
+		ChannelBuilder b;
+		b("")("/");
+		QCOMPARE(ChannelUrlPathHandler::getUrlPathForChannel(b.ret()), QString("/%2F"));
+	}
+	void pathOneEncodedSpace() {
+		ChannelBuilder b;
+		b("")(" ");
+		QCOMPARE(ChannelUrlPathHandler::getUrlPathForChannel(b.ret()), QString("/%20"));
+	}
+	void pathTwo1() {
+		ChannelBuilder b;
+		b("")(" ")(" ");
+		QCOMPARE(ChannelUrlPathHandler::getUrlPathForChannel(b.ret()), QString("/%20/%20"));
+	}
+	void pathTwo2() {
+		ChannelBuilder b;
+		b("")("syyx123123123")("hgbre");
+		QCOMPARE(ChannelUrlPathHandler::getUrlPathForChannel(b.ret()), QString("/syyx123123123/hgbre"));
+	}
+	void pathTwo3() {
+		ChannelBuilder b;
+		b("")(" ")("hgbre");
+		QCOMPARE(ChannelUrlPathHandler::getUrlPathForChannel(b.ret()), QString("/%20/hgbre"));
+	}
+	void pathSeven() {
+		ChannelBuilder b;
+		b("")("., &%/da-_s76FASD~")("hgbre")("as")("vb")("0")("")("888");
+		QCOMPARE(ChannelUrlPathHandler::getUrlPathForChannel(b.ret()), QString("/.%2C%20%26%25%2Fda-_s76FASD~/hgbre/as/vb/0//888"));
+	}
+};
+
+QTEST_MAIN(TestURLHandler)
+#include "TestURLHandler.moc"

--- a/src/tests/TestURLHandler.pro
+++ b/src/tests/TestURLHandler.pro
@@ -1,0 +1,19 @@
+include(../../compiler.pri)
+
+QT += testlib
+
+TEMPLATE = app
+TARGET = testurlhandler
+CONFIG += warn_on
+
+VPATH += .
+VPATH += ..
+VPATH += ../mumble
+INCLUDEPATH += ..
+INCLUDEPATH += ../mumble
+
+HEADERS += URLHandler.h \
+	Channel.h
+SOURCES += TestURLHandler.cpp \
+	URLHandler.cpp \
+	Channel.cpp


### PR DESCRIPTION
Introduce a better defined, less ambiguous Mumble URL encoding.
Previously, case did not matter and slashes were not encoded,
both of which could lead to ambiguous URLs on specific channel setups.

The new format always encodes non ASCII characters, including slashes and
spaces. Other special characters were already being encoded in the past.

Additionally, URLs are now case sensitive.
While this means URLs are less robust against case changes, that should
be a pretty rare case anyway.

As a result, URLs are now unambiguously well-targeted.

The implementation of URL handling (opening) is backwards compatible.
While the old URLs are ambiguous and can thus lead to ambiguous/undesired
results, the behavior should be the same as before.
The logic is implemented in a helper class ChannelUrlPathHandler,
which contains handling code for the old scheme (V1) and new
encoded and case sensitive format (V2).

This also fixes #2584 introduced in 9c5d02cc0e92807348405aa5e071e7d2c5c4cd4d
and also fixes #2585 (case ambiguity).

---

Testdata used:
![murmur-testdata-urls](https://cloud.githubusercontent.com/assets/93181/19623177/5a323480-98c0-11e6-8957-e40a92229870.png)

```
mumble://localhost/%25/%25?title=Root&version=1.2.0
mumble://localhost/s?title=Root&version=1.2.0
mumble://localhost/a?title=Root&version=1.2.0
mumble://localhost/A?title=Root&version=1.2.0
mumble://localhost/x%20x?title=Root&version=1.2.0
mumble://localhost/----j?title=Root&version=1.2.0
mumble://localhost/s//g?title=Root&version=1.2.0
mumble://localhost/s//g/k?title=Root&version=1.2.0
mumble://localhost/s//g/o/p?title=o/p&version=1.2.0
mumble://localhost?title=Root&version=1.2.0
mumble://localhost/?title=Root&version=1.2.0
mumble://localhost/s/s?title=Root&version=1.2.0
mumble://localhost/s/?title=Root&version=1.2.0
mumble://localhost/m/?title=Root&version=1.2.0

mumble://localhost/s/g?title=Root&version=1.2.0

mumble://localhost/%2Fs%2Fg?title=/s/g&version=1.2.0
mumble://localhost/%2Fs/%2Fg?title=/g&version=1.2.0
mumble://localhost/s%2F?title=s/&version=1.2.0
mumble://localhost/s%2Fs?title=s/s&version=1.2.0
mumble://localhost/x%20x?title=x%20x&version=1.2.0
mumble://localhost/%C3%A0?title=%C3%A0&version=1.2.0
mumble://localhost/a?title=a&version=1.2.0
mumble://localhost/A?title=A&version=1.2.0
mumble://localhost/%25/%25?title=%25&version=1.2.0
mumble://localhost/%2Fs/%2Fg?title=/g&version=1.2.0
mumble://localhost/%2Fs/%2Fg/o%2Fp?title=o/p&version=1.2.0
mumble://localhost/%2Fs/%2Fg/k?title=o/p&version=1.2.0
mumble://localhost/%2Fs/%2Fg/yyy?version=1.2.0
```
