### PR TITLE
Only link against -lrt when using a linux mkspec.

### DIFF
--- a/plugins/link/link.pro
+++ b/plugins/link/link.pro
@@ -15,7 +15,7 @@ win32 {
 unix {
 	SOURCES		= link-posix.cpp
 
-        !macx {
+        linux {
 		LIBS          += -lrt
 	}
 }

--- a/src/mumble/mumble.pro
+++ b/src/mumble/mumble.pro
@@ -478,7 +478,10 @@ unix {
     HEADERS *= GlobalShortcut_unix.h
     SOURCES *= GlobalShortcut_unix.cpp TextToSpeech_unix.cpp Overlay_unix.cpp SharedMemory_unix.cpp Log_unix.cpp
     must_pkgconfig(x11)
-    LIBS *= -lrt -lXi
+    linux {
+      LIBS *= -lrt
+    }
+    LIBS *= -lXi
 
     # For MumbleSSL::qsslSanityCheck()
     contains(UNAME, Linux) {


### PR DESCRIPTION
In this case, the linux mkspec should really be a
check for glibc. But there isn't an easily available
way to check that in qmake -- so gate it behind linux
instead.

If/when we need to support other libcs on Linux, we'll
find a suitable solution.