### PR TITLE
Added a "Undo Idle action upon activity" setting.

### DIFF
--- a/src/mumble/AudioConfigDialog.cpp
+++ b/src/mumble/AudioConfigDialog.cpp
@@ -143,6 +143,7 @@ void AudioInputDialog::load(const Settings &r) {
 	// Idle auto actions
 	qsbIdle->setValue(r.iIdleTime / 60);
 	loadComboBox(qcbIdleAction, r.iaeIdleAction);
+	loadCheckBox(qcbUndoIdleAction, r.bUndoIdleActionUponActivity);
 
 	int echo = 0;
 	if (r.bEcho)
@@ -168,6 +169,7 @@ void AudioInputDialog::save() const {
 	// Idle auto actions
 	s.iIdleTime = qsbIdle->value() * 60;
 	s.iaeIdleAction = static_cast<Settings::IdleAction>(qcbIdleAction->currentIndex());
+	s.bUndoIdleActionUponActivity = qcbUndoIdleAction->isChecked();
 
 	s.bShowPTTButtonWindow = qcbPushWindow->isChecked();
 	s.bTxAudioCue = qcbPushClick->isChecked();
@@ -397,6 +399,7 @@ void AudioInputDialog::on_qcbIdleAction_currentIndexChanged(int v) {
 	qlIdle->setEnabled(enabled);
 	qlIdle2->setEnabled(enabled);
 	qsbIdle->setEnabled(enabled);
+	qcbUndoIdleAction->setEnabled(enabled);
 }
 
 AudioOutputDialog::AudioOutputDialog(Settings &st) : ConfigWidget(st) {

--- a/src/mumble/AudioInput.h
+++ b/src/mumble/AudioInput.h
@@ -142,6 +142,10 @@ class AudioInput : public QThread {
 		void doDeaf();
 		void doMute();
 	public:
+		typedef enum { ActivityStateIdle, ActivityStateReturnedFromIdle, ActivityStateActive } ActivityState;
+
+		ActivityState activityState;
+
 		bool bResetProcessor;
 
 		Timer tIdle;

--- a/src/mumble/AudioInput.ui
+++ b/src/mumble/AudioInput.ui
@@ -786,6 +786,16 @@
         </property>
        </widget>
       </item>
+      <item row="4" column="4">
+       <widget class="QCheckBox" name="qcbUndoIdleAction">
+        <property name="toolTip">
+         <string>The idle action will be reversed upon any key or mouse button input</string>
+        </property>
+        <property name="text">
+         <string>Undo Idle action upon activity</string>
+        </property>
+       </widget>
+      </item>
       <item row="3" column="4">
        <layout class="QHBoxLayout" name="horizontalLayout">
         <item>

--- a/src/mumble/GlobalShortcut.cpp
+++ b/src/mumble/GlobalShortcut.cpp
@@ -849,8 +849,14 @@ bool GlobalShortcutEngine::handleButton(const QVariant &button, bool down) {
 
 	if (down) {
 		AudioInputPtr ai = g.ai;
-		if (ai.get())
+		if (ai.get()) {
+			// XXX: This is a data race: we write to ai->activityState
+			// (accessed by the AudioInput thread) from the main thread.
+			if (ai->activityState == AudioInput::ActivityStateIdle) {
+				ai->activityState = AudioInput::ActivityStateReturnedFromIdle;
+			}
 			ai->tIdle.restart();
+		}
 	}
 
 	int idx = qlButtonList.indexOf(button);

--- a/src/mumble/Settings.cpp
+++ b/src/mumble/Settings.cpp
@@ -244,6 +244,7 @@ Settings::Settings() {
 	// Idle auto actions
 	iIdleTime = 5 * 60;
 	iaeIdleAction = Nothing;
+	bUndoIdleActionUponActivity = false;
 
 	vsVAD = Amplitude;
 	fVADmin = 0.80f;
@@ -611,6 +612,7 @@ void Settings::load(QSettings* settings_ptr) {
 	// Idle auto actions
 	SAVELOAD(iIdleTime, "audio/idletime");
 	LOADENUM(iaeIdleAction, "audio/idleaction");
+	SAVELOAD(bUndoIdleActionUponActivity, "audio/undoidleactionuponactivity");
 
 	SAVELOAD(fAudioMinDistance, "audio/mindistance");
 	SAVELOAD(fAudioMaxDistance, "audio/maxdistance");
@@ -938,6 +940,7 @@ void Settings::save() {
 	// Idle auto actions
 	SAVELOAD(iIdleTime, "audio/idletime");
 	SAVELOAD(iaeIdleAction, "audio/idleaction");
+	SAVELOAD(bUndoIdleActionUponActivity, "audio/undoidleactionuponactivity");
 
 	SAVELOAD(fAudioMinDistance, "audio/mindistance");
 	SAVELOAD(fAudioMaxDistance, "audio/maxdistance");

--- a/src/mumble/Settings.h
+++ b/src/mumble/Settings.h
@@ -187,6 +187,7 @@ struct Settings {
 	// Idle auto actions
 	unsigned int iIdleTime;
 	IdleAction iaeIdleAction;
+	bool bUndoIdleActionUponActivity;
 
 	VADSource vsVAD;
 	float fVADmin, fVADmax;


### PR DESCRIPTION
Added a new "Undo Idle action upon activity" checkbox underneath the idle action area in the Audio Input settings.

When this checkbox is enabled, the idle action will be reversed as soon as the user returns from idle. (i.e. If the idle action mutes you, when you're active again, it unmutes. If the idle action deafened you, when you're active again, it undeafens you). I tried to keep this as simple as possible to increase the chances of it being merged.

I know there are other, more ambitious efforts around this such as https://github.com/mumble-voip/mumble/pull/1724, but it appears to be trying to do a lot of things and has been stalled for nearly a couple of years now. I'd very much like to get this merged, so feedback is welcome.