### PR TITLE
Overlay_win: properly initialize m_helper_enabled, m_helper64_enabled and m_mumble_handle.

### DIFF
--- a/src/mumble/Overlay_win.cpp
+++ b/src/mumble/Overlay_win.cpp
@@ -46,8 +46,12 @@ static bool canRun64BitPrograms() {
 #endif
 }
 
-OverlayPrivateWin::OverlayPrivateWin(QObject *p) : OverlayPrivate(p) {
-	m_active = false;
+OverlayPrivateWin::OverlayPrivateWin(QObject *p)
+	: OverlayPrivate(p)
+	, m_active(false)
+	, m_helper_enabled(true)
+	, m_helper64_enabled(true)
+	, m_mumble_handle(0) {
 
 	// Acquire a handle to ourselves and duplicate it. We duplicate it because
 	// want it to be inheritable by our helper processes, and the handle returned


### PR DESCRIPTION
We neglected to properly initialize these variables in OverlayPrivateWin,
causing the overlay helpers to sometimes not be launched.