### PR TITLE
MainWindow: only perform changeEvent's hide-in-tray logic if there is a system tray available.

### DIFF
--- a/src/mumble/MainWindow.cpp
+++ b/src/mumble/MainWindow.cpp
@@ -512,7 +512,7 @@ void MainWindow::changeEvent(QEvent *e) {
 	// So, let's not do it on macOS.
 
 #else
-	if (isMinimized() && g.s.bHideInTray) {
+	if (isMinimized() && qstiIcon->isSystemTrayAvailable() && g.s.bHideInTray) {
 		// Workaround http://qt-project.org/forums/viewthread/4423/P15/#50676
 		QTimer::singleShot(0, this, SLOT(hide()));
 	}


### PR DESCRIPTION
Previously, this would hide Mumble when switching workspaces in XMonad, and possibly other WMs
without a default notification area/system tray.

See mumble-voip/mumble#1679