### PR TITLE
Mumble: convert AudioInputPtr and AudioOutputPtr to use QSharedPointer instead of boost::shared_ptr.

### DIFF
--- a/src/mumble/Audio.cpp
+++ b/src/mumble/Audio.cpp
@@ -199,15 +199,13 @@ void Audio::startOutput(const QString &output) {
 }
 
 void Audio::stopOutput() {
-	AudioOutputPtr ao = g.ao;
+	QWeakPointer<AudioOutput> weak_ao = g.ao.toWeakRef();
 
-	g.ao.reset();
+	g.ao.clear();
 
-	while (ao.get() && ! ao.unique()) {
+	while (weak_ao) {
 		QThread::yieldCurrentThread();
 	}
-
-	ao.reset();
 }
 
 void Audio::startInput(const QString &input) {
@@ -217,15 +215,13 @@ void Audio::startInput(const QString &input) {
 }
 
 void Audio::stopInput() {
-	AudioInputPtr ai = g.ai;
+	QWeakPointer<AudioInput> weak_ai = g.ai.toWeakRef();
 
-	g.ai.reset();
+	g.ai.clear();
 
-	while (ai.get() && ! ai.unique()) {
+	while (weak_ai) {
 		QThread::yieldCurrentThread();
 	}
-
-	ai.reset();
 }
 
 void Audio::start(const QString &input, const QString &output) {
@@ -234,16 +230,13 @@ void Audio::start(const QString &input, const QString &output) {
 }
 
 void Audio::stop() {
-	AudioInputPtr ai = g.ai;
-	AudioOutputPtr ao = g.ao;
+	QWeakPointer<AudioInput> weak_ai = g.ai.toWeakRef();
+	QWeakPointer<AudioOutput> weak_ao = g.ao.toWeakRef();
 
-	g.ao.reset();
-	g.ai.reset();
+	g.ao.clear();
+	g.ai.clear();
 
-	while ((ai.get() && ! ai.unique()) || (ao.get() && ! ao.unique())) {
+	while (weak_ai && weak_ao) {
 		QThread::yieldCurrentThread();
 	}
-
-	ai.reset();
-	ao.reset();
 }

--- a/src/mumble/AudioConfigDialog.cpp
+++ b/src/mumble/AudioConfigDialog.cpp
@@ -388,9 +388,9 @@ void AudioInputDialog::on_qcbSystem_currentIndexChanged(int) {
 
 void AudioInputDialog::on_Tick_timeout() {
 	AudioInputPtr ai = g.ai;
-
-	if (ai.get() == NULL || ! ai->sppPreprocess)
+	if (!ai || !ai->sppPreprocess) {
 		return;
+	}
 
 	abSpeech->iBelow = qsTransmitMin->value();
 	abSpeech->iAbove = qsTransmitMax->value();

--- a/src/mumble/AudioInput.cpp
+++ b/src/mumble/AudioInput.cpp
@@ -521,7 +521,7 @@ void AudioInput::setMaxBandwidth(int bitspersec) {
 		return;
 	}
 
-	ai.reset();
+	ai.clear();
 
 	Audio::stopInput();
 	Audio::startInput();

--- a/src/mumble/AudioInput.h
+++ b/src/mumble/AudioInput.h
@@ -6,7 +6,6 @@
 #ifndef MUMBLE_MUMBLE_AUDIOINPUT_H_
 #define MUMBLE_MUMBLE_AUDIOINPUT_H_
 
-#include <boost/shared_ptr.hpp>
 #include <boost/array.hpp>
 #include <speex/speex.h>
 #include <speex/speex_echo.h>
@@ -14,6 +13,7 @@
 #include <speex/speex_resampler.h>
 #include <QtCore/QObject>
 #include <QtCore/QThread>
+#include <QtCore/QSharedPointer>
 #include <vector>
 
 #include "Audio.h"
@@ -25,7 +25,7 @@ class AudioInput;
 class CELTCodec;
 struct CELTEncoder;
 struct OpusEncoder;
-typedef boost::shared_ptr<AudioInput> AudioInputPtr;
+typedef QSharedPointer<AudioInput> AudioInputPtr;
 
 class AudioInputRegistrar {
 	private:

--- a/src/mumble/AudioOutput.h
+++ b/src/mumble/AudioOutput.h
@@ -6,9 +6,9 @@
 #ifndef MUMBLE_MUMBLE_AUDIOOUTPUT_H_
 #define MUMBLE_MUMBLE_AUDIOOUTPUT_H_
 
-#include <boost/shared_ptr.hpp>
 #include <QtCore/QObject>
 #include <QtCore/QThread>
+#include <QtCore/QSharedPointer>
 
 // AudioOutput depends on User being valid. This means it's important
 // to removeBuffer from here BEFORE MainWindow gets any UserLeft
@@ -45,7 +45,7 @@ class ClientUser;
 class AudioOutputUser;
 class AudioOutputSample;
 
-typedef boost::shared_ptr<AudioOutput> AudioOutputPtr;
+typedef QSharedPointer<AudioOutput> AudioOutputPtr;
 
 class AudioOutputRegistrar {
 	private:

--- a/src/mumble/AudioStats.cpp
+++ b/src/mumble/AudioStats.cpp
@@ -210,8 +210,9 @@ void AudioNoiseWidget::paintEvent(QPaintEvent *) {
 	paint.fillRect(rect(), pal.color(QPalette::Background));
 
 	AudioInputPtr ai = g.ai;
-	if (ai.get() == NULL || ! ai->sppPreprocess)
+	if (!ai || !ai->sppPreprocess) {
 		return;
+	}
 
 	QPolygonF poly;
 
@@ -300,9 +301,9 @@ AudioStats::~AudioStats() {
 
 void AudioStats::on_Tick_timeout() {
 	AudioInputPtr ai = g.ai;
-
-	if (ai.get() == NULL || ! ai->sppPreprocess)
+	if (!ai || !ai->sppPreprocess) {
 		return;
+	}
 
 	bool nTalking = ai->isTransmitting();
 

--- a/src/mumble/Global.h
+++ b/src/mumble/Global.h
@@ -8,6 +8,7 @@
 
 #include <boost/shared_ptr.hpp>
 #include <QtCore/QDir>
+#include <QtCore/QSharedPointer>
 
 #include "ACL.h"
 #include "Settings.h"
@@ -40,8 +41,8 @@ public:
 	MainWindow *mw;
 	Settings s;
 	boost::shared_ptr<ServerHandler> sh;
-	boost::shared_ptr<AudioInput> ai;
-	boost::shared_ptr<AudioOutput> ao;
+	QSharedPointer<AudioInput> ai;
+	QSharedPointer<AudioOutput> ao;
 	Database *db;
 	Log *l;
 	Plugins *p;

--- a/src/mumble/GlobalShortcut.cpp
+++ b/src/mumble/GlobalShortcut.cpp
@@ -849,8 +849,9 @@ bool GlobalShortcutEngine::handleButton(const QVariant &button, bool down) {
 
 	if (down) {
 		AudioInputPtr ai = g.ai;
-		if (ai.get())
+		if (ai) {
 			ai->tIdle.restart();
+		}
 	}
 
 	int idx = qlButtonList.indexOf(button);

--- a/src/mumble/PulseAudio.cpp
+++ b/src/mumble/PulseAudio.cpp
@@ -170,8 +170,8 @@ void PulseAudioSystem::eventCallback(pa_mainloop_api *api, pa_defer_event *) {
 
 	AudioInputPtr ai = g.ai;
 	AudioOutputPtr ao = g.ao;
-	AudioInput *raw_ai = ai.get();
-	AudioOutput *raw_ao = ao.get();
+	AudioInput *raw_ai = ai.data();
+	AudioOutput *raw_ao = ao.data();
 	PulseAudioInput *pai = dynamic_cast<PulseAudioInput *>(raw_ai);
 	PulseAudioOutput *pao = dynamic_cast<PulseAudioOutput *>(raw_ao);
 
@@ -474,7 +474,7 @@ void PulseAudioSystem::read_callback(pa_stream *s, size_t bytes, void *userdata)
 	}
 
 	AudioInputPtr ai = g.ai;
-	PulseAudioInput *pai = dynamic_cast<PulseAudioInput *>(ai.get());
+	PulseAudioInput *pai = dynamic_cast<PulseAudioInput *>(ai.data());
 	if (! pai) {
 		if (length > 0) {
 			pa_stream_drop(s);
@@ -525,7 +525,7 @@ void PulseAudioSystem::write_callback(pa_stream *s, size_t bytes, void *userdata
 	Q_ASSERT(s == pas->pasOutput);
 
 	AudioOutputPtr ao = g.ao;
-	PulseAudioOutput *pao = dynamic_cast<PulseAudioOutput *>(ao.get());
+	PulseAudioOutput *pao = dynamic_cast<PulseAudioOutput *>(ao.data());
 
 	unsigned char buffer[bytes];
 


### PR DESCRIPTION
QSharedPointer is thread-safe and atomic, while boost::shared_ptr isn't.

For some audio systems, this is necessary for proper implementation (for
example, an audio system where AudioOutput runs the show, and AudioInput
is simply 'fed' data from AudioOutput -- like my upcoming 'sndio' backend).

Most of this commit is straight-forward. Most of the change is simply
renaming the types and fixing up uses of boost::shared_ptr::get() to
use QSharedPointer::data() instead. Some places also use operator bool()
now.

In Audio.cpp, in stop(), stopInput() and stopOutput(), the
boost::shared_ptr-based code used the unique() method on
boost::shared_ptr. That doesn't exist for QSharedPointer,
so we emulate the old behavior by keeping a QWeakPointer to
the object around. Once the weak pointer is no longer valid,
we know the AudioInput/AudioOutput object has been fully
destroyed.