### PR TITLE
ServerHandler: reconnect to the server if it is not responding to TCP pings

### DIFF
--- a/src/mumble/ServerHandler.h
+++ b/src/mumble/ServerHandler.h
@@ -73,6 +73,7 @@ class ServerHandler : public QThread {
 		void handleVoicePacket(unsigned int msgFlags, PacketDataStream &pds, MessageHandler::UDPMessageType type);
 	public:
 		Timer tTimestamp;
+		int iInFlightTCPPings;
 		QTimer *tConnectionTimeoutTimer;
 		QList<QSslError> qlErrors;
 		QList<QSslCertificate> qscCert;

--- a/src/mumble/Settings.cpp
+++ b/src/mumble/Settings.cpp
@@ -344,6 +344,7 @@ Settings::Settings() {
 	bAutoConnect = false;
 	ptProxyType = NoProxy;
 	usProxyPort = 0;
+	iMaxInFlightTCPPings = 2;
 
 	iMaxImageSize = ciDefaultMaxImageSize;
 	iMaxImageWidth = 1024; // Allow 1024x1024 resolution
@@ -644,6 +645,7 @@ void Settings::load(QSettings* settings_ptr) {
 	SAVELOAD(iMaxImageWidth, "net/maximagewidth");
 	SAVELOAD(iMaxImageHeight, "net/maximageheight");
 	SAVELOAD(qsServicePrefix, "net/serviceprefix");
+	SAVELOAD(iMaxInFlightTCPPings, "net/maxinflighttcppings");
 
 	// Network settings - SSL
 	SAVELOAD(qsSslCiphers, "net/sslciphers");
@@ -956,6 +958,7 @@ void Settings::save() {
 	SAVELOAD(iMaxImageWidth, "net/maximagewidth");
 	SAVELOAD(iMaxImageHeight, "net/maximageheight");
 	SAVELOAD(qsServicePrefix, "net/serviceprefix");
+	SAVELOAD(iMaxInFlightTCPPings, "net/maxinflighttcppings");
 
 	// Network settings - SSL
 	SAVELOAD(qsSslCiphers, "net/sslciphers");

--- a/src/mumble/Settings.h
+++ b/src/mumble/Settings.h
@@ -290,6 +290,18 @@ struct Settings {
 	QString qsProxyHost, qsProxyUsername, qsProxyPassword;
 	unsigned short usProxyPort;
 
+	/// iMaxInFlightTCPPings specifies the maximum
+	/// number of ping messages that the client has
+	/// sent, but not yet recieved a response for
+	/// from the server. This value is checked when
+	/// the client sends its next ping message. If
+	/// the maximum is reached, the connection will
+	/// be closed.
+	/// If this setting is assigned a value of 0 or
+	/// a negative number, the TCP ping check is
+	/// disabled.
+	int iMaxInFlightTCPPings;
+
 	/// The service prefix that the WebFetch class will use
 	/// when it constructs its fully-qualified URL. If this
 	/// is empty, no prefix is used.


### PR DESCRIPTION
This is implemened via a 'max in-flight TCP pings' counter, and
a rule for how many in-flight TCP pings there can be at one
point in time. (The default being 2, which means a client will
disconnect from a server if it takes the server more than 10
seconds to reply to a single ping message, given that Mumble
sends ping messages every 5 seconds.)

The idea is simple: ServerHandler keeps a counter of the number
of TCP pings it has sent, but has not yet received a response for.

When ServerHandler sends a ping, it increments the counter.

Once a pong or response for the ping has been received, it
decrements the counter.

But most importantly, ServerHandler now checks the amount
of in-flight TCP pings before it sends a new ping message.
If the counter exceeds the maximum number of allowed in-flight
TCP pings, it disconects from the server, allowing the client
to try to re-establish the connection.

One scenario where this is useful, is for IPv6 privacy addresses.
Privacy addresses are temporary, often with a default expiry time
of 4 hours. After this time, the address is removed from the system,
and TCP connections using that address will be terminated.
(See for example mumble-voip/mumble#1377)

One would naturally expect it to be possible to observe the fact
that the TCP connection has been terminated, but that doesn't seem
to be what's happening. At times, I've observed it taking up
to 30 minutes until my client realized that the connection wasn't
there anymore. (However, the server that I was connected to
found out immediately, and disconneted me.)

Because of this behavior, this TCP ping check was implemented.