### PR TITLE
Fix Murmur build inside the Linux buildenv

### DIFF
--- a/buildenv.pri
+++ b/buildenv.pri
@@ -1,0 +1,12 @@
+# Copyright 2005-2016 The Mumble Developers. All rights reserved.
+# Use of this source code is governed by a BSD-style license
+# that can be found in the LICENSE file at the root of the
+# Mumble source tree or at <https://www.mumble.info/LICENSE>.
+
+# This .pri detects whether Mumble is being built in a
+# Mumble buildenv, and if so, sets the buildenv CONFIG.
+
+MUMBLE_PREFIX=$$(MUMBLE_PREFIX)
+!isEmpty(MUMBLE_PREFIX) {
+	CONFIG += buildenv
+}

--- a/compiler.pri
+++ b/compiler.pri
@@ -71,8 +71,7 @@ win32 {
 	# Always enable warnings-as-errors
 	# if we're inside a Mumble build environment.
 	# Can be disabled with CONFIG+=no-warnings-as-errors.
-	MUMBLE_PREFIX=$$(MUMBLE_PREFIX)
-	!isEmpty(MUMBLE_PREFIX):!CONFIG(no-warnings-as-errors) {
+	CONFIG(buildenv):!CONFIG(no-warnings-as-errors) {
 		CONFIG += warnings-as-errors
 	}
 
@@ -196,8 +195,7 @@ unix {
 	# Always enable warnings-as-errors
 	# if we're inside a Mumble build environment.
 	# Can be disabled with CONFIG+=no-warnings-as-errors.
-	MUMBLE_PREFIX=$$(MUMBLE_PREFIX)
-	!isEmpty(MUMBLE_PREFIX):!CONFIG(no-warnings-as-errors) {
+	CONFIG(buildenv):!CONFIG(no-warnings-as-errors) {
 		CONFIG += warnings-as-errors
 	}
 
@@ -275,8 +273,7 @@ contains(UNAME, FreeBSD) {
 unix:!macx {
 	# If we're building in a Mumble build environment,
 	# add its include and lib dirs to the build configuration.
-	MUMBLE_PREFIX=$$(MUMBLE_PREFIX)
-	!isEmpty(MUMBLE_PREFIX) {
+	CONFIG(buildenv) {
 		SYSTEM_INCLUDES = $$(MUMBLE_PREFIX)/include $$[QT_INSTALL_HEADERS]
 		QMAKE_LIBDIR *= $$(MUMBLE_PREFIX)/lib
 

--- a/compiler.pri
+++ b/compiler.pri
@@ -265,8 +265,8 @@ unix {
 }
 
 contains(UNAME, FreeBSD) {
-	QMAKE_CFLAGS *= -isystem /usr/local/include
-	QMAKE_CXXFLAGS *= -isystem /usr/local/include
+	QMAKE_CFLAGS *= "-I/usr/local/include" "-isystem /usr/local/include"
+	QMAKE_CXXFLAGS *= "-I/usr/local/include" "-isystem /usr/local/include"
 	QMAKE_LIBDIR *= /usr/lib
 	QMAKE_LIBDIR *= /usr/local/lib
 }
@@ -280,8 +280,8 @@ unix:!macx {
 		QMAKE_LIBDIR *= $$(MUMBLE_PREFIX)/lib
 
 		for(inc, $$list($$SYSTEM_INCLUDES)) {
-			QMAKE_CFLAGS += -isystem $$inc
-			QMAKE_CXXFLAGS += -isystem $$inc
+			QMAKE_CFLAGS *= "-I$$inc" "-isystem $$inc"
+			QMAKE_CXXFLAGS += "-I$$inc" "-isystem $$inc"
 		}
 	}
 
@@ -330,10 +330,10 @@ macx {
 	QMAKE_LIBDIR *= $$(MUMBLE_PREFIX)/lib
 
 	for(inc, $$list($$SYSTEM_INCLUDES)) {
-		QMAKE_CFLAGS += -isystem $$inc
-		QMAKE_CXXFLAGS += -isystem $$inc
-		QMAKE_OBJECTIVE_CFLAGS += -isystem $$inc
-		QMAKE_OBJECTIVE_CXXFLAGS += -isystem $$inc
+		QMAKE_CFLAGS += "-I$$inc" "-isystem $$inc"
+		QMAKE_CXXFLAGS += "-I$$inc" "-isystem $$inc"
+		QMAKE_OBJECTIVE_CFLAGS += "-I$$inc" "-isystem $$inc"
+		QMAKE_OBJECTIVE_CXXFLAGS += "-I$$inc" "-isystem $$inc"
 	}
 
 	!CONFIG(universal) {

--- a/compiler.pri
+++ b/compiler.pri
@@ -5,6 +5,7 @@
 
 include(qt.pri)
 include(uname.pri)
+include(buildenv.pri)
 include(cplusplus.pri)
  
 CONFIG *= warn_on

--- a/cplusplus.pri
+++ b/cplusplus.pri
@@ -115,7 +115,18 @@ unix {
 	CONFIG(c++11)|CONFIG(c++14)|CONFIG(c++1z) {
 		MULTIARCH_TRIPLE = $$system($${QMAKE_CC} -print-multiarch)
 		!isEmpty(MULTIARCH_TRIPLE) {
-			QMAKE_LIBDIR *= /usr/lib/$${MULTIARCH_TRIPLE}/c++11
+			# Don't add the Debian-specfic c++11 libdir when using
+			# a Mumble buildenv.
+			#
+			# Adding this directory to QMAKE_LIBDIR this early in
+			# the build process will  cause Mumble to prefer this
+			# lib dir to the buildenv's own.
+			# The easiest way to fix this is to simply avoid adding
+			# this dir when building using a Mumble buildenv, since
+			# it is irrelevant for us in that setting.
+			!CONFIG(buildenv) {
+				QMAKE_LIBDIR *= /usr/lib/$${MULTIARCH_TRIPLE}/c++11
+			}
 		}
 	}
 }

--- a/main.pro
+++ b/main.pro
@@ -65,9 +65,8 @@ SUBDIRS *= src/mumble_proto
   }
 
   macx {
-    MUMBLE_PREFIX = $$(MUMBLE_PREFIX)
-    isEmpty(MUMBLE_PREFIX) {
-      error("Missing $MUMBLE_PREFIX environment variable");
+    !CONFIG(buildenv) {
+      error("Not inside a Mumble buildenv ($MUMBLE_PREFIX environment variable is missing)");
     }
     SUBDIRS *= 3rdparty/mach-override-build
     SUBDIRS *= overlay_gl

--- a/src/mumble.pri
+++ b/src/mumble.pri
@@ -47,8 +47,8 @@ unix {
 		PKG_CONFIG = pkg-config --static
 	}
 
-	QMAKE_CFLAGS *= "-isystem ../mumble_proto"
-	QMAKE_CXXFLAGS *= "-isystem ../mumble_proto"
+	QMAKE_CFLAGS *= "-I../mumble_proto" "-isystem ../mumble_proto"
+	QMAKE_CXXFLAGS *= "-I../mumble_proto" "-isystem ../mumble_proto"
 
 	CONFIG *= link_pkgconfig
 

--- a/src/mumble/mumble.pro
+++ b/src/mumble/mumble.pro
@@ -309,15 +309,15 @@ CONFIG(sbcelt) {
   CONFIG(no-bundled-celt) {
     INCLUDEPATH	*= /usr/include/celt
     unix {
-      QMAKE_CFLAGS *= "-isystem /usr/include/celt"
-      QMAKE_CXXFLAGS *= "-isystem /usr/include/celt"
+      QMAKE_CFLAGS *= "-I/usr/include/celt" "-isystem /usr/include/celt"
+      QMAKE_CXXFLAGS *= "-I/usr/include/celt" "-isystem /usr/include/celt"
     }
   }
   !CONFIG(no-bundled-celt) {
     INCLUDEPATH *= ../../3rdparty/celt-0.7.0-src/libcelt
     unix {
-      QMAKE_CFLAGS *= "-isystem ../../3rdparty/celt-0.7.0-src/libcelt"
-      QMAKE_CXXFLAGS *= "-isystem ../../3rdparty/celt-0.7.0-src/libcelt"
+      QMAKE_CFLAGS *= "-I../../3rdparty/celt-0.7.0-src/libcelt" "-isystem ../../3rdparty/celt-0.7.0-src/libcelt"
+      QMAKE_CXXFLAGS *= "-I../../3rdparty/celt-0.7.0-src/libcelt" "-isystem ../../3rdparty/celt-0.7.0-src/libcelt"
     }
   }
 }
@@ -350,8 +350,10 @@ unix:!CONFIG(bundled-opus):system(pkg-config --exists opus) {
     DEFINES *= USE_OPUS
     LIBS *= -lopus
     unix {
-      QMAKE_CFLAGS *= "-isystem  ../../3rdparty/opus-src/celt" "-isystem ../../3rdparty/opus-src/include"
-      QMAKE_CXXFLAGS *= "-isystem  ../../3rdparty/opus-src/celt" "-isystem ../../3rdparty/opus-src/include"
+      QMAKE_CFLAGS *= "-I../../3rdparty/opus-src/celt" "-isystem  ../../3rdparty/opus-src/celt"
+      QMAKE_CFLAGS *= "-I../../3rdparty/opus-src/include" "-isystem ../../3rdparty/opus-src/include"
+      QMAKE_CXXFLAGS *= "-I../../3rdparty/opus-src/celt" "-isystem  ../../3rdparty/opus-src/celt"
+      QMAKE_CXXFLAGS *= "-I../../3rdparty/opus-src/include" "-isystem ../../3rdparty/opus-src/include"
     }
   }
 }

--- a/src/murmur/murmur.pro
+++ b/src/murmur/murmur.pro
@@ -204,8 +204,7 @@ bonjour {
 	# could break the build in the future, with newer versions of Qt,
 	# if the API of QSslDiffieHellmanParameters changes when it is
 	# upstreamed.
-	MUMBLE_PREFIX=$$(MUMBLE_PREFIX)
-	!isEmpty(MUMBLE_PREFIX) {
+	CONFIG(buildenv) {
 		DEFINES += USE_QSSLDIFFIEHELLMANPARAMETERS
 	}
 }


### PR DESCRIPTION
Some non-pristine systems (in this context, systems that have some of Mumble's dependencies already installed outside the Mumble buildenv) had problems building Murmur inside the Linux buildenv.

The two cases were:

1. Adding the Linux buildenv's $MUMBLE_PREFIX/include to CXXFLAGS via -isystem caused the compiler to prefer /usr/include to $MUMBLE_PREFIX/include. This caused the compiler to use the system headers instead of the buildenv headers, causing build problems.

2. Because cplusplus.pri put the  C++11 Debian libdir (/usr/lib/$MULTILIB_ARCH/c++1) into QMAKE_LIBDIR as one of the first entries, any libraries in that directory were preferred to libraries in $MUMBLE_PREFIX/lib. The fix for this is to simply not use the C++11-specific libdir when inside a buildenv.

The commits in this PR fix these problems.

Problem 1 is fixed by using a new pattern for adding -isystem includes. Now, we add both -I and -isystem flags for the given include path. This is because -I has priority over -isystem. Adding both gives us the best of both worlds -- no errors from the headers, and no correct include path prioritization.

Problem 2 is fixed by adding buildenv.pri, which sets CONFIG+=buildenv when inside a buildenv.
A CONFIG(buildenv) check is then added to cplusplus.pri to not add the Debian C++11 libdir when inside a buildenv.

As a bonus, now that we have CONFIG(buildenv) we can remove various hacky buildenv checks throughout our .pri and .pro files, and simply use CONFIG(buildenv) instead.