### PR TITLE
Allow hiding Muble from the menu without minimizing

### DIFF
--- a/src/mumble/MainWindow.cpp
+++ b/src/mumble/MainWindow.cpp
@@ -1216,6 +1216,7 @@ void MainWindow::on_qmServer_aboutToShow() {
 	qmServer->addAction(qaServerUserList);
 	qmServer->addAction(qaServerBanList);
 	qmServer->addSeparator();
+	qmServer->addAction(qaHide);
 	qmServer->addAction(qaQuit);
 
 	qaServerBanList->setEnabled(g.pPermissions & (ChanACL::Ban | ChanACL::Write));
@@ -1791,6 +1792,10 @@ void MainWindow::on_qaUserInformation_triggered() {
 		return;
 
 	g.sh->requestUserStats(p->uiSession, false);
+}
+
+void MainWindow::on_qaHide_triggered() {
+	hide();
 }
 
 void MainWindow::on_qaQuit_triggered() {

--- a/src/mumble/MainWindow.h
+++ b/src/mumble/MainWindow.h
@@ -239,6 +239,7 @@ class MainWindow : public QMainWindow, public MessageHandler, public Ui::MainWin
 		void on_qaHelpAboutQt_triggered();
 		void on_qaHelpVersionCheck_triggered();
 		void on_qaQuit_triggered();
+		void on_qaHide_triggered();
 		void on_qteChat_tabPressed();
 		void on_qteChat_backtabPressed();
 		void on_qteChat_ctrlSpacePressed();

--- a/src/mumble/MainWindow.ui
+++ b/src/mumble/MainWindow.ui
@@ -207,6 +207,17 @@
     <string>Ctrl+Q</string>
    </property>
   </action>
+  <action name="qaHide">
+   <property name="text">
+    <string>&amp;Hide Mumble</string>
+   </property>
+   <property name="toolTip">
+    <string>Hides the main Mumble window.</string>
+   </property>
+   <property name="whatsThis">
+    <string>Hides the main Mumble window. Restore by clicking on the tray icon or starting Mumble again.</string>
+   </property>
+  </action>
   <action name="qaServerConnect">
    <property name="icon">
     <iconset>


### PR DESCRIPTION
Add a new entry to the menu, allowing users to hide Mumble without minimizing it.

This is especially useful for users with a window manager that does not support minimizing windows, as these users were previously unable to hide Mumble. Mumble can (as always) be restored by clicking on the tray icon (if present) or starting Mumble again (without the --multiple switch). Fixes #2737.

A possible further change would be to change the "Minimize" option in the closing dialogue to "Hide", which I feel would be more appropriate in most cases. Also, a shortcut could be added to hide Mumble directly.