### PR TITLE
AppVeyor: add no-pch build for x86_64 MSVC.

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -8,10 +8,18 @@ cache:
 clone_folder: C:\MumbleBuild\mumble
 
 environment:
+  global:
     MUMBLE_BUILDSCRIPT: 1.3.x/mumble-win64-static.cmd
     MUMBLE_ENVIRONMENT_VERSION: win64-static-no-ltcg-1.3.x-2017-03-04-1ddd966-811
     MUMBLE_ENVIRONMENT_SOURCE: https://s3.amazonaws.com/mumble-appveyor-buildenvs
     APPVEYOR_CACHE_ENTRY_ZIP_ARGS: -t7z -mx0  # Do not compress cache. Env. is already a 7z.
+
+  matrix:
+    - MUMBLE_QT: qt5
+      MUMBLE_HOST: x86_64-pc-windows-msvc
+    - MUMBLE_QT: qt5
+      MUMBLE_HOST: x86_64-pc-windows-msvc
+      MUMBLE_NO_PCH: 1
 
 install:
   - "git submodule --quiet update --init --recursive"

--- a/scripts/appveyor/appveyor-build.ps1
+++ b/scripts/appveyor/appveyor-build.ps1
@@ -19,10 +19,18 @@ $MUMBLE_SOURCE_DIR = Join-Path $MUMBLE_BUILD_DIR "mumble"
 $MUMBLE_BUILDENV_DIR = Join-Path $MUMBLE_BUILD_DIR $env:MUMBLE_ENVIRONMENT_VERSION
 $MUMBLE_BUILDSCRIPT = Join-Path $MUMBLE_BUILDENV_DIR "mumble-releng\buildscripts\$env:MUMBLE_BUILDSCRIPT"
 
+$env:MUMBLE_EXTRA_QMAKE_CONFIG_FLAGS = ""
+
 # We do not sign the appveyor CI builds, so we must disable
 # uiaccess elevation. Also no intermediary signing is wanted.
 # Also use jom to use both cores we get on the builder.
-$env:MUMBLE_EXTRA_QMAKE_CONFIG_FLAGS = "no-elevation"
+$env:MUMBLE_EXTRA_QMAKE_CONFIG_FLAGS = $env:MUMBLE_EXTRA_QMAKE_CONFIG_FLAGS + " no-elevation"
+
+# If MUMBLE_NO_PCH is enabled, pass no-pch.
+if ($env:MUMBLE_NO_PCH -eq 1) {
+	$env:MUMBLE_EXTRA_QMAKE_CONFIG_FLAGS = $env:MUMBLE_EXTRA_QMAKE_CONFIG_FLAGS + " no-pch"
+}
+
 $env:MUMBLE_SKIP_INTERNAL_SIGNING = "1"
 $env:MUMBLE_SKIP_COLLECT_SYMBOLS = "1"
 $env:MUMBLE_NMAKE = "jom"


### PR DESCRIPTION
If we don't track this, we'll just break the build.
It helps with correctness of header includes, etc. -- so I think it is
worth tracking.