### PR TITLE
qmake/compiler.pri: add CONFIG(dpkg-buildflags).

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -195,3 +195,7 @@ CONFIG+=qtspeech (Mumble)
  Use Qt's text-to-speech system (part of the experimental
  Qt Speech module), if available, instead of Mumble's own
  OS-specific text-to-speech implementations.
+
+CONFIG+=dpkg-buildflags
+ Add CFLAGS, CXXFLAGS, CPPFLAGS and LDFLAGS
+ from dpkg-buildflags to Mumble's build flags.

--- a/qmake/compiler.pri
+++ b/qmake/compiler.pri
@@ -281,6 +281,13 @@ unix:!macx {
 		}
 	}
 
+	CONFIG(dpkg-buildflags) {
+		QMAKE_CFLAGS *= $$system(dpkg-buildflags --get CFLAGS)
+		QMAKE_CXXFLAGS *= $$system(dpkg-buildflags --get CXXFLAGS)
+		QMAKE_CPPFLAGS *= $$system(dpkg-buildflags --get CPPFLAGS)
+		QMAKE_LFLAGS *= $$system(dpkg-buildflags --get LDFLAGS)
+	}
+
 	CONFIG(debug, debug|release) {
 		QMAKE_CFLAGS *= -fstack-protector -fPIE
 		QMAKE_CXXFLAGS *= -fstack-protector -fPIE


### PR DESCRIPTION
Shelling out to dpkg-buildflags to get the preferred build flags
is now the way to on Debian.

Previously, our PPA packages used hardening-wrapper to pass the
proper hardening flags to the package. That package is no longer
available in Debian unstable or Ubuntu zesty.

This commit implements a new CONFIG flag, CONFIG(dpkg-buildflags)
which will query dpkg-buildflags and append the retrieved CFLAGS,
CXXFLAGS, CPPFLAGS and LDFLAGS to QMAKE_CFLAGS, QMAKE_CXXFLAGS,
QMAKE_CPPFLAGS, QMAKE_LDFLAGS to ensure they are used in the Mumble
build.