### PR TITLE
PasswordGenerator: add new class for generating human-friendly passwords via CryptographicRandom.

### DIFF
--- a/src/PasswordGenerator.cpp
+++ b/src/PasswordGenerator.cpp
@@ -1,0 +1,54 @@
+// Copyright 2005-2017 The Mumble Developers. All rights reserved.
+// Use of this source code is governed by a BSD-style license
+// that can be found in the LICENSE file at the root of the
+// Mumble source tree or at <https://www.mumble.info/LICENSE>.
+
+#include "murmur_pch.h"
+
+#include "CryptographicRandom.h"
+#include "PasswordGenerator.h"
+
+// This is a password alphabet that tries to be human-friendly.
+// Most cases of ambiguitiy have been removed.
+//
+// Removed characters:
+// "0" (zero)
+// "1" (one)
+// "5" (five)
+// "O" (uppercase O)
+// "o" (lowercase O)
+// "l" (lowercase L)
+// "I" (uppercase i)
+static char password_alphabet[] = {
+	'a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k', 'm', 'n',
+	'p', 'q', 'r', 's', 't', 'u', 'v', 'w', 'x', 'y', 'z',
+
+	'A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'J', 'K', 'L', 'M', 'N',
+	'P', 'Q', 'R', 'S', 'T', 'U', 'V', 'W', 'X', 'Y', 'Z',
+
+	'2', '3', '4', '6', '7', '8', '9'
+};
+
+// Getter function for TestPasswordGenerator to get the
+// alphabet we're using.
+QVector<QChar> mumble_password_generator_alphabet() {
+	QVector<QChar> v;
+	size_t numAlphabetEntries = sizeof(password_alphabet);
+	for (size_t i = 0; i < numAlphabetEntries; i++) {
+		v << QChar(QLatin1Char(password_alphabet[i]));
+	}
+	return v;
+}
+
+QString PasswordGenerator::generatePassword(int length) {
+	QByteArray buf(length, '\0');
+
+	uint32_t numAlphabetEntries = sizeof(password_alphabet);
+
+	for (int i = 0; i < length; i++) {
+		uint32_t index = CryptographicRandom::uniform(numAlphabetEntries-1);
+		buf[i] = password_alphabet[index];
+	}
+
+	return QString::fromLatin1(buf.constData(), buf.size());
+}

--- a/src/PasswordGenerator.h
+++ b/src/PasswordGenerator.h
@@ -1,0 +1,16 @@
+// Copyright 2005-2017 The Mumble Developers. All rights reserved.
+// Use of this source code is governed by a BSD-style license
+// that can be found in the LICENSE file at the root of the
+// Mumble source tree or at <https://www.mumble.info/LICENSE>.
+
+#ifndef MUMBLE_PASSWORDGENERATOR_H_
+#define MUMBLE_PASSWORDGENERATOR_H_
+
+#include <QString>
+
+class PasswordGenerator {
+	public:
+		static QString generatePassword(int length);
+};
+
+#endif

--- a/src/mumble.pri
+++ b/src/mumble.pri
@@ -14,8 +14,8 @@ CONFIG		+= qt thread debug_and_release warn_on
 DEFINES		*= MUMBLE_VERSION_STRING=$$VERSION
 INCLUDEPATH	+= $$PWD . ../mumble_proto
 VPATH		+= $$PWD
-HEADERS		*= ACL.h Channel.h CryptState.h Connection.h Group.h HTMLFilter.h User.h Net.h OSInfo.h Timer.h SSL.h Version.h SSLCipherInfo.h SSLCipherInfoTable.h licenses.h License.h LogEmitter.h CryptographicHash.h CryptographicRandom.h
-SOURCES 	*= ACL.cpp Group.cpp Channel.cpp Connection.cpp HTMLFilter.cpp User.cpp Timer.cpp CryptState.cpp OSInfo.cpp Net.cpp SSL.cpp Version.cpp SSLCipherInfo.cpp License.cpp LogEmitter.cpp CryptographicHash.cpp CryptographicRandom.cpp
+HEADERS		*= ACL.h Channel.h CryptState.h Connection.h Group.h HTMLFilter.h User.h Net.h OSInfo.h Timer.h SSL.h Version.h SSLCipherInfo.h SSLCipherInfoTable.h licenses.h License.h LogEmitter.h CryptographicHash.h CryptographicRandom.h PasswordGenerator.h
+SOURCES 	*= ACL.cpp Group.cpp Channel.cpp Connection.cpp HTMLFilter.cpp User.cpp Timer.cpp CryptState.cpp OSInfo.cpp Net.cpp SSL.cpp Version.cpp SSLCipherInfo.cpp License.cpp LogEmitter.cpp CryptographicHash.cpp CryptographicRandom.cpp PasswordGenerator.cpp
 LIBS		*= -lmumble_proto
 
 # Add arc4random_uniform

--- a/src/tests/TestPasswordGenerator/TestPasswordGenerator.cpp
+++ b/src/tests/TestPasswordGenerator/TestPasswordGenerator.cpp
@@ -1,0 +1,32 @@
+// Copyright 2005-2017 The Mumble Developers. All rights reserved.
+// Use of this source code is governed by a BSD-style license
+// that can be found in the LICENSE file at the root of the
+// Mumble source tree or at <https://www.mumble.info/LICENSE>.
+
+#include <QtCore>
+#include <QtTest>
+
+#include "PasswordGenerator.h"
+
+// Get the password alphabet from PasswordGenerator.
+extern QVector<QChar> mumble_password_generator_alphabet();
+
+class TestPasswordGenerator : public QObject {
+		Q_OBJECT
+	private slots:
+		void random();
+};
+
+void TestPasswordGenerator::random() {
+	QVector<QChar> alphabet = mumble_password_generator_alphabet();
+	for (int i = 0; i < 100; i++) {
+		QString out = PasswordGenerator::generatePassword(i);
+		QVERIFY(out.size() == i);
+		for (int j = 0; j < out.size(); j++) {
+			QVERIFY(alphabet.contains(out.at(j)));
+		}
+	}
+}
+
+QTEST_MAIN(TestPasswordGenerator)
+#include "TestPasswordGenerator.moc"

--- a/src/tests/TestPasswordGenerator/TestPasswordGenerator.pro
+++ b/src/tests/TestPasswordGenerator/TestPasswordGenerator.pro
@@ -1,0 +1,30 @@
+# Copyright 2005-2017 The Mumble Developers. All rights reserved.
+# Use of this source code is governed by a BSD-style license
+# that can be found in the LICENSE file at the root of the
+# Mumble source tree or at <https://www.mumble.info/LICENSE>.
+
+include(../../../compiler.pri)
+include(../../../qmake/openssl.pri)
+
+TEMPLATE = app
+QT = core testlib
+CONFIG += testcase
+CONFIG += warn_on
+CONFIG -= app_bundle
+
+# We build this test without 'gui' in QT,
+# but we include the QtGui headers from
+# murmur_pch.h. This causes an error when Qt
+# tries to find the OpenGL headers to use, since
+# we're missing the include paths from QtGui's
+# .pri files. Define QT_NO_OPENGL to avoid these
+# build errors.
+DEFINES += QT_NO_OPENGL
+
+LANGUAGE = C++
+TARGET = TestPasswordGenerator
+SOURCES = TestPasswordGenerator.cpp PasswordGenerator.cpp CryptographicRandom.cpp arc4random_uniform.cpp
+HEADERS = PasswordGenerator.h CryptographicHash.h
+VPATH += ../..
+VPATH += ../../../3rdparty/arc4random-src
+INCLUDEPATH += ../.. ../../murmur ../../mumble ../../../3rdparty/arc4random-src

--- a/src/tests/tests.pro
+++ b/src/tests/tests.pro
@@ -10,4 +10,5 @@ SUBDIRS += \
 	TestCryptographicHash \
 	TestCryptographicRandom \
 	TestPacketDataStream \
+	TestPasswordGenerator \
 	TestTimer


### PR DESCRIPTION
This depends on https://github.com/mumble-voip/mumble/pull/2882 and includes the commits of that PR as well. Will need to be removed before landing. 