### PR TITLE
WIP: detect Ice 3.6 C++11 builds and warn the user

### DIFF
--- a/src/murmur/murmur.pro
+++ b/src/murmur/murmur.pro
@@ -82,56 +82,12 @@ dbus {
 }
 
 ice {
+	include(murmur_ice/ice_config.pri)
+
 	SOURCES *= MurmurIce.cpp
 	HEADERS *= MurmurIce.h
 
-	win32:CONFIG(debug, debug|release) {
-		LIBS *= -lIceD -lIceUtilD
-	} else {
-		LIBS *= -lIce -lIceUtil
-	}
 	DEFINES *= USE_ICE
-
-	win32 {
-		INCLUDEPATH *= "$$ICE_PATH/include"
-		!CONFIG(static) {
-			QMAKE_LIBDIR *= "$$ICE_PATH/lib/vc100"
-		} else {
-			DEFINES *= ICE_STATIC_LIBS
-			QMAKE_LIBDIR *= $$BZIP2_PATH/lib
-			equals(MUMBLE_ARCH, x86) {
-				QMAKE_LIBDIR *= $$ICE_PATH/lib
-			}
-			equals(MUMBLE_ARCH, x86_64) {
-				QMAKE_LIBDIR *= $$ICE_PATH/lib/x64
-			}
-			CONFIG(release, debug|release): LIBS *= -llibbz2
-			CONFIG(debug, debug|release):   LIBS *= -llibbz2d
-			LIBS *= -ldbghelp -liphlpapi -lrpcrt4
-		}
-	}
-
-	macx {
-		INCLUDEPATH *= $$(MUMBLE_PREFIX)/Ice-3.4.2/include/
-		QMAKE_LIBDIR *= $$(MUMBLE_PREFIX)/Ice-3.4.2/lib/
-	}
-
-	CONFIG(ermine) {
-		INCLUDEPATH *= $$(MUMBLE_ICE_PREFIX)/include/
-		QMAKE_LIBDIR *= $$(MUMBLE_ICE_PREFIX)/lib/
-	}
-
-	unix:!macx:CONFIG(static) {
-		INCLUDEPATH *= /opt/Ice-3.3/include
-		QMAKE_LIBDIR *= /opt/Ice-3.3/lib
-		LIBS *= -lbz2
-		QMAKE_CXXFLAGS *= -fPIC
-	}
-
-	macx:CONFIG(static) {
-		LIBS *= -lbz2 -liconv
-		QMAKE_CXXFLAGS *= -fPIC
-	}
 
 	LIBS *= -lmurmur_ice
 	INCLUDEPATH *= murmur_ice

--- a/src/murmur/murmur_ice/Ice36Cpp11Test.cpp
+++ b/src/murmur/murmur_ice/Ice36Cpp11Test.cpp
@@ -1,0 +1,19 @@
+// Copyright 2005-2016 The Mumble Developers. All rights reserved.
+// Use of this source code is governed by a BSD-style license
+// that can be found in the LICENSE file at the root of the
+// Mumble source tree or at <https://www.mumble.info/LICENSE>.
+
+// This is small test case that can detect whether the
+// Ice libraries on the system are built in C++11 mode.
+
+#include <Ice/Ice.h>
+
+static void response__() {}
+static void exception__(const Ice::Exception &) {}
+static void sent__(bool) {}
+
+int main(int argc, char *argv[]) {
+#if ICE_INT_VERSION >= 30600
+	new ::IceInternal::Cpp11FnOnewayCallbackNC(response__, exception__, sent__);
+#endif
+}

--- a/src/murmur/murmur_ice/ice_config.pri
+++ b/src/murmur/murmur_ice/ice_config.pri
@@ -1,0 +1,51 @@
+# Copyright 2005-2016 The Mumble Developers. All rights reserved.
+# Use of this source code is governed by a BSD-style license
+# that can be found in the LICENSE file at the root of the
+# Mumble source tree or at <https://www.mumble.info/LICENSE>.
+
+win32:CONFIG(debug, debug|release) {
+	LIBS *= -lIceD -lIceUtilD
+} else {
+	LIBS *= -lIce -lIceUtil
+}
+
+win32 {
+	INCLUDEPATH *= "$$ICE_PATH/include"
+	!CONFIG(static) {
+		QMAKE_LIBDIR *= "$$ICE_PATH/lib/vc100"
+	} else {
+		DEFINES *= ICE_STATIC_LIBS
+		QMAKE_LIBDIR *= $$BZIP2_PATH/lib
+		equals(MUMBLE_ARCH, x86) {
+			QMAKE_LIBDIR *= $$ICE_PATH/lib
+		}
+		equals(MUMBLE_ARCH, x86_64) {
+			QMAKE_LIBDIR *= $$ICE_PATH/lib/x64
+		}
+		CONFIG(release, debug|release): LIBS *= -llibbz2
+		CONFIG(debug, debug|release):   LIBS *= -llibbz2d
+		LIBS *= -ldbghelp -liphlpapi -lrpcrt4
+	}
+}
+
+macx {
+	INCLUDEPATH *= $$(MUMBLE_PREFIX)/Ice-3.4.2/include/
+	QMAKE_LIBDIR *= $$(MUMBLE_PREFIX)/Ice-3.4.2/lib/
+}
+
+CONFIG(ermine) {
+	INCLUDEPATH *= $$(MUMBLE_ICE_PREFIX)/include/
+	QMAKE_LIBDIR *= $$(MUMBLE_ICE_PREFIX)/lib/
+}
+
+unix:!macx:CONFIG(static) {
+	INCLUDEPATH *= /opt/Ice-3.3/include
+	QMAKE_LIBDIR *= /opt/Ice-3.3/lib
+	LIBS *= -lbz2
+	QMAKE_CXXFLAGS *= -fPIC
+}
+
+macx:CONFIG(static) {
+	LIBS *= -lbz2 -liconv
+	QMAKE_CXXFLAGS *= -fPIC
+}

--- a/src/murmur/murmur_ice/murmur_ice.pro
+++ b/src/murmur/murmur_ice/murmur_ice.pro
@@ -5,6 +5,27 @@
 
 include(../../../compiler.pri)
 
+# Ice 3.6 C++11 check
+!CONFIG(no-ice-cpp11-check):unix {
+	include(ice_config.pri)
+
+	# TODO:
+	# strip -std=c++XX from QMAKE_CXXFLAGS
+	# include INCLUDEPATHS and QMAKE_LIBS in the compiler flags
+	# ... this is pretty tough to do inside a .pro file, since
+	# qmake has not expanded everything yet :(
+	OUTPUT=$$system($${QMAKE_CXX} ${QMAKE_CXXFLAGS} ${QMAKE_LFLAGS} -lIce -lIceUtil -std=c++11 Ice36Cpp11Test.cpp -o /dev/null 2>&1)
+	!contains($$OUTPUT, "error:") {
+		CONFIG += ice-cpp11
+	}
+	CONFIG(ice-cpp11) {
+		# XXX: correct?
+		!CONFIG(c++11)|!CONFIG(c++14)|!CONFIG(c++1z) {
+			error(Ice libraries on the system require C++11)
+		}
+	}
+}
+
 SLICEFILES = ../Murmur.ice
 
 slice.output = ${QMAKE_FILE_BASE}.cpp


### PR DESCRIPTION
This is a WIP PR for warning users about a mismatch between Mumble's C++11 standard and the system's Ice library.

Fixes https://github.com/mumble-voip/mumble/issues/2629

...This is a very rough WIP.