### PR TITLE
Move RichTextEditor XML tool methods into separate class

### DIFF
--- a/src/mumble/RichTextEditor.cpp
+++ b/src/mumble/RichTextEditor.cpp
@@ -380,6 +380,8 @@ void RichTextEditor::richToPlain() {
 
 	bool changed;
 	do {
+		// Make sure the XML has a root element (would be invalid XML otherwise)
+		// The "unduplicate" element will be dropped by XMLTools::unduplciateTags
 		qsOutput = QString::fromLatin1("<unduplicate>%1</unduplicate>").arg(qsOutput);
 
 		QXmlStreamReader r(qsOutput);

--- a/src/mumble/RichTextEditor.cpp
+++ b/src/mumble/RichTextEditor.cpp
@@ -10,6 +10,7 @@
 #include "Global.h"
 #include "Log.h"
 #include "MainWindow.h"
+#include "XMLTools.h"
 
 RichTextHtmlEdit::RichTextHtmlEdit(QWidget *p) : QTextEdit(p) {
 	m_document = new LogDocument(this);
@@ -356,204 +357,6 @@ void RichTextEditor::updateActions() {
 	updateColor(qteRichText->textColor());
 }
 
-/* Recursively parse and output XHTML.
- * This will drop <head>, <html> etc, take the contents of <body> and strip out unnecesarry styles.
- * It will also change <span style=""> into matching <b>, <i> or <u>.
- */
-
-static void recurseParse(QXmlStreamReader &reader, QXmlStreamWriter &writer, int &paragraphs, const QMap<QString, QString> &opstyle = QMap<QString, QString>(), const int close = 0, bool ignore = true) {
-	while (! reader.atEnd()) {
-		QXmlStreamReader::TokenType tt = reader.readNext();
-
-		QXmlStreamAttributes a = reader.attributes();
-		QMap<QString, QString> style;
-		QMap<QString, QString> pstyle = opstyle;
-
-		QStringRef styleref = a.value(QLatin1String("style"));
-		if (!styleref.isNull()) {
-			QString stylestring = styleref.toString();
-			QStringList styles = stylestring.split(QLatin1String(";"), QString::SkipEmptyParts);
-			foreach(QString s, styles) {
-				s = s.simplified();
-				int idx = s.indexOf(QLatin1Char(':'));
-				QString key = (idx > 0) ? s.left(idx).simplified() : s;
-				QString val = (idx > 0) ? s.mid(idx+1).simplified() : QString();
-
-				if (! pstyle.contains(key) || (pstyle.value(key) != val)) {
-					style.insert(key,val);
-					pstyle.insert(key,val);
-				}
-			}
-		}
-
-		switch (tt) {
-			case QXmlStreamReader::StartElement: {
-					QString name = reader.name().toString();
-					int rclose = 1;
-					if (name == QLatin1String("body")) {
-						rclose = 0;
-						ignore = false;
-					} else if (name == QLatin1String("span")) {
-						// Substitute style with <b>, <i> and <u>
-
-						rclose = 0;
-						if (style.value(QLatin1String("font-weight")) == QLatin1String("600")) {
-							writer.writeStartElement(QLatin1String("b"));
-							rclose++;
-							style.remove(QLatin1String("font-weight"));
-						}
-						if (style.value(QLatin1String("font-style")) == QLatin1String("italic")) {
-							writer.writeStartElement(QLatin1String("i"));
-							rclose++;
-							style.remove(QLatin1String("font-style"));
-						}
-						if (style.value(QLatin1String("text-decoration")) == QLatin1String("underline")) {
-							writer.writeStartElement(QLatin1String("u"));
-							rclose++;
-							style.remove(QLatin1String("text-decoration"));
-						}
-						if (! style.isEmpty()) {
-							rclose++;
-							writer.writeStartElement(name);
-
-							QStringList qsl;
-							QMap<QString, QString>::const_iterator i;
-							for (i=style.constBegin(); i != style.constEnd(); ++i) {
-								if (! i.value().isEmpty())
-									qsl << QString::fromLatin1("%1:%2").arg(i.key(), i.value());
-								else
-									qsl << i.key();
-							}
-
-							writer.writeAttribute(QLatin1String("style"), qsl.join(QLatin1String("; ")));
-						}
-					} else if (name == QLatin1String("p")) {
-						paragraphs++;
-						if (paragraphs == 1) {
-							// Ignore first paragraph. If it is styled empty drop its contents (e.g. <br />) too.
-							if (style.value(QLatin1String("-qt-paragraph-type")) == QLatin1String("empty")) {
-								reader.skipCurrentElement();
-								continue;
-							}
-							rclose = 0;
-						}
-						else {
-							rclose = 1;
-							writer.writeStartElement(name);
-
-							if (! style.isEmpty()) {
-								QStringList qsl;
-								QMap<QString, QString>::const_iterator i;
-								for (i=style.constBegin(); i != style.constEnd(); ++i) {
-									if (! i.value().isEmpty())
-										qsl << QString::fromLatin1("%1:%2").arg(i.key(), i.value());
-									else
-										qsl << i.key();
-								}
-
-								writer.writeAttribute(QLatin1String("style"), qsl.join(QLatin1String("; ")));
-							}
-						}
-					} else if (name == QLatin1String("a")) {
-						// Set pstyle to include implicit blue underline.
-						rclose = 1;
-						writer.writeCurrentToken(reader);
-						pstyle.insert(QLatin1String("text-decoration"), QLatin1String("underline"));
-						pstyle.insert(QLatin1String("color"), QLatin1String("#0000ff"));
-					} else if (! ignore) {
-						rclose = 1;
-						writer.writeCurrentToken(reader);
-					}
-
-					recurseParse(reader, writer, paragraphs, pstyle, rclose, ignore);
-					break;
-				}
-			case QXmlStreamReader::EndElement:
-				if (!ignore)
-					for (int i=0;i<close;++i)
-						writer.writeEndElement();
-				return;
-			case QXmlStreamReader::Characters:
-				if (! ignore)
-					writer.writeCharacters(reader.text().toString());
-				break;
-			default:
-				break;
-		}
-	}
-}
-
-/* Iterate XML and remove close-followed-by-open.
- * For example, make "<b>bold with </b><b><i>italic</i></b>" into
- * "<b>bold with <i>italic</i></b>"
- */
-
-static bool unduplicateTags(QXmlStreamReader &reader, QXmlStreamWriter &writer) {
-	bool changed = false;
-	bool needclose = false;
-
-	QStringList qslConcat;
-	qslConcat << QLatin1String("b");
-	qslConcat << QLatin1String("i");
-	qslConcat << QLatin1String("u");
-	qslConcat << QLatin1String("a");
-
-	QList<QString> qlNames;
-	QList<QXmlStreamAttributes> qlAttributes;
-
-	while (! reader.atEnd()) {
-		QXmlStreamReader::TokenType tt = reader.readNext();
-		QString name = reader.name().toString();
-		switch (tt) {
-			case QXmlStreamReader::StartDocument:
-			case QXmlStreamReader::EndDocument:
-				break;
-			case QXmlStreamReader::StartElement: {
-					QXmlStreamAttributes a = reader.attributes();
-
-					if (name == QLatin1String("unduplicate"))
-						break;
-
-					if (needclose) {
-						needclose = false;
-
-						if ((a == qlAttributes.last()) && (name == qlNames.last()) && (qslConcat.contains(name))) {
-							changed = true;
-							break;
-						}
-						qlNames.takeLast();
-						qlAttributes.takeLast();
-						writer.writeEndElement();
-					}
-					writer.writeCurrentToken(reader);
-					qlNames.append(name);
-					qlAttributes.append(a);
-				}
-				break;
-			case QXmlStreamReader::EndElement: {
-					if (name == QLatin1String("unduplicate"))
-						break;
-					if (needclose) {
-						qlNames.takeLast();
-						qlAttributes.takeLast();
-						writer.writeCurrentToken(reader);
-					}
-					needclose = true;
-				}
-				break;
-			default:
-				if (needclose) {
-					writer.writeEndElement();
-					needclose = false;
-				}
-				writer.writeCurrentToken(reader);
-		}
-	}
-	if (needclose)
-		writer.writeEndElement();
-	return changed;
-}
-
 void RichTextEditor::richToPlain() {
 	QXmlStreamReader reader(qteRichText->toHtml());
 
@@ -571,7 +374,7 @@ void RichTextEditor::richToPlain() {
 	def.insert(QLatin1String("-qt-block-indent"), QLatin1String("0"));
 	def.insert(QLatin1String("text-indent"), QLatin1String("0px"));
 
-	recurseParse(reader, writer, paragraphs, def);
+	XMLTools::recurseParse(reader, writer, paragraphs, def);
 
 	qsOutput = qsOutput.trimmed();
 
@@ -582,7 +385,7 @@ void RichTextEditor::richToPlain() {
 		QXmlStreamReader r(qsOutput);
 		qsOutput = QString();
 		QXmlStreamWriter w(&qsOutput);
-		changed = unduplicateTags(r, w);
+		changed = XMLTools::unduplicateTags(r, w);
 		qsOutput = qsOutput.trimmed();
 	} while (changed);
 

--- a/src/mumble/XMLTools.cpp
+++ b/src/mumble/XMLTools.cpp
@@ -1,0 +1,203 @@
+// Copyright 2005-2017 The Mumble Developers. All rights reserved.
+// Use of this source code is governed by a BSD-style license
+// that can be found in the LICENSE file at the root of the
+// Mumble source tree or at <https://www.mumble.info/LICENSE>.
+
+#include "XMLTools.h"
+
+#include <QXmlStreamReader>
+#include <QXmlStreamWriter>
+#include <QStringList>
+
+void XMLTools::recurseParse(QXmlStreamReader &reader,
+							QXmlStreamWriter &writer,
+							int &paragraphs,
+							const QMap<QString, QString> &opstyle,
+							const int close,
+							bool ignore) {
+	while (! reader.atEnd()) {
+		QXmlStreamReader::TokenType tt = reader.readNext();
+
+		QXmlStreamAttributes a = reader.attributes();
+		QMap<QString, QString> style;
+		QMap<QString, QString> pstyle = opstyle;
+
+		QStringRef styleref = a.value(QLatin1String("style"));
+		if (!styleref.isNull()) {
+			QString stylestring = styleref.toString();
+			QStringList styles = stylestring.split(QLatin1String(";"), QString::SkipEmptyParts);
+			foreach(QString s, styles) {
+				s = s.simplified();
+				int idx = s.indexOf(QLatin1Char(':'));
+				QString key = (idx > 0) ? s.left(idx).simplified() : s;
+				QString val = (idx > 0) ? s.mid(idx+1).simplified() : QString();
+
+				if (! pstyle.contains(key) || (pstyle.value(key) != val)) {
+					style.insert(key,val);
+					pstyle.insert(key,val);
+				}
+			}
+		}
+
+		switch (tt) {
+			case QXmlStreamReader::StartElement: {
+					QString name = reader.name().toString();
+					int rclose = 1;
+					if (name == QLatin1String("body")) {
+						rclose = 0;
+						ignore = false;
+					} else if (name == QLatin1String("span")) {
+						// Substitute style with <b>, <i> and <u>
+
+						rclose = 0;
+						if (style.value(QLatin1String("font-weight")) == QLatin1String("600")) {
+							writer.writeStartElement(QLatin1String("b"));
+							rclose++;
+							style.remove(QLatin1String("font-weight"));
+						}
+						if (style.value(QLatin1String("font-style")) == QLatin1String("italic")) {
+							writer.writeStartElement(QLatin1String("i"));
+							rclose++;
+							style.remove(QLatin1String("font-style"));
+						}
+						if (style.value(QLatin1String("text-decoration")) == QLatin1String("underline")) {
+							writer.writeStartElement(QLatin1String("u"));
+							rclose++;
+							style.remove(QLatin1String("text-decoration"));
+						}
+						if (! style.isEmpty()) {
+							rclose++;
+							writer.writeStartElement(name);
+
+							QStringList qsl;
+							QMap<QString, QString>::const_iterator i;
+							for (i=style.constBegin(); i != style.constEnd(); ++i) {
+								if (! i.value().isEmpty())
+									qsl << QString::fromLatin1("%1:%2").arg(i.key(), i.value());
+								else
+									qsl << i.key();
+							}
+
+							writer.writeAttribute(QLatin1String("style"), qsl.join(QLatin1String("; ")));
+						}
+					} else if (name == QLatin1String("p")) {
+						paragraphs++;
+						if (paragraphs == 1) {
+							// Ignore first paragraph. If it is styled empty drop its contents (e.g. <br />) too.
+							if (style.value(QLatin1String("-qt-paragraph-type")) == QLatin1String("empty")) {
+								reader.skipCurrentElement();
+								continue;
+							}
+							rclose = 0;
+						}
+						else {
+							rclose = 1;
+							writer.writeStartElement(name);
+
+							if (! style.isEmpty()) {
+								QStringList qsl;
+								QMap<QString, QString>::const_iterator i;
+								for (i=style.constBegin(); i != style.constEnd(); ++i) {
+									if (! i.value().isEmpty())
+										qsl << QString::fromLatin1("%1:%2").arg(i.key(), i.value());
+									else
+										qsl << i.key();
+								}
+
+								writer.writeAttribute(QLatin1String("style"), qsl.join(QLatin1String("; ")));
+							}
+						}
+					} else if (name == QLatin1String("a")) {
+						// Set pstyle to include implicit blue underline.
+						rclose = 1;
+						writer.writeCurrentToken(reader);
+						pstyle.insert(QLatin1String("text-decoration"), QLatin1String("underline"));
+						pstyle.insert(QLatin1String("color"), QLatin1String("#0000ff"));
+					} else if (! ignore) {
+						rclose = 1;
+						writer.writeCurrentToken(reader);
+					}
+
+					recurseParse(reader, writer, paragraphs, pstyle, rclose, ignore);
+					break;
+				}
+			case QXmlStreamReader::EndElement:
+				if (!ignore)
+					for (int i=0;i<close;++i)
+						writer.writeEndElement();
+				return;
+			case QXmlStreamReader::Characters:
+				if (! ignore)
+					writer.writeCharacters(reader.text().toString());
+				break;
+			default:
+				break;
+		}
+	}
+}
+
+bool XMLTools::unduplicateTags(QXmlStreamReader &reader, QXmlStreamWriter &writer) {
+	bool changed = false;
+	bool needclose = false;
+
+	QStringList qslConcat;
+	qslConcat << QLatin1String("b");
+	qslConcat << QLatin1String("i");
+	qslConcat << QLatin1String("u");
+	qslConcat << QLatin1String("a");
+
+	QList<QString> qlNames;
+	QList<QXmlStreamAttributes> qlAttributes;
+
+	while (! reader.atEnd()) {
+		QXmlStreamReader::TokenType tt = reader.readNext();
+		QString name = reader.name().toString();
+		switch (tt) {
+			case QXmlStreamReader::StartDocument:
+			case QXmlStreamReader::EndDocument:
+				break;
+			case QXmlStreamReader::StartElement: {
+					QXmlStreamAttributes a = reader.attributes();
+
+					if (name == QLatin1String("unduplicate"))
+						break;
+
+					if (needclose) {
+						needclose = false;
+
+						if ((a == qlAttributes.last()) && (name == qlNames.last()) && (qslConcat.contains(name))) {
+							changed = true;
+							break;
+						}
+						qlNames.takeLast();
+						qlAttributes.takeLast();
+						writer.writeEndElement();
+					}
+					writer.writeCurrentToken(reader);
+					qlNames.append(name);
+					qlAttributes.append(a);
+				}
+				break;
+			case QXmlStreamReader::EndElement: {
+					if (name == QLatin1String("unduplicate"))
+						break;
+					if (needclose) {
+						qlNames.takeLast();
+						qlAttributes.takeLast();
+						writer.writeCurrentToken(reader);
+					}
+					needclose = true;
+				}
+				break;
+			default:
+				if (needclose) {
+					writer.writeEndElement();
+					needclose = false;
+				}
+				writer.writeCurrentToken(reader);
+		}
+	}
+	if (needclose)
+		writer.writeEndElement();
+	return changed;
+}

--- a/src/mumble/XMLTools.h
+++ b/src/mumble/XMLTools.h
@@ -1,0 +1,35 @@
+// Copyright 2005-2017 The Mumble Developers. All rights reserved.
+// Use of this source code is governed by a BSD-style license
+// that can be found in the LICENSE file at the root of the
+// Mumble source tree or at <https://www.mumble.info/LICENSE>.
+
+#ifndef MUMBLE_MUMBLE_XMLTOOLS_H_
+#define MUMBLE_MUMBLE_XMLTOOLS_H_
+
+#include <QObject>
+#include <QMap>
+
+class QXmlStreamReader;
+class QXmlStreamWriter;
+
+class XMLTools : public QObject {
+		Q_OBJECT
+	public:
+		/* Recursively parse and output XHTML.
+		 * This will drop <head>, <html> etc, take the contents of <body> and strip out unnecesarry styles.
+		 * It will also change <span style=""> into matching <b>, <i> or <u>.
+		 */
+		static void recurseParse(QXmlStreamReader &reader,
+		                         QXmlStreamWriter &writer,
+		                         int &paragraphs,
+		                         const QMap<QString, QString> &opstyle = QMap<QString, QString>(),
+		                         const int close = 0, bool ignore = true);
+
+		/* Iterate XML and remove close-followed-by-open.
+		 * For example, make "<b>bold with </b><b><i>italic</i></b>" into
+		 * "<b>bold with <i>italic</i></b>"
+		 */
+		static bool unduplicateTags(QXmlStreamReader &reader, QXmlStreamWriter &writer);
+};
+
+#endif // XMLTOOLS_H

--- a/src/mumble/XMLTools.h
+++ b/src/mumble/XMLTools.h
@@ -28,6 +28,13 @@ class XMLTools : public QObject {
 		/* Iterate XML and remove close-followed-by-open.
 		 * For example, make "<b>bold with </b><b><i>italic</i></b>" into
 		 * "<b>bold with <i>italic</i></b>"
+		 *
+		 * If the input XML is or may not be valid, a "unduplicate" tag can be used as a root element,
+		 * which will be dropped and not written to writer.
+		 *
+		 * Input XML has to be valid XML.
+		 *
+		 * Works on b, i, u, and a elements.
 		 */
 		static bool unduplicateTags(QXmlStreamReader &reader, QXmlStreamWriter &writer);
 };

--- a/src/mumble/mumble.pro
+++ b/src/mumble/mumble.pro
@@ -139,7 +139,8 @@ HEADERS *= BanEditor.h \
     OverlayPositionableItem.h \
     widgets/MUComboBox.h \
     DeveloperConsole.h \
-    PathListWidget.h
+    PathListWidget.h \
+    XMLTools.h
 
 SOURCES *= BanEditor.cpp \
     ACLEditor.cpp \
@@ -206,7 +207,8 @@ SOURCES *= BanEditor.cpp \
     OverlayPositionableItem.cpp \
     widgets/MUComboBox.cpp \
     DeveloperConsole.cpp \
-    PathListWidget.cpp
+    PathListWidget.cpp \
+    XMLTools.cpp
 
 CONFIG(qtspeech) {
   SOURCES *= TextToSpeech.cpp

--- a/src/tests/TestXMLTools/TestXMLTools.cpp
+++ b/src/tests/TestXMLTools/TestXMLTools.cpp
@@ -1,0 +1,220 @@
+// Copyright 2005-2017 The Mumble Developers. All rights reserved.
+// Use of this source code is governed by a BSD-style license
+// that can be found in the LICENSE file at the root of the
+// Mumble source tree or at <https://www.mumble.info/LICENSE>.
+
+#include <QtCore>
+#include <QtTest>
+#include <QXmlStreamReader>
+#include <QXmlStreamWriter>
+#include <QBuffer>
+
+#include "XMLTools.h"
+
+class TestXMLTools : public QObject {
+		Q_OBJECT
+	public:
+		TestXMLTools(QObject *parent=0);
+	private slots:
+		void testParseExtractBody();
+		void testParseConvertStyleBold();
+		void testParseConvertStyleUnderline();
+		void testParseConvertStyleItalic();
+		void testParseKeepTags();
+		void testParseDropEmptyFirstParagraphs();
+		void testUndupNoopB();
+		void testUndupNoopU();
+		void testUndupNoopI();
+		void testUndupNoopA();
+		void testUndupSimpleB();
+		void testUndupSimpleU();
+		void testUndupSimpleI();
+		void testUndupSimpleA();
+		void testUndupMixedBU();
+		void testUndupMixedBUIA();
+		void testUndupWithSpace();
+		void testUndupAnchor();
+		void testUndupLinkSameHref();
+		void testUndupLinkDifferingHref();
+		void testUndupNoRootUndupTag();
+		void testUndupUndupTagsRemoval();
+		void testUndupStandard();
+//		void testUndupInvalidXml1();
+	private:
+		QString doParse(QString input);
+		QString doUnduplicate(QString input);
+};
+
+TestXMLTools::TestXMLTools(QObject *parent) : QObject(parent) {
+}
+
+QString TestXMLTools::doParse(QString input) {
+	QXmlStreamReader reader(input);
+	QBuffer outBuf;
+	QXmlStreamWriter writerOut(&outBuf);
+	outBuf.open(QIODevice::WriteOnly);
+	int paragraphs = 0;
+	XMLTools::recurseParse(reader, writerOut, paragraphs);
+	outBuf.close();
+	return QString(outBuf.data());
+}
+
+void TestXMLTools::testParseExtractBody() {
+	QCOMPARE(doParse(QLatin1String("<html><head></head><body>one</body></html>")), QLatin1String("one"));
+	QCOMPARE(doParse(QLatin1String("<!DOCTYPE invalid><html><head></head><body>one</body></html>")), QLatin1String("one"));
+	QCOMPARE(doParse(QLatin1String("<html><head><title>ttt</title></head><body>one</body></html>")), QLatin1String("one"));
+	QCOMPARE(doParse(QLatin1String("<html><head></head><body><b>one</b></body></html>")), QLatin1String("<b>one</b>"));
+}
+
+void TestXMLTools::testParseConvertStyleBold() {
+	// The numeric values for font-weight provide a more granular option to specify boldness.
+	// On fonts with two boldness levels (normal and bold) this is fine (100-500, 600-900).
+	// For fonts wiht more boldness levels, the conversion we do here from a weight value to a <b> tag is problematic.
+	// http://doc.qt.io/qt-4.8/stylesheet-reference.html#list-of-property-types
+	// https://developer.mozilla.org/en-US/docs/Web/CSS/font-weight
+	QCOMPARE(doParse(QLatin1String("<html><head></head><body><span style=\"font-weight:100\">one</span></body></html>")), QLatin1String("<span style=\"font-weight:100\">one</span>"));
+	QCOMPARE(doParse(QLatin1String("<html><head></head><body><span style=\"font-weight:100;\">one</span></body></html>")), QLatin1String("<span style=\"font-weight:100\">one</span>"));
+	QCOMPARE(doParse(QLatin1String("<html><head></head><body><span style=\"font-weight:200;\">one</span></body></html>")), QLatin1String("<span style=\"font-weight:200\">one</span>"));
+	QCOMPARE(doParse(QLatin1String("<html><head></head><body><span style=\"font-weight:300;\">one</span></body></html>")), QLatin1String("<span style=\"font-weight:300\">one</span>"));
+	QCOMPARE(doParse(QLatin1String("<html><head></head><body><span style=\"font-weight:400;\">one</span></body></html>")), QLatin1String("<span style=\"font-weight:400\">one</span>"));
+	QCOMPARE(doParse(QLatin1String("<html><head></head><body><span style=\"font-weight:500;\">one</span></body></html>")), QLatin1String("<span style=\"font-weight:500\">one</span>"));
+	QCOMPARE(doParse(QLatin1String("<html><head></head><body><span style=\"font-weight:600\">one</span></body></html>")), QLatin1String("<b>one</b>"));
+	QCOMPARE(doParse(QLatin1String("<html><head></head><body><span style=\"font-weight:600;\">one</span></body></html>")), QLatin1String("<b>one</b>"));
+	QCOMPARE(doParse(QLatin1String("<html><head></head><body><span style=\"font-weight: 600;\">one</span></body></html>")), QLatin1String("<b>one</b>"));
+	QCOMPARE(doParse(QLatin1String("<html><head></head><body><span style=\"font-weight: 600\">one</span></body></html>")), QLatin1String("<b>one</b>"));
+	// These currently fail
+//	QCOMPARE(doParse(QLatin1String("<html><head></head><body><span style=\"font-weight:700;\">one</span></body></html>")), QLatin1String("<b>one</b>"));
+//	QCOMPARE(doParse(QLatin1String("<html><head></head><body><span style=\"font-weight:800;\">one</span></body></html>")), QLatin1String("<b>one</b>"));
+//	QCOMPARE(doParse(QLatin1String("<html><head></head><body><span style=\"font-weight:900;\">one</span></body></html>")), QLatin1String("<b>one</b>"));
+//	QCOMPARE(doParse(QLatin1String("<html><head></head><body><span style=\"font-weight:bold;\">one</span></body></html>")), QLatin1String("<b>one</b>"));
+}
+
+void TestXMLTools::testParseConvertStyleUnderline() {
+		QCOMPARE(doParse(QLatin1String("<html><head></head><body><span style=\"text-decoration:underline\">one</span></body></html>")), QLatin1String("<u>one</u>"));
+		// We only convert spans, so this will not create a u tag
+		QCOMPARE(doParse(QLatin1String("<html><head></head><body><b style=\"text-decoration:underline\">one</b></body></html>")), QLatin1String("<b style=\"text-decoration:underline\">one</b>"));
+}
+
+void TestXMLTools::testParseConvertStyleItalic() {
+		QCOMPARE(doParse(QLatin1String("<html><head></head><body><span style=\"font-style:italic\">one</span></body></html>")), QLatin1String("<i>one</i>"));
+}
+
+void TestXMLTools::testParseKeepTags() {
+	QCOMPARE(doParse(QLatin1String("<html><head></head><body><b>one</b><i>two</i><u>three</u></body></html>")), QLatin1String("<b>one</b><i>two</i><u>three</u>"));
+	QCOMPARE(doParse(QLatin1String("<html><head></head><body><i><b><u>one</u></b></i></body></html>")), QLatin1String("<i><b><u>one</u></b></i>"));
+}
+
+void TestXMLTools::testParseDropEmptyFirstParagraphs() {
+	QCOMPARE(doParse(QLatin1String("<html><head></head><body><p></p><p>one</p></body></html>")), QLatin1String("<p>one</p>"));
+	QCOMPARE(doParse(QLatin1String("<html><head></head><body><p></p><p>one</p><p></p></body></html>")), QLatin1String("<p>one</p><p/>"));
+	QCOMPARE(doParse(QLatin1String("<html><head></head><body><p></p><p></p><p>one</p><p></p></body></html>")), QLatin1String("<p/><p>one</p><p/>"));
+	QCOMPARE(doParse(QLatin1String("<html><head></head><body><p></p><div>one</div></body></html>")), QLatin1String("<div>one</div>"));
+	// <br> would be invalid XML. It is not dropped "correctly".
+//	QCOMPARE(doParse(QLatin1String("<html><head></head><body><p><br></p><p>one</p></body></html>")), QLatin1String("<p>one</p>"));
+	// This is different from what is expected from a comment in the method being tested. It says
+	// contents of empty paragraph would be dropped as well, but the br/space persists.
+	QCOMPARE(doParse(QLatin1String("<html><head></head><body><p><br/></p><p>one</p></body></html>")), QLatin1String("<br/><p>one</p>"));
+	QCOMPARE(doParse(QLatin1String("<html><head></head><body><p><br /></p><p>one</p></body></html>")), QLatin1String("<br/><p>one</p>"));
+	QCOMPARE(doParse(QLatin1String("<html><head></head><body><p> </p><p>one</p></body></html>")), QLatin1String(" <p>one</p>"));
+}
+
+QString TestXMLTools::doUnduplicate(QString input) {
+	QXmlStreamReader reader(input);
+	QBuffer outBuf;
+	QXmlStreamWriter writerOut(&outBuf);
+	outBuf.open(QIODevice::WriteOnly);
+	XMLTools::unduplicateTags(reader, writerOut);
+	outBuf.close();
+	return QString(outBuf.data());
+}
+
+void TestXMLTools::testUndupNoopB() {
+	QCOMPARE(doUnduplicate(QLatin1String("<unduplicate><b>test</b></unduplicate>")), QLatin1String("<b>test</b>"));
+}
+
+void TestXMLTools::testUndupNoopU() {
+	QCOMPARE(doUnduplicate(QLatin1String("<unduplicate><u>test</u></unduplicate>")), QLatin1String("<u>test</u>"));
+}
+
+void TestXMLTools::testUndupNoopI() {
+	QCOMPARE(doUnduplicate(QLatin1String("<unduplicate><i>test</i></unduplicate>")), QLatin1String("<i>test</i>"));
+}
+
+void TestXMLTools::testUndupNoopA() {
+	QCOMPARE(doUnduplicate(QLatin1String("<unduplicate><a>test</a></unduplicate>")), QLatin1String("<a>test</a>"));
+}
+
+void TestXMLTools::testUndupSimpleB() {
+	QCOMPARE(doUnduplicate(QLatin1String("<unduplicate><b>one</b><b>two</b></unduplicate>")), QLatin1String("<b>onetwo</b>"));
+}
+
+void TestXMLTools::testUndupSimpleU() {
+	QCOMPARE(doUnduplicate(QLatin1String("<unduplicate><u>one</u><u>two</u></unduplicate>")), QLatin1String("<u>onetwo</u>"));
+}
+
+void TestXMLTools::testUndupSimpleI() {
+	QCOMPARE(doUnduplicate(QLatin1String("<unduplicate><i>one</i><i>two</i></unduplicate>")), QLatin1String("<i>onetwo</i>"));
+}
+
+void TestXMLTools::testUndupSimpleA() {
+	QCOMPARE(doUnduplicate(QLatin1String("<unduplicate><a>one</a><a>two</a></unduplicate>")), QLatin1String("<a>onetwo</a>"));
+}
+
+void TestXMLTools::testUndupWithSpace() {
+	QCOMPARE(doUnduplicate(QLatin1String("<unduplicate><b>one</b><b> two</b></unduplicate>")), QLatin1String("<b>one two</b>"));
+}
+
+void TestXMLTools::testUndupMixedBU() {
+	QCOMPARE(doUnduplicate(QLatin1String("<unduplicate><b>one</b><u>two</u></unduplicate>")), QLatin1String("<b>one</b><u>two</u>"));
+}
+
+void TestXMLTools::testUndupMixedBUIA() {
+	QCOMPARE(doUnduplicate(QLatin1String("<unduplicate><a><i><b>one</b><u>two</u></i></a></unduplicate>")), QLatin1String("<a><i><b>one</b><u>two</u></i></a>"));
+}
+
+void TestXMLTools::testUndupAnchor() {
+	QCOMPARE(doUnduplicate(QLatin1String("<unduplicate><a>one</a><a>two</a></unduplicate>")), QLatin1String("<a>onetwo</a>"));
+}
+
+void TestXMLTools::testUndupLinkSameHref() {
+	QCOMPARE(doUnduplicate(QLatin1String("<unduplicate><a href=\"#\">one</a><a href=\"#\">two</a></unduplicate>")),
+			 QLatin1String("<a href=\"#\">onetwo</a>"));
+	QCOMPARE(doUnduplicate(QLatin1String("<unduplicate><a href=\"http://example.org\">one</a><a href=\"http://example.org\">two</a></unduplicate>")),
+			 QLatin1String("<a href=\"http://example.org\">onetwo</a>"));
+}
+
+void TestXMLTools::testUndupLinkDifferingHref() {
+	QCOMPARE(doUnduplicate(QLatin1String("<unduplicate><a href=\"#\">one</a><a>two</a></unduplicate>")),
+			 QLatin1String("<a href=\"#\">one</a><a>two</a>"));
+	QCOMPARE(doUnduplicate(QLatin1String("<unduplicate><a href=\"http://example.org\">one</a><a>two</a></unduplicate>")),
+			 QLatin1String("<a href=\"http://example.org\">one</a><a>two</a>"));
+	QCOMPARE(doUnduplicate(QLatin1String("<unduplicate><a>one</a><a href=\"http://example.org\">two</a></unduplicate>")),
+			 QLatin1String("<a>one</a><a href=\"http://example.org\">two</a>"));
+	QCOMPARE(doUnduplicate(QLatin1String("<unduplicate><a href=\"http://example.org/path1\">one</a><a href=\"http://example.org/path2\">two</a></unduplicate>")),
+			 QLatin1String("<a href=\"http://example.org/path1\">one</a><a href=\"http://example.org/path2\">two</a>"));
+}
+
+void TestXMLTools::testUndupNoRootUndupTag() {
+	QCOMPARE(doUnduplicate(QLatin1String("<u><b>one</b><b>two</b></u>")), QLatin1String("<u><b>onetwo</b></u>"));
+	QCOMPARE(doUnduplicate(QLatin1String("<i><b>one</b><b>two</b></i>")), QLatin1String("<i><b>onetwo</b></i>"));
+}
+
+void TestXMLTools::testUndupUndupTagsRemoval() {
+	QCOMPARE(doUnduplicate(QLatin1String("<unduplicate><b>one</b><unduplicate><unduplicate></unduplicate><b>two</b></unduplicate></unduplicate>")), QLatin1String("<b>onetwo</b>"));
+}
+
+void TestXMLTools::testUndupStandard() {
+
+	QCOMPARE(doUnduplicate(QLatin1String("<unduplicate><b>bold with </b><b><i>italic</i></b></unduplicate>")), QLatin1String("<b>bold with <i>italic</i></b>"));
+	QCOMPARE(doUnduplicate(QLatin1String("<unduplicate><b>bold with </b><b><i></i><i>italic</i></b></unduplicate>")), QLatin1String("<b>bold with <i>italic</i></b>"));
+	QCOMPARE(doUnduplicate(QLatin1String("<unduplicate><b>test</b></unduplicate>")), QLatin1String("<b>test</b>"));
+	QCOMPARE(doUnduplicate(QLatin1String("<unduplicate><b>bold with </b><b><i></i><i>italic</i></b></unduplicate>")), QLatin1String("<b>bold with <i>italic</i></b>"));
+}
+
+// Will warn and fail.
+//void TestXMLTools::testUndupInvalidXml1() {
+//	QCOMPARE(doUnduplicate(QLatin1String("<unduplicate><b>bold with <i></b>italic</i></unduplicate>")), QLatin1String("<b>bold with <i>italic</i></b>"));
+//}
+
+QTEST_MAIN(TestXMLTools)
+#include "TestXMLTools.moc"

--- a/src/tests/TestXMLTools/TestXMLTools.pro
+++ b/src/tests/TestXMLTools/TestXMLTools.pro
@@ -3,13 +3,8 @@
 # that can be found in the LICENSE file at the root of the
 # Mumble source tree or at <https://www.mumble.info/LICENSE>.
 
-TEMPLATE = subdirs
+include(../test.pri)
 
-SUBDIRS += \
-	TestCrypt \
-	TestCryptographicHash \
-	TestCryptographicRandom \
-	TestPacketDataStream \
-	TestPasswordGenerator \
-	TestTimer \
-	TestXMLTools
+TARGET = TestXMLTools
+HEADERS = XMLTools.h
+SOURCES = TestXMLTools.cpp XMLTools.cpp

--- a/src/tests/test.pri
+++ b/src/tests/test.pri
@@ -24,7 +24,7 @@ DEFINES += QT_NO_OPENGL
 
 LANGUAGE = C++
 
-VPATH *= ../..
+VPATH *= ../.. ../../murmur ../../mumble
 INCLUDEPATH *= ../.. ../../murmur ../../mumble
 
 # We have to depend on OpenSSL in all tests


### PR DESCRIPTION
Implements #3055

Makes some potential implementation issues visible that should be discussed further/later with potential changes to the implementation.

I had to add the mumble and murmur source folders to the VPATH. It seems existing tests only used files from the src folder (parent of the two).

---

Time spent: > 4 hours