### PR TITLE
compiler.pri: improve modern C++ detection

### DIFF
--- a/compiler.pri
+++ b/compiler.pri
@@ -5,6 +5,7 @@
 
 include(qt.pri)
 include(uname.pri)
+include(cplusplus.pri)
  
 CONFIG *= warn_on
 

--- a/cplusplus.pri
+++ b/cplusplus.pri
@@ -102,4 +102,20 @@ unix {
 		QMAKE_CXXFLAGS += -std=c++98
 		QMAKE_LFLAGS += -std=c++98
 	}
+
+
+	# Debian seems to put C++11 variants of shared libraries
+	# in /usr/lib/$triple/c++11.
+	#
+	# At least, that's the case for ZeroC Ice.
+	#
+	# The expectation is that this is a general convention,
+	# so add it to our library search path in C++11, C++14
+	# and C++1z mode.
+	CONFIG(c++11)|CONFIG(c++14)|CONFIG(c++1z) {
+		MULTIARCH_TRIPLE = $$system($${QMAKE_CC} -print-multiarch)
+		!isEmpty(MULTIARCH_TRIPLE) {
+			QMAKE_LIBDIR *= /usr/lib/$${MULTIARCH_TRIPLE}/c++11
+		}
+	}
 }

--- a/cplusplus.pri
+++ b/cplusplus.pri
@@ -1,0 +1,105 @@
+# Copyright 2005-2016 The Mumble Developers. All rights reserved.
+# Use of this source code is governed by a BSD-style license
+# that can be found in the LICENSE file at the root of the
+# Mumble source tree or at <https://www.mumble.info/LICENSE>.
+
+# This .pri file implements modern C++ detection for Mumble.
+#
+# With this file, it's possible to pass one of
+#   c++03, c++11, c++14 or c++1z
+# to qmake via CONFIG when building Mumble, to
+# manually specify the C++ standard the build
+# should target.
+#
+# If no C++ standard is explicitly chosen on
+# the command-line, an appropriate default will
+# be chosen by an auto-detection mechanism.
+# This mechanism looks at QT_CONFIG and automatically
+# adds c++11, c++14 or c++1z to CONFIG. If none of
+# these are available, it adds c++03 to CONFIG.
+#
+# In Qt 5, qmake understands the c++11, c++14, and c++1z
+# CONFIG options, and will automatically populate
+# QMAKE_CXXFLAGS and QMAKE_LFLAGS with the appropriate
+# -std=c++XX values for the chosen C++ standard.
+# For Qt 4, this .pri files will add the proper flags,
+# because Qt 4's qmake doesn't know of the c++XX CONFIG
+# options.
+# 
+# The c++03 option is unknown for both Qt 4 and Qt 5.
+# We handle setting up the proper CXXFLAGS and LFLAGS for
+# both versions of Qt when c++03 is in CONFIG.
+
+# First, auto-populate CONFIG with the latest C++ standard
+# that Qt has detected support for.
+!CONFIG(c++03):!CONFIG(c++11):!CONFIG(c++14):!CONFIG(c++1z) {
+	# For the c++1z and c++14 cases below, we also
+	# add the prior "modern" standards to CONFIG.
+	#
+	# This is because Qt 5.6 (and maybe earlier
+	# versions) use the presence of CONFIG(c++11)
+	# to mean "modern C++".
+	#
+	# For example, Qt 5.6's
+	# mkspecs/features/qt_module_headers.prf
+	# file will automatically add -std=c++98 to
+	# CXXFLAGS if CONFIG(c++11) isn't set.
+	#
+	# The result is that if we ONLY put c++1z in
+	# CONFIG, that check will cause us to have
+	# *both* -std=c++98 *and* -std=gnu++1z in
+	# CXXFLAGS when building on Qt 5.6, which
+	# is bad.
+	#
+	# In order to be compatible with such checks,
+	# ensure that we have all prior "modern"
+	# C++ standards in CONFIG, to please Qt.
+	contains(QT_CONFIG, c++1z) {
+		CONFIG *= c++1z
+		# Add prior modern standards...
+		CONFIG *= c++11 c++14
+	} else:contains(QT_CONFIG, c++14) {
+		CONFIG *= c++14
+		# Add prior modern standards...
+		CONFIG *= c++11
+	} else:contains(QT_CONFIG, c++11) {
+		CONFIG *= c++11
+	}
+}
+# If no appropriate C++ standard was found in QT_CONFIG, populate
+# CONFIG with c++03.
+!CONFIG(c++03):!CONFIG(c++11):!CONFIG(c++14):!CONFIG(c++1z) {
+	CONFIG += c++03
+}
+
+# Unix-specific handling of modern C++ features.
+unix {
+	# Qt 4, as opposed to Qt 5, doesn't automatically
+	# populate QMAKE_CXXFLAGS and QMAKE_LFLAGS with the
+	# appropriate -std=c++XX flags. So, for Qt 4, we'll
+	# have to set them up manually.
+	lessThan(QT_MAJOR_VERSION, 5) {
+		CONFIG(c++1z) {
+			QMAKE_CXXFLAGS += -std=c++1z
+			QMAKE_LFLAGS += -std=c++1z
+		} else:CONFIG(c++14) {
+			QMAKE_CXXFLAGS += -std=c++14
+			QMAKE_LFLAGS += -std=c++14
+		} else:CONFIG(c++11) {
+			QMAKE_CXXFLAGS += -std=c++11
+			QMAKE_LFLAGS += -std=c++11
+		}
+	}
+	# No Qt versions know about CONFIG(c++03), since
+	# its our own internal hint -- so for CONFIG(c++03)
+	# we set QMAKE_CXXFLAGS and QMAKE_LFLAGS for both Qt 4
+	# and Qt 5.
+	CONFIG(c++03):!CONFIG(c++11):!CONFIG(c++14):!CONFIG(c++1z) {
+		# Note: we use -std=c++98 to support
+		# older compilers. In GCC, the following
+		# flags mean the same thing:
+		# -std=c++98, -std=c++03, -ansi.
+		QMAKE_CXXFLAGS += -std=c++98
+		QMAKE_LFLAGS += -std=c++98
+	}
+}


### PR DESCRIPTION
This PR adds a cplusplus.pri file (which gets included by compiler.pri).

Its purpose is to handle selection of C++ standards at build time via qmake's CONFIG variable.

Builders can now specify, say, `qmake -recursive -Wall main.pro CONFIG+="release c++11"` to select C++ mode.

Besides the ability to explicitly select a C++ standard, cplusplus.pri will auto-detect an appropriate C++ standard for the current system.

Supercedes PRs #2608 and #2628

