### PR TITLE
.gitignore: make xxx_plugin_import.cpp a glob entry.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,11 +33,7 @@ src/murmur/MurmurRPC.proto.Wrapper.cpp
 winpaths_custom.pri
 mocinclude.opt
 src/mumble/mumble_qt_auto.qrc
-src/mumble/mumble_plugin_import.cpp
-src/mumble/mumble_app_plugin_import.cpp
-src/murmur/murmurd_plugin_import.cpp
-src/murmur/murmur_plugin_import.cpp
-g15helper/mumble-g15-helper_plugin_import.cpp
+*_plugin_import.cpp
 doxygen/
 .qmake.cache
 .qmake.stash


### PR DESCRIPTION
The _plugin_import.cpp files are auto-generated by the Qt build
process for importing plugins.

To avoid listing every present plugin_import.cpp file, and to avoid
having to update .gitignore every time we add a new target, we
change the existings to a glob, *_plugin_import.cpp.