### PR TITLE
plugins: use the short form of peekProc

### DIFF
--- a/plugins/aoc/aoc.cpp
+++ b/plugins/aoc/aoc.cpp
@@ -49,10 +49,10 @@ static int fetch(float *avatar_pos, float *avatar_front, float *avatar_top, floa
 	wostringstream new_identity;
 	ostringstream new_context;
 
-	ok = peekProc(posptr, ipos, 12) &&
-	     peekProc(rotptr, rot, 12) &&
-	     peekProc(stateptr, &state, 1) &&
-	     peekProc(hostptr, chHostStr, 40);
+	ok = peekProc(posptr, ipos) &&
+	     peekProc(rotptr, rot) &&
+	     peekProc(stateptr, state) &&
+	     peekProc(hostptr, chHostStr);
 	if (!ok)
 		return false;
 
@@ -120,7 +120,7 @@ static int trylock(const std::multimap<std::wstring, unsigned long long int> &pi
 
 	//Gamecheck
 	char sMagic[13];
-	if (!peekProc(pModule + 0x7071e8, sMagic, 13) || strncmp("ageofchivalry", sMagic, 13)!=0)
+	if (!peekProc(pModule + 0x7071e8, sMagic) || strncmp("ageofchivalry", sMagic, 13)!=0)
 		return false;
 
 	// Check if we can get meaningful data from it

--- a/plugins/arma2/arma2.cpp
+++ b/plugins/arma2/arma2.cpp
@@ -35,9 +35,9 @@ static int fetch(float *avatar_pos, float *avatar_front, float *avatar_top, floa
 	          return true; // This results in all vectors beeing zero which tells Mumble to ignore them.
 	*/
 
-	ok = peekProc(posptr, avatar_pos, 12) &&
-	     peekProc(frontptr, avatar_front, 12) &&
-	     peekProc(topptr, avatar_top, 12);
+	ok = peekProc(posptr, avatar_pos) &&
+	     peekProc(frontptr, avatar_front) &&
+	     peekProc(topptr, avatar_top);
 
 	if (avatar_pos[1] > 999000000.0)
 		return false;

--- a/plugins/bf1/bf1.cpp
+++ b/plugins/bf1/bf1.cpp
@@ -60,11 +60,11 @@ static int fetch(float *avatar_pos, float *avatar_front, float *avatar_top, floa
 	if (!squad_offset_3) return false;
 
 	// Peekproc and assign game addresses to our containers, so we can retrieve positional data
-	ok = peekProc(state_offset_3 + 0x50, &state, 1) && // Magical state value: 1 when in-game and 0 when not spawned or playing.
-			peekProc(pModule + 0x35D2C60, avatar_pos, 12) && // Avatar position values (X, Y and Z).
-			peekProc(camera_base + 0x2B0, camera_pos, 12) && // Camera position values (X, Y and Z).
-			peekProc(camera_base + 0x260, camera_front, 12) && // Avatar front vector values (X, Y and Z).
-			peekProc(camera_base + 0x250, camera_top, 12) && // Avatar top vector values (X, Y and Z).
+	ok = peekProc(state_offset_3 + 0x50, state) && // Magical state value: 1 when in-game and 0 when not spawned or playing.
+			peekProc(pModule + 0x35D2C60, avatar_pos) && // Avatar position values (X, Y and Z).
+			peekProc(camera_base + 0x2B0, camera_pos) && // Camera position values (X, Y and Z).
+			peekProc(camera_base + 0x260, camera_front) && // Avatar front vector values (X, Y and Z).
+			peekProc(camera_base + 0x250, camera_top) && // Avatar top vector values (X, Y and Z).
 			peekProc(server_name_offset, server_name) && // Server name.
 			peekProc(team_offset_2 + 0x13, team) && // Team name.
 			peekProc(squad_offset_3 + 0x240, squad) && // Squad value: 0 (not in a squad), 1 (Apples), 2 (Butter), 3 (Charlie)... 26 (Zebra).

--- a/plugins/bf1942/bf1942.cpp
+++ b/plugins/bf1942/bf1942.cpp
@@ -27,9 +27,9 @@ static int fetch(float *avatar_pos, float *avatar_front, float *avatar_top, floa
 
 	//peekProc(contextptr, ccontext, 128);
 
-	ok = peekProc(0x00976274, avatar_pos, 12) &&
-	     peekProc(faceptr, avatar_front, 12) &&
-	     peekProc(topptr, avatar_top, 12);
+	ok = peekProc(0x00976274, avatar_pos) &&
+	     peekProc(faceptr, avatar_front) &&
+	     peekProc(topptr, avatar_top);
 
 	if (! ok)
 		return false;

--- a/plugins/bf2/bf2.cpp
+++ b/plugins/bf2/bf2.cpp
@@ -79,7 +79,7 @@ static int fetch(float *avatar_pos, float *avatar_front, float *avatar_top, floa
 
 	bool ok;
 	BYTE logincheck;
-	ok = peekProc(login_ptr, &logincheck, 1);
+	ok = peekProc(login_ptr, logincheck);
 	if (! ok)
 		return false;
 
@@ -87,7 +87,7 @@ static int fetch(float *avatar_pos, float *avatar_front, float *avatar_top, floa
 		return false;
 
 	BYTE state;
-	ok = peekProc(state_ptr , &state, 1); // Magical state value
+	ok = peekProc(state_ptr , state); // Magical state value
 	if (! ok)
 		return false;
 
@@ -109,14 +109,14 @@ static int fetch(float *avatar_pos, float *avatar_front, float *avatar_top, floa
 	BYTE is_in_squad;
 	BYTE is_opfor;
 
-	ok = peekProc(pos_ptr, avatar_pos, 12) &&
-	     peekProc(face_ptr, avatar_front, 12) &&
-	     peekProc(top_ptr, avatar_top, 12) &&
-	     peekProc(ipport_ptr, ccontext, 128) &&
-	     peekProc(commander_ptr, &is_commander, 1) &&
-	     peekProc(squad_leader_ptr, &is_squad_leader, 1) &&
-	     peekProc(squad_state_ptr, &is_in_squad, 1) &&
-	     peekProc(team_state_ptr, &is_opfor, 1);
+	ok = peekProc(pos_ptr, avatar_pos) &&
+	     peekProc(face_ptr, avatar_front) &&
+	     peekProc(top_ptr, avatar_top) &&
+	     peekProc(ipport_ptr, ccontext) &&
+	     peekProc(commander_ptr, is_commander) &&
+	     peekProc(squad_leader_ptr, is_squad_leader) &&
+	     peekProc(squad_state_ptr, is_in_squad) &&
+	     peekProc(team_state_ptr, is_opfor);
 
 	if (! ok)
 		return false;

--- a/plugins/bf2142/bf2142.cpp
+++ b/plugins/bf2142/bf2142.cpp
@@ -16,7 +16,7 @@ static int fetch(float *avatar_pos, float *avatar_front, float *avatar_top, floa
 	char logincheck;
 	bool ok;
 
-	ok = peekProc(0x00A1D908, &logincheck, 1);
+	ok = peekProc(0x00A1D908, logincheck);
 	if (! ok)
 		return false;
 
@@ -33,10 +33,10 @@ static int fetch(float *avatar_pos, float *avatar_front, float *avatar_top, floa
 	if (! ok)
 		return false;
 
-	ok = peekProc(posptr, avatar_pos, 12) &&
-	     peekProc(faceptr, avatar_front, 12) &&
-	     peekProc(topptr, avatar_top, 12) &&
-	     peekProc(0x00B527B8, ccontext, 128);
+	ok = peekProc(posptr, avatar_pos) &&
+	     peekProc(faceptr, avatar_front) &&
+	     peekProc(topptr, avatar_top) &&
+	     peekProc(0x00B527B8, ccontext);
 
 	if (! ok)
 		return false;

--- a/plugins/bf3/bf3.cpp
+++ b/plugins/bf3/bf3.cpp
@@ -146,13 +146,13 @@ static int fetch(float *avatar_pos, float *avatar_front, float *avatar_top, floa
         ptr_chain_valid = true;
     }
 
-    ok = peekProc(avatar_pos_ptr, avatar_pos, 12) &&
-        peekProc(avatar_front_ptr, avatar_front, 12) &&
-        peekProc(avatar_top_ptr, avatar_top, 12) &&
-        peekProc(squad_state_ptr,&squad_state,1) &&
-        peekProc(squad_lead_state_ptr, &is_squadleader,1) &&
-        peekProc(team_state_ptr,&team_state,1) &&
-        peekProc(ipport_ptr,ccontext,128);
+    ok = peekProc(avatar_pos_ptr, avatar_pos) &&
+        peekProc(avatar_front_ptr, avatar_front) &&
+        peekProc(avatar_top_ptr, avatar_top) &&
+        peekProc(squad_state_ptr,squad_state) &&
+        peekProc(squad_lead_state_ptr, is_squadleader) &&
+        peekProc(team_state_ptr,team_state) &&
+        peekProc(ipport_ptr,ccontext);
 
     if (! ok)
         return false;

--- a/plugins/bf4/bf4.cpp
+++ b/plugins/bf4/bf4.cpp
@@ -36,11 +36,11 @@ static int fetch(float *avatar_pos, float *avatar_front, float *avatar_top, floa
     if (!squad_offset_2) return false;
 
     // Peekproc and assign game addresses to our containers, so we can retrieve positional data
-    ok = peekProc(pModule + 0x21CAFF0, &state, 1) && // Magical state value: 0 when in-game and 1 when in menu/dead.
-            peekProc(pModule + 0x21C6D40, avatar_pos, 12) && // Avatar Position values (X, Y and Z).
-            peekProc(pModule + 0x21CAF80, camera_pos, 12) && // Camera Position values (X, Y and Z).
-            peekProc(pModule + 0x21CAF60, avatar_top, 12) && // Avatar Top Vector values (X, Y and Z).
-            peekProc(pModule + 0x21CAF70, avatar_front, 12) && // Avatar Front Vector values (X, Y and Z).
+    ok = peekProc(pModule + 0x21CAFF0, state) && // Magical state value: 0 when in-game and 1 when in menu/dead.
+            peekProc(pModule + 0x21C6D40, avatar_pos) && // Avatar Position values (X, Y and Z).
+            peekProc(pModule + 0x21CAF80, camera_pos) && // Camera Position values (X, Y and Z).
+            peekProc(pModule + 0x21CAF60, avatar_top) && // Avatar Top Vector values (X, Y and Z).
+            peekProc(pModule + 0x21CAF70, avatar_front) && // Avatar Front Vector values (X, Y and Z).
             peekProc(serverid_offset, serverid) && // Server ID (36 characters).
             peekProc(pModule + 0x21B80C0, host) && // Host value: "IP:Port" when in a server, "bot" when loading and empty when it's hidden.
             peekProc(pModule + 0x24AFAE5, team) && // Team value: US (United States); RU (Russia); CH (China).

--- a/plugins/bf4_x86/bf4_x86.cpp
+++ b/plugins/bf4_x86/bf4_x86.cpp
@@ -34,11 +34,11 @@ static int fetch(float *avatar_pos, float *avatar_front, float *avatar_top, floa
     if (!squad_offset_1) return false;
 
     // Peekproc and assign game addresses to our containers, so we can retrieve positional data
-    ok = peekProc(pModule + 0x1BB6AC2, &state, 1) && // Magical state value: 0 when in-game and 1 when in menu/dead.
-            peekProc(pModule + 0x1BB3C30, avatar_pos, 12) && // Avatar Position values (X, Y and Z).
-            peekProc(pModule + 0x1BB6A90, camera_pos, 12) && // Camera Position values (X, Y and Z).
-            peekProc(pModule + 0x1BB6A70, avatar_top, 12) && // Avatar Top Vector values (X, Y and Z).
-            peekProc(pModule + 0x1BB6A80, avatar_front, 12) && // Avatar Front Vector values (X, Y and Z).
+    ok = peekProc(pModule + 0x1BB6AC2, state) && // Magical state value: 0 when in-game and 1 when in menu/dead.
+            peekProc(pModule + 0x1BB3C30, avatar_pos) && // Avatar Position values (X, Y and Z).
+            peekProc(pModule + 0x1BB6A90, camera_pos) && // Camera Position values (X, Y and Z).
+            peekProc(pModule + 0x1BB6A70, avatar_top) && // Avatar Top Vector values (X, Y and Z).
+            peekProc(pModule + 0x1BB6A80, avatar_front) && // Avatar Front Vector values (X, Y and Z).
             peekProc(serverid_offset, serverid) && // Server ID (36 characters).
             peekProc(pModule + 0x1BA8A10, host) && // Host value: "IP:Port" when in a server, "bot" when loading and empty when it's hidden.
             peekProc(pModule + 0x1C814B5, team) && // Team value: US (United States); RU (Russia); CH (China).

--- a/plugins/bfbc2/bfbc2.cpp
+++ b/plugins/bfbc2/bfbc2.cpp
@@ -23,7 +23,7 @@ static int fetch(float *avatar_pos, float *avatar_front, float *avatar_top, floa
 
 	// Find out whether this is the steam version
 	char sMagic[6];
-	if (!peekProc(0x015715b4, sMagic, 6)) {
+	if (!peekProc(0x015715b4, sMagic)) {
 		generic_unlock();
 		return false;
 	}
@@ -31,13 +31,13 @@ static int fetch(float *avatar_pos, float *avatar_front, float *avatar_top, floa
 	is_steam = (strncmp("Score:", sMagic, 6) == 0);
 
 	if (is_steam) {
-		ok = peekProc(0x01571E90, avatar_pos, 12) &&
-		     peekProc(0x01571E80, avatar_front, 12) &&
-		     peekProc(0x01571E70, avatar_top, 12);
+		ok = peekProc(0x01571E90, avatar_pos) &&
+		     peekProc(0x01571E80, avatar_front) &&
+		     peekProc(0x01571E70, avatar_top);
 	} else {
-		ok = peekProc(0x01579600, avatar_pos, 12) &&
-		     peekProc(0x015795F0, avatar_front, 12) &&
-		     peekProc(0x015795E0, avatar_top, 12);
+		ok = peekProc(0x01579600, avatar_pos) &&
+		     peekProc(0x015795F0, avatar_front) &&
+		     peekProc(0x015795E0, avatar_top);
 	}
 
 	if (! ok)

--- a/plugins/bfheroes/bfheroes.cpp
+++ b/plugins/bfheroes/bfheroes.cpp
@@ -15,17 +15,17 @@ static int fetch(float *avatar_pos, float *avatar_front, float *avatar_top, floa
 	char logincheck;
 	bool ok;
 
-	ok = peekProc(0x00A24D6C, &logincheck, 1);
+	ok = peekProc(0x00A24D6C, logincheck);
 	if (! ok)
 		return false;
 
 	if (logincheck == 0)
 		return false;
 
-	ok = peekProc(posptr, avatar_pos, 12) &&
-	     peekProc(faceptr, avatar_front, 12) &&
-	     peekProc(topptr, avatar_top, 12) &&
-	     peekProc(stateptr, &state, 1);
+	ok = peekProc(posptr, avatar_pos) &&
+	     peekProc(faceptr, avatar_front) &&
+	     peekProc(topptr, avatar_top) &&
+	     peekProc(stateptr, state);
 
 	if (! ok)
 		return false;

--- a/plugins/blacklight/blacklight.cpp
+++ b/plugins/blacklight/blacklight.cpp
@@ -90,8 +90,8 @@ static int fetch(float *avatar_pos, float *avatar_front, float *avatar_top, floa
 	bool ok;
 	char hostipport[sizeof(prev_hostipport)];
 
-	ok = peekProc(camfrontptr, camfront, 12) &&
-		 peekProc(camtopptr, camtop, 12) &&
+	ok = peekProc(camfrontptr, camfront) &&
+		 peekProc(camtopptr, camtop) &&
 		 peekProc(hostipportptr, hostipport) &&
 		 peekProc(camptr, cam);
 

--- a/plugins/borderlands/borderlands.cpp
+++ b/plugins/borderlands/borderlands.cpp
@@ -76,9 +76,9 @@ static int fetch(float *avatar_pos, float *avatar_front, float *avatar_top, floa
 	float pos_corrector[3];
 	float front_corrector[3];
 	float top_corrector[3];
-	ok = peekProc(posptr, &pos_corrector, 12) &&
-	     peekProc(frontptr, &front_corrector, 12) &&
-	     peekProc(topptr, &top_corrector, 12);
+	ok = peekProc(posptr, pos_corrector) &&
+	     peekProc(frontptr, front_corrector) &&
+	     peekProc(topptr, top_corrector);
 	if (! ok)
 		return false;
 

--- a/plugins/breach/breach.cpp
+++ b/plugins/breach/breach.cpp
@@ -54,9 +54,9 @@ static int fetch(float *avatar_pos, float *avatar_front, float *avatar_top, floa
 		return true; // This results in all vectors beeing zero which tells Mumble to ignore them
 
 	// coordinate systems is already left handed so no change needed
-	ok = peekProc(posptr, avatar_pos, 12) &&
-	     peekProc(frontptr, avatar_front, 12) &&
-	     peekProc(topptr, avatar_top, 12);
+	ok = peekProc(posptr, avatar_pos) &&
+	     peekProc(frontptr, avatar_front) &&
+	     peekProc(topptr, avatar_top);
 	if (! ok)
 		return false;
 

--- a/plugins/cod2/cod2.cpp
+++ b/plugins/cod2/cod2.cpp
@@ -26,18 +26,18 @@ static int fetch(float *avatar_pos, float *avatar_front, float *avatar_top, floa
 			0x0151A110		float	Vertical view (degrees) (=0 out-of-game)
 			0x0096B688		byte	Magic value (0=ingame/out-of-game, 4=spectator)
 	*/
-	ok = peekProc(0x0096B688, &state, 1);
+	ok = peekProc(0x0096B688, state);
 	if (! ok)
 		return false;
 
 	if (state == 4)
 		return true; // If this magic value is 4 we are spectating, so switch of PA
 
-	ok = peekProc(0x01516608, avatar_pos+2, 4) &&	//Z
-	     peekProc(0x0151660C, avatar_pos, 4) &&	//X
-	     peekProc(0x01516610, avatar_pos+1, 4) && //Y
-	     peekProc(0x0151A114, &viewHor, 4) && //Hor
-	     peekProc(0x0151A110, &viewVer, 4); //Ver
+	ok = peekProc(0x01516608, avatar_pos[2]) &&	//Z
+	     peekProc(0x0151660C, avatar_pos[0]) &&	//X
+	     peekProc(0x01516610, avatar_pos[1]) && //Y
+	     peekProc(0x0151A114, viewHor) && //Hor
+	     peekProc(0x0151A110, viewVer); //Ver
 
 	if (! ok)
 		return false;

--- a/plugins/cod4/cod4.cpp
+++ b/plugins/cod4/cod4.cpp
@@ -30,7 +30,7 @@ static int fetch(float *avatar_pos, float *avatar_front, float *avatar_top, floa
 
 			0x0074E380		byte	Magical state value
 	*/
-	ok = peekProc(0x0074E380, &state, 1); // Magical state value
+	ok = peekProc(0x0074E380, state); // Magical state value
 	if (! ok)
 		return false;
 	/*
@@ -45,12 +45,12 @@ static int fetch(float *avatar_pos, float *avatar_front, float *avatar_top, floa
 	if (state != 4)
 		return true; // This results in all vectors beeing zero which tells mumble to ignore them.
 
-	ok = peekProc(0x0072AFD0, avatar_pos+2, 4) &&	//Z
-	     peekProc(0x0072AFE0, avatar_pos, 4) &&	//X
-	     peekProc(0x0072AFF0, avatar_pos+1, 4) && //Y
-	     peekProc(0x0072AF3C, &viewHor, 4) && //Hor
-	     peekProc(0x0072AF38, &viewVer, 4) && //Ver
-	     peekProc(0x00956D88, ccontext, 128);
+	ok = peekProc(0x0072AFD0, avatar_pos[2]) &&	//Z
+	     peekProc(0x0072AFE0, avatar_pos[0]) &&	//X
+	     peekProc(0x0072AFF0, avatar_pos[1]) && //Y
+	     peekProc(0x0072AF3C, viewHor) && //Hor
+	     peekProc(0x0072AF38, viewVer) && //Ver
+	     peekProc(0x00956D88, ccontext);
 
 	if (! ok)
 		return false;

--- a/plugins/cod5/cod5.cpp
+++ b/plugins/cod5/cod5.cpp
@@ -27,7 +27,7 @@ static int fetch(float *avatar_pos, float *avatar_front, float *avatar_top, floa
 
 			0x0098FD2C		byte	Magical state value
 	*/
-	ok = peekProc(0x0098FD2C, &state, 1); // Magical state value
+	ok = peekProc(0x0098FD2C, state); // Magical state value
 	if (! ok)
 		return false;
 	/*
@@ -42,11 +42,11 @@ static int fetch(float *avatar_pos, float *avatar_front, float *avatar_top, floa
 	if (state != 4)
 		return true; // This results in all vectors beeing zero which tells mumble to ignore them.
 
-	ok = peekProc(0x008DE23C, avatar_pos+2, 4) &&	//Z
-	     peekProc(0x008DE234, avatar_pos, 4) &&	//X
-	     peekProc(0x008DE238, avatar_pos+1, 4) && //Y
-	     peekProc(0x008DE244, &viewHor, 4) && //Hor
-	     peekProc(0x008DE240, &viewVer, 4); //Ver
+	ok = peekProc(0x008DE23C, avatar_pos[2]) &&	//Z
+	     peekProc(0x008DE234, avatar_pos[0]) &&	//X
+	     peekProc(0x008DE238, avatar_pos[1]) && //Y
+	     peekProc(0x008DE244, viewHor) && //Hor
+	     peekProc(0x008DE240, viewVer); //Ver
 
 	if (! ok)
 		return false;

--- a/plugins/codmw2/codmw2.cpp
+++ b/plugins/codmw2/codmw2.cpp
@@ -27,7 +27,7 @@ static int fetch(float *avatar_pos, float *avatar_front, float *avatar_top, floa
 
 			0x007F7A34		byte	Magical state value
 	*/
-	ok = peekProc(0x007F8AB4, &state, 1); // Magical state value
+	ok = peekProc(0x007F8AB4, state); // Magical state value
 	if (! ok)
 		return false;
 	/*
@@ -42,11 +42,11 @@ static int fetch(float *avatar_pos, float *avatar_front, float *avatar_top, floa
 	if (state != 1)
 		return true; // This results in all vectors beeing zero which tells mumble to ignore them.
 
-	ok = peekProc(0x008F1FF8, avatar_pos+2, 4) &&	//Z
-	     peekProc(0x008F1FFC, avatar_pos, 4) &&	//X
-	     peekProc(0x008F2000, avatar_pos+1, 4) && //Y
-	     peekProc(0x008F2008, &viewHor, 4) && //Hor
-	     peekProc(0x008F2004, &viewVer, 4); //Ver
+	ok = peekProc(0x008F1FF8, avatar_pos[2]) &&	//Z
+	     peekProc(0x008F1FFC, avatar_pos[0]) &&	//X
+	     peekProc(0x008F2000, avatar_pos[1]) && //Y
+	     peekProc(0x008F2008, viewHor) && //Hor
+	     peekProc(0x008F2004, viewVer); //Ver
 
 	if (! ok)
 		return false;

--- a/plugins/codmw2so/codmw2so.cpp
+++ b/plugins/codmw2so/codmw2so.cpp
@@ -62,14 +62,14 @@ static int fetch(float *avatar_pos, float *avatar_front, float *avatar_top, floa
 			0x009270F0		byte	Magical state value
 	*/
 
-	ok = peekProc(0x019713F0, &specops, 1); // Magical state value
+	ok = peekProc(0x019713F0, specops); // Magical state value
 	if (! ok)
 		return false;
 
 	if (specops != 2)
 		return false; // 2 value indicates you are playing Special Ops, 1 indicates SP, 0 indicates at three-way selection menu
 
-	ok = peekProc(0x009270F0, &state, 1); // Magical state value
+	ok = peekProc(0x009270F0, state); // Magical state value
 	if (! ok)
 		return false;
 
@@ -85,11 +85,11 @@ static int fetch(float *avatar_pos, float *avatar_front, float *avatar_top, floa
 	if (state == 0)
 		return true; // This results in all vectors beeing zero which tells mumble to ignore them.
 
-	ok = peekProc(0x00783A64, avatar_pos+2, 4) &&	//Z
-	     peekProc(0x00783A68, avatar_pos, 4) &&	//X
-	     peekProc(0x00783A6C, avatar_pos+1, 4) && //Y
-	     peekProc(0x00783A34, &viewHor, 4) && //Hor
-	     peekProc(0x00783A30, &viewVer, 4); //Ver
+	ok = peekProc(0x00783A64, avatar_pos[2]) &&	//Z
+	     peekProc(0x00783A68, avatar_pos[0]) &&	//X
+	     peekProc(0x00783A6C, avatar_pos[1]) && //Y
+	     peekProc(0x00783A34, viewHor) && //Hor
+	     peekProc(0x00783A30, viewVer); //Ver
 
 	if (! ok)
 		return false;

--- a/plugins/cs/cs.cpp
+++ b/plugins/cs/cs.cpp
@@ -76,12 +76,12 @@ static int fetch(float *avatar_pos, float *avatar_front, float *avatar_top, floa
 	                        |                   270     T spawn
 	*/
 
-	ok = peekProc(pModule + 0x11D470, avatar_pos, 12) &&
-	     peekProc(pModule + 0x11D47C, &fViewHor, 4) &&
-	     peekProc(pModule + 0x11D480, &fViewVer, 4) &&
-	     peekProc(pModule + 0xFC228, &bConnected, 1) &&
-	     peekProc(pModule + 0xFBC2C, &cPlayerState, 1) &&
-	     peekProc(pEngine + 0x697E60, cHostAddr, 40);
+	ok = peekProc(pModule + 0x11D470, avatar_pos) &&
+	     peekProc(pModule + 0x11D47C, fViewHor) &&
+	     peekProc(pModule + 0x11D480, fViewVer) &&
+	     peekProc(pModule + 0xFC228, bConnected) &&
+	     peekProc(pModule + 0xFBC2C, cPlayerState) &&
+	     peekProc(pEngine + 0x697E60, cHostAddr);
 	if (!ok)
 		return false;
 

--- a/plugins/dys/dys.cpp
+++ b/plugins/dys/dys.cpp
@@ -49,10 +49,10 @@ static int fetch(float *avatar_pos, float *avatar_front, float *avatar_top, floa
 	wostringstream new_identity;
 	ostringstream new_context;
 
-	ok = peekProc(posptr, ipos, 12) &&
-	     peekProc(rotptr, rot, 12) &&
-	     peekProc(stateptr, &state, 1) &&
-	     peekProc(hostptr, chHostStr, 40);
+	ok = peekProc(posptr, ipos) &&
+	     peekProc(rotptr, rot) &&
+	     peekProc(stateptr, state) &&
+	     peekProc(hostptr, chHostStr);
 	if (!ok)
 		return false;
 
@@ -118,7 +118,7 @@ static int trylock(const std::multimap<std::wstring, unsigned long long int> &pi
 
 	//Gamecheck
 	char sMagic[14];
-	if (!peekProc(pModule + 0x463726, sMagic, 14) || strncmp("DysObjective@@", sMagic, 14)!=0)
+	if (!peekProc(pModule + 0x463726, sMagic) || strncmp("DysObjective@@", sMagic, 14)!=0)
 		return false;
 
 	// Check if we can get meaningful data from it

--- a/plugins/etqw/etqw.cpp
+++ b/plugins/etqw/etqw.cpp
@@ -31,18 +31,18 @@ static int fetch(float *avatar_pos, float *avatar_front, float *avatar_top, floa
 			0x013F9E1C		float	Vertical view
 			0x013E8D18		byte	Magic value (32 ingame / 0 spectating)
 	*/
-	ok = peekProc(0x00801BA4, &menustate, 1);
+	ok = peekProc(0x00801BA4, menustate);
 	if (! ok)
 		return false;
 	if (menustate == 0)
 		return true;
 
-	ok = peekProc(pos1ptr, avatar_pos+1, 4) &&	//Y
-	     peekProc(pos2ptr, avatar_pos, 4) &&	//X
-	     peekProc(pos3ptr, avatar_pos+2, 4) && //Z
-	     peekProc(rot1ptr, &viewHor, 4) && //Hor
-	     peekProc(rot2ptr, &viewVer, 4) && //Ver
-	     peekProc(0x0122E0B8, ccontext, 128);
+	ok = peekProc(pos1ptr, avatar_pos[1]) &&	//Y
+	     peekProc(pos2ptr, avatar_pos[0]) &&	//X
+	     peekProc(pos3ptr, avatar_pos[2]) && //Z
+	     peekProc(rot1ptr, viewHor) && //Hor
+	     peekProc(rot2ptr, viewVer) && //Ver
+	     peekProc(0x0122E0B8, ccontext);
 
 	if (! ok)
 		return false;

--- a/plugins/gmod/gmod.cpp
+++ b/plugins/gmod/gmod.cpp
@@ -48,10 +48,10 @@ static int fetch(float *avatar_pos, float *avatar_front, float *avatar_top, floa
 	string sHost;
 	ostringstream new_context;
 
-	ok = peekProc(posptr, ipos, 12)
-	     && peekProc(rotptr, rot, 12)
+	ok = peekProc(posptr, ipos)
+	     && peekProc(rotptr, rot)
 	     //&& peekProc(stateptr, &state, 1)
-	     && peekProc(hostptr, chHostStr, 40)
+	     && peekProc(hostptr, chHostStr)
 	     ;
 	if (!ok)
 		return false;
@@ -116,7 +116,7 @@ static int trylock(const std::multimap<std::wstring, unsigned long long int> &pi
 	// Gamecheck
 	const char ID[] = "garrysmod";
 	char sMagic[18];
-	if (!peekProc(idptr, sMagic, sizeof(ID)) || strncmp(ID, sMagic, sizeof(ID))!=0)
+	if (!peekProc(idptr, sMagic) || strncmp(ID, sMagic, sizeof(ID))!=0)
 		return false;
 
 	// Check if we can get meaningful data from it

--- a/plugins/gtaiv/gtaiv.cpp
+++ b/plugins/gtaiv/gtaiv.cpp
@@ -51,10 +51,10 @@ static int setuppointers() {
 	if (!peekProc(base_address + 0x11A7008 + (playerid * 4), &playerptr, 4) || !playerptr)
 		return false;
 
-	if (!peekProc(playerptr + 0x58C, &charptr, 4) || !charptr)
+	if (!peekProc(playerptr + 0x58C, charptr) || !charptr)
 		return false;
 
-	if (!peekProc(charptr + 0x20, &cvecptr, 4) || !cvecptr)
+	if (!peekProc(charptr + 0x20, cvecptr) || !cvecptr)
 		return false;
 
 	return true;
@@ -84,12 +84,12 @@ static int fetch(float *avatar_pos, float *avatar_front, float *avatar_top, floa
 	float camtop_corrector[3];
 
 	// Peekproc and assign game addresses to our containers, so we can retrieve positional data
-	ok = peekProc(cvecptr + 0x30, &pos_corrector, 12) &&
-	     peekProc(cvecptr + 0x20, &top_corrector, 12) &&
-	     peekProc(cvecptr + 0x10, &front_corrector, 12) &&
-	     peekProc(displayptr + 0x30, &campos_corrector, 12) &&
-	     peekProc(displayptr + 0x10, &camtop_corrector, 12) &&
-	     peekProc(displayptr + 0x20, &camfront_corrector, 12);
+	ok = peekProc(cvecptr + 0x30, pos_corrector) &&
+	     peekProc(cvecptr + 0x20, top_corrector) &&
+	     peekProc(cvecptr + 0x10, front_corrector) &&
+	     peekProc(displayptr + 0x30, campos_corrector) &&
+	     peekProc(displayptr + 0x10, camtop_corrector) &&
+	     peekProc(displayptr + 0x20, camfront_corrector);
 
 	if (!ok)
 		return false;
@@ -135,7 +135,7 @@ static int trylock(const std::multimap<std::wstring, unsigned long long int> &pi
 
 	base_address = pModule - 0x400000;
 
-	if (!peekProc(base_address + 0x10F47F0, &viewportptr, 4) || !viewportptr)
+	if (!peekProc(base_address + 0x10F47F0, viewportptr) || !viewportptr)
 		return false;
 
 	displayptr = viewportptr + 0x50;

--- a/plugins/gtav/gtav.cpp
+++ b/plugins/gtav/gtav.cpp
@@ -63,14 +63,14 @@ static int fetch(float *avatar_pos, float *avatar_front, float *avatar_top, floa
 	char state, in_game, player[50], vehicle[50], location[50], street[50];
 
 	// Peekproc and assign game addresses to our containers, so we can retrieve positional data
-	ok = peekProc(state_address, &state, 1) && // Magical state value: 0 when in single player, 2 when online and 3 when in a lobby.
-			peekProc(in_game_address, &in_game, 1) && // 0 when loading or not in-game, 1 when in-game.
-			peekProc(avatar_pos_address, avatar_pos_corrector, 12) && // Avatar Position values (X, Z and Y).
-			peekProc(camera_pos_address, camera_pos_corrector, 12) && // Camera Position values (X, Z and Y).
-			peekProc(avatar_base + 0x70, avatar_front_corrector, 12) && // Avatar Front Vector values (X, Z and Y).
-			peekProc(avatar_base + 0x80, avatar_top_corrector, 12) && // Avatar Top Vector values (X, Z and Y).
-			peekProc(camera_front_address, camera_front_corrector, 12) && // Camera Front Vector values (X, Z and Y).
-			peekProc(camera_top_address, camera_top_corrector, 12) && // Camera Top Vector values (X, Z and Y).
+	ok = peekProc(state_address, state) && // Magical state value: 0 when in single player, 2 when online and 3 when in a lobby.
+			peekProc(in_game_address, in_game) && // 0 when loading or not in-game, 1 when in-game.
+			peekProc(avatar_pos_address, avatar_pos_corrector) && // Avatar Position values (X, Z and Y).
+			peekProc(camera_pos_address, camera_pos_corrector) && // Camera Position values (X, Z and Y).
+			peekProc(avatar_base + 0x70, avatar_front_corrector) && // Avatar Front Vector values (X, Z and Y).
+			peekProc(avatar_base + 0x80, avatar_top_corrector) && // Avatar Top Vector values (X, Z and Y).
+			peekProc(camera_front_address, camera_front_corrector) && // Camera Front Vector values (X, Z and Y).
+			peekProc(camera_top_address, camera_top_corrector) && // Camera Top Vector values (X, Z and Y).
 			peekProc(player_address, player) && // Player nickname.
 			peekProc(vehicle_address, vehicle) && // Vehicle name if in a vehicle, empty if not.
 			peekProc(location_address, location) && // Location name.

--- a/plugins/gw/gw.cpp
+++ b/plugins/gw/gw.cpp
@@ -140,8 +140,8 @@ static int fetch(float *avatar_pos, float *avatar_front, float *avatar_top, floa
 	ok = peekProc(camptr, cam) &&
 		 peekProc(posptr, pos) &&
 		 peekProc(camfrontptr, camfront) &&
-		 peekProc(locationptr, &location, 1) &&
-		 peekProc(areaptr, &areaid, 4);
+		 peekProc(locationptr, location) &&
+		 peekProc(areaptr, areaid);
 
 	if (!ok) // First we check, if the game is even running or if we should unlink because it's not / it's broken
 		return false;

--- a/plugins/insurgency/insurgency.cpp
+++ b/plugins/insurgency/insurgency.cpp
@@ -49,10 +49,10 @@ static int fetch(float *avatar_pos, float *avatar_front, float *avatar_top, floa
 	wostringstream new_identity;
 	ostringstream new_context;
 
-	ok = peekProc(posptr, ipos, 12) &&
-	     peekProc(rotptr, rot, 12) &&
-	     peekProc(stateptr, &state, 1) &&
-	     peekProc(hostptr, chHostStr, 40);
+	ok = peekProc(posptr, ipos) &&
+	     peekProc(rotptr, rot) &&
+	     peekProc(stateptr, state) &&
+	     peekProc(hostptr, chHostStr);
 	if (!ok)
 		return false;
 
@@ -118,7 +118,7 @@ static int trylock(const std::multimap<std::wstring, unsigned long long int> &pi
 
 	//Gamecheck
 	char sMagic[14];
-	if (!peekProc(pModule + 0x46B512, sMagic, 14) || strncmp("CombatWeapon@@", sMagic, 14)!=0)
+	if (!peekProc(pModule + 0x46B512, sMagic) || strncmp("CombatWeapon@@", sMagic, 14)!=0)
 		return false;
 
 	// Check if we can get meaningful data from it

--- a/plugins/jc2/jc2.cpp
+++ b/plugins/jc2/jc2.cpp
@@ -65,18 +65,18 @@ typedef struct {
 static int setuppointers() {
 	procptr32_t character_manager, local_player, character, camera_manager;
 
-	if (!peekProc(pModule + off_character_manager, &character_manager, 4) || !character_manager)
+	if (!peekProc(pModule + off_character_manager, character_manager) || !character_manager)
 		return false;
 
-	if (!peekProc(character_manager + off_local_player, &local_player, 4) || !local_player)
+	if (!peekProc(character_manager + off_local_player, local_player) || !local_player)
 		return false;
 
-	if (!peekProc(local_player + off_character, &character, 4) || !character)
+	if (!peekProc(local_player + off_character, character) || !character)
 		return false;
 
 	char_matrix_ptr = character + off_char_matrix;
 
-	if (!peekProc(pModule + off_camera_manager, &camera_manager, 4) || !camera_manager)
+	if (!peekProc(pModule + off_camera_manager, camera_manager) || !camera_manager)
 		return false;
 
 	cam_matrix_ptr = camera_manager + off_cam_matrix;

--- a/plugins/l4d2/l4d2_linux.cpp
+++ b/plugins/l4d2/l4d2_linux.cpp
@@ -23,11 +23,11 @@ static int fetch(float *avatar_pos, float *avatar_front, float *avatar_top, floa
 	unsigned char state;
 
 	// Peekproc and assign game addresses to our containers, so we can retrieve positional data
-	ok = peekProc(pModule + 0xE0A24C, &state, 1) && // Magical state value: 0 or 255 when in main menu and 1 when in-game.
-			peekProc(pModule + 0xE773FC, avatar_pos_corrector, 12) && // Avatar Position values (X, Z and Y).
-			peekProc(pModule + 0xED8700, camera_pos_corrector, 12) && // Camera Position values (X, Z and Y).
-			peekProc(pModule + 0xE3C138, avatar_front_corrector, 12) && // Front vector values (X, Z and Y).
-			peekProc(pModule + 0xE3C150, avatar_top_corrector, 12) && // Top vector values (Z, X and Y).
+	ok = peekProc(pModule + 0xE0A24C, state) && // Magical state value: 0 or 255 when in main menu and 1 when in-game.
+			peekProc(pModule + 0xE773FC, avatar_pos_corrector) && // Avatar Position values (X, Z and Y).
+			peekProc(pModule + 0xED8700, camera_pos_corrector) && // Camera Position values (X, Z and Y).
+			peekProc(pModule + 0xE3C138, avatar_front_corrector) && // Front vector values (X, Z and Y).
+			peekProc(pModule + 0xE3C150, avatar_top_corrector) && // Top vector values (Z, X and Y).
 			peekProc(serverid_steamclient, serverid) && // Unique server Steam ID.
 			peekProc(pModule + 0xE356D0, host) && // Server value: "IP:Port" (xxx.xxx.xxx.xxx:yyyyy) when in a remote server, "loopback:0" when on a local server and empty when not playing.
 			peekProc(pModule + 0xE358D8, servername) && // Server name.

--- a/plugins/l4d2/l4d2_win32.cpp
+++ b/plugins/l4d2/l4d2_win32.cpp
@@ -23,11 +23,11 @@ static int fetch(float *avatar_pos, float *avatar_front, float *avatar_top, floa
 	BYTE state;
 
 	// Peekproc and assign game addresses to our containers, so we can retrieve positional data
-	ok = peekProc(pModule + 0x6ACBD5, &state, 1) && // Magical state value: 0 or 255 when in main menu and 1 when in-game.
-			peekProc(pModule + 0x6B9E1C, avatar_pos_corrector, 12) && // Avatar Position values (X, Z and Y).
-			peekProc(pModule + 0x774B98, camera_pos_corrector, 12) && // Camera Position values (X, Z and Y).
-			peekProc(pModule + 0x774BF8, avatar_front_corrector, 12) && // Front vector values (X, Z and Y).
-			peekProc(pModule + 0x774C28, avatar_top_corrector, 12) && // Top vector values (Z, X and Y).
+	ok = peekProc(pModule + 0x6ACBD5, state) && // Magical state value: 0 or 255 when in main menu and 1 when in-game.
+			peekProc(pModule + 0x6B9E1C, avatar_pos_corrector) && // Avatar Position values (X, Z and Y).
+			peekProc(pModule + 0x774B98, camera_pos_corrector) && // Camera Position values (X, Z and Y).
+			peekProc(pModule + 0x774BF8, avatar_front_corrector) && // Front vector values (X, Z and Y).
+			peekProc(pModule + 0x774C28, avatar_top_corrector) && // Top vector values (Z, X and Y).
 			peekProc(serverid_steamclient, serverid) && // Unique server Steam ID.
 			peekProc(pModule + 0x772B24, host) && // Server value: "IP:Port" (xxx.xxx.xxx.xxx:yyyyy) when in a remote server, "loopback:0" when on a local server and empty when not playing.
 			peekProc(pModule + 0x772D2C, servername) && // Server name.

--- a/plugins/lol/lol.cpp
+++ b/plugins/lol/lol.cpp
@@ -113,12 +113,12 @@ static int fetch(float *avatar_pos, float *avatar_front, float *avatar_top, floa
 	if (!peekProc<procptr32_t>(gameptr))
 		return false;
 
-	ok = peekProc(camfrontptr, camera_front, 12) &&
-		 peekProc(camptr, cam, 12) &&
-		 peekProc(posptr, ipos, 12) &&
-		 peekProc(afrontptr, avatar_front, 12) &&
+	ok = peekProc(camfrontptr, camera_front) &&
+		 peekProc(camptr, cam) &&
+		 peekProc(posptr, ipos) &&
+		 peekProc(afrontptr, avatar_front) &&
 		 peekProc(hostipptr, hostip) &&
-		 peekProc(hostportptr, &hostport, 4);
+		 peekProc(hostportptr, hostport);
 
 	if (!ok) 
 		return false;

--- a/plugins/lotro/lotro.cpp
+++ b/plugins/lotro/lotro.cpp
@@ -66,16 +66,16 @@ static int fetch(float *avatar_pos, float *avatar_front, float *avatar_top, floa
 		nPtr = pointer to character name (unique on a server)
 	*/
 
-	ok = peekProc(0x01272D34, o, 12) &&
-	     peekProc(0x01272D2C, l, 2) &&
-	     peekProc(0x01272D28, &r, 1) &&
-	     peekProc(0x01272D20, &i, 1) &&
-	     peekProc(pModule + 0x00A138A4, &hPtr, 4);
+	ok = peekProc(0x01272D34, o) &&
+	     peekProc(0x01272D2C, l) &&
+	     peekProc(0x01272D28, r) &&
+	     peekProc(0x01272D20, i) &&
+	     peekProc(pModule + 0x00A138A4, hPtr);
 
 	if (! ok)
 		return false;
 
-	ok = peekProc((procptr32_t)(hPtr  + 0x0000046F), &h, 4);
+	ok = peekProc((procptr32_t)(hPtr  + 0x0000046F), h);
 
 	if (! ok)
 		return false;

--- a/plugins/ql/ql.cpp
+++ b/plugins/ql/ql.cpp
@@ -21,12 +21,12 @@ static int fetch(float *avatar_pos, float *avatar_front, float *avatar_top, floa
 	BYTE team;
 
 	// Peekproc and assign game addresses to our containers, so we can retrieve positional data
-	ok = peekProc(pModule + 0x0188248, &state, 1) && // Magical state value: 1 when in-game and 0 when in main menu.
-			peekProc(pModule + 0x1041C68, &spec, 1) && // Spectator state value: 1 when spectating and 0 when playing.
-			peekProc(pModule + 0x0EB8950, avatar_pos_corrector, 12) && // Avatar Position values (X, Z and Y, respectively).
-			peekProc(pModule + 0x0E6093C, camera_pos_corrector, 12) && // Camera Position values (X, Z and Y, respectively).
-			peekProc(pModule + 0x0EC5B50, avatar_front_corrector, 12) && // Avatar front values (X, Z and Y, respectively).
-			peekProc(pModule + 0x0EC5B68, avatar_top_corrector, 12) && // Avatar top values (X, Z and Y, respectively).
+	ok = peekProc(pModule + 0x0188248, state) && // Magical state value: 1 when in-game and 0 when in main menu.
+			peekProc(pModule + 0x1041C68, spec) && // Spectator state value: 1 when spectating and 0 when playing.
+			peekProc(pModule + 0x0EB8950, avatar_pos_corrector) && // Avatar Position values (X, Z and Y, respectively).
+			peekProc(pModule + 0x0E6093C, camera_pos_corrector) && // Camera Position values (X, Z and Y, respectively).
+			peekProc(pModule + 0x0EC5B50, avatar_front_corrector) && // Avatar front values (X, Z and Y, respectively).
+			peekProc(pModule + 0x0EC5B68, avatar_top_corrector) && // Avatar top values (X, Z and Y, respectively).
 			peekProc(pModule + 0x0E4A638, host) && // Server value: "IP:Port" when in a remote server, "loopback" when on a local server.
 			peekProc(pModule + 0x106E24B, servername) && // Server name.
 			peekProc(pModule + 0x12DE8D8, map) && // Map name.

--- a/plugins/rl/rl_linux.cpp
+++ b/plugins/rl/rl_linux.cpp
@@ -23,11 +23,11 @@ static int fetch(float *avatar_pos, float *avatar_front, float *avatar_top, floa
 	if (!avatar_offset) return false;
 
 	// Peekproc and assign game addresses to our containers, so we can retrieve positional data
-	ok = peekProc(avatar_offset + 0x60, avatar_pos, 12) && // Avatar Position values (X, Y and Z).
-			peekProc(pModule + 0x3021398, camera_pos, 12) && // Camera Position values (X, Y and Z).
-			peekProc(avatar_offset + 0x6C, avatar_front, 12) && // Avatar Front values (X, Y and Z).
-			peekProc(pModule + 0x3021380, camera_front, 12) && // Camera Front Vector values (X, Y and Z).
-			peekProc(pModule + 0x302138C, camera_top, 12); // Camera Top Vector values (X, Y and Z).
+	ok = peekProc(avatar_offset + 0x60, avatar_pos) && // Avatar Position values (X, Y and Z).
+			peekProc(pModule + 0x3021398, camera_pos) && // Camera Position values (X, Y and Z).
+			peekProc(avatar_offset + 0x6C, avatar_front) && // Avatar Front values (X, Y and Z).
+			peekProc(pModule + 0x3021380, camera_front) && // Camera Front Vector values (X, Y and Z).
+			peekProc(pModule + 0x302138C, camera_top); // Camera Top Vector values (X, Y and Z).
 
 	// This prevents the plugin from linking to the game in case something goes wrong during values retrieval from memory addresses.
 	if (! ok)

--- a/plugins/rl/rl_win32.cpp
+++ b/plugins/rl/rl_win32.cpp
@@ -25,11 +25,11 @@ static int fetch(float *avatar_pos, float *avatar_front, float *avatar_top, floa
 	if (!avatar_offset) return false;
 
 	// Peekproc and assign game addresses to our containers, so we can retrieve positional data
-	ok = peekProc(avatar_offset + 0x0, avatar_pos, 12) && // Avatar Position values (X, Y and Z).
-			peekProc(pModule + 0x171ABF8, camera_pos, 12) && // Camera Position values (X, Y and Z).
-			peekProc(avatar_offset + 0xC, avatar_front, 12) && // Avatar Front values (X, Y and Z).
-			peekProc(pModule + 0x171ABE0, camera_front, 12) && // Camera Front Vector values (X, Y and Z).
-			peekProc(pModule + 0x171ABEC, camera_top, 12); // Camera Top Vector values (X, Y and Z).
+	ok = peekProc(avatar_offset + 0x0, avatar_pos) && // Avatar Position values (X, Y and Z).
+			peekProc(pModule + 0x171ABF8, camera_pos) && // Camera Position values (X, Y and Z).
+			peekProc(avatar_offset + 0xC, avatar_front) && // Avatar Front values (X, Y and Z).
+			peekProc(pModule + 0x171ABE0, camera_front) && // Camera Front Vector values (X, Y and Z).
+			peekProc(pModule + 0x171ABEC, camera_top); // Camera Top Vector values (X, Y and Z).
 
 	// This prevents the plugin from linking to the game in case something goes wrong during values retrieval from memory addresses.
 	if (! ok)

--- a/plugins/sr/sr.cpp
+++ b/plugins/sr/sr.cpp
@@ -59,9 +59,9 @@ static int fetch(float *avatar_pos, float *avatar_front, float *avatar_top, floa
 		return true; // This results in all vectors beeing zero which tells Mumble to ignore them.
 	
 	// Peekproc and assign game addresses to our containers, so we can retrieve positional data
-	ok = peekProc(0x1243BE84, &pos_corrector, 12) &&
-	        peekProc(0x1243BEA8, &front_corrector, 12) &&
-	        peekProc(0x1243BE9C, &top_corrector, 12);
+	ok = peekProc(0x1243BE84, pos_corrector) &&
+	        peekProc(0x1243BEA8, front_corrector) &&
+	        peekProc(0x1243BE9C, top_corrector);
 	
 	if (! ok)
 		return false;

--- a/plugins/ut2004/ut2004.cpp
+++ b/plugins/ut2004/ut2004.cpp
@@ -27,11 +27,11 @@ static int fetch(float *avatar_pos, float *avatar_front, float *avatar_top, floa
 	   Y-Value is increasing when going up
 				  decreasing when going down
 	*/
-	ok = peekProc(pos2ptr, avatar_pos, 4) &&	//X
-	     peekProc(pos1ptr, avatar_pos+1, 4) &&	//Y
-	     peekProc(pos0ptr, avatar_pos+2, 4) &&  //Z
-	     peekProc(faceptr, &face_corrector, 12) &&
-	     peekProc(topptr, &top_corrector, 12);
+	ok = peekProc(pos2ptr, avatar_pos) &&	//X
+	     peekProc(pos1ptr, avatar_pos[1]) &&	//Y
+	     peekProc(pos0ptr, avatar_pos[2]) &&  //Z
+	     peekProc(faceptr, face_corrector) &&
+	     peekProc(topptr, top_corrector);
 	//peekProc((BYTE *) 0x0122E0B8, ccontext, 128);
 
 	if (! ok)

--- a/plugins/ut3/ut3.cpp
+++ b/plugins/ut3/ut3.cpp
@@ -21,7 +21,7 @@ static int fetch(float *avatar_pos, float *avatar_front, float *avatar_top, floa
 	for (int i=0;i<3;i++)
 		avatar_pos[i] = avatar_front[i] = avatar_top[i] = camera_pos[i] = camera_front[i] = camera_top[i] = 0.0f;
 
-	ok = peekProc(0x01DEAFD9, &state, 1);
+	ok = peekProc(0x01DEAFD9, state);
 	if (! ok)
 		return false;
 
@@ -39,11 +39,11 @@ static int fetch(float *avatar_pos, float *avatar_front, float *avatar_top, floa
 
 	//Convert to left-handed coordinate system
 
-	ok = peekProc(pos2ptr, avatar_pos, 4) &&	//X
-	     peekProc(pos1ptr, avatar_pos+1, 4) &&	//Y
-	     peekProc(pos0ptr, avatar_pos+2, 4) &&  //Z
-	     peekProc(faceptr, &face_corrector, 12) &&
-	     peekProc(topptr, &top_corrector, 12);
+	ok = peekProc(pos2ptr, avatar_pos) &&	//X
+	     peekProc(pos1ptr, avatar_pos[1]) &&	//Y
+	     peekProc(pos0ptr, avatar_pos[2]) &&  //Z
+	     peekProc(faceptr, face_corrector) &&
+	     peekProc(topptr, top_corrector);
 
 	//peekProc((BYTE *) 0x0122E0B8, ccontext, 128);
 

--- a/plugins/wolfet/wolfet.cpp
+++ b/plugins/wolfet/wolfet.cpp
@@ -57,7 +57,7 @@ static int fetch(float *avatar_pos, float *avatar_front, float *avatar_top, floa
 		avatar_pos[i] = avatar_front[i] = avatar_top[i] = camera_pos[i] = camera_front[i] = camera_top[i] = 0.0f;
 
 	bool ok;
-	ok = peekProc(0x013E8DFC, &team, 1);
+	ok = peekProc(0x013E8DFC, team);
 	if (!ok)
 		return false;
 
@@ -65,9 +65,9 @@ static int fetch(float *avatar_pos, float *avatar_front, float *avatar_top, floa
 	if (team == 0 || team == 3)
 		return true;
 
-	ok = peekProc(0x013E8CF4, avatar_pos, 12) &&   // X, Y, Z
-		peekProc(0x013F9E20, &viewHor, 4) &&      // Hor-Angle
-		peekProc(0x013F9E1C, &viewVer, 4);        // Ver-Angle
+	ok = peekProc(0x013E8CF4, avatar_pos) &&   // X, Y, Z
+		peekProc(0x013F9E20, viewHor) &&      // Hor-Angle
+		peekProc(0x013F9E1C, viewVer);        // Ver-Angle
 
 	if (!ok)
 		return false;
@@ -91,8 +91,8 @@ static int fetch(float *avatar_pos, float *avatar_front, float *avatar_top, floa
 	// Context - concatenated server-ip, mapname and team value
 	char hostip[32];
 	char mapname[40];
-	ok = peekProc(0x009FFD30, hostip, sizeof(hostip)) &&
-		peekProc(0x010B4908, mapname, sizeof(hostip));
+	ok = peekProc(0x009FFD30, hostip) &&
+		peekProc(0x010B4908, mapname);
 	hostip[sizeof(hostip)-1] = '\0';
 	mapname[sizeof(mapname)-1] = '\0';
 	// Context in JSON format, {} with fields ipport (server hostname), map, and team (: int)

--- a/plugins/wow/wow.cpp
+++ b/plugins/wow/wow.cpp
@@ -47,12 +47,12 @@ static int fetch(float *avatar_pos, float *avatar_front, float *avatar_top, floa
 	char state, player[50], realm[50];
 
 	// Peekproc and assign game addresses to our containers, so we can retrieve positional data
-	ok = peekProc(pModule + state_address, &state, 1) && // Magical state value: 1 when in-game, 0 when not.
-			peekProc(avatar_offset + avatar_pos_address, avatar_pos_corrector, 12) && // Avatar Position values (Z, -X and Y).
-			peekProc(camera_offset + camera_pos_address, camera_pos_corrector, 12) && // Camera Position values (Z, -X and Y).
+	ok = peekProc(pModule + state_address, state) && // Magical state value: 1 when in-game, 0 when not.
+			peekProc(avatar_offset + avatar_pos_address, avatar_pos_corrector) && // Avatar Position values (Z, -X and Y).
+			peekProc(camera_offset + camera_pos_address, camera_pos_corrector) && // Camera Position values (Z, -X and Y).
 			peekProc(avatar_offset + avatar_heading_address, avatar_heading) && // Avatar heading.
-			peekProc(camera_offset + camera_front_address, camera_front_corrector, 12) && // Camera Front Vector values (Z, -X and Y).
-			peekProc(camera_offset + camera_top_address, camera_top_corrector, 12) && // Camera Top Vector values (Z, -X and Y).
+			peekProc(camera_offset + camera_front_address, camera_front_corrector) && // Camera Front Vector values (Z, -X and Y).
+			peekProc(camera_offset + camera_top_address, camera_top_corrector) && // Camera Top Vector values (Z, -X and Y).
 			peekProc(realm_offset + realm_address, realm) && // Realm name.
 			peekProc(pModule + player_address, player); // Player nickname.
 

--- a/plugins/wow_x64/wow_x64.cpp
+++ b/plugins/wow_x64/wow_x64.cpp
@@ -47,12 +47,12 @@ static int fetch(float *avatar_pos, float *avatar_front, float *avatar_top, floa
 	char state, player[50], realm[50];
 
 	// Peekproc and assign game addresses to our containers, so we can retrieve positional data
-	ok = peekProc(pModule + state_address, &state, 1) && // Magical state value: 1 when in-game, 0 when not.
-			peekProc(avatar_offset + avatar_pos_address, avatar_pos_corrector, 12) && // Avatar Position values (Z, -X and Y).
-			peekProc(camera_offset + camera_pos_address, camera_pos_corrector, 12) && // Camera Position values (Z, -X and Y).
+	ok = peekProc(pModule + state_address, state) && // Magical state value: 1 when in-game, 0 when not.
+			peekProc(avatar_offset + avatar_pos_address, avatar_pos_corrector) && // Avatar Position values (Z, -X and Y).
+			peekProc(camera_offset + camera_pos_address, camera_pos_corrector) && // Camera Position values (Z, -X and Y).
 			peekProc(avatar_offset + avatar_heading_address, avatar_heading) && // Avatar heading.
-			peekProc(camera_offset + camera_front_address, camera_front_corrector, 12) && // Camera Front Vector values (Z, -X and Y).
-			peekProc(camera_offset + camera_top_address, camera_top_corrector, 12) && // Camera Top Vector values (Z, -X and Y).
+			peekProc(camera_offset + camera_front_address, camera_front_corrector) && // Camera Front Vector values (Z, -X and Y).
+			peekProc(camera_offset + camera_top_address, camera_top_corrector) && // Camera Top Vector values (Z, -X and Y).
 			peekProc(realm_offset + realm_address, realm) && // Realm name.
 			peekProc(pModule + player_address, player); // Player nickname.
 


### PR DESCRIPTION
The short form of peekProc automatically uses the correct size for the target.