### PR TITLE
main.pro: use qmake/compiler.pri -- the compiler.pri in the root does not exist.

### DIFF
--- a/main.pro
+++ b/main.pro
@@ -3,7 +3,7 @@
 # that can be found in the LICENSE file at the root of the
 # Mumble source tree or at <https://www.mumble.info/LICENSE>.
 
-include(compiler.pri)
+include(qmake/compiler.pri)
 
 TEMPLATE = subdirs
 CONFIG *= ordered debug_and_release


### PR DESCRIPTION
Apparenty, a lot of our builders didn't catch this, apparently because
they don't clean the Git repo on every build.