### PR TITLE
Fix CONFIG(no-pch) build on MSVC.

### DIFF
--- a/src/mumble/DirectSound.cpp
+++ b/src/mumble/DirectSound.cpp
@@ -5,6 +5,13 @@
 
 #include "mumble_pch.hpp"
 
+#define DIRECTSOUND_VERSION 0x1000
+
+#include <mmsystem.h>
+#include <dsound.h>
+#include <ks.h>
+#include <ksmedia.h>
+
 #include "DirectSound.h"
 
 #include "MainWindow.h"

--- a/src/mumble/DirectSound.h
+++ b/src/mumble/DirectSound.h
@@ -8,12 +8,6 @@
 
 #include "AudioInput.h"
 #include "AudioOutput.h"
-#define DIRECTSOUND_VERSION 0x1000
-
-#include <mmsystem.h>
-#include <dsound.h>
-#include <ks.h>
-#include <ksmedia.h>
 
 class DXAudioOutput : public AudioOutput {
 	private:

--- a/src/mumble/WinGUIDs.cpp
+++ b/src/mumble/WinGUIDs.cpp
@@ -3,6 +3,7 @@
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.
 
+#include <wtypes.h>
 #include <initguid.h>
 #include <propkey.h>
 #include <windows.h>


### PR DESCRIPTION
This fixes CONFIG(no-pch) on MSVC.

In DirectSound, move includes to headers to fix moc invocation.

In WinGUIDS, add missing wtypes.h header to get PROPERTYKEY type.