### PR TITLE
LCD: drop workaround for Qt >= 5.6.2.

### DIFF
--- a/src/mumble/LCD.cpp
+++ b/src/mumble/LCD.cpp
@@ -189,7 +189,7 @@ LCD::LCD() : QObject() {
 	}
 	qiLogo = QIcon(QLatin1String("skin:mumble.svg")).pixmap(48,48).toImage().convertToFormat(QImage::Format_MonoLSB);
 
-#if QT_VERSION >= 0x050600
+#if QT_VERSION >= 0x050600 && QT_VERSION <= 0x050601
 	// Don't invert the logo image when using Qt 5.6.
 	// See mumble-voip/mumble#2429
 #else
@@ -250,7 +250,7 @@ void LCD::updateUserView() {
 		QPainter painter(img);
 		painter.setRenderHints(QPainter::Antialiasing | QPainter::TextAntialiasing, false);
 
-#if QT_VERSION >= 0x050600
+#if QT_VERSION >= 0x050600 && QT_VERSION <= 0x050601
 		// Use Qt::white instead of Qt::color1 on Qt 5.6.
 		// See mumble-voip/mumble#2429
 		painter.setPen(Qt::white);


### PR DESCRIPTION
This drops the workaround we added in c04aa4e8 (see also
mumble-voip/mumble#2429). There was a Qt regression in
early 5.6 versions that caused our previously working
monochrome bitmap drawing code to break.

To be fair, our original code was not exactly correct
per the Qt docs, but it did produce correct results before
Qt 5.6.

Qt accepted the bug as a regression, and restored the old
behavior, so we can now keep using the old behavior.

We should re-visit this soon, because the drawing code
isn't actually correct according to the Qt docs.

But it works. At least until Qt 6.

Fixes mumble-voip/mumble#2815