### PR TITLE
mumble.pro: use forward slash for GENQRC also on Windows

### DIFF
--- a/src/mumble/mumble.pro
+++ b/src/mumble/mumble.pro
@@ -643,9 +643,6 @@ CONFIG(no-update) {
 		}
 	}
 	GENQRC = $$PYTHON ../../scripts/generate-mumble_qt-qrc.py
-	win32 {
-		GENQRC = $$PYTHON ..\\..\\scripts\\generate-mumble_qt-qrc.py
-	}
 	!system($$GENQRC mumble_qt_auto.qrc $$[QT_INSTALL_TRANSLATIONS] $$QT_TRANSLATIONS_FALLBACK_DIR) {
 		error(Failed to run generate-mumble_qt-qrc.py script)
 	}


### PR DESCRIPTION
This fixes a problem with MinGW on Linux where the "win32" block is triggered and the two backslashes are used, resulting in a path without slashes.
Python on Windows handles the path correctly with both methods.