### PR TITLE
MainWindow: avoid floor/ceil in VolumeUp/VolumeDown global shortcut handlers.

### DIFF
--- a/src/mumble/MainWindow.cpp
+++ b/src/mumble/MainWindow.cpp
@@ -2497,17 +2497,21 @@ void MainWindow::on_PushToMute_triggered(bool down, QVariant) {
 
 void MainWindow::on_VolumeUp_triggered(bool down, QVariant) {
 	if (down) {
-		float v = floorf(g.s.fVolume * 10.0f);
-		if (v < 20.0f)
-			g.s.fVolume = ++v / 10.0f;
+		float vol = g.s.fVolume + 0.1f;
+		if (vol > 2.0f) {
+			vol = 2.0f;
+		}
+		g.s.fVolume = vol;
 	}
 }
 
 void MainWindow::on_VolumeDown_triggered(bool down, QVariant) {
 	if (down) {
-		float v = ceilf(g.s.fVolume * 10.0f);
-		if (v > 0.0f)
-			g.s.fVolume = --v / 10.0f;
+		float vol = g.s.fVolume - 0.1f;
+		if (vol < 0.0f) {
+			vol = 0.0f;
+		}
+		g.s.fVolume = vol;
 	}
 }
 


### PR DESCRIPTION
Previously, the code tried to use floorf (in VolumeUp) and ceilf (in
VolumeDown) in order to ensure that VolumeUp and VolumeDown rounded to
the nearest 10%.

However, with /fp:fast on MSVC, that didn't work in all cases. For
example, in VolumeDown, the volume was previously always calculated via
ceilf(). On some occasions, a previous invocation of VolumeDown will have
set g.s.fVolume to a value close to 1.3 (130%). This value, when passed to
ceilf() would become 1.4 (140%) and subtracting 10% from that would still
be 130%. Not as we would expect.

This commit fixes the logic to not expect on exactness of floats via
floorf/ceilf. Instead of rounding to the nearest 10%, we just subtract
or add 10% to the current volume. It doesn't matter that it isn't a
multiple of 10.