### PR TITLE
compiler.pri: drop old modern C++ detection logic that is now handled by cplusplus.pri.

### DIFF
--- a/compiler.pri
+++ b/compiler.pri
@@ -227,41 +227,6 @@ unix {
 		QMAKE_OBJECTIVE_CFLAGS *= -O3 -march=native -ffast-math -ftree-vectorize -fprofile-use
 		QMAKE_OBJECTIVE_CXXFLAGS *= -O3 -march=native -ffast-math -ftree-vectorize -fprofile-use
 	}
-
-	CONFIG(c++11) {
-		# Qt 5 will pass the expected compiler flags
-		# needed for C++11 mode when CONFIG includes c++11.
-		# But Qt 4 won't, so we add it manually.
-		lessThan(QT_MAJOR_VERSION, 5) {
-			QMAKE_CXXFLAGS *= -std=c++11
-		}
-
-		# Debian seems to put C++11 variants of shared libraries
-		# in /usr/lib/$triple/c++11.
-		#
-		# At least, that is the case for ZeroC Ice.
-		#
-		# The expectation is that this is a general convention,
-		# so add it to our library search path in C++11 mode.
-		MULTIARCH_TRIPLE = $$system($${QMAKE_CXX} -print-multiarch)
-		!isEmpty(MULTIARCH_TRIPLE) {
-			QMAKE_LIBDIR *= /usr/lib/$${MULTIARCH_TRIPLE}/c++11
-		}
-	} else {
-		# If C++11 support hasn't been explicitly enabled,
-		# force C++98/C++03 mode. If we don't do this, newer
-		# compilers (such as G++ 6) will default to C++11
-		# without us being aware.
-		#
-		# The flag passed below might seem archaic. And it is.
-		# But GCC treats -std=c++98, -std=c++03 and -ansi to
-		# mean the same thing. (See the GCC man page in Debian,
-		# or https://gcc.gnu.org/onlinedocs/gcc/Standards.html)
-		# We use the -std=c++98 variant to be compatible with
-		# older compilers such as CentOS 5's default compiler,
-		# GCC 4.1.
-		QMAKE_CXXFLAGS *= -std=c++98
-	}
 }
 
 contains(UNAME, FreeBSD) {


### PR DESCRIPTION
Seems like I forgot to remove this when I added
the new method.

Let's remove it.