### PR TITLE
Refactor LogEmitter from Murmur into its own file in src/.

### DIFF
--- a/src/LogEmitter.cpp
+++ b/src/LogEmitter.cpp
@@ -1,0 +1,15 @@
+// Copyright 2005-2016 The Mumble Developers. All rights reserved.
+// Use of this source code is governed by a BSD-style license
+// that can be found in the LICENSE file at the root of the
+// Mumble source tree or at <https://www.mumble.info/LICENSE>.
+
+#include "murmur_pch.h"
+
+#include "LogEmitter.h"
+
+LogEmitter::LogEmitter(QObject *p) : QObject(p) {
+};
+
+void LogEmitter::addLogEntry(const QString &msg) {
+	emit newLogEntry(msg);
+};

--- a/src/LogEmitter.h
+++ b/src/LogEmitter.h
@@ -1,0 +1,20 @@
+// Copyright 2005-2016 The Mumble Developers. All rights reserved.
+// Use of this source code is governed by a BSD-style license
+// that can be found in the LICENSE file at the root of the
+// Mumble source tree or at <https://www.mumble.info/LICENSE>.
+
+#ifndef MUMBLE_LOGEMITTER_H_
+#define MUMBLE_LOGEMITTER_H_
+
+class LogEmitter : public QObject {
+	private:
+		Q_OBJECT
+		Q_DISABLE_COPY(LogEmitter)
+	signals:
+		void newLogEntry(const QString &msg);
+	public:
+		LogEmitter(QObject *parent = NULL);
+		void addLogEntry(const QString &msg);
+};
+
+#endif

--- a/src/mumble.pri
+++ b/src/mumble.pri
@@ -14,8 +14,8 @@ CONFIG		+= qt thread debug_and_release warn_on
 DEFINES		*= MUMBLE_VERSION_STRING=$$VERSION
 INCLUDEPATH	+= $$PWD . ../mumble_proto
 VPATH		+= $$PWD
-HEADERS		*= ACL.h Channel.h CryptState.h Connection.h Group.h HTMLFilter.h User.h Net.h OSInfo.h Timer.h SSL.h Version.h SSLCipherInfo.h SSLCipherInfoTable.h licenses.h License.h
-SOURCES 	*= ACL.cpp Group.cpp Channel.cpp Connection.cpp HTMLFilter.cpp User.cpp Timer.cpp CryptState.cpp OSInfo.cpp Net.cpp SSL.cpp Version.cpp SSLCipherInfo.cpp License.cpp
+HEADERS		*= ACL.h Channel.h CryptState.h Connection.h Group.h HTMLFilter.h User.h Net.h OSInfo.h Timer.h SSL.h Version.h SSLCipherInfo.h SSLCipherInfoTable.h licenses.h License.h LogEmitter.h
+SOURCES 	*= ACL.cpp Group.cpp Channel.cpp Connection.cpp HTMLFilter.cpp User.cpp Timer.cpp CryptState.cpp OSInfo.cpp Net.cpp SSL.cpp Version.cpp SSLCipherInfo.cpp License.cpp LogEmitter.cpp
 LIBS		*= -lmumble_proto
 # Note: Protobuf generates into its own directory so we can mark it as a
 #       system include folder for unix. Otherwise the generated code creates

--- a/src/murmur/Server.cpp
+++ b/src/murmur/Server.cpp
@@ -31,13 +31,6 @@
 
 #define UDP_PACKET_SIZE 1024
 
-LogEmitter::LogEmitter(QObject *p) : QObject(p) {
-};
-
-void LogEmitter::addLogEntry(const QString &msg) {
-	emit newLogEntry(msg);
-};
-
 ExecEvent::ExecEvent(boost::function<void ()> f) : QEvent(static_cast<QEvent::Type>(EXEC_QEVENT)) {
 	func = f;
 }

--- a/src/murmur/Server.h
+++ b/src/murmur/Server.h
@@ -51,17 +51,6 @@ struct TextMessage {
 	QString qsText;
 };
 
-class LogEmitter : public QObject {
-	private:
-		Q_OBJECT
-		Q_DISABLE_COPY(LogEmitter)
-	signals:
-		void newLogEntry(const QString &msg);
-	public:
-		LogEmitter(QObject *parent = NULL);
-		void addLogEntry(const QString &msg);
-};
-
 class SslServer : public QTcpServer {
 	private:
 		Q_OBJECT;

--- a/src/murmur/Tray.cpp
+++ b/src/murmur/Tray.cpp
@@ -11,6 +11,7 @@
 #include "Meta.h"
 #include "Server.h"
 #include "Version.h"
+#include "LogEmitter.h"
 
 Tray::Tray(QObject *p, LogEmitter *logger) : QObject(p) {
 	le = logger;

--- a/src/murmur/main.cpp
+++ b/src/murmur/main.cpp
@@ -17,6 +17,7 @@
 #include "Version.h"
 #include "SSL.h"
 #include "License.h"
+#include "LogEmitter.h"
 
 #ifdef Q_OS_UNIX
 #include "UnixMurmur.h"


### PR DESCRIPTION
It's a natural refactoring and it'd be nice to be able to
use LogEmitter in Mumble as well.