### PR TITLE
Overlay_win.cpp: Fix MinGW compilation warning

### DIFF
--- a/src/mumble/Overlay_win.cpp
+++ b/src/mumble/Overlay_win.cpp
@@ -192,6 +192,8 @@ static const char *processErrorString(QProcess::ProcessError processError) {
 			return "an error occurred when attempting to write to the process";
 		case QProcess::ReadError:
 			return "an error occurred when attempting to read from the process";
+		case QProcess::UnknownError:
+			return "an unknown error occurred";
 	}
 
 	return "unknown";


### PR DESCRIPTION
Overlay_win.cpp:184:9: warning: enumeration value 'UnknownError' not handled in switch [-Wswitch]
  switch (processError) {
         ^