### PR TITLE
Add itch.exe as known overlay launcher

### DIFF
--- a/overlay/overlay_launchers.h
+++ b/overlay/overlay_launchers.h
@@ -13,6 +13,7 @@ static const char *overlayLaunchers[] = {
 	"GalaxyClient.exe", // GOG Galaxy
 	"UbisoftGameLauncher.exe", // Uplay
 	"UbisoftGameLauncher64.exe", // Uplay
+	"itch.exe", // itch.io
 
 	"evelauncher.exe", // EVE Online launcher
 	"ffxivlauncher.exe", // Final Fantasy XIV Launcher


### PR DESCRIPTION
See #3043, fix if the itch user does not use the sandboxing feature of
the itch launcher.