### PR TITLE
qmake/compiler.pri: fix value of MUMBLE_ARCH on Qt 5.

### DIFF
--- a/qmake/compiler.pri
+++ b/qmake/compiler.pri
@@ -28,6 +28,11 @@ MUMBLE_ARCH = $$QMAKE_TARGET.arch
 # It also works for cross-builds.
 isEqual(QT_MAJOR_VERSION, 5) {
 	MUMBLE_ARCH = $$QT_ARCH
+	# QT_ARCH uses 'i386' instead of 'x86',
+	# so map that value back to what we expect.
+	equals(MUMBLE_ARCH, i386) {
+		MUMBLE_ARCH=x86
+	}
 }
 
 win32-g++ {


### PR DESCRIPTION
The MinGW PR changed MUMBLE_ARCH to use QT_ARCH on Qt 5.
However, QT_ARCH uses 'i386' for 32-bit x86, we're currently
using 'x86' throughout our .pro files.
To fix this problem, we map 'i386' back to 'x86'.

This is currently breaking the win32-static (x86) build.