### PR TITLE
os_win.cpp: Fix unused "mumbleMessageOutput()" function with Qt 5

### DIFF
--- a/src/mumble/os_win.cpp
+++ b/src/mumble/os_win.cpp
@@ -64,9 +64,11 @@ static void mumbleMessageOutputQString(QtMsgType type, const QString &msg) {
 	}
 }
 
+#if QT_VERSION < 0x050000
 static void mumbleMessageOutput(QtMsgType type, const char *msg) {
 	mumbleMessageOutputQString(type, QString::fromUtf8(msg));
 }
+#endif
 
 #if QT_VERSION >= 0x050000
 static void mumbleMessageOutputWithContext(QtMsgType type, const QMessageLogContext &ctx, const QString &msg) {


### PR DESCRIPTION
Fixes:
```
os_win.cpp:71:13: error: 'void mumbleMessageOutput(QtMsgType, const char*)' defined but not used [-Werror=unused-function]
 static void mumbleMessageOutput(QtMsgType type, const char *msg) {
             ^
```