### PR TITLE
mumble.pro: handle case where QSQLite a plugin in static builds.

### DIFF
--- a/src/mumble/mumble.pro
+++ b/src/mumble/mumble.pro
@@ -655,6 +655,11 @@ CONFIG(no-update) {
 
 CONFIG(static_qt_plugins) {
   DEFINES += USE_STATIC_QT_PLUGINS
+  
+  # If QSQLite is a plugin we need to import it in order to use the database
+  exists($$[QT_INSTALL_PLUGINS]/sqldrivers/*qsqlite*) {
+      QTPLUGIN += qsqlite
+  }
 
   # Since Qt 5.3, qt.prf will automatically populate QT_PLUGINS for static builds
   # for TEMPLATE=app.


### PR DESCRIPTION
Qt for MinGW on Linux doesn't import it automatically, which results in Mumble being unable to create or open the SQLite database.