### PR TITLE
Fix #2586: Use QAtomicInt continuously-existing methods

### DIFF
--- a/src/murmur/MurmurGRPCImpl.cpp
+++ b/src/murmur/MurmurGRPCImpl.cpp
@@ -254,7 +254,7 @@ void ToRPC(const ::Server *srv, const ::User *u, ::MurmurRPC::User *ru) {
 	ru->set_udp_ping_msecs(su->dUDPPingAvg);
 	ru->set_tcp_ping_msecs(su->dTCPPingAvg);
 
-	ru->set_tcp_only(su->aiUdpFlag.load() == 0);
+	ru->set_tcp_only(su->aiUdpFlag.fetchAndAddRelaxed(0) == 0);
 
 	ru->set_address(su->haAddress.toStdString());
 }

--- a/src/murmur/MurmurIce.cpp
+++ b/src/murmur/MurmurIce.cpp
@@ -72,7 +72,7 @@ static void userToUser(const ::User *p, Murmur::User &mp) {
 	mp.udpPing = u->dUDPPingAvg;
 	mp.tcpPing = u->dTCPPingAvg;
 
-	mp.tcponly = u->aiUdpFlag.load() == 0;
+	mp.tcponly = u->aiUdpFlag.fetchAndAddRelaxed(0) == 0;
 
 	::Murmur::NetAddress addr(16, 0);
 	const Q_IPV6ADDR &a = u->haAddress.qip6;

--- a/src/murmur/Server.cpp
+++ b/src/murmur/Server.cpp
@@ -894,7 +894,7 @@ bool Server::checkDecrypt(ServerUser *u, const char *encrypt, char *plain, unsig
 }
 
 void Server::sendMessage(ServerUser *u, const char *data, int len, QByteArray &cache, bool force) {
-	if ((u->aiUdpFlag.load() == 1 || force) && (u->sUdpSocket != INVALID_SOCKET)) {
+	if ((u->aiUdpFlag.fetchAndAddRelaxed(0) == 1 || force) && (u->sUdpSocket != INVALID_SOCKET)) {
 #if defined(__LP64__)
 		STACKVAR(char, ebuffer, len+4+16);
 		char *buffer = reinterpret_cast<char *>(((reinterpret_cast<quint64>(ebuffer) + 8) & ~7) + 4);


### PR DESCRIPTION
load() exists only in Qt5, int() exists only in Qt<5 and Qt>5.3.
The fetchAndAddRelaxed method exists in all these Qt versions we support.