### PR TITLE
CertWizard: Password requirement notice on import

### DIFF
--- a/src/mumble/Cert.cpp
+++ b/src/mumble/Cert.cpp
@@ -120,6 +120,7 @@ CertWizard::CertWizard(QWidget *p) : QWizard(p) {
 
 	qwpExport->setCommitPage(true);
 	qwpExport->setComplete(false);
+	qlPasswordNotice->setVisible(false);
 }
 
 int CertWizard::nextId() const {
@@ -305,6 +306,8 @@ void CertWizard::on_qleImportFile_textChanged(const QString &text) {
 		qlePassword->clear();
 		qlePassword->setEnabled(false);
 		qlPassword->setEnabled(false);
+		qlPasswordNotice->clear();
+		qlPasswordNotice->setVisible(false);
 		qwpImport->setComplete(false);
 		return;
 	}
@@ -318,17 +321,23 @@ void CertWizard::on_qleImportFile_textChanged(const QString &text) {
 		if (validateCert(imp)) {
 			qlePassword->setEnabled(false);
 			qlPassword->setEnabled(false);
+			qlPasswordNotice->clear();
+			qlPasswordNotice->setVisible(false);
 			cvImport->setCert(imp.first);
 			qwpImport->setComplete(true);
 			return;
 		} else {
 			qlePassword->setEnabled(true);
 			qlPassword->setEnabled(true);
+			qlPasswordNotice->setText(tr("Unable to import. Missing password or incompatible file type."));
+			qlPasswordNotice->setVisible(true);
 		}
 	} else {
 		qlePassword->clear();
 		qlePassword->setEnabled(false);
 		qlPassword->setEnabled(false);
+		qlPasswordNotice->clear();
+		qlPasswordNotice->setVisible(false);
 	}
 	cvImport->setCert(QList<QSslCertificate>());
 	qwpImport->setComplete(false);

--- a/src/mumble/Cert.ui
+++ b/src/mumble/Cert.ui
@@ -227,6 +227,24 @@ It is &lt;b&gt;strongly&lt;/b&gt; recommended that you &lt;a href=&quot;http://m
      </widget>
     </item>
     <item row="3" column="0" colspan="3">
+     <widget class="QLabel" name="qlPasswordNotice">
+      <property name="font">
+       <font>
+        <italic>true</italic>
+       </font>
+      </property>
+      <property name="wordWrap">
+       <bool>true</bool>
+      </property>
+      <property name="styleSheet">
+       <string notr="true">color:#ff0000;</string>
+      </property>
+      <property name="text">
+       <string/>
+      </property>
+     </widget>
+    </item>
+    <item row="4" column="0" colspan="3">
      <widget class="CertView" name="cvImport">
       <property name="toolTip">
        <string>Certificate to import</string>


### PR DESCRIPTION
When a (p12) certificate file is specified, it is being imported. If this
is not successful it is either because of a missing or wrong password, or
because the file is in fact otherwise not valid.

Instead of simply disabling and enabling the wizard Next button we now
display a text notice to the user to make this clear (especially for the
common use-case of having to provide a correct password).

Fixes #1025

---

![nopw](https://cloud.githubusercontent.com/assets/93181/22491002/d89140c8-e820-11e6-9d41-3601309eff62.png)
![pw-req](https://cloud.githubusercontent.com/assets/93181/22491005/da1ed1bc-e820-11e6-8203-e6a2ef0aa240.png)
![pw-suc](https://cloud.githubusercontent.com/assets/93181/22491004/d980d57a-e820-11e6-8ef6-8b24ec8f9712.png)