### PR TITLE
OSInfo.cpp: Fix MinGW compilation warnings

### DIFF
--- a/src/OSInfo.cpp
+++ b/src/OSInfo.cpp
@@ -71,7 +71,7 @@ static QString win10DisplayableVersion() {
 	QString ubr;
 	QString arch;
 
-	err = RegOpenKeyEx(HKEY_LOCAL_MACHINE, L"SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion", NULL, KEY_READ, &key);
+	err = RegOpenKeyEx(HKEY_LOCAL_MACHINE, L"SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion", 0, KEY_READ, &key);
 	if (err != ERROR_SUCCESS) {
 		RegCloseKey(key);
 		return QString();
@@ -194,7 +194,7 @@ QString OSInfo::getOSVersion() {
 		return QString();
 	}
 
-	os.sprintf("%d.%d.%d.%d", ovi.dwMajorVersion, ovi.dwMinorVersion, ovi.dwBuildNumber, (ovi.wProductType == VER_NT_WORKSTATION) ? 1 : 0);
+	os.sprintf("%lu.%lu.%lu.%lu", static_cast<unsigned long>(ovi.dwMajorVersion), static_cast<unsigned long>(ovi.dwMinorVersion), static_cast<unsigned long>(ovi.dwBuildNumber), (ovi.wProductType == VER_NT_WORKSTATION) ? 1UL : 0UL);
 #elif defined(Q_OS_MAC)
 	SInt32 major, minor, bugfix;
 	OSErr err = Gestalt(gestaltSystemVersionMajor, &major);
@@ -461,7 +461,7 @@ QString OSInfo::getOSDisplayableVersion() {
 	}
 
 	QString osv;
-	osv.sprintf(" - %d.%d.%d", ovi.dwMajorVersion, ovi.dwMinorVersion, ovi.dwBuildNumber);
+	osv.sprintf(" - %lu.%lu.%lu", static_cast<unsigned long>(ovi.dwMajorVersion), static_cast<unsigned long>(ovi.dwMinorVersion), static_cast<unsigned long>(ovi.dwBuildNumber));
 	osdispver.append(osv);
 
 	return osdispver;


### PR DESCRIPTION
```
../OSInfo.cpp:74:113: warning: passing NULL to non-pointer argument 3 of 'LONG RegOpenKeyExW(HKEY, LPCWSTR, DWORD, REGSAM, PHKEY)' [-Wconversion-null]
  err = RegOpenKeyEx(HKEY_LOCAL_MACHINE, L"SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion", NULL, KEY_READ, &key);
                                                                                                                 ^
../OSInfo.cpp: In static member function 'static QString OSInfo::getOSVersion()':
../OSInfo.cpp:197:135: warning: format '%d' expects argument of type 'int', but argument 3 has type 'DWORD {aka long unsigned int}' [-Wformat=]
  os.sprintf("%d.%d.%d.%d", ovi.dwMajorVersion, ovi.dwMinorVersion, ovi.dwBuildNumber, (ovi.wProductType == VER_NT_WORKSTATION) ? 1 : 0);
                                                                                                                                       ^
../OSInfo.cpp:197:135: warning: format '%d' expects argument of type 'int', but argument 4 has type 'DWORD {aka long unsigned int}' [-Wformat=]
../OSInfo.cpp:197:135: warning: format '%d' expects argument of type 'int', but argument 5 has type 'DWORD {aka long unsigned int}' [-Wformat=]
../OSInfo.cpp: In static member function 'static QString OSInfo::getOSDisplayableVersion()':
../OSInfo.cpp:466:86: warning: format '%d' expects argument of type 'int', but argument 3 has type 'DWORD {aka long unsigned int}' [-Wformat=]
  osv.sprintf(" - %d.%d.%d", ovi.dwMajorVersion, ovi.dwMinorVersion, ovi.dwBuildNumber);
                                                                                      ^
../OSInfo.cpp:466:86: warning: format '%d' expects argument of type 'int', but argument 4 has type 'DWORD {aka long unsigned int}' [-Wformat=]
../OSInfo.cpp:466:86: warning: format '%d' expects argument of type 'int', but argument 5 has type 'DWORD {aka long unsigned int}' [-Wformat=]
```