### PR TITLE
Document workaround in LogTextBrowser

### DIFF
--- a/src/mumble/MainWindow.cpp
+++ b/src/mumble/MainWindow.cpp
@@ -715,6 +715,14 @@ void MainWindow::on_qteLog_customContextMenuRequested(const QPoint &mpos) {
 
 	QTextCursor cursor = qteLog->cursorForPosition(mpos);
 	QTextCharFormat fmt = cursor.charFormat();
+
+	// Work around imprecise cursor image identification
+	// Apparently, the cursor is shifted half the characters width to the right on the image
+	// element. This is in contrast to hyperlinks for example, which have correct edge detection.
+	// For the image, we get the right half (plus the left half of the next character) for the
+	// image, and have to move the cursor forward to also detect on the left half of the image
+	// (plus the right half of the previous character).
+	// It is unclear why we have to use NextCharacter instead of PreviousCharacter.
 	if (fmt.objectType() == QTextFormat::NoObject) {
 		cursor.movePosition(QTextCursor::NextCharacter);
 		fmt = cursor.charFormat();


### PR DESCRIPTION
Document workaround to identify image in text under position

It was originally implemented without an explanation in b0c9521e4b5f743325380a67e6c68aa057cd635a

I was able to verify the issue and that this change solves the issue (the noticeable part of left half of the image; it also introduces half of the previous character identified as image). When using PreviousCharacter the following element is used/identified and the left half of the image stays unidentified.