### PR TITLE
TestPacketDataStream: use UTF-8 instead of Latin1.

### DIFF
--- a/src/tests/TestPacketDataStream/TestPacketDataStream.cpp
+++ b/src/tests/TestPacketDataStream/TestPacketDataStream.cpp
@@ -93,7 +93,7 @@ void TestPacketDataStream::string_data() {
 	QTest::addColumn<QString>("string");
 	QTest::newRow("Empty") << QString("");
 	QTest::newRow("Null") << QString();
-	QTest::newRow("Bærtur") << QString("Bærtur");
+	QTest::newRow("BÃ¦rtur") << QString("BÃ¦rtur");
 }
 
 void TestPacketDataStream::string() {


### PR DESCRIPTION
The string test for PacketDataStream uses the string
Bærtur -- but encoded as Latin1.

Keep the string -- it's as good as any -- but use UTF-8 instead,
to make clang happy.

Fixes mumble-voip/mumble#2978