### PR TITLE
overlay_blacklist.h: add "kodi.exe"

### DIFF
--- a/overlay/overlay_blacklist.h
+++ b/overlay/overlay_blacklist.h
@@ -29,6 +29,7 @@ static const char *overlayBlacklist[] = {
 	"blender.exe",
 	"googleearth.exe",
 	"XBMC.exe", // http://xbmc.org/
+	"kodi.exe", // https://kodi.tv/
 	"BOXEE.exe", // http://www.boxee.tv/
 	"hammer.exe", // VALVE Hammer Editor
 	"hlmv.exe", // Half-Life Model Viewer


### PR DESCRIPTION
XBMC is now Kodi. Add `kodi.exe` to the overlay blacklist.