### PR TITLE
Add 'always visible' channels to filtering mechanism

### DIFF
--- a/src/Channel.h
+++ b/src/Channel.h
@@ -54,17 +54,41 @@ class Channel : public QObject {
 
 #ifdef MUMBLE
 		unsigned int uiPermissions;
-		bool bFiltered;
 
+		/// List of possible visibility properties for channels
+		/// when filtering is active. Only append to this enum
+		/// as its values are used in the client DB.
+		enum FilteredVisibility {
+			/// Channel has normal behavior when filtering, it might get hidden if unoccupied
+			FILTERED_VISIBILITY_NORMAL,
+			/// Channel is never visible when filtering is active, even when occupied
+			FILTERED_VISIBILITY_NEVER,
+			/// Channel is always visible when filtering is active, even when empty
+			FILTERED_VISIBILITY_ALWAYS,
+		};
+		
+		/// Visibility properties of this channel when filtering is active
+		FilteredVisibility filteredVisibility;
+		
 		static QHash<int, Channel *> c_qhChannels;
 		static QReadWriteLock c_qrwlChannels;
 
 		static Channel *get(int);
 		static Channel *add(int, const QString &);
 		static void remove(Channel *);
+		
+		/// Returns true if this channel or one of its subchannels has a visibility of FILTERED_VISIBILITY_ALWAYS.
+		bool isAlwaysVisibleWhenFiltering() const;
+		/// Returns true if this channel or one of its parent channels has a visibility of FILTERED_VISIBILITY_NEVER.
+		/// Note: You have to check isAlwaysVisibleWhenFiltering to ensure a channel isn't forced visible by a subchannel.
+		bool isNeverVisibleWhenFiltering() const;
 
 		void addClientUser(ClientUser *p);
-#endif
+#endif // MUMBLE
+		
+		bool hasAnyUsersInOrBelow() const;
+		bool isUserInOrBelow(const User *user) const;
+		
 		static bool lessThan(const Channel *, const Channel *);
 
 		size_t getLevel() const;

--- a/src/mumble/Database.h
+++ b/src/mumble/Database.h
@@ -7,6 +7,7 @@
 #define MUMBLE_MUMBLE_DATABASE_H_
 
 #include "Settings.h"
+#include "Channel.h"
 
 struct FavoriteServer {
 	QString qsName;
@@ -38,8 +39,8 @@ class Database : public QObject {
 		static float getUserLocalVolume(const QString &hash);
 		static void setUserLocalVolume(const QString &hash, float volume);
 
-		static bool isChannelFiltered(const QByteArray &server_cert_digest, const int channel_id);
-		static void setChannelFiltered(const QByteArray &server_cert_digest, const int channel_id, bool hidden);
+		static Channel::FilteredVisibility getChannelFilteredVisibility(const QByteArray &server_cert_digest, const int channel_id);
+		static void setChannelFilteredVisibility(const QByteArray &server_cert_digest, const int channel_id, Channel::FilteredVisibility visibility);
 
 		static QMap<QPair<QString, unsigned short>, unsigned int> getPingCache();
 		static void setPingCache(const QMap<QPair<QString, unsigned short>, unsigned int> &cache);

--- a/src/mumble/MainWindow.h
+++ b/src/mumble/MainWindow.h
@@ -69,6 +69,7 @@ class MainWindow : public QMainWindow, public MessageHandler, public Ui::MainWin
 		QMenu *qmUser;
 		QMenu *qmChannel;
 		QMenu *qmTray;
+		QActionGroup *qagChannelVisibilityFilterGroup;
 		QIcon qiIcon, qiIconMuteSelf, qiIconMuteServer, qiIconDeafSelf, qiIconDeafServer, qiIconMuteSuppressed;
 		QIcon qiTalkingOn, qiTalkingWhisper, qiTalkingShout, qiTalkingOff;
 		QMap<unsigned int, UserLocalVolumeDialog *> qmUserVolTracker;
@@ -218,7 +219,9 @@ class MainWindow : public QMainWindow, public MessageHandler, public Ui::MainWin
 		void on_qaChannelUnlink_triggered();
 		void on_qaChannelUnlinkAll_triggered();
 		void on_qaChannelSendMessage_triggered();
-		void on_qaChannelFilter_triggered();
+		void on_qaChannelFilterVisibilityAlways_triggered();
+		void on_qaChannelFilterVisibilityNever_triggered();
+		void on_qaChannelFilterVisibilityNormal_triggered();
 		void on_qaChannelCopyURL_triggered();
 		void on_qaAudioReset_triggered();
 		void on_qaAudioMute_triggered();

--- a/src/mumble/MainWindow.ui
+++ b/src/mumble/MainWindow.ui
@@ -48,7 +48,7 @@
      <x>0</x>
      <y>0</y>
      <width>671</width>
-     <height>21</height>
+     <height>25</height>
     </rect>
    </property>
    <widget class="QMenu" name="qmConfig">
@@ -106,7 +106,7 @@
    <property name="minimumSize">
     <size>
      <width>250</width>
-     <height>93</height>
+     <height>103</height>
     </size>
    </property>
    <property name="features">
@@ -841,12 +841,15 @@ the channel's context menu.</string>
     <string>&amp;Join Channel</string>
    </property>
   </action>
-  <action name="qaChannelFilter">
+  <action name="qaChannelFilterVisibilityNever">
    <property name="checkable">
     <bool>true</bool>
    </property>
    <property name="text">
-    <string>&amp;Hide Channel when Filtering</string>
+    <string>&amp;Never show channel</string>
+   </property>
+   <property name="toolTip">
+    <string>When the channel filter is enabled, hide this channel. Even if it is not empty.</string>
    </property>
   </action>
   <action name="qaUserCommentView">
@@ -914,6 +917,28 @@ the channel's context menu.</string>
    </property>
    <property name="iconVisibleInMenu">
     <bool>false</bool>
+   </property>
+  </action>
+  <action name="qaChannelFilterVisibilityAlways">
+   <property name="checkable">
+    <bool>true</bool>
+   </property>
+   <property name="text">
+    <string>&amp;Always show channel</string>
+   </property>
+   <property name="toolTip">
+    <string>When the channel filter is enabled, show this channel. Even if it is empty.</string>
+   </property>
+  </action>
+  <action name="qaChannelFilterVisibilityNormal">
+   <property name="checkable">
+    <bool>true</bool>
+   </property>
+   <property name="text">
+    <string>&amp;Default</string>
+   </property>
+   <property name="toolTip">
+    <string>Do not apply any special channel filtering rules to this channel.</string>
    </property>
   </action>
  </widget>

--- a/src/mumble/Messages.cpp
+++ b/src/mumble/Messages.cpp
@@ -584,7 +584,7 @@ void MainWindow::msgChannelState(const MumbleProto::ChannelState &msg) {
 
 			ServerHandlerPtr sh = g.sh;
 			if (sh)
-				c->bFiltered = Database::isChannelFiltered(sh->qbaDigest, c->iId);
+				c->filteredVisibility = Database::getChannelFilteredVisibility(sh->qbaDigest, c->iId);
 
 		} else {
 			qWarning("Server attempted state change on nonexistent channel");
@@ -658,11 +658,12 @@ void MainWindow::msgChannelState(const MumbleProto::ChannelState &msg) {
 void MainWindow::msgChannelRemove(const MumbleProto::ChannelRemove &msg) {
 	Channel *c = Channel::get(msg.channel_id());
 	if (c && (c->iId != 0)) {
-		if (c->bFiltered) {
+		if (c->filteredVisibility != Channel::FILTERED_VISIBILITY_NORMAL) {
 			ServerHandlerPtr sh = g.sh;
-			if (sh)
-				Database::setChannelFiltered(sh->qbaDigest, c->iId, false);
-			c->bFiltered = false;
+			if (sh) {
+				Database::setChannelFilteredVisibility(sh->qbaDigest, c->iId, Channel::FILTERED_VISIBILITY_NORMAL);
+			}
+			c->filteredVisibility = Channel::FILTERED_VISIBILITY_NORMAL;
 		}
 		pmModel->removeChannel(c);
 	}

--- a/src/mumble/UserModel.h
+++ b/src/mumble/UserModel.h
@@ -12,9 +12,10 @@
 #include <QtCore/QSet>
 #include <QtGui/QIcon>
 
+#include "Channel.h"
+
 class User;
 class ClientUser;
-class Channel;
 
 struct ModelItem Q_DECL_FINAL {
 	friend class UserModel;
@@ -70,7 +71,7 @@ class UserModel : public QAbstractItemModel {
 		QIcon qiDeafenedSelf, qiDeafenedServer;
 		QIcon qiAuthenticated, qiChannel, qiLinkedChannel, qiActiveChannel;
 		QIcon qiFriend;
-		QIcon qiComment, qiCommentSeen, qiFilter;
+		QIcon qiComment, qiCommentSeen, qiFilterVisibilityNever, qiFilterVisibilityAlways;
 		ModelItem *miRoot;
 		QSet<Channel *> qsLinked;
 		QMap<QString, ClientUser *> qmHashes;
@@ -147,7 +148,10 @@ class UserModel : public QAbstractItemModel {
 		void ensureSelfVisible();
 		void recheckLinks();
 		void updateOverlay() const;
-		void toggleChannelFiltered(Channel *c);
+		/// Updates the filtered visibility of a given channel 
+		void updateChannelFilteredVisibility(Channel *c, Channel::FilteredVisibility newVisibility);
+		/// Trigger dataChanged events and other updates for given index range
+		void notifyDataChanged(QModelIndex topLeft = QModelIndex(), QModelIndex bottomRight = QModelIndex());
 };
 
 #endif

--- a/src/mumble/UserView.h
+++ b/src/mumble/UserView.h
@@ -57,7 +57,7 @@ class UserView : public QTreeView {
 #else
 		void dataChanged(const QModelIndex & topLeft, const QModelIndex & bottomRight) Q_DECL_OVERRIDE;
 #endif
-		
+
 	public slots:
 		void nodeActivated(const QModelIndex &idx);
 		void selectSearchResult();


### PR DESCRIPTION
Previously it was only possible to mark channels that are
supposed to get filtered when channel filtering is active.
This patch adds the capability to mark channels that ought
to never be filtered also. This is important if the "Hide
empty channels when filtering" feature is used.

To enable this we add an additional column to the channels_filtered
table which tracks our new possible channel filter configuration
states:
* Always visible when filtering:
  The channels is always visible even if it is empty
  and filtering empty channels is enabled.
* Never visible when filtering:
  The channel is never visible. It is filtered even if it
  contains users. The only exception is if the user itself
  is in a channel in which case it is not filtered.
* Normal/Default:
  The channel is hidden when filtering if it is empty and
  hiding empty channels when filtering is enabled.

The current version of this patch uses the filter_on.svg
and filter_off.svg icons as placeholders. Instead two new
icons ought to be chosen for this purpose.

This PR is meant as a basis for discussion and testing:
* Do we want this feature?
* Is the UI integration the best we can do (kinda hope not)?
* Is it robust?
* Does it work on all plattforms (only tested Linux)?
* Does upgrading work (ought to)?
* ???

Fixes  #1830