### PR TITLE
Overlay_macx: fix code to work with removal of OverlaySettings::bUseWhitelist.

### DIFF
--- a/src/mumble/Overlay_macx.mm
+++ b/src/mumble/Overlay_macx.mm
@@ -76,12 +76,24 @@ static NSString *MumbleOverlayLoaderBundleIdentifier = @"net.sourceforge.mumble.
 
 		QString qsBundleIdentifier = QString::fromUtf8([bundleId UTF8String]);
 
-		if (g.s.os.bUseWhitelist) {
-			if (g.s.os.qslWhitelist.contains(qsBundleIdentifier))
+		switch (g.s.os.oemOverlayExcludeMode) {
+			case OverlaySettings::LauncherFilterExclusionMode: {
+				qWarning("Overlay_macx: launcher filter mode not implemented on macOS, allowing everything");
 				overlayEnabled = YES;
-		} else {
-			if (! g.s.os.qslBlacklist.contains(qsBundleIdentifier))
-				overlayEnabled = YES;
+				break;
+			}
+			case OverlaySettings::WhitelistExclusionMode: {
+				if (g.s.os.qslWhitelist.contains(qsBundleIdentifier)) {
+					overlayEnabled = YES;
+				}
+				break;
+			}
+			case OverlaySettings::BlacklistExclusionMode: {
+				if (! g.s.os.qslBlacklist.contains(qsBundleIdentifier)) {
+					overlayEnabled = YES;
+				}
+				break;
+			}
 		}
 
 		if (overlayEnabled) {


### PR DESCRIPTION
This a quick band-aid until we implement proper support for
launcher-detection in Overlay_macx.