### PR TITLE
3rdparty/opus-build: remove unnecessary shared library handling for macOS

### DIFF
--- a/3rdparty/opus-build/opus-build.pro
+++ b/3rdparty/opus-build/opus-build.pro
@@ -272,13 +272,4 @@ CONFIG(release, debug|release) {
 	DESTDIR = ../../release
 }
 
-macx:!CONFIG(static) {
-	libname.target = libname
-	libname.commands = cd ${DESTDIR} && install_name_tool -id `pwd`/${TARGET} ${TARGET}
-	libname.depends = ${DESTDIR}${TARGET}
-	libname.CONFIG = recursive
-	QMAKE_EXTRA_TARGETS *= libname
-	ALL_DEPS += libname
-}
-
 include(../../qmake/symbols.pri)


### PR DESCRIPTION
This removes a section of opus-build.pro that sets the proper install name on the Opus shared library.
This commit removes it because it is not needed anymore -- we only ever build Opus as a static library on Unix-like systems.