### PR TITLE
Use forward slash for paths in .rc files

### DIFF
--- a/g15helper/g15helper.rc
+++ b/g15helper/g15helper.rc
@@ -5,7 +5,7 @@
 
 #include <winver.h>
 
-IDI_ICON1               ICON    DISCARDABLE     "..\\icons\\g15helper.ico"
+IDI_ICON1               ICON    DISCARDABLE     "../icons/g15helper.ico"
 
 #ifndef DEBUG
 #define VER_DEBUG                   0L

--- a/src/mumble/mumble.rc
+++ b/src/mumble/mumble.rc
@@ -5,7 +5,7 @@
 
 #include <winver.h>
 
-IDI_ICON1               ICON    DISCARDABLE     "..\\..\\icons\\mumble.ico"
+IDI_ICON1               ICON    DISCARDABLE     "../../icons/mumble.ico"
 
 #ifndef DEBUG
 #define VER_DEBUG                   0L

--- a/src/murmur/murmur.rc
+++ b/src/murmur/murmur.rc
@@ -5,7 +5,7 @@
 
 #include <winver.h>
 
-IDI_ICON1               ICON    DISCARDABLE     "..\\..\\icons\\murmur.ico"
+IDI_ICON1               ICON    DISCARDABLE     "../../icons/murmur.ico"
 
 #ifndef DEBUG
 #define VER_DEBUG                   0L


### PR DESCRIPTION
This fixes a problem with MinGW on Linux where it can't find the icon file, because of the backslashes.
Windows handles the path correctly with both methods.