### PR TITLE
Fix usage of QFileInfo for Qt4

### DIFF
--- a/src/mumble/ConnectDialog.cpp
+++ b/src/mumble/ConnectDialog.cpp
@@ -437,7 +437,7 @@ QVariant ServerItem::data(int column, int role) const {
 						return loadIcon(QLatin1String("skin:places/network-workgroup.svg"));
 					else if (! qsCountryCode.isEmpty()) {
 						QString flag = QString::fromLatin1(":/flags/%1.svg").arg(qsCountryCode);
-						if (!QFileInfo::exists(flag)) {
+						if (!QFileInfo(flag).exists()) {
 							flag = QLatin1String("skin:categories/applications-internet.svg");
 						}
 						return loadIcon(flag);


### PR DESCRIPTION
This should fix our PPA build.
See log https://launchpadlibrarian.net/305049230/buildlog_ubuntu-precise-i386.mumble_1.3.0~1902~gd871f34~snapshot-1~ppa1~precise1_BUILDING.txt.gz