### PR TITLE
WASAPI.h: Include missing header for MinGW on Linux

### DIFF
--- a/src/mumble/WASAPI.h
+++ b/src/mumble/WASAPI.h
@@ -17,6 +17,7 @@
 #include <audioclient.h>
 #include <ksmedia.h>
 #include <functiondiscoverykeys.h>
+#include <functiondiscoverykeys_devpkey.h>
 #include <propidl.h>
 #include <initguid.h>
 #include <Audiopolicy.h>


### PR DESCRIPTION
This fixes an error when compiling with MinGW on Linux.
```
error: 'PKEY_Device_FriendlyName' was not declared in this scope
```