### PR TITLE
Always prepend 'release' or 'debug' dirs when adding to QMAKE_LIBDIR.

### DIFF
--- a/3rdparty/speex-build/AGC.pro
+++ b/3rdparty/speex-build/AGC.pro
@@ -8,4 +8,4 @@ SOURCES = AGC.cpp
 HEADERS = Timer.h
 INCLUDEPATH = ../src ../speex-src/include
 LIBS += -lspeex
-QMAKE_LIBDIR += ../../release
+QMAKE_LIBDIR = ../../release $$QMAKE_LIBDIR

--- a/3rdparty/speex-build/ResampMark.pro
+++ b/3rdparty/speex-build/ResampMark.pro
@@ -8,4 +8,4 @@ SOURCES = ResampMark.cpp
 HEADERS = Timer.h
 INCLUDEPATH = ../../src ../speex-src/include
 LIBS += -lspeex
-QMAKE_LIBDIR += ../../release
+QMAKE_LIBDIR = ../../release $$QMAKE_LIBDIR

--- a/3rdparty/speex-build/SpeexMark.pro
+++ b/3rdparty/speex-build/SpeexMark.pro
@@ -8,4 +8,4 @@ SOURCES = SpeexMark.cpp
 HEADERS = Timer.h
 INCLUDEPATH = ../src ../speex-src/include
 LIBS += -lspeex
-QMAKE_LIBDIR += ../../release
+QMAKE_LIBDIR = ../../release $$QMAKE_LIBDIR

--- a/overlay/overlay-shared.pro
+++ b/overlay/overlay-shared.pro
@@ -39,12 +39,12 @@ CONFIG(force-x86_64-toolchain) {
 
 CONFIG(release, debug|release) {
   DESTDIR = ../release
-  QMAKE_LIBDIR += ../release
+  QMAKE_LIBDIR = ../release $$QMAKE_LIBDIR
 }
 
 CONFIG(debug, debug|release) {
   DESTDIR = ../debug
-  QMAKE_LIBDIR += ../debug
+  QMAKE_LIBDIR = ../debug $$QMAKE_LIBDIR
   DEFINES *= DEBUG
 }
 

--- a/overlay_gl/overlay_gl.pro
+++ b/overlay_gl/overlay_gl.pro
@@ -58,12 +58,12 @@ macx {
 }
 
 CONFIG(debug, debug|release) {
-	QMAKE_LIBDIR *= ../debug$(DESTDIR_ADD)
+	QMAKE_LIBDIR = ../debug$(DESTDIR_ADD) $$QMAKE_LIBDIR
 	DESTDIR = ../debug$(DESTDIR_ADD)
 }
 
 CONFIG(release, debug|release) {
-	QMAKE_LIBDIR *= ../release$(DESTDIR_ADD)
+	QMAKE_LIBDIR = ../release$(DESTDIR_ADD) $$QMAKE_LIBDIR
 	DESTDIR = ../release$(DESTDIR_ADD)
 }
 

--- a/src/mumble.pri
+++ b/src/mumble.pri
@@ -70,11 +70,11 @@ isEqual(QT_MAJOR_VERSION, 4) {
 
 CONFIG(debug, debug|release) {
   CONFIG += console
-  QMAKE_LIBDIR += ../../debug
+  QMAKE_LIBDIR = ../../debug $$QMAKE_LIBDIR
   DESTDIR	= ../../debug
 }
 
 CONFIG(release, debug|release) {
-  QMAKE_LIBDIR += ../../release
+  QMAKE_LIBDIR = ../../release $$QMAKE_LIBDIR
   DESTDIR	= ../../release
 }

--- a/src/tests/Resample.pro
+++ b/src/tests/Resample.pro
@@ -21,11 +21,11 @@ win32 {
 }
 
 CONFIG(debug, debug|release) {
-  QMAKE_LIBDIR += ../../debug
+  QMAKE_LIBDIR = ../../debug $$QMAKE_LIBDIR
   DESTDIR	= ../../debug
 }
 
 CONFIG(release, debug|release) {
-  QMAKE_LIBDIR += ../../release
+  QMAKE_LIBDIR = ../../release $$QMAKE_LIBDIR
   DESTDIR	= ../../release
 }


### PR DESCRIPTION
This commit changes various pri and pro files to always prepend
the global build output directory (which can be either 'release'
or 'debug', depending on the current build configuration).

Otherwise, if a library that we build ourselves, such as -lspeex in
CONFIG+=bundled-speex, is also available in one of the other lib dirs,
we can't be sure that the one in our build output directory will be used.

This is a problem on FreeBSD, where we add /usr/local/lib
to the QMAKE_LIBDIR in compiler.pri. That directory might contain
its own -lspeex.

With this change, we now prefer libraries in our build output directory
to system libraries.