### PR TITLE
Add appveyor configuration for windows proof builds

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,22 @@
+version: 1.3.x-proofbuild-{build}
+
+image: Visual Studio 2015
+
+cache:
+    - C:\MumbleBuild\cache -> appveyor.yml
+
+clone_folder: C:\MumbleBuild\mumble
+
+environment:
+    MUMBLE_BUILDSCRIPT: 1.3.x/mumble-win64-static.cmd
+    MUMBLE_ENVIRONMENT_VERSION: win64-static-no-ltcg-1.3.x-2017-02-02-ec94ddb-790
+    MUMBLE_ENVIRONMENT_SOURCE:
+        secure: PCLhmhoHWRRXfxd7m1hlfWZXmTxP55BicfSaxWPJjeI=
+    APPVEYOR_CACHE_ENTRY_ZIP_ARGS: -t7z -mx0  # Do not compress cache. Env. is already a 7z.
+
+install:
+  - "git submodule --quiet update --init --recursive"
+  - "powershell ./scripts/appveyor/appveyor-install-environment.ps1"
+
+build_script:
+  - "powershell ./scripts/appveyor/appveyor-build.ps1"

--- a/scripts/appveyor/appveyor-build.ps1
+++ b/scripts/appveyor/appveyor-build.ps1
@@ -1,0 +1,33 @@
+﻿#
+# Builds mumble using the given environment and build script.
+# The configuration we build with is adjusted to be close to
+# our release builds.
+#
+# Configuration variables used from environment:
+#
+#  MUMBLE_ENVIRONMENT_VERSION - Full build environment version
+#                               (e.g. win64-static-no-ltcg-1.3.x-2017-02-02-ec94ddb-790).
+#                               Must match .7z and extracted folder name.
+#  MUMBLE_BUILDSCRIPT         - Path to required build script cmd file. Relative to build
+#                               environment mumble-releng\buildscripts.
+#                               E.g.  1.3.x/buildenv-win64-static.cmd
+#
+$ErrorActionPreference = "Stop"
+
+$MUMBLE_BUILD_DIR = "C:\MumbleBuild"
+$MUMBLE_SOURCE_DIR = Join-Path $MUMBLE_BUILD_DIR "mumble"
+$MUMBLE_BUILDENV_DIR = Join-Path $MUMBLE_BUILD_DIR $env:MUMBLE_ENVIRONMENT_VERSION
+$MUMBLE_BUILDSCRIPT = Join-Path $MUMBLE_BUILDENV_DIR "mumble-releng\buildscripts\$env:MUMBLE_BUILDSCRIPT"
+
+# We do not sign the appveyor CI builds so we mustn't disable
+# uiaccess elevation. Also no intermediary signing is wanted.
+# Also use jom to use both cores we get on the builder.
+$env:MUMBLE_EXTRA_QMAKE_CONFIG_FLAGS = "no-elevation"
+$env:MUMBLE_SKIP_INTERNAL_SIGNING = "1"
+$env:MUMBLE_SKIP_COLLECT_SYMBOLS = "1"
+$env:MUMBLE_NMAKE = "jom"
+$env:MUMBLE_BUILDENV_DIR = $MUMBLE_BUILDENV_DIR
+
+Set-Location $MUMBLE_SOURCE_DIR
+& $MUMBLE_BUILDSCRIPT
+exit $lastexitcode

--- a/scripts/appveyor/appveyor-install-environment.ps1
+++ b/scripts/appveyor/appveyor-install-environment.ps1
@@ -1,0 +1,39 @@
+#
+# Ensures we have downloaded and extracted a build environment
+# into our appveyor VM before we attempt to build. If the
+# environment was already cached and hence already present
+# this script will detect that.
+#
+# Configuration variables used from environment:
+#
+#  MUMBLE_ENVIRONMENT_VERSION - Full build environment version
+#                               (e.g. win64-static-no-ltcg-1.3.x-2017-02-02-ec94ddb-790).
+#                               Must match .7z and extracted folder name.
+#  MUMBLE_ENVIRONMENT_SOURCE  - Build environment web source folder URL
+#                               (e.g. https://somehost/folder)
+#
+$ErrorActionPreference = "Stop"
+
+$MUMBLE_ENVIRONMENT_VERSION = $env:MUMBLE_ENVIRONMENT_VERSION     # Env. name (must match .7z and extracted folder name)
+$MUMBLE_ENVIRONMENT_SOURCE = $env:MUMBLE_ENVIRONMENT_SOURCE       # Env. web source folder URL
+$MUMBLE_BUILD_DIR = "C:\MumbleBuild"
+$MUMBLE_ENVIRONMENT_STORE = Join-Path $MUMBLE_BUILD_DIR "\cache"
+
+if (-Not (Test-Path $MUMBLE_ENVIRONMENT_STORE)) {
+    New-Item $MUMBLE_ENVIRONMENT_STORE -ItemType Directory | Out-Null
+ }
+
+$cached_env = Join-Path $MUMBLE_ENVIRONMENT_STORE "$MUMBLE_ENVIRONMENT_VERSION.7z";
+
+if (-Not (Test-Path $cached_env)) {
+    Write-Host "Environment not cached. Downloading"
+    $env_url = "$MUMBLE_ENVIRONMENT_SOURCE/$MUMBLE_ENVIRONMENT_VERSION.7z"
+    Invoke-WebRequest -Uri $env_url -OutFile $cached_env
+}
+
+if (-Not (Test-Path (Join-Path $MUMBLE_BUILD_DIR $MUMBLE_ENVIRONMENT_VERSION))) {
+    Write-Host "Extracting build environment to $MUMBLE_BUILD_DIR"
+    & 7z x $cached_env -o"$MUMBLE_BUILD_DIR"
+}
+
+Get-ChildItem -Path $MUMBLE_BUILD_DIR


### PR DESCRIPTION
The current configuration uses a hacked up
win64-static-no-ltcg build environment until we
build our next set of real ones. As we do not want
to distribute our build env at this point the source
is obfuscated for now.

We utilize the appveyor cache to cache the compressed
build environment we downloaded. We do not cache the
uncompressed variant to save the time it takes to package
it up in case of cache invalidation. Cache invalidation
is keyed on changes to the appveyor.yml .