### PR TITLE
src/tests: remove fragile TestTimer tests.

### DIFF
--- a/src/tests/TestTimer/TestTimer.cpp
+++ b/src/tests/TestTimer/TestTimer.cpp
@@ -12,38 +12,8 @@ class TestTimer : public QObject {
 		Q_OBJECT
 	private slots:
 		void resolution();
-		void accuracy();
-		void atomicity();
 		void order();
 };
-
-static quint64 delta64(quint64 a, quint64 b) {
-	if (a > b) {
-		return a - b;
-	}
-	return b - a;
-}
-
-void TestTimer::accuracy() {
-	QTime a;
-	Timer t;
-
-	a.restart();
-	t.restart();
-	do {
-	} while (a.elapsed() < 1000);
-
-	quint64 tElapsedMs = t.elapsed() / 1000ULL;
-	quint64 aElapsedMs = a.elapsed();
-
-	quint64 delta = delta64(tElapsedMs, aElapsedMs);
-
-	qWarning("Timer elapsed time: %llu milliseconds", static_cast<unsigned long long>(tElapsedMs));
-	qWarning("QTime elapsed time: %llu milliseconds", static_cast<unsigned long long>(aElapsedMs));
-	qWarning("Delta: %llu milliseconds", static_cast<unsigned long long >(delta));
-
-	QVERIFY(delta < 10);
-}
 
 // This tests that the timer implemented by the Timer
 // class is a high resolution timer. In this case, we
@@ -76,32 +46,6 @@ void TestTimer::resolution() {
 	if (usecsPerChange >= 5.0f) {
 		QFAIL("Insufficient timer resolution. Got >= 5 usec, expected < 5 usec resolution...");
 	}
-}
-
-void TestTimer::atomicity() {
-	QTime t;
-	Timer a, b;
-
-	a = b;
-
-	quint64 ttime = 0;
-
-	t.restart();
-	do {
-		ttime += a.restart();
-	} while (t.elapsed() < 10);
-
-	quint64 elapsed = b.elapsed();
-
-	// Find the delta between the calculated elapsed time (ttime)
-	// and the elapsed time according to the Timer class (elapsed).
-	quint64 delta = delta64(elapsed, ttime);
-
-	qWarning("Timer class's elapsed time: %llu microseconds", static_cast<unsigned long long>(elapsed));
-	qWarning("Calculated elapsed time: %llu microseconds", static_cast<unsigned long long>(elapsed));
-	qWarning("Delta: %llu microseconds", static_cast<unsigned long long>(delta));
-
-	QVERIFY(delta < 100);
 }
 
 void TestTimer::order() {


### PR DESCRIPTION
This commit drops the tests in TestTimer that depend on comparisons
to QTime to work.

In some environments, such as CI VMs/containers, we don't seem to get
the resolution we desire from QTime.

It's also worth noting that these tests were dormant in the repository
for a long time, until we hooked up 'make check'. So, they were quite
old, and assumptions made when the code was written might not hold up
any longer.

Fixes mumble-voip/mumble#3060