### PR TITLE
3rdparty/qqbonjour-src: in BonjourServiceResolver, always tear down ResolveRecord on error.

### DIFF
--- a/3rdparty/qqbonjour-src/BonjourServiceResolver.cpp
+++ b/3rdparty/qqbonjour-src/BonjourServiceResolver.cpp
@@ -80,9 +80,11 @@ void BonjourServiceResolver::bonjourSocketReadyRead(int sockfd) {
 		return;
 
 	DNSServiceErrorType err = DNSServiceProcessResult(rr->dnssref);
-	if (err != kDNSServiceErr_NoError)
+	if (err != kDNSServiceErr_NoError) {
 		emit error(rr->record, err);
-
+		qmResolvers.remove(DNSServiceRefSockFD(rr->dnssref));
+		delete rr;
+	}
 }
 
 
@@ -95,6 +97,7 @@ void BonjourServiceResolver::bonjourResolveReply(DNSServiceRef, DNSServiceFlags 
 
 	if (errorCode != kDNSServiceErr_NoError) {
 		emit rr->bsr->error(rr->record, errorCode);
+		delete rr;
 		return;
 	}
 	rr->bonjourPort = qFromBigEndian<quint16>(port);


### PR DESCRIPTION
This fixes mumble-voip/mumble#2223

Before this commit, BonjourServiceResolver would not consistently
tear down the ResolveRecord when an error occurred.

The 100% CPU usage problem from issue 2223 happens in
BonjourServiceResolver::bonjourResolveReply, where previously,
the ResolveRecord was removed from qmResolvers for both error
and success -- but was never deleted on error. To fix this issue,
we delete the ResolveRecord for bonjourResolveReply's error case.

For constency, we also introduce similar code in the
BonjourServiceResolver::bonjourSocketReadyRead method.
Now, if DNSServiceProcessResult returns an error, we tear down
the ResolveRecord and remove it from qmResolvers.