### PR TITLE
plugins/bf1: better squad pointer

### DIFF
--- a/plugins/bf1/bf1.cpp
+++ b/plugins/bf1/bf1.cpp
@@ -48,14 +48,16 @@ static int fetch(float *avatar_pos, float *avatar_front, float *avatar_top, floa
 	if (!team_offset_2) return false;
 
 	// Squad pointers
-	procptr64_t squad_base = peekProc<procptr64_t>(pModule + 0x3318860);
+	procptr64_t squad_base = peekProc<procptr64_t>(pModule + 0x31016D0);
 	if (!squad_base) return false;
-	procptr64_t squad_offset_0 = peekProc<procptr64_t>(squad_base + 0x658);
+	procptr64_t squad_offset_0 = peekProc<procptr64_t>(squad_base + 0x30);
 	if (!squad_offset_0) return false;
-	procptr64_t squad_offset_1 = peekProc<procptr64_t>(squad_offset_0 + 0xC0);
+	procptr64_t squad_offset_1 = peekProc<procptr64_t>(squad_offset_0 + 0x578);
 	if (!squad_offset_1) return false;
-	procptr64_t squad_offset_2 = peekProc<procptr64_t>(squad_offset_1 + 0x58);
+	procptr64_t squad_offset_2 = peekProc<procptr64_t>(squad_offset_1 + 0xC0);
 	if (!squad_offset_2) return false;
+	procptr64_t squad_offset_3 = peekProc<procptr64_t>(squad_offset_2 + 0x58);
+	if (!squad_offset_3) return false;
 
 	// Peekproc and assign game addresses to our containers, so we can retrieve positional data
 	ok = peekProc(state_offset_3 + 0x50, &state, 1) && // Magical state value: 1 when in-game and 0 when not spawned or playing.
@@ -65,8 +67,8 @@ static int fetch(float *avatar_pos, float *avatar_front, float *avatar_top, floa
 			peekProc(camera_base + 0x250, camera_top, 12) && // Avatar top vector values (X, Y and Z).
 			peekProc(server_name_offset, server_name) && // Server name.
 			peekProc(team_offset_2 + 0x13, team) && // Team name.
-			peekProc(squad_offset_2 + 0x240, squad) && // Squad value: 0 (not in a squad), 1 (Apples), 2 (Butter), 3 (Charlie)... 26 (Zebra).
-			peekProc(squad_offset_2 + 0xDCC, squad_leader); // Squad leader value: 0 (False), 1 (True).
+			peekProc(squad_offset_3 + 0x240, squad) && // Squad value: 0 (not in a squad), 1 (Apples), 2 (Butter), 3 (Charlie)... 26 (Zebra).
+			peekProc(squad_offset_3 + 0xDCC, squad_leader); // Squad leader value: 0 (False), 1 (True).
 
 	// This prevents the plugin from linking to the game in case something goes wrong during values retrieval from memory addresses.
 	if (!ok) {


### PR DESCRIPTION
The last update did not have a working pointer for the squad and squad leader values. This one works. 