### PR TITLE
plugins: Build x64 ones only when the target is x86_64

### DIFF
--- a/installer/Plugins.wxs
+++ b/installer/Plugins.wxs
@@ -14,9 +14,6 @@
       <Component Id="arma2.dll">
         <File Source="$(var.SourceDir)\release\plugins\arma2.dll" KeyPath="yes" />
       </Component>
-      <Component Id="bf1.dll">
-        <File Source="$(var.SourceDir)\release\plugins\bf1.dll" KeyPath="yes" />
-      </Component>
       <Component Id="bf1942.dll">
         <File Source="$(var.SourceDir)\release\plugins\bf1942.dll" KeyPath="yes" />
       </Component>
@@ -34,9 +31,6 @@
       </Component>
       <Component Id="bfheroes.dll">
         <File Source="$(var.SourceDir)\release\plugins\bfheroes.dll" KeyPath="yes" />
-      </Component>
-      <Component Id="bf4.dll">
-        <File Source="$(var.SourceDir)\release\plugins\bf4.dll" KeyPath="yes" />
       </Component>
       <Component Id="bf4_x86.dll">
         <File Source="$(var.SourceDir)\release\plugins\bf4_x86.dll" KeyPath="yes" />
@@ -88,9 +82,6 @@
       </Component>
       <Component Id="gtaiv.dll">
         <File Source="$(var.SourceDir)\release\plugins\gtaiv.dll" KeyPath="yes" />
-      </Component>
-      <Component Id="gtav.dll">
-        <File Source="$(var.SourceDir)\release\plugins\gtav.dll" KeyPath="yes" />
       </Component>
       <Component Id="gw.dll">
         <File Source="$(var.SourceDir)\release\plugins\gw.dll" KeyPath="yes" />
@@ -146,23 +137,33 @@
       <Component Id="wow.dll">
         <File Source="$(var.SourceDir)\release\plugins\wow.dll" KeyPath="yes" />
       </Component>
-      <Component Id="wow_x64.dll">
-        <File Source="$(var.SourceDir)\release\plugins\wow_x64.dll" KeyPath="yes" />
-      </Component>
+
+      <?if $(sys.BUILDARCH) = "x64" ?>
+        <Component Id="bf1.dll">
+          <File Source="$(var.SourceDir)\release\plugins\bf1.dll" KeyPath="yes" />
+        </Component>
+        <Component Id="bf4.dll">
+          <File Source="$(var.SourceDir)\release\plugins\bf4.dll" KeyPath="yes" />
+        </Component>
+        <Component Id="gtav.dll">
+          <File Source="$(var.SourceDir)\release\plugins\gtav.dll" KeyPath="yes" />
+        </Component>
+        <Component Id="wow_x64.dll">
+          <File Source="$(var.SourceDir)\release\plugins\wow_x64.dll" KeyPath="yes" />
+        </Component>
+      <?endif ?>
     </DirectoryRef>
 
     <ComponentGroup Id="Plugins">
       <ComponentRef Id="link.dll" />
       <ComponentRef Id="aoc.dll" />
       <ComponentRef Id="arma2.dll" />
-      <ComponentRef Id="bf1.dll" />
       <ComponentRef Id="bf1942.dll" />
       <ComponentRef Id="bf2.dll" />
       <ComponentRef Id="bf2142.dll" />
       <ComponentRef Id="bf3.dll" />
       <ComponentRef Id="bfbc2.dll" />
       <ComponentRef Id="bfheroes.dll" />
-      <ComponentRef Id="bf4.dll" />
       <ComponentRef Id="bf4_x86.dll" />
       <ComponentRef Id="borderlands.dll" />
       <ComponentRef Id="borderlands2.dll" />
@@ -180,7 +181,6 @@
       <ComponentRef Id="etqw.dll" />
       <ComponentRef Id="gmod.dll" />
       <ComponentRef Id="gtaiv.dll" />
-      <ComponentRef Id="gtav.dll" />
       <ComponentRef Id="gw.dll" />
       <ComponentRef Id="hl2dm.dll" />
       <ComponentRef Id="insurgency.dll" />
@@ -199,7 +199,13 @@
       <ComponentRef Id="ut3.dll" />
       <ComponentRef Id="wolfet.dll" />
       <ComponentRef Id="wow.dll" />
-      <ComponentRef Id="wow_x64.dll" />
+
+      <?if $(sys.BUILDARCH) = "x64" ?>
+        <ComponentRef Id="bf1.dll" />
+        <ComponentRef Id="bf4.dll" />
+        <ComponentRef Id="gtav.dll" />
+        <ComponentRef Id="wow_x64.dll" />
+      <?endif ?>
     </ComponentGroup>
   </Fragment>
 </Wix>

--- a/plugins/plugins.pro
+++ b/plugins/plugins.pro
@@ -3,6 +3,8 @@
 # that can be found in the LICENSE file at the root of the
 # Mumble source tree or at <https://www.mumble.info/LICENSE>.
 
+include(../compiler.pri)
+
 TEMPLATE = subdirs
 
 CONFIG += debug_and_release
@@ -10,7 +12,11 @@ SUBDIRS = link
 DIST = plugins.pri
 
 win32 {
-	SUBDIRS += aoc arma2 bf1 bf1942 bf2 bf3 bf2142 bfbc2 bfheroes bf4 bf4_x86 blacklight borderlands borderlands2 breach cod2 cod4 cod5 codmw2 codmw2so cs css dods dys etqw tf2 gmod gtaiv gtav gw hl2dm insurgency jc2 l4d l4d2 lol lotro ql rl sr sto ut2004 ut3 ut99 wolfet wow wow_x64
+	SUBDIRS += aoc arma2 bf1942 bf2 bf3 bf2142 bfbc2 bfheroes bf4_x86 blacklight borderlands borderlands2 breach cod2 cod4 cod5 codmw2 codmw2so cs css dods dys etqw tf2 gmod gtaiv gw hl2dm insurgency jc2 l4d l4d2 lol lotro ql rl sr sto ut2004 ut3 ut99 wolfet wow
+
+	equals(MUMBLE_ARCH, x86_64) {
+		SUBDIRS += bf1 bf4 gtav wow_x64
+	}
 }
 
 linux {


### PR DESCRIPTION
x64 plugins only work if Mumble is x64 too, this means that we should avoid building them with Mumble x86.