### PR TITLE
TextToSpeech.cpp: Fix build problem

### DIFF
--- a/src/mumble/TextToSpeech.cpp
+++ b/src/mumble/TextToSpeech.cpp
@@ -9,9 +9,7 @@
 
 #include <QTextToSpeech>
 
-class TextToSpeechPrivate : public QObject {
-	Q_OBJECT
-
+class TextToSpeechPrivate {
 	public:
 		QTextToSpeech *m_tts;
 		QVector<QVoice> m_voices;
@@ -22,10 +20,12 @@ class TextToSpeechPrivate : public QObject {
 };
 
 TextToSpeechPrivate::TextToSpeechPrivate() {
-	m_tts = new QTextToSpeech(this);
+	m_tts = new QTextToSpeech();
 }
 
-TextToSpeechPrivate::~TextToSpeechPrivate() {}
+TextToSpeechPrivate::~TextToSpeechPrivate() {
+	delete m_tts;
+}
 
 void TextToSpeechPrivate::say(const QString &text) {
 	m_tts->say(text);


### PR DESCRIPTION
This commit removes the parent of the QTextToSpeech object and deletes it in TextToSpeechPrivate's destructor.

We do this in order to avoid generating and including a Moc file, since we don't actually need QObject functions for QTextToSpeech.