### PR TITLE
overlay: fall back to fxc.exe on PATH if DXSDK is not set.

### DIFF
--- a/overlay/overlay-shared.pro
+++ b/overlay/overlay-shared.pro
@@ -50,7 +50,11 @@ CONFIG(debug, debug|release) {
 
 # Override fxc binary for the x86 build.
 CONFIG(force-x86-toolchain) {
-  FXC = "\"$$(DXSDK_DIR)\\Utilities\\bin\\x86\\fxc.exe\""
+  exists($$DXSDK_DIR) {
+    FXC = "\"$$(DXSDK_DIR)\\Utilities\\bin\\x86\\fxc.exe\""
+  } else {
+    FXC = fxc.exe
+  }
 } else {
   FXC = fxc.exe
 }


### PR DESCRIPTION
This allows the overlay to build with the Windows SDK version
of fxc.exe.

This removes the need for people developing locally to install
the legacy DirectX SDK.