### PR TITLE
Cert: require Qt 5.5 for QSsl::Ec.

### DIFF
--- a/src/murmur/Cert.cpp
+++ b/src/murmur/Cert.cpp
@@ -75,7 +75,7 @@ QSslKey Server::privateKeyFromPEM(const QByteArray &buf, const QByteArray &pass)
 	key = QSslKey(buf, QSsl::Rsa, QSsl::Pem, QSsl::PrivateKey, pass);
 	if (key.isNull())
 		key = QSslKey(buf, QSsl::Dsa, QSsl::Pem, QSsl::PrivateKey, pass);
-#if QT_VERSION >= 0x050000
+#if QT_VERSION >= 0x050500
 	if (key.isNull())
 		key = QSslKey(buf, QSsl::Ec, QSsl::Pem, QSsl::PrivateKey, pass);
 #endif


### PR DESCRIPTION
It was not implemented until Qt 5.5:
https://github.com/qt/qtbase/commit/962ea5690cb9351822c30da534ecae7aeeba667d

No trace in the Qt docs.