### PR TITLE
Add travis configuration for linux proof builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,10 @@
+sudo: required # Required for apt-get build-dep
+language: cpp
+compiler: gcc
+
+before_install:
+    - sudo apt-get -qq update
+    - sudo apt-get build-dep -qq mumble
+
+script:
+    - qmake CONFIG+="release g15-emulator qt4-legacy-compat" -recursive && make -j2


### PR DESCRIPTION
Travis builds with Ubuntu 12.04 so this is more of a
legacy compilation test with qt4. Should still be
helpful.