### PR TITLE
os_win: remove MumbleHWNDForQWidget, add mumble_mw_hwnd.

### DIFF
--- a/src/mumble/ASIOInput.cpp
+++ b/src/mumble/ASIOInput.cpp
@@ -11,7 +11,7 @@
 #include "Global.h"
 
 // From os_win.cpp.
-extern HWND MumbleHWNDForQWidget(QWidget *w);
+extern HWND mumble_mw_hwnd;
 
 class ASIOAudioInputRegistrar : public AudioInputRegistrar {
 	public:
@@ -185,7 +185,7 @@ void ASIOConfig::on_qpbQuery_clicked() {
 	CLSIDFromString(const_cast<wchar_t *>(reinterpret_cast<const wchar_t *>(qsCls.utf16())), &clsid);
 	if (CoCreateInstance(clsid, NULL, CLSCTX_INPROC_SERVER, clsid, reinterpret_cast<void **>(&iasio)) == S_OK) {
 		SleepEx(10, false);
-		if (iasio->init(MumbleHWNDForQWidget(this))) {
+		if (iasio->init(mumble_mw_hwnd)) {
 			SleepEx(10, false);
 			char buff[512];
 			memset(buff, 0, 512);
@@ -267,7 +267,7 @@ void ASIOConfig::on_qpbConfig_clicked() {
 	CLSIDFromString(const_cast<wchar_t *>(reinterpret_cast<const wchar_t *>(qsCls.utf16())), &clsid);
 	if (CoCreateInstance(clsid, NULL, CLSCTX_INPROC_SERVER, clsid, reinterpret_cast<void **>(&iasio)) == S_OK) {
 		SleepEx(10, false);
-		if (iasio->init(MumbleHWNDForQWidget(this))) {
+		if (iasio->init(mumble_mw_hwnd)) {
 			SleepEx(10, false);
 			iasio->controlPanel();
 			SleepEx(10, false);

--- a/src/mumble/DirectSound.cpp
+++ b/src/mumble/DirectSound.cpp
@@ -13,7 +13,7 @@
 #include "Global.h"
 
 // from os_win.cpp
-extern HWND MumbleHWNDForQWidget(QWidget *w);
+extern HWND mumble_mw_hwnd;
 
 #undef FAILED
 #define FAILED(Status) (static_cast<HRESULT>(Status)<0)
@@ -236,7 +236,7 @@ void DXAudioOutput::run() {
 	if (! pDS && FAILED(hr = DirectSoundCreate8(&DSDEVID_DefaultVoicePlayback, &pDS, NULL))) {
 		qWarning("DXAudioOutput: DirectSoundCreate failed: hr=0x%08lx", hr);
 		goto cleanup;
-	} else if (FAILED(hr = pDS->SetCooperativeLevel(MumbleHWNDForQWidget(g.mw), DSSCL_PRIORITY))) {
+	} else if (FAILED(hr = pDS->SetCooperativeLevel(mumble_mw_hwnd, DSSCL_PRIORITY))) {
 		qWarning("DXAudioOutput: SetCooperativeLevel failed: hr=0x%08lx", hr);
 		goto cleanup;
 	} else if (FAILED(hr = pDS->CreateSoundBuffer(&dsbdesc, &pDSBPrimary, NULL))) {

--- a/src/mumble/GlobalShortcut_win.cpp
+++ b/src/mumble/GlobalShortcut_win.cpp
@@ -20,7 +20,7 @@
 #define DX_SAMPLE_BUFFER_SIZE 512
 
 // from os_win.cpp
-extern HWND MumbleHWNDForQWidget(QWidget *w);
+extern HWND mumble_mw_hwnd;
 
 static uint qHash(const GUID &a) {
 	uint val = a.Data1 ^ a.Data2 ^ a.Data3;
@@ -272,24 +272,6 @@ LRESULT CALLBACK GlobalShortcutWin::HookKeyboard(int nCode, WPARAM wParam, LPARA
 		ql << QVariant(QUuid(GUID_SysKeyboard));
 		bool suppress = gsw->handleButton(ql, !(key->flags & LLKHF_UP));
 
-		if (! suppress && g.ocIntercept) {
-			// In full-GUI-overlay always suppress
-			suppress = true;
-
-			HWND hwnd = MumbleHWNDForQWidget(&g.ocIntercept->qgv);
-
-			GUITHREADINFO gti;
-			ZeroMemory(&gti, sizeof(gti));
-			gti.cbSize = sizeof(gti);
-			::GetGUIThreadInfo(::GetWindowThreadProcessId(hwnd, NULL), &gti);
-
-			if (gti.hwndFocus)
-				hwnd = gti.hwndFocus;
-
-			if (! nomsg)
-				::PostMessage(hwnd, msg, w, l);
-		}
-
 		if (suppress)
 			return 1;
 
@@ -341,54 +323,6 @@ LRESULT CALLBACK GlobalShortcutWin::HookMouse(int nCode, WPARAM wParam, LPARAM l
 				break;
 			default:
 				break;
-		}
-
-		if (g.ocIntercept) {
-			// In full-GUI-overlay always suppress
-			suppress = true;
-
-			POINT p;
-			GetCursorPos(&p);
-
-			int dx = mouse->pt.x - p.x;
-			int dy = mouse->pt.y - p.y;
-
-			g.ocIntercept->iMouseX = qBound<int>(0, g.ocIntercept->iMouseX + dx, g.ocIntercept->uiWidth - 1);
-			g.ocIntercept->iMouseY = qBound<int>(0, g.ocIntercept->iMouseY + dy, g.ocIntercept->uiHeight - 1);
-
-			WPARAM w = 0;
-			LPARAM l = (static_cast<short>(g.ocIntercept->iMouseX) & 0xFFFF) | ((g.ocIntercept->iMouseY << 16) & 0xFFFF0000);
-
-			if (ucKeyState[VK_CONTROL] & 0x80)
-				w |= MK_CONTROL;
-			if (ucKeyState[VK_LBUTTON] & 0x80)
-				w |= MK_LBUTTON;
-			if (ucKeyState[VK_MBUTTON] & 0x80)
-				w |= MK_MBUTTON;
-			if (ucKeyState[VK_RBUTTON] & 0x80)
-				w |= MK_RBUTTON;
-			if (ucKeyState[VK_SHIFT] & 0x80)
-				w |= MK_SHIFT;
-			if (ucKeyState[VK_XBUTTON1] & 0x80)
-				w |= MK_XBUTTON1;
-			if (ucKeyState[VK_XBUTTON2] & 0x80)
-				w |= MK_XBUTTON2;
-
-			w |= (mouse->mouseData & 0xFFFF0000);
-
-			HWND hwnd = MumbleHWNDForQWidget(&g.ocIntercept->qgv);
-
-			GUITHREADINFO gti;
-			ZeroMemory(&gti, sizeof(gti));
-			gti.cbSize = sizeof(gti);
-			::GetGUIThreadInfo(::GetWindowThreadProcessId(hwnd, NULL), &gti);
-
-			if (gti.hwndCapture)
-				hwnd = gti.hwndCapture;
-
-			::PostMessage(hwnd, msg, w, l);
-
-			QMetaObject::invokeMethod(g.ocIntercept, "updateMouse", Qt::QueuedConnection);
 		}
 
 		bool down = false;
@@ -569,7 +503,7 @@ BOOL GlobalShortcutWin::EnumDevicesCB(LPCDIDEVICEINSTANCE pdidi, LPVOID pContext
 			id->qhTypeToOfs[dwType] = dwOfs;
 		}
 
-		if (FAILED(hr = id->pDID->SetCooperativeLevel(MumbleHWNDForQWidget(g.mw), DISCL_NONEXCLUSIVE|DISCL_BACKGROUND)))
+		if (FAILED(hr = id->pDID->SetCooperativeLevel(mumble_mw_hwnd, DISCL_NONEXCLUSIVE|DISCL_BACKGROUND)))
 			qFatal("GlobalShortcutWin: SetCooperativeLevel: %lx", hr);
 
 		if (FAILED(hr = id->pDID->SetDataFormat(&df)))

--- a/src/mumble/main.cpp
+++ b/src/mumble/main.cpp
@@ -411,6 +411,13 @@ int main(int argc, char **argv) {
 	g.mw=new MainWindow(NULL);
 	g.mw->show();
 
+#ifdef Q_OS_WIN
+	// Set mumble_mw_hwnd in os_win.cpp.
+	// Used by APIs in ASIOInput, DirectSound and GlobalShortcut_win that require a HWND.
+	extern HWND mumble_mw_hwnd;
+	mumble_mw_hwnd = GetForegroundWindow();
+#endif
+
 #ifdef USE_DBUS
 	new MumbleDBus(g.mw);
 	QDBusConnection::sessionBus().registerObject(QLatin1String("/"), g.mw);

--- a/src/mumble/mumble.pro
+++ b/src/mumble/mumble.pro
@@ -64,7 +64,6 @@ QT		*= network sql xml svg
 isEqual(QT_MAJOR_VERSION, 5) {
   QT *= widgets
   # Allow native widget access.
-  win32:QT *= gui-private
   macx:QT *= gui-private
 }
 

--- a/src/mumble/os_win.cpp
+++ b/src/mumble/os_win.cpp
@@ -5,10 +5,6 @@
 
 #include "mumble_pch.hpp"
 
-#if QT_VERSION >= 0x050000
-# include <qpa/qplatformnativeinterface.h>
-#endif
-
 #include <windows.h>
 #include <tlhelp32.h>
 #include <dbghelp.h>
@@ -35,6 +31,8 @@ static int cpuinfo[4];
 
 bool bIsWin7 = false;
 bool bIsVistaSP1 = false;
+
+HWND mumble_mw_hwnd = 0;
 
 static void mumbleMessageOutputQString(QtMsgType type, const QString &msg) {
 	char c;
@@ -312,22 +310,4 @@ DWORD WinVerifySslCert(const QByteArray& cert) {
 	CertFreeCertificateContext(certContext);
 
 	return errorStatus;
-}
-
-HWND MumbleHWNDForQWidget(QWidget *widget) {
-#if QT_VERSION >= 0x050000
-	QWindow *window = widget->windowHandle();
-	if (window == NULL) {
-		QWidget *npw = widget->nativeParentWidget();
-		if (npw != NULL) {
-			window = npw->windowHandle();
-		}
-	}
-	if (window != NULL && window->handle() != 0) {
-		return static_cast<HWND>(qApp->platformNativeInterface()->nativeResourceForWindow("handle", window));
-	}
-	return 0;
-#else
-	return widget->winId();
-#endif
 }


### PR DESCRIPTION
This commit removes MumbleHWNDForQWidget -- the only user of
private Qt API in Mumble on Windows.

It is replaced with a variable, mumble_hw_hwnd, which gets
filled out in main.cpp just after creating MainWindow.

Most MumbleHWNDForQWidget() uses were for g.mw, so the change
makes sense. The ones that weren't have been changed to use it,
or removed. Most of the removed instances are g.ocIntercept-related,
which is already broken beyond repair in Qt 5.