### PR TITLE
installer: ship app-local copies of UCRT DLLs.

### DIFF
--- a/installer/Files.wxs
+++ b/installer/Files.wxs
@@ -75,6 +75,10 @@
       </Component>
       <?endif ?>
 
+      <?ifdef RedistDirUCRT ?>
+       <?include "MumbleUCRTComponents.wxi" ?>
+      <?endif ?>
+
       <Component Id="dbghelp.dll">
         <File Source="$(var.DebugToolsDir)\dbghelp.dll" KeyPath="yes" />
       </Component>
@@ -142,6 +146,9 @@
         <Component Id="Murmur_vcruntime140.dll">
           <File Id="Murmur_vcruntime140.dll" Source="$(var.RedistDirVC14)\vcruntime140.dll" KeyPath="yes" />
         </Component>
+        <?endif ?>
+        <?ifdef RedistDirUCRT ?>
+          <?include "MurmurUCRTComponents.wxi" ?>
         <?endif ?>
         <Component Id="Murmur_dbghelp.dll">
           <File Id="Murmur_dbghelp.dll" Source="$(var.DebugToolsDir)\dbghelp.dll" KeyPath="yes" />

--- a/installer/MumbleUCRTComponentRefs.wxi
+++ b/installer/MumbleUCRTComponentRefs.wxi
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Include>
+
+<!-- This file is auto-generated via gen-ucrt.py. Please don't touch by hand -->
+
+<ComponentRef Id="api_ms_win_core_console_l1_1_0.dll" />
+<ComponentRef Id="api_ms_win_core_datetime_l1_1_0.dll" />
+<ComponentRef Id="api_ms_win_core_debug_l1_1_0.dll" />
+<ComponentRef Id="api_ms_win_core_errorhandling_l1_1_0.dll" />
+<ComponentRef Id="api_ms_win_core_file_l1_1_0.dll" />
+<ComponentRef Id="api_ms_win_core_file_l1_2_0.dll" />
+<ComponentRef Id="api_ms_win_core_file_l2_1_0.dll" />
+<ComponentRef Id="api_ms_win_core_handle_l1_1_0.dll" />
+<ComponentRef Id="api_ms_win_core_heap_l1_1_0.dll" />
+<ComponentRef Id="api_ms_win_core_interlocked_l1_1_0.dll" />
+<ComponentRef Id="api_ms_win_core_libraryloader_l1_1_0.dll" />
+<ComponentRef Id="api_ms_win_core_localization_l1_2_0.dll" />
+<ComponentRef Id="api_ms_win_core_memory_l1_1_0.dll" />
+<ComponentRef Id="api_ms_win_core_namedpipe_l1_1_0.dll" />
+<ComponentRef Id="api_ms_win_core_processenvironment_l1_1_0.dll" />
+<ComponentRef Id="api_ms_win_core_processthreads_l1_1_0.dll" />
+<ComponentRef Id="api_ms_win_core_processthreads_l1_1_1.dll" />
+<ComponentRef Id="api_ms_win_core_profile_l1_1_0.dll" />
+<ComponentRef Id="api_ms_win_core_rtlsupport_l1_1_0.dll" />
+<ComponentRef Id="api_ms_win_core_string_l1_1_0.dll" />
+<ComponentRef Id="api_ms_win_core_synch_l1_1_0.dll" />
+<ComponentRef Id="api_ms_win_core_synch_l1_2_0.dll" />
+<ComponentRef Id="api_ms_win_core_sysinfo_l1_1_0.dll" />
+<ComponentRef Id="api_ms_win_core_timezone_l1_1_0.dll" />
+<ComponentRef Id="api_ms_win_core_util_l1_1_0.dll" />
+<ComponentRef Id="api_ms_win_crt_conio_l1_1_0.dll" />
+<ComponentRef Id="api_ms_win_crt_convert_l1_1_0.dll" />
+<ComponentRef Id="api_ms_win_crt_environment_l1_1_0.dll" />
+<ComponentRef Id="api_ms_win_crt_filesystem_l1_1_0.dll" />
+<ComponentRef Id="api_ms_win_crt_heap_l1_1_0.dll" />
+<ComponentRef Id="api_ms_win_crt_locale_l1_1_0.dll" />
+<ComponentRef Id="api_ms_win_crt_math_l1_1_0.dll" />
+<ComponentRef Id="api_ms_win_crt_multibyte_l1_1_0.dll" />
+<ComponentRef Id="api_ms_win_crt_private_l1_1_0.dll" />
+<ComponentRef Id="api_ms_win_crt_process_l1_1_0.dll" />
+<ComponentRef Id="api_ms_win_crt_runtime_l1_1_0.dll" />
+<ComponentRef Id="api_ms_win_crt_stdio_l1_1_0.dll" />
+<ComponentRef Id="api_ms_win_crt_string_l1_1_0.dll" />
+<ComponentRef Id="api_ms_win_crt_time_l1_1_0.dll" />
+<ComponentRef Id="api_ms_win_crt_utility_l1_1_0.dll" />
+<ComponentRef Id="ucrtbase.dll" />
+
+</Include>

--- a/installer/MumbleUCRTComponents.wxi
+++ b/installer/MumbleUCRTComponents.wxi
@@ -1,0 +1,130 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Include>
+
+<!-- This file is auto-generated via gen-ucrt.py. Please don't touch by hand -->
+
+<Component Id="api_ms_win_core_console_l1_1_0.dll">
+  <File Id="api_ms_win_core_console_l1_1_0.dll" Source="$(var.RedistDirUCRT)\api-ms-win-core-console-l1-1-0.dll" KeyPath="yes" />
+</Component>
+<Component Id="api_ms_win_core_datetime_l1_1_0.dll">
+  <File Id="api_ms_win_core_datetime_l1_1_0.dll" Source="$(var.RedistDirUCRT)\api-ms-win-core-datetime-l1-1-0.dll" KeyPath="yes" />
+</Component>
+<Component Id="api_ms_win_core_debug_l1_1_0.dll">
+  <File Id="api_ms_win_core_debug_l1_1_0.dll" Source="$(var.RedistDirUCRT)\api-ms-win-core-debug-l1-1-0.dll" KeyPath="yes" />
+</Component>
+<Component Id="api_ms_win_core_errorhandling_l1_1_0.dll">
+  <File Id="api_ms_win_core_errorhandling_l1_1_0.dll" Source="$(var.RedistDirUCRT)\api-ms-win-core-errorhandling-l1-1-0.dll" KeyPath="yes" />
+</Component>
+<Component Id="api_ms_win_core_file_l1_1_0.dll">
+  <File Id="api_ms_win_core_file_l1_1_0.dll" Source="$(var.RedistDirUCRT)\api-ms-win-core-file-l1-1-0.dll" KeyPath="yes" />
+</Component>
+<Component Id="api_ms_win_core_file_l1_2_0.dll">
+  <File Id="api_ms_win_core_file_l1_2_0.dll" Source="$(var.RedistDirUCRT)\api-ms-win-core-file-l1-2-0.dll" KeyPath="yes" />
+</Component>
+<Component Id="api_ms_win_core_file_l2_1_0.dll">
+  <File Id="api_ms_win_core_file_l2_1_0.dll" Source="$(var.RedistDirUCRT)\api-ms-win-core-file-l2-1-0.dll" KeyPath="yes" />
+</Component>
+<Component Id="api_ms_win_core_handle_l1_1_0.dll">
+  <File Id="api_ms_win_core_handle_l1_1_0.dll" Source="$(var.RedistDirUCRT)\api-ms-win-core-handle-l1-1-0.dll" KeyPath="yes" />
+</Component>
+<Component Id="api_ms_win_core_heap_l1_1_0.dll">
+  <File Id="api_ms_win_core_heap_l1_1_0.dll" Source="$(var.RedistDirUCRT)\api-ms-win-core-heap-l1-1-0.dll" KeyPath="yes" />
+</Component>
+<Component Id="api_ms_win_core_interlocked_l1_1_0.dll">
+  <File Id="api_ms_win_core_interlocked_l1_1_0.dll" Source="$(var.RedistDirUCRT)\api-ms-win-core-interlocked-l1-1-0.dll" KeyPath="yes" />
+</Component>
+<Component Id="api_ms_win_core_libraryloader_l1_1_0.dll">
+  <File Id="api_ms_win_core_libraryloader_l1_1_0.dll" Source="$(var.RedistDirUCRT)\api-ms-win-core-libraryloader-l1-1-0.dll" KeyPath="yes" />
+</Component>
+<Component Id="api_ms_win_core_localization_l1_2_0.dll">
+  <File Id="api_ms_win_core_localization_l1_2_0.dll" Source="$(var.RedistDirUCRT)\api-ms-win-core-localization-l1-2-0.dll" KeyPath="yes" />
+</Component>
+<Component Id="api_ms_win_core_memory_l1_1_0.dll">
+  <File Id="api_ms_win_core_memory_l1_1_0.dll" Source="$(var.RedistDirUCRT)\api-ms-win-core-memory-l1-1-0.dll" KeyPath="yes" />
+</Component>
+<Component Id="api_ms_win_core_namedpipe_l1_1_0.dll">
+  <File Id="api_ms_win_core_namedpipe_l1_1_0.dll" Source="$(var.RedistDirUCRT)\api-ms-win-core-namedpipe-l1-1-0.dll" KeyPath="yes" />
+</Component>
+<Component Id="api_ms_win_core_processenvironment_l1_1_0.dll">
+  <File Id="api_ms_win_core_processenvironment_l1_1_0.dll" Source="$(var.RedistDirUCRT)\api-ms-win-core-processenvironment-l1-1-0.dll" KeyPath="yes" />
+</Component>
+<Component Id="api_ms_win_core_processthreads_l1_1_0.dll">
+  <File Id="api_ms_win_core_processthreads_l1_1_0.dll" Source="$(var.RedistDirUCRT)\api-ms-win-core-processthreads-l1-1-0.dll" KeyPath="yes" />
+</Component>
+<Component Id="api_ms_win_core_processthreads_l1_1_1.dll">
+  <File Id="api_ms_win_core_processthreads_l1_1_1.dll" Source="$(var.RedistDirUCRT)\api-ms-win-core-processthreads-l1-1-1.dll" KeyPath="yes" />
+</Component>
+<Component Id="api_ms_win_core_profile_l1_1_0.dll">
+  <File Id="api_ms_win_core_profile_l1_1_0.dll" Source="$(var.RedistDirUCRT)\api-ms-win-core-profile-l1-1-0.dll" KeyPath="yes" />
+</Component>
+<Component Id="api_ms_win_core_rtlsupport_l1_1_0.dll">
+  <File Id="api_ms_win_core_rtlsupport_l1_1_0.dll" Source="$(var.RedistDirUCRT)\api-ms-win-core-rtlsupport-l1-1-0.dll" KeyPath="yes" />
+</Component>
+<Component Id="api_ms_win_core_string_l1_1_0.dll">
+  <File Id="api_ms_win_core_string_l1_1_0.dll" Source="$(var.RedistDirUCRT)\api-ms-win-core-string-l1-1-0.dll" KeyPath="yes" />
+</Component>
+<Component Id="api_ms_win_core_synch_l1_1_0.dll">
+  <File Id="api_ms_win_core_synch_l1_1_0.dll" Source="$(var.RedistDirUCRT)\api-ms-win-core-synch-l1-1-0.dll" KeyPath="yes" />
+</Component>
+<Component Id="api_ms_win_core_synch_l1_2_0.dll">
+  <File Id="api_ms_win_core_synch_l1_2_0.dll" Source="$(var.RedistDirUCRT)\api-ms-win-core-synch-l1-2-0.dll" KeyPath="yes" />
+</Component>
+<Component Id="api_ms_win_core_sysinfo_l1_1_0.dll">
+  <File Id="api_ms_win_core_sysinfo_l1_1_0.dll" Source="$(var.RedistDirUCRT)\api-ms-win-core-sysinfo-l1-1-0.dll" KeyPath="yes" />
+</Component>
+<Component Id="api_ms_win_core_timezone_l1_1_0.dll">
+  <File Id="api_ms_win_core_timezone_l1_1_0.dll" Source="$(var.RedistDirUCRT)\api-ms-win-core-timezone-l1-1-0.dll" KeyPath="yes" />
+</Component>
+<Component Id="api_ms_win_core_util_l1_1_0.dll">
+  <File Id="api_ms_win_core_util_l1_1_0.dll" Source="$(var.RedistDirUCRT)\api-ms-win-core-util-l1-1-0.dll" KeyPath="yes" />
+</Component>
+<Component Id="api_ms_win_crt_conio_l1_1_0.dll">
+  <File Id="api_ms_win_crt_conio_l1_1_0.dll" Source="$(var.RedistDirUCRT)\api-ms-win-crt-conio-l1-1-0.dll" KeyPath="yes" />
+</Component>
+<Component Id="api_ms_win_crt_convert_l1_1_0.dll">
+  <File Id="api_ms_win_crt_convert_l1_1_0.dll" Source="$(var.RedistDirUCRT)\api-ms-win-crt-convert-l1-1-0.dll" KeyPath="yes" />
+</Component>
+<Component Id="api_ms_win_crt_environment_l1_1_0.dll">
+  <File Id="api_ms_win_crt_environment_l1_1_0.dll" Source="$(var.RedistDirUCRT)\api-ms-win-crt-environment-l1-1-0.dll" KeyPath="yes" />
+</Component>
+<Component Id="api_ms_win_crt_filesystem_l1_1_0.dll">
+  <File Id="api_ms_win_crt_filesystem_l1_1_0.dll" Source="$(var.RedistDirUCRT)\api-ms-win-crt-filesystem-l1-1-0.dll" KeyPath="yes" />
+</Component>
+<Component Id="api_ms_win_crt_heap_l1_1_0.dll">
+  <File Id="api_ms_win_crt_heap_l1_1_0.dll" Source="$(var.RedistDirUCRT)\api-ms-win-crt-heap-l1-1-0.dll" KeyPath="yes" />
+</Component>
+<Component Id="api_ms_win_crt_locale_l1_1_0.dll">
+  <File Id="api_ms_win_crt_locale_l1_1_0.dll" Source="$(var.RedistDirUCRT)\api-ms-win-crt-locale-l1-1-0.dll" KeyPath="yes" />
+</Component>
+<Component Id="api_ms_win_crt_math_l1_1_0.dll">
+  <File Id="api_ms_win_crt_math_l1_1_0.dll" Source="$(var.RedistDirUCRT)\api-ms-win-crt-math-l1-1-0.dll" KeyPath="yes" />
+</Component>
+<Component Id="api_ms_win_crt_multibyte_l1_1_0.dll">
+  <File Id="api_ms_win_crt_multibyte_l1_1_0.dll" Source="$(var.RedistDirUCRT)\api-ms-win-crt-multibyte-l1-1-0.dll" KeyPath="yes" />
+</Component>
+<Component Id="api_ms_win_crt_private_l1_1_0.dll">
+  <File Id="api_ms_win_crt_private_l1_1_0.dll" Source="$(var.RedistDirUCRT)\api-ms-win-crt-private-l1-1-0.dll" KeyPath="yes" />
+</Component>
+<Component Id="api_ms_win_crt_process_l1_1_0.dll">
+  <File Id="api_ms_win_crt_process_l1_1_0.dll" Source="$(var.RedistDirUCRT)\api-ms-win-crt-process-l1-1-0.dll" KeyPath="yes" />
+</Component>
+<Component Id="api_ms_win_crt_runtime_l1_1_0.dll">
+  <File Id="api_ms_win_crt_runtime_l1_1_0.dll" Source="$(var.RedistDirUCRT)\api-ms-win-crt-runtime-l1-1-0.dll" KeyPath="yes" />
+</Component>
+<Component Id="api_ms_win_crt_stdio_l1_1_0.dll">
+  <File Id="api_ms_win_crt_stdio_l1_1_0.dll" Source="$(var.RedistDirUCRT)\api-ms-win-crt-stdio-l1-1-0.dll" KeyPath="yes" />
+</Component>
+<Component Id="api_ms_win_crt_string_l1_1_0.dll">
+  <File Id="api_ms_win_crt_string_l1_1_0.dll" Source="$(var.RedistDirUCRT)\api-ms-win-crt-string-l1-1-0.dll" KeyPath="yes" />
+</Component>
+<Component Id="api_ms_win_crt_time_l1_1_0.dll">
+  <File Id="api_ms_win_crt_time_l1_1_0.dll" Source="$(var.RedistDirUCRT)\api-ms-win-crt-time-l1-1-0.dll" KeyPath="yes" />
+</Component>
+<Component Id="api_ms_win_crt_utility_l1_1_0.dll">
+  <File Id="api_ms_win_crt_utility_l1_1_0.dll" Source="$(var.RedistDirUCRT)\api-ms-win-crt-utility-l1-1-0.dll" KeyPath="yes" />
+</Component>
+<Component Id="ucrtbase.dll">
+  <File Id="ucrtbase.dll" Source="$(var.RedistDirUCRT)\ucrtbase.dll" KeyPath="yes" />
+</Component>
+
+</Include>

--- a/installer/MurmurUCRTComponentRefs.wxi
+++ b/installer/MurmurUCRTComponentRefs.wxi
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Include>
+
+<!-- This file is auto-generated via gen-ucrt.py. Please don't touch by hand -->
+
+<ComponentRef Id="Murmur_api_ms_win_core_console_l1_1_0.dll" />
+<ComponentRef Id="Murmur_api_ms_win_core_datetime_l1_1_0.dll" />
+<ComponentRef Id="Murmur_api_ms_win_core_debug_l1_1_0.dll" />
+<ComponentRef Id="Murmur_api_ms_win_core_errorhandling_l1_1_0.dll" />
+<ComponentRef Id="Murmur_api_ms_win_core_file_l1_1_0.dll" />
+<ComponentRef Id="Murmur_api_ms_win_core_file_l1_2_0.dll" />
+<ComponentRef Id="Murmur_api_ms_win_core_file_l2_1_0.dll" />
+<ComponentRef Id="Murmur_api_ms_win_core_handle_l1_1_0.dll" />
+<ComponentRef Id="Murmur_api_ms_win_core_heap_l1_1_0.dll" />
+<ComponentRef Id="Murmur_api_ms_win_core_interlocked_l1_1_0.dll" />
+<ComponentRef Id="Murmur_api_ms_win_core_libraryloader_l1_1_0.dll" />
+<ComponentRef Id="Murmur_api_ms_win_core_localization_l1_2_0.dll" />
+<ComponentRef Id="Murmur_api_ms_win_core_memory_l1_1_0.dll" />
+<ComponentRef Id="Murmur_api_ms_win_core_namedpipe_l1_1_0.dll" />
+<ComponentRef Id="Murmur_api_ms_win_core_processenvironment_l1_1_0.dll" />
+<ComponentRef Id="Murmur_api_ms_win_core_processthreads_l1_1_0.dll" />
+<ComponentRef Id="Murmur_api_ms_win_core_processthreads_l1_1_1.dll" />
+<ComponentRef Id="Murmur_api_ms_win_core_profile_l1_1_0.dll" />
+<ComponentRef Id="Murmur_api_ms_win_core_rtlsupport_l1_1_0.dll" />
+<ComponentRef Id="Murmur_api_ms_win_core_string_l1_1_0.dll" />
+<ComponentRef Id="Murmur_api_ms_win_core_synch_l1_1_0.dll" />
+<ComponentRef Id="Murmur_api_ms_win_core_synch_l1_2_0.dll" />
+<ComponentRef Id="Murmur_api_ms_win_core_sysinfo_l1_1_0.dll" />
+<ComponentRef Id="Murmur_api_ms_win_core_timezone_l1_1_0.dll" />
+<ComponentRef Id="Murmur_api_ms_win_core_util_l1_1_0.dll" />
+<ComponentRef Id="Murmur_api_ms_win_crt_conio_l1_1_0.dll" />
+<ComponentRef Id="Murmur_api_ms_win_crt_convert_l1_1_0.dll" />
+<ComponentRef Id="Murmur_api_ms_win_crt_environment_l1_1_0.dll" />
+<ComponentRef Id="Murmur_api_ms_win_crt_filesystem_l1_1_0.dll" />
+<ComponentRef Id="Murmur_api_ms_win_crt_heap_l1_1_0.dll" />
+<ComponentRef Id="Murmur_api_ms_win_crt_locale_l1_1_0.dll" />
+<ComponentRef Id="Murmur_api_ms_win_crt_math_l1_1_0.dll" />
+<ComponentRef Id="Murmur_api_ms_win_crt_multibyte_l1_1_0.dll" />
+<ComponentRef Id="Murmur_api_ms_win_crt_private_l1_1_0.dll" />
+<ComponentRef Id="Murmur_api_ms_win_crt_process_l1_1_0.dll" />
+<ComponentRef Id="Murmur_api_ms_win_crt_runtime_l1_1_0.dll" />
+<ComponentRef Id="Murmur_api_ms_win_crt_stdio_l1_1_0.dll" />
+<ComponentRef Id="Murmur_api_ms_win_crt_string_l1_1_0.dll" />
+<ComponentRef Id="Murmur_api_ms_win_crt_time_l1_1_0.dll" />
+<ComponentRef Id="Murmur_api_ms_win_crt_utility_l1_1_0.dll" />
+<ComponentRef Id="Murmur_ucrtbase.dll" />
+
+</Include>

--- a/installer/MurmurUCRTComponents.wxi
+++ b/installer/MurmurUCRTComponents.wxi
@@ -1,0 +1,130 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Include>
+
+<!-- This file is auto-generated via gen-ucrt.py. Please don't touch by hand -->
+
+<Component Id="Murmur_api_ms_win_core_console_l1_1_0.dll">
+  <File Id="Murmur_api_ms_win_core_console_l1_1_0.dll" Source="$(var.RedistDirUCRT)\api-ms-win-core-console-l1-1-0.dll" KeyPath="yes" />
+</Component>
+<Component Id="Murmur_api_ms_win_core_datetime_l1_1_0.dll">
+  <File Id="Murmur_api_ms_win_core_datetime_l1_1_0.dll" Source="$(var.RedistDirUCRT)\api-ms-win-core-datetime-l1-1-0.dll" KeyPath="yes" />
+</Component>
+<Component Id="Murmur_api_ms_win_core_debug_l1_1_0.dll">
+  <File Id="Murmur_api_ms_win_core_debug_l1_1_0.dll" Source="$(var.RedistDirUCRT)\api-ms-win-core-debug-l1-1-0.dll" KeyPath="yes" />
+</Component>
+<Component Id="Murmur_api_ms_win_core_errorhandling_l1_1_0.dll">
+  <File Id="Murmur_api_ms_win_core_errorhandling_l1_1_0.dll" Source="$(var.RedistDirUCRT)\api-ms-win-core-errorhandling-l1-1-0.dll" KeyPath="yes" />
+</Component>
+<Component Id="Murmur_api_ms_win_core_file_l1_1_0.dll">
+  <File Id="Murmur_api_ms_win_core_file_l1_1_0.dll" Source="$(var.RedistDirUCRT)\api-ms-win-core-file-l1-1-0.dll" KeyPath="yes" />
+</Component>
+<Component Id="Murmur_api_ms_win_core_file_l1_2_0.dll">
+  <File Id="Murmur_api_ms_win_core_file_l1_2_0.dll" Source="$(var.RedistDirUCRT)\api-ms-win-core-file-l1-2-0.dll" KeyPath="yes" />
+</Component>
+<Component Id="Murmur_api_ms_win_core_file_l2_1_0.dll">
+  <File Id="Murmur_api_ms_win_core_file_l2_1_0.dll" Source="$(var.RedistDirUCRT)\api-ms-win-core-file-l2-1-0.dll" KeyPath="yes" />
+</Component>
+<Component Id="Murmur_api_ms_win_core_handle_l1_1_0.dll">
+  <File Id="Murmur_api_ms_win_core_handle_l1_1_0.dll" Source="$(var.RedistDirUCRT)\api-ms-win-core-handle-l1-1-0.dll" KeyPath="yes" />
+</Component>
+<Component Id="Murmur_api_ms_win_core_heap_l1_1_0.dll">
+  <File Id="Murmur_api_ms_win_core_heap_l1_1_0.dll" Source="$(var.RedistDirUCRT)\api-ms-win-core-heap-l1-1-0.dll" KeyPath="yes" />
+</Component>
+<Component Id="Murmur_api_ms_win_core_interlocked_l1_1_0.dll">
+  <File Id="Murmur_api_ms_win_core_interlocked_l1_1_0.dll" Source="$(var.RedistDirUCRT)\api-ms-win-core-interlocked-l1-1-0.dll" KeyPath="yes" />
+</Component>
+<Component Id="Murmur_api_ms_win_core_libraryloader_l1_1_0.dll">
+  <File Id="Murmur_api_ms_win_core_libraryloader_l1_1_0.dll" Source="$(var.RedistDirUCRT)\api-ms-win-core-libraryloader-l1-1-0.dll" KeyPath="yes" />
+</Component>
+<Component Id="Murmur_api_ms_win_core_localization_l1_2_0.dll">
+  <File Id="Murmur_api_ms_win_core_localization_l1_2_0.dll" Source="$(var.RedistDirUCRT)\api-ms-win-core-localization-l1-2-0.dll" KeyPath="yes" />
+</Component>
+<Component Id="Murmur_api_ms_win_core_memory_l1_1_0.dll">
+  <File Id="Murmur_api_ms_win_core_memory_l1_1_0.dll" Source="$(var.RedistDirUCRT)\api-ms-win-core-memory-l1-1-0.dll" KeyPath="yes" />
+</Component>
+<Component Id="Murmur_api_ms_win_core_namedpipe_l1_1_0.dll">
+  <File Id="Murmur_api_ms_win_core_namedpipe_l1_1_0.dll" Source="$(var.RedistDirUCRT)\api-ms-win-core-namedpipe-l1-1-0.dll" KeyPath="yes" />
+</Component>
+<Component Id="Murmur_api_ms_win_core_processenvironment_l1_1_0.dll">
+  <File Id="Murmur_api_ms_win_core_processenvironment_l1_1_0.dll" Source="$(var.RedistDirUCRT)\api-ms-win-core-processenvironment-l1-1-0.dll" KeyPath="yes" />
+</Component>
+<Component Id="Murmur_api_ms_win_core_processthreads_l1_1_0.dll">
+  <File Id="Murmur_api_ms_win_core_processthreads_l1_1_0.dll" Source="$(var.RedistDirUCRT)\api-ms-win-core-processthreads-l1-1-0.dll" KeyPath="yes" />
+</Component>
+<Component Id="Murmur_api_ms_win_core_processthreads_l1_1_1.dll">
+  <File Id="Murmur_api_ms_win_core_processthreads_l1_1_1.dll" Source="$(var.RedistDirUCRT)\api-ms-win-core-processthreads-l1-1-1.dll" KeyPath="yes" />
+</Component>
+<Component Id="Murmur_api_ms_win_core_profile_l1_1_0.dll">
+  <File Id="Murmur_api_ms_win_core_profile_l1_1_0.dll" Source="$(var.RedistDirUCRT)\api-ms-win-core-profile-l1-1-0.dll" KeyPath="yes" />
+</Component>
+<Component Id="Murmur_api_ms_win_core_rtlsupport_l1_1_0.dll">
+  <File Id="Murmur_api_ms_win_core_rtlsupport_l1_1_0.dll" Source="$(var.RedistDirUCRT)\api-ms-win-core-rtlsupport-l1-1-0.dll" KeyPath="yes" />
+</Component>
+<Component Id="Murmur_api_ms_win_core_string_l1_1_0.dll">
+  <File Id="Murmur_api_ms_win_core_string_l1_1_0.dll" Source="$(var.RedistDirUCRT)\api-ms-win-core-string-l1-1-0.dll" KeyPath="yes" />
+</Component>
+<Component Id="Murmur_api_ms_win_core_synch_l1_1_0.dll">
+  <File Id="Murmur_api_ms_win_core_synch_l1_1_0.dll" Source="$(var.RedistDirUCRT)\api-ms-win-core-synch-l1-1-0.dll" KeyPath="yes" />
+</Component>
+<Component Id="Murmur_api_ms_win_core_synch_l1_2_0.dll">
+  <File Id="Murmur_api_ms_win_core_synch_l1_2_0.dll" Source="$(var.RedistDirUCRT)\api-ms-win-core-synch-l1-2-0.dll" KeyPath="yes" />
+</Component>
+<Component Id="Murmur_api_ms_win_core_sysinfo_l1_1_0.dll">
+  <File Id="Murmur_api_ms_win_core_sysinfo_l1_1_0.dll" Source="$(var.RedistDirUCRT)\api-ms-win-core-sysinfo-l1-1-0.dll" KeyPath="yes" />
+</Component>
+<Component Id="Murmur_api_ms_win_core_timezone_l1_1_0.dll">
+  <File Id="Murmur_api_ms_win_core_timezone_l1_1_0.dll" Source="$(var.RedistDirUCRT)\api-ms-win-core-timezone-l1-1-0.dll" KeyPath="yes" />
+</Component>
+<Component Id="Murmur_api_ms_win_core_util_l1_1_0.dll">
+  <File Id="Murmur_api_ms_win_core_util_l1_1_0.dll" Source="$(var.RedistDirUCRT)\api-ms-win-core-util-l1-1-0.dll" KeyPath="yes" />
+</Component>
+<Component Id="Murmur_api_ms_win_crt_conio_l1_1_0.dll">
+  <File Id="Murmur_api_ms_win_crt_conio_l1_1_0.dll" Source="$(var.RedistDirUCRT)\api-ms-win-crt-conio-l1-1-0.dll" KeyPath="yes" />
+</Component>
+<Component Id="Murmur_api_ms_win_crt_convert_l1_1_0.dll">
+  <File Id="Murmur_api_ms_win_crt_convert_l1_1_0.dll" Source="$(var.RedistDirUCRT)\api-ms-win-crt-convert-l1-1-0.dll" KeyPath="yes" />
+</Component>
+<Component Id="Murmur_api_ms_win_crt_environment_l1_1_0.dll">
+  <File Id="Murmur_api_ms_win_crt_environment_l1_1_0.dll" Source="$(var.RedistDirUCRT)\api-ms-win-crt-environment-l1-1-0.dll" KeyPath="yes" />
+</Component>
+<Component Id="Murmur_api_ms_win_crt_filesystem_l1_1_0.dll">
+  <File Id="Murmur_api_ms_win_crt_filesystem_l1_1_0.dll" Source="$(var.RedistDirUCRT)\api-ms-win-crt-filesystem-l1-1-0.dll" KeyPath="yes" />
+</Component>
+<Component Id="Murmur_api_ms_win_crt_heap_l1_1_0.dll">
+  <File Id="Murmur_api_ms_win_crt_heap_l1_1_0.dll" Source="$(var.RedistDirUCRT)\api-ms-win-crt-heap-l1-1-0.dll" KeyPath="yes" />
+</Component>
+<Component Id="Murmur_api_ms_win_crt_locale_l1_1_0.dll">
+  <File Id="Murmur_api_ms_win_crt_locale_l1_1_0.dll" Source="$(var.RedistDirUCRT)\api-ms-win-crt-locale-l1-1-0.dll" KeyPath="yes" />
+</Component>
+<Component Id="Murmur_api_ms_win_crt_math_l1_1_0.dll">
+  <File Id="Murmur_api_ms_win_crt_math_l1_1_0.dll" Source="$(var.RedistDirUCRT)\api-ms-win-crt-math-l1-1-0.dll" KeyPath="yes" />
+</Component>
+<Component Id="Murmur_api_ms_win_crt_multibyte_l1_1_0.dll">
+  <File Id="Murmur_api_ms_win_crt_multibyte_l1_1_0.dll" Source="$(var.RedistDirUCRT)\api-ms-win-crt-multibyte-l1-1-0.dll" KeyPath="yes" />
+</Component>
+<Component Id="Murmur_api_ms_win_crt_private_l1_1_0.dll">
+  <File Id="Murmur_api_ms_win_crt_private_l1_1_0.dll" Source="$(var.RedistDirUCRT)\api-ms-win-crt-private-l1-1-0.dll" KeyPath="yes" />
+</Component>
+<Component Id="Murmur_api_ms_win_crt_process_l1_1_0.dll">
+  <File Id="Murmur_api_ms_win_crt_process_l1_1_0.dll" Source="$(var.RedistDirUCRT)\api-ms-win-crt-process-l1-1-0.dll" KeyPath="yes" />
+</Component>
+<Component Id="Murmur_api_ms_win_crt_runtime_l1_1_0.dll">
+  <File Id="Murmur_api_ms_win_crt_runtime_l1_1_0.dll" Source="$(var.RedistDirUCRT)\api-ms-win-crt-runtime-l1-1-0.dll" KeyPath="yes" />
+</Component>
+<Component Id="Murmur_api_ms_win_crt_stdio_l1_1_0.dll">
+  <File Id="Murmur_api_ms_win_crt_stdio_l1_1_0.dll" Source="$(var.RedistDirUCRT)\api-ms-win-crt-stdio-l1-1-0.dll" KeyPath="yes" />
+</Component>
+<Component Id="Murmur_api_ms_win_crt_string_l1_1_0.dll">
+  <File Id="Murmur_api_ms_win_crt_string_l1_1_0.dll" Source="$(var.RedistDirUCRT)\api-ms-win-crt-string-l1-1-0.dll" KeyPath="yes" />
+</Component>
+<Component Id="Murmur_api_ms_win_crt_time_l1_1_0.dll">
+  <File Id="Murmur_api_ms_win_crt_time_l1_1_0.dll" Source="$(var.RedistDirUCRT)\api-ms-win-crt-time-l1-1-0.dll" KeyPath="yes" />
+</Component>
+<Component Id="Murmur_api_ms_win_crt_utility_l1_1_0.dll">
+  <File Id="Murmur_api_ms_win_crt_utility_l1_1_0.dll" Source="$(var.RedistDirUCRT)\api-ms-win-crt-utility-l1-1-0.dll" KeyPath="yes" />
+</Component>
+<Component Id="Murmur_ucrtbase.dll">
+  <File Id="Murmur_ucrtbase.dll" Source="$(var.RedistDirUCRT)\ucrtbase.dll" KeyPath="yes" />
+</Component>
+
+</Include>

--- a/installer/Product.wxs
+++ b/installer/Product.wxs
@@ -137,6 +137,10 @@
         <ComponentRef Id="vcruntime140.dll" />
       <?endif ?>
 
+      <?ifdef RedistDirUCRT ?>
+        <?include "MumbleUCRTComponentRefs.wxi" ?>
+      <?endif ?>
+
       <ComponentRef Id="dbghelp.dll" />
 
       <Feature Id="MumbleDesktopShortcutFeature" Title="!(loc.MUMBLE_SEC_DesktopShortcut)" Description="!(loc.DESC_DesktopShortcut)" InstallDefault="followParent" AllowAdvertise="no">
@@ -153,6 +157,9 @@
         <?ifdef RedistDirVC14 ?>
           <ComponentRef Id="Murmur_msvcp140.dll" />
           <ComponentRef Id="Murmur_vcruntime140.dll" />
+        <?endif ?>
+        <?ifdef RedistDirUCRT ?>
+          <?include "MurmurUCRTComponentRefs.wxi" ?>
         <?endif ?>
         <ComponentRef Id="Murmur_dbghelp.dll" />
       <?endif ?>

--- a/installer/Settings.wxi
+++ b/installer/Settings.wxi
@@ -92,6 +92,7 @@
   
   <!-- Don't embed VCRedist files if MumbleNoEmbedVCRedist env var is set. -->
   <?ifndef env.MumbleNoEmbedVCRedist ?>
+     <!-- VC CRT -->
      <?ifndef env.MumbleRedistDirVC14 ?>
        <?if $(sys.BUILDARCH) = "x86" ?>
          <?define RedistDirVC14 = "C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\redist\x86\Microsoft.VC140.CRT" ?>
@@ -100,6 +101,17 @@
        <?endif ?>
      <?else ?>
        <?define RedistDirVC14 = "$(env.MumbleRedistDirVC14)" ?>
+     <?endif ?>
+
+     <!-- Universal CRT -->
+     <?ifndef env.MumbleRedistDirUCRT ?>
+       <?if $(sys.BUILDARCH) = "x86" ?>
+         <?define RedistDirUCRT = "C:\Program Files (x86)\Windows Kits\10\Redist\ucrt\DLLs\x86" ?>
+       <?elseif $(sys.BUILDARCH) = "x64" ?>
+         <?define RedistDirUCRT = "C:\Program Files (x86)\Windows Kits\10\Redist\ucrt\DLLs\x64" ?>
+       <?endif ?>
+     <?else ?>
+       <?define RedistDirUCRT = "$(env.MumbleRedistDirUCRT)" ?>
      <?endif ?>
   <?endif ?>
 

--- a/installer/gen-ucrt.py
+++ b/installer/gen-ucrt.py
@@ -1,0 +1,74 @@
+#!/usr/bin/env python
+# Copyright 2005-2017 The Mumble Developers. All rights reserved.
+# Use of this source code is governed by a BSD-style license
+# that can be found in the LICENSE file at the root of the
+# Mumble source tree or at <https://www.mumble.info/LICENSE>.
+
+from __future__ import (unicode_literals, print_function, division)
+
+import os
+import codecs
+
+def mangleComponentId(fn):
+	# Component IDs in WiX can't contain dashes. Mangle them with _ instead.
+	return fn.replace('-', '_')
+
+def fileHeader(f):
+	f.write('<?xml version="1.0" encoding="utf-8"?>\r\n')
+	f.write('<Include>\r\n')
+	f.write('\r\n')
+	f.write('<!-- This file is auto-generated via gen-ucrt.py. Please don\'t touch by hand -->\r\n')
+	f.write('\r\n')
+
+def fileFooter(f):
+	f.write('\r\n')
+	f.write('</Include>\r\n')
+
+def gencomponents(f, files, prefix=''):
+	for fn in files:
+		f.write('<Component Id="{0}">\r\n'.format(mangleComponentId(prefix+fn)))
+		f.write('  <File Id="{0}" Source="$(var.RedistDirUCRT)\{1}" KeyPath="yes" />\r\n'.format(mangleComponentId(prefix+fn), fn))
+		f.write('</Component>\r\n')
+
+def gencomponentrefs(f, files, prefix=''):
+	for fn in files:
+		f.write('''<ComponentRef Id="{0}" />\r\n'''.format(mangleComponentId(prefix+fn)))
+
+def main():
+	ucrtx64 = 'C:\\Program Files (x86)\\Windows Kits\\10\\Redist\\ucrt\\DLLs\\x64'
+	ucrtx86 = 'C:\\Program Files (x86)\\Windows Kits\\10\\Redist\\ucrt\\DLLs\\x86'
+
+	filesx86 = os.listdir(ucrtx86)
+	filesx64 = os.listdir(ucrtx64)
+
+	# Perform a quick sanity test to ensure that both x86 and x64 UCRT variants
+	# use the same filenames.
+	if set(filesx86) != set(filesx64):
+		raise Exception('Fatal error: x86 UCRT files are not equivalent to x64 UCRT files')
+
+	# ...Since they're the same, let's just use the
+	# filenames from x86.
+	files = filesx86
+
+	with codecs.open('MumbleUCRTComponents.wxi', 'wb', 'utf-8') as f:
+		fileHeader(f)
+		gencomponents(f, files)
+		fileFooter(f)
+
+	with codecs.open('MurmurUCRTComponents.wxi', 'wb', 'utf-8') as f:
+		fileHeader(f)
+		gencomponents(f, files, 'Murmur_')
+		fileFooter(f)
+
+	with codecs.open('MumbleUCRTComponentRefs.wxi', 'wb', 'utf-8') as f:
+		fileHeader(f)
+		gencomponentrefs(f, files)
+		fileFooter(f)
+
+	with codecs.open('MurmurUCRTComponentRefs.wxi', 'wb', 'utf-8') as f:
+		fileHeader(f)
+		gencomponentrefs(f, files, 'Murmur_')
+		fileFooter(f)
+
+if __name__ == '__main__':
+	main()


### PR DESCRIPTION
MSVC2015 uses a new CRT called the Universal CRT.

This CRT is distributed in different ways, depending on your
OS.

For Windows XP, the official distribution is a VCRedist installer.
(Or, for Windows XP only -- merge modules).

For Vista through 8.1, UCRT is distributed via Windows Update.

For Windows 10, it's shipped as part of Windows.

This commit amends our installer to install an app-local copy of
the Universal CRT. This is the sanest way for us to distribute the
Universal CRT across all supported targets.

Even if we could drop Windows XP support, the fact that earlier
Windows versions deploy the Universal CRT through Windows Update
makes it a hard pill to swallow. People's hacked up machines might
not be able to get the update from Windows Update for whatever reason.
(Maybe they disabled the Windows Update service for performance reasons,
because a guide on the web told them to?)

So, for now, this is what we'll do. Perhaps it makes more sense to
statically link the UCRT instead of this massive soup of DLLs. But
this is a quick fix to keep our snapshots going until we can work
out the details for statically linking UCRT.

Note: Because Murmur is outside the versioned root-dir, we ship a
separate CRT copy for Murmur. Now that we have to ship the UCRT as
well, that's suddenly a lot more files we'll have to carry. That's
also an unfortunate side-effect of the UCRT. But if you look at it
from the perspective that shipping the VCRUNTIME+UCRT on MSVC2015
"the same thing" as shipping MSVCRT on MSVC2013, we're not really
doing anything much different. Except, we're being "punished" by
the fact that Microsoft decided to split up the CRT into tiny pieces.

Future work: Ideally, we wouldn't include these .wxi files in the
repo, and instead depend on gen-ucrt.py being run before building
the installer. However, that would require buildenv changes, and
require us to redeploy buildenvs, which takes time. To get the UCRT
fix out into a snapshot, let's add them to the repo for now, and we
can clean it up later.