### PR TITLE
mumble.pri: split out OpenSSL depenency lookup into qmake/openssl.pri for easier use in tests.

### DIFF
--- a/qmake/openssl.pri
+++ b/qmake/openssl.pri
@@ -1,0 +1,28 @@
+# Copyright 2005-2017 The Mumble Developers. All rights reserved.
+# Use of this source code is governed by a BSD-style license
+# that can be found in the LICENSE file at the root of the
+# Mumble source tree or at <https://www.mumble.info/LICENSE>.
+
+include(../pkgconfig.pri)
+
+# Include this file to portably link
+# against OpenSSL.
+#
+# It requires compiler.pri to be included
+# for $$OPENSSL_PATH, etc. to work on win32.
+# This file can't include compiler.pri: it can
+# only be included once per .pro file.
+
+win32 {
+	INCLUDEPATH *= "$$OPENSSL_PATH/include"
+	QMAKE_LIBDIR *= "$$OPENSSL_PATH/lib"
+	LIBS *= -llibeay32
+}
+
+unix {
+	contains(UNAME, FreeBSD) {
+		LIBS *= -lcrypto -lssl
+	} else {
+		must_pkgconfig(openssl)
+	}
+}

--- a/src/mumble.pri
+++ b/src/mumble.pri
@@ -28,6 +28,9 @@ CONFIG(packaged) {
 	}
 }
 
+# Add OpenSSL dependency
+include(../qmake/openssl.pri)
+
 win32 {
 	INCLUDEPATH *= "$$PROTOBUF_PATH/vsprojects/include" "$$PROTOBUF_PATH/src" protobuf
 	CONFIG(debug, debug|release) {
@@ -35,10 +38,8 @@ win32 {
 	} else {
 		QMAKE_LIBDIR *= "$$PROTOBUF_PATH/vsprojects/Release"
 	}
-	INCLUDEPATH *= "$$OPENSSL_PATH/include"
-	QMAKE_LIBDIR *= "$$OPENSSL_PATH/lib"
 
-	LIBS *= -llibprotobuf -lcrypt32 -lws2_32 -llibeay32
+	LIBS *= -llibprotobuf -lcrypt32 -lws2_32
 	LIBS *= -ldelayimp -lQwave -delayload:Qwave.DLL
 }
 
@@ -53,12 +54,6 @@ unix {
 	CONFIG *= link_pkgconfig
 
 	must_pkgconfig(protobuf)
-
-	contains(UNAME, FreeBSD) {
-		LIBS *= -lcrypto -lssl
-	} else {
-		must_pkgconfig(openssl)
-	}
 }
 
 # Make Q_DECL_OVERRIDE and Q_DECL_FINAL no-ops


### PR DESCRIPTION
This is needed to be able to add tests that depend on OpenSSL.