### PR TITLE
By default do not use attenuation

### DIFF
--- a/src/mumble/Settings.cpp
+++ b/src/mumble/Settings.cpp
@@ -231,7 +231,7 @@ Settings::Settings() {
 	fVolume = 1.0f;
 	fOtherVolume = 0.5f;
 	bAttenuateOthersOnTalk = false;
-	bAttenuateOthers = true;
+	bAttenuateOthers = false;
 	bAttenuateUsersOnPrioritySpeak = false;
 	bOnlyAttenuateSameOutput = false;
 	bAttenuateLoopbacks = false;


### PR DESCRIPTION
The setting is still available in the audio wizard, which should point
users to the possibility of enabling it, should they choose to want it
enabled.

See discussion in #2711