### PR TITLE
ServerDB, Meta: add support for SQLite WAL. 

### DIFF
--- a/scripts/murmur.ini
+++ b/scripts/murmur.ini
@@ -15,6 +15,26 @@
 ; murmur.sqlite in default locations or create it if not found.
 database=
 
+; Murmur defaults to using SQLite with its default rollback journal.
+; In some situations, using SQLite's write-ahead log (WAL) can be
+; advantageous.
+; If you encounter slowdowns when moving between channels and similar
+; operations, enabling the SQLite write-ahead log might help.
+;
+; To use SQLite's write-ahead log, set sqlite_wal to one of the following
+; values:
+;
+; 0 - Use SQLite's default rollback journal.
+; 1 - Use write-ahead log with synchronous=NORMAL.
+;     If Murmur crashes, the database will be in a consistent state, but
+;     the most recent changes might be lost if the operating system did
+;     not write them to disk yet. This option can improve Murmur's
+;     interactivity on busy servers, or servers with slow storage.
+; 2 - Use write-ahead log with synchronous=FULL.
+;     All database writes are synchronized to disk when they are made.
+;     If Murmur crashes, the database will be include all completed writes.
+;sqlite_wal=0
+
 ; If you wish to use something other than SQLite, you'll need to set the name
 ; of the database above, and also uncomment the below.
 ; Sticking with SQLite is strongly recommended, as it's the most well tested

--- a/src/murmur/Meta.cpp
+++ b/src/murmur/Meta.cpp
@@ -41,6 +41,7 @@ MetaParams::MetaParams() {
 	bRememberChan = true;
 	qsWelcomeText = QString();
 	qsDatabase = QString();
+	iSQLiteWAL = 0;
 	iDBPort = 0;
 	qsDBusService = "net.sourceforge.mumble.murmur";
 	qsDBDriver = "QSQLITE";
@@ -280,6 +281,7 @@ void MetaParams::read(QString fname) {
 	bForceExternalAuth = typeCheckedFromSettings("forceExternalAuth", bForceExternalAuth);
 
 	qsDatabase = typeCheckedFromSettings("database", qsDatabase);
+	iSQLiteWAL = typeCheckedFromSettings("sqlite_wal", iSQLiteWAL);
 
 	qsDBDriver = typeCheckedFromSettings("dbDriver", qsDBDriver);
 	qsDBUserName = typeCheckedFromSettings("dbUsername", qsDBUserName);

--- a/src/murmur/Meta.h
+++ b/src/murmur/Meta.h
@@ -56,6 +56,7 @@ public:
 	int iBanTime;
 
 	QString qsDatabase;
+	int iSQLiteWAL;
 	QString qsDBDriver;
 	QString qsDBUserName;
 	QString qsDBPassword;

--- a/src/murmur/ServerDB.cpp
+++ b/src/murmur/ServerDB.cpp
@@ -147,6 +147,51 @@ ServerDB::ServerDB() {
 		qFatal("ServerDB: Failed initialization: %s",qPrintable(e.text()));
 	}
 
+	// Use SQLite in WAL mode if possible.
+	if (Meta::mp.qsDBDriver == "QSQLITE") {
+		if (Meta::mp.iSQLiteWAL == 0) {
+			qWarning("ServerDB: Using SQLite's default rollback journal.");
+		} else if (Meta::mp.iSQLiteWAL > 0 && Meta::mp.iSQLiteWAL <= 2) {
+			QSqlQuery query;
+
+			bool hasversion = false;
+			bool okversion = false;
+			QString version;
+			SQLDO("SELECT sqlite_version();");
+			if (query.next()) {
+				version = query.value(0).toString();
+			}
+
+			QStringList splitVersion = version.split(QLatin1String("."));
+			int major = 0, minor = 0;
+			if (splitVersion.count() >= 3) {
+				major = splitVersion.at(0).toInt();
+				minor = splitVersion.at(1).toInt();
+				hasversion = true;
+			}
+			if (major >= 3 || (major == 3 && minor >= 7)) {
+				okversion = true;
+			}
+
+			if (okversion) {
+				SQLDO("PRAGMA journal_mode=WAL;");
+				if (Meta::mp.iSQLiteWAL == 1) {
+					SQLDO("PRAGMA synchronous=NORMAL;");
+					qWarning("ServerDB: Configured SQLite for journal_mode=WAL, synchronous=NORMAL");
+				} else if (Meta::mp.iSQLiteWAL == 2) {
+					SQLDO("PRAGMA synchronous=FULL;");
+					qWarning("ServerDB: Configured SQLite for journal_mode=WAL, synchronous=FULL");
+				}
+			} else if (hasversion) {
+				qWarning("ServerDB: Unable to use SQLite in WAL mode due to incompatible SQLite version %i.%i", major, minor);
+			} else {
+				qWarning("ServerDB: Unable to use SQLite in WAL mode because the SQLite version could not be determined.");
+			}
+		} else {
+			qFatal("ServerDB: Invalid value '%i' for sqlite_wal. Please use 0 (no wal), 1 (wal), 2 (wal with synchronous=full)", Meta::mp.iSQLiteWAL);
+		}
+	}
+
 	TransactionHolder th;
 
 	QSqlQuery &query = *th.qsqQuery;


### PR DESCRIPTION
Using SQLite's WAL (write-ahead log) can create less disk I/O while
still providing good consistency and durability.

This change uses SQLite's WAL with synchronous=NORMAL which can
can cause loss of transactions on power failure. Only the transactions
which haven't been synced to the disk by the OS are lost. The database
itself will still be in a consistent state, but it might not have all
recent changes.