### PR TITLE
Update murmur_ice to work with Ice-3.6.3

### DIFF
--- a/src/murmur/murmur_ice/murmur_ice.pro
+++ b/src/murmur/murmur_ice/murmur_ice.pro
@@ -11,7 +11,7 @@ slice.output = ${QMAKE_FILE_BASE}.cpp
 win32 {
 	slice.commands = slice2cpp --checksum -I\"$$ICE_PATH/slice\" ${QMAKE_FILE_NAME}
 } else {
-	slice.commands = slice2cpp --checksum -I/usr/local/share/Ice -I/usr/share/Ice/slice -I/usr/share/slice -I/usr/share/Ice-3.4.1/slice/ -I/usr/share/Ice-3.3.1/slice/ -I/usr/share/Ice-3.4.2/slice/ -I/usr/share/Ice-3.5.0/slice/ -I/usr/share/Ice-3.5.1/slice/ ${QMAKE_FILE_NAME}
+	slice.commands = slice2cpp --checksum -I/usr/local/share/Ice -I/usr/share/Ice/slice -I/usr/share/slice -I/usr/share/Ice-3.4.1/slice/ -I/usr/share/Ice-3.3.1/slice/ -I/usr/share/Ice-3.4.2/slice/ -I/usr/share/Ice-3.5.0/slice/ -I/usr/share/Ice-3.5.1/slice/ -I/usr/share/Ice-3.6.3/slice/ ${QMAKE_FILE_NAME}
 }
 slice.input = SLICEFILES
 slice.CONFIG *= no_link explicit_dependencies


### PR DESCRIPTION
Debian Stretch uses Ice-3.6.3.

Add it to the include path so murmur will build.