### PR TITLE
SocketRPC: ensure pipe paths match up.

### DIFF
--- a/src/mumble/SocketRPC.cpp
+++ b/src/mumble/SocketRPC.cpp
@@ -272,7 +272,16 @@ bool SocketRPC::send(const QString &basename, const QString &request, const QMap
 #ifdef Q_OS_WIN
 	pipepath = basename;
 #else
-	pipepath = QDir::home().absoluteFilePath(QLatin1String(".") + basename + QLatin1String("Socket"));
+	{
+		QString xdgRuntimePath = QProcessEnvironment::systemEnvironment().value(QLatin1String("XDG_RUNTIME_DIR"));
+		QDir xdgRuntimeDir = QDir(xdgRuntimePath);
+
+		if (! xdgRuntimePath.isNull() && xdgRuntimeDir.exists()) {
+			pipepath = xdgRuntimeDir.absoluteFilePath(basename + QLatin1String("Socket"));
+		} else {
+			pipepath = QDir::home().absoluteFilePath(QLatin1String(".") + basename + QLatin1String("Socket"));
+		}
+	}
 #endif
 
 	QLocalSocket qls;


### PR DESCRIPTION
Cross-compiled the latest mumble to run on the Raspberry Pi 3 specifically to use the RPC calls and discovered that none of them worked. Tracked the problem down to the creation of the the pipepath in the client send method. The pipepath didn't match the pipepath created for the server SocketRPC::SocketRPC.