### PR TITLE
mumble_en.ts: Add missing translation for "Hide Mumble"

### DIFF
--- a/src/mumble/mumble_en.ts
+++ b/src/mumble/mumble_en.ts
@@ -5228,6 +5228,21 @@ Otherwise abort and check your certificate and username.</source>
     </message>
     <message>
         <location/>
+        <source>&amp;Hide Mumble</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location/>
+        <source>Hides the main Mumble window.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location/>
+        <source>Hides the main Mumble window. Restore by clicking on the tray icon or starting Mumble again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location/>
         <source>&amp;Connect</source>
         <translation type="unfinished"></translation>
     </message>


### PR DESCRIPTION
This resulted in "Hide Mumble" and the correlated strings, introduced in https://github.com/mumble-voip/mumble/commit/74572fd66ee1d7f317379bb5f4116eb9a88e9d55, being unavailable on Transifex, therefore the text was always in English, regardless of the chosen language.