### PR TITLE
murmur_ice: various fixes in preparation of macOS Travis-CI PR

### DIFF
--- a/src/murmur/murmur_ice/murmur_ice.pro
+++ b/src/murmur/murmur_ice/murmur_ice.pro
@@ -48,7 +48,7 @@ macx {
 	    MUMBLE_ICE_PREFIX = $$(MUMBLE_PREFIX)/Ice-3.4.2
 	}
 	INCLUDEPATH *= $$MUMBLE_ICE_PREFIX/include/
-	slice.commands = $$MUMBLE_ICE_PREFIX/bin/slice2cpp --checksum -I$$MUMBLE_ICE_PREFIX/slice/ ../Murmur.ice
+	slice.commands = $$MUMBLE_ICE_PREFIX/bin/slice2cpp --checksum -I$$MUMBLE_ICE_PREFIX/slice/ -I$$MUMBLE_ICE_PREFIX/share/slice/ ../Murmur.ice
 }
 
 CONFIG(ermine) {

--- a/src/murmur/murmur_ice/murmur_ice.pro
+++ b/src/murmur/murmur_ice/murmur_ice.pro
@@ -43,8 +43,12 @@ win32 {
 }
 
 macx {
-	INCLUDEPATH *= $$(MUMBLE_PREFIX)/Ice-3.4.2/include/
-	slice.commands = $$(MUMBLE_PREFIX)/Ice-3.4.2/bin/slice2cpp --checksum -I$$(MUMBLE_PREFIX)/Ice-3.4.2/slice/ ../Murmur.ice
+	MUMBLE_ICE_PREFIX = $$(MUMBLE_ICE_PREFIX)
+	isEmpty(MUMBLE_ICE_PREFIX) {
+	    MUMBLE_ICE_PREFIX = $$(MUMBLE_PREFIX)/Ice-3.4.2
+	}
+	INCLUDEPATH *= $$MUMBLE_ICE_PREFIX/include/
+	slice.commands = $$MUMBLE_ICE_PREFIX/bin/slice2cpp --checksum -I$$MUMBLE_ICE_PREFIX/slice/ ../Murmur.ice
 }
 
 CONFIG(ermine) {


### PR DESCRIPTION
- Add support for specifying MUMBLE_ICE_PREFIX on macOS, allowing us to use a Homebrew-installed Ice.
- Add Homebrew's default slice path variant to the default include path in murmur_ice.pro.