### PR TITLE
mumble_proto.pro: fix protoc invocation for out-of-tree builds

### DIFF
--- a/src/mumble_proto/mumble_proto.pro
+++ b/src/mumble_proto/mumble_proto.pro
@@ -15,7 +15,7 @@ pbh.CONFIG *= no_link explicit_dependencies target_predeps
 pbh.variable_out = HEADERS
 
 pb.output = ${QMAKE_FILE_BASE}.pb.cc
-pb.commands = protoc --cpp_out=. -I. -I.. ${QMAKE_FILE_NAME}
+pb.commands = protoc --cpp_out=. -I. -I.. -I${QMAKE_FILE_IN_PATH} ${QMAKE_FILE_NAME}
 pb.input = PROTOBUF
 pb.CONFIG *= no_link explicit_dependencies
 pb.variable_out = SOURCES


### PR DESCRIPTION
This fixes the error:
```
File does not reside within any path specified using --proto_path (or -I). You must specify a --proto_path which encompasses this file. Note that the proto_path must be an exact prefix of the .proto file names -- protoc is too dumb to figure out when two paths (e.g. absolute and relative) are equivalent (it's harder than you think).
```