### PR TITLE
XboxInput: Fix type-punned pointer dereference warning

### DIFF
--- a/src/mumble/XboxInput.cpp
+++ b/src/mumble/XboxInput.cpp
@@ -45,11 +45,11 @@ XboxInput::XboxInput()
 		return;
 	}
 
-	*(reinterpret_cast<void **>(&m_getStateFunc)) = reinterpret_cast<void *>(GetProcAddress(m_xinputlib, "XInputGetState"));
+	m_getStateFunc = reinterpret_cast<XboxInputGetStateFunc>(GetProcAddress(m_xinputlib, "XInputGetState"));
 	// Undocumented XInputGetStateEx -- ordinal 100. It is available in XInput 1.3 and greater.
 	// It provides access to the state of the guide button.
 	// For reference, see SDL's XInput support: http://www.libsdl.org/tmp/SDL/src/core/windows/SDL_xinput.c
-	*(reinterpret_cast<void **>(&m_getStateExFunc)) = reinterpret_cast<void *>(GetProcAddress(m_xinputlib, (char *)100));
+	m_getStateExFunc = reinterpret_cast<XboxInputGetStateFunc>(GetProcAddress(m_xinputlib, (char *)100));
 
 	if (m_getStateExFunc != NULL) {
 		GetState = m_getStateExFunc;

--- a/src/mumble/XboxInput.h
+++ b/src/mumble/XboxInput.h
@@ -38,6 +38,8 @@ struct XboxInputState {
 	uint32_t  paddingReserved; // Required for XInputGetStateEx. Not required for XInputGetState. 
 };
 
+typedef uint32_t (WINAPI *XboxInputGetStateFunc)(uint32_t deviceIndex, XboxInputState *state);
+
 /// XboxInput is an XInput wrapper that dynamically loads an appropriate
 /// xinput*.dll on construction and provides access to its GetState(Ex)
 /// function.
@@ -58,15 +60,15 @@ class XboxInput {
 		/// Query the state of the Xbox controller at deviceIndex.
 		/// If the function succeeds, it returns 0 (Windows's ERROR_SUCCESS).
 		/// If no device is connected, it returns 0x48F (Windows's ERROR_DEVICE_NOT_CONNECTED).
-		uint32_t (WINAPI *GetState)(uint32_t deviceIndex, XboxInputState *state);
+		XboxInputGetStateFunc GetState;
 
 	protected:
 		/// m_getStateFunc represents XInputGetState from the XInput DLL.
-		uint32_t (WINAPI *m_getStateFunc)(uint32_t deviceIndex, XboxInputState *state);
+		XboxInputGetStateFunc m_getStateFunc;
 
 		/// m_getStateFuncEx represents XInputGetStateEx, which is optionally
 		/// available in the XInput DLL.
-		uint32_t (WINAPI *m_getStateExFunc)(uint32_t deviceIndex, XboxInputState *state);
+		XboxInputGetStateFunc m_getStateExFunc;
 
 		/// m_xinputlib is the handle to the XInput DLL as returned by
 		/// LoadLibrary.


### PR DESCRIPTION
Fixes:
```
XboxInput.cpp:48:46: error: dereferencing type-punned pointer will break strict-aliasing rules [-Werror=strict-aliasing]
  *(reinterpret_cast<void **>(&m_getStateFunc)) = reinterpret_cast<void *>(GetPr
                                              ^
XboxInput.cpp:52:48: error: dereferencing type-punned pointer will break strict-aliasing rules [-Werror=strict-aliasing]
  *(reinterpret_cast<void **>(&m_getStateExFunc)) = reinterpret_cast<void *>(Get
                                                ^
```