### PR TITLE
Revert PR 2674 and document audio backend initialization and teardown

### DIFF
--- a/src/mumble/Audio.cpp
+++ b/src/mumble/Audio.cpp
@@ -200,14 +200,29 @@ void Audio::startOutput(const QString &output) {
 }
 
 void Audio::stopOutput() {
+	// Take a copy of the global AudioOutput shared pointer
+	// to keep a reference around.
 	AudioOutputPtr ao = g.ao;
 
+	// Reset the global AudioOutput shared pointer to the null pointer.
 	g.ao.reset();
 
+	// Wait until our copy of the AudioOutput shared pointer (ao)
+	// is the only one left.
 	while (ao.get() && ! ao.unique()) {
 		QThread::yieldCurrentThread();
 	}
 
+	// Reset our copy of the AudioOutput shared pointer.
+	// This causes the AudioOutput destructor to be called
+	// right here in this function, on the main thread.
+	// Our audio backends expect this to happen.
+	//
+	// One such example is PulseAudioInput, whose destructor
+	// takes the PulseAudio mainloop lock. If the destructor
+	// is called inside one of the PulseAudio callbacks that
+	// take copies of g.ai, the destructor will try to also
+	// take the mainloop lock, causing an abort().
 	ao.reset();
 }
 
@@ -218,14 +233,29 @@ void Audio::startInput(const QString &input) {
 }
 
 void Audio::stopInput() {
+	// Take a copy of the global AudioInput shared pointer
+	// to keep a reference around.
 	AudioInputPtr ai = g.ai;
 
+	// Reset the global AudioInput shared pointer to the null pointer.
 	g.ai.reset();
 
+	// Wait until our copy of the AudioInput shared pointer (ai)
+	// is the only one left.
 	while (ai.get() && ! ai.unique()) {
 		QThread::yieldCurrentThread();
 	}
 
+	// Reset our copy of the AudioInput shared pointer.
+	// This causes the AudioInput destructor to be called
+	// right here in this function, on the main thread.
+	// Our audio backends expect this to happen.
+	//
+	// One such example is PulseAudioInput, whose destructor
+	// takes the PulseAudio mainloop lock. If the destructor
+	// is called inside one of the PulseAudio callbacks that
+	// take copies of g.ai, the destructor will try to also
+	// take the mainloop lock, causing an abort().
 	ai.reset();
 }
 
@@ -235,16 +265,34 @@ void Audio::start(const QString &input, const QString &output) {
 }
 
 void Audio::stop() {
+	// Take copies of the global AudioInput and AudioOutput
+	// shared pointers to keep a reference to each of them
+	// around.
 	AudioInputPtr ai = g.ai;
 	AudioOutputPtr ao = g.ao;
 
+	// Reset the global AudioInput and AudioOutput shared pointers
+	// to the null pointer.
 	g.ao.reset();
 	g.ai.reset();
 
+	// Wait until our copies of the AudioInput and AudioOutput shared pointers
+	// (ai and ao) are the only ones left.
 	while ((ai.get() && ! ai.unique()) || (ao.get() && ! ao.unique())) {
 		QThread::yieldCurrentThread();
 	}
 
+	// Reset our copies of the AudioInput and AudioOutput
+	// shared pointers.
+	// This causes the AudioInput and AudioOutput destructors
+	// to be called right here in this function, on the main
+	// thread. Our audio backends expect this to happen.
+	//
+	// One such example is PulseAudioInput, whose destructor
+	// takes the PulseAudio mainloop lock. If the destructor
+	// is called inside one of the PulseAudio callbacks that
+	// take copies of g.ai, the destructor will try to also
+	// take the mainloop lock, causing an abort().
 	ai.reset();
 	ao.reset();
 }

--- a/src/mumble/Audio.cpp
+++ b/src/mumble/Audio.cpp
@@ -200,13 +200,15 @@ void Audio::startOutput(const QString &output) {
 }
 
 void Audio::stopOutput() {
-	QWeakPointer<AudioOutput> weak_ao = g.ao.toWeakRef();
+	AudioOutputPtr ao = g.ao;
 
-	g.ao.clear();
+	g.ao.reset();
 
-	while (weak_ao) {
+	while (ao.get() && ! ao.unique()) {
 		QThread::yieldCurrentThread();
 	}
+
+	ao.reset();
 }
 
 void Audio::startInput(const QString &input) {
@@ -216,13 +218,15 @@ void Audio::startInput(const QString &input) {
 }
 
 void Audio::stopInput() {
-	QWeakPointer<AudioInput> weak_ai = g.ai.toWeakRef();
+	AudioInputPtr ai = g.ai;
 
-	g.ai.clear();
+	g.ai.reset();
 
-	while (weak_ai) {
+	while (ai.get() && ! ai.unique()) {
 		QThread::yieldCurrentThread();
 	}
+
+	ai.reset();
 }
 
 void Audio::start(const QString &input, const QString &output) {
@@ -231,13 +235,16 @@ void Audio::start(const QString &input, const QString &output) {
 }
 
 void Audio::stop() {
-	QWeakPointer<AudioInput> weak_ai = g.ai.toWeakRef();
-	QWeakPointer<AudioOutput> weak_ao = g.ao.toWeakRef();
+	AudioInputPtr ai = g.ai;
+	AudioOutputPtr ao = g.ao;
 
-	g.ao.clear();
-	g.ai.clear();
+	g.ao.reset();
+	g.ai.reset();
 
-	while (weak_ai && weak_ao) {
+	while ((ai.get() && ! ai.unique()) || (ao.get() && ! ao.unique())) {
 		QThread::yieldCurrentThread();
 	}
+
+	ai.reset();
+	ao.reset();
 }

--- a/src/mumble/AudioConfigDialog.cpp
+++ b/src/mumble/AudioConfigDialog.cpp
@@ -388,9 +388,9 @@ void AudioInputDialog::on_qcbSystem_currentIndexChanged(int) {
 
 void AudioInputDialog::on_Tick_timeout() {
 	AudioInputPtr ai = g.ai;
-	if (!ai || !ai->sppPreprocess) {
+
+	if (ai.get() == NULL || ! ai->sppPreprocess)
 		return;
-	}
 
 	abSpeech->iBelow = qsTransmitMin->value();
 	abSpeech->iAbove = qsTransmitMax->value();

--- a/src/mumble/AudioInput.cpp
+++ b/src/mumble/AudioInput.cpp
@@ -521,7 +521,7 @@ void AudioInput::setMaxBandwidth(int bitspersec) {
 		return;
 	}
 
-	ai.clear();
+	ai.reset();
 
 	Audio::stopInput();
 	Audio::startInput();

--- a/src/mumble/AudioInput.h
+++ b/src/mumble/AudioInput.h
@@ -6,6 +6,7 @@
 #ifndef MUMBLE_MUMBLE_AUDIOINPUT_H_
 #define MUMBLE_MUMBLE_AUDIOINPUT_H_
 
+#include <boost/shared_ptr.hpp>
 #include <boost/array.hpp>
 #include <speex/speex.h>
 #include <speex/speex_echo.h>
@@ -13,7 +14,6 @@
 #include <speex/speex_resampler.h>
 #include <QtCore/QObject>
 #include <QtCore/QThread>
-#include <QtCore/QSharedPointer>
 #include <vector>
 
 #include "Audio.h"
@@ -25,7 +25,7 @@ class AudioInput;
 class CELTCodec;
 struct CELTEncoder;
 struct OpusEncoder;
-typedef QSharedPointer<AudioInput> AudioInputPtr;
+typedef boost::shared_ptr<AudioInput> AudioInputPtr;
 
 class AudioInputRegistrar {
 	private:

--- a/src/mumble/AudioInput.h
+++ b/src/mumble/AudioInput.h
@@ -153,7 +153,16 @@ class AudioInput : public QThread {
 		static int getNetworkBandwidth(int bitrate, int frames);
 		static void setMaxBandwidth(int bitspersec);
 
+		/// Construct an AudioInput.
+		///
+		/// This constructor is only ever called by Audio::startInput(), and is guaranteed
+		/// to be called on the application's main thread.
 		AudioInput();
+
+		/// Destroy an AudioInput.
+		///
+		/// This destructor is only ever called by Audio::stopInput() and Audio::stop(),
+		/// and is guaranteed to be called on the application's main thread.
 		~AudioInput() Q_DECL_OVERRIDE;
 		void run() Q_DECL_OVERRIDE = 0;
 		virtual bool isAlive() const;

--- a/src/mumble/AudioOutput.h
+++ b/src/mumble/AudioOutput.h
@@ -92,7 +92,16 @@ class AudioOutput : public QThread {
 	public:
 		void wipe();
 
+                /// Construct an AudioOutput.
+                ///
+                /// This constructor is only ever called by Audio::startOutput(), and is guaranteed
+                /// to be called on the application's main thread.
 		AudioOutput();
+
+                /// Destroy an AudioOutput.
+                ///
+                /// This destructor is only ever called by Audio::stopOutput() and Audio::stop(),
+                /// and is guaranteed to be called on the application's main thread.
 		~AudioOutput() Q_DECL_OVERRIDE;
 
 		void addFrameToBuffer(ClientUser *, const QByteArray &, unsigned int iSeq, MessageHandler::UDPMessageType type);

--- a/src/mumble/AudioOutput.h
+++ b/src/mumble/AudioOutput.h
@@ -6,9 +6,9 @@
 #ifndef MUMBLE_MUMBLE_AUDIOOUTPUT_H_
 #define MUMBLE_MUMBLE_AUDIOOUTPUT_H_
 
+#include <boost/shared_ptr.hpp>
 #include <QtCore/QObject>
 #include <QtCore/QThread>
-#include <QtCore/QSharedPointer>
 
 // AudioOutput depends on User being valid. This means it's important
 // to removeBuffer from here BEFORE MainWindow gets any UserLeft
@@ -45,7 +45,7 @@ class ClientUser;
 class AudioOutputUser;
 class AudioOutputSample;
 
-typedef QSharedPointer<AudioOutput> AudioOutputPtr;
+typedef boost::shared_ptr<AudioOutput> AudioOutputPtr;
 
 class AudioOutputRegistrar {
 	private:

--- a/src/mumble/AudioStats.cpp
+++ b/src/mumble/AudioStats.cpp
@@ -210,9 +210,8 @@ void AudioNoiseWidget::paintEvent(QPaintEvent *) {
 	paint.fillRect(rect(), pal.color(QPalette::Background));
 
 	AudioInputPtr ai = g.ai;
-	if (!ai || !ai->sppPreprocess) {
+	if (ai.get() == NULL || ! ai->sppPreprocess)
 		return;
-	}
 
 	QPolygonF poly;
 
@@ -301,9 +300,9 @@ AudioStats::~AudioStats() {
 
 void AudioStats::on_Tick_timeout() {
 	AudioInputPtr ai = g.ai;
-	if (!ai || !ai->sppPreprocess) {
+
+	if (ai.get() == NULL || ! ai->sppPreprocess)
 		return;
-	}
 
 	bool nTalking = ai->isTransmitting();
 

--- a/src/mumble/Global.h
+++ b/src/mumble/Global.h
@@ -8,7 +8,6 @@
 
 #include <boost/shared_ptr.hpp>
 #include <QtCore/QDir>
-#include <QtCore/QSharedPointer>
 
 #include "ACL.h"
 #include "Settings.h"
@@ -43,8 +42,8 @@ public:
 	MainWindow *mw;
 	Settings s;
 	boost::shared_ptr<ServerHandler> sh;
-	QSharedPointer<AudioInput> ai;
-	QSharedPointer<AudioOutput> ao;
+	boost::shared_ptr<AudioInput> ai;
+	boost::shared_ptr<AudioOutput> ao;
 	Database *db;
 	Log *l;
 	Plugins *p;

--- a/src/mumble/GlobalShortcut.cpp
+++ b/src/mumble/GlobalShortcut.cpp
@@ -849,9 +849,8 @@ bool GlobalShortcutEngine::handleButton(const QVariant &button, bool down) {
 
 	if (down) {
 		AudioInputPtr ai = g.ai;
-		if (ai) {
+		if (ai.get())
 			ai->tIdle.restart();
-		}
 	}
 
 	int idx = qlButtonList.indexOf(button);

--- a/src/mumble/PulseAudio.cpp
+++ b/src/mumble/PulseAudio.cpp
@@ -170,8 +170,8 @@ void PulseAudioSystem::eventCallback(pa_mainloop_api *api, pa_defer_event *) {
 
 	AudioInputPtr ai = g.ai;
 	AudioOutputPtr ao = g.ao;
-	AudioInput *raw_ai = ai.data();
-	AudioOutput *raw_ao = ao.data();
+	AudioInput *raw_ai = ai.get();
+	AudioOutput *raw_ao = ao.get();
 	PulseAudioInput *pai = dynamic_cast<PulseAudioInput *>(raw_ai);
 	PulseAudioOutput *pao = dynamic_cast<PulseAudioOutput *>(raw_ao);
 
@@ -474,7 +474,7 @@ void PulseAudioSystem::read_callback(pa_stream *s, size_t bytes, void *userdata)
 	}
 
 	AudioInputPtr ai = g.ai;
-	PulseAudioInput *pai = dynamic_cast<PulseAudioInput *>(ai.data());
+	PulseAudioInput *pai = dynamic_cast<PulseAudioInput *>(ai.get());
 	if (! pai) {
 		if (length > 0) {
 			pa_stream_drop(s);
@@ -525,7 +525,7 @@ void PulseAudioSystem::write_callback(pa_stream *s, size_t bytes, void *userdata
 	Q_ASSERT(s == pas->pasOutput);
 
 	AudioOutputPtr ao = g.ao;
-	PulseAudioOutput *pao = dynamic_cast<PulseAudioOutput *>(ao.data());
+	PulseAudioOutput *pao = dynamic_cast<PulseAudioOutput *>(ao.get());
 
 	unsigned char buffer[bytes];
 


### PR DESCRIPTION
Two commits:

- Revert PR 2674.
- Add docs about the expected behavior of `AudioInput`/`AudioOutput` constructors/destructors and `Audio::start*()` and `Audio::stop*()` methods.

This fixes mumble-voip/mumble#2745