### PR TITLE
installer: use WiX from buildenv.

### DIFF
--- a/installer/MumbleInstall.wixproj
+++ b/installer/MumbleInstall.wixproj
@@ -1,6 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
+    <WixToolPath>$(MUMBLE_PREFIX)\wix\</WixToolPath>
+    <WixTargetsPath>$(WixToolPath)Wix.targets</WixTargetsPath>
+    <WixTasksPath>$(WixToolPath)wixtasks.dll</WixTasksPath>
+  </PropertyGroup>
+  <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">x86</Platform>
     <ProductVersion>3.5</ProductVersion>


### PR DESCRIPTION
Previously, we required people to install WiX globally.
That's yet another tedious dependency required in order to build Mumble.

We'll now be distributing WiX in our buildenvs, so tell our .wixproj
to use that version.