### PR TITLE
WIP Fix race condition during shutdown

### DIFF
--- a/src/mumble/Messages.cpp
+++ b/src/mumble/Messages.cpp
@@ -556,7 +556,7 @@ void MainWindow::msgUserRemove(const MumbleProto::UserRemove &msg) {
 			g.l->log((pSrc == pSelf) ? Log::YouKicked : Log::UserKicked, tr("%3 was kicked and banned from the server by %1: %2.").arg(Log::formatClientUser(pSrc, Log::Source)).arg(reason).arg(Log::formatClientUser(pDst, Log::Target)));
 		else
 			g.l->log((pSrc == pSelf) ? Log::YouKicked : Log::UserKicked, tr("%3 was kicked from the server by %1: %2.").arg(Log::formatClientUser(pSrc, Log::Source)).arg(reason).arg(Log::formatClientUser(pDst, Log::Target)));
-	} else {
+	} else if (pSelf && pDst) {
 		if (pDst->cChannel == pSelf->cChannel || pDst->cChannel->allLinks().contains(pSelf->cChannel)) {
 			g.l->log(Log::ChannelLeave, tr("%1 left channel and disconnected.").arg(Log::formatClientUser(pDst, Log::Source)));
 		} else {


### PR DESCRIPTION
Saw a crash during shutdown. pSelf was NULL. WIP PR to keep track of the issue.

Pretty sure this fixes the specific crash I saw but I haven't looked into whether the function is vulnerable otherwise and whether this should even occurring and isn't a bug somewhere else. Also I haven't compiled this.