### PR TITLE
qt.pri: introduce QT_VERSION_INT for easier version comparisons in qmake files.

### DIFF
--- a/qt.pri
+++ b/qt.pri
@@ -3,6 +3,22 @@
 # that can be found in the LICENSE file at the root of the
 # Mumble source tree or at <https://www.mumble.info/LICENSE>.
 
-QT_VERSION = $$[QT_VERSION]
-QT_MAJOR_VERSION = $$section(QT_VERSION, ., 0, 0)
-QT_MINOR_VERSION = $$section(QT_VERSION, ., 1, 1)
+QT_VERSION_INT_MAJOR = $$QT_MAJOR_VERSION
+
+greaterThan(QT_MINOR_VERSION, 99) {
+	error(bad Qt minor version)
+} greaterThan(QT_MINOR_VERSION, 9) {
+	QT_VERSION_INT_MINOR = "$$QT_MINOR_VERSION"
+} else {
+	QT_VERSION_INT_MINOR = "0$$QT_MINOR_VERSION"
+}
+
+greaterThan(QT_PATCH_VERSION, 99) {
+	error(bad Qt patch version)
+} greaterThan(QT_PATCH_VERSION, 9) {
+	QT_VERSION_INT_PATCH = "$$QT_PATCH_VERSION"
+} else {
+	QT_VERSION_INT_PATCH = "0$$QT_PATCH_VERSION"
+}
+
+QT_VERSION_INT = "$$QT_VERSION_INT_MAJOR$$QT_VERSION_INT_MINOR$$QT_VERSION_INT_PATCH"


### PR DESCRIPTION
This introduces a new variable, QT_VERSION_INT, which allows
qmake files to more easily do Qt version checks.

Previosly, code would chain greaterThan/equals/lessThan with
logical ands for QT_MAJOR_VERSION and QT_MINOR_VERSION.

That worked OK, but was a little verbose, and is inconvenient
if you want to use a QT_VERSION check alongside other conditions
in a conditional.

The QT_VERSION_INT is a string variable is of the form:

  Qt 5.0.0:   50000
  Qt 5.6.1:   50601

it is base 10, and can be used with qmake's comparison operators
like so:

  greaterThan(QT_VERSION_INT, 50600) {
    // Do stuff for Qt > 5.6
  }

This commit also removes our own copies of QT_MAJOR_VERSION
and QT_MINOR_VERSION. These are provided by mkspecs/qconfig.pri,
and have been since (at least) Qt 4. So they're already available.
We don't need to provide them. Our method of fetching them was also
buggy due to Qt 4 compatibility - so that's fixed now.