### PR TITLE
WIP: MainWindow, Settings: update cert pinning to prefer SHA-256.

### DIFF
--- a/src/CryptographicHash.cpp
+++ b/src/CryptographicHash.cpp
@@ -1,0 +1,140 @@
+// Copyright 2005-2017 The Mumble Developers. All rights reserved.
+// Use of this source code is governed by a BSD-style license
+// that can be found in the LICENSE file at the root of the
+// Mumble source tree or at <https://www.mumble.info/LICENSE>.
+
+#include "murmur_pch.h"
+
+#include "CryptographicHash.h"
+
+class CryptographicHashPrivate {
+	public:
+		CryptographicHashPrivate(const EVP_MD *type);
+		~CryptographicHashPrivate();
+		void addData(const QByteArray &buf);
+		QByteArray result();
+
+	private:
+		EVP_MD_CTX *mdctx;
+		bool ok;
+		QByteArray final;
+
+		CryptographicHashPrivate();
+};
+
+CryptographicHashPrivate::CryptographicHashPrivate()
+	: ok(false)
+	, mdctx(NULL) {
+}
+
+CryptographicHashPrivate::CryptographicHashPrivate(const EVP_MD *type) {
+	ok = true;
+	mdctx = EVP_MD_CTX_create();
+
+	if (mdctx == NULL) {
+		ok = false;
+		return;
+	}
+
+	int err = EVP_DigestInit_ex(mdctx, type, NULL);
+	if (err != 1) {
+		ok = false;
+		return;
+	}
+}
+
+CryptographicHashPrivate::~CryptographicHashPrivate() {
+	if (mdctx) {
+		EVP_MD_CTX_destroy(mdctx);
+		mdctx = NULL;
+	}
+}
+
+void CryptographicHashPrivate::addData(const QByteArray &buf) {
+	if (!ok) {
+		return;
+	}
+
+	int err = EVP_DigestUpdate(mdctx, buf.constData(), buf.size());
+	if (err != 1) {
+		ok = false;
+	}
+}
+
+QByteArray CryptographicHashPrivate::result() {
+	if (!ok) {
+		return QByteArray();
+	}
+
+	if (!final.isNull()) {
+		return final;
+	}
+
+	QByteArray digest(EVP_MD_CTX_size(mdctx), '\0');
+	int err = EVP_DigestFinal_ex(mdctx, reinterpret_cast<unsigned char *>(digest.data()), NULL);
+	if (err != 1) {
+		ok = false;
+		return QByteArray();
+	}
+
+	final = digest;
+	return final;
+}
+
+CryptographicHash::CryptographicHash()
+	: d(NULL) {
+}
+
+CryptographicHash::CryptographicHash(CryptographicHash::Algorithm algo)
+	: d(NULL) {
+
+	switch (algo) {
+		case CryptographicHash::Sha1:
+			d = new CryptographicHashPrivate(EVP_sha1());
+			break;
+		case CryptographicHash::Sha256:
+			d = new CryptographicHashPrivate(EVP_sha256());
+			break;
+	}
+}
+
+void CryptographicHash::addData(const QByteArray &buf) {
+	if (d) {
+		d->addData(buf);
+	}
+}
+
+QByteArray CryptographicHash::result() const {
+	if (d) {
+		return d->result();
+	}
+	return QByteArray();
+}
+
+QByteArray CryptographicHash::hash(const QByteArray &buf, Algorithm algo) {
+	CryptographicHash h(algo);
+	h.addData(buf);
+	return h.result();
+}
+
+QString CryptographicHash::humanReadableAlgorithmName(CryptographicHash::Algorithm algo) {
+	switch (algo) {
+		case CryptographicHash::Sha1:
+			return QLatin1String("SHA-1");
+		case CryptographicHash::Sha256:
+			return QLatin1String("SHA-256");
+	}
+
+	return QString();
+}
+
+QString CryptographicHash::shortAlgorithmName(CryptographicHash::Algorithm algo) {
+	switch (algo) {
+		case CryptographicHash::Sha1:
+			return QLatin1String("sha1");
+		case CryptographicHash::Sha256:
+			return QLatin1String("sha256");
+	}
+
+	return QString();
+}

--- a/src/CryptographicHash.h
+++ b/src/CryptographicHash.h
@@ -1,0 +1,64 @@
+// Copyright 2005-2017 The Mumble Developers. All rights reserved.
+// Use of this source code is governed by a BSD-style license
+// that can be found in the LICENSE file at the root of the
+// Mumble source tree or at <https://www.mumble.info/LICENSE>.
+
+#ifndef MUMBLE_CRYPTOGRAPHICHASH_H_
+#define MUMBLE_CRYPTOGRAPHICHASH_H_
+
+#include <QByteArray>
+
+class CryptographicHashPrivate;
+
+/// CryptographicHash is used for computing cryptographic hashes.
+class CryptographicHash {
+	public:
+		/// Algorithm specifies an algorithm for use with CryptographicHash.
+		enum Algorithm {
+			/// The SHA-1 hashing algorithm.
+			Sha1,
+			/// The SHA-256 hashing algorithm.
+			Sha256
+		};
+
+		/// Consruct a CryptographicHash object that can be used
+		/// to incrementally compute a cryptographic hash using the
+		/// hash function specified in |algo|.
+		CryptographicHash(Algorithm algo);
+
+		/// addData adds the content of |buf| to the hash computation.
+		void addData(const QByteArray &buf);
+
+		/// result() finalizes the CryptographicHash object,
+		/// and returns the computed hash.
+		/// If an error occurred during the computatiopn, the
+		/// returned QByteArray will be empty.
+		QByteArray result() const;
+
+		/// Compute the cryptographic hash of |buf| using algorithm |algo|
+		/// and return the result.
+		/// On failure, the returned QByteArray will be empty.
+		static QByteArray hash(const QByteArray &buf, Algorithm algo);
+
+		/// Return the human readable name of |algo|.
+		///
+		/// Examples:
+		///  CryptographicHash::Sha1 -> "SHA-1"
+		///  CryptographicHash::Sha256 -> "SHA-256"
+		static QString humanReadableAlgorithmName(CryptographicHash::Algorithm algo);
+
+		/// Return a machine-readable short name of |algo|.
+		/// This variant is a short, lower-case name for the algorithm, suitable
+		/// for prefixing when serializing a cryptographic hash.
+		///
+		/// Examples:
+		///  CryptographicHash::Sha1 -> "sha1"
+		///  CryptographicHash::Sha256 -> "sha256"
+		static QString shortAlgorithmName(CryptographicHash::Algorithm algo);
+
+	private:
+		CryptographicHash();
+		CryptographicHashPrivate *d;
+};
+
+#endif

--- a/src/mumble.pri
+++ b/src/mumble.pri
@@ -14,8 +14,8 @@ CONFIG		+= qt thread debug_and_release warn_on
 DEFINES		*= MUMBLE_VERSION_STRING=$$VERSION
 INCLUDEPATH	+= $$PWD . ../mumble_proto
 VPATH		+= $$PWD
-HEADERS		*= ACL.h Channel.h CryptState.h Connection.h Group.h HTMLFilter.h User.h Net.h OSInfo.h Timer.h SSL.h Version.h SSLCipherInfo.h SSLCipherInfoTable.h licenses.h License.h LogEmitter.h
-SOURCES 	*= ACL.cpp Group.cpp Channel.cpp Connection.cpp HTMLFilter.cpp User.cpp Timer.cpp CryptState.cpp OSInfo.cpp Net.cpp SSL.cpp Version.cpp SSLCipherInfo.cpp License.cpp LogEmitter.cpp
+HEADERS		*= ACL.h Channel.h CryptState.h Connection.h Group.h HTMLFilter.h User.h Net.h OSInfo.h Timer.h SSL.h Version.h SSLCipherInfo.h SSLCipherInfoTable.h licenses.h License.h LogEmitter.h CryptographicHash.h
+SOURCES 	*= ACL.cpp Group.cpp Channel.cpp Connection.cpp HTMLFilter.cpp User.cpp Timer.cpp CryptState.cpp OSInfo.cpp Net.cpp SSL.cpp Version.cpp SSLCipherInfo.cpp License.cpp LogEmitter.cpp CryptographicHash.cpp
 LIBS		*= -lmumble_proto
 # Note: Protobuf generates into its own directory so we can mark it as a
 #       system include folder for unix. Otherwise the generated code creates

--- a/src/mumble/Settings.cpp
+++ b/src/mumble/Settings.cpp
@@ -354,6 +354,9 @@ Settings::Settings() {
 	bSuppressIdentity = false;
 	qsSslCiphers = MumbleSSL::defaultOpenSSLCipherString();
 
+	// Network settings - Cert pinning
+	bCertPinningAllowLegacySHA1Pins = true;
+
 	bShowTransmitModeComboBox = false;
 
 	// Accessibility
@@ -676,6 +679,9 @@ void Settings::load(QSettings* settings_ptr) {
 	// Network settings - SSL
 	SAVELOAD(qsSslCiphers, "net/sslciphers");
 
+	// Network settings - Cert pinning
+	SAVELOAD(bCertPinningAllowLegacySHA1Pins, "net/certpin/allowsha1");
+
 	SAVELOAD(bExpert, "ui/expert");
 	SAVELOAD(qsLanguage, "ui/language");
 	SAVELOAD(themeName, "ui/theme");
@@ -990,6 +996,9 @@ void Settings::save() {
 
 	// Network settings - SSL
 	SAVELOAD(qsSslCiphers, "net/sslciphers");
+
+	// Network settings - Cert pinning
+	SAVELOAD(bCertPinningAllowLegacySHA1Pins, "net/certpin/allowsha1");
 
 	SAVELOAD(bExpert, "ui/expert");
 	SAVELOAD(qsLanguage, "ui/language");

--- a/src/mumble/Settings.h
+++ b/src/mumble/Settings.h
@@ -321,6 +321,21 @@ struct Settings {
 	// Network settings - SSL
 	QString qsSslCiphers;
 
+	// Network settings - Cert pinning
+
+	/// Allow Mumble to verify servers it connects to against
+	/// legacy SHA1 certificate pins in its database.
+	///
+	/// If this setting is enabled, Mumble will be allowed to verify
+	/// servers that use self-signed certificates against SHA1 hashes
+	/// stored in its certificate pin database.
+	/// If not, a stored SHA1 pin will simply be ignored -- as if it
+	/// doesn't exist.
+	///
+	/// After connecting once, the SHA1 hash will be updated with a
+	/// more modern hash -- currently SHA256.
+	bool bCertPinningAllowLegacySHA1Pins;
+
 	static const int ciDefaultMaxImageSize = 50 * 1024; // Restrict to 50KiB as a default
 	int iMaxImageSize;
 	int iMaxImageWidth;

--- a/src/tests/TestCryptographicHash.cpp
+++ b/src/tests/TestCryptographicHash.cpp
@@ -1,0 +1,75 @@
+// Copyright 2005-2017 The Mumble Developers. All rights reserved.
+// Use of this source code is governed by a BSD-style license
+// that can be found in the LICENSE file at the root of the
+// Mumble source tree or at <https://www.mumble.info/LICENSE>.
+
+#include <QtCore>
+#include <QtTest>
+#include <QLatin1String>
+
+#include "CryptographicHash.h"
+
+class TestCryptographicHash : public QObject {
+		Q_OBJECT
+	private slots:
+		void sha1_data();
+		void sha1();
+
+		void sha256_data();
+		void sha256();
+};
+
+void TestCryptographicHash::sha1_data() {
+	QTest::addColumn<QString>("input");
+	QTest::addColumn<QString>("expectedOutput");
+
+	// First 4 SHA1 test vectors from http://www.di-mgt.com.au/sha_testvectors.html
+	// ...The rest are a bit too excessive to put in a table-based test.
+	QTest::newRow("1") << QString(QLatin1String("abc")) << QString(QLatin1String("a9993e36 4706816a ba3e2571 7850c26c 9cd0d89d"));
+	QTest::newRow("2") << QString(QLatin1String("")) << QString(QLatin1String("da39a3ee 5e6b4b0d 3255bfef 95601890 afd80709"));
+	QTest::newRow("3") << QString(QLatin1String("abcdbcdecdefdefgefghfghighijhijkijkljklmklmnlmnomnopnopq")) << QString(QLatin1String("84983e44 1c3bd26e baae4aa1 f95129e5 e54670f1"));
+	QTest::newRow("4") << QString(QLatin1String("abcdefghbcdefghicdefghijdefghijkefghijklfghijklmghijklmnhijklmnoijklmnopjklmnopqklmnopqrlmnopqrsmnopqrstnopqrstu")) << QString(QLatin1String("a49b2446 a02c645b f419f995 b6709125 3a04a259"));
+}
+
+void TestCryptographicHash::sha1() {
+	QFETCH(QString, input);
+	QFETCH(QString, expectedOutput);
+
+	QByteArray outBuf = CryptographicHash::hash(input.toLatin1(), CryptographicHash::Sha1);
+	QByteArray hexBuf = outBuf.toHex();
+	QString output = QString::fromLatin1(hexBuf);
+
+	// Strip whitespace from the expected form in the table.
+	expectedOutput.remove(QChar(' '));
+
+	QCOMPARE(output, expectedOutput);
+}
+
+void TestCryptographicHash::sha256_data() {
+	QTest::addColumn<QString>("input");
+	QTest::addColumn<QString>("expectedOutput");
+
+	// First 4 SHA256 test vectors from http://www.di-mgt.com.au/sha_testvectors.html
+	// ...The rest are a bit too excessive to put in a table-based test.
+	QTest::newRow("1") << QString(QLatin1String("abc")) << QString(QLatin1String("ba7816bf 8f01cfea 414140de 5dae2223 b00361a3 96177a9c b410ff61 f20015ad"));
+	QTest::newRow("2") << QString(QLatin1String("")) << QString(QLatin1String("e3b0c442 98fc1c14 9afbf4c8 996fb924 27ae41e4 649b934c a495991b 7852b855"));
+	QTest::newRow("3") << QString(QLatin1String("abcdbcdecdefdefgefghfghighijhijkijkljklmklmnlmnomnopnopq")) << QString(QLatin1String("248d6a61 d20638b8 e5c02693 0c3e6039 a33ce459 64ff2167 f6ecedd4 19db06c1"));
+	QTest::newRow("4") << QString(QLatin1String("abcdefghbcdefghicdefghijdefghijkefghijklfghijklmghijklmnhijklmnoijklmnopjklmnopqklmnopqrlmnopqrsmnopqrstnopqrstu")) << QString(QLatin1String("cf5b16a7 78af8380 036ce59e 7b049237 0b249b11 e8f07a51 afac4503 7afee9d1"));
+}
+
+void TestCryptographicHash::sha256() {
+	QFETCH(QString, input);
+	QFETCH(QString, expectedOutput);
+
+	QByteArray outBuf = CryptographicHash::hash(input.toLatin1(), CryptographicHash::Sha256);
+	QByteArray hexBuf = outBuf.toHex();
+	QString output = QString::fromLatin1(hexBuf);
+
+	// Strip whitespace from the expected form in the table.
+	expectedOutput.remove(QChar(' '));
+
+	QCOMPARE(output, expectedOutput);
+}
+
+QTEST_MAIN(TestCryptographicHash)
+#include "TestCryptographicHash.moc"

--- a/src/tests/TestCryptographicHash.pro
+++ b/src/tests/TestCryptographicHash.pro
@@ -1,0 +1,17 @@
+# Copyright 2005-2017 The Mumble Developers. All rights reserved.
+# Use of this source code is governed by a BSD-style license
+# that can be found in the LICENSE file at the root of the
+# Mumble source tree or at <https://www.mumble.info/LICENSE>.
+
+include(../../compiler.pri)
+include(../../qmake/openssl.pri)
+
+TEMPLATE = app
+CONFIG += qt warn_on qtestlib
+CONFIG -= app_bundle
+LANGUAGE = C++
+TARGET = TestCryptographicHash
+SOURCES = TestCryptographicHash.cpp CryptographicHash.cpp
+HEADERS = CryptographicHash.h
+VPATH += ..
+INCLUDEPATH += .. ../murmur ../mumble


### PR DESCRIPTION
This commits updates Mumble's certificate pinning to prefer SHA-256.

By default, Mumble will still consider a users's stored SHA-1 pins, but
after the first successful connection attempt, the pin will be updated
to the preferred hash (currently SHA-256).

Note: This PR depends on PR #2868 and includes its commits to be able to build in CI. I will fix this once PR #2868 is landed.