### PR TITLE
Backport PR #3033 to 1.2.x: compiler.pri: add CONFIG(dpkg-buildflags).

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -157,3 +157,7 @@ CONFIG+=no-xinput2 (Mumble, Linux)
 CONFIG+=no-xboxinput (Mumble, Win32)
  Don't build in support for global shortcuts
  from Xbox controllers via the XInput DLL.
+
+CONFIG+=dpkg-buildflags
+ Add CFLAGS, CXXFLAGS, CPPFLAGS and LDFLAGS
+ from dpkg-buildflags to Mumble's build flags.

--- a/compiler.pri
+++ b/compiler.pri
@@ -111,6 +111,14 @@ unix {
 }
 
 unix:!macx {
+	CONFIG(dpkg-buildflags) {
+		QMAKE_CFLAGS *= $$system(dpkg-buildflags --get CFLAGS)
+		QMAKE_CXXFLAGS *= $$system(dpkg-buildflags --get CXXFLAGS)
+		QMAKE_CPPFLAGS *= $$system(dpkg-buildflags --get CPPFLAGS)
+		QMAKE_LFLAGS *= $$system(dpkg-buildflags --get LDFLAGS)
+	}
+
+
 	CONFIG(debug, debug|release) {
 		QMAKE_CFLAGS *= -fstack-protector -fPIE -pie
 		QMAKE_CXXFLAGS *= -fstack-protector -fPIE -pie


### PR DESCRIPTION
Shelling out to dpkg-buildflags to get the preferred build flags
is now the way to go on Debian.

Previously, our PPA packages used hardening-wrapper to pass the
proper hardening flags to the package. That package is no longer
available in Debian unstable or Ubuntu zesty. To remedy that situation,
we have to add flags ourselves via dpkg-buildflags.

This commit implements a new CONFIG flag, CONFIG(dpkg-buildflags)
which will query dpkg-buildflags and append the retrieved CFLAGS,
CXXFLAGS, CPPFLAGS and LDFLAGS to QMAKE_CFLAGS, QMAKE_CXXFLAGS,
QMAKE_CPPFLAGS, QMAKE_LDFLAGS to ensure they are used in the Mumble
build.