### PR TITLE
WASAPI.h: Change header name capitalization for MinGW on Linux

### DIFF
--- a/src/mumble/WASAPI.h
+++ b/src/mumble/WASAPI.h
@@ -19,7 +19,7 @@
 #include <functiondiscoverykeys.h>
 #include <propidl.h>
 #include <initguid.h>
-#include <Audiopolicy.h>
+#include <audiopolicy.h>
 
 #include "AudioInput.h"
 #include "AudioOutput.h"


### PR DESCRIPTION
This fixes a problem with MinGW on Linux where it can't find "Audiopolicy.h".