### PR TITLE
Accept File And Folder Drops In Overlay Exceptions

### DIFF
--- a/src/mumble/Overlay.cpp
+++ b/src/mumble/Overlay.cpp
@@ -44,10 +44,12 @@ QString OverlayAppInfo::applicationIdentifierForPath(const QString &path) {
 		}
 	}
 
-	if (data)
+	if (data) {
 		CFRelease(data);
-	if (plist)
+	}
+	if (plist) {
 		CFRelease(plist);
+	}
 
 	return qsIdentifier;
 #else
@@ -85,21 +87,26 @@ OverlayAppInfo OverlayAppInfo::applicationInfoForId(const QString &identifier) {
 					CFStringGetCString(iconFileName, buf, 4096, kCFStringEncodingUTF8);
 					QString qsIconPath = QString::fromLatin1("%1/Contents/Resources/%2")
 					                     .arg(qsBundlePath, QString::fromUtf8(buf));
-					if (! QFile::exists(qsIconPath))
+					if (! QFile::exists(qsIconPath)) {
 						qsIconPath += QString::fromLatin1(".icns");
-					if (QFile::exists(qsIconPath))
+					}
+					if (QFile::exists(qsIconPath)) {
 						qiAppIcon = QIcon(qsIconPath);
+					}
 				}
 			}
 		}
 	}
 
-	if (bundleId)
+	if (bundleId) {
 		CFRelease(bundleId);
-	if (bundleUrl)
+	}
+	if (bundleUrl) {
 		CFRelease(bundleUrl);
-	if (bundle)
+	}
+	if (bundle) {
 		CFRelease(bundle);
+	}
 
 #elif defined(Q_OS_WIN)
 	// qWinAppInst(), whose return value we used to pass

--- a/src/mumble/Overlay.cpp
+++ b/src/mumble/Overlay.cpp
@@ -21,6 +21,113 @@
 #include "User.h"
 #include "WebFetch.h"
 
+QString OverlayAppInfo::applicationIdentifierForPath(const QString &path) {
+#ifdef Q_OS_MAC
+	QString qsIdentifier;
+	CFDictionaryRef plist = NULL;
+	CFDataRef data = NULL;
+
+	QFile qfAppBundle(QString::fromLatin1("%1/Contents/Info.plist").arg(path));
+	if (qfAppBundle.exists()) {
+		qfAppBundle.open(QIODevice::ReadOnly);
+		QByteArray qbaPlistData = qfAppBundle.readAll();
+
+		data = CFDataCreateWithBytesNoCopy(NULL, reinterpret_cast<UInt8 *>(qbaPlistData.data()), qbaPlistData.count(), kCFAllocatorNull);
+		plist = static_cast<CFDictionaryRef>(CFPropertyListCreateFromXMLData(NULL, data, kCFPropertyListImmutable, NULL));
+		if (plist) {
+			CFStringRef ident = static_cast<CFStringRef>(CFDictionaryGetValue(plist, CFSTR("CFBundleIdentifier")));
+			if (ident) {
+				char buf[4096];
+				CFStringGetCString(ident, buf, 4096, kCFStringEncodingUTF8);
+				qsIdentifier = QString::fromUtf8(buf);
+			}
+		}
+	}
+
+	if (data)
+		CFRelease(data);
+	if (plist)
+		CFRelease(plist);
+
+	return qsIdentifier;
+#else
+	return QDir::toNativeSeparators(path);
+#endif
+}
+
+OverlayAppInfo OverlayAppInfo::applicationInfoForId(const QString &identifier) {
+	QString qsAppName(identifier);
+	QIcon qiAppIcon;
+#if defined(Q_OS_MAC)
+	CFStringRef bundleId = NULL;
+	CFURLRef bundleUrl = NULL;
+	CFBundleRef bundle = NULL;
+	OSStatus err = noErr;
+	char buf[4096];
+
+	bundleId = CFStringCreateWithCharacters(kCFAllocatorDefault, reinterpret_cast<const UniChar *>(identifier.unicode()), identifier.length());
+	err = LSFindApplicationForInfo(kLSUnknownCreator, bundleId, NULL, NULL, &bundleUrl);
+	if (err == noErr) {
+		// Figure out the bundle name of the application.
+		CFStringRef absBundlePath = CFURLCopyFileSystemPath(bundleUrl, kCFURLPOSIXPathStyle);
+		CFStringGetCString(absBundlePath, buf, 4096, kCFStringEncodingUTF8);
+		QString qsBundlePath = QString::fromUtf8(buf);
+		CFRelease(absBundlePath);
+		qsAppName = QFileInfo(qsBundlePath).bundleName();
+
+		// Load the bundle's icon.
+		bundle = CFBundleCreate(NULL, bundleUrl);
+		if (bundle) {
+			CFDictionaryRef info = CFBundleGetInfoDictionary(bundle);
+			if (info) {
+				CFStringRef iconFileName = reinterpret_cast<CFStringRef>(CFDictionaryGetValue(info, CFSTR("CFBundleIconFile")));
+				if (iconFileName) {
+					CFStringGetCString(iconFileName, buf, 4096, kCFStringEncodingUTF8);
+					QString qsIconPath = QString::fromLatin1("%1/Contents/Resources/%2")
+					                     .arg(qsBundlePath, QString::fromUtf8(buf));
+					if (! QFile::exists(qsIconPath))
+						qsIconPath += QString::fromLatin1(".icns");
+					if (QFile::exists(qsIconPath))
+						qiAppIcon = QIcon(qsIconPath);
+				}
+			}
+		}
+	}
+
+	if (bundleId)
+		CFRelease(bundleId);
+	if (bundleUrl)
+		CFRelease(bundleUrl);
+	if (bundle)
+		CFRelease(bundle);
+
+#elif defined(Q_OS_WIN)
+	// qWinAppInst(), whose return value we used to pass
+	// to ExtractIcon below, was removed in Qt 5.8.
+	//
+	// It was removed via
+	// https://github.com/qt/qtbase/commit/64507c7165e42c2a5029353d8f97a0d841fa6b01
+	//
+	// In both Qt 4 and Qt 5, the qWinAppInst() implementation
+	// simply calls GetModuleHandle(0).
+	//
+	// To sidestep the removal of the function, we simply
+	// call through to GetModuleHandle() directly.
+	HINSTANCE qWinAppInstValue = GetModuleHandle(NULL);
+	HICON icon = ExtractIcon(qWinAppInstValue, identifier.toStdWString().c_str(), 0);
+	if (icon) {
+#if QT_VERSION >= 0x050000
+		extern QPixmap qt_pixmapFromWinHICON(HICON icon);
+		qiAppIcon = QIcon(qt_pixmapFromWinHICON(icon));
+#else
+		qiAppIcon = QIcon(QPixmap::fromWinHICON(icon));
+#endif
+		DestroyIcon(icon);
+	}
+#endif
+	return OverlayAppInfo(qsAppName, qiAppIcon);
+}
+
 OverlayAppInfo::OverlayAppInfo(QString name, QIcon icon) {
 	qsDisplayName = name;
 	qiIcon = icon;

--- a/src/mumble/Overlay.h
+++ b/src/mumble/Overlay.h
@@ -28,9 +28,13 @@ class OverlayClient;
 class OverlayConfig;
 
 struct OverlayAppInfo {
+	static QString applicationIdentifierForPath(const QString &path);
+	static OverlayAppInfo applicationInfoForId(const QString &identifier);
+
 	QString qsDisplayName;
 	QIcon qiIcon;
 
+private:
 	OverlayAppInfo(QString name, QIcon icon = QIcon());
 };
 

--- a/src/mumble/Overlay.ui
+++ b/src/mumble/Overlay.ui
@@ -357,7 +357,7 @@
                  </widget>
                 </item>
                 <item>
-                 <widget class="QListWidget" name="qlwLaunchers"/>
+                 <widget class="PathListWidget" name="qlwLaunchers" native="true"/>
                 </item>
                 <item>
                  <layout class="QHBoxLayout" name="horizontalLayout_2">
@@ -394,7 +394,7 @@
                  </widget>
                 </item>
                 <item>
-                 <widget class="QListWidget" name="qlwWhitelist"/>
+                 <widget class="PathListWidget" name="qlwWhitelist" native="true"/>
                 </item>
                 <item>
                  <layout class="QHBoxLayout" name="horizontalLayout_5">
@@ -431,7 +431,7 @@
                  </widget>
                 </item>
                 <item>
-                 <widget class="QListWidget" name="qlwPaths"/>
+                 <widget class="PathListWidget" name="qlwPaths" native="true"/>
                 </item>
                 <item>
                  <layout class="QHBoxLayout" name="horizontalLayout_7">
@@ -468,7 +468,7 @@
                  </widget>
                 </item>
                 <item>
-                 <widget class="QListWidget" name="qlwBlacklist"/>
+                 <widget class="PathListWidget" name="qlwBlacklist" native="true"/>
                 </item>
                 <item>
                  <layout class="QHBoxLayout" name="horizontalLayout_10">
@@ -702,6 +702,13 @@ To upgrade these files to their latest versions, click the button below.</string
    </item>
   </layout>
  </widget>
+ <customwidgets>
+  <customwidget>
+   <class>PathListWidget</class>
+   <extends>QListWidget</extends>
+   <header>PathListWidget.h</header>
+  </customwidget>
+ </customwidgets>
  <resources>
   <include location="mumble.qrc"/>
  </resources>

--- a/src/mumble/OverlayConfig.cpp
+++ b/src/mumble/OverlayConfig.cpp
@@ -20,6 +20,7 @@
 #include "ServerHandler.h"
 #include "MainWindow.h"
 #include "GlobalShortcut.h"
+#include "PathListWidget.h"
 
 #ifdef Q_OS_WIN
 #include "../../overlay/overlay_launchers.h"
@@ -147,6 +148,8 @@ OverlayConfig::OverlayConfig(Settings &st) :
 		qgtiInstructions(NULL),
 		fViewScale(1.0f) {
 	setupUi(this);
+
+	qlwPaths->setPathType(PathListWidget::FOLDER);
 
 	qcbOverlayExclusionMode->insertItem(static_cast<int>(OverlaySettings::LauncherFilterExclusionMode), tr("Launcher Filter"));
 	qcbOverlayExclusionMode->insertItem(static_cast<int>(OverlaySettings::WhitelistExclusionMode), tr("Whitelist"));

--- a/src/mumble/OverlayConfig.cpp
+++ b/src/mumble/OverlayConfig.cpp
@@ -631,6 +631,20 @@ void OverlayConfig::on_qlwWhitelist_itemSelectionChanged() {
 	}
 }
 
+void OverlayConfig::addWhitelistPath(const QString &path) {
+	QString qsAppIdentifier = OverlayAppInfo::applicationIdentifierForPath(path);
+	QListWidget *sel = qlwWhitelist;
+	QStringList qslIdentifiers;
+	for (int i = 0; i < sel->count(); i++)
+		qslIdentifiers << sel->item(i)->data(Qt::UserRole).toString();
+	if (! qslIdentifiers.contains(qsAppIdentifier)) {
+		OverlayAppInfo oai = OverlayAppInfo::applicationInfoForId(qsAppIdentifier);
+		QListWidgetItem *qlwiApplication = new QListWidgetItem(oai.qiIcon, oai.qsDisplayName, sel);
+		qlwiApplication->setData(Qt::UserRole, QVariant(qsAppIdentifier));
+		sel->setCurrentItem(qlwiApplication);
+	}
+}
+
 void OverlayConfig::on_qpbWhitelistAdd_clicked() {
 #if defined(Q_OS_WIN)
 	QString file = QFileDialog::getOpenFileName(this, tr("Choose executable"), QString(), QLatin1String("*.exe"));
@@ -641,17 +655,7 @@ void OverlayConfig::on_qpbWhitelistAdd_clicked() {
 #endif
 
 	if (! file.isEmpty()) {
-		QString qsAppIdentifier = OverlayAppInfo::applicationIdentifierForPath(path);
-		QListWidget *sel = qlwWhitelist;
-		QStringList qslIdentifiers;
-		for (int i = 0; i < sel->count(); i++)
-			qslIdentifiers << sel->item(i)->data(Qt::UserRole).toString();
-		if (! qslIdentifiers.contains(qsAppIdentifier)) {
-			OverlayAppInfo oai = OverlayAppInfo::applicationInfoForId(qsAppIdentifier);
-			QListWidgetItem *qlwiApplication = new QListWidgetItem(oai.qiIcon, oai.qsDisplayName, sel);
-			qlwiApplication->setData(Qt::UserRole, QVariant(qsAppIdentifier));
-			sel->setCurrentItem(qlwiApplication);
-		}
+		addWhitelistPath(file);
 	}
 }
 

--- a/src/mumble/OverlayConfig.h
+++ b/src/mumble/OverlayConfig.h
@@ -53,9 +53,6 @@ class OverlayConfig : public ConfigWidget, public Ui::OverlayConfig {
 		void showCertificates();
 
 		void updateOverlayExclusionModeState();
-
-		QString applicationIdentifierForPath(const QString &path);
-		OverlayAppInfo applicationInfoForId(const QString &identifier);
 	protected slots:
 		void on_qpbInstall_clicked();
 		void on_qpbUninstall_clicked();

--- a/src/mumble/OverlayConfig.h
+++ b/src/mumble/OverlayConfig.h
@@ -26,6 +26,7 @@ class OverlayConfig : public ConfigWidget, public Ui::OverlayConfig {
 		void refreshFpsDemo();
 		void refreshFpsLive();
 		void refreshTimeLive();
+		void addWhitelistPath(const QString & path);
 	protected:
 		QPixmap qpScreen;
 		QGraphicsPixmapItem *qgpiScreen;

--- a/src/mumble/PathListWidget.cpp
+++ b/src/mumble/PathListWidget.cpp
@@ -1,0 +1,94 @@
+// Copyright 2005-2017 The Mumble Developers. All rights reserved.
+// Use of this source code is governed by a BSD-style license
+// that can be found in the LICENSE file at the root of the
+// Mumble source tree or at <https://www.mumble.info/LICENSE>.
+
+#include "mumble_pch.hpp"
+
+#include "PathListWidget.h"
+
+#include <QDragEnterEvent>
+#include <QDragMoveEvent>
+#include <QDropEvent>
+#include <QFile>
+#include <QDir>
+#include "Overlay.h"
+
+PathListWidget::PathListWidget(QWidget *parent)
+	: QListWidget(parent)
+	, pathType(FILE_EXE) {
+	setAcceptDrops(true);
+}
+
+void PathListWidget::setPathType(PathType type) {
+	pathType = type;
+}
+
+void PathListWidget::addFilePath(const QString &path) {
+	QString qsAppIdentifier = OverlayAppInfo::applicationIdentifierForPath(path);
+	QStringList qslIdentifiers;
+	for (int i = 0; i < count(); i++) {
+		qslIdentifiers << item(i)->data(Qt::UserRole).toString();
+	}
+	if (! qslIdentifiers.contains(qsAppIdentifier)) {
+		OverlayAppInfo oai = OverlayAppInfo::applicationInfoForId(qsAppIdentifier);
+		QListWidgetItem *qlwiApplication = new QListWidgetItem(oai.qiIcon, oai.qsDisplayName, this);
+		qlwiApplication->setData(Qt::UserRole, QVariant(qsAppIdentifier));
+		setCurrentItem(qlwiApplication);
+	}
+}
+
+void PathListWidget::addFolderPath(const QString &path) {
+	QString dir = QDir::toNativeSeparators(path);
+	QStringList qslIdentifiers;
+	for (int i = 0; i < count(); i++) {
+		qslIdentifiers << item(i)->data(Qt::UserRole).toString();
+	}
+	if (! dir.isEmpty() && ! qslIdentifiers.contains(dir)) {
+		QListWidgetItem *qlwiPath = new QListWidgetItem(QIcon(), QDir(dir).path(), this);
+		qlwiPath->setData(Qt::UserRole, QVariant(dir));
+		setCurrentItem(qlwiPath);
+	}
+}
+
+void PathListWidget::checkAcceptDragEvent(QDropEvent *event, bool store) {
+	if (event->mimeData()->hasUrls()) {
+		foreach (QUrl url, event->mimeData()->urls()) {
+			if (url.isLocalFile()) {
+				QFileInfo info(url.toLocalFile());
+				switch (pathType) {
+					case FILE_EXE:
+						if (info.isFile() && info.isExecutable()) {
+							if (store) {
+								addFilePath(info.filePath());
+							}
+							event->setDropAction(Qt::LinkAction);
+							event->accept();
+						}
+						break;
+					case FOLDER:
+						if (info.isDir()) {
+							if (store) {
+								addFolderPath(url.toLocalFile());
+							}
+							event->setDropAction(Qt::LinkAction);
+							event->accept();
+						}
+						break;
+				}
+			}
+		}
+	}
+}
+
+void PathListWidget::dragEnterEvent(QDragEnterEvent *event) {
+	checkAcceptDragEvent(event, false);
+}
+
+void PathListWidget::dragMoveEvent(QDragMoveEvent *event) {
+	checkAcceptDragEvent(event, false);
+}
+
+void PathListWidget::dropEvent(QDropEvent *event) {
+	checkAcceptDragEvent(event, true);
+}

--- a/src/mumble/PathListWidget.h
+++ b/src/mumble/PathListWidget.h
@@ -1,0 +1,39 @@
+// Copyright 2005-2017 The Mumble Developers. All rights reserved.
+// Use of this source code is governed by a BSD-style license
+// that can be found in the LICENSE file at the root of the
+// Mumble source tree or at <https://www.mumble.info/LICENSE>.
+
+#ifndef MUMBLE_MUMBLE_PATHLISTWIDGET_H_
+#define MUMBLE_MUMBLE_PATHLISTWIDGET_H_
+
+#include <QListWidget>
+
+class QGraphicsSceneDragDropEvent;
+class QDropEvent;
+
+/**
+ * ListWidget that adds functionality for being able to drop files or folders to add them to the list.
+ *
+ * It makes use of OverlayAppInfo to display file/app information (e.g. the appropriate icon).
+ */
+class PathListWidget : public QListWidget {
+public:
+	enum PathType { FILE_EXE, FOLDER };
+
+	PathListWidget(QWidget *parent=0);
+	void setPathType(PathType type);
+	virtual void dragEnterEvent(QDragEnterEvent *event) Q_DECL_OVERRIDE;
+	virtual void dragMoveEvent(QDragMoveEvent *event) Q_DECL_OVERRIDE;
+	virtual void dropEvent(QDropEvent *event) Q_DECL_OVERRIDE;
+private:
+	Q_OBJECT
+	Q_DISABLE_COPY(PathListWidget)
+
+	PathType pathType;
+
+	void addFilePath(const QString &path);
+	void addFolderPath(const QString &path);
+	void checkAcceptDragEvent(QDropEvent *event, bool store);
+};
+
+#endif

--- a/src/mumble/mumble.pro
+++ b/src/mumble/mumble.pro
@@ -139,7 +139,8 @@ HEADERS *= BanEditor.h \
     OverlayPositionableItem.h \
     widgets/MUComboBox.h \
     DeveloperConsole.h \
-    EnvUtils.h
+    EnvUtils.h \
+    PathListWidget.h
 
 SOURCES *= BanEditor.cpp \
     ACLEditor.cpp \
@@ -206,7 +207,8 @@ SOURCES *= BanEditor.cpp \
     OverlayPositionableItem.cpp \
     widgets/MUComboBox.cpp \
     DeveloperConsole.cpp \
-    EnvUtils.cpp
+    EnvUtils.cpp \
+    PathListWidget.cpp
 
 CONFIG(qtspeech) {
   SOURCES *= TextToSpeech.cpp


### PR DESCRIPTION
Implements #2998

~~Implemented in two commits. (The first commit prior to these is a fix, used in PR #3000.)~~

As described in the second commit, there's an open issue:
> Issue: With an "Add" dialog open, dragging and dropping a file or folder
to where the dialog does not accept them will make the underlying widget
accept it.

The dialogs are modal `QFileDialog`s, so that is not the behaviour I would except. Dropping into a droppable area of the dialog (the file list area) captures the event as expected, with no bleeding into the window and widget below. With the dialog in front, and the mouse/drag events over non-droppable areas apparently propagates the mouse drag events to the window and widget below rather than discarding/blocking them.

I could make all four list widgets not accept drops before opening the dialog, and then making them accept them afterwards again, but that seems tedious; a lot of logic to fix unexpected (to me) behaviour. @mkrautz any input/ideas regarding this?