### PR TITLE
.mailmap: add dark_skeleton's preferred author line.

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -109,3 +109,6 @@ Joel Kees <joelkees@gmail.com> Joeliam <joelkees@gmail.com>
 
 # Alias of Karl Dietz <dekarl@spaetfruehstuecken.org>
 Karl Dietz <dekarl@spaetfruehstuecken.org> Karl Dietz <dekarl@users.sourceforge.net>
+
+# dark_skeleton's preferred author line
+d-rez <dark.skeleton@gmail.com>


### PR DESCRIPTION
dark_skeleton contacted us, asking us to use this
variant of their author line for our mailmap.