### PR TITLE
qmake/openssl.pri: when using OpenSSL via pkgconfig, ensure link_pkgconfig is in CONFIG.

### DIFF
--- a/qmake/openssl.pri
+++ b/qmake/openssl.pri
@@ -23,6 +23,7 @@ unix {
 	contains(UNAME, FreeBSD) {
 		LIBS *= -lcrypto -lssl
 	} else {
+		CONFIG *= link_pkgconfig
 		must_pkgconfig(openssl)
 	}
 }


### PR DESCRIPTION
This fixes a problem I encountered where including openssl.pri
in TestCryptographicHash.pro on Qt 4 wouldn't link OpenSSL.

This commit fixes that problem by ensuring link_pkgconfig is
always included in CONFIG when openssl.pri uses pkgconfig.