### PR TITLE
MainWindow: Don't open tooltips when not active

### DIFF
--- a/src/mumble/MainWindow.cpp
+++ b/src/mumble/MainWindow.cpp
@@ -3161,7 +3161,7 @@ void MainWindow::on_qteLog_highlighted(const QUrl &url) {
 	if (! url.isValid())
 		QToolTip::hideText();
 	else {
-		if (qApp->activeWindow() != NULL) {
+		if (isActiveWindow()) {
 			QToolTip::showText(QCursor::pos(), url.toString(), qteLog, QRect());
 		}
 	}


### PR DESCRIPTION
This makes sure that MainWindow is active when showing tooltips. Previously any mumble window (including user information) could be in the foreground and tooltips would still show for the MainWindow, foregrounding the MainWindow. 