### PR TITLE
Murmur: refactor private key loading sequence.

### DIFF
--- a/src/murmur/Cert.cpp
+++ b/src/murmur/Cert.cpp
@@ -85,6 +85,10 @@ void Server::initializeCert() {
 		qskKey = QSslKey(key, QSsl::Rsa, QSsl::Pem, QSsl::PrivateKey, pass);
 		if (qskKey.isNull())
 			qskKey = QSslKey(key, QSsl::Dsa, QSsl::Pem, QSsl::PrivateKey, pass);
+#if QT_VERSION >= 0x050000
+		if (qskKey.isNull())
+			qskKey = QSslKey(key, QSsl::Ec, QSsl::Pem, QSsl::PrivateKey, pass);
+#endif
 	}
 
 	// If we still can't load the key, try loading any keys from the certificate
@@ -92,6 +96,10 @@ void Server::initializeCert() {
 		qskKey = QSslKey(crt, QSsl::Rsa, QSsl::Pem, QSsl::PrivateKey, pass);
 		if (qskKey.isNull())
 			qskKey = QSslKey(crt, QSsl::Dsa, QSsl::Pem, QSsl::PrivateKey, pass);
+#if QT_VERSION >= 0x050000
+		if (qskKey.isNull())
+			qskKey = QSslKey(crt, QSsl::Ec, QSsl::Pem, QSsl::PrivateKey, pass);
+#endif
 	}
 
 	// If have a key, walk the list of certs, find the one for our key,

--- a/src/murmur/Cert.cpp
+++ b/src/murmur/Cert.cpp
@@ -70,6 +70,18 @@ bool Server::isKeyForCert(const QSslKey &key, const QSslCertificate &cert) {
 	return false;
 }
 
+QSslKey Server::privateKeyFromPEM(const QByteArray &buf, const QByteArray &pass) {
+	QSslKey key;
+	key = QSslKey(buf, QSsl::Rsa, QSsl::Pem, QSsl::PrivateKey, pass);
+	if (key.isNull())
+		key = QSslKey(buf, QSsl::Dsa, QSsl::Pem, QSsl::PrivateKey, pass);
+#if QT_VERSION >= 0x050000
+	if (key.isNull())
+		key = QSslKey(buf, QSsl::Ec, QSsl::Pem, QSsl::PrivateKey, pass);
+#endif
+	return key;
+}
+
 void Server::initializeCert() {
 	QByteArray crt, key, pass, dhparams;
 

--- a/src/murmur/Cert.cpp
+++ b/src/murmur/Cert.cpp
@@ -92,26 +92,14 @@ void Server::initializeCert() {
 
 	QList<QSslCertificate> ql;
 
-	// Attempt to load key as an RSA key or a DSA key
+	// Attempt to load the private key.
 	if (! key.isEmpty()) {
-		qskKey = QSslKey(key, QSsl::Rsa, QSsl::Pem, QSsl::PrivateKey, pass);
-		if (qskKey.isNull())
-			qskKey = QSslKey(key, QSsl::Dsa, QSsl::Pem, QSsl::PrivateKey, pass);
-#if QT_VERSION >= 0x050000
-		if (qskKey.isNull())
-			qskKey = QSslKey(key, QSsl::Ec, QSsl::Pem, QSsl::PrivateKey, pass);
-#endif
+		qskKey = Server::privateKeyFromPEM(key, pass);
 	}
 
 	// If we still can't load the key, try loading any keys from the certificate
 	if (qskKey.isNull() && ! crt.isEmpty()) {
-		qskKey = QSslKey(crt, QSsl::Rsa, QSsl::Pem, QSsl::PrivateKey, pass);
-		if (qskKey.isNull())
-			qskKey = QSslKey(crt, QSsl::Dsa, QSsl::Pem, QSsl::PrivateKey, pass);
-#if QT_VERSION >= 0x050000
-		if (qskKey.isNull())
-			qskKey = QSslKey(crt, QSsl::Ec, QSsl::Pem, QSsl::PrivateKey, pass);
-#endif
+		qskKey = Server::privateKeyFromPEM(crt);
 	}
 
 	// If have a key, walk the list of certs, find the one for our key,

--- a/src/murmur/Meta.cpp
+++ b/src/murmur/Meta.cpp
@@ -407,11 +407,19 @@ void MetaParams::read(QString fname) {
 			qskKey = QSslKey(key, QSsl::Rsa, QSsl::Pem, QSsl::PrivateKey, qbaPassPhrase);
 			if (qskKey.isNull())
 				qskKey = QSslKey(key, QSsl::Dsa, QSsl::Pem, QSsl::PrivateKey, qbaPassPhrase);
+#if QT_VERSION >= 0x050000
+			if (qskKey.isNull())
+				qskKey = QSslKey(key, QSsl::Ec, QSsl::Pem, QSsl::PrivateKey, qbaPassPhrase);
+#endif
 		}
 		if (qskKey.isNull() && ! crt.isEmpty()) {
 			qskKey = QSslKey(crt, QSsl::Rsa, QSsl::Pem, QSsl::PrivateKey, qbaPassPhrase);
 			if (qskKey.isNull())
 				qskKey = QSslKey(crt, QSsl::Dsa, QSsl::Pem, QSsl::PrivateKey, qbaPassPhrase);
+#if QT_VERSION >= 0x050000
+			if (qskKey.isNull())
+				qskKey = QSslKey(crt, QSsl::Ec, QSsl::Pem, QSsl::PrivateKey, qbaPassPhrase);
+#endif
 			if (! qskKey.isNull())
 				qCritical("Using private key found in certificate file.");
 		}

--- a/src/murmur/Meta.cpp
+++ b/src/murmur/Meta.cpp
@@ -404,22 +404,10 @@ void MetaParams::read(QString fname) {
 
 	if (! key.isEmpty() || ! crt.isEmpty()) {
 		if (! key.isEmpty()) {
-			qskKey = QSslKey(key, QSsl::Rsa, QSsl::Pem, QSsl::PrivateKey, qbaPassPhrase);
-			if (qskKey.isNull())
-				qskKey = QSslKey(key, QSsl::Dsa, QSsl::Pem, QSsl::PrivateKey, qbaPassPhrase);
-#if QT_VERSION >= 0x050000
-			if (qskKey.isNull())
-				qskKey = QSslKey(key, QSsl::Ec, QSsl::Pem, QSsl::PrivateKey, qbaPassPhrase);
-#endif
+			qskKey = Server::privateKeyFromPEM(key, qbaPassPhrase);
 		}
 		if (qskKey.isNull() && ! crt.isEmpty()) {
-			qskKey = QSslKey(crt, QSsl::Rsa, QSsl::Pem, QSsl::PrivateKey, qbaPassPhrase);
-			if (qskKey.isNull())
-				qskKey = QSslKey(crt, QSsl::Dsa, QSsl::Pem, QSsl::PrivateKey, qbaPassPhrase);
-#if QT_VERSION >= 0x050000
-			if (qskKey.isNull())
-				qskKey = QSslKey(crt, QSsl::Ec, QSsl::Pem, QSsl::PrivateKey, qbaPassPhrase);
-#endif
+			qskKey = Server::privateKeyFromPEM(crt, qbaPassPhrase);
 			if (! qskKey.isNull())
 				qCritical("Using private key found in certificate file.");
 		}

--- a/src/murmur/MurmurIce.cpp
+++ b/src/murmur/MurmurIce.cpp
@@ -1550,7 +1550,7 @@ static void impl_Server_updateCertificate(const ::Murmur::AMD_Server_updateCerti
 	}
 
 	// Verify that we can load the private key.
-	QSslKey privKey(privateKeyPem, QSsl::Rsa, QSsl::Pem, QSsl::PrivateKey, passphraseBytes);
+	QSslKey privKey = ::Server::privateKeyFromPEM(privateKeyPem, passphraseBytes);
 	if (privKey.isNull()) {
 		ERR_clear_error();
 		cb->ice_exception(InvalidInputDataException());

--- a/src/murmur/Server.h
+++ b/src/murmur/Server.h
@@ -169,6 +169,11 @@ class Server : public QThread {
 		// Certificate stuff, implemented partially in Cert.cpp
 	public:
 		static bool isKeyForCert(const QSslKey &key, const QSslCertificate &cert);
+		/// Attempt to load a private key in PEM format from |buf|.
+		/// If |passphrase| is non-empty, it will be used for decrypting the private key in |buf|.
+		/// If a valid RSA, DSA or EC key is found, it is returned.
+		/// If no valid private key is found, a null QSslKey is returned.
+		static QSslKey privateKeyFromPEM(const QByteArray &buf, const QByteArray &pass = QByteArray());
 		void initializeCert();
 		const QString getDigest() const;
 


### PR DESCRIPTION
This PR introduces support for loading EC certificates by @tycho.

It also introduces a new method, Server::privateKeyForPEM(). This method
moves the chain of of QSslKey constructor calls into a single method, so we
can remove a bit of code duplication across the source tree.

Finally, it also introduces a series of commits to make use of this new method.