### PR TITLE
WIP: Settings, PulseAudio, add 'audio/inputdelay' setting for controlling input stream latency requirements.

### DIFF
--- a/src/mumble/PulseAudio.cpp
+++ b/src/mumble/PulseAudio.cpp
@@ -295,7 +295,7 @@ void PulseAudioSystem::eventCallback(pa_mainloop_api *api, pa_defer_event *) {
 			buff.minreq = iBlockLen;
 			buff.maxlength = -1;
 			buff.prebuf = -1;
-			buff.fragsize = iBlockLen;
+			buff.fragsize = iBlockLen * (g.s.iInputDelay + 1);
 
 			qsInputCache = idev;
 

--- a/src/mumble/Settings.cpp
+++ b/src/mumble/Settings.cpp
@@ -305,6 +305,7 @@ Settings::Settings() {
 	ssFilter = ShowReachable;
 
 	iOutputDelay = 5;
+	iInputDelay = 0;
 
 	bASIOEnable = true;
 
@@ -598,6 +599,7 @@ void Settings::load(QSettings* settings_ptr) {
 	SAVELOAD(iNoiseSuppress, "audio/noisesupress");
 	SAVELOAD(iVoiceHold, "audio/voicehold");
 	SAVELOAD(iOutputDelay, "audio/outputdelay");
+	SAVELOAD(iInputDelay, "audio/inputdelay");
 
 	// Idle auto actions
 	SAVELOAD(iIdleTime, "audio/idletime");
@@ -914,6 +916,7 @@ void Settings::save() {
 	SAVELOAD(iNoiseSuppress, "audio/noisesupress");
 	SAVELOAD(iVoiceHold, "audio/voicehold");
 	SAVELOAD(iOutputDelay, "audio/outputdelay");
+	SAVELOAD(iInputDelay, "audio/inputdelay");
 
 	// Idle auto actions
 	SAVELOAD(iIdleTime, "audio/idletime");

--- a/src/mumble/Settings.h
+++ b/src/mumble/Settings.h
@@ -190,6 +190,7 @@ struct Settings {
 	bool bOnlyAttenuateSameOutput;
 	bool bAttenuateLoopbacks;
 	int iOutputDelay;
+	int iInputDelay;
 	bool bUseOpusMusicEncoding;
 
 	QString qsALSAInput, qsALSAOutput;


### PR DESCRIPTION
…input stream latency requirements.

The setting is specified in increments of 10 ms. The default, 0,
means 10 ms. (I.e., setting audio/inputdelay = 9 will give you 100 ms.)

This allows users to control the buffer size for AudioInput.
We've usually always run Mumble in a mode where we're delivered audio
frames from our audio systems every 10 ms -- 10 ms being the size of a
single frame of audio in Mumble.

This knob allows you to change that, such that such that Mumble is instead
not woken up as often, but is given multiple audio frames at once.

For example, at 100 ms, AudioInput will only wake Mumble up every 100 ms,
but will give it 10 audio frames (of 10 ms each) to work with at once.

The previous 10 ms requirement for AudioInput has caused high CPU
usage for Mumble on PulseAudio -- perhaps because of communication
overhead. This setting will allow people to adjust their input delay
to their preference.

For now, it is a hidden setting and is only implemented for PulseAudio.

On Linux, it can be set by adding a line, such as:

    inputdelay=9

under the `[audio]` section of the config file at
`$HOME/.config/Mumble/Mumble.conf`.