### PR TITLE
Fix no-pch build and add a no-pch configuration to Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ env:
   matrix:
     - MUMBLE_QT=qt4 MUMBLE_HOST=x86_64-linux-gnu
     - MUMBLE_QT=qt5 MUMBLE_HOST=x86_64-linux-gnu
+    - MUMBLE_QT=qt5 MUMBLE_HOST=x86_64-linux-gnu MUMBLE_NO_PCH=1
     - MUMBLE_QT=qt5 MUMBLE_HOST=i686-w64-mingw32
     - MUMBLE_QT=qt5 MUMBLE_HOST=x86_64-w64-mingw32
   allow_failures:

--- a/scripts/travis-ci/script.bash
+++ b/scripts/travis-ci/script.bash
@@ -7,16 +7,28 @@
 
 if [ "${TRAVIS_OS_NAME}" == "linux" ]; then
 	if [ "${MUMBLE_QT}" == "qt4" ] && [ "${MUMBLE_HOST}" == "x86_64-linux-gnu" ]; then
-		qmake-qt4 CONFIG+="release tests g15-emulator qt4-legacy-compat" -recursive && make -j2 && make check
+		EXTRA_CONFIG=
+		if [ ${MUMBLE_NO_PCH} -eq 1 ]; then
+			EXTRA_CONFIG="no-pch ${EXTRA_CONFIG}"
+		fi
+		qmake-qt4 CONFIG+="release tests g15-emulator qt4-legacy-compat ${EXTRA_CONFIG}" -recursive && make -j2 && make check
 	elif [ "${MUMBLE_QT}" == "qt5" ] && [ "${MUMBLE_HOST}" == "x86_64-linux-gnu" ]; then
-		qmake CONFIG+="release tests g15-emulator" -recursive && make -j2 && make check
+		EXTRA_CONFIG=
+		if [ ${MUMBLE_NO_PCH} -eq 1 ]; then
+			EXTRA_CONFIG="no-pch ${EXTRA_CONFIG}"
+		fi
+		qmake CONFIG+="release tests g15-emulator ${EXTRA_CONFIG}" -recursive && make -j2 && make check
 	elif [ "${MUMBLE_QT}" == "qt5" ] && [ "${MUMBLE_HOST}" == "i686-w64-mingw32" ]; then
 		wget http://www.steinberg.net/sdk_downloads/asiosdk2.3.zip -P ../
 		unzip ../asiosdk2.3.zip -d ../
 		mv ../ASIOSDK2.3 3rdparty/asio
 		PATH=$PATH:/usr/lib/mxe/usr/bin
 		export MUMBLE_PROTOC=/usr/lib/mxe/usr/x86_64-unknown-linux-gnu/bin/protoc
-		${MUMBLE_HOST}.static-qmake-qt5 -recursive -Wall CONFIG+="release tests warnings-as-errors g15-emulator no-overlay no-bonjour no-elevation no-ice"
+		EXTRA_CONFIG=
+		if [ ${MUMBLE_NO_PCH} -eq 1 ]; then
+			EXTRA_CONFIG="no-pch ${EXTRA_CONFIG}"
+		fi
+		${MUMBLE_HOST}.static-qmake-qt5 -recursive -Wall CONFIG+="release tests warnings-as-errors g15-emulator no-overlay no-bonjour no-elevation no-ice ${EXTRA_CONFIG}"
 		make -j2
 		make check TESTRUNNER="wine"
 	elif [ "${MUMBLE_QT}" == "qt5" ] && [ "${MUMBLE_HOST}" == "x86_64-w64-mingw32" ]; then
@@ -25,7 +37,11 @@ if [ "${TRAVIS_OS_NAME}" == "linux" ]; then
 		mv ../ASIOSDK2.3 3rdparty/asio
 		PATH=$PATH:/usr/lib/mxe/usr/bin
 		export MUMBLE_PROTOC=/usr/lib/mxe/usr/x86_64-unknown-linux-gnu/bin/protoc
-		${MUMBLE_HOST}.static-qmake-qt5 -recursive -Wall CONFIG+="release tests warnings-as-errors g15-emulator no-overlay no-bonjour no-elevation no-ice"
+		EXTRA_CONFIG=
+		if [ ${MUMBLE_NO_PCH} -eq 1 ]; then
+			EXTRA_CONFIG="no-pch ${EXTRA_CONFIG}"
+		fi
+		${MUMBLE_HOST}.static-qmake-qt5 -recursive -Wall CONFIG+="release tests warnings-as-errors g15-emulator no-overlay no-bonjour no-elevation no-ice ${EXTRA_CONFIG}"
 		make -j2
 		make check TESTRUNNER="wine"
 	else

--- a/src/murmur/Meta.h
+++ b/src/murmur/Meta.h
@@ -13,6 +13,7 @@
 #include <QtNetwork/QHostAddress>
 #include <QtNetwork/QSslCertificate>
 #include <QtNetwork/QSslKey>
+#include <QtNetwork/QSslCipher>
 #ifdef Q_OS_WIN
 #include <windows.h>
 #endif


### PR DESCRIPTION
This PR fixes a recently introduced no-pch error in Meta.h.
It also adds a no-pch configuration to Travis CI so we can catch these beforehand in the future.