### PR TITLE
Show fallback icon on missing country flag icon

### DIFF
--- a/src/mumble/ConnectDialog.cpp
+++ b/src/mumble/ConnectDialog.cpp
@@ -435,8 +435,13 @@ QVariant ServerItem::data(int column, int role) const {
 						return loadIcon(QLatin1String("skin:emblems/emblem-favorite.svg"));
 					else if (itType == LANType)
 						return loadIcon(QLatin1String("skin:places/network-workgroup.svg"));
-					else if (! qsCountryCode.isEmpty())
-						return loadIcon(QString::fromLatin1(":/flags/%1.svg").arg(qsCountryCode));
+					else if (! qsCountryCode.isEmpty()) {
+						QString flag = QString::fromLatin1(":/flags/%1.svg").arg(qsCountryCode);
+						if (!QFileInfo::exists(flag)) {
+							flag = QLatin1String("skin:categories/applications-internet.svg");
+						}
+						return loadIcon(flag);
+					}
 					else
 						return loadIcon(QLatin1String("skin:categories/applications-internet.svg"));
 			}


### PR DESCRIPTION
If a country flag icon does not exist, we now display a placeholder (`__.svg`)

It looks like this, with the Aland Islands missing its flag.

![2017-01-30 21_02_32-mumble server connect](https://cloud.githubusercontent.com/assets/93181/22439404/c420867c-e72f-11e6-9950-ecfc8d9b3d27.png)

---

* Is the placeholder ok? Maybe make it less dark, and increase the question mark size?
* I’m not too fond of adding the `__.svg` to the `icons/flags` folder, which is otherwise only SVGs from emojione, plus our own README and LICENSE files. But I don’t know where else I would put it, it fits best in there after all.