### PR TITLE
ServerResolver: add new class for hostname resolving (including SRV support).

### DIFF
--- a/src/HostAddress.h
+++ b/src/HostAddress.h
@@ -47,4 +47,8 @@ Q_DECLARE_TYPEINFO(HostAddress, Q_MOVABLE_TYPE);
 
 quint32 qHash(const HostAddress &);
 
+/// qpAddress combines a HostAddress with a port to represent
+/// a full server address.
+typedef QPair<HostAddress, unsigned short> qpAddress;
+
 #endif

--- a/src/ServerResolver.h
+++ b/src/ServerResolver.h
@@ -1,0 +1,40 @@
+// Copyright 2005-2017 The Mumble Developers. All rights reserved.
+// Use of this source code is governed by a BSD-style license
+// that can be found in the LICENSE file at the root of the
+// Mumble source tree or at <https://www.mumble.info/LICENSE>.
+
+#ifndef MUMBLE_MUMBLE_SERVERRESOLVER_H_
+#define MUMBLE_MUMBLE_SERVERRESOLVER_H_
+
+#include <QtCore/QObject>
+#include <QtCore/QString>
+#include <QtCore/QList>
+
+#include "Net.h" // for HostAddress
+#include "ServerResolverRecord.h"
+
+class ServerResolverPrivate;
+
+class ServerResolver : public QObject {
+	private:
+		Q_OBJECT
+		Q_DISABLE_COPY(ServerResolver)
+	public:
+		ServerResolver(QObject *parent = NULL);
+
+		QString hostname();
+		quint16 port();
+
+		void resolve(QString hostname, quint16 port);
+		QList<ServerResolverRecord> records();
+
+	signals:
+		/// Resolved is fired once the ServerResolver
+		/// has resolved the server address.
+		void resolved();
+
+	private:
+		ServerResolverPrivate *d;
+};
+
+#endif

--- a/src/ServerResolverRecord.cpp
+++ b/src/ServerResolverRecord.cpp
@@ -1,0 +1,32 @@
+// Copyright 2005-2017 The Mumble Developers. All rights reserved.
+// Use of this source code is governed by a BSD-style license
+// that can be found in the LICENSE file at the root of the
+// Mumble source tree or at <https://www.mumble.info/LICENSE>.
+
+#include "ServerResolverRecord.h"
+
+ServerResolverRecord::ServerResolverRecord() {
+}
+
+ServerResolverRecord::ServerResolverRecord(QString hostname_, quint16 port_, qint64 priority_, QList<HostAddress> addresses_)
+	: m_hostname(hostname_)
+	, m_port(port_)
+	, m_priority(priority_)
+	, m_addresses(addresses_) {
+}
+
+qint64 ServerResolverRecord::priority() {
+	return m_priority;
+}
+
+QString ServerResolverRecord::hostname() {
+	return m_hostname;
+}
+
+quint16 ServerResolverRecord::port() {
+	return m_port;
+}
+
+QList<HostAddress> ServerResolverRecord::addresses() {
+	return m_addresses;
+}

--- a/src/ServerResolverRecord.h
+++ b/src/ServerResolverRecord.h
@@ -1,0 +1,31 @@
+// Copyright 2005-2017 The Mumble Developers. All rights reserved.
+// Use of this source code is governed by a BSD-style license
+// that can be found in the LICENSE file at the root of the
+// Mumble source tree or at <https://www.mumble.info/LICENSE>.
+
+#ifndef MUMBLE_MUMBLE_SERVERRESOLVERRECORD_H_
+#define MUMBLE_MUMBLE_SERVERRESOLVERRECORD_H_
+
+#include <QtCore/QString>
+#include <QtCore/QList>
+
+#include "Net.h" // for HostAddress
+
+class ServerResolverRecord {
+	public:
+		ServerResolverRecord();
+		ServerResolverRecord(QString hostname_, quint16 port_, qint64 priority_, QList<HostAddress> addresses_);
+
+		QString hostname();
+		quint16 port();
+		qint64 priority();
+		QList<HostAddress> addresses();
+
+	protected:
+		QString m_hostname;
+		quint16 m_port;
+		qint64 m_priority;
+		QList<HostAddress> m_addresses;
+};
+
+#endif

--- a/src/ServerResolver_nosrv.cpp
+++ b/src/ServerResolver_nosrv.cpp
@@ -1,0 +1,102 @@
+// Copyright 2005-2017 The Mumble Developers. All rights reserved.
+// Use of this source code is governed by a BSD-style license
+// that can be found in the LICENSE file at the root of the
+// Mumble source tree or at <https://www.mumble.info/LICENSE>.
+
+#include "murmur_pch.h"
+
+#include "ServerResolver.h"
+
+#include <QtNetwork/QHostInfo>
+
+class ServerResolverPrivate : public QObject {
+	private:
+		Q_OBJECT
+		Q_DISABLE_COPY(ServerResolverPrivate)
+	public:
+		ServerResolverPrivate(QObject *parent);
+
+		void resolve(QString hostname, quint16 port);
+		QList<ServerResolverRecord> records();
+
+		QString m_origHostname;
+		quint16 m_origPort;
+
+		QList<ServerResolverRecord> m_resolved;
+
+	signals:
+		void resolved();
+
+	public slots:
+		void hostResolved(QHostInfo hostInfo);
+};
+
+ServerResolverPrivate::ServerResolverPrivate(QObject *parent)
+	: QObject(parent)
+	, m_origPort(0) {
+}
+
+void ServerResolverPrivate::resolve(QString hostname, quint16 port) {
+	m_origHostname = hostname;
+	m_origPort = port;
+
+	QHostInfo::lookupHost(hostname, this, SLOT(hostResolved(QHostInfo)));
+}
+
+QList<ServerResolverRecord> ServerResolverPrivate::records() {
+	return m_resolved;
+}
+
+void ServerResolverPrivate::hostResolved(QHostInfo hostInfo) {
+	if (hostInfo.error() == QHostInfo::NoError) {
+		QList<QHostAddress> resolvedAddresses = hostInfo.addresses();
+		
+		// Convert QHostAddress -> HostAddress.
+		QList<HostAddress> addresses;
+		foreach (QHostAddress ha, resolvedAddresses) {
+			addresses << HostAddress(ha);
+		}
+
+		m_resolved << ServerResolverRecord(m_origHostname, m_origPort, 0, addresses);
+	}
+
+	emit resolved();
+}
+
+ServerResolver::ServerResolver(QObject *parent)
+	: QObject(parent) {
+
+	d = new ServerResolverPrivate(this);
+}
+
+QString ServerResolver::hostname() {
+	if (d) {
+		return d->m_origHostname;
+	}
+
+	return QString();
+}
+
+quint16 ServerResolver::port() {
+	if (d) {
+		return d->m_origPort;
+	}
+
+	return 0;
+}
+
+void ServerResolver::resolve(QString hostname, quint16 port) {
+	if (d) {
+		connect(d, SIGNAL(resolved()), this, SIGNAL(resolved()));
+		d->resolve(hostname, port);
+	}
+}
+
+QList<ServerResolverRecord> ServerResolver::records() {
+	if (d) {
+		return d->records();
+	}
+	return QList<ServerResolverRecord>();
+}
+
+#include "ServerResolver_nosrv.moc"

--- a/src/ServerResolver_qt5.cpp
+++ b/src/ServerResolver_qt5.cpp
@@ -1,0 +1,162 @@
+// Copyright 2005-2017 The Mumble Developers. All rights reserved.
+// Use of this source code is governed by a BSD-style license
+// that can be found in the LICENSE file at the root of the
+// Mumble source tree or at <https://www.mumble.info/LICENSE>.
+
+#include "murmur_pch.h"
+
+#include "ServerResolver.h"
+
+#include <QtNetwork/QDnsLookup>
+#include <QtNetwork/QHostInfo>
+
+static qint64 normalizeSrvPriority(quint16 priority, quint16 weight) {
+	return static_cast<qint64>((65535U * priority) + weight);
+}
+
+class ServerResolverPrivate : public QObject {
+	private:
+		Q_OBJECT
+		Q_DISABLE_COPY(ServerResolverPrivate)
+	public:
+		ServerResolverPrivate(QObject *parent);
+
+		void resolve(QString hostname, quint16 port);
+		QList<ServerResolverRecord> records();
+
+		QString m_origHostname;
+		quint16 m_origPort;
+
+		QList<QDnsServiceRecord> m_srvQueue;
+		QMap<int, int> m_hostInfoIdToIndexMap;
+		int m_srvQueueRemain;
+
+		QList<ServerResolverRecord> m_resolved;
+
+	signals:
+		void resolved();
+
+	public slots:
+		void srvResolved();
+		void hostResolved(QHostInfo hostInfo);
+		void hostFallbackResolved(QHostInfo hostInfo);
+};
+
+ServerResolverPrivate::ServerResolverPrivate(QObject *parent)
+	: QObject(parent)
+	, m_origPort(0)
+	, m_srvQueueRemain(0) {
+}
+
+void ServerResolverPrivate::resolve(QString hostname, quint16 port) {
+	m_origHostname = hostname;
+	m_origPort = port;
+
+	QDnsLookup *resolver = new QDnsLookup(this);
+	connect(resolver, SIGNAL(finished()), this, SLOT(srvResolved()));
+	resolver->setType(QDnsLookup::SRV);
+
+	resolver->setName(QLatin1String("_mumble._tcp.") + hostname);
+	resolver->lookup();
+}
+
+QList<ServerResolverRecord> ServerResolverPrivate::records() {
+	return m_resolved;
+}
+
+void ServerResolverPrivate::srvResolved() {
+	QDnsLookup *resolver = qobject_cast<QDnsLookup *>(sender());
+
+	if (resolver->error() == QDnsLookup::NoError) {
+		m_srvQueue = resolver->serviceRecords();
+		m_srvQueueRemain = m_srvQueue.count();
+
+		for (int i = 0; i < m_srvQueue.count(); i++) {
+			QDnsServiceRecord record = m_srvQueue.at(i);
+			int hostInfoId = QHostInfo::lookupHost(record.target(), this, SLOT(hostResolved(QHostInfo)));
+			m_hostInfoIdToIndexMap[hostInfoId] = i;
+		}
+	} else {
+		QHostInfo::lookupHost(m_origHostname, this, SLOT(hostFallbackResolved(QHostInfo)));
+	}
+
+	delete resolver;
+}
+
+void ServerResolverPrivate::hostResolved(QHostInfo hostInfo) {
+	int lookupId = hostInfo.lookupId();
+	int idx = m_hostInfoIdToIndexMap[lookupId];
+	QDnsServiceRecord record = m_srvQueue.at(idx);
+
+	if (hostInfo.error() == QHostInfo::NoError) {
+		QList<QHostAddress> resolvedAddresses = hostInfo.addresses();
+		
+		// Convert QHostAddress -> HostAddress.
+		QList<HostAddress> addresses;
+		foreach (QHostAddress ha, resolvedAddresses) {
+			addresses << HostAddress(ha);
+		}
+
+		qint64 priority = normalizeSrvPriority(record.priority(), record.weight());
+		m_resolved << ServerResolverRecord(m_origHostname, m_origPort, priority, addresses);
+	}
+
+	m_srvQueueRemain -= 1;
+	if (m_srvQueueRemain == 0) {
+		emit resolved();
+	}
+}
+
+void ServerResolverPrivate::hostFallbackResolved(QHostInfo hostInfo) {
+	if (hostInfo.error() == QHostInfo::NoError) {
+		QList<QHostAddress> resolvedAddresses = hostInfo.addresses();
+		
+		// Convert QHostAddress -> HostAddress.
+		QList<HostAddress> addresses;
+		foreach (QHostAddress ha, resolvedAddresses) {
+			addresses << HostAddress(ha);
+		}
+
+		m_resolved << ServerResolverRecord(m_origHostname, m_origPort, 0, addresses);
+	}
+
+	emit resolved();
+}
+
+ServerResolver::ServerResolver(QObject *parent)
+	: QObject(parent) {
+
+	d = new ServerResolverPrivate(this);
+}
+
+QString ServerResolver::hostname() {
+	if (d) {
+		return d->m_origHostname;
+	}
+
+	return QString();
+}
+
+quint16 ServerResolver::port() {
+	if (d) {
+		return d->m_origPort;
+	}
+
+	return 0;
+}
+
+void ServerResolver::resolve(QString hostname, quint16 port) {
+	if (d) {
+		connect(d, SIGNAL(resolved()), this, SIGNAL(resolved()));
+		d->resolve(hostname, port);
+	}
+}
+
+QList<ServerResolverRecord> ServerResolver::records() {
+	if (d) {
+		return d->records();
+	}
+	return QList<ServerResolverRecord>();
+}
+
+#include "ServerResolver_qt5.moc"

--- a/src/mumble.pri
+++ b/src/mumble.pri
@@ -14,9 +14,19 @@ CONFIG		+= qt thread debug_and_release warn_on
 DEFINES		*= MUMBLE_VERSION_STRING=$$VERSION
 INCLUDEPATH	+= $$PWD . ../mumble_proto
 VPATH		+= $$PWD
-HEADERS		*= ACL.h Channel.h CryptState.h Connection.h Group.h HTMLFilter.h User.h Net.h OSInfo.h Timer.h SSL.h Version.h SSLCipherInfo.h SSLCipherInfoTable.h licenses.h License.h LogEmitter.h CryptographicHash.h CryptographicRandom.h PasswordGenerator.h ByteSwap.h HostAddress.cpp Ban.h EnvUtils.h
-SOURCES 	*= ACL.cpp Group.cpp Channel.cpp Connection.cpp HTMLFilter.cpp User.cpp Timer.cpp CryptState.cpp OSInfo.cpp SSL.cpp Version.cpp SSLCipherInfo.cpp License.cpp LogEmitter.cpp CryptographicHash.cpp CryptographicRandom.cpp PasswordGenerator.cpp HostAddress.cpp Ban.cpp EnvUtils.cpp
+HEADERS		*= ACL.h Channel.h CryptState.h Connection.h Group.h HTMLFilter.h User.h Net.h OSInfo.h Timer.h SSL.h Version.h SSLCipherInfo.h SSLCipherInfoTable.h licenses.h License.h LogEmitter.h CryptographicHash.h CryptographicRandom.h PasswordGenerator.h ByteSwap.h HostAddress.cpp Ban.h EnvUtils.h ServerResolver.h ServerResolverRecord.h
+SOURCES 	*= ACL.cpp Group.cpp Channel.cpp Connection.cpp HTMLFilter.cpp User.cpp Timer.cpp CryptState.cpp OSInfo.cpp SSL.cpp Version.cpp SSLCipherInfo.cpp License.cpp LogEmitter.cpp CryptographicHash.cpp CryptographicRandom.cpp PasswordGenerator.cpp HostAddress.cpp Ban.cpp EnvUtils.cpp ServerResolver_qt5.cpp ServerResolverRecord.cpp
 LIBS		*= -lmumble_proto
+
+equals(QT_MAJOR_VERSION, 4) {
+	CONFIG *= no-srv
+}
+
+CONFIG(no-srv) {
+	DEFINES += USE_NO_SRV
+	SOURCES -= ServerResolver_qt5.cpp
+	SOURCES *= ServerResolver_nosrv.cpp
+}
 
 # Add arc4random_uniform
 INCLUDEPATH *= ../../3rdparty/arc4random-src

--- a/src/mumble/ConnectDialog.cpp
+++ b/src/mumble/ConnectDialog.cpp
@@ -329,7 +329,7 @@ ServerItem::ServerItem(const ServerItem *si) {
 	qsUrl = si->qsUrl;
 	qsBonjourHost = si->qsBonjourHost;
 	brRecord = si->brRecord;
-	qlAddresses = si->qlAddresses;
+	qlAddressPorts = si->qlAddressPorts;
 	bCA = si->bCA;
 
 	uiVersion = si->uiVersion;
@@ -458,8 +458,9 @@ QVariant ServerItem::data(int column, int role) const {
 			}
 		} else if (role == Qt::ToolTipRole) {
 			QStringList qsl;
-			foreach(const QHostAddress &qha, qlAddresses)
-				qsl << Qt::escape(qha.toString());
+			foreach(const qpAddress &addr, qlAddressPorts) {
+				qsl << Qt::escape(addr.first.toString() + QLatin1String(":") + QString::number(static_cast<unsigned long>(addr.second)));
+			}
 
 			double ploss = 100.0;
 
@@ -1006,7 +1007,7 @@ ConnectDialog::~ConnectDialog() {
 
 void ConnectDialog::accept() {
 	ServerItem *si = static_cast<ServerItem *>(qtwServers->currentItem());
-	if (! si || (bAllowHostLookup && si->qlAddresses.isEmpty()) || si->qsHostname.isEmpty()) {
+	if (! si || (bAllowHostLookup && si->qlAddressPorts.isEmpty()) || si->qsHostname.isEmpty()) {
 		qWarning() << "Invalid server";
 		return;
 	}
@@ -1118,7 +1119,7 @@ void ConnectDialog::on_qaFavoriteEdit_triggered() {
 		if ((cde->qsHostname != host) || (cde->usPort != si->usPort)) {
 			stopDns(si);
 
-			si->qlAddresses.clear();
+			si->qlAddressPorts.clear();
 			si->reset();
 
 			si->usPort = cde->usPort;
@@ -1235,7 +1236,7 @@ void ConnectDialog::on_qtwServers_currentItemChanged(QTreeWidgetItem *item, QTre
 		qpbEdit->setEnabled(false);
 	}
 	
-	bool bOk = !si->qlAddresses.isEmpty();
+	bool bOk = !si->qlAddressPorts.isEmpty();
 	if (!bAllowHostLookup) {
 		bOk = true;
 	}
@@ -1377,7 +1378,7 @@ void ConnectDialog::timeTick() {
 			qtwServers->setCurrentItem(items.at(0));
 			if (g.s.bAutoConnect && bAutoConnect) {
 				siAutoConnect = static_cast<ServerItem *>(items.at(0));
-				if (! siAutoConnect->qlAddresses.isEmpty()) {
+				if (! siAutoConnect->qlAddressPorts.isEmpty()) {
 					accept();
 					return;
 				} else if (!bAllowHostLookup) {
@@ -1416,7 +1417,7 @@ void ConnectDialog::timeTick() {
 	if (si) {
 		QString host = si->qsHostname.toLower();
 
-		if (si->qlAddresses.isEmpty()) {
+		if (si->qlAddressPorts.isEmpty()) {
 			if (! host.isEmpty()) {
 				qlDNSLookup.removeAll(host);
 				qlDNSLookup.prepend(host);
@@ -1447,7 +1448,7 @@ void ConnectDialog::timeTick() {
 				expanded = expanded && p->isExpanded();
 				p = p->siParent;
 			}
-		} while (si->qlAddresses.isEmpty() || ! expanded);
+		} while (si->qlAddressPorts.isEmpty() || ! expanded);
 	}
 
 	if (si == current)
@@ -1455,8 +1456,8 @@ void ConnectDialog::timeTick() {
 	if (si == hover)
 		tHover.restart();
 
-	foreach(const QHostAddress &host, si->qlAddresses)
-		sendPing(host, si->usPort);
+	foreach(const qpAddress &addr, si->qlAddressPorts)
+		sendPing(addr.first.toAddress(), addr.second);
 }
 
 
@@ -1467,20 +1468,21 @@ void ConnectDialog::startDns(ServerItem *si) {
 
 	QString host = si->qsHostname.toLower();
 
-	if (si->qlAddresses.isEmpty()) {
+	if (si->qlAddressPorts.isEmpty()) {
 		QHostAddress qha(si->qsHostname);
-		if (! qha.isNull())
-			si->qlAddresses.append(qha);
-		else
-			si->qlAddresses = qhDNSCache.value(host);
+		if (! qha.isNull()) {
+			si->qlAddressPorts.append(qpAddress(HostAddress(qha), si->usPort));
+		} else {
+			si->qlAddressPorts = qhDNSCache.value(host);
+		}
 	}
 
 	if (qtwServers->currentItem() == si)
-		qdbbButtonBox->button(QDialogButtonBox::Ok)->setEnabled(! si->qlAddresses.isEmpty());
+		qdbbButtonBox->button(QDialogButtonBox::Ok)->setEnabled(! si->qlAddressPorts.isEmpty());
 
-	if (! si->qlAddresses.isEmpty()) {
-		foreach(const QHostAddress &qha, si->qlAddresses) {
-			qhPings[qpAddress(HostAddress(qha), si->usPort)].insert(si);
+	if (! si->qlAddressPorts.isEmpty()) {
+		foreach(const qpAddress &addr, si->qlAddressPorts) {
+			qhPings[addr].insert(si);
 		}
 		return;
 	}
@@ -1509,8 +1511,7 @@ void ConnectDialog::stopDns(ServerItem *si) {
 		return;
 	}
 
-	foreach(const QHostAddress &qha, si->qlAddresses) {
-		qpAddress addr(HostAddress(qha), si->usPort);
+	foreach(const qpAddress &addr, si->qlAddressPorts) {
 		if (qhPings.contains(addr)) {
 			qhPings[addr].remove(si);
 			if (qhPings[addr].isEmpty()) {
@@ -1538,18 +1539,17 @@ void ConnectDialog::lookedUp(QHostInfo info) {
 	if (info.error() != QHostInfo::NoError)
 		return;
 
-	qlDNSLookup.removeAll(host);
-	qhDNSCache.insert(host, info.addresses());
-
 	QSet<qpAddress> qs;
 
 	foreach(ServerItem *si, qhDNSWait[host]) {
-		si->qlAddresses = info.addresses();
+		QList<qpAddress> addresses;
 		foreach(const QHostAddress &qha, info.addresses()) {
 			qpAddress addr(HostAddress(qha), si->usPort);
+			addresses.append(addr);
 			qs.insert(addr);
 			qhPings[addr].insert(si);
 		}
+		si->qlAddressPorts = addresses;
 
 		if (si == qtwServers->currentItem()) {
 			on_qtwServers_currentItemChanged(si, si);
@@ -1558,6 +1558,8 @@ void ConnectDialog::lookedUp(QHostInfo info) {
 		}
 	}
 
+	qlDNSLookup.removeAll(host);
+	qhDNSCache.insert(host, qs.toList());
 	qhDNSWait.remove(host);
 
 	if (bAllowPing) {

--- a/src/mumble/ConnectDialog.h
+++ b/src/mumble/ConnectDialog.h
@@ -38,8 +38,6 @@
 struct FavoriteServer;
 class QUdpSocket;
 
-typedef QPair<HostAddress, unsigned short> qpAddress;
-
 struct PublicInfo {
 	QString qsName;
 	QUrl quUrl;

--- a/src/mumble/ConnectDialog.h
+++ b/src/mumble/ConnectDialog.h
@@ -145,7 +145,7 @@ class ServerItem : public QTreeWidgetItem, public PingStats {
 		QString qsBonjourHost;
 		BonjourRecord brRecord;
 
-		QList<QHostAddress> qlAddresses;
+		QList<qpAddress> qlAddressPorts;
 
 		ItemType itType;
 
@@ -245,7 +245,7 @@ class ConnectDialog : public QDialog, public Ui::ConnectDialog {
 		QList<QString> qlDNSLookup;
 		QSet<QString> qsDNSActive;
 		QHash<QString, QSet<ServerItem *> > qhDNSWait;
-		QHash<QString, QList<QHostAddress> > qhDNSCache;
+		QHash<QString, QList<qpAddress> > qhDNSCache;
 
 		QHash<qpAddress, quint64> qhPingRand;
 		QHash<qpAddress, QSet<ServerItem *> > qhPings;

--- a/src/mumble/ConnectDialog.h
+++ b/src/mumble/ConnectDialog.h
@@ -288,7 +288,7 @@ class ConnectDialog : public QDialog, public Ui::ConnectDialog {
 		void fetched(QByteArray xmlData, QUrl, QMap<QString, QString>);
 
 		void udpReply();
-		void lookedUp(QHostInfo);
+		void lookedUp();
 		void timeTick();
 
 		void on_qaFavoriteAdd_triggered();

--- a/src/mumble/ServerHandler.cpp
+++ b/src/mumble/ServerHandler.cpp
@@ -260,6 +260,7 @@ void ServerHandler::run() {
 	qbaDigest = QByteArray();
 	bStrong = true;
 	qtsSock = new QSslSocket(this);
+	qtsSock->setPeerVerifyName(qsHostName);
 
 	if (! g.s.bSuppressIdentity && CertWizard::validateCert(g.s.kpCertificate)) {
 		qtsSock->setPrivateKey(g.s.kpCertificate.second);

--- a/src/mumble/ServerHandler.cpp
+++ b/src/mumble/ServerHandler.cpp
@@ -397,6 +397,10 @@ void ServerHandler::sendPing() {
 	if (!connection)
 		return;
 
+	if (qtsSock->state() != QAbstractSocket::ConnectedState) {
+		return;
+	}
+
 	if (g.s.iMaxInFlightTCPPings >= 0 && iInFlightTCPPings >= g.s.iMaxInFlightTCPPings) {
 		serverConnectionClosed(QAbstractSocket::UnknownSocketError, tr("Server is not responding to TCP pings"));
 		return;

--- a/src/mumble/ServerHandler.cpp
+++ b/src/mumble/ServerHandler.cpp
@@ -297,7 +297,7 @@ void ServerHandler::run() {
 #else
 	qtsSock->setProtocol(QSsl::TlsV1);
 #endif
-	qtsSock->connectToHostEncrypted(qsHostName, usPort);
+	qtsSock->connectToHost(qsHostName, usPort);
 
 	tTimestamp.restart();
 
@@ -547,6 +547,9 @@ void ServerHandler::serverConnectionStateChanged(QAbstractSocket::SocketState st
 		connect(tConnectionTimeoutTimer, SIGNAL(timeout()), this, SLOT(serverConnectionTimeoutOnConnect()));
 		tConnectionTimeoutTimer->setSingleShot(true);
 		tConnectionTimeoutTimer->start(30000);
+	} else if (state == QAbstractSocket::ConnectedState) {
+		// Start TLS handshake
+		qtsSock->startClientEncryption();
 	}
 }
 

--- a/src/mumble/ServerHandler.cpp
+++ b/src/mumble/ServerHandler.cpp
@@ -259,7 +259,7 @@ void ServerHandler::sendProtoMessage(const ::google::protobuf::Message &msg, uns
 void ServerHandler::run() {
 	qbaDigest = QByteArray();
 	bStrong = true;
-	QSslSocket *qtsSock = new QSslSocket(this);
+	qtsSock = new QSslSocket(this);
 
 	if (! g.s.bSuppressIdentity && CertWizard::validateCert(g.s.kpCertificate)) {
 		qtsSock->setPrivateKey(g.s.kpCertificate.second);

--- a/src/mumble/ServerHandler.cpp
+++ b/src/mumble/ServerHandler.cpp
@@ -23,6 +23,8 @@
 #include "User.h"
 #include "Net.h"
 #include "HostAddress.h"
+#include "ServerResolver.h"
+#include "ServerResolverRecord.h"
 
 ServerHandlerMessageEvent::ServerHandlerMessageEvent(const QByteArray &msg, unsigned int mtype, bool flush) : QEvent(static_cast<QEvent::Type>(SERVERSEND_EVENT)) {
 	qbaMsg = msg;
@@ -256,8 +258,49 @@ void ServerHandler::sendProtoMessage(const ::google::protobuf::Message &msg, uns
 	}
 }
 
+void ServerHandler::hostnameResolved() {
+	ServerResolver *sr = qobject_cast<ServerResolver *>(QObject::sender());
+	QList<ServerResolverRecord> records = sr->records();
+
+	// Exit the ServerHandler thread's event loop with an
+	// error code in case our hostname lookup failed.
+	if (records.isEmpty()) {
+		exit(-1);
+	}
+
+	// Create the list of target host:port pairs
+	// that the ServerHandler should try to connect to.
+	QList<qpAddress> ql;
+	foreach (ServerResolverRecord record, records) {
+		foreach (HostAddress addr, record.addresses()) {
+			ql.append(qpAddress(addr, record.port()));
+		}
+	}
+	qlAddressPorts = ql;
+
+	// Exit the event loop with 'success' status code,
+	// to continue connecting to the server.
+	exit(0);
+}
+
 void ServerHandler::run() {
+	// Resolve the hostname...
+	{
+		ServerResolver *sr = new ServerResolver();
+		QObject::connect(sr, SIGNAL(resolved()), this, SLOT(hostnameResolved()));
+		sr->resolve(qsHostName, usPort);
+		int ret = exec();
+		if (ret < 0) {
+			qWarning("ServerHandler: failed to resolve hostname");
+			return;
+		}
+	}
+
+	QList<qpAddress> targetAddresses(qlAddressPorts);
+	bool shouldTryNextTargetServer = true;
 	do {
+		qpaTargetServer = qlAddressPorts.takeFirst();
+
 		qbaDigest = QByteArray();
 		bStrong = true;
 		qtsSock = new QSslSocket(this);
@@ -297,7 +340,7 @@ void ServerHandler::run() {
 	#else
 		qtsSock->setProtocol(QSsl::TlsV1);
 	#endif
-		qtsSock->connectToHost(qsHostName, usPort);
+		qtsSock->connectToHost(qpaTargetServer.first.toAddress(), qpaTargetServer.second);
 
 		tTimestamp.restart();
 
@@ -315,7 +358,12 @@ void ServerHandler::run() {
 		qsOS = QString();
 		qsOSVersion = QString();
 
-		exec();
+		int ret = exec();
+		if (ret == -2) {
+			shouldTryNextTargetServer = true;
+		} else {
+			shouldTryNextTargetServer = false;
+		}
 
 		if (qusUdp) {
 			QMutexLocker qml(&qmUdp);
@@ -343,7 +391,7 @@ void ServerHandler::run() {
 			msleep(100);
 		}
 		delete qtsSock;
-	} while (false);
+	} while (shouldTryNextTargetServer && !qlAddressPorts.isEmpty());
 }
 
 #ifdef Q_OS_WIN
@@ -529,6 +577,20 @@ void ServerHandler::serverConnectionClosed(QAbstractSocket::SocketError err, con
 	AudioOutputPtr ao = g.ao;
 	if (ao)
 		ao->wipe();
+
+	// Try next server in the list if possible.
+	// Otherwise, emit disconnect and exit with
+	// a normal status code.
+	if (!qlAddressPorts.isEmpty()) {
+		if (err == QAbstractSocket::ConnectionRefusedError || err == QAbstractSocket::SocketTimeoutError) {
+			qWarning("ServerHandler: connection attempt to %s:%i failed: %s (%li); trying next server....",
+						qPrintable(qpaTargetServer.first.toString()), qpaTargetServer.second,
+						qPrintable(reason), static_cast<long>(err));
+			exit(-2);
+			return;
+		}
+	}
+
 	emit disconnected(err, reason);
 	exit(0);
 }

--- a/src/mumble/ServerHandler.h
+++ b/src/mumble/ServerHandler.h
@@ -37,6 +37,7 @@ class Connection;
 class Message;
 class PacketDataStream;
 class QUdpSocket;
+class QSslSocket;
 class VoiceRecorder;
 
 class ServerHandlerMessageEvent : public QEvent {
@@ -82,6 +83,7 @@ class ServerHandler : public QThread {
 		ConnectionPtr cConnection;
 		QByteArray qbaDigest;
 		boost::shared_ptr<VoiceRecorder> recorder;
+		QSslSocket *qtsSock;
 
 		unsigned int uiVersion;
 		QString qsRelease;

--- a/src/mumble/ServerHandler.h
+++ b/src/mumble/ServerHandler.h
@@ -32,6 +32,7 @@
 #include "Timer.h"
 #include "Message.h"
 #include "Mumble.pb.h"
+#include "HostAddress.h"
 
 class Connection;
 class Message;
@@ -84,6 +85,8 @@ class ServerHandler : public QThread {
 		QByteArray qbaDigest;
 		boost::shared_ptr<VoiceRecorder> recorder;
 		QSslSocket *qtsSock;
+		QList<qpAddress> qlAddressPorts;
+		qpAddress qpaTargetServer;
 
 		unsigned int uiVersion;
 		QString qsRelease;
@@ -142,6 +145,7 @@ class ServerHandler : public QThread {
 		void serverConnectionClosed(QAbstractSocket::SocketError, const QString &);
 		void setSslErrors(const QList<QSslError> &);
 		void udpReady();
+		void hostnameResolved();
 	public slots:
 		void sendPing();
 };

--- a/src/tests/TestServerResolver/TestServerResolver.cpp
+++ b/src/tests/TestServerResolver/TestServerResolver.cpp
@@ -29,8 +29,13 @@ void TestServerResolver::simpleSrv() {
 	quint16 port = 64738;
 
 	r.resolve(hostname, port);
-	
-	QVERIFY(spy.wait());
+
+	// Equivalent to QSignalSpy::wait() in Qt 5.
+	{
+		QTestEventLoop loop;
+		loop.enterLoop(5);
+	}
+
 	QCOMPARE(spy.count(), 1);
 
 	QList<ServerResolverRecord> records = r.records();
@@ -72,7 +77,12 @@ void TestServerResolver::simpleA() {
 
 	r.resolve(hostname, port);
 
-	QVERIFY(spy.wait());
+	// Equivalent to QSignalSpy::wait() in Qt 5.
+	{
+		QTestEventLoop loop;
+		loop.enterLoop(5);
+	}
+
 	QCOMPARE(spy.count(), 1);
 
 	QList<ServerResolverRecord> records = r.records();
@@ -106,7 +116,12 @@ void TestServerResolver::simpleAAAA() {
 
 	r.resolve(hostname, port);
 
-	QVERIFY(spy.wait());
+	// Equivalent to QSignalSpy::wait() in Qt 5.
+	{
+		QTestEventLoop loop;
+		loop.enterLoop(5);
+	}
+
 	QCOMPARE(spy.count(), 1);
 
 	QList<ServerResolverRecord> records = r.records();

--- a/src/tests/TestServerResolver/TestServerResolver.cpp
+++ b/src/tests/TestServerResolver/TestServerResolver.cpp
@@ -1,0 +1,115 @@
+// Copyright 2005-2017 The Mumble Developers. All rights reserved.
+// Use of this source code is governed by a BSD-style license
+// that can be found in the LICENSE file at the root of the
+// Mumble source tree or at <https://www.mumble.info/LICENSE>.
+
+#include <QtCore>
+#include <QtTest>
+#include <QSignalSpy>
+
+#include "ServerResolver.h"
+
+class TestServerResolver : public QObject {
+		Q_OBJECT
+	private slots:
+		void simpleSrv();
+		void simpleA();
+		void simpleAAAA();
+};
+
+void TestServerResolver::simpleSrv() {
+#ifdef USE_NO_SRV
+	return;
+#endif
+
+	ServerResolver r;
+	QSignalSpy spy(&r, SIGNAL(resolved()));
+
+	QString hostname = QString::fromLatin1("simple.serverresolver.mumble.info");
+	quint16 port = 64738;
+
+	r.resolve(hostname, port);
+	
+	QVERIFY(spy.wait());
+	QCOMPARE(spy.count(), 1);
+
+	QList<ServerResolverRecord> records = r.records();
+	QCOMPARE(records.size(), 1);
+
+	ServerResolverRecord record = records.at(0);
+	QCOMPARE(record.hostname(), hostname);
+	QCOMPARE(record.port(), port);
+	QCOMPARE(record.addresses().size(), 2);
+	QCOMPARE(record.priority(), 65545); // priority=1, weight=10 -> 1 * 65535 + 10
+
+	bool hasipv4 = false;
+	bool hasipv6 = false;
+
+	HostAddress v4(QHostAddress(QLatin1String("127.0.0.1")));
+	HostAddress v6(QHostAddress(QLatin1String("::1")));
+
+	foreach (HostAddress ha, record.addresses()) {
+		if (ha == v4) {
+			hasipv4 = true;
+		}
+		if (ha == v6) {
+			hasipv6 = true;
+		}
+	}
+	QVERIFY(hasipv4 && hasipv6);
+}
+
+void TestServerResolver::simpleA() {
+	ServerResolver r;
+	QSignalSpy spy(&r, SIGNAL(resolved()));
+
+	QString hostname = QString::fromLatin1("simplea.serverresolver.mumble.info");
+	quint16 port = 64738;
+
+	r.resolve(hostname, port);
+
+	QVERIFY(spy.wait());
+	QCOMPARE(spy.count(), 1);
+
+	QList<ServerResolverRecord> records = r.records();
+	QCOMPARE(records.size(), 1);
+
+	ServerResolverRecord record = records.at(0);
+	QCOMPARE(record.hostname(), hostname);
+	QCOMPARE(record.port(), port);
+	QCOMPARE(record.addresses().size(), 1);
+	QCOMPARE(record.priority(), static_cast<qint64>(0));
+
+	HostAddress want(QHostAddress(QLatin1String("127.0.0.1")));
+	HostAddress got = record.addresses().at(0);
+	QCOMPARE(want, got);
+}
+
+void TestServerResolver::simpleAAAA() {
+	ServerResolver r;
+	QSignalSpy spy(&r, SIGNAL(resolved()));
+
+	QString hostname = QString::fromLatin1("simpleaaaa.serverresolver.mumble.info");
+	quint16 port = 64738;
+
+	r.resolve(hostname, port);
+
+	QVERIFY(spy.wait());
+	QCOMPARE(spy.count(), 1);
+
+	QList<ServerResolverRecord> records = r.records();
+	QCOMPARE(records.size(), 1);
+
+	ServerResolverRecord record = records.at(0);
+	QCOMPARE(record.hostname(), hostname);
+	QCOMPARE(record.port(), port);
+	QCOMPARE(record.addresses().size(), 1);
+	QCOMPARE(record.priority(), static_cast<qint64>(0));
+
+	HostAddress want(QHostAddress(QLatin1String("::1")));
+	HostAddress got = record.addresses().at(0);
+	QCOMPARE(want, got);
+}
+
+QTEST_MAIN(TestServerResolver)
+#include "TestServerResolver.moc"

--- a/src/tests/TestServerResolver/TestServerResolver.cpp
+++ b/src/tests/TestServerResolver/TestServerResolver.cpp
@@ -39,7 +39,9 @@ void TestServerResolver::simpleSrv() {
 	ServerResolverRecord record = records.at(0);
 	QCOMPARE(record.hostname(), hostname);
 	QCOMPARE(record.port(), port);
-	QCOMPARE(record.addresses().size(), 2);
+	// Allow 1 or 2 results. The answer depends on whether
+	// the system supports IPv4, IPv6, or both.
+	QVERIFY(record.addresses().size() == 1 || record.addresses().size() == 2);
 	QCOMPARE(record.priority(), 65545); // priority=1, weight=10 -> 1 * 65535 + 10
 
 	bool hasipv4 = false;
@@ -56,7 +58,9 @@ void TestServerResolver::simpleSrv() {
 			hasipv6 = true;
 		}
 	}
-	QVERIFY(hasipv4 && hasipv6);
+
+	// Require either an IPv4 match, or an IPv6 match.
+	QVERIFY(hasipv4 || hasipv6);
 }
 
 void TestServerResolver::simpleA() {
@@ -72,6 +76,14 @@ void TestServerResolver::simpleA() {
 	QCOMPARE(spy.count(), 1);
 
 	QList<ServerResolverRecord> records = r.records();
+	// Since not all systems have IPv4 support, we have to
+	// skip this test if we get no matches. Not ideal, but
+	// at least we get some test coverage on IPv4 systems.
+	if (records.size() == 0) {
+		qWarning("Skipping test: No results returned. Assuming non-IPv4 system.");
+		return;
+	}
+
 	QCOMPARE(records.size(), 1);
 
 	ServerResolverRecord record = records.at(0);
@@ -98,6 +110,14 @@ void TestServerResolver::simpleAAAA() {
 	QCOMPARE(spy.count(), 1);
 
 	QList<ServerResolverRecord> records = r.records();
+	// Since not all systems have IPv6 support, we have to
+	// skip this test if we get no matches. Not ideal, but
+	// at least we get some test coverage on IPv6 systems.
+	if (records.size() == 0) {
+		qWarning("Skipping test: No results returned. Assuming non-IPv6 system.");
+		return;
+	}
+
 	QCOMPARE(records.size(), 1);
 
 	ServerResolverRecord record = records.at(0);

--- a/src/tests/TestServerResolver/TestServerResolver.pro
+++ b/src/tests/TestServerResolver/TestServerResolver.pro
@@ -1,0 +1,23 @@
+# Copyright 2005-2017 The Mumble Developers. All rights reserved.
+# Use of this source code is governed by a BSD-style license
+# that can be found in the LICENSE file at the root of the
+# Mumble source tree or at <https://www.mumble.info/LICENSE>.
+
+include(../test.pri)
+include(../../../qmake/qt.pri)
+
+QT *= network
+
+TARGET = TestServerResolver
+SOURCES = TestServerResolver.cpp HostAddress.cpp ServerResolver_qt5.cpp ServerResolverRecord.cpp
+HEADERS = HostAddress.h ServerResolver.h ServerResolverRecord.h
+
+isEqual(QT_MAJOR_VERSION, 4) {
+	CONFIG *= no-srv
+}
+
+CONFIG(no-srv) {
+	DEFINES += USE_NO_SRV
+	SOURCES -= ServerResolver_qt5.cpp
+	SOURCES *= ServerResolver_nosrv.cpp
+}

--- a/src/tests/tests.pro
+++ b/src/tests/tests.pro
@@ -12,4 +12,5 @@ SUBDIRS += \
 	TestPacketDataStream \
 	TestPasswordGenerator \
 	TestTimer \
-	TestXMLTools
+	TestXMLTools \
+	TestServerResolver


### PR DESCRIPTION
This PR implements support for SRV records in Mumble.

This PR implements support for SRV resolving in a new class, ServerResolver.

The class isn't meant to be used exclusively for SRV records. We could add an alternative later on. For example, something I've toyed with is using a ".well-known" HTTPS URL, like https://gaming.example.com/.well-known/mumble as a "server pointer". The file at /.well-known/mumble would then link to a Mumble server (maybe something as simple as mumble://my-host:64800/). However, users would be able to connect to the server via mumble://gaming.example.com/ because of the pointer file. ...Just something I've toyed around with. Not related to this PR.

The PR changes ConnectDialog and ServerHandler to use ServerResolver for resolving hostnames of Mumble servers.

This changes the Mumble client to prefer SRV record. If no SRV record is available, the old code path is taken. (A/AAAA/CNAME).
