### PR TITLE
Add option to hide OS information from server ("privacy mode")

### DIFF
--- a/src/mumble/NetworkConfig.cpp
+++ b/src/mumble/NetworkConfig.cpp
@@ -55,6 +55,7 @@ void NetworkConfig::load(const Settings &r) {
 	qlePassword->setText(r.qsProxyPassword);
 
 	loadCheckBox(qcbImageDownload, r.iMaxImageSize <= 0);
+	loadCheckBox(qcbHideOS, s.bHideOS);
 
 	loadCheckBox(qcbAutoUpdate, r.bUpdateCheck);
 	loadCheckBox(qcbPluginUpdate, r.bPluginCheck);
@@ -72,6 +73,7 @@ void NetworkConfig::save() const {
 	s.bReconnect = qcbAutoReconnect->isChecked();
 	s.bAutoConnect = qcbAutoConnect->isChecked();
 	s.bSuppressIdentity = qcbSuppressIdentity->isChecked();
+	s.bHideOS = qcbHideOS->isChecked();
 
 	s.ptProxyType = static_cast<Settings::ProxyType>(qcbType->currentIndex());
 	s.qsProxyHost = qleHostname->text();

--- a/src/mumble/NetworkConfig.ui
+++ b/src/mumble/NetworkConfig.ui
@@ -296,6 +296,29 @@ Prevents the client from downloading images embedded into chat messages with the
     </widget>
    </item>
    <item>
+    <widget class="QGroupBox" name="qgbPrivacy">
+     <property name="title">
+      <string>Privacy</string>
+     </property>
+     <layout class="QVBoxLayout" name="verticalLayout_4">
+      <item>
+       <widget class="QCheckBox" name="qcbHideOS">
+        <property name="toolTip">
+         <string>Prevent OS information being sent to the server</string>
+        </property>
+        <property name="whatsThis">
+         <string>&lt;b&gt;Don't send OS information to the server&lt;/b&gt;&lt;br/&gt;
+Prevents the client from sending potentially identifying information about the operating system to the server.</string>
+        </property>
+        <property name="text">
+         <string>Do not send OS information to Mumble servers</string>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item>
     <widget class="QGroupBox" name="qgbServices">
      <property name="title">
       <string>Mumble services</string>

--- a/src/mumble/ServerHandler.cpp
+++ b/src/mumble/ServerHandler.cpp
@@ -577,8 +577,11 @@ void ServerHandler::serverConnectionConnected() {
 		mpv.set_version(version);
 	}
 
-	mpv.set_os(u8(OSInfo::getOS()));
-	mpv.set_os_version(u8(OSInfo::getOSDisplayableVersion()));
+	if (!g.s.bHideOS) {
+		mpv.set_os(u8(OSInfo::getOS()));
+		mpv.set_os_version(u8(OSInfo::getOSDisplayableVersion()));
+	}
+
 	sendMessage(mpv);
 
 	MumbleProto::Authenticate mpa;

--- a/src/mumble/Settings.cpp
+++ b/src/mumble/Settings.cpp
@@ -354,6 +354,7 @@ Settings::Settings() {
 	iMaxImageHeight = 1024;
 	bSuppressIdentity = false;
 	qsSslCiphers = MumbleSSL::defaultOpenSSLCipherString();
+	bHideOS = false;
 
 	bShowTransmitModeComboBox = false;
 
@@ -684,6 +685,9 @@ void Settings::load(QSettings* settings_ptr) {
 	// Network settings - SSL
 	SAVELOAD(qsSslCiphers, "net/sslciphers");
 
+	// Privacy settings
+	SAVELOAD(bHideOS, "privacy/hideos");
+
 	SAVELOAD(bExpert, "ui/expert");
 	SAVELOAD(qsLanguage, "ui/language");
 	SAVELOAD(themeName, "ui/theme");
@@ -1006,6 +1010,9 @@ void Settings::save() {
 
 	// Network settings - SSL
 	SAVELOAD(qsSslCiphers, "net/sslciphers");
+
+	// Privacy settings
+	SAVELOAD(bHideOS, "privacy/hideos");
 
 	SAVELOAD(bExpert, "ui/expert");
 	SAVELOAD(qsLanguage, "ui/language");

--- a/src/mumble/Settings.h
+++ b/src/mumble/Settings.h
@@ -333,6 +333,9 @@ struct Settings {
 	// Network settings - SSL
 	QString qsSslCiphers;
 
+	// Privacy settings
+	bool bHideOS;
+
 	static const int ciDefaultMaxImageSize = 50 * 1024; // Restrict to 50KiB as a default
 	int iMaxImageSize;
 	int iMaxImageWidth;


### PR DESCRIPTION
This patch adds an option to not send information about the user's OS and OS version to the server. It implements the request from #2899.

The Mumble version and release is still sent, since the server seems to use it for certain decisions. This information alone should not reveal much information about the user.

The option is currently placed in the "Misc" section of the "Network" tab.