### PR TITLE
Update QSslDiffieHellmanParameters API calls to final Qt 5.8 API

### DIFF
--- a/src/murmur/Cert.cpp
+++ b/src/murmur/Cert.cpp
@@ -112,7 +112,7 @@ void Server::initializeCert() {
 
 #if defined(USE_QSSLDIFFIEHELLMANPARAMETERS)
 	if (! dhparams.isEmpty()) {
-		QSslDiffieHellmanParameters qdhp = QSslDiffieHellmanParameters(dhparams);
+		QSslDiffieHellmanParameters qdhp = QSslDiffieHellmanParameters::fromEncoded(dhparams);
 		if (qdhp.isValid()) {
 			qsdhpDHParams = qdhp;
 		} else {
@@ -242,7 +242,7 @@ void Server::initializeCert() {
 		}
 
 		QByteArray pemdh(pem, len);
-		QSslDiffieHellmanParameters qdhp(pemdh);
+		QSslDiffieHellmanParameters qdhp = QSslDiffieHellmanParameters::fromEncoded(pemdh);
 		if (!qdhp.isValid()) {
 			qFatal("QSslDiffieHellmanParameters: unable to import generated Diffie-HellmanParameters: %s", qdhp.errorString().toStdString().c_str());
 		}

--- a/src/murmur/Meta.cpp
+++ b/src/murmur/Meta.cpp
@@ -449,7 +449,7 @@ void MetaParams::read(QString fname) {
 	}
 
 	if (! dhparams.isEmpty()) {
-		QSslDiffieHellmanParameters qdhp = QSslDiffieHellmanParameters(dhparams);
+		QSslDiffieHellmanParameters qdhp = QSslDiffieHellmanParameters::fromEncoded(dhparams);
 		if (qdhp.isValid()) {
 			qbaDHParams = dhparams;
 		} else {

--- a/src/murmur/murmur.pro
+++ b/src/murmur/murmur.pro
@@ -199,14 +199,7 @@ bonjour {
 #
 # Can be disabled with no-qssldiffiehellmanparameters.
 !CONFIG(no-qssldiffiehellmanparameters):exists($$[QT_INSTALL_HEADERS]/QtNetwork/QSslDiffieHellmanParameters) {
-	# ...but only if we're inside a Mumble build environment for now.
-	# If someone decides to put a Mumble snapshot into a distro, this
-	# could break the build in the future, with newer versions of Qt,
-	# if the API of QSslDiffieHellmanParameters changes when it is
-	# upstreamed.
-	CONFIG(buildenv) {
-		DEFINES += USE_QSSLDIFFIEHELLMANPARAMETERS
-	}
+	DEFINES += USE_QSSLDIFFIEHELLMANPARAMETERS
 }
 
 include(../../symbols.pri)


### PR DESCRIPTION
This consists of two changes:

 - First, ensure we use the final API throughout Murmur.
 - Second, allow QSslDiffieHellmanParameters usage without being in a Mumble buildenv
   This allows Murmur to use QSslDiffieHellmanParameters on stock Qt installations.