### PR TITLE
mumble_plugin_win32_ptr_type.h: Prevent redefinition of "NOMINMAX"

### DIFF
--- a/plugins/mumble_plugin_win32_ptr_type.h
+++ b/plugins/mumble_plugin_win32_ptr_type.h
@@ -13,7 +13,11 @@
 #define _USE_MATH_DEFINES
 #include <stdio.h>
 #include <stdlib.h>
-#define NOMINMAX
+// Define "NOMINMAX" only if it isn't already.
+// MinGW defines it by default, which results in a redefinition warning.
+#ifndef NOMINMAX
+# define NOMINMAX
+#endif
 #include <windows.h>
 #include <tlhelp32.h>
 #include <math.h>


### PR DESCRIPTION
Define "NOMINMAX" only if it isn't already.
MinGW defines it by default, which results in the following warning:
```
warning: "NOMINMAX" redefined
```