### PR TITLE
Add OpenBSD to compiler.pri and, in main.pro disable the overlay on OpenBSD.

### DIFF
--- a/compiler.pri
+++ b/compiler.pri
@@ -228,7 +228,7 @@ unix {
 	}
 }
 
-contains(UNAME, FreeBSD) {
+contains(UNAME, FreeBSD)|contains(UNAME, OpenBSD) {
 	QMAKE_CFLAGS *= "-I/usr/local/include" "-isystem /usr/local/include"
 	QMAKE_CXXFLAGS *= "-I/usr/local/include" "-isystem /usr/local/include"
 	QMAKE_LIBDIR *= /usr/lib

--- a/main.pro
+++ b/main.pro
@@ -62,6 +62,10 @@ SUBDIRS *= src/mumble_proto
     }
   }
 
+  contains(UNAME, OpenBSD) {
+    CONFIG *= no-overlay
+  }
+
   unix:!macx:!CONFIG(no-overlay) {
     SUBDIRS *= overlay_gl
   }


### PR DESCRIPTION
This PR contains two separate commits.

1. Handle OpenBSD like FreeBSD in compiler.pri. (/usr/local/include includepath an /usr/local/lib lib dir)
2. Disable building the overlay on OpenBSD for now.