### PR TITLE
mumble_exe: when using a versioned root, set the CWD to it.

### DIFF
--- a/src/mumble_exe/mumble_exe.cpp
+++ b/src/mumble_exe/mumble_exe.cpp
@@ -48,22 +48,6 @@ static const std::wstring GetExecutableDirPath() {
 	return exe_path.append(L"\\");
 }
 
-// ConfigureEnvironment prepares mumble.exe's environment to
-// run mumble_app.dll.
-static bool ConfigureEnvironment() {
-	const std::wstring exe_path = GetExecutableDirPath();
-
-	// Remove the current directory from the DLL search path.
-	if (!SetDllDirectoryW(L""))
-		return false;
-
-	// Set mumble.exe's directory as the current working directory.
-	if (!SetCurrentDirectoryW(exe_path.c_str()))
-		return false;
-
-	return true;
-}
-
 // GetVersionedRootPath returns the versioned root path if
 // Mumble is configured to work with versioned paths.
 // If Mumble is not configured for versioned paths, this
@@ -80,6 +64,25 @@ static const std::wstring GetVersionedRootPath() {
 	}
 
 	return std::wstring();
+}
+
+// ConfigureEnvironment prepares mumble.exe's environment to
+// run mumble_app.dll.
+static bool ConfigureEnvironment() {
+	// Remove the current directory from the DLL search path.
+	if (!SetDllDirectoryW(L""))
+		return false;
+
+	// Set the versioned root as the working directory if one is available.
+	// If not, use the directory containing mumble.exe as the working directory.
+	std::wstring cwd = GetVersionedRootPath();
+	if (cwd.empty()) {
+		cwd = GetExecutableDirPath();
+	}
+	if (!SetCurrentDirectoryW(cwd.c_str()))
+		return false;
+
+	return true;
 }
 
 // GetAbsoluteMumbleAppDllPath returns the absolute path to


### PR DESCRIPTION
Previously, we always used the directory holding mumble.exe
as the working directory.

This commit changes that to use the versioned root directory
as the working directory -- if we're using one.
When not using a versioned root directory, the old behavior
is kept intact.

This is primarily done to work around mumble-voip/mumble#2837,
where, when loading mumble_app.dll, the search order for ucrtbase.dll
seems to be using the "Standard Search Order for Desktop Applications"
instead of the "Alternate Search ORder for Desktop Applications", as it
should when we specify LOAD_WITH_ALTERED_SEARCH_PATH to LoadLibraryEx.

For context, see the following MSDN page:
https://msdn.microsoft.com/en-us/library/ms682586.aspx

Changing the working directory to the versioned root path allows
the Universal CRT to be correctly loaded -- via step 5 of the "Standard
Search Order for Desktop Applications" if SafeDllSearchMode is on --
despite this weird behavior from the system.