### PR TITLE
lrelease.pri: add Windows-specific code path, to fix nmake build.

### DIFF
--- a/lrelease.pri
+++ b/lrelease.pri
@@ -6,5 +6,11 @@
 # This .pri file finds the correct lrelease binary name on the system.
 
 isEmpty(QMAKE_LRELEASE) {
-	QMAKE_LRELEASE = $$[QT_INSTALL_BINS]/lrelease
+	equals(QMAKE_HOST.os, "Windows")|equals(QMAKE_VERSION_INT_MAJOR, 4):win32 {
+		MY_QT_INSTALL_BINS = $$[QT_INSTALL_BINS]
+		WINDOWS_QT_INSTALL_BINS = $$replace(MY_QT_INSTALL_BINS, $$quote(/), $$quote(\\))
+		QMAKE_LRELEASE = $$WINDOWS_QT_INSTALL_BINS\\lrelease.exe
+	} else {
+		QMAKE_LRELEASE = $$[QT_INSTALL_BINS]/lrelease
+	}
 }


### PR DESCRIPTION
NMake doesn't like Unix-style paths, whereas jom doesn't care.
This lead to a situation where AppVeyor builds (that use jom)
succeeded, but Jenkins builds (that use nmake) failed.

This commit fixes that by adding a Windows-specific codepath to
lrelease.pri that finds a Windows-style path for lrelease.exe.