### PR TITLE
Murmur: set detach=false for -limits (implies -fg).

### DIFF
--- a/src/murmur/main.cpp
+++ b/src/murmur/main.cpp
@@ -349,6 +349,7 @@ int main(int argc, char **argv) {
 			       "default locations.", qPrintable(args.at(0)));
 #ifdef Q_OS_UNIX
 		} else if (arg == "-limits") {
+			detach = false;
 			Meta::mp.read(inifile);
 			unixhandler.setuid();
 			unixhandler.finalcap();


### PR DESCRIPTION
Without this, we delay the log messages from -limits
until we exit with a qFatal.

This isn't good, because -limits *can* fail in ways that
cause it to get stuck. One example of this is when Murmur
runs out of memory. This typically happens on 32-bit systems
during the test that counts the number of threads Murmur can
spawn, given the system's resource limits.

One such instance is if we reach the virtual memory limit on
i386. Then, QThread::start() will try to call pthread_create(),
which fails with EACCESS. (Insufficient resources, system-imposed
or otherwise). Qt doesn't handle this error situation, but
instead calls qWarning to make the user aware.

Without this change, we would never present this warning to
the user, because Murmur would be stuck.

With this change, the user can at least see the warning, to
know something has gone wrong.

Fixes mumble-voip/mumble#2752