### PR TITLE
main.pro: don't build minhook if "no-overlay" option specified

### DIFF
--- a/main.pro
+++ b/main.pro
@@ -39,7 +39,6 @@ SUBDIRS *= src/mumble_proto
 
   win32 {
     SUBDIRS *= 3rdparty/xinputcheck-build
-    SUBDIRS *= 3rdparty/minhook-build
   }
 
   SUBDIRS *= src/mumble
@@ -53,6 +52,7 @@ SUBDIRS *= src/mumble_proto
   }
 
   win32:!CONFIG(no-overlay) {
+    SUBDIRS *= 3rdparty/minhook-build
     SUBDIRS *= overlay
     SUBDIRS *= overlay/overlay_exe
     SUBDIRS *= overlay_winx64


### PR DESCRIPTION
We use minhook only for the overlay. Therefore, If the option "no-overlay" is present, we shouldn't build it.