### PR TITLE
WIP: Implement Animated Gif Support

### DIFF
--- a/src/mumble/CustomElements.cpp
+++ b/src/mumble/CustomElements.cpp
@@ -96,6 +96,12 @@ void LogTextBrowser::animationFrameUpdated(const QRect &) {
 	// Need to send event or else the image will not be redrawn.
 	QEvent *e = new QEvent(QEvent::FontChange);
 	QApplication::postEvent(this, e);
+
+//TODO: Can we improve performance by invalidating only the element?
+//      And only if it is visible?
+//	doc->setModified(true); // Only this did not work
+//	doc->markContentsDirty()
+	// Get text block, ->setRevision()
 }
 
 

--- a/src/mumble/CustomElements.cpp
+++ b/src/mumble/CustomElements.cpp
@@ -44,42 +44,39 @@ void LogTextBrowser::scrollLogToBottom() {
 }
 
 void LogTextBrowser::mouseMoveEvent(QMouseEvent *e) {
-	do {
-		QTextCursor cursor = cursorForPosition(e->pos());
-		QTextCharFormat fmt = cursor.charFormat();
-		if (fmt.objectType() == QTextFormat::NoObject) {
-			cursor.movePosition(QTextCursor::NextCharacter);
-			fmt = cursor.charFormat();
-		}
-		if (!fmt.isImageFormat()) {
-			if (qmActiveAnimation) {
-				qmActiveAnimation->setPaused(true);
-				qmActiveAnimation = 0;
-			}
-			break;
-		}
+	QTextCursor cursor = cursorForPosition(e->pos());
+	QTextCharFormat fmt = cursor.charFormat();
+
+	if (fmt.objectType() == QTextFormat::NoObject) {
+		cursor.movePosition(QTextCursor::NextCharacter);
+		fmt = cursor.charFormat();
+	}
+
+	QMovie *movie = NULL;
+	if (fmt.isImageFormat()) {
 		QString name = fmt.toImageFormat().name();
 		LogDocument *doc = qobject_cast<LogDocument *>(document());
-		QMovie *movie = doc->qhAnimations.value(name);
-		if (!movie) {
-			if (qmActiveAnimation) {
-				qmActiveAnimation->setPaused(true);
-				qmActiveAnimation = 0;
-			}
-			break;
-		}
-		if (movie == qmActiveAnimation) {
-			break;
-		}
-		if (qmActiveAnimation) {
-			qmActiveAnimation->setPaused(true);
-			qmActiveAnimation = 0;
-		}
-		movie->setPaused(false);
-		qmActiveAnimation = movie;
-	} while(false);
+		movie = doc->qhAnimations.value(name);
+	}
+	setPlayingAnimation(movie);
 
 	QTextBrowser::mouseMoveEvent(e);
+}
+
+void LogTextBrowser::setPlayingAnimation(QMovie *movie) {
+	if (movie == qmActiveAnimation) {
+		return;
+	}
+
+	if (qmActiveAnimation) {
+		qmActiveAnimation->setPaused(true);
+		qmActiveAnimation = 0;
+	}
+
+	if (movie) {
+		movie->setPaused(false);
+		qmActiveAnimation = movie;
+	}
 }
 
 void LogTextBrowser::animationFrameUpdated(const QRect &) {

--- a/src/mumble/CustomElements.cpp
+++ b/src/mumble/CustomElements.cpp
@@ -71,6 +71,10 @@ void LogTextBrowser::mouseMoveEvent(QMouseEvent *e) {
 		if (movie == qmActiveAnimation) {
 			break;
 		}
+		if (qmActiveAnimation) {
+			qmActiveAnimation->setPaused(true);
+			qmActiveAnimation = 0;
+		}
 		movie->setPaused(false);
 		qmActiveAnimation = movie;
 	} while(false);

--- a/src/mumble/CustomElements.cpp
+++ b/src/mumble/CustomElements.cpp
@@ -47,6 +47,13 @@ void LogTextBrowser::mouseMoveEvent(QMouseEvent *e) {
 	QTextCursor cursor = cursorForPosition(e->pos());
 	QTextCharFormat fmt = cursor.charFormat();
 
+	// Work around imprecise cursor image identification
+	// Apparently, the cursor is shifted half the characters width to the right on the image
+	// element. This is in contrast to hyperlinks for example, which have correct edge detection.
+	// For the image, we get the right half (plus the left half of the next character) for the
+	// image, and have to move the cursor forward to also detect on the left half of the image
+	// (plus the right half of the previous character).
+	// I do not know why we have to use NextCharacter and not PreviousCharacter.
 	if (fmt.objectType() == QTextFormat::NoObject) {
 		cursor.movePosition(QTextCursor::NextCharacter);
 		fmt = cursor.charFormat();

--- a/src/mumble/CustomElements.h
+++ b/src/mumble/CustomElements.h
@@ -18,13 +18,18 @@
 # include <QtGui/QTextEdit>
 #endif
 
+#include <QMovie>
+
 class LogTextBrowser : public QTextBrowser {
 	private:
 		Q_OBJECT
 		Q_DISABLE_COPY(LogTextBrowser)
+
+		QMovie *qmActiveAnimation;
 	protected:
 		void resizeEvent(QResizeEvent *e) Q_DECL_OVERRIDE;
 		bool event(QEvent *e) Q_DECL_OVERRIDE;
+		void mouseMoveEvent(QMouseEvent *e) Q_DECL_OVERRIDE;
 	public:
 		LogTextBrowser(QWidget *p = NULL);
 
@@ -32,6 +37,8 @@ class LogTextBrowser : public QTextBrowser {
 		int getLogScrollMaximum();
 		void setLogScroll(int scroll_pos);
 		void scrollLogToBottom();
+	public slots:
+		void animationFrameUpdated(const QRect &);
 };
 
 class ChatbarTextEdit : public QTextEdit {

--- a/src/mumble/CustomElements.h
+++ b/src/mumble/CustomElements.h
@@ -30,6 +30,7 @@ class LogTextBrowser : public QTextBrowser {
 		void resizeEvent(QResizeEvent *e) Q_DECL_OVERRIDE;
 		bool event(QEvent *e) Q_DECL_OVERRIDE;
 		void mouseMoveEvent(QMouseEvent *e) Q_DECL_OVERRIDE;
+		void setPlayingAnimation(QMovie *movie=NULL);
 	public:
 		LogTextBrowser(QWidget *p = NULL);
 

--- a/src/mumble/CustomElements.h
+++ b/src/mumble/CustomElements.h
@@ -12,13 +12,13 @@
 # include <QtWidgets/QLabel>
 # include <QtWidgets/QTextBrowser>
 # include <QtWidgets/QTextEdit>
+# include <QtGui/QMovie>
 #else
 # include <QtGui/QLabel>
 # include <QtGui/QTextBrowser>
 # include <QtGui/QTextEdit>
 #endif
 
-#include <QMovie>
 
 class LogTextBrowser : public QTextBrowser {
 	private:

--- a/src/mumble/Log.cpp
+++ b/src/mumble/Log.cpp
@@ -708,7 +708,6 @@ void LogDocument::finished() {
 						buffer->setData(ba);
 						buffer->open(QIODevice::ReadOnly);
 						animation->setDevice(buffer);
-						animation->setPaused(true);
 
 						qhAnimations[name.toString()] = animation;
 						connect(animation, SIGNAL(updated(const QRect&)), ltb, SLOT(animationFrameUpdated(const QRect&)));

--- a/src/mumble/Log.cpp
+++ b/src/mumble/Log.cpp
@@ -696,7 +696,23 @@ void LogDocument::finished() {
 					ok = (qi.width() <= g.s.iMaxImageWidth && qi.height() <= g.s.iMaxImageHeight);
 				}
 				if (ok) {
-					addResource(QTextDocument::ImageResource, rep->request().url(), qi);
+					const QUrl &name = rep->request().url();
+					addResource(QTextDocument::ImageResource, name, qi);
+
+					LogTextBrowser *ltb = qobject_cast<LogTextBrowser *>(this->parent());
+					if (ltb && fmt == QByteArray("gif")) {
+						// Currently, only animations inside of a LogTextBrowser is
+						// supported.
+						QMovie *animation = new QMovie(this);
+						QBuffer *buffer = new QBuffer(animation);
+						buffer->setData(ba);
+						buffer->open(QIODevice::ReadOnly);
+						animation->setDevice(buffer);
+						animation->setPaused(true);
+
+						qhAnimations[name.toString()] = animation;
+						connect(animation, SIGNAL(updated(const QRect&)), ltb, SLOT(animationFrameUpdated(const QRect&)));
+					}
 
 					// Force a re-layout of the QTextEdit the next
 					// time we enter the event loop.

--- a/src/mumble/Log.h
+++ b/src/mumble/Log.h
@@ -9,6 +9,7 @@
 #include <QtCore/QDate>
 #include <QtGui/QTextCursor>
 #include <QtGui/QTextDocument>
+#include <QMovie>
 
 #include "ConfigDialog.h"
 #include "ui_Log.h"
@@ -88,6 +89,7 @@ class LogDocument : public QTextDocument {
 		void setAllowHTTPResources(bool allowHttpResources);
 		void setOnlyLoadDataURLs(bool onlyLoadDataURLs);
 		bool isValid();
+		QHash<QString, QMovie *> qhAnimations;
 	public slots:
 		void receivedHead();
 		void finished();

--- a/src/mumble/Log.h
+++ b/src/mumble/Log.h
@@ -9,7 +9,7 @@
 #include <QtCore/QDate>
 #include <QtGui/QTextCursor>
 #include <QtGui/QTextDocument>
-#include <QMovie>
+#include <QtGui/QMovie>
 
 #include "ConfigDialog.h"
 #include "ui_Log.h"

--- a/src/mumble/MainWindow.cpp
+++ b/src/mumble/MainWindow.cpp
@@ -3154,7 +3154,7 @@ void MainWindow::context_triggered() {
 QPair<QByteArray, QImage> MainWindow::openImageFile() {
 	QPair<QByteArray, QImage> retval;
 
-	QString fname = QFileDialog::getOpenFileName(this, tr("Choose image file"), getImagePath(), tr("Images (*.png *.jpg *.jpeg)"));
+	QString fname = QFileDialog::getOpenFileName(this, tr("Choose image file"), getImagePath(), tr("Images (*.png *.jpg *.jpeg *.gif)"));
 
 	if (fname.isNull())
 		return retval;

--- a/src/mumble/MainWindow.cpp
+++ b/src/mumble/MainWindow.cpp
@@ -715,6 +715,14 @@ void MainWindow::on_qteLog_customContextMenuRequested(const QPoint &mpos) {
 
 	QTextCursor cursor = qteLog->cursorForPosition(mpos);
 	QTextCharFormat fmt = cursor.charFormat();
+
+	// Work around imprecise cursor image identification
+	// Apparently, the cursor is shifted half the characters width to the right on the image
+	// element. This is in contrast to hyperlinks for example, which have correct edge detection.
+	// For the image, we get the right half (plus the left half of the next character) for the
+	// image, and have to move the cursor forward to also detect on the left half of the image
+	// (plus the right half of the previous character).
+	// I do not know why we have to use NextCharacter and not PreviousCharacter.
 	if (fmt.objectType() == QTextFormat::NoObject) {
 		cursor.movePosition(QTextCursor::NextCharacter);
 		fmt = cursor.charFormat();


### PR DESCRIPTION
This PR replaces #1992 to implement #1698. The basic animated displaying works, but there are still open issues:

- [ ] Saving a gif image from log does not work
- [ ] Image continues to play when moving outside of the log view to the left or right if there is no character/element before/after the image (we have no mouseMoveEvent to handle)
- [ ] We relayout the entire log content on every frame (FontChangeEvent)
- [ ] The animation does not play in the send message dialogue
- [ ] The same image added to the log will play on all instances when one of them is hovered

The log view extends [`QTextBrowser`](http://doc.qt.io/qt-5/qtextbrowser.html), which uses a [`QTextDocument`](http://doc.qt.io/Qt-5/qtextdocument.html). This is for [rich text](http://doc.qt.io/qt-5/richtext.html), including hyperlinks and (unanimated) images. Images are handled through a special replacement character, and a resource cache, in which the image data is stored and then displayed in place of the placeholder.

As there is no native support for animated images, we use [`QMovie`](http://doc.qt.io/qt-5/qmovie.html) to play the animation and put every frame into the resource buffer, replacing the image, and we then trigger a redraw through the `QEvent::FontChange` event (complete redraw).

The complete relayout/redraw is a big performance hit for just displaying an image - probably unacceptable.

(Honestly, I think this implementation is only half of what we want. There has been a lot of movement towards using no-audio video files instead of gifs due to their superior compression for anything that could be a gif. This is [not supported by QMovie/QImageReader](http://doc.qt.io/qt-4.8/qimagereader.html#supportedImageFormats) though.)