### PR TITLE
TestCryptographicHash: make test GUI-less.

### DIFF
--- a/src/tests/TestCryptographicHash/TestCryptographicHash.pro
+++ b/src/tests/TestCryptographicHash/TestCryptographicHash.pro
@@ -7,8 +7,9 @@ include(../../../compiler.pri)
 include(../../../qmake/openssl.pri)
 
 TEMPLATE = app
+QT = core testlib
 CONFIG += testcase
-CONFIG += qt warn_on qtestlib
+CONFIG += qt warn_on
 CONFIG -= app_bundle
 LANGUAGE = C++
 TARGET = TestCryptographicHash


### PR DESCRIPTION
Explicitly set QT = core in order to force Qt's QTEST_MAIN
to use a QCoreApplicaiton instead of a QApplication.

Also, while we're here, move from the deprecated

  CONFIG += qtestlib

to

  QT += testlib