### PR TITLE
MurmurIce: fix signed/unsigned comparison between string size and std::numeric_limits.

### DIFF
--- a/src/murmur/MurmurIce.cpp
+++ b/src/murmur/MurmurIce.cpp
@@ -73,7 +73,7 @@ static std::string iceString(const QString &s) {
 /// If the function is passed a string bigger than that,
 /// it will return an empty string.
 static std::string iceBase64(const std::string &s) {
-	if (s.size() > std::numeric_limits<int>::max()) {
+	if (s.size() > static_cast<size_t>(std::numeric_limits<int>::max())) {
 		return std::string();
 	}
 


### PR DESCRIPTION
std::numeric_limit's max() method return a T, so when comparing it against
a container size, we have to cast it to size_t.

This is currently breaking the win32-static (32-bit) build.