### PR TITLE
Overlay_win: Fix "m_active" variable order

### DIFF
--- a/src/mumble/Overlay_win.cpp
+++ b/src/mumble/Overlay_win.cpp
@@ -48,10 +48,10 @@ static bool canRun64BitPrograms() {
 
 OverlayPrivateWin::OverlayPrivateWin(QObject *p)
 	: OverlayPrivate(p)
-	, m_active(false)
 	, m_helper_enabled(true)
 	, m_helper64_enabled(true)
-	, m_mumble_handle(0) {
+	, m_mumble_handle(0)
+	, m_active(false) {
 
 	// Acquire a handle to ourselves and duplicate it. We duplicate it because
 	// want it to be inheritable by our helper processes, and the handle returned


### PR DESCRIPTION
Fixes:
```
Overlay_win.h:51:8: error: 'OverlayPrivateWin::m_active' will be initialized after [-Werror=reorder]
   bool m_active;
        ^
Overlay_win.h:41:8: error:   'bool OverlayPrivateWin::m_helper_enabled' [-Werror=reorder]
   bool m_helper_enabled;
        ^
Overlay_win.cpp:49:1: error:   when initialized here [-Werror=reorder]
 OverlayPrivateWin::OverlayPrivateWin(QObject *p)
 ^
```