### PR TITLE
.gitignore: add mocinclude.opt.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,7 @@ src/murmur/murmur_ice/Murmur.h
 src/murmur/murmur_ice/Murmur.cpp
 src/murmur/MurmurRPC.proto.Wrapper.cpp
 winpaths_custom.pri
+mocinclude.opt
 src/mumble/mumble_qt_auto.qrc
 src/mumble/mumble_plugin_import.cpp
 src/mumble/mumble_app_plugin_import.cpp


### PR DESCRIPTION
Qt generates this file when I build on Windows
with the latest win64-static-no-ltcg buildenv.

Let's add it to gitignore.