### PR TITLE
plugins/ql: Fix spectator state offset

### DIFF
--- a/plugins/ql/ql.cpp
+++ b/plugins/ql/ql.cpp
@@ -22,7 +22,7 @@ static int fetch(float *avatar_pos, float *avatar_front, float *avatar_top, floa
 
 	// Peekproc and assign game addresses to our containers, so we can retrieve positional data
 	ok = peekProc(pModule + 0x0188248, &state, 1) && // Magical state value: 1 when in-game and 0 when in main menu.
-			peekProc(pModule + 0x1041C68, &spec, 1) && // Spectator state value: 1 when spectating and 0 when playing.
+			peekProc(pModule + 0x1041CAC, &spec, 1) && // Spectator state value: 1 when spectating and 0 when playing.
 			peekProc(pModule + 0x0EB8950, avatar_pos_corrector, 12) && // Avatar Position values (X, Z and Y, respectively).
 			peekProc(pModule + 0x0E6093C, camera_pos_corrector, 12) && // Camera Position values (X, Z and Y, respectively).
 			peekProc(pModule + 0x0EC5B50, avatar_front_corrector, 12) && // Avatar front values (X, Z and Y, respectively).


### PR DESCRIPTION
The previous offset was pointing at a value of "32" when in-game, which resulted in the plugin being disabled even when not spectating.