### PR TITLE
Remove unnecessary "-ldl" library from Mumble and Murmur project files

### DIFF
--- a/src/mumble/mumble.pro
+++ b/src/mumble/mumble.pro
@@ -506,11 +506,6 @@ unix {
     }
     LIBS *= -lXi
 
-    # For MumbleSSL::qsslSanityCheck()
-    contains(UNAME, Linux) {
-      LIBS *= -ldl
-    }
-
     !CONFIG(no-oss) {
       CONFIG  *= oss
     }

--- a/src/murmur/murmur.pro
+++ b/src/murmur/murmur.pro
@@ -53,9 +53,6 @@ win32 {
 unix {
   contains(UNAME, Linux) {
     LIBS *= -lcap
-
-    # For MumbleSSL::qsslSanityCheck()
-    LIBS *= -ldl
   }
 
   CONFIG(static):!macx {


### PR DESCRIPTION
This library has been added in commit 4aa902ded33072c97cb91052e66da9eab41750f7 and it should have been removed in commit f544524d4c3289bf3341d685277de0e6a6895469.