### PR TITLE
WIP: Mumble: use WindowModal for all modal dialogs.

### DIFF
--- a/src/mumble/AudioWizard.ui
+++ b/src/mumble/AudioWizard.ui
@@ -2,6 +2,9 @@
 <ui version="4.0">
  <class>AudioWizard</class>
  <widget class="QWizard" name="AudioWizard">
+  <property name="windowModality">
+   <enum>Qt::WindowModal</enum>
+  </property>
   <property name="geometry">
    <rect>
     <x>0</x>
@@ -503,7 +506,16 @@ Speak loudly, as when you are annoyed or excited. Decrease the volume in the sou
     <item row="5" column="0" colspan="2">
      <widget class="QWidget" name="qwVAD" native="true">
       <layout class="QVBoxLayout" name="verticalLayout_6">
-       <property name="margin">
+       <property name="leftMargin">
+        <number>0</number>
+       </property>
+       <property name="topMargin">
+        <number>0</number>
+       </property>
+       <property name="rightMargin">
+        <number>0</number>
+       </property>
+       <property name="bottomMargin">
         <number>0</number>
        </property>
        <item>

--- a/src/mumble/Cert.ui
+++ b/src/mumble/Cert.ui
@@ -2,6 +2,9 @@
 <ui version="4.0">
  <class>Certificates</class>
  <widget class="QWizard" name="Certificates">
+  <property name="windowModality">
+   <enum>Qt::WindowModal</enum>
+  </property>
   <property name="geometry">
    <rect>
     <x>0</x>
@@ -233,14 +236,14 @@ It is &lt;b&gt;strongly&lt;/b&gt; recommended that you &lt;a href=&quot;http://m
         <italic>true</italic>
        </font>
       </property>
-      <property name="wordWrap">
-       <bool>true</bool>
-      </property>
       <property name="styleSheet">
        <string notr="true">color:#ff0000;</string>
       </property>
       <property name="text">
        <string/>
+      </property>
+      <property name="wordWrap">
+       <bool>true</bool>
       </property>
      </widget>
     </item>

--- a/src/mumble/ConfigDialog.ui
+++ b/src/mumble/ConfigDialog.ui
@@ -2,6 +2,9 @@
 <ui version="4.0">
  <class>ConfigDialog</class>
  <widget class="QDialog" name="ConfigDialog">
+  <property name="windowModality">
+   <enum>Qt::WindowModal</enum>
+  </property>
   <property name="geometry">
    <rect>
     <x>0</x>

--- a/src/mumble/ConnectDialog.ui
+++ b/src/mumble/ConnectDialog.ui
@@ -2,6 +2,9 @@
 <ui version="4.0">
  <class>ConnectDialog</class>
  <widget class="QDialog" name="ConnectDialog">
+  <property name="windowModality">
+   <enum>Qt::WindowModal</enum>
+  </property>
   <property name="geometry">
    <rect>
     <x>0</x>

--- a/src/mumble/MainWindow.cpp
+++ b/src/mumble/MainWindow.cpp
@@ -431,6 +431,7 @@ void MainWindow::closeEvent(QCloseEvent *e) {
 	ServerHandlerPtr sh = g.sh;
 	if (sh && sh->isRunning() && g.s.bAskOnQuit && !bSuppressAskOnQuit) {
 		QMessageBox mb(QMessageBox::Warning, QLatin1String("Mumble"), tr("Mumble is currently connected to a server. Do you want to Close or Minimize it?"), QMessageBox::NoButton, this);
+		mb.setWindowModality(Qt::WindowModal);
 		QPushButton *qpbClose = mb.addButton(tr("Close"), QMessageBox::YesRole);
 		QPushButton *qpbMinimize = mb.addButton(tr("Minimize"), QMessageBox::NoRole);
 		QPushButton *qpbCancel = mb.addButton(tr("Cancel"), QMessageBox::RejectRole);
@@ -1377,6 +1378,7 @@ void MainWindow::on_qaServerInformation_triggered() {
 	qsAudio=tr("<h2>Audio bandwidth</h2><p>Maximum %1 kbit/s<br />Current %2 kbit/s<br />Codec: %3</p>").arg(g.iMaxBandwidth / 1000.0,0,'f',1).arg(g.iAudioBandwidth / 1000.0,0,'f',1).arg(currentCodec());
 
 	QMessageBox qmb(QMessageBox::Information, tr("Mumble Server Information"), qsVersion + qsControl + qsVoice + qsCrypt + qsAudio, QMessageBox::Ok, this);
+	qmb.setWindowModality(Qt::WindowModal);
 	qmb.setDefaultButton(QMessageBox::Ok);
 	qmb.setEscapeButton(QMessageBox::Ok);
 


### PR DESCRIPTION
By default, Qt uses ApplicationModal for all QDialogs
when you exec() them.

However, in Mumble, some windows are in a separate window hierarchy,
and it would be nice to be able to switch to them even when a modal
dialog is shown on top of Mumble's MainWindow. These windows are the
Developer Console, and also the configuration dialog for ManualPlugin.

This commit tries to remedy that by marking all of Mumble's modal
windows as WindowModal instead of AppliationModal.

Note: as of now, this commit is not exhaustive, but it covers most
of the obvious cases. Right now, we can't set the window modality
for QMessageBoxes create via QMessageBox's static factory methods.
We'll probably have to provide our own MUMessageBox (or similar)
for that.