### PR TITLE
installer: don't ship dbghelp.dll anymore.

### DIFF
--- a/installer/Files.wxs
+++ b/installer/Files.wxs
@@ -79,10 +79,6 @@
        <?include "MumbleUCRTComponents.wxi" ?>
       <?endif ?>
 
-      <Component Id="dbghelp.dll">
-        <File Source="$(var.DebugToolsDir)\dbghelp.dll" KeyPath="yes" />
-      </Component>
-
     <?ifdef VersionSubDir ?>
       </DirectoryRef>
     <?else ?>
@@ -150,9 +146,6 @@
         <?ifdef RedistDirUCRT ?>
           <?include "MurmurUCRTComponents.wxi" ?>
         <?endif ?>
-        <Component Id="Murmur_dbghelp.dll">
-          <File Id="Murmur_dbghelp.dll" Source="$(var.DebugToolsDir)\dbghelp.dll" KeyPath="yes" />
-        </Component>
       <?endif ?>
 
       <Component Id="licence.txt" Guid="$(var.LicenseTextGuid)">

--- a/installer/Product.wxs
+++ b/installer/Product.wxs
@@ -141,8 +141,6 @@
         <?include "MumbleUCRTComponentRefs.wxi" ?>
       <?endif ?>
 
-      <ComponentRef Id="dbghelp.dll" />
-
       <Feature Id="MumbleDesktopShortcutFeature" Title="!(loc.MUMBLE_SEC_DesktopShortcut)" Description="!(loc.DESC_DesktopShortcut)" InstallDefault="followParent" AllowAdvertise="no">
         <ComponentRef Id="MumbleDesktopShortcutComponent" />
       </Feature>
@@ -161,7 +159,6 @@
         <?ifdef RedistDirUCRT ?>
           <?include "MurmurUCRTComponentRefs.wxi" ?>
         <?endif ?>
-        <ComponentRef Id="Murmur_dbghelp.dll" />
       <?endif ?>
 
       <Feature Id="MurmurDesktopShortcutFeature" Title="!(loc.MUMBLE_SEC_DesktopShortcut)" Description="!(loc.DESC_DesktopShortcut)"  InstallDefault="followParent" AllowAdvertise="no">

--- a/installer/Settings.wxi
+++ b/installer/Settings.wxi
@@ -36,16 +36,6 @@
     <?define QtDir = "$(env.MumbleQtDir)" ?>
   <?endif ?>
   
-  <?ifndef env.MumbleDebugToolsDir ?>
-    <?if $(sys.BUILDARCH) = "x86" ?>
-      <?define DebugToolsDir = "C:\Program Files (x86)\Debugging Tools for Windows (x86)" ?>
-    <?elseif $(sys.BUILDARCH) = "x64" ?>
-      <?define DebugToolsDir = "C:\Program Files\Debugging Tools for Windows (x64)" ?>
-    <?endif ?>
-  <?else ?>
-    <?define DebugToolsDir = "$(env.MumbleDebugToolsDir)" ?>
-  <?endif ?>
-  
   <?ifndef env.MumbleSndFileDir ?>
     <?ifndef env.MumbleNoSndFile ?>
       <?define SndFileDir = "\Program Files (x86)\Mega-Nerd\libsndfile\bin" ?>


### PR DESCRIPTION
Only older versions of dbghelp.dll are redistributable by themselves.
Newer versions only allow redistribution via MSI files, which are
useless for us.

To sidestep this problem, we'll simply go back to relying on the OSes
version of dbghelp.dll. Shipping an outdated version of dbghelp.dll
isn't sensible. We're better off allowing Windows 10 to use a modern
(its own) version of dbghelp.dll than using a year-old version.

To give some context on how we use dbghelp.dll:

In Mumble, we use dbghelp.dll for writing our Minidumps.

In Murmur, Ice uses it for symbolicating stack traces in
Ice exceptions.