### PR TITLE
scripts/rcc-depends.py: fall back to using the absolute path when os.path.relpath() fails on Windows.

### DIFF
--- a/scripts/rcc-depends.py
+++ b/scripts/rcc-depends.py
@@ -28,10 +28,18 @@ def main():
 			for fileTag in fileTags:
 				textNode = fileTag.childNodes[0].wholeText
 				absPath = os.path.normpath(os.path.join(fnDir, textNode))
-				relPath = os.path.relpath(absPath)
-				output = relPath
 				if platform.system() == 'Windows':
+					try:
+						output = os.path.relpath(absPath)
+					except ValueError:
+						# In some cases, Qt lives on another drive than Mumble.
+						# This means that we can't create relative path from
+						# our absolute path.
+						# In those cases, use the absolute path instead.
+						output = absPath
 					output = output.replace('\\', '/')
+				else:
+					output = os.path.relpath(absPath)
 				print(output)
 
 if __name__ == '__main__':


### PR DESCRIPTION
On Windows, it is not always possible to create a relative path from an
absolute path. For example, if Qt lives on C:, and Mumble is being built
on Z:.

Things will fall apart then, because we include some of Qt's
translations in our .qrc files.

This commit works around that issue by falling back to absolute paths
when finding a relative path fails.