### PR TITLE
UserView.cpp: Fix deprecated Qt class

### DIFF
--- a/src/mumble/UserView.cpp
+++ b/src/mumble/UserView.cpp
@@ -36,7 +36,12 @@ void UserDelegate::paint(QPainter * painter, const QStyleOptionViewItem &option,
 
 	painter->save();
 
+#if QT_VERSION >= 0x050000
+	QStyleOptionViewItem o = option;
+#else
 	QStyleOptionViewItemV4 o = option;
+#endif
+
 	initStyleOption(&o, index);
 
 	QStyle *style = o.widget->style();


### PR DESCRIPTION
```
UserView.cpp:39:25: error: 'QStyleOptionViewItemV4' is deprecated [-Werror=deprecated-declarations]
  QStyleOptionViewItemV4 o = option;
                         ^
```

Fixes #2381.