### PR TITLE
Fix crash when using the VoiceRecorder with voice target shortcuts

### DIFF
--- a/src/Message.h
+++ b/src/Message.h
@@ -54,6 +54,21 @@ class MessageHandler {
 #undef MUMBLE_MH_MSG
 };
 
+/// UDPMessageTypeIsValidVoicePacket checks whether the given
+/// UDPMessageType is a valid voice packet.
+inline bool UDPMessageTypeIsValidVoicePacket(MessageHandler::UDPMessageType umt) {
+	switch (umt) {
+		case MessageHandler::UDPVoiceCELTAlpha:
+		case MessageHandler::UDPVoiceSpeex:
+		case MessageHandler::UDPVoiceCELTBeta:
+		case MessageHandler::UDPVoiceOpus:
+			return true;
+		case MessageHandler::UDPPing:
+			return false;
+	}
+	return false;
+}
+
 inline QString u8(const ::std::string &str) {
 	return QString::fromUtf8(str.data(), static_cast<int>(str.length()));
 }

--- a/src/mumble/AudioInput.cpp
+++ b/src/mumble/AudioInput.cpp
@@ -914,9 +914,13 @@ void AudioInput::flushCheck(const QByteArray &frame, bool terminator) {
 	if (! terminator && iBufferedFrames < iAudioFrames)
 		return;
 
-	int flags = g.iTarget;
-	if (terminator)
+	int flags = 0;
+	if (g.iTarget > 0) {
+		flags = g.iTarget;
+	}
+	if (terminator && g.iPrevTarget > 0) {
 		flags = g.iPrevTarget;
+	}
 
 	if (g.s.lmLoopMode == Settings::Server)
 		flags = 0x1f; // Server loopback

--- a/src/mumble/AudioOutput.cpp
+++ b/src/mumble/AudioOutput.cpp
@@ -160,6 +160,11 @@ void AudioOutput::addFrameToBuffer(ClientUser *user, const QByteArray &qbaPacket
 	qrwlOutputs.lockForRead();
 	AudioOutputSpeech *aop = qobject_cast<AudioOutputSpeech *>(qmOutputs.value(user));
 
+	if (!UDPMessageTypeIsValidVoicePacket(type)) {
+		qWarning("AudioOutput: ignored frame with invalid message type 0x%x in addFrameToBuffer().", static_cast<unsigned char>(type));
+		return;
+	}
+
 	if (! aop || (aop->umtType != type)) {
 		qrwlOutputs.unlock();
 

--- a/src/mumble/AudioOutputSpeech.cpp
+++ b/src/mumble/AudioOutputSpeech.cpp
@@ -301,7 +301,7 @@ bool AudioOutputSpeech::needSamples(unsigned int snum) {
 						memset(pOut, 0, iFrameSize * sizeof(float));
 					}
 #endif
-				} else {
+				} else if (umtType == MessageHandler::UDPVoiceSpeex) {
 					if (qba.isEmpty()) {
 						speex_decode(dsSpeex, NULL, pOut);
 					} else {
@@ -310,6 +310,8 @@ bool AudioOutputSpeech::needSamples(unsigned int snum) {
 					}
 					for (unsigned int i=0;i<iFrameSize;++i)
 						pOut[i] *= (1.0f / 32767.f);
+				} else {
+					qWarning("AudioOutputSpeech: encountered unknown message type %li in needSamples().", static_cast<long>(umtType));
 				}
 
 				bool update = true;


### PR DESCRIPTION
This patch series fixes mumble-voip/mumble#2863 (Mumble segfaults during recording.)

During a VoiceRecorder session, when pressing a voice target shortcut, it was possible to set iPrevTarget to -1. That, combined with the fact that flushCheck() in AudioInput didn't properly check whether the values for iTarget and iPrevTarget were valid. This caused a voice packet with the an invalid flag byte to generated. This caused a crash in AudioOutputSpeech's needSamples(), because it would treat the bad packet as a Speex packet. Basically -- the logic was that anything that isn't CELT or Opus must be Speex -- which obviously isn't true: invalid packets would be treated as Speex.

The first commit in this series fixes the problem with missing validation for iTarget/iPrevTarget.

The second commit fixes the crash-site: When a bad packet was generated by the VoiceRecorder due to iPrevTarget being -1, AudioOutputSpeech::needSamples() would treat the bad packet as Speex, and would try to decode it, and fail. We now explicitly check whether the message type is Speex, before treating a packet as Speex.

The final commit adds an additional guard to AudioOutputSpeech, to catch invalid voice packets before they get into the audio subsystem.