### PR TITLE
ServerHandler: use QUdpSocket::bind(QHostAddress, int) overload to fix Qt 4 build.

### DIFF
--- a/src/mumble/ServerHandler.cpp
+++ b/src/mumble/ServerHandler.cpp
@@ -607,7 +607,7 @@ void ServerHandler::serverConnectionConnected() {
 
 		qusUdp = new QUdpSocket(this);
 		if (g.s.bUdpForceTcpAddr) {
-			qusUdp->bind(qhaLocal);
+			qusUdp->bind(qhaLocal, 0);
 		} else {
 			if (qhaRemote.protocol() == QAbstractSocket::IPv6Protocol) {
 				qusUdp->bind(QHostAddress(QHostAddress::AnyIPv6), 0);


### PR DESCRIPTION
Qt 5 has a QUdpSocket::bind(QHostAddress), which is what we used to use
here.

Qt 4 does not. Fix this by using port 0, like we do for the
non-UdpForceTcpAddr cases.