### PR TITLE
overlay: add gw2-64.exe to the default launcher-filter program whitelist.

### DIFF
--- a/overlay/overlay_whitelist.h
+++ b/overlay/overlay_whitelist.h
@@ -7,7 +7,10 @@
 #define MUMBLE_OVERLAY_WHITELIST_H_
 
 static const char *overlayWhitelist[] = {
-	"gw2.exe", // We can't whitelist the GW2 launcher
+	// We can't whitelist the GW2 launcher
+	"gw2.exe",
+	"gw2-64.exe",
+
 	NULL
 };
 


### PR DESCRIPTION
The original launcher filter PR only added the 32-bit Guild Wars 2 client.
This adds the 64-bit client.