### PR TITLE
cplusplus.pri: pipe gcc -print-multiarch output to stderr.

### DIFF
--- a/cplusplus.pri
+++ b/cplusplus.pri
@@ -117,7 +117,7 @@ unix {
 	# so add it to our library search path in C++11, C++14
 	# and C++1z mode.
 	CONFIG(c++11)|CONFIG(c++14)|CONFIG(c++1z) {
-		MULTIARCH_TRIPLE = $$system($${QMAKE_CC} -print-multiarch)
+		MULTIARCH_TRIPLE = $$system($${QMAKE_CC} -print-multiarch 2>/dev/null)
 		!isEmpty(MULTIARCH_TRIPLE) {
 			# Don't add the Debian-specfic c++11 libdir when using
 			# a Mumble buildenv.


### PR DESCRIPTION
This avoid a lot of logspam on OS X's clang, where
-print-multiarch doesn't exist.