### PR TITLE
OpenSSL include fixes

### DIFF
--- a/src/murmur/murmur_pch.h
+++ b/src/murmur/murmur_pch.h
@@ -105,6 +105,7 @@ extern "C" {
 #include <dns_sd.h>
 #endif
 
+#include <openssl/bn.h>
 #include <openssl/aes.h>
 #include <openssl/rand.h>
 #include <openssl/pem.h>

--- a/src/murmur/murmur_pch.h
+++ b/src/murmur/murmur_pch.h
@@ -105,6 +105,7 @@ extern "C" {
 #include <dns_sd.h>
 #endif
 
+#include <openssl/opensslv.h>
 #include <openssl/bn.h>
 #include <openssl/aes.h>
 #include <openssl/rand.h>


### PR DESCRIPTION
This PR contains two commits that fix some OpenSSL include problems in Murmur.

First, we explicitly include <openssl/bn.h>. We make use of BN_GENCB, but we never explicitly included the header -- instead, we relied on the fact that current versions of OpenSSL seem to include bn.h via the other headers we include. Future versions might not. So let's be explicit here.

Second, we now include opensslv.h to get access to OPENSSL_VERSION. We added OPENSSL_VERSION preprocessor checks to src/murmur/Cert.cpp recently -- but they did not work, because this header was not included. Oops.