### PR TITLE
Use same source address for UDP packets that is used for TCP packets

### DIFF
--- a/src/Connection.cpp
+++ b/src/Connection.cpp
@@ -213,6 +213,14 @@ quint16 Connection::peerPort() const {
 	return qtsSocket->peerPort();
 }
 
+QHostAddress Connection::localAddress() const {
+	return qtsSocket->localAddress();
+}
+
+quint16 Connection::localPort() const {
+	return qtsSocket->localPort();
+}
+
 QList<QSslCertificate> Connection::peerCertificateChain() const {
 	const QSslCertificate cert = qtsSocket->peerCertificate();
 	if (cert.isNull())

--- a/src/Connection.h
+++ b/src/Connection.h
@@ -79,6 +79,10 @@ class Connection : public QObject {
 		QString sessionProtocolString() const;
 		QHostAddress peerAddress() const;
 		quint16 peerPort() const;
+		/// Look up the local address of this Connection.
+		QHostAddress localAddress() const;
+		/// Look up the local port of this Connection.
+		quint16 localPort() const;
 		bool bDisconnectedEmitted;
 
 		void setToS();

--- a/src/mumble/ServerHandler.cpp
+++ b/src/mumble/ServerHandler.cpp
@@ -600,12 +600,21 @@ void ServerHandler::serverConnectionConnected() {
 		QMutexLocker qml(&qmUdp);
 
 		qhaRemote = connection->peerAddress();
+		qhaLocal = connection->localAddress();
+		if (qhaLocal.isNull()) {
+			qFatal("ServerHandler: qhaLocal is unexpectedly a null addr");
+		}
 
 		qusUdp = new QUdpSocket(this);
-		if (qhaRemote.protocol() == QAbstractSocket::IPv6Protocol)
-			qusUdp->bind(QHostAddress(QHostAddress::AnyIPv6), 0);
-		else
-			qusUdp->bind(QHostAddress(QHostAddress::Any), 0);
+		if (g.s.bUdpForceTcpAddr) {
+			qusUdp->bind(qhaLocal);
+		} else {
+			if (qhaRemote.protocol() == QAbstractSocket::IPv6Protocol) {
+				qusUdp->bind(QHostAddress(QHostAddress::AnyIPv6), 0);
+			} else {
+				qusUdp->bind(QHostAddress(QHostAddress::Any), 0);
+			}
+		}
 
 		connect(qusUdp, SIGNAL(readyRead()), this, SLOT(udpReady()));
 

--- a/src/mumble/ServerHandler.h
+++ b/src/mumble/ServerHandler.h
@@ -67,6 +67,7 @@ class ServerHandler : public QThread {
 #endif
 
 		QHostAddress qhaRemote;
+		QHostAddress qhaLocal;
 		QUdpSocket *qusUdp;
 		QMutex qmUdp;
 

--- a/src/mumble/Settings.cpp
+++ b/src/mumble/Settings.cpp
@@ -345,6 +345,7 @@ Settings::Settings() {
 	ptProxyType = NoProxy;
 	usProxyPort = 0;
 	iMaxInFlightTCPPings = 2;
+	bUdpForceTcpAddr = true;
 
 	iMaxImageSize = ciDefaultMaxImageSize;
 	iMaxImageWidth = 1024; // Allow 1024x1024 resolution
@@ -646,6 +647,7 @@ void Settings::load(QSettings* settings_ptr) {
 	SAVELOAD(iMaxImageHeight, "net/maximageheight");
 	SAVELOAD(qsServicePrefix, "net/serviceprefix");
 	SAVELOAD(iMaxInFlightTCPPings, "net/maxinflighttcppings");
+	SAVELOAD(bUdpForceTcpAddr, "net/udpforcetcpaddr");
 
 	// Network settings - SSL
 	SAVELOAD(qsSslCiphers, "net/sslciphers");
@@ -959,6 +961,7 @@ void Settings::save() {
 	SAVELOAD(iMaxImageHeight, "net/maximageheight");
 	SAVELOAD(qsServicePrefix, "net/serviceprefix");
 	SAVELOAD(iMaxInFlightTCPPings, "net/maxinflighttcppings");
+	SAVELOAD(bUdpForceTcpAddr, "net/udpforcetcpaddr");
 
 	// Network settings - SSL
 	SAVELOAD(qsSslCiphers, "net/sslciphers");

--- a/src/mumble/Settings.h
+++ b/src/mumble/Settings.h
@@ -289,6 +289,10 @@ struct Settings {
 	ProxyType ptProxyType;
 	QString qsProxyHost, qsProxyUsername, qsProxyPassword;
 	unsigned short usProxyPort;
+	/// bUdpForceTcpAddr forces Mumble to bind its UDP
+	/// socket to the same address as its TCP
+	/// connection is using.
+	bool bUdpForceTcpAddr;
 
 	/// iMaxInFlightTCPPings specifies the maximum
 	/// number of ping messages that the client has


### PR DESCRIPTION
This PR changes ServerHandler to bind our UDP socket to the same address that our TCP socket is bound to locally.

Murmur actually requires this for UDP to work, due to the way checkDecrypt in Murmur works.
See: https://github.com/mumble-voip/mumble/blob/2e6625b191874b3dd8af5bed15bd78f559e2005a/src/murmur/Server.cpp#L816-L846
It only tries to look up potential users by the address they're mapped to in qhUsers, which is the TCP address that user is connected with.

This PR also adds a config option. This is to allow users to switch back to the old behavior, if necessary.

This fixes some of the problems raised in mumble-voip/mumble#1377. Before this change, Murmur would immediately switch to using a new temporary address as the source address for UDP packets, once a new preferred temporary address was available. 

That is, for IPv6 privacy addresses, in a scenario where a given temporary address has a validity of 1 day, but a preferred lifetime of only 4 hours, Mumble would keep connected (via TCP) for the whole day, but voice would only work during the initial 4 hour window. After the 4 hours, Mumble would switch to using whichever new temporary address was made available to it (or even a regular address... we let the kernel decide.)