### PR TITLE
Always use lrelease binary from QT_INSTALL_BINS.

### DIFF
--- a/lrelease.pri
+++ b/lrelease.pri
@@ -1,0 +1,10 @@
+# Copyright 2005-2017 The Mumble Developers. All rights reserved.
+# Use of this source code is governed by a BSD-style license
+# that can be found in the LICENSE file at the root of the
+# Mumble source tree or at <https://www.mumble.info/LICENSE>.
+
+# This .pri file finds the correct lrelease binary name on the system.
+
+isEmpty(QMAKE_LRELEASE) {
+	QMAKE_LRELEASE = $$[QT_INSTALL_BINS]/lrelease
+}

--- a/src/mumble/mumble.pro
+++ b/src/mumble/mumble.pro
@@ -5,6 +5,7 @@
 
 include(../mumble.pri)
 include(../../python.pri)
+include(../../lrelease.pri)
 
 DEFINES		*= MUMBLE
 TEMPLATE	= app
@@ -251,16 +252,6 @@ CONFIG(static) {
   macx {
     QMAKE_LFLAGS -= -Wl,-dead_strip
     QMAKE_LFLAGS += -Wl,-all_load
-  }
-}
-
-isEmpty(QMAKE_LRELEASE) {
-  QMAKE_QMAKE_BASE = $$basename(QMAKE_QMAKE)
-  QMAKE_LRELEASE_PATH = $$dirname(QMAKE_QMAKE)/$$replace(QMAKE_QMAKE_BASE,qmake,lrelease)
-  isEqual(QT_MAJOR_VERSION, 5) {
-    QMAKE_LRELEASE = $$shell_path($$QMAKE_LRELEASE_PATH)
-  } else {
-    QMAKE_LRELEASE = $$QMAKE_LRELEASE_PATH
   }
 }
 


### PR DESCRIPTION
In MXE's Qt 5 package the binary is called lrelease, unlike QMake's one, which has a prefix.
This resulted in the script using the wrong name.