### PR TITLE
Add setting for enabling the Developer menu

### DIFF
--- a/src/mumble/LookConfig.cpp
+++ b/src/mumble/LookConfig.cpp
@@ -157,6 +157,7 @@ void LookConfig::load(const Settings &r) {
 	loadComboBox(qcbUserDrag, r.ceUserDrag);
 	loadCheckBox(qcbUsersTop, r.bUserTop);
 	loadCheckBox(qcbAskOnQuit, r.bAskOnQuit);
+	loadCheckBox(qcbEnableDeveloperMenu, r.bEnableDeveloperMenu);
 	loadCheckBox(qcbHideTray, r.bHideInTray);
 	loadCheckBox(qcbStateInTray, r.bStateInTray);
 	loadCheckBox(qcbShowUserCount, r.bShowUserCount);
@@ -203,6 +204,7 @@ void LookConfig::save() const {
 	
 	s.aotbAlwaysOnTop = static_cast<Settings::AlwaysOnTopBehaviour>(qcbAlwaysOnTop->currentIndex());
 	s.bAskOnQuit = qcbAskOnQuit->isChecked();
+	s.bEnableDeveloperMenu = qcbEnableDeveloperMenu->isChecked();
 	s.bHideInTray = qcbHideTray->isChecked();
 	s.bStateInTray = qcbStateInTray->isChecked();
 	s.bShowUserCount = qcbShowUserCount->isChecked();

--- a/src/mumble/LookConfig.ui
+++ b/src/mumble/LookConfig.ui
@@ -233,6 +233,16 @@
         </property>
        </widget>
       </item>
+      <item row="3" column="0" colspan="2">
+       <widget class="QCheckBox" name="qcbEnableDeveloperMenu">
+        <property name="whatsThis">
+         <string>&lt;b&gt;Enable Developer menu&lt;/b&gt;&lt;br /&gt;This enables the &quot;Developer&quot;-menu in Mumble. This menu is used for developer-specific features, such as the Developer Console.</string>
+        </property>
+        <property name="text">
+         <string>Enable Developer menu</string>
+        </property>
+       </widget>
+      </item>
      </layout>
     </widget>
    </item>

--- a/src/mumble/MainWindow.cpp
+++ b/src/mumble/MainWindow.cpp
@@ -138,6 +138,8 @@ MainWindow::MainWindow(QWidget *p) : QMainWindow(p) {
 	qmUser = new QMenu(tr("&User"), this);
 	qmChannel = new QMenu(tr("&Channel"), this);
 
+	qmDeveloper = new QMenu(tr("&Developer"), this);
+
 	createActions();
 	setupUi(this);
 	setupGui();
@@ -156,6 +158,7 @@ MainWindow::MainWindow(QWidget *p) : QMainWindow(p) {
 	qmChannel_aboutToShow();
 	qmUser_aboutToShow();
 	on_qmConfig_aboutToShow();
+	qmDeveloper->addAction(qaDeveloperConsole);
 
 	setOnTop(g.s.aotbAlwaysOnTop == Settings::OnTopAlways ||
 	         (g.s.bMinimalView && g.s.aotbAlwaysOnTop == Settings::OnTopInMinimal) ||
@@ -1037,6 +1040,22 @@ void MainWindow::setupView(bool toggle_minimize) {
 	} else {
 		menuBar()->removeAction(qmUser->menuAction());
 		menuBar()->removeAction(qmChannel->menuAction());
+	}
+
+	if (g.s.bEnableDeveloperMenu) {
+		bool found = false;
+		foreach(QAction *a, menuBar()->actions()) {
+			if (a == qmDeveloper->menuAction()) {
+				found = true;
+				break;
+			}
+		}
+
+		if (!found) {
+			menuBar()->insertMenu(qmHelp->menuAction(), qmDeveloper);
+		}
+	} else {
+		menuBar()->removeAction(qmDeveloper->menuAction());
 	}
 
 	if (! showit) {

--- a/src/mumble/MainWindow.h
+++ b/src/mumble/MainWindow.h
@@ -68,6 +68,7 @@ class MainWindow : public QMainWindow, public MessageHandler, public Ui::MainWin
 		QSystemTrayIcon *qstiIcon;
 		QMenu *qmUser;
 		QMenu *qmChannel;
+		QMenu *qmDeveloper;
 		QMenu *qmTray;
 		QIcon qiIcon, qiIconMutePushToMute, qiIconMuteSelf, qiIconMuteServer, qiIconDeafSelf, qiIconDeafServer, qiIconMuteSuppressed;
 		QIcon qiTalkingOn, qiTalkingWhisper, qiTalkingShout, qiTalkingOff;

--- a/src/mumble/MainWindow.ui
+++ b/src/mumble/MainWindow.ui
@@ -68,12 +68,6 @@
     <addaction name="separator"/>
     <addaction name="qaHelpVersionCheck"/>
    </widget>
-   <widget class="QMenu" name="qmDeveloper">
-    <property name="title">
-     <string>&amp;Developer</string>
-    </property>
-    <addaction name="qaDeveloperConsole"/>
-   </widget>
    <widget class="QMenu" name="qmServer">
     <property name="title">
      <string>S&amp;erver</string>
@@ -99,7 +93,6 @@
    <addaction name="qmServer"/>
    <addaction name="qmSelf"/>
    <addaction name="qmConfig"/>
-   <addaction name="qmDeveloper"/>
    <addaction name="qmHelp"/>
   </widget>
   <widget class="QDockWidget" name="qdwLog">

--- a/src/mumble/Settings.cpp
+++ b/src/mumble/Settings.cpp
@@ -284,6 +284,7 @@ Settings::Settings() {
 	bHideFrame = false;
 	aotbAlwaysOnTop = OnTopNever;
 	bAskOnQuit = true;
+	bEnableDeveloperMenu = false;
 #ifdef Q_OS_WIN
 	// Don't enable minimize to tray by default on Windows >= 7
 	const QSysInfo::WinVersion winVer = QSysInfo::windowsVersion();
@@ -685,6 +686,7 @@ void Settings::load(QSettings* settings_ptr) {
 	LOADENUM(ceUserDrag, "ui/userdrag");
 	LOADENUM(aotbAlwaysOnTop, "ui/alwaysontop");
 	SAVELOAD(bAskOnQuit, "ui/askonquit");
+	SAVELOAD(bEnableDeveloperMenu, "ui/developermenu");
 	SAVELOAD(bMinimalView, "ui/minimalview");
 	SAVELOAD(bHideFrame, "ui/hideframe");
 	SAVELOAD(bUserTop, "ui/usertop");
@@ -1000,6 +1002,7 @@ void Settings::save() {
 	SAVELOAD(ceUserDrag, "ui/userdrag");
 	SAVELOAD(aotbAlwaysOnTop, "ui/alwaysontop");
 	SAVELOAD(bAskOnQuit, "ui/askonquit");
+	SAVELOAD(bEnableDeveloperMenu, "ui/developermenu");
 	SAVELOAD(bMinimalView, "ui/minimalview");
 	SAVELOAD(bHideFrame, "ui/hideframe");
 	SAVELOAD(bUserTop, "ui/usertop");

--- a/src/mumble/Settings.h
+++ b/src/mumble/Settings.h
@@ -258,6 +258,7 @@ struct Settings {
 	enum AlwaysOnTopBehaviour { OnTopNever, OnTopAlways, OnTopInMinimal, OnTopInNormal };
 	AlwaysOnTopBehaviour aotbAlwaysOnTop;
 	bool bAskOnQuit;
+	bool bEnableDeveloperMenu;
 	bool bHideInTray;
 	bool bStateInTray;
 	bool bUsage;


### PR DESCRIPTION
Prior to this PR, the Developer menu was always enabled.
That was OK for snapshots, but for release, we're going to want it disabled by default.

This PR....
 - Adds a new setting, 'ui/developerconsole' for enabling the Developer menu.
 - Adds a checkbox in LookConfig and hooks it up to the 'ui/developerconsole' setting.
 - Hooks up MainWindow to dynamically show/hide the Developer menu depending on the state of 'ui/developerconsole'.