### PR TITLE
WASAPI.cpp: Fix print format warnings

### DIFF
--- a/src/mumble/WASAPI.cpp
+++ b/src/mumble/WASAPI.cpp
@@ -147,7 +147,7 @@ bool getAndCheckMixFormat(const char* sourceName,
 			return false;
 		}
 	} else {
-		qFatal("%s: %s unexpected sample format %d", sourceName, deviceName, sampleFormat);
+		qFatal("%s: %s unexpected sample format %lu", sourceName, deviceName, static_cast<unsigned long>(*sampleFormat));
 		return false;
 	}
 	
@@ -928,7 +928,7 @@ void WASAPIOutput::run() {
 			WAVEFORMATEX *closestFormat = NULL;
 			hr = pAudioClient->IsFormatSupported(AUDCLNT_SHAREMODE_SHARED, pwfx, &closestFormat);
 			if (hr == S_FALSE) {
-				qWarning("WASAPIOutput: Driver says no to 2 channel output. Closest format: %d channels @ %d kHz", closestFormat->nChannels, closestFormat->nSamplesPerSec);
+				qWarning("WASAPIOutput: Driver says no to 2 channel output. Closest format: %d channels @ %lu kHz", closestFormat->nChannels, static_cast<unsigned long>(closestFormat->nSamplesPerSec));
 				CoTaskMemFree(pwfx);
 				
 				// Fall back to whatever the device offers.


### PR DESCRIPTION
Fixes:
```
WASAPI.cpp: In member function 'virtual void WASAPIOutput::run()':
WASAPI.cpp:929:0: error: format '%d' expects argument of type 'int', but argument 4 has type 'DWORD {aka long unsigned int}' [-Werror=format=]
     qWarning("WASAPIOutput: Driver says no to 2 channel output. Closest format: %d channels @ %d kHz", closestFormat->nChannels, closestFormat->nSamplesPerSec);
 ^
In file included from /usr/lib/mxe/usr/x86_64-w64-mingw32.static/qt5/include/QtCore/qglobal.h:1125:0,
                 from /usr/lib/mxe/usr/x86_64-w64-mingw32.static/qt5/include/QtCore/QtCore:4,
                 from mumble_pch.hpp:39:
WASAPI.cpp: In instantiation of 'bool getAndCheckMixFormat(const char*, const char*, IAudioClient*, WAVEFORMATEX**, WAVEFORMATEXTENSIBLE**, SAMPLEFORMAT*) [with SAMPLEFORMAT = AudioInput::SampleFormat; IAudioClient = IAudioClient; WAVEFORMATEX = tWAVEFORMATEX]':
WASAPI.cpp:439:61:   required from here
/usr/lib/mxe/usr/x86_64-w64-mingw32.static/qt5/include/QtCore/qlogging.h:162:16: error: format '%d' expects argument of type 'int', but argument 5 has type 'AudioInput::SampleFormat*' [-Werror=format=]
 #define qFatal QMessageLogger(QT_MESSAGELOG_FILE, QT_MESSAGELOG_LINE, QT_MESSAGELOG_FUNC).fatal
                ^
WASAPI.cpp:152:3: note: in expansion of macro 'qFatal'
   qFatal("%s: %s unexpected sample format %d", sourceName, deviceName, sampleFormat);
   ^
WASAPI.cpp: In instantiation of 'bool getAndCheckMixFormat(const char*, const char*, IAudioClient*, WAVEFORMATEX**, WAVEFORMATEXTENSIBLE**, SAMPLEFORMAT*) [with SAMPLEFORMAT = AudioOutput::<anonymous enum>; IAudioClient = IAudioClient; WAVEFORMATEX = tWAVEFORMATEX]':
WASAPI.cpp:913:58:   required from here
/usr/lib/mxe/usr/x86_64-w64-mingw32.static/qt5/include/QtCore/qlogging.h:162:16: error: format '%d' expects argument of type 'int', but argument 5 has type 'AudioOutput::<anonymous enum>*' [-Werror=format=]
 #define qFatal QMessageLogger(QT_MESSAGELOG_FILE, QT_MESSAGELOG_LINE, QT_MESSAGELOG_FUNC).fatal
                ^
WASAPI.cpp:152:3: note: in expansion of macro 'qFatal'
   qFatal("%s: %s unexpected sample format %d", sourceName, deviceName, sampleFormat);
   ^
```