### PR TITLE
Implement QtSpeech-based text-to-speech backend

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -189,3 +189,8 @@ CONFIG+=g15-emulator (Mumble, Win32)
 CONFIG+=no-manual-plugin (Mumble)
  Don't include the built-in 'manual' positional
  audio plugin.
+
+CONFIG+=qtspeech (Mumble)
+ Use Qt's text-to-speech system (part of the experimental
+ Qt Speech module), if available, instead of Mumble's own
+ OS-specific text-to-speech implementations.

--- a/src/mumble/TextToSpeech.cpp
+++ b/src/mumble/TextToSpeech.cpp
@@ -1,0 +1,62 @@
+// Copyright 2005-2017 The Mumble Developers. All rights reserved.
+// Use of this source code is governed by a BSD-style license
+// that can be found in the LICENSE file at the root of the
+// Mumble source tree or at <https://www.mumble.info/LICENSE>.
+
+#include "mumble_pch.hpp"
+
+#include "TextToSpeech.h"
+
+#include <QTextToSpeech>
+
+class TextToSpeechPrivate : public QObject {
+	Q_OBJECT
+
+	public:
+		QTextToSpeech *m_tts;
+		QVector<QVoice> m_voices;
+		TextToSpeechPrivate();
+		~TextToSpeechPrivate();
+		void say(const QString &text);
+		void setVolume(int v);
+};
+
+TextToSpeechPrivate::TextToSpeechPrivate() {
+	m_tts = new QTextToSpeech(this);
+}
+
+TextToSpeechPrivate::~TextToSpeechPrivate() {}
+
+void TextToSpeechPrivate::say(const QString &text) {
+	m_tts->say(text);
+}
+
+void TextToSpeechPrivate::setVolume(int volume) {
+	m_tts->setVolume(volume);
+}
+
+TextToSpeech::TextToSpeech(QObject *p) : QObject(p) {
+	enabled = true;
+	d = new TextToSpeechPrivate();
+}
+
+TextToSpeech::~TextToSpeech() {
+	delete d;
+}
+
+void TextToSpeech::say(const QString &text) {
+	if (enabled)
+		d->say(text);
+}
+
+void TextToSpeech::setEnabled(bool e) {
+	enabled = e;
+}
+
+void TextToSpeech::setVolume(int volume) {
+	d->setVolume(volume);
+}
+
+bool TextToSpeech::isEnabled() const {
+	return enabled;
+}

--- a/src/mumble/mumble.pro
+++ b/src/mumble/mumble.pro
@@ -64,6 +64,14 @@ CONFIG(static) {
 QT		*= network sql xml svg
 isEqual(QT_MAJOR_VERSION, 5) {
   QT *= widgets
+
+  CONFIG(qtspeech) {
+    qtHaveModule(texttospeech) {
+      QT *= texttospeech
+    } else {
+      error("You enabled the 'qtspeech' CONFIG option, but the required 'texttospeech' module is not available on your system!")
+    }
+  }
 }
 
 HEADERS *= BanEditor.h \
@@ -197,6 +205,10 @@ SOURCES *= BanEditor.cpp \
     OverlayPositionableItem.cpp \
     widgets/MUComboBox.cpp \
     DeveloperConsole.cpp
+
+CONFIG(qtspeech) {
+  SOURCES *= TextToSpeech.cpp
+}
 
 DIST		*= ../../icons/mumble.ico ../../icons/mumble.xpm murmur_pch.h mumble.plist
 RESOURCES	*= mumble.qrc mumble_translations.qrc ../../themes/MumbleTheme.qrc
@@ -358,7 +370,12 @@ win32 {
     RC_FILE = mumble.rc
   }
   HEADERS	*= GlobalShortcut_win.h Overlay_win.h TaskList.h UserLockFile.h
-  SOURCES	*= GlobalShortcut_win.cpp TextToSpeech_win.cpp Overlay_win.cpp SharedMemory_win.cpp Log_win.cpp os_win.cpp TaskList.cpp ../../overlay/ods.cpp UserLockFile_win.cpp
+  SOURCES	*= GlobalShortcut_win.cpp Overlay_win.cpp SharedMemory_win.cpp Log_win.cpp os_win.cpp TaskList.cpp ../../overlay/ods.cpp UserLockFile_win.cpp
+
+  !CONFIG(qtspeech) {
+    SOURCES *= TextToSpeech_win.cpp
+  }
+
   LIBS		*= -ldxguid -ldinput8 -lsapi -lole32 -lws2_32 -ladvapi32 -lwintrust -ldbghelp -lshell32 -lshlwapi -luser32 -lgdi32 -lpsapi
   LIBS		*= -logg -lvorbis -lvorbisfile -lFLAC -lsndfile
   LIBS		*= -ldelayimp -delayload:shell32.dll
@@ -440,7 +457,11 @@ unix {
 
     HEADERS *= GlobalShortcut_macx.h AppNap.h
     SOURCES *= SharedMemory_unix.cpp
-    OBJECTIVE_SOURCES *= TextToSpeech_macx.mm GlobalShortcut_macx.mm os_macx.mm Log_macx.mm AppNap.mm
+    OBJECTIVE_SOURCES *= GlobalShortcut_macx.mm os_macx.mm Log_macx.mm AppNap.mm
+
+    !CONFIG(qtspeech) {
+      OBJECTIVE_SOURCES *= TextToSpeech_macx.mm
+    }
 
     !CONFIG(universal) {
       # Link against libxar so we can inspect Mac OS X installer packages.
@@ -462,7 +483,12 @@ unix {
     HEADERS += CoreAudio.h
   } else {
     HEADERS *= GlobalShortcut_unix.h
-    SOURCES *= os_unix.cpp GlobalShortcut_unix.cpp TextToSpeech_unix.cpp Overlay_unix.cpp SharedMemory_unix.cpp Log_unix.cpp
+    SOURCES *= os_unix.cpp GlobalShortcut_unix.cpp Overlay_unix.cpp SharedMemory_unix.cpp Log_unix.cpp
+    
+    !CONFIG(qtspeech) {
+      SOURCES *= TextToSpeech_unix.cpp
+    }
+    
     must_pkgconfig(x11)
     linux* {
       LIBS *= -lrt


### PR DESCRIPTION
Qt 5.8 introduced Qt Speech, a module that contains a TTS system which works on every OS.

This commit provides a new file called "TextToSpeech.cpp", without any suffix, indicating that it is OS-independent.
If the "qtspeech" CONFIG option is present and the "texttospeech" Qt module is available, the new file is included instead of the OS-specific one.