### PR TITLE
Fix #3021: Update cert wizard introductory text

### DIFF
--- a/src/mumble/Cert.ui
+++ b/src/mumble/Cert.ui
@@ -30,11 +30,7 @@
     <item>
      <widget class="QLabel" name="qlIntroText">
       <property name="text">
-       <string>&lt;p&gt;Mumble can use certificates to authenticate with servers. Using certificates avoids passwords, meaning you don't need to disclose any password to the remote site. It also enables very easy user registration.&lt;/p&gt;&lt;p&gt;While Mumble can work without certificates, the majority of servers will expect you to have one.&lt;/p&gt;
-&lt;p&gt;
-It is &lt;b&gt;strongly&lt;/b&gt; recommended that you &lt;a href=&quot;http://mumble.info/certificate.php&quot;&gt;create a trusted certificate&lt;/a&gt;.
-&lt;/p&gt;
-</string>
+       <string>&lt;p&gt;Mumble can use certificates to authenticate with servers. Using certificates avoids passwords, meaning you don't need to disclose any password to the remote site. It also enables very easy user registration and a client side friends list independent of servers.&lt;/p&gt;&lt;p&gt;While Mumble can work without certificates, the majority of servers will expect you to have one.&lt;/p&gt;&lt;p&gt;Creating a new certificate automatically is sufficient for most use cases. But Mumble also supports certificates representing trust in the users ownership of an email address. These certificates are issued by third parties. For more information see our &lt;a href=&quot;http://mumble.info/certificate.php&quot;&gt;user certificate documentation&lt;/a&gt;. &lt;/p&gt;</string>
       </property>
       <property name="wordWrap">
        <bool>true</bool>


### PR DESCRIPTION
Implemented (2 people) consensus of #3021 plus some more improvements.

* Drop strong recommendation of issued email certificates
* Mention friends list independent of servers
* Mention user certificate automatic creation vs third party email
certificates

![image](https://cloud.githubusercontent.com/assets/93181/25862775/8e242a30-34e9-11e7-936c-35d7a471f6d3.png)
