### PR TITLE
Add commandline argument to close mumble as soon as config was achieved

### DIFF
--- a/src/mumble/AudioWizard.cpp
+++ b/src/mumble/AudioWizard.cpp
@@ -640,3 +640,11 @@ void AudioWizard::on_qrbQualityCustom_clicked() {
 	g.s.iFramesPerPacket = sOldSettings.iFramesPerPacket;
 	restartAudio();
 }
+
+void AudioWizard::on_AudioWizard_finished(int result) {
+	qInfo( "quit result %d", result);
+	if (g.s.bQuitWhenConfigCompleted) {
+		g.bQuit = true;
+		qApp->exit(0);
+	}
+}

--- a/src/mumble/AudioWizard.h
+++ b/src/mumble/AudioWizard.h
@@ -84,6 +84,7 @@ class AudioWizard: public QWizard, public Ui::AudioWizard {
 		void on_qrbQualityBalanced_clicked();
 		void on_qrbQualityLow_clicked();
 		void on_qrbQualityCustom_clicked();
+		void on_AudioWizard_finished(int);
 		void showPage(int);
 		void updateTriggerWidgets(bool);
 	public:

--- a/src/mumble/Settings.cpp
+++ b/src/mumble/Settings.cpp
@@ -353,6 +353,7 @@ Settings::Settings() {
 	iMaxImageWidth = 1024; // Allow 1024x1024 resolution
 	iMaxImageHeight = 1024;
 	bSuppressIdentity = false;
+	bQuitWhenConfigCompleted = false;
 	qsSslCiphers = MumbleSSL::defaultOpenSSLCipherString();
 
 	bShowTransmitModeComboBox = false;

--- a/src/mumble/Settings.h
+++ b/src/mumble/Settings.h
@@ -331,6 +331,7 @@ struct Settings {
 	int iMaxImageHeight;
 	KeyPair kpCertificate;
 	bool bSuppressIdentity;
+	bool bQuitWhenConfigCompleted;
 
 	bool bShowTransmitModeComboBox;
 

--- a/src/mumble/main.cpp
+++ b/src/mumble/main.cpp
@@ -145,6 +145,8 @@ int main(int argc, char **argv) {
 					"                Allow multiple instances of the client to be started.\n"
 					"  -n, --noidentity\n"
 					"                Suppress loading of identity files (i.e., certificates.)\n"
+					"  -q, --quit-when-config-completed\n"
+					"                Quit mumble when config was finished\n"
 					"  --license\n"
 					"                Show the Mumble license.\n"
 					"  --authors\n"
@@ -195,6 +197,8 @@ int main(int argc, char **argv) {
 			} else if (args.at(i) == QLatin1String("-n") || args.at(i) == QLatin1String("--noidentity")) {
 				suppressIdentity = true;
 				g.s.bSuppressIdentity = true;
+			} else if (args.at(i) == QLatin1String("-q") || args.at(i) == QLatin1String("--quit-when-config-completed")) {
+				g.s.bQuitWhenConfigCompleted = true;
 			} else if (args.at(i) == QLatin1String("-license") || args.at(i) == QLatin1String("--license")) {
 				printf("%s\n", qPrintable(License::license()));
 				return 0;


### PR DESCRIPTION
I use mumble inside my application. When user need a voice call, program will run mumble execuatable file. But user need configure mumble when they first start it. If user a in a game or some program like it, the configure page will pop up. It's not a good experience.
Also, I can run mumble when my program was installed and let user config it. But I need close it as soon as the config was done, or it will be two mumble run when user start it in program.
So I think mumble should add a commandline argument to let it can be close as soon as the config was achieved.