### PR TITLE
MainWindow: don't include 'Hide Mumble' menu item on macOS.

### DIFF
--- a/src/mumble/MainWindow.cpp
+++ b/src/mumble/MainWindow.cpp
@@ -1216,7 +1216,12 @@ void MainWindow::on_qmServer_aboutToShow() {
 	qmServer->addAction(qaServerUserList);
 	qmServer->addAction(qaServerBanList);
 	qmServer->addSeparator();
+#if !defined(Q_OS_MAC)
+	// Don't add qaHide on macOS.
+	// There is no way to bring the window back (no 'tray' for Mumble on macOS),
+	// and the system has built-in hide functionality via Cmd-H.
 	qmServer->addAction(qaHide);
+#endif
 	qmServer->addAction(qaQuit);
 
 	qaServerBanList->setEnabled(g.pPermissions & (ChanACL::Ban | ChanACL::Write));


### PR DESCRIPTION
It is unnecessary (the system has window-hiding built-in) and
can get us in a state where the window can't be shown again.

Easier just to leave it out.