### PR TITLE
plugins: fix compile error on Linux

### DIFF
--- a/plugins/mumble_plugin_linux.h
+++ b/plugins/mumble_plugin_linux.h
@@ -185,7 +185,7 @@ bool peekProc(PTR_TYPE base, T &dest) {
 	in.iov_len = sizeof(T); // Length
 
 	struct iovec out;
-	out.iov_base = dest;
+	out.iov_base = &dest;
 	out.iov_len = sizeof(T);
 
 	ssize_t nread = process_vm_readv(pPid, &out, 1, &in, 1, 0);


### PR DESCRIPTION
This fixes #2615, introduced by #2611.