### PR TITLE
Updating ServerDB.cpp to check for MySQL, SQLite, and Postgres

### DIFF
--- a/src/murmur/ServerDB.cpp
+++ b/src/murmur/ServerDB.cpp
@@ -80,6 +80,9 @@ void ServerDB::loadOrSetupMetaPKBDF2IterationsCount(QSqlQuery &query) {
 }
 
 ServerDB::ServerDB() {
+	if (Meta::mp.qsDBDriver != QLatin1String("QMYSQL") && Meta::mp.qsDBDriver != QLatin1String("QSQLITE")  && Meta::mp.qsDBDriver != QLatin1String("QPSQL")) {
+		qFatal("ServerDB: invalid DB driver specified: '%s'. Murmur only supports QSQLITE, QMYSQL, and QPSQL.", qPrintable(Meta::mp.qsDBDriver));
+	}
 	if (! QSqlDatabase::isDriverAvailable(Meta::mp.qsDBDriver)) {
 		qFatal("ServerDB: Database driver %s not available", qPrintable(Meta::mp.qsDBDriver));
 	}


### PR DESCRIPTION
As a fix to issue #1269 

https://github.com/mumble-voip/mumble/issues/1269

Updated ServerDB::ServerDB() with a check for MySQL, SQLite, and Postgres