### PR TITLE
installer: use "vcruntime140.dll" instead of "msvcr140.dll" for vcruntime140.dll's component ID.

### DIFF
--- a/installer/Files.wxs
+++ b/installer/Files.wxs
@@ -70,7 +70,7 @@
       <Component Id="msvcp140.dll">
         <File Source="$(var.RedistDirVC14)\msvcp140.dll" KeyPath="yes" />
       </Component>
-      <Component Id="msvcr140.dll">
+      <Component Id="vcruntime140.dll">
         <File Source="$(var.RedistDirVC14)\vcruntime140.dll" KeyPath="yes" />
       </Component>
       <?endif ?>


### PR DESCRIPTION
I accidently neglected to rename this to the new name in MSVC2015.
The "msvcr" file is now "vcruntime".