### PR TITLE
Fix issue #2600

### DIFF
--- a/compiler.pri
+++ b/compiler.pri
@@ -227,13 +227,12 @@ unix {
 		QMAKE_OBJECTIVE_CXXFLAGS *= -O3 -march=native -ffast-math -ftree-vectorize -fprofile-use
 	}
 
+	contains( QT_CONFIG, c++11 ) {
+		CONFIG += c++11
+	}
+
 	CONFIG(c++11) {
-		# Qt 5 will pass the expected compiler flags
-		# needed for C++11 mode when CONFIG includes c++11.
-		# But Qt 4 won't, so we add it manually.
-		lessThan(QT_MAJOR_VERSION, 5) {
-			QMAKE_CXXFLAGS *= -std=c++11
-		}
+		QMAKE_CXXFLAGS *= -std=c++11
 
 		# Debian seems to put C++11 variants of shared libraries
 		# in /usr/lib/$triple/c++11.


### PR DESCRIPTION
Alternative to pull #2608 

Builders no longer have to use qmake "CONFIG += c++11" to build,
like they've been forced to since e99b0c9093a5df19a1d45d0c48ac0cd7b6641a00.


The `lessThan(QT_MAJOR_VERSION, 5)` was removed because qmake was not setting `QMAKE_CXXFLAGS`.  It still worked, because modern compilers default to c++11, but this makes it explicit.

Without removing `lessThan(QT_MAJOR_VERSION, 5)` mumble will not build with a modern version of QT on a compiler that defaults to c++98.