### PR TITLE
Cert: use classic wizard style for the Certificate Wizard.

### DIFF
--- a/src/mumble/Cert.ui
+++ b/src/mumble/Cert.ui
@@ -13,6 +13,9 @@
   <property name="windowTitle">
    <string>Certificate Management</string>
   </property>
+  <property name="wizardStyle">
+   <enum>QWizard::ClassicStyle</enum>
+  </property>
   <widget class="QWizardPage" name="qwpWelcome">
    <property name="title">
     <string>Certificate Authentication</string>


### PR DESCRIPTION
This fixes a styling issue, where the button container at
the botom of the wizard is styled in white in the Dark theme.

Fixes mummble-voip/mumble#3019