### PR TITLE
plugins: Fix visibility, warnings and errors when compiled with MinGW

### DIFF
--- a/plugins/aoc/aoc.cpp
+++ b/plugins/aoc/aoc.cpp
@@ -92,7 +92,7 @@ static int fetch(float *avatar_pos, float *avatar_front, float *avatar_top, floa
 }
 
 static int trylock(const std::multimap<std::wstring, unsigned long long int> &pids) {
-	posptr = rotptr = NULL;
+	posptr = rotptr = 0;
 
 	if (! initialize(pids, L"hl2.exe", L"client.dll"))
 		return false;

--- a/plugins/arma2/arma2.cpp
+++ b/plugins/arma2/arma2.cpp
@@ -74,7 +74,7 @@ static int fetch(float *avatar_pos, float *avatar_front, float *avatar_top, floa
 }
 
 static int trylock(const std::multimap<std::wstring, unsigned long long int> &pids) {
-	posptr = NULL;
+	posptr = 0;
 
 	if (! initialize(pids, L"arma2.exe"))
 		return false;

--- a/plugins/bf1942/bf1942.cpp
+++ b/plugins/bf1942/bf1942.cpp
@@ -51,7 +51,7 @@ static int fetch(float *avatar_pos, float *avatar_front, float *avatar_top, floa
 }
 
 static int trylock(const std::multimap<std::wstring, unsigned long long int> &pids) {
-	faceptr = topptr = NULL;
+	faceptr = topptr = 0;
 
 	if (! initialize(pids, L"BF1942.exe"))
 		return false;

--- a/plugins/bf2/bf2.cpp
+++ b/plugins/bf2/bf2.cpp
@@ -26,7 +26,7 @@ procptr32_t const ipport_ptr = 0x009A80B8;
 procptr32_t commander_ptr, squad_leader_ptr, squad_state_ptr, team_state_ptr;
 
 inline bool resolve_ptrs() {
-	pos_ptr = face_ptr = top_ptr = commander_ptr = squad_leader_ptr = squad_state_ptr = team_state_ptr = NULL;
+	pos_ptr = face_ptr = top_ptr = commander_ptr = squad_leader_ptr = squad_state_ptr = team_state_ptr = 0;
 	//
 	// Resolve all pointer chains to the values we want to fetch
 	//

--- a/plugins/bf2142/bf2142.cpp
+++ b/plugins/bf2142/bf2142.cpp
@@ -61,7 +61,7 @@ static int fetch(float *avatar_pos, float *avatar_front, float *avatar_top, floa
 }
 
 static int trylock(const std::multimap<std::wstring, unsigned long long int> &pids) {
-	posptr = faceptr = topptr = NULL;
+	posptr = faceptr = topptr = 0;
 
 	if (! initialize(pids, L"BF2142.exe", L"BF2142Audio.dll"))
 		return false;

--- a/plugins/bf3/bf3.cpp
+++ b/plugins/bf3/bf3.cpp
@@ -71,7 +71,7 @@ enum state_values {
 };
 
 inline bool resolve_ptrs() {
-    team_state_ptr = squad_state_ptr = squad_lead_state_ptr = NULL;
+	team_state_ptr = squad_state_ptr = squad_lead_state_ptr = 0;
 
     /*
       Analysis for future patches:

--- a/plugins/bfheroes/bfheroes.cpp
+++ b/plugins/bfheroes/bfheroes.cpp
@@ -46,7 +46,7 @@ static int fetch(float *avatar_pos, float *avatar_front, float *avatar_top, floa
 }
 
 static int trylock(const std::multimap<std::wstring, unsigned long long int> &pids) {
-	posptr = faceptr = topptr = NULL;
+	posptr = faceptr = topptr = 0;
 
 	if (! initialize(pids, L"BFHeroes.exe", L"BFAudio.dll"))
 		return false;

--- a/plugins/blacklight/blacklight.cpp
+++ b/plugins/blacklight/blacklight.cpp
@@ -75,7 +75,7 @@ static bool calcout(float *cam, float *camfront, float *camtop, float *ocam, flo
 }
 
 static bool refreshPointers(void) {
-	hostipportptr = NULL;
+	hostipportptr = 0;
 
 	hostipportptr = pModule + 0xB8C57;
 

--- a/plugins/borderlands/borderlands.cpp
+++ b/plugins/borderlands/borderlands.cpp
@@ -127,7 +127,7 @@ static int fetch(float *avatar_pos, float *avatar_front, float *avatar_top, floa
 }
 
 static int trylock(const std::multimap<std::wstring, unsigned long long int> &pids) {
-	posptr = frontptr = topptr = contextptraddress = stateaddress = loginaddress = NULL;
+	posptr = frontptr = topptr = contextptraddress = stateaddress = loginaddress = 0;
 
 	if (!initialize(pids, L"Borderlands.exe"))
 		return false;

--- a/plugins/breach/breach.cpp
+++ b/plugins/breach/breach.cpp
@@ -75,7 +75,7 @@ static int fetch(float *avatar_pos, float *avatar_front, float *avatar_top, floa
 }
 
 static int trylock(const std::multimap<std::wstring, unsigned long long int> &pids) {
-	posptr = frontptr = topptr = NULL;
+	posptr = frontptr = topptr = 0;
 
 	if (! initialize(pids, L"Breach.exe", L"fmodex.dll"))
 		return false;

--- a/plugins/dys/dys.cpp
+++ b/plugins/dys/dys.cpp
@@ -92,7 +92,7 @@ static int fetch(float *avatar_pos, float *avatar_front, float *avatar_top, floa
 }
 
 static int trylock(const std::multimap<std::wstring, unsigned long long int> &pids) {
-	posptr = rotptr = NULL;
+	posptr = rotptr = 0;
 
 	if (! initialize(pids, L"hl2.exe", L"client.dll"))
 		return false;

--- a/plugins/etqw/etqw.cpp
+++ b/plugins/etqw/etqw.cpp
@@ -95,7 +95,7 @@ static int fetch(float *avatar_pos, float *avatar_front, float *avatar_top, floa
 }
 
 static int trylock(const std::multimap<std::wstring, unsigned long long int> &pids) {
-	pos1ptr = pos2ptr = pos3ptr = rot1ptr = rot2ptr = NULL;
+	pos1ptr = pos2ptr = pos3ptr = rot1ptr = rot2ptr = 0;
 
 	if (! initialize(pids, L"etqw.exe", L"gamex86.dll"))
 		return false;

--- a/plugins/gmod/gmod.cpp
+++ b/plugins/gmod/gmod.cpp
@@ -86,7 +86,7 @@ static int fetch(float *avatar_pos, float *avatar_front, float *avatar_top, floa
 }
 
 static int trylock(const std::multimap<std::wstring, unsigned long long int> &pids) {
-	posptr = rotptr = NULL;
+	posptr = rotptr = 0;
 
 	if (! initialize(pids, L"hl2.exe", L"client.dll"))
 		return false;

--- a/plugins/gw/gw.cpp
+++ b/plugins/gw/gw.cpp
@@ -112,7 +112,7 @@ static bool calcout(float *pos, float *front, float *cam, float *camfront, float
 
 static bool refreshPointers(void)
 {
-	frontptr = NULL;
+	frontptr = 0;
 
 	frontptr = peekProc<procptr32_t>(frontptr_);
 	if (!frontptr)

--- a/plugins/insurgency/insurgency.cpp
+++ b/plugins/insurgency/insurgency.cpp
@@ -92,7 +92,7 @@ static int fetch(float *avatar_pos, float *avatar_front, float *avatar_top, floa
 }
 
 static int trylock(const std::multimap<std::wstring, unsigned long long int> &pids) {
-	posptr = rotptr = NULL;
+	posptr = rotptr = 0;
 
 	if (! initialize(pids, L"hl2.exe", L"client.dll"))
 		return false;

--- a/plugins/lol/lol.cpp
+++ b/plugins/lol/lol.cpp
@@ -81,7 +81,7 @@ static bool calcout(float *pos, float *cam, float *opos, float *ocam) {
 }
 
 static bool refreshPointers(void) {
-	posptr = afrontptr = tmpptr = NULL;
+	posptr = afrontptr = tmpptr = 0;
 	
 	// Avatar front vector pointer
 	tmpptr = peekProc<procptr32_t>(gameptr);

--- a/plugins/mumble_plugin.h
+++ b/plugins/mumble_plugin.h
@@ -11,14 +11,18 @@
 
 #if defined(_MSC_VER)
 # define MUMBLE_PLUGIN_CALLING_CONVENTION __cdecl
+#elif defined(__MINGW32__)
+# define MUMBLE_PLUGIN_CALLING_CONVENTION __attribute__((cdecl))
 #else
 # define MUMBLE_PLUGIN_CALLING_CONVENTION
 #endif
 
-#if defined(__GNUC__)
+#if defined(__GNUC__) && !defined(__MINGW32__) // GCC on Unix-like systems
 # define MUMBLE_PLUGIN_EXPORT __attribute__((visibility("default")))
 #elif defined(_MSC_VER)
 # define MUMBLE_PLUGIN_EXPORT __declspec(dllexport)
+#elif defined(__MINGW32__)
+# define MUMBLE_PLUGIN_EXPORT __attribute__((dllexport))
 #else
 # error No MUMBLE_PLUGIN_EXPORT definition available
 #endif

--- a/plugins/mumble_plugin_win32_ptr_type.h
+++ b/plugins/mumble_plugin_win32_ptr_type.h
@@ -50,7 +50,7 @@ static inline DWORD getProcess(const wchar_t *exename) {
 
 static inline PTR_TYPE_CONCRETE getModuleAddr(DWORD pid, const wchar_t *modname) {
 	MODULEENTRY32 me;
-	PTR_TYPE_CONCRETE ret = NULL;
+	PTR_TYPE_CONCRETE ret = 0;
 	me.dwSize = sizeof(me);
 	HANDLE hSnap = CreateToolhelp32Snapshot(TH32CS_SNAPMODULE|TH32CS_SNAPMODULE32, pid);
 	if (hSnap != INVALID_HANDLE_VALUE) {
@@ -97,7 +97,7 @@ T peekProc(PTR_TYPE base) {
 
 static bool inline initialize(const std::multimap<std::wstring, unsigned long long int> &pids, const wchar_t *procname, const wchar_t *modname = NULL) {
 	hProcess = NULL;
-	pModule = NULL;
+	pModule = 0;
 
 	if (! pids.empty()) {
 		std::multimap<std::wstring, unsigned long long int>::const_iterator iter = pids.find(std::wstring(procname));
@@ -122,7 +122,7 @@ static bool inline initialize(const std::multimap<std::wstring, unsigned long lo
 	hProcess=OpenProcess(PROCESS_VM_READ, false, dwPid);
 	if (!hProcess) {
 		dwPid = 0;
-		pModule = NULL;
+		pModule = 0;
 		return false;
 	}
 
@@ -133,7 +133,7 @@ static void generic_unlock() {
 	if (hProcess) {
 		CloseHandle(hProcess);
 		hProcess = NULL;
-		pModule = NULL;
+		pModule = 0;
 		dwPid = 0;
 	}
 }

--- a/plugins/ql/ql.cpp
+++ b/plugins/ql/ql.cpp
@@ -84,7 +84,7 @@ static int fetch(float *avatar_pos, float *avatar_front, float *avatar_top, floa
 	}
 
 	// Team
-	if (team >= 0 && team <= 3) {
+	if (team <= 3) {
 		if (team == 0)
 			oidentity << std::endl << "\"Team\": \"FFA\""; // If team value is 0, set "FFA" as team in identity.
 		if (team == 1)

--- a/plugins/sto/sto.cpp
+++ b/plugins/sto/sto.cpp
@@ -3,7 +3,8 @@
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.
 
-#include "../mumble_plugin_win32_32bit.h"
+#include "../mumble_plugin_win32_32bit.h" // Include standard plugin header.
+#include <limits> // Include limits header for the "u8" function.
 
 static procptr32_t identptr, contextptr, posptr;
 
@@ -70,7 +71,7 @@ static int fetch(float *avatar_pos, float *avatar_front, float *avatar_top, floa
 }
 
 static int trylock(const std::multimap<std::wstring, unsigned long long int> &pids) {
-	identptr = contextptr = posptr = NULL;
+	identptr = contextptr = posptr = 0;
 
 	if (! initialize(pids, L"GameClient.exe"))
 		return false;

--- a/plugins/ut2004/ut2004.cpp
+++ b/plugins/ut2004/ut2004.cpp
@@ -62,7 +62,7 @@ static int fetch(float *avatar_pos, float *avatar_front, float *avatar_top, floa
 }
 
 static int trylock(const std::multimap<std::wstring, unsigned long long int> &pids) {
-	pos0ptr = pos1ptr = pos2ptr = faceptr = topptr = NULL;
+	pos0ptr = pos1ptr = pos2ptr = faceptr = topptr = 0;
 
 	if (! initialize(pids, L"UT2004.exe", L"Engine.dll"))
 		return false;

--- a/plugins/ut3/ut3.cpp
+++ b/plugins/ut3/ut3.cpp
@@ -85,7 +85,7 @@ static int fetch(float *avatar_pos, float *avatar_front, float *avatar_top, floa
 }
 
 static int trylock(const std::multimap<std::wstring, unsigned long long int> &pids) {
-	pos0ptr = pos1ptr = pos2ptr = faceptr = NULL;
+	pos0ptr = pos1ptr = pos2ptr = faceptr = 0;
 
 	if (! initialize(pids, L"UT3.exe", L"wrap_oal.dll"))
 		return false;


### PR DESCRIPTION
```
warning: converting to non-pointer type 'procptr32_t {aka long unsigned int}' from NULL [-Wconversion-null]`
```
```
ql\ql.cpp:87: warning: comparison is always true due to limited range of data type [-Wtype-limits]
  if (team >= 0 && team <= 3) {
```
```
sto\sto.cpp:11: error: 'numeric_limits' is not a member of 'std'
  if (src.length() > static_cast<size_t>(std::numeric_limits<int>::max())) {
```

Not fixed:
```
sto\sto.cpp:55: warning: dereferencing type-punned pointer will break strict-aliasing rules [-Wstrict-aliasing]
  if (* reinterpret_cast<DWORD *>(& posblock[52]) == 1) {
```