### PR TITLE
Fix local volume dialog default size

### DIFF
--- a/src/mumble/UserLocalVolumeDialog.ui
+++ b/src/mumble/UserLocalVolumeDialog.ui
@@ -2,13 +2,11 @@
 <ui version="4.0">
  <class>UserLocalVolumeDialog</class>
  <widget class="QDialog" name="UserLocalVolumeDialog">
-  <property name="geometry">
-   <rect>
-    <x>0</x>
-    <y>0</y>
+  <property name="minimumSize">
+   <size>
     <width>500</width>
-    <height>200</height>
-   </rect>
+    <height>0</height>
+   </size>
   </property>
   <layout class="QGridLayout">
    <item row="0" column="0">


### PR DESCRIPTION
The default geometry was too small on macOS (#2993).

Remove default geometry and instead specify a minimum width. The dialog
will auto-adjust its height for content.

Fixes #2993

---

As I don't have a macOS, untested.