### PR TITLE
mumble_pch.hpp: Change header name capitalization for MinGW on Linux

### DIFF
--- a/src/mumble/mumble_pch.hpp
+++ b/src/mumble/mumble_pch.hpp
@@ -87,8 +87,8 @@
 #include <winsock2.h>
 #include <qos2.h>
 #include <wintrust.h>
-#include <Softpub.h>
-#include <Dbt.h>
+#include <softpub.h>
+#include <dbt.h>
 #include <delayimp.h>
 #include <shlobj.h>
 #include <tlhelp32.h>


### PR DESCRIPTION
This fixes a problem with MinGW on Linux where it can't find "Softpub.h" and "Dbt.h".