### PR TITLE
Checking with PVS-Studio static analyser.

### DIFF
--- a/src/mumble/AudioOutput.cpp
+++ b/src/mumble/AudioOutput.cpp
@@ -496,7 +496,6 @@ bool AudioOutput::mix(void *outbuff, unsigned int nsamp) {
 
 			if (recorder) {
 				AudioOutputSpeech *aos = qobject_cast<AudioOutputSpeech *>(aop);
-				Q_ASSERT(aos != nullptr);
 
 				if (aos) {
 					for (unsigned int i = 0; i < nsamp; ++i) {

--- a/src/mumble/AudioOutput.cpp
+++ b/src/mumble/AudioOutput.cpp
@@ -496,6 +496,7 @@ bool AudioOutput::mix(void *outbuff, unsigned int nsamp) {
 
 			if (recorder) {
 				AudioOutputSpeech *aos = qobject_cast<AudioOutputSpeech *>(aop);
+				Q_ASSERT(aos != nullptr);
 
 				if (aos) {
 					for (unsigned int i = 0; i < nsamp; ++i) {
@@ -503,12 +504,7 @@ bool AudioOutput::mix(void *outbuff, unsigned int nsamp) {
 					}
 
 					if (!recorder->isInMixDownMode()) {
-						if (aos) {
-							recorder->addBuffer(aos->p, recbuff, nsamp);
-						} else {
-							// this should be unreachable
-							Q_ASSERT(false);
-						}
+						recorder->addBuffer(aos->p, recbuff, nsamp);
 						recbuff = boost::shared_array<float>(new float[nsamp]);
 						memset(recbuff.get(), 0, sizeof(float) * nsamp);
 					}

--- a/src/mumble/Database.cpp
+++ b/src/mumble/Database.cpp
@@ -220,7 +220,7 @@ bool Database::isLocalIgnored(const QString &hash) {
 	query.prepare(QLatin1String("SELECT `hash` FROM `ignored` WHERE `hash` = ?"));
 	query.addBindValue(hash);
 	execQueryAndLogFailure(query);
-	while (query.next()) {
+	if (query.next()) {
 		return true;
 	}
 	return false;
@@ -243,7 +243,7 @@ bool Database::isLocalMuted(const QString &hash) {
 	query.prepare(QLatin1String("SELECT `hash` FROM `muted` WHERE `hash` = ?"));
 	query.addBindValue(hash);
 	execQueryAndLogFailure(query);
-	while (query.next()) {
+	if (query.next()) {
 		return true;
 	}
 	return false;
@@ -289,7 +289,7 @@ bool Database::isChannelFiltered(const QByteArray &server_cert_digest, const int
 	query.addBindValue(channel_id);
 	execQueryAndLogFailure(query);
 
-	while (query.next()) {
+	if (query.next()) {
 		return true;
 	}
 	return false;

--- a/src/mumble/Database.cpp
+++ b/src/mumble/Database.cpp
@@ -220,10 +220,7 @@ bool Database::isLocalIgnored(const QString &hash) {
 	query.prepare(QLatin1String("SELECT `hash` FROM `ignored` WHERE `hash` = ?"));
 	query.addBindValue(hash);
 	execQueryAndLogFailure(query);
-	if (query.next()) {
-		return true;
-	}
-	return false;
+	return query.next();
 }
 
 void Database::setLocalIgnored(const QString &hash, bool ignored) {
@@ -243,10 +240,7 @@ bool Database::isLocalMuted(const QString &hash) {
 	query.prepare(QLatin1String("SELECT `hash` FROM `muted` WHERE `hash` = ?"));
 	query.addBindValue(hash);
 	execQueryAndLogFailure(query);
-	if (query.next()) {
-		return true;
-	}
-	return false;
+	return query.next();
 }
 
 void Database::setUserLocalVolume(const QString &hash, float volume) {
@@ -289,10 +283,7 @@ bool Database::isChannelFiltered(const QByteArray &server_cert_digest, const int
 	query.addBindValue(channel_id);
 	execQueryAndLogFailure(query);
 
-	if (query.next()) {
-		return true;
-	}
-	return false;
+	return query.next();
 }
 
 void Database::setChannelFiltered(const QByteArray &server_cert_digest, const int channel_id, const bool hidden) {

--- a/src/mumble/MainWindow.cpp
+++ b/src/mumble/MainWindow.cpp
@@ -2376,9 +2376,7 @@ void MainWindow::on_qaAudioUnlink_triggered() {
 }
 
 void MainWindow::on_qaConfigDialog_triggered() {
-	QDialog *dlg = NULL;
-	if (! dlg)
-		dlg = new ConfigDialog(this);
+	QDialog *dlg = new ConfigDialog(this);
 
 	if (dlg->exec() == QDialog::Accepted) {
 		setupView(false);

--- a/src/mumble/RichTextEditor.cpp
+++ b/src/mumble/RichTextEditor.cpp
@@ -93,8 +93,7 @@ void RichTextHtmlEdit::insertFromMimeData(const QMimeData *source) {
 #endif
 			urls = decodeMimeString(source->data(QLatin1String("text/uri-list"))).split(newline);
 		if (! urls.isEmpty())
-			uri = urls.at(0);
-		uri = urls.at(0).trimmed();
+			uri = urls.at(0).trimmed();
 	}
 
 	if (uri.isEmpty()) {
@@ -538,8 +537,6 @@ static bool unduplicateTags(QXmlStreamReader &reader, QXmlStreamWriter &writer) 
 						qlNames.takeLast();
 						qlAttributes.takeLast();
 						writer.writeCurrentToken(reader);
-					} else {
-						needclose = true;
 					}
 					needclose = true;
 				}


### PR DESCRIPTION
We have found and fixed a bug using PVS-Studio tool. PVS-Studio is a static code analyzer for C, C++ and C#: https://www.viva64.com/en/pvs-studio/

We suggests having a look at the emails, sent from @pvs-studio.com.

Analyzer warnings:

- V519 The 'uri' variable is assigned values twice successively. Perhaps this is a mistake. Check lines: 96, 97. RichTextEditor.cpp 97
- V519 The 'needclose' variable is assigned values twice successively. Perhaps this is a mistake. Check lines: 542, 544. RichTextEditor.cpp 544
- V547 Expression 'aos' is always true. AudioOutput.cpp 506
- V547 Expression '!dlg' is always true. MainWindow.cpp 2380
- V612 An unconditional 'return' within a loop. Database.cpp 224
- V612 An unconditional 'return' within a loop. Database.cpp 247
- V612 An unconditional 'return' within a loop. Database.cpp 293
