### PR TITLE
CryptState: introduce AES_KEY_SIZE_* constants.

### DIFF
--- a/src/CryptState.cpp
+++ b/src/CryptState.cpp
@@ -31,20 +31,20 @@ bool CryptState::isValid() const {
 }
 
 void CryptState::genKey() {
-	RAND_bytes(raw_key, AES_BLOCK_SIZE);
+	RAND_bytes(raw_key, AES_KEY_SIZE_BYTES);
 	RAND_bytes(encrypt_iv, AES_BLOCK_SIZE);
 	RAND_bytes(decrypt_iv, AES_BLOCK_SIZE);
-	AES_set_encrypt_key(raw_key, 128, &encrypt_key);
-	AES_set_decrypt_key(raw_key, 128, &decrypt_key);
+	AES_set_encrypt_key(raw_key, AES_KEY_SIZE_BITS, &encrypt_key);
+	AES_set_decrypt_key(raw_key, AES_KEY_SIZE_BITS, &decrypt_key);
 	bInit = true;
 }
 
 void CryptState::setKey(const unsigned char *rkey, const unsigned char *eiv, const unsigned char *div) {
-	memcpy(raw_key, rkey, AES_BLOCK_SIZE);
+	memcpy(raw_key, rkey, AES_KEY_SIZE_BYTES);
 	memcpy(encrypt_iv, eiv, AES_BLOCK_SIZE);
 	memcpy(decrypt_iv, div, AES_BLOCK_SIZE);
-	AES_set_encrypt_key(raw_key, 128, &encrypt_key);
-	AES_set_decrypt_key(raw_key, 128, &decrypt_key);
+	AES_set_encrypt_key(raw_key, AES_KEY_SIZE_BITS, &encrypt_key);
+	AES_set_decrypt_key(raw_key, AES_KEY_SIZE_BITS, &decrypt_key);
 	bInit = true;
 }
 

--- a/src/CryptState.h
+++ b/src/CryptState.h
@@ -8,13 +8,16 @@
 
 #include <openssl/aes.h>
 
+#define AES_KEY_SIZE_BITS   128
+#define AES_KEY_SIZE_BYTES  (AES_KEY_SIZE_BITS/8)
+
 #include "Timer.h"
 
 class CryptState {
 	private:
 		Q_DISABLE_COPY(CryptState)
 	public:
-		unsigned char raw_key[AES_BLOCK_SIZE];
+		unsigned char raw_key[AES_KEY_SIZE_BYTES];
 		unsigned char encrypt_iv[AES_BLOCK_SIZE];
 		unsigned char decrypt_iv[AES_BLOCK_SIZE];
 		unsigned char decrypt_history[0x100];

--- a/src/mumble/Messages.cpp
+++ b/src/mumble/Messages.cpp
@@ -28,6 +28,7 @@
 #include "UserModel.h"
 #include "VersionCheck.h"
 #include "ViewCert.h"
+#include "CryptState.h"
 
 #define ACTOR_INIT \
 	ClientUser *pSrc=NULL; \
@@ -718,7 +719,7 @@ void MainWindow::msgCryptSetup(const MumbleProto::CryptSetup &msg) {
 		const std::string &key = msg.key();
 		const std::string &client_nonce = msg.client_nonce();
 		const std::string &server_nonce = msg.server_nonce();
-		if (key.size() == AES_BLOCK_SIZE && client_nonce.size() == AES_BLOCK_SIZE && server_nonce.size() == AES_BLOCK_SIZE)
+		if (key.size() == AES_KEY_SIZE_BYTES && client_nonce.size() == AES_BLOCK_SIZE && server_nonce.size() == AES_BLOCK_SIZE)
 			c->csCrypt.setKey(reinterpret_cast<const unsigned char *>(key.data()), reinterpret_cast<const unsigned char *>(client_nonce.data()), reinterpret_cast<const unsigned char *>(server_nonce.data()));
 	} else if (msg.has_server_nonce()) {
 		const std::string &server_nonce = msg.server_nonce();

--- a/src/murmur/Messages.cpp
+++ b/src/murmur/Messages.cpp
@@ -15,6 +15,7 @@
 #include "Server.h"
 #include "ServerUser.h"
 #include "Version.h"
+#include "CryptState.h"
 
 #define MSG_SETUP(st) \
 	if (uSource->sState != st) { \
@@ -200,7 +201,7 @@ void Server::msgAuthenticate(ServerUser *uSource, MumbleProto::Authenticate &msg
 		uSource->csCrypt.genKey();
 
 		MumbleProto::CryptSetup mpcrypt;
-		mpcrypt.set_key(std::string(reinterpret_cast<const char *>(uSource->csCrypt.raw_key), AES_BLOCK_SIZE));
+		mpcrypt.set_key(std::string(reinterpret_cast<const char *>(uSource->csCrypt.raw_key), AES_KEY_SIZE_BYTES));
 		mpcrypt.set_server_nonce(std::string(reinterpret_cast<const char *>(uSource->csCrypt.encrypt_iv), AES_BLOCK_SIZE));
 		mpcrypt.set_client_nonce(std::string(reinterpret_cast<const char *>(uSource->csCrypt.decrypt_iv), AES_BLOCK_SIZE));
 		sendMessage(uSource, mpcrypt);


### PR DESCRIPTION
This change modifies CryptState to use AES_KEY_SIZE_BYTES and
AES_KEY_SIZE_BITS constants instead of using AES_BLOCK_SIZE.

This cleans up the code, making it easier to read and understand.
The key size is a distinct concept from the block size, even though
Mumble only offiiclaly supports OCB-AES128.

This also allows users of custom builds to bump their key size to
256-bit, if they desire. Of course, such builds will not be compatible
with any existing Mumble server, because neither Mumble nor Murmur
currently supports negotiating the crypto mode used for voice packets.