### PR TITLE
Use 'Third-Party Licenses' in About dialog instead of "3rd party licenses"

### DIFF
--- a/src/mumble/About.cpp
+++ b/src/mumble/About.cpp
@@ -61,7 +61,7 @@ AboutDialog::AboutDialog(QWidget *p) : QDialog(p) {
 	qtwTab->addTab(about, tr("&About Mumble"));
 	qtwTab->addTab(qteLicense, tr("&License"));
 	qtwTab->addTab(qteAuthors, tr("A&uthors"));
-	qtwTab->addTab(qtb3rdPartyLicense, tr("3rd &party licenses"));
+	qtwTab->addTab(qtb3rdPartyLicense, tr("&Third-Party Licenses"));
 
 	QPushButton *okButton = new QPushButton(tr("OK"), this);
 	connect(okButton, SIGNAL(clicked()), this, SLOT(accept()));

--- a/src/murmur/About.cpp
+++ b/src/murmur/About.cpp
@@ -66,7 +66,7 @@ AboutDialog::AboutDialog(QWidget *p, AboutDialogOptions options) : QDialog(p) {
 	qtwTab->addTab(about, tr("&About Murmur"));
 	qtwTab->addTab(qteLicense, tr("&License"));
 	qtwTab->addTab(qteAuthors, tr("A&uthors"));
-	qtwTab->addTab(qtb3rdPartyLicense, tr("&Third-party licenses"));
+	qtwTab->addTab(qtb3rdPartyLicense, tr("&Third-Party Licenses"));
 
 	if (options == AboutDialogOptionsShowAbout) {
 		qtwTab->setCurrentWidget(about);


### PR DESCRIPTION
This changes the string "3rd party licenses" to be "Third-Party Licenses" instead.
It also fixes all occurrences to be Title Case, which what we use all across our UI already.