### PR TITLE
AudioInput: limit echo canceller queue to 1 second of audio.

### DIFF
--- a/src/mumble/AudioInput.cpp
+++ b/src/mumble/AudioInput.cpp
@@ -384,6 +384,17 @@ void AudioInput::addMic(const void *data, unsigned int nsamp) {
 					if (qlEchoFrames.isEmpty()) {
 						iJitterSeq = 0;
 						iMinBuffered = 1000;
+					} else if (qlEchoFrames.count() >= 100) {
+						// Declare buffer bankruptcy. More than 1 second of buffered echo frames.
+
+						foreach(short *buf, qlEchoFrames)
+							delete [] buf;
+						qlEchoFrames.clear();
+
+						iJitterSeq = 0;
+						iMinBuffered = 1000;
+
+						qWarning("AudioInput: echo buffer overrun: resetting echo canceller state");
 					} else {
 						// Compensate for drift between the microphone and the echo source
 						iMinBuffered = qMin(iMinBuffered, qlEchoFrames.count());


### PR DESCRIPTION
This sets an upper bound on the echo canceller's queue to avoid
situations like mumble-voip/mumble#1074 where a bug in PulseAudio
causes our echo queue to grow unbounded.

This fixes the memory leak aspect of mumble-voip/#1074, but echo
cancellation will be flakey in such setups.

We don't know if there is a workaround for the PulseAudio bug, so
let us do this for now.