### PR TITLE
Add missing include

### DIFF
--- a/src/mumble/ConnectDialog.cpp
+++ b/src/mumble/ConnectDialog.cpp
@@ -13,6 +13,7 @@
 #include "BonjourServiceResolver.h"
 #endif
 
+#include <QFileInfo>
 #include "Channel.h"
 #include "Database.h"
 #include "Global.h"


### PR DESCRIPTION
While the code compiled on Windows, it does not on (some) other systems.

This should fix our PPA build.
See log https://launchpadlibrarian.net/305049230/buildlog_ubuntu-precise-i386.mumble_1.3.0~1902~gd871f34~snapshot-1~ppa1~precise1_BUILDING.txt.gz