### PR TITLE
Add support for custom "protoc" path and scan using "which" on Linux

### DIFF
--- a/protoc.pri
+++ b/protoc.pri
@@ -1,0 +1,67 @@
+# Copyright 2005-2017 The Mumble Developers. All rights reserved.
+# Use of this source code is governed by a BSD-style license
+# that can be found in the LICENSE file at the root of the
+# Mumble source tree or at <https://www.mumble.info/LICENSE>.
+
+# This .pri files finds a suitable protoc binary on the system.
+#
+# It exposes the found protoc binary as the 'PROTOC' qmake variable.
+# This variable contains the absolute path to a working protoc binary.
+#
+# Why do we need to do this?
+#
+# The protobuf compiler's binary name in MinGW packages for Linux
+# cross-compiling is never 'protoc', but something like
+# 'x86_64-w64-mingw32.static-protoc'.
+#
+# This file tries to use the right binary, by searching in $PATH
+# using the 'which' tool.
+#
+# If no binary is found, an error is shown to the user.
+#
+# This script also supports setting a MUMBLE_PROTOC environment
+# variable to specify an absolute path to a protoc binary to use.
+# Setting this environment variable overrides any querying.
+
+include(qt.pri)
+
+PROTOC = $$(MUMBLE_PROTOC)
+
+# If the MUMBLE_PROTOC environment variable isn't set
+isEmpty(PROTOC) {
+	# If we're on Qt 4 on win32, or we're building from Windows, use "protoc"
+	equals(QMAKE_HOST.os, "Windows")|equals(QMAKE_VERSION_INT_MAJOR, 4):win32 {
+		PROTOC=protoc
+	} else {
+		# Determine if the 'which' tool is available. We need it
+		# to determine which PROTOC binary on the system to use.
+		# If 'which' isn't available, error out.
+		# Calling 'which which' is intentional.
+		# If which is available, it will print the path to it.
+		# If it isn't available, it will not print anything.
+		WHICH=$$system(which which 2>/dev/null)
+		isEmpty(WHICH) {
+			message("The 'which' command is not available on the system. Unable to search for protoc installations. Assuming 'protoc'... If this is not correct, please point the MUMBLE_PROTOC environment variable at a working protoc binary.")
+			PROTOC=protoc
+		} else {
+			TARGET_TRIPLE = $$system($${QMAKE_CC} -dumpmachine 2>/dev/null)
+			!isEmpty(TARGET_TRIPLE) {
+				isEmpty(PROTOC) {
+					PROTOC=$$system(which $$TARGET_TRIPLE"-protoc" 2>/dev/null)
+				}
+				isEmpty(PROTOC) {
+					PROTOC=$$system(which $$TARGET_TRIPLE".static-protoc" 2>/dev/null)
+				}
+				isEmpty(PROTOC) {
+					PROTOC=$$system(which $$TARGET_TRIPLE".shared-protoc" 2>/dev/null)
+				}
+			}
+			isEmpty(PROTOC) {
+				PROTOC=$$system(which protoc 2>/dev/null)
+			}
+			isEmpty(PROTOC) {
+				error("Unable to find system's protoc binary. Some scripts invoked during the Mumble build use the protobuf compiler. You can manually specify it via the MUMBLE_PROTOC environment variable.")
+			}
+		}
+	}
+}

--- a/src/mumble_proto/mumble_proto.pro
+++ b/src/mumble_proto/mumble_proto.pro
@@ -4,6 +4,7 @@
 # Mumble source tree or at <https://www.mumble.info/LICENSE>.
 
 include(../../compiler.pri)
+include(../../protoc.pri)
 
 PROTOBUF	*= ../Mumble.proto
 
@@ -15,7 +16,7 @@ pbh.CONFIG *= no_link explicit_dependencies target_predeps
 pbh.variable_out = HEADERS
 
 pb.output = ${QMAKE_FILE_BASE}.pb.cc
-pb.commands = protoc --cpp_out=. -I. -I.. -I${QMAKE_FILE_IN_PATH} ${QMAKE_FILE_NAME}
+pb.commands = $${PROTOC} --cpp_out=. -I. -I.. -I${QMAKE_FILE_IN_PATH} ${QMAKE_FILE_NAME}
 pb.input = PROTOBUF
 pb.CONFIG *= no_link explicit_dependencies
 pb.variable_out = SOURCES

--- a/src/murmur/murmur.pro
+++ b/src/murmur/murmur.pro
@@ -4,6 +4,7 @@
 # Mumble source tree or at <https://www.mumble.info/LICENSE>.
 
 include(../mumble.pri)
+include(../../protoc.pri)
 
 DEFINES *= MURMUR
 TEMPLATE	=app
@@ -156,7 +157,7 @@ grpc {
 
 	GRPC_WRAPPER = MurmurRPC.proto
 	grpc_wrapper.output = MurmurRPC.proto.Wrapper.cpp
-	grpc_wrapper.commands = protoc --plugin=${DESTDIR}protoc-gen-murmur-grpcwrapper -I. --murmur-grpcwrapper_out=. MurmurRPC.proto
+	grpc_wrapper.commands = $${PROTOC} --plugin=${DESTDIR}protoc-gen-murmur-grpcwrapper -I. --murmur-grpcwrapper_out=. MurmurRPC.proto
 	grpc_wrapper.input = GRPC_WRAPPER
 	grpc_wrapper.variable_out =
 	QMAKE_EXTRA_COMPILERS += grpc_wrapper

--- a/src/murmur/murmur_grpc/murmur_grpc.pro
+++ b/src/murmur/murmur_grpc/murmur_grpc.pro
@@ -4,6 +4,7 @@
 # Mumble source tree or at <https://www.mumble.info/LICENSE>.
 
 include(../../../compiler.pri)
+include(../../../protoc.pri)
 
 GRPC *= ../MurmurRPC.proto
 
@@ -15,7 +16,7 @@ grpc_pbh.CONFIG *= no_link explicit_dependencies target_predeps
 grpc_pbh.variable_out = HEADERS
 
 grpc_pb.output = ${QMAKE_FILE_BASE}.pb.cc
-grpc_pb.commands = protoc --cpp_out=. -I. -I.. ${QMAKE_FILE_NAME}
+grpc_pb.commands = $${PROTOC} --cpp_out=. -I. -I.. ${QMAKE_FILE_NAME}
 grpc_pb.input = GRPC
 grpc_pb.CONFIG *= no_link explicit_dependencies
 grpc_pb.variable_out = SOURCES
@@ -28,7 +29,7 @@ grpch.CONFIG *= no_link explicit_dependencies target_predeps
 
 grpc.output = ${QMAKE_FILE_BASE}.grpc.pb.cc
 grpc.depends = ${QMAKE_FILE_BASE}.pb.h
-grpc.commands = protoc --grpc_out=. --plugin=protoc-gen-grpc=$$system(which grpc_cpp_plugin) -I. -I.. ${QMAKE_FILE_NAME}
+grpc.commands = $${PROTOC} --grpc_out=. --plugin=protoc-gen-grpc=$$system(which grpc_cpp_plugin) -I. -I.. ${QMAKE_FILE_NAME}
 grpc.input = GRPC
 grpc.CONFIG *= no_link explicit_dependencies
 grpc.variable_out = SOURCES


### PR DESCRIPTION
On Linux the protobuf compiler binary's name is usually _protoc_, except when using a MinGW one to cross-compile for Windows.
The binary in the MXE Debian package is called _x86_64-w64-mingw32.static-protoc_, _x86_64-w64-mingw32.shared-protoc_, _i686-w64-mingw32.static-protoc_ or _i686-w64-mingw32.shared-protoc_, depending on the chosen target.