### PR TITLE
tests: depend on OpenSSL in test.pri instead of each individual test.

### DIFF
--- a/src/tests/TestCrypt/TestCrypt.pro
+++ b/src/tests/TestCrypt/TestCrypt.pro
@@ -4,7 +4,6 @@
 # Mumble source tree or at <https://www.mumble.info/LICENSE>.
 
 include(../test.pri)
-include(../../../qmake/openssl.pri)
 
 QT *= network
 

--- a/src/tests/TestCryptographicHash/TestCryptographicHash.pro
+++ b/src/tests/TestCryptographicHash/TestCryptographicHash.pro
@@ -4,7 +4,6 @@
 # Mumble source tree or at <https://www.mumble.info/LICENSE>.
 
 include(../test.pri)
-include(../../../qmake/openssl.pri)
 
 TARGET = TestCryptographicHash
 SOURCES = TestCryptographicHash.cpp CryptographicHash.cpp

--- a/src/tests/TestCryptographicRandom/TestCryptographicRandom.pro
+++ b/src/tests/TestCryptographicRandom/TestCryptographicRandom.pro
@@ -4,7 +4,6 @@
 # Mumble source tree or at <https://www.mumble.info/LICENSE>.
 
 include(../test.pri)
-include(../../../qmake/openssl.pri)
 
 TARGET = TestCryptographicRandom
 SOURCES = TestCryptographicRandom.cpp CryptographicRandom.cpp arc4random_uniform.cpp

--- a/src/tests/TestPasswordGenerator/TestPasswordGenerator.pro
+++ b/src/tests/TestPasswordGenerator/TestPasswordGenerator.pro
@@ -4,7 +4,6 @@
 # Mumble source tree or at <https://www.mumble.info/LICENSE>.
 
 include(../test.pri)
-include(../../../qmake/openssl.pri)
 
 TARGET = TestPasswordGenerator
 SOURCES = TestPasswordGenerator.cpp PasswordGenerator.cpp CryptographicRandom.cpp arc4random_uniform.cpp

--- a/src/tests/test.pri
+++ b/src/tests/test.pri
@@ -26,3 +26,9 @@ LANGUAGE = C++
 
 VPATH *= ../..
 INCLUDEPATH *= ../.. ../../murmur ../../mumble
+
+# We have to depend on OpenSSL in all tests
+# for no-pch builds to work. Our PCH headers
+# include OpenSSL, and if the headers aren't
+# in the include path, the build will break.
+include(../../qmake/openssl.pri)


### PR DESCRIPTION
The murmur_pch.h file which most tests use -- either directly,
or indrectly -- depends on being able to include OpenSSL headers.

Some of our tests did not include(qmake/openssl.pri), which meant that
those tests would fail to build in CONFIG(no-pch), such as on macOS.

This commit works around that issue by depending on OpenSSL for all tests.