### PR TITLE
Murmur: update registration URL to use mumble.info instead of mumble.hive.no.

### DIFF
--- a/src/murmur/Register.cpp
+++ b/src/murmur/Register.cpp
@@ -89,7 +89,7 @@ void Server::update() {
 		tag.appendChild(t);
 	}
 
-	QNetworkRequest qnr(QUrl(QLatin1String("https://mumble.hive.no/register.cgi")));
+	QNetworkRequest qnr(QUrl(QLatin1String("https://mumble.info/register.cgi")));
 	qnr.setHeader(QNetworkRequest::ContentTypeHeader, QLatin1String("text/xml"));
 
 	QSslConfiguration ssl = qnr.sslConfiguration();


### PR DESCRIPTION
The 1.2.x branch already does this.