### PR TITLE
Update description of configuring lib paths

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -38,8 +38,9 @@ To build mumble and murmur, type
 qmake main.pro
 make release
 
-You may need to edit src/mumble/mumble.pro to reflect the installation paths you
-use for libraries.
+You may need to specify dependency installation paths. Please refer to the
+files in the qmake directory. (For windows, copy winpaths_default.pri to
+winpaths_custom.pri and adjust the copies contents.)
 After building, the binaries will be in the release/ directory.
 
 The qmake step supports a number of configurations options. To enable an


### PR DESCRIPTION
Paths are no longer specified in mumble.pro (directly).

---

I guess there’s no single place to configure for *nix and OSX, like there is for Windows? Anyway, this change should be an improvement over people looking in the mumble.pro file and expecting (configurable) paths in there.