### PR TITLE
overlay: remove ability for overlay to decline being attached to a process.

### DIFF
--- a/overlay/lib.cpp
+++ b/overlay/lib.cpp
@@ -662,8 +662,6 @@ static void dllmainThreadAttach() {
 }
 
 extern "C" BOOL WINAPI DllMain(HINSTANCE, DWORD fdwReason, LPVOID) {
-	BOOL status = TRUE;
-
 	char procname[PROCNAMEFILEPATH_EXTENDED_BUFFER_BUFLEN];
 	GetModuleFileNameA(NULL, procname, ARRAY_NUM_ELEMENTS(procname));
 	// Fix for windows XP; on length nSize does not include null-termination
@@ -673,10 +671,7 @@ extern "C" BOOL WINAPI DllMain(HINSTANCE, DWORD fdwReason, LPVOID) {
 	switch (fdwReason) {
 		case DLL_PROCESS_ATTACH: {
 			ods("Lib: ProcAttach: %s", procname);
-			bool shouldAttach = dllmainProcAttach(procname);
-			if (!shouldAttach) {
-				status = FALSE;
-			}
+			dllmainProcAttach(procname);
 			break;
 		}
 		case DLL_PROCESS_DETACH:
@@ -691,7 +686,7 @@ extern "C" BOOL WINAPI DllMain(HINSTANCE, DWORD fdwReason, LPVOID) {
 			break;
 	}
 
-	return status;
+	return TRUE;
 }
 
 bool IsFnInModule(voidFunc fnptr, wchar_t *refmodulepath, const std::string &logPrefix, const std::string &fnName) {


### PR DESCRIPTION
This was originally implemented in
2f07778a0eaf349b6a80489007ac31b7e54064f2.

This change was a mistake. We use the WH_CBT hook to inject our DLL into
potential targets. That means that every mouse/keyboard event will trigger
an attempt to load our overlay DLL, if it isn't already loaded.

That, combined with the new ability for the overlay to decline being
injected caused problems for processes that are blacklisted by Mumble:
Every mouse/keyboard event would attempt to load the DLL, go through the
exclusion checks (query the process tree, query the registry, find out
that the process is blacklisted, unload the DLL...).

We can't have that, so let's just revert this.