### PR TITLE
Fixed uname() query on Solaris.

### DIFF
--- a/src/OSInfo.cpp
+++ b/src/OSInfo.cpp
@@ -239,7 +239,11 @@ QString OSInfo::getOSVersion() {
 #endif
 	if (os.isEmpty()) {
 		struct utsname un;
+#ifdef Q_OS_SOLARIS
+		if (uname(&un) >= 0) {
+#else
 		if (uname(&un) == 0) {
+#endif
 			os.sprintf("%s %s", un.sysname, un.release);
 		}
 	}

--- a/src/OSInfo.cpp
+++ b/src/OSInfo.cpp
@@ -240,8 +240,10 @@ QString OSInfo::getOSVersion() {
 	if (os.isEmpty()) {
 		struct utsname un;
 #ifdef Q_OS_SOLARIS
+		// Solaris's uname() returns a non-negative number on success.
 		if (uname(&un) >= 0) {
 #else
+		// other UNIX-like systems return a 0 on success.
 		if (uname(&un) == 0) {
 #endif
 			os.sprintf("%s %s", un.sysname, un.release);


### PR DESCRIPTION
Solaris returns "non-negative" result for uname() upon success.

See: http://www.unix.com/man-page/sunos/2/uname/