### PR TITLE
Do not include OS in HTTP user agent depending on privacy setting

### DIFF
--- a/src/mumble/NetworkConfig.cpp
+++ b/src/mumble/NetworkConfig.cpp
@@ -158,5 +158,11 @@ QNetworkReply *Network::get(const QUrl &url) {
 
 void Network::prepareRequest(QNetworkRequest &req) {
 	req.setAttribute(QNetworkRequest::HttpPipeliningAllowedAttribute, true);
-	req.setRawHeader(QString::fromLatin1("User-Agent").toUtf8(), QString::fromLatin1("Mozilla/5.0 (%1; %2) Mumble/%3 %4").arg(OSInfo::getOS(), OSInfo::getOSVersion(), QLatin1String(MUMTEXT(MUMBLE_VERSION_STRING)), QLatin1String(MUMBLE_RELEASE)).toUtf8());
+
+        // Do not send OS information if the corresponding privacy setting is enabled
+        if (g.s.bHideOS) {
+		req.setRawHeader(QString::fromLatin1("User-Agent").toUtf8(), QString::fromLatin1("Mozilla/5.0 Mumble/%1 %2").arg(QLatin1String(MUMTEXT(MUMBLE_VERSION_STRING)), QLatin1String(MUMBLE_RELEASE)).toUtf8());
+        } else {
+		req.setRawHeader(QString::fromLatin1("User-Agent").toUtf8(), QString::fromLatin1("Mozilla/5.0 (%1; %2) Mumble/%3 %4").arg(OSInfo::getOS(), OSInfo::getOSVersion(), QLatin1String(MUMTEXT(MUMBLE_VERSION_STRING)), QLatin1String(MUMBLE_RELEASE)).toUtf8());
+	}
 }

--- a/src/mumble/NetworkConfig.ui
+++ b/src/mumble/NetworkConfig.ui
@@ -304,14 +304,14 @@ Prevents the client from downloading images embedded into chat messages with the
       <item>
        <widget class="QCheckBox" name="qcbHideOS">
         <property name="toolTip">
-         <string>Prevent OS information being sent to the server</string>
+         <string>Prevent OS information being sent to Mumble servers and web servers</string>
         </property>
         <property name="whatsThis">
-         <string>&lt;b&gt;Don't send OS information to the server&lt;/b&gt;&lt;br/&gt;
-Prevents the client from sending potentially identifying information about the operating system to the server.</string>
+         <string>&lt;b&gt;Don't send OS information to servers&lt;/b&gt;&lt;br/&gt;
+Prevents the client from sending potentially identifying information about the operating system to the Mumble server and web servers.</string>
         </property>
         <property name="text">
-         <string>Do not send OS information to Mumble servers</string>
+         <string>Do not send OS information to Mumble servers and web servers</string>
         </property>
        </widget>
       </item>


### PR DESCRIPTION
This is a followup to #3009 (and #2899). Currently, information about the user's operating system is sent regardless of the privacy setting
* by the crash reporter and
* in the HTTP User-Agent header field.

IMO, crash reports should contain this information. They are also not sent without the user's approval.

This patch changes the HTTP user agent to not include the user's OS if the privacy setting is enabled and changes the setting's description.

RFC 7231 does not mandate the OS to be included in the user agent, see [section 5.5.3](https://tools.ietf.org/html/rfc7231#section-5.5.3).