### PR TITLE
main.pro: fix-ups for "no-overlay" CONFIG option on Windows

### DIFF
--- a/main.pro
+++ b/main.pro
@@ -52,14 +52,15 @@ SUBDIRS *= src/mumble_proto
     SUBDIRS *= plugins
   }
 
-  win32 {
+  win32:!CONFIG(no-overlay) {
     SUBDIRS *= overlay
     SUBDIRS *= overlay/overlay_exe
     SUBDIRS *= overlay_winx64
     SUBDIRS *= overlay_winx64/overlay_exe_winx64
-    !CONFIG(no-g15) {
-      SUBDIRS *= g15helper
-    }
+  }
+
+  win32:!CONFIG(no-g15) {
+    SUBDIRS *= g15helper
   }
 
   contains(UNAME, OpenBSD) {

--- a/main.pro
+++ b/main.pro
@@ -66,7 +66,7 @@ SUBDIRS *= src/mumble_proto
     CONFIG *= no-overlay
   }
 
-  !CONFIG(no-overlay) {
+  unix:!macx:!CONFIG(no-overlay) {
     SUBDIRS *= overlay_gl
   }
 


### PR DESCRIPTION
The option currently works only on Linux, since there was no need in Windows, until now.
During a MinGW build test we noticed that minhook can be compiled only with MSVC, for various macros and probably other things.