### PR TITLE
Restore green background for strong certificate in UserView (root channel) and ServerView (ConnectDialog)

### DIFF
--- a/src/mumble/ConnectDialog.cpp
+++ b/src/mumble/ConnectDialog.cpp
@@ -53,6 +53,22 @@ void PingStats::reset() {
 	init();
 }
 
+ServerViewDelegate::ServerViewDelegate(QObject *p) : QStyledItemDelegate(p) {
+}
+
+ServerViewDelegate::~ServerViewDelegate() {
+}
+
+void ServerViewDelegate::paint(QPainter *painter, const QStyleOptionViewItem &option, const QModelIndex &index) const {
+	// Allow a ServerItem's BackgroundRole to override the current theme's default color.
+	QVariant bg = index.data(Qt::BackgroundRole);
+	if (bg.isValid()) {
+		painter->fillRect(option.rect, bg.value<QBrush>());
+	}
+
+	QStyledItemDelegate::paint(painter, option, index);
+}
+
 ServerView::ServerView(QWidget *p) : QTreeWidget(p) {
 	siFavorite = new ServerItem(tr("Favorite"), ServerItem::FavoriteType);
 	addTopLevelItem(siFavorite);
@@ -837,6 +853,8 @@ ConnectDialog::ConnectDialog(QWidget *p, bool autoconnect) : QDialog(p), bAutoCo
 	
 	qpbAdd->setHidden(g.s.disableConnectDialogEditing);
 	qpbEdit->setHidden(g.s.disableConnectDialogEditing);
+
+	qtwServers->setItemDelegate(new ServerViewDelegate());
 
 	// Hide ping and user count if we are not allowed to ping.
 	if (!bAllowPing) {

--- a/src/mumble/ConnectDialog.h
+++ b/src/mumble/ConnectDialog.h
@@ -74,6 +74,16 @@ public:
 
 class ServerItem;
 
+class ServerViewDelegate : public QStyledItemDelegate {
+	Q_OBJECT
+	Q_DISABLE_COPY(ServerViewDelegate)
+public:
+	ServerViewDelegate(QObject *p = NULL);
+	~ServerViewDelegate();
+
+	void paint(QPainter *painter, const QStyleOptionViewItem &option, const QModelIndex &index) const Q_DECL_OVERRIDE;
+};
+
 class ServerView : public QTreeWidget {
 		Q_OBJECT
 		Q_DISABLE_COPY(ServerView)

--- a/src/mumble/UserView.cpp
+++ b/src/mumble/UserView.cpp
@@ -28,6 +28,12 @@ void UserDelegate::paint(QPainter * painter, const QStyleOptionViewItem &option,
 	QVariant data = m->data(idxc1);
 	QList<QVariant> ql = data.toList();
 
+	// Allow a UserView's BackgroundRole to override the current theme's default color.
+	QVariant bg = index.data(Qt::BackgroundRole);
+	if (bg.isValid()) {
+		painter->fillRect(option.rect, bg.value<QBrush>());
+	}
+
 	painter->save();
 
 	QStyleOptionViewItemV4 o = option;


### PR DESCRIPTION
This restores the green background color we've had in the ConnectDialog and on the root channel when connected to a server.

It doesn't fully fix mumble-voip/mumble#1543, since it doesn't make the color fully configurable in the theme. However, it makes it possible to once again discern whether a given server uses a "strong" (in Mumble-speak) certificate.