### PR TITLE
Various minor fixes in preparation for hot-cert reload

### DIFF
--- a/src/murmur/Cert.cpp
+++ b/src/murmur/Cert.cpp
@@ -159,6 +159,10 @@ void Server::initializeCert() {
 		qscCert = Meta::mp.qscCert;
 		qskKey = Meta::mp.qskKey;
 		qlIntermediates = Meta::mp.qlIntermediates;
+
+		if (!qscCert.isNull() && !qskKey.isNull()) {
+			bUsingMetaCert = true;
+		}
 	}
 
 	// If we still don't have a certificate by now, try to load the one from Meta
@@ -166,9 +170,14 @@ void Server::initializeCert() {
 		if (! key.isEmpty() || ! crt.isEmpty()) {
 			log("Certificate specified, but failed to load.");
 		}
+
 		qskKey = Meta::mp.qskKey;
 		qscCert = Meta::mp.qscCert;
 		qlIntermediates = Meta::mp.qlIntermediates;
+
+		if (!qscCert.isNull() && !qskKey.isNull()) {
+			bUsingMetaCert = true;
+		}
 
 		// If loading from Meta doesn't work, build+sign a new one
 		if (qscCert.isNull() || qskKey.isNull()) {

--- a/src/murmur/Meta.cpp
+++ b/src/murmur/Meta.cpp
@@ -467,10 +467,6 @@ void MetaParams::read(QString fname) {
 	}
 #endif
 
-	if (! QSslSocket::supportsSsl()) {
-		qFatal("Qt without SSL Support");
-	}
-
 	{
 		QList<QSslCipher> ciphers = MumbleSSL::ciphersFromOpenSSLCipherString(qsCiphers);
 		if (ciphers.isEmpty()) {
@@ -506,8 +502,6 @@ void MetaParams::read(QString fname) {
 		}
 		qWarning("Meta: TLS cipher preference is \"%s\"", qPrintable(pref.join(QLatin1String(":"))));
 	}
-
-	qWarning("OpenSSL: %s", SSLeay_version(SSLEAY_VERSION));
 
 	QStringList hosts;
 	foreach(const QHostAddress &qha, qlBind) {

--- a/src/murmur/Meta.cpp
+++ b/src/murmur/Meta.cpp
@@ -112,6 +112,8 @@ T MetaParams::typeCheckedFromSettings(const QString &name, const T &defaultValue
 }
 
 void MetaParams::read(QString fname) {
+	qmConfig.clear();
+
 	if (fname.isEmpty()) {
 		QStringList datapaths;
 
@@ -507,7 +509,6 @@ void MetaParams::read(QString fname) {
 
 	qWarning("OpenSSL: %s", SSLeay_version(SSLEAY_VERSION));
 
-	qmConfig.clear();
 	QStringList hosts;
 	foreach(const QHostAddress &qha, qlBind) {
 		hosts << qha.toString();

--- a/src/murmur/Meta.cpp
+++ b/src/murmur/Meta.cpp
@@ -90,11 +90,18 @@ MetaParams::~MetaParams() {
  *	@param T Conversion target type (type of 'defaultValue', auto inducable)
  *	@param name qsSettings variable name
  *	@param defaultValue Default value for 'name'
+ *	@param settings The QSettings object to read from. If null, the Meta's qsSettings will be used.
  *	@return Setting if valid, default if not or setting not set.
  */
 template <class T>
-T MetaParams::typeCheckedFromSettings(const QString &name, const T &defaultValue) {
-	QVariant cfgVariable = qsSettings->value(name, defaultValue);
+T MetaParams::typeCheckedFromSettings(const QString &name, const T &defaultValue, QSettings *settings) {
+	// Use qsSettings unless a specific QSettings instance
+	// is requested.
+	if (settings == NULL) {
+		settings = qsSettings;
+	}
+
+	QVariant cfgVariable = settings->value(name, defaultValue);
 
 	if (!cfgVariable.convert(QVariant(defaultValue).type())) { // Bit convoluted as canConvert<T>() only does a static check without considering whether say a string like "blub" is actually a valid double (which convert does).
 		qCritical() << "Configuration variable" << name << "is of invalid format. Set to default value of" << defaultValue << ".";

--- a/src/murmur/Meta.cpp
+++ b/src/murmur/Meta.cpp
@@ -153,15 +153,15 @@ void MetaParams::read(QString fname) {
 				QFileInfo fi(p, "murmur.ini");
 				if (fi.exists() && fi.isReadable()) {
 					qdBasePath = QDir(p);
-					fname = fi.absoluteFilePath();
+					qsAbsSettingsFilePath = fi.absoluteFilePath();
 					break;
 				}
 			}
 		}
-		if (fname.isEmpty()) {
+		if (qsAbsSettingsFilePath.isEmpty()) {
 			QDir::root().mkpath(qdBasePath.absolutePath());
 			qdBasePath = QDir(datapaths.at(0));
-			fname = qdBasePath.absolutePath() + QLatin1String("/murmur.ini");
+			qsAbsSettingsFilePath = qdBasePath.absolutePath() + QLatin1String("/murmur.ini");
 		}
 	} else {
 		QFile f(fname);
@@ -169,11 +169,11 @@ void MetaParams::read(QString fname) {
 			qFatal("Specified ini file %s could not be opened", qPrintable(fname));
 		}
 		qdBasePath = QFileInfo(f).absoluteDir();
-		fname = QFileInfo(f).absoluteFilePath();
+		qsAbsSettingsFilePath = QFileInfo(f).absoluteFilePath();
 		f.close();
 	}
 	QDir::setCurrent(qdBasePath.absolutePath());
-	qsSettings = new QSettings(fname, QSettings::IniFormat);
+	qsSettings = new QSettings(qsAbsSettingsFilePath, QSettings::IniFormat);
 #if QT_VERSION >= 0x040500
 	qsSettings->setIniCodec("UTF-8");
 #endif

--- a/src/murmur/Meta.h
+++ b/src/murmur/Meta.h
@@ -133,7 +133,7 @@ public:
 
 private:
 	template <class T>
-	T typeCheckedFromSettings(const QString &name, const T &variable);
+	T typeCheckedFromSettings(const QString &name, const T &variable, QSettings *settings = NULL);
 };
 
 class Meta : public QObject {

--- a/src/murmur/Meta.h
+++ b/src/murmur/Meta.h
@@ -109,6 +109,10 @@ public:
 	/// sslCA option.
 	QList<QSslCertificate> qlCA;
 
+	/// qlCiphers contains the list of supported
+	/// cipher suites.
+	QList<QSslCipher> qlCiphers;
+
 	QByteArray qbaDHParams;
 	QByteArray qbaPassPhrase;
 	QString qsCiphers;

--- a/src/murmur/Meta.h
+++ b/src/murmur/Meta.h
@@ -125,6 +125,9 @@ public:
 	QVariant qvSuggestPositional;
 	QVariant qvSuggestPushToTalk;
 
+	/// qsAbsSettingsFilePath is the absolute path to
+	/// the murmur.ini used by this Meta instance.
+	QString qsAbsSettingsFilePath;
 	QSettings *qsSettings;
 
 	MetaParams();

--- a/src/murmur/Register.cpp
+++ b/src/murmur/Register.cpp
@@ -104,6 +104,8 @@ void Server::update() {
 	calist << qscCert;
 	ssl.setCaCertificates(calist);
 
+	ssl.setCiphers(Meta::mp.qlCiphers);
+
 	qnr.setSslConfiguration(ssl);
 
 	QNetworkReply *rep = qnamNetwork->post(qnr, doc.toString().toUtf8());

--- a/src/murmur/Server.cpp
+++ b/src/murmur/Server.cpp
@@ -100,6 +100,7 @@ Server::Server(int snum, QObject *p) : QThread(p) {
 #ifdef USE_BONJOUR
 	bsRegistration = NULL;
 #endif
+	bUsingMetaCert = false;
 
 #ifdef Q_OS_UNIX
 	aiNotify[0] = aiNotify[1] = -1;

--- a/src/murmur/Server.cpp
+++ b/src/murmur/Server.cpp
@@ -1214,6 +1214,8 @@ void Server::newClient() {
 		// bundle used for this server's certificate.
 		sock->addCaCertificates(qlIntermediates);
 
+		sock->setCiphers(Meta::mp.qlCiphers);
+
 #if defined(USE_QSSLDIFFIEHELLMANPARAMETERS)
 		QSslConfiguration cfg = sock->sslConfiguration();
 		cfg.setDiffieHellmanParameters(qsdhpDHParams);

--- a/src/murmur/Server.h
+++ b/src/murmur/Server.h
@@ -131,6 +131,7 @@ class Server : public QThread {
 		QVariant qvSuggestPositional;
 		QVariant qvSuggestPushToTalk;
 
+		bool bUsingMetaCert;
 		QSslCertificate qscCert;
 		QSslKey qskKey;
 

--- a/src/murmur/UnixMurmur.cpp
+++ b/src/murmur/UnixMurmur.cpp
@@ -85,6 +85,7 @@ extern QFile *qfLog;
 
 int UnixMurmur::iHupFd[2];
 int UnixMurmur::iTermFd[2];
+int UnixMurmur::iUsr1Fd[2];
 
 UnixMurmur::UnixMurmur() {
 	bRoot = true;
@@ -99,13 +100,18 @@ UnixMurmur::UnixMurmur() {
 	if (::socketpair(AF_UNIX, SOCK_STREAM, 0, iTermFd))
 		qFatal("Couldn't create TERM socketpair");
 
+	if (::socketpair(AF_UNIX, SOCK_STREAM, 0, iUsr1Fd))
+		qFatal("Couldn't create USR1 socketpair");
+
 	qsnHup = new QSocketNotifier(iHupFd[1], QSocketNotifier::Read, this);
 	qsnTerm = new QSocketNotifier(iTermFd[1], QSocketNotifier::Read, this);
+	qsnUsr1 = new QSocketNotifier(iUsr1Fd[1], QSocketNotifier::Read, this);
 
 	connect(qsnHup, SIGNAL(activated(int)), this, SLOT(handleSigHup()));
 	connect(qsnTerm, SIGNAL(activated(int)), this, SLOT(handleSigTerm()));
+	connect(qsnUsr1, SIGNAL(activated(int)), this, SLOT(handleSigUsr1()));
 
-	struct sigaction hup, term;
+	struct sigaction hup, term, usr1;
 
 	hup.sa_handler = hupSignalHandler;
 	sigemptyset(&hup.sa_mask);
@@ -121,20 +127,31 @@ UnixMurmur::UnixMurmur() {
 	if (sigaction(SIGTERM, &term, NULL))
 		qFatal("Failed to install SIGTERM handler");
 
+	usr1.sa_handler = usr1SignalHandler;
+	sigemptyset(&usr1.sa_mask);
+	usr1.sa_flags = SA_RESTART;
+
+	if (sigaction(SIGUSR1, &usr1, NULL))
+		qFatal("Failed to install SIGUSR1 handler");
+
 	umask(S_IRWXO);
 }
 
 UnixMurmur::~UnixMurmur() {
 	delete qsnHup;
 	delete qsnTerm;
+	delete qsnUsr1;
 
 	qsnHup = NULL;
 	qsnTerm = NULL;
+	qsnUsr1 = NULL;
 
 	close(iHupFd[0]);
 	close(iHupFd[1]);
 	close(iTermFd[0]);
 	close(iTermFd[1]);
+	close(iUsr1Fd[0]);
+	close(iUsr1Fd[1]);
 }
 
 void UnixMurmur::hupSignalHandler(int) {
@@ -146,6 +163,12 @@ void UnixMurmur::hupSignalHandler(int) {
 void UnixMurmur::termSignalHandler(int) {
 	char a = 1;
 	ssize_t len = ::write(iTermFd[0], &a, sizeof(a));
+	Q_UNUSED(len);
+}
+
+void UnixMurmur::usr1SignalHandler(int) {
+	char a = 1;
+	ssize_t len = ::write(iUsr1Fd[0], &a, sizeof(a));
 	Q_UNUSED(len);
 }
 
@@ -197,6 +220,17 @@ void UnixMurmur::handleSigTerm() {
 	QCoreApplication::instance()->quit();
 
 	qsnTerm->setEnabled(true);
+}
+
+void UnixMurmur::handleSigUsr1() {
+	qsnUsr1->setEnabled(false);
+	char tmp;
+	ssize_t len = ::read(iUsr1Fd[1], &tmp, sizeof(tmp));
+	Q_UNUSED(len);
+
+	qWarning("Received USR1 signal... Ignoring...");
+
+	qsnUsr1->setEnabled(true);
 }
 
 void UnixMurmur::setuid() {

--- a/src/murmur/UnixMurmur.h
+++ b/src/murmur/UnixMurmur.h
@@ -32,14 +32,16 @@ class UnixMurmur : public QObject {
 		Q_DISABLE_COPY(UnixMurmur)
 	protected:
 		bool bRoot;
-		static int iHupFd[2], iTermFd[2];
-		QSocketNotifier *qsnHup, *qsnTerm;
+		static int iHupFd[2], iTermFd[2], iUsr1Fd[2];
+		QSocketNotifier *qsnHup, *qsnTerm, *qsnUsr1;
 
 		static void hupSignalHandler(int);
 		static void termSignalHandler(int);
+		static void usr1SignalHandler(int);
 	public slots:
 		void handleSigHup();
 		void handleSigTerm();
+		void handleSigUsr1();
 	public:
 		bool logToSyslog;
 

--- a/src/murmur/main.cpp
+++ b/src/murmur/main.cpp
@@ -365,6 +365,12 @@ int main(int argc, char **argv) {
 		}
 	}
 
+	if (QSslSocket::supportsSsl()) {
+		qWarning("SSL: OpenSSL version is '%s'", SSLeay_version(SSLEAY_VERSION));
+	} else {
+		qFatal("SSL: this version of Murmur is built against Qt without SSL Support. Aborting.");
+	}
+
 #ifdef Q_OS_UNIX
 	inifile = unixhandler.trySystemIniFiles(inifile);
 #endif


### PR DESCRIPTION
- Commit 1: Change MetaParams::typeCheckedFromSettings to take an optional QSettings parameter.
- Commit 2: Add USR1 signal handler implementation.
- Commit 3: Move callsite of qmConfig.clear() in MetaParams::read() to allow MetaParams::read() to be split out into separate functions.
- Commit 4: Add Server::bUsingMetaCert flag, such that hot cert reload knows which servers to reload.
- Commit 5: Add qAbsSettingsFn, such that hot cert reload knows where to read murmur.ini.
- Commit 6: Move SSL check and OpenSSL version advertisement from MetaParams::read() to main.cpp.
- Commit 7: Avoid use of global QSslSocket::defaultCiphers() list; prefer applying the default list to each QSslSocket/QSslConfiguration individually.