### PR TITLE
travis-ci: add macOS target.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,13 +3,33 @@ dist: trusty
 language: cpp
 compiler: gcc
 
+os:
+  - linux
+  - osx
+
 env:
-  matrix:
-    - MUMBLE_QT=qt4 MUMBLE_HOST=x86_64-linux-gnu
-    - MUMBLE_QT=qt5 MUMBLE_HOST=x86_64-linux-gnu
-    - MUMBLE_QT=qt5 MUMBLE_HOST=x86_64-linux-gnu MUMBLE_NO_PCH=1
-    - MUMBLE_QT=qt5 MUMBLE_HOST=i686-w64-mingw32
-    - MUMBLE_QT=qt5 MUMBLE_HOST=x86_64-w64-mingw32
+  - MUMBLE_QT=qt4 MUMBLE_HOST=x86_64-linux-gnu
+  - MUMBLE_QT=qt5 MUMBLE_HOST=x86_64-linux-gnu
+  - MUMBLE_QT=qt5 MUMBLE_HOST=x86_64-linux-gnu MUMBLE_NO_PCH=1
+  - MUMBLE_QT=qt5 MUMBLE_HOST=i686-w64-mingw32
+  - MUMBLE_QT=qt5 MUMBLE_HOST=x86_64-w64-mingw32
+  - MUMBLE_QT=qt5 MUMBLE_HOST=x86_64-apple-darwin
+
+matrix:
+  exclude:
+    - os: linux
+      env: MUMBLE_QT=qt5 MUMBLE_HOST=x86_64-apple-darwin
+    - os: osx
+      env: MUMBLE_QT=qt4 MUMBLE_HOST=x86_64-linux-gnu
+    - os: osx
+      env: MUMBLE_QT=qt5 MUMBLE_HOST=x86_64-linux-gnu
+    - os: osx
+      env: MUMBLE_QT=qt5 MUMBLE_HOST=x86_64-linux-gnu MUMBLE_NO_PCH=1
+    - os: osx
+      env: MUMBLE_QT=qt5 MUMBLE_HOST=i686-w64-mingw32
+    - os: osx
+      env: MUMBLE_QT=qt5 MUMBLE_HOST=x86_64-w64-mingw32
+
   allow_failures:
     - env: MUMBLE_QT=qt5 MUMBLE_HOST=i686-w64-mingw32
     - env: MUMBLE_QT=qt5 MUMBLE_HOST=x86_64-w64-mingw32

--- a/scripts/travis-ci/before_install.bash
+++ b/scripts/travis-ci/before_install.bash
@@ -56,6 +56,8 @@ if [ "${TRAVIS_OS_NAME}" == "linux" ]; then
 	else
 		exit 1
 	fi
+elif [ "${TRAVIS_OS_NAME}" == "osx" ]; then
+	brew install qt5 libogg libvorbis flac libsndfile protobuf openssl ice
 else
 	exit 1
 fi

--- a/scripts/travis-ci/script.bash
+++ b/scripts/travis-ci/script.bash
@@ -47,6 +47,13 @@ if [ "${TRAVIS_OS_NAME}" == "linux" ]; then
 	else
 		exit 1
 	fi
+elif [ "${TRAVIS_OS_NAME}" == "osx" ]; then
+	export PKG_CONFIG_PATH=$PKG_CONFIG_PATH:/usr/local/lib/pkgconfig
+	export PKG_CONFIG_PATH=$PKG_CONFIG_PATH:/usr/local/opt/openssl/lib/pkgconfig
+	export PATH=$PATH:/usr/local/opt/qt5/bin:/usr/local/bin
+	export MUMBLE_PREFIX=/usr/local
+	export MUMBLE_ICE_PREFIX=/usr/local/opt/ice
+	qmake CONFIG+="release tests warnings-as-errors" && make -j2 && make check
 else
 	exit 1
 fi


### PR DESCRIPTION
This commit adds a Homebrew-based macOS build to our Travis CI build
matrix.

It also cleans up the exising build matrix such such that Linux builds
are built only on Linux hosts, and macOS builds are only built on macOS
hosts.