### PR TITLE
Introduce protobuf.pri helper for depending on protobuf

### DIFF
--- a/qmake/protobuf.pri
+++ b/qmake/protobuf.pri
@@ -1,0 +1,39 @@
+# Copyright 2005-2017 The Mumble Developers. All rights reserved.
+# Use of this source code is governed by a BSD-style license
+# that can be found in the LICENSE file at the root of the
+# Mumble source tree or at <https://www.mumble.info/LICENSE>.
+
+include(pkgconfig.pri)
+
+# Include this file to portably link
+# against protobuf.
+#
+# It requires compiler.pri to be included
+# for $$PROTOBUF_PATH, etc. to work on win32.
+# This file can't include compiler.pri: it can
+# only be included once per .pro file.
+
+win32-msvc* {
+	# Legacy win32-static paths (protobuf 2.x)
+	INCLUDEPATH *= "$$PROTOBUF_PATH/vsprojects/include" "$$PROTOBUF_PATH/src" protobuf
+	CONFIG(debug, debug|release) {
+		QMAKE_LIBDIR *= "$$PROTOBUF_PATH/vsprojects/Debug"
+	} else {
+		QMAKE_LIBDIR *= "$$PROTOBUF_PATH/vsprojects/Release"
+	}
+
+	# New win32-static paths (protobuf 3.2+)
+	INCLUDEPATH *= "$$PROTOBUF_PATH/include"
+	QMAKE_LIBDIR *= "$$PROTOBUF_PATH/lib"
+
+	LIBS *= -llibprotobuf
+}
+
+win32-g++ {
+	LIBS *= -lprotobuf
+}
+
+unix {
+	CONFIG *= link_pkgconfig
+	must_pkgconfig(protobuf)
+}

--- a/src/mumble.pri
+++ b/src/mumble.pri
@@ -36,15 +36,11 @@ CONFIG(packaged) {
 # Add OpenSSL dependency
 include(../qmake/openssl.pri)
 
-win32-msvc* {
-	INCLUDEPATH *= "$$PROTOBUF_PATH/vsprojects/include" "$$PROTOBUF_PATH/src" protobuf
-	CONFIG(debug, debug|release) {
-		QMAKE_LIBDIR *= "$$PROTOBUF_PATH/vsprojects/Debug"
-	} else {
-		QMAKE_LIBDIR *= "$$PROTOBUF_PATH/vsprojects/Release"
-	}
+# Add protobuf dependency
+include(../qmake/protobuf.pri)
 
-	LIBS *= -llibprotobuf -lcrypt32 -lws2_32
+win32-msvc* {
+	LIBS *= -lcrypt32 -lws2_32
 	LIBS *= -ldelayimp -lQwave -delayload:Qwave.DLL
 }
 
@@ -60,10 +56,6 @@ unix {
 
 	QMAKE_CFLAGS *= "-I../mumble_proto" "-isystem ../mumble_proto"
 	QMAKE_CXXFLAGS *= "-I../mumble_proto" "-isystem ../mumble_proto"
-
-	CONFIG *= link_pkgconfig
-
-	must_pkgconfig(protobuf)
 }
 
 # Make Q_DECL_OVERRIDE and Q_DECL_FINAL no-ops

--- a/src/mumble_proto/mumble_proto.pro
+++ b/src/mumble_proto/mumble_proto.pro
@@ -26,7 +26,8 @@ CONFIG -= qt
 CONFIG += debug_and_release
 CONFIG += staticlib
 
-INCLUDEPATH *= "$$PROTOBUF_PATH/vsprojects/include" "$$PROTOBUF_PATH/src" protobuf
+# Add protobuf dependency
+include(../../qmake/protobuf.pri)
 
 QMAKE_EXTRA_COMPILERS *= pb pbh
 


### PR DESCRIPTION
This PR adds a new helper for depending on protobuf called protobuf.pri.

Then, it modifies src/mumble.pri and src/mumble_proto/mumble_proto.pro to use the new helper include.