### PR TITLE
macx/compat: fix build of compat.m shim with Sierra SDK.

### DIFF
--- a/macx/compat/compat.m
+++ b/macx/compat/compat.m
@@ -6,10 +6,17 @@
 #import <AppKit/AppKit.h>
 
 @interface CompatApp : NSObject
-#if MAC_OS_X_VERSION_MIN_REQUIRED >= 1070
-<NSFileManagerDelegate>
-#endif
 @end
+
+#if MAC_OS_X_VERSION_MAX_ALLOWED >= 1060
+@interface CompatApp (NSApplicationDelegateExtension) <NSApplicationDelegate>
+@end
+#endif
+
+#if MAC_OS_X_VERSION_MAX_ALLOWED >= 1070
+@interface CompatApp (NSFileManagerDelegateExtension) <NSFileManagerDelegate>
+@end
+#endif
 
 @implementation CompatApp
 


### PR DESCRIPTION
The Sierra SDK seems to require an id<NSApplicationDelegate>
for its setDelegate: call.

To accomplish this, split off the existing adoption of
NSFileManagerDelegate into a seperate class extension.

Then, add another class extension for conforming to the
NSApplicationDelegate protocol.

Both of them are gated with MAC_OS_X_VERSION_MAX_ALLOWED
to allow building with older SDKs.