### PR TITLE
Show continent icons in connect dialog

### DIFF
--- a/src/mumble/ConnectDialog.cpp
+++ b/src/mumble/ConnectDialog.cpp
@@ -437,6 +437,8 @@ QVariant ServerItem::data(int column, int role) const {
 						return loadIcon(QLatin1String("skin:places/network-workgroup.svg"));
 					else if (! qsCountryCode.isEmpty())
 						return loadIcon(QString::fromLatin1(":/flags/%1.svg").arg(qsCountryCode));
+					else if (! qsContinentCode.isEmpty())
+						return loadIcon(QString::fromLatin1(":/flags/%1.svg").arg(qsContinentCode));
 					else
 						return loadIcon(QLatin1String("skin:categories/applications-internet.svg"));
 			}


### PR DESCRIPTION
We already have the svg flag icons for continents, as well as the continent [county] code.

This is how it looks (as you can see it seems we have no Oceania icon).

![2017-01-31 12_33_04-mumble server connect](https://cloud.githubusercontent.com/assets/93181/22463357/88e8e4e6-e7b1-11e6-8878-9bb7a696181e.png) ![2017-01-31 12_32_37-mumble server connect](https://cloud.githubusercontent.com/assets/93181/22463428/dfdaea60-e7b1-11e6-8d93-8348eb8ca9d8.png)
