### PR TITLE
src/tests: fix various MSVC build issues.

### DIFF
--- a/qmake/openssl.pri
+++ b/qmake/openssl.pri
@@ -16,7 +16,7 @@ include(../pkgconfig.pri)
 win32 {
 	INCLUDEPATH *= "$$OPENSSL_PATH/include"
 	QMAKE_LIBDIR *= "$$OPENSSL_PATH/lib"
-	LIBS *= -llibeay32
+	LIBS *= -lgdi32 -llibeay32
 }
 
 unix {

--- a/src/tests/TestCrypt/TestCrypt.cpp
+++ b/src/tests/TestCrypt/TestCrypt.cpp
@@ -3,6 +3,9 @@
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.
 
+// Include murmur_pch.h for STACKVAR
+#include "murmur_pch.h"
+
 #include <QtCore>
 #include <QtTest>
 
@@ -166,14 +169,14 @@ void TestCrypt::authcrypt() {
 		CryptState cs;
 		cs.setKey(rawkey, nonce, nonce);
 
-		unsigned char src[len];
+		STACKVAR(unsigned char, src, len);
 		for (int i=0;i<len;i++)
 			src[i] = (i + 1);
 
 		unsigned char enctag[AES_BLOCK_SIZE];
 		unsigned char dectag[AES_BLOCK_SIZE];
-		unsigned char encrypted[len];
-		unsigned char decrypted[len];
+		STACKVAR(unsigned char, encrypted, len);
+		STACKVAR(unsigned char, decrypted, len);
 
 		cs.ocb_encrypt(src, encrypted, len, nonce, enctag);
 		cs.ocb_decrypt(encrypted, decrypted, len, nonce, dectag);
@@ -195,8 +198,8 @@ void TestCrypt::tamper() {
 	const unsigned char msg[] = "It was a funky funky town!";
 	int len = sizeof(msg);
 
-	unsigned char encrypted[len+4];
-	unsigned char decrypted[len];
+	STACKVAR(unsigned char, encrypted, len+4);
+	STACKVAR(unsigned char, decrypted, len);
 	cs.encrypt(msg, encrypted, len);
 
 	for (int i=0;i<len*8;i++) {

--- a/src/tests/TestCrypt/TestCrypt.pro
+++ b/src/tests/TestCrypt/TestCrypt.pro
@@ -9,8 +9,16 @@ include(../../../qmake/openssl.pri)
 TEMPLATE = app
 QT = core network testlib
 CONFIG += testcase
-CONFIG += qt thread warn_on
+CONFIG += thread warn_on
 CONFIG -= app_bundle
+
+# We build this test with 'gui' in QT,
+# but we include the QtGui headers from
+# murmur_pch.h. Define QT_NO_OPENGL to
+# avoid build errors about a missing GLES/gles2.h
+# header.
+DEFINES += QT_NO_OPENGL
+
 LANGUAGE = C++
 TARGET = TestCrypt
 HEADERS = Timer.h CryptState.h

--- a/src/tests/TestCryptographicHash/TestCryptographicHash.pro
+++ b/src/tests/TestCryptographicHash/TestCryptographicHash.pro
@@ -9,8 +9,16 @@ include(../../../qmake/openssl.pri)
 TEMPLATE = app
 QT = core testlib
 CONFIG += testcase
-CONFIG += qt warn_on
+CONFIG += warn_on
 CONFIG -= app_bundle
+
+# We build this test with 'gui' in QT,
+# but we include the QtGui headers from
+# murmur_pch.h. Define QT_NO_OPENGL to
+# avoid build errors about a missing GLES/gles2.h
+# header.
+DEFINES += QT_NO_OPENGL
+
 LANGUAGE = C++
 TARGET = TestCryptographicHash
 SOURCES = TestCryptographicHash.cpp CryptographicHash.cpp

--- a/src/tests/TestTimer/TestTimer.pro
+++ b/src/tests/TestTimer/TestTimer.pro
@@ -3,11 +3,21 @@
 # that can be found in the LICENSE file at the root of the
 # Mumble source tree or at <https://www.mumble.info/LICENSE>.
 
+include(../../../compiler.pri)
+
 TEMPLATE = app
 QT = core testlib
 CONFIG += testcase
-CONFIG += qt warn_on
+CONFIG += warn_on
 CONFIG -= app_bundle
+
+# We build this test with 'gui' in QT,
+# but we include the QtGui headers from
+# murmur_pch.h. Define QT_NO_OPENGL to
+# avoid build errors about a missing GLES/gles2.h
+# header.
+DEFINES += QT_NO_OPENGL
+
 LANGUAGE = C++
 TARGET = TestTimer
 SOURCES = TestTimer.cpp Timer.cpp


### PR DESCRIPTION
This makes 'jom check' pass on our win32-static buildenv with MSVC 2015.