### PR TITLE
ffxiv_x64 Plugin: Add a plugin for Final Fantasy XIV DX11/x64

### DIFF
--- a/installer/Plugins.wxs
+++ b/installer/Plugins.wxs
@@ -148,6 +148,9 @@
         <Component Id="bf4.dll">
           <File Source="$(var.SourceDir)\release\plugins\bf4.dll" KeyPath="yes" />
         </Component>
+        <Component Id="ffxiv_x64.dll">
+          <File Source="$(var.SourceDir)\release\plugins\ffxiv_x64.dll" KeyPath="yes" />
+        </Component>
         <Component Id="gtav.dll">
           <File Source="$(var.SourceDir)\release\plugins\gtav.dll" KeyPath="yes" />
         </Component>
@@ -207,6 +210,7 @@
       <?if $(sys.BUILDARCH) = "x64" ?>
         <ComponentRef Id="bf1.dll" />
         <ComponentRef Id="bf4.dll" />
+        <ComponentRef Id="ffxiv_x64.dll" />
         <ComponentRef Id="gtav.dll" />
         <ComponentRef Id="wow_x64.dll" />
       <?endif ?>

--- a/plugins/ffxiv_x64/ffxiv_x64.pro
+++ b/plugins/ffxiv_x64/ffxiv_x64.pro
@@ -1,0 +1,12 @@
+# Copyright 2005-2016 The Mumble Developers. All rights reserved.
+# Use of this source code is governed by a BSD-style license
+# that can be found in the LICENSE file at the root of the
+# Mumble source tree or at <https://www.mumble.info/LICENSE>.
+
+include(../plugins.pri)
+
+TARGET		= ffxiv_x64
+SOURCES		= ../ffxiv/ffxiv.cpp
+
+DEFINES *= FFXIV_USE_x64
+win32:LIBS		+= -luser32

--- a/plugins/plugins.pro
+++ b/plugins/plugins.pro
@@ -15,7 +15,7 @@ win32 {
 	SUBDIRS += aoc arma2 bf1942 bf2 bf3 bf2142 bfbc2 bfheroes bf4_x86 blacklight borderlands borderlands2 breach cod2 cod4 cod5 codmw2 codmw2so cs css dods dys etqw ffxiv tf2 gmod gtaiv gw hl2dm insurgency jc2 l4d l4d2 lol lotro ql rl sr sto ut2004 ut3 ut99 wolfet wow
 
 	equals(MUMBLE_ARCH, x86_64) {
-		SUBDIRS += bf1 bf4 gtav wow_x64
+		SUBDIRS += bf1 bf4 ffxiv_x64 gtav wow_x64
 	}
 }
 


### PR DESCRIPTION
This is almost identical to the DirectX 9 plugin, just using 64 bit pointers and new addresses.

I'd love to combine both plugins, and could do it with something like `#ifdef IS_DX11`, but am not familiar enough with qmake to set the `#define` and have both versions build.

Note:  The plugin short name is the same, since that seems to be part of the context. 