### PR TITLE
3rdparty/speex-build: add CONFIG += no_batch to speex-build.pro.

### DIFF
--- a/3rdparty/speex-build/speex-build.pro
+++ b/3rdparty/speex-build/speex-build.pro
@@ -28,7 +28,14 @@ CONFIG += debug_and_release
 CONFIG -= warn_on
 CONFIG += warn_off
 CONFIG += no_include_pwd
+
+# Enable no_batch, which disables nmake's inference rules.
+# We have to do this because we use files from two VPATHs
+# below, and nmake is unable to figure out how to handle
+# that.
+CONFIG += no_batch
 VPATH	= ../speex-src/libspeex ../speexdsp-src/libspeexdsp
+
 TARGET = speex
 DEFINES += NDEBUG HAVE_CONFIG_H
 INCLUDEPATH = ../speex-src/include ../speex-src/libspeex ../speexdsp-src/include ../speexdsp-src/libspeexdsp


### PR DESCRIPTION
If we don't do it ourselves, qmake will add it automatically, and
warn to stdout.

The reason we need it here is because we use two VPATHs that include
files with the same names. That confuses nmake's inference rules, so
we have to disable them with no_batch.