### PR TITLE
rcc.pri: Fix script path for MinGW on Linux

### DIFF
--- a/rcc.pri
+++ b/rcc.pri
@@ -13,6 +13,9 @@
 # We have to do this because we're loading the
 # 'resources' feature a bit earlier than usual.
 # By default, Qt would have set these itself.
+
+include(python.pri)
+
 CONFIG(debug, debug|release) {
 	RCC_DIR = debug
 }
@@ -22,11 +25,5 @@ CONFIG(release, debug|release) {
 
 load(resources)
 
-win32 {
-	WINPWD = $$shell_path($${PWD})
-	RCC_DEPENDS = $$escape_expand(\")$${WINPWD}\\scripts\\rcc-depends.py$$escape_expand(\")
-	rcc.depend_command = python $${RCC_DEPENDS} ${QMAKE_FILE_IN}
-} else {
-	RCC_DEPENDS = $$escape_expand(\")$${PWD}/scripts/rcc-depends.py$$escape_expand(\")
-	rcc.depend_command = $${RCC_DEPENDS} ${QMAKE_FILE_IN}
-}
+RCC_DEPENDS = $$escape_expand(\")$${PWD}/scripts/rcc-depends.py$$escape_expand(\")
+rcc.depend_command = $${PYTHON} $${RCC_DEPENDS} ${QMAKE_FILE_IN}


### PR DESCRIPTION
This fixes a problem with MinGW on Linux where it can't find the script file, because of the backslashes.
Windows handles the path correctly with both methods.