### PR TITLE
WIP: Use SHA-256 hashes for large blobs in protocol messages

### DIFF
--- a/src/Message.h
+++ b/src/Message.h
@@ -10,6 +10,8 @@
 #include <QtCore/QCryptographicHash>
 #include <QtCore/QString>
 
+#include "CryptographicHash.h"
+
 /**
   Protobuf packet type enumeration for message handler generation.
 
@@ -81,6 +83,27 @@ inline QByteArray sha1(const QByteArray &blob) {
 
 inline QByteArray sha1(const QString &str) {
 	return QCryptographicHash::hash(str.toUtf8(), QCryptographicHash::Sha1);
+}
+
+/// namedSha256 returns a named SHA-256 hash of blob in
+/// the form of "sha256:<hash-value>".
+inline QByteArray namedSha256(const QByteArray &blob) {
+	CryptographicHash::Algorithm algo = CryptographicHash::Sha256;
+
+	QByteArray ret;
+	ret.append(CryptographicHash::shortAlgorithmName(algo).toLatin1());
+	ret.append(":");
+
+	QByteArray hash = CryptographicHash::hash(blob, algo);
+	ret.append(hash);
+
+	return ret;
+}
+
+/// namedSha256 returns a named SHA-256 hash of str in
+/// the form of "sha256:<hash-value>".
+inline QByteArray namedSha256(const QString &str) {
+	return namedSha256(str.toUtf8());
 }
 
 #endif

--- a/src/mumble/ACLEditor.cpp
+++ b/src/mumble/ACLEditor.cpp
@@ -268,7 +268,7 @@ void ACLEditor::accept() {
 			const QString &descriptionText = rteChannelDescription->text();
 			mpcs.set_description(u8(descriptionText));
 			needs_update = true;
-			Database::setBlob(sha1(descriptionText), descriptionText.toUtf8());
+			Database::setBlob(namedSha256(descriptionText), descriptionText.toUtf8());
 		}
 		if (pChannel->iPosition != qsbChannelPosition->value()) {
 			mpcs.set_position(qsbChannelPosition->value());

--- a/src/mumble/MainWindow.cpp
+++ b/src/mumble/MainWindow.cpp
@@ -1173,7 +1173,7 @@ void MainWindow::on_qaSelfComment_triggered() {
 		g.sh->sendMessage(mpus);
 
 		if (! msg.isEmpty())
-			Database::setBlob(sha1(msg), msg.toUtf8());
+			Database::setBlob(namedSha256(msg), msg.toUtf8());
 	}
 	delete texm;
 }

--- a/src/mumble/Messages.cpp
+++ b/src/mumble/Messages.cpp
@@ -528,7 +528,7 @@ void MainWindow::msgUserState(const MumbleProto::UserState &msg) {
 		if (pDst->qbaTexture.isEmpty()) {
 			pDst->qbaTextureHash = QByteArray();
 		} else {
-			pDst->qbaTextureHash = sha1(pDst->qbaTexture);
+			pDst->qbaTextureHash = namedSha256(pDst->qbaTexture);
 			Database::setBlob(pDst->qbaTextureHash, pDst->qbaTexture);
 		}
 		g.o->verifyTexture(pDst);

--- a/src/mumble/ServerHandler.cpp
+++ b/src/mumble/ServerHandler.cpp
@@ -807,7 +807,7 @@ void ServerHandler::setUserTexture(unsigned int uiSession, const QByteArray &qba
 	sendMessage(mpus);
 
 	if (! texture.isEmpty()) {
-		Database::setBlob(sha1(texture), texture);
+		Database::setBlob(namedSha256(texture), texture);
 	}
 }
 

--- a/src/mumble/UserModel.cpp
+++ b/src/mumble/UserModel.cpp
@@ -951,7 +951,7 @@ void UserModel::setFriendName(ClientUser *p, const QString &name) {
 }
 
 void UserModel::setComment(ClientUser *cu, const QString &comment) {
-	cu->qbaCommentHash = comment.isEmpty() ? QByteArray() : sha1(comment);
+	cu->qbaCommentHash = comment.isEmpty() ? QByteArray() : namedSha256(comment);
 
 	if (comment != cu->qsComment) {
 		ModelItem *item = ModelItem::c_qhUsers.value(cu);
@@ -1014,7 +1014,7 @@ void UserModel::setCommentHash(ClientUser *cu, const QByteArray &hash) {
 }
 
 void UserModel::setComment(Channel *c, const QString &comment) {
-	c->qbaDescHash = comment.isEmpty() ? QByteArray() : sha1(comment);
+	c->qbaDescHash = comment.isEmpty() ? QByteArray() : namedSha256(comment);
 
 	if (comment != c->qsDesc) {
 		ModelItem *item = ModelItem::c_qhChannels.value(c);

--- a/src/murmur/Server.cpp
+++ b/src/murmur/Server.cpp
@@ -1917,7 +1917,7 @@ void Server::recheckCodecVersions(ServerUser *connectingUser) {
 void Server::hashAssign(QString &dest, QByteArray &hash, const QString &src) {
 	dest = src;
 	if (src.length() >= 128)
-		hash = sha1(src);
+		hash = namedSha256(src);
 	else
 		hash = QByteArray();
 }
@@ -1925,7 +1925,7 @@ void Server::hashAssign(QString &dest, QByteArray &hash, const QString &src) {
 void Server::hashAssign(QByteArray &dest, QByteArray &hash, const QByteArray &src) {
 	dest = src;
 	if (src.length() >= 128)
-		hash = sha1(src);
+		hash = namedSha256(src);
 	else
 		hash = QByteArray();
 }


### PR DESCRIPTION
Previously, we used SHA-1 for content-hashes of large blobs in protocol messages. This long overdue PR changes that to use SHA-256 hashes.

Clients trust the content hash that the server provides it -- it will store the blobs directly in its database using the hash advertised by the server. So, from a client perspective, changing the hash function used for blob keys is fairly uneventful. The only effect is that when the server changes the hash function, clients will have to re-download all blobs once again. Once they've been downloaded and stored under their new key, everything should work as it did before.

The Mumble client also tries to eagerly cache blobs it generates itself. This PR changes that eager caching to use SHA-256 instead of SHA-1. For servers that use SHA-256 for blobs, the cache will work. But for servers that use SHA-1, it will not: There will simply be  a superfluous blob in the blob database. This doesn't matter much, as the client's eager caching is best-effort.

