### PR TITLE
overlay: add LaunchPad.exe (Daybreak Games's launcher) to the launcher list.

### DIFF
--- a/overlay/overlay_launchers.h
+++ b/overlay/overlay_launchers.h
@@ -14,6 +14,7 @@ static const char *overlayLaunchers[] = {
 	"UbisoftGameLauncher.exe", // Uplay
 	"UbisoftGameLauncher64.exe", // Uplay
 	"itch.exe", // itch.io
+	"LaunchPad.exe", // Daybreak Games LaunchPad
 
 	"evelauncher.exe", // EVE Online launcher
 	"ffxivlauncher.exe", // Final Fantasy XIV Launcher


### PR DESCRIPTION
As provided by Remadan in mumble-voip/mumble#3029.

LaunchPad is Daybreak Games's own launcher, used for games such as
PlanetSide 2 (Standalone) and others.