### PR TITLE
Use SHA256 hashes for large blobs in protocol messages

### DIFF
--- a/src/Message.h
+++ b/src/Message.h
@@ -83,4 +83,19 @@ inline QByteArray sha1(const QString &str) {
 	return QCryptographicHash::hash(str.toUtf8(), QCryptographicHash::Sha1);
 }
 
+/// namedSha256 returns a named SHA-256 hash of blob in
+/// the form of "sha256:<hash-value>".
+inline QByteArray namedSha256(const QByteArray &blob) {
+	QByteArray ret("sha256:");
+	QByteArray hash = QCryptographicHash::hash(blob, QCryptographicHash::Sha256);
+	ret.append(hash);
+	return ret;
+}
+
+/// namedSha256 returns a named SHA-256 hash of str in
+/// the form of "sha256:<hash-value>".
+inline QByteArray namedSha256(const QString &str) {
+	return namedSha256(str.toUtf8());
+}
+
 #endif

--- a/src/mumble/ACLEditor.cpp
+++ b/src/mumble/ACLEditor.cpp
@@ -268,7 +268,7 @@ void ACLEditor::accept() {
 			const QString &descriptionText = rteChannelDescription->text();
 			mpcs.set_description(u8(descriptionText));
 			needs_update = true;
-			Database::setBlob(sha1(descriptionText), descriptionText.toUtf8());
+			Database::setBlob(namedSha256(descriptionText), descriptionText.toUtf8());
 		}
 		if (pChannel->iPosition != qsbChannelPosition->value()) {
 			mpcs.set_position(qsbChannelPosition->value());

--- a/src/mumble/MainWindow.cpp
+++ b/src/mumble/MainWindow.cpp
@@ -1173,7 +1173,7 @@ void MainWindow::on_qaSelfComment_triggered() {
 		g.sh->sendMessage(mpus);
 
 		if (! msg.isEmpty())
-			Database::setBlob(sha1(msg), msg.toUtf8());
+			Database::setBlob(namedSha256(msg), msg.toUtf8());
 	}
 	delete texm;
 }

--- a/src/mumble/Messages.cpp
+++ b/src/mumble/Messages.cpp
@@ -528,7 +528,7 @@ void MainWindow::msgUserState(const MumbleProto::UserState &msg) {
 		if (pDst->qbaTexture.isEmpty()) {
 			pDst->qbaTextureHash = QByteArray();
 		} else {
-			pDst->qbaTextureHash = sha1(pDst->qbaTexture);
+			pDst->qbaTextureHash = namedSha256(pDst->qbaTexture);
 			Database::setBlob(pDst->qbaTextureHash, pDst->qbaTexture);
 		}
 		g.o->verifyTexture(pDst);

--- a/src/mumble/ServerHandler.cpp
+++ b/src/mumble/ServerHandler.cpp
@@ -807,7 +807,7 @@ void ServerHandler::setUserTexture(unsigned int uiSession, const QByteArray &qba
 	sendMessage(mpus);
 
 	if (! texture.isEmpty()) {
-		Database::setBlob(sha1(texture), texture);
+		Database::setBlob(namedSha256(texture), texture);
 	}
 }
 

--- a/src/mumble/UserModel.cpp
+++ b/src/mumble/UserModel.cpp
@@ -951,7 +951,7 @@ void UserModel::setFriendName(ClientUser *p, const QString &name) {
 }
 
 void UserModel::setComment(ClientUser *cu, const QString &comment) {
-	cu->qbaCommentHash = comment.isEmpty() ? QByteArray() : sha1(comment);
+	cu->qbaCommentHash = comment.isEmpty() ? QByteArray() : namedSha256(comment);
 
 	if (comment != cu->qsComment) {
 		ModelItem *item = ModelItem::c_qhUsers.value(cu);
@@ -1014,7 +1014,7 @@ void UserModel::setCommentHash(ClientUser *cu, const QByteArray &hash) {
 }
 
 void UserModel::setComment(Channel *c, const QString &comment) {
-	c->qbaDescHash = comment.isEmpty() ? QByteArray() : sha1(comment);
+	c->qbaDescHash = comment.isEmpty() ? QByteArray() : namedSha256(comment);
 
 	if (comment != c->qsDesc) {
 		ModelItem *item = ModelItem::c_qhChannels.value(c);

--- a/src/murmur/Server.cpp
+++ b/src/murmur/Server.cpp
@@ -1904,7 +1904,7 @@ void Server::recheckCodecVersions(ServerUser *connectingUser) {
 void Server::hashAssign(QString &dest, QByteArray &hash, const QString &src) {
 	dest = src;
 	if (src.length() >= 128)
-		hash = sha1(src);
+		hash = namedSha256(src);
 	else
 		hash = QByteArray();
 }
@@ -1912,7 +1912,7 @@ void Server::hashAssign(QString &dest, QByteArray &hash, const QString &src) {
 void Server::hashAssign(QByteArray &dest, QByteArray &hash, const QByteArray &src) {
 	dest = src;
 	if (src.length() >= 128)
-		hash = sha1(src);
+		hash = namedSha256(src);
 	else
 		hash = QByteArray();
 }


### PR DESCRIPTION
Previously, we used SHA1 for content-hashes of large blobs in protocol messages. This long overdue PR changes that to use SHA256 hashes.

Clients that use SHA256, but connect to a server that uses SHA1 will not be able to store blobs for later use.
Likewise, clients that use SHA1 but connect to a server that uses SHA256 will not be able to store blobs for later user either.

In both cases, every time the client connects, it will have to download all blobs from scratch every time they connect to the server.