### PR TITLE
src/tests: make all test .pro files 'inherit' from common test.pri file.

### DIFF
--- a/src/tests/TestCrypt/TestCrypt.pro
+++ b/src/tests/TestCrypt/TestCrypt.pro
@@ -3,25 +3,11 @@
 # that can be found in the LICENSE file at the root of the
 # Mumble source tree or at <https://www.mumble.info/LICENSE>.
 
-include(../../../compiler.pri)
+include(../test.pri)
 include(../../../qmake/openssl.pri)
 
-TEMPLATE = app
-QT = core network testlib
-CONFIG += testcase
-CONFIG += thread warn_on
-CONFIG -= app_bundle
+QT *= network
 
-# We build this test with 'gui' in QT,
-# but we include the QtGui headers from
-# murmur_pch.h. Define QT_NO_OPENGL to
-# avoid build errors about a missing GLES/gles2.h
-# header.
-DEFINES += QT_NO_OPENGL
-
-LANGUAGE = C++
 TARGET = TestCrypt
 HEADERS = Timer.h CryptState.h
 SOURCES = TestCrypt.cpp CryptState.cpp Timer.cpp
-VPATH += ../..
-INCLUDEPATH += ../.. ../../murmur ../../mumble

--- a/src/tests/TestCryptographicHash/TestCryptographicHash.pro
+++ b/src/tests/TestCryptographicHash/TestCryptographicHash.pro
@@ -3,25 +3,9 @@
 # that can be found in the LICENSE file at the root of the
 # Mumble source tree or at <https://www.mumble.info/LICENSE>.
 
-include(../../../compiler.pri)
+include(../test.pri)
 include(../../../qmake/openssl.pri)
 
-TEMPLATE = app
-QT = core testlib
-CONFIG += testcase
-CONFIG += warn_on
-CONFIG -= app_bundle
-
-# We build this test with 'gui' in QT,
-# but we include the QtGui headers from
-# murmur_pch.h. Define QT_NO_OPENGL to
-# avoid build errors about a missing GLES/gles2.h
-# header.
-DEFINES += QT_NO_OPENGL
-
-LANGUAGE = C++
 TARGET = TestCryptographicHash
 SOURCES = TestCryptographicHash.cpp CryptographicHash.cpp
 HEADERS = CryptographicHash.h
-VPATH += ../..
-INCLUDEPATH += ../.. ../../murmur ../../mumble

--- a/src/tests/TestCryptographicRandom/TestCryptographicRandom.pro
+++ b/src/tests/TestCryptographicRandom/TestCryptographicRandom.pro
@@ -3,26 +3,12 @@
 # that can be found in the LICENSE file at the root of the
 # Mumble source tree or at <https://www.mumble.info/LICENSE>.
 
-include(../../../compiler.pri)
+include(../test.pri)
 include(../../../qmake/openssl.pri)
-
-TEMPLATE = app
-QT = core testlib
-CONFIG += testcase
-CONFIG += qt warn_on
-CONFIG -= app_bundle
-LANGUAGE = C++
-
-# We build this test with 'gui' in QT,
-# but we include the QtGui headers from
-# murmur_pch.h. Define QT_NO_OPENGL to
-# avoid build errors about a missing GLES/gles2.h
-# header.
-DEFINES += QT_NO_OPENGL
 
 TARGET = TestCryptographicRandom
 SOURCES = TestCryptographicRandom.cpp CryptographicRandom.cpp arc4random_uniform.cpp
 HEADERS = CryptographicHash.h
-VPATH += ../..
-VPATH += ../../../3rdparty/arc4random-src
-INCLUDEPATH += ../.. ../../murmur ../../mumble ../../../3rdparty/arc4random-src
+
+VPATH *= ../../../3rdparty/arc4random-src
+INCLUDEPATH *= ../../../3rdparty/arc4random-src

--- a/src/tests/TestPacketDataStream/TestPacketDataStream.pro
+++ b/src/tests/TestPacketDataStream/TestPacketDataStream.pro
@@ -3,12 +3,9 @@
 # that can be found in the LICENSE file at the root of the
 # Mumble source tree or at <https://www.mumble.info/LICENSE>.
 
-TEMPLATE = app
-QT = core network testlib
-CONFIG += testcase
-CONFIG += qt thread warn_on
-CONFIG -= app_bundle
-LANGUAGE = C++
+include(../test.pri)
+
+QT *= network
+
 TARGET = TestPacketDataStream
 SOURCES = TestPacketDataStream.cpp
-INCLUDEPATH += ../.. ../../murmur ../../mumble

--- a/src/tests/TestPasswordGenerator/TestPasswordGenerator.pro
+++ b/src/tests/TestPasswordGenerator/TestPasswordGenerator.pro
@@ -3,28 +3,12 @@
 # that can be found in the LICENSE file at the root of the
 # Mumble source tree or at <https://www.mumble.info/LICENSE>.
 
-include(../../../compiler.pri)
+include(../test.pri)
 include(../../../qmake/openssl.pri)
 
-TEMPLATE = app
-QT = core testlib
-CONFIG += testcase
-CONFIG += warn_on
-CONFIG -= app_bundle
-
-# We build this test without 'gui' in QT,
-# but we include the QtGui headers from
-# murmur_pch.h. This causes an error when Qt
-# tries to find the OpenGL headers to use, since
-# we're missing the include paths from QtGui's
-# .pri files. Define QT_NO_OPENGL to avoid these
-# build errors.
-DEFINES += QT_NO_OPENGL
-
-LANGUAGE = C++
 TARGET = TestPasswordGenerator
 SOURCES = TestPasswordGenerator.cpp PasswordGenerator.cpp CryptographicRandom.cpp arc4random_uniform.cpp
 HEADERS = PasswordGenerator.h CryptographicHash.h
-VPATH += ../..
-VPATH += ../../../3rdparty/arc4random-src
-INCLUDEPATH += ../.. ../../murmur ../../mumble ../../../3rdparty/arc4random-src
+
+VPATH *= ../../../3rdparty/arc4random-src
+INCLUDEPATH *=  ../../../3rdparty/arc4random-src

--- a/src/tests/TestTimer/TestTimer.pro
+++ b/src/tests/TestTimer/TestTimer.pro
@@ -3,24 +3,8 @@
 # that can be found in the LICENSE file at the root of the
 # Mumble source tree or at <https://www.mumble.info/LICENSE>.
 
-include(../../../compiler.pri)
+include(../test.pri)
 
-TEMPLATE = app
-QT = core testlib
-CONFIG += testcase
-CONFIG += warn_on
-CONFIG -= app_bundle
-
-# We build this test with 'gui' in QT,
-# but we include the QtGui headers from
-# murmur_pch.h. Define QT_NO_OPENGL to
-# avoid build errors about a missing GLES/gles2.h
-# header.
-DEFINES += QT_NO_OPENGL
-
-LANGUAGE = C++
 TARGET = TestTimer
 SOURCES = TestTimer.cpp Timer.cpp
 HEADERS = Timer.h
-VPATH += ../..
-INCLUDEPATH += ../.. ../../murmur ../../mumble

--- a/src/tests/test.pri
+++ b/src/tests/test.pri
@@ -1,0 +1,28 @@
+# Copyright 2005-2017 The Mumble Developers. All rights reserved.
+# Use of this source code is governed by a BSD-style license
+# that can be found in the LICENSE file at the root of the
+# Mumble source tree or at <https://www.mumble.info/LICENSE>.
+
+# Common include file for tests.
+
+include(../../compiler.pri)
+
+TEMPLATE = app
+QT = core testlib
+CONFIG += testcase
+CONFIG += thread warn_on
+CONFIG -= app_bundle
+
+# We build this test without 'gui' in QT,
+# but we include the QtGui headers from
+# murmur_pch.h. This causes an error when Qt
+# tries to find the OpenGL headers to use, since
+# we're missing the include paths from QtGui's
+# .pri files. Define QT_NO_OPENGL to avoid these
+# build errors.
+DEFINES += QT_NO_OPENGL
+
+LANGUAGE = C++
+
+VPATH *= ../..
+INCLUDEPATH *= ../.. ../../murmur ../../mumble


### PR DESCRIPTION
This refactors a lot of the common code from each test file into
a test.pri file, which is then included by all of our tests.