### PR TITLE
ACLEditor: fix tooltip for channel sort order.

### DIFF
--- a/src/mumble/ACLEditor.ui
+++ b/src/mumble/ACLEditor.ui
@@ -77,7 +77,7 @@
           </size>
          </property>
          <property name="toolTip">
-          <string>Channel positioning facility value</string>
+          <string>This is the sort order for the channel.</string>
          </property>
          <property name="whatsThis">
           <string>&lt;b&gt;Position&lt;/b&gt;&lt;br/&gt;


### PR DESCRIPTION
The tooltip for the channel sort order was previously the very obscure
"Channel positioning facility value".

This commit makes it more understandable: "This is the sort order for the channel."