### PR TITLE
WASAPI, Settings: expose 'wasapi/role' setting to allow users to set WASAPI role.

### DIFF
--- a/src/mumble/Settings.cpp
+++ b/src/mumble/Settings.cpp
@@ -643,6 +643,7 @@ void Settings::load(QSettings* settings_ptr) {
 
 	SAVELOAD(qsWASAPIInput, "wasapi/input");
 	SAVELOAD(qsWASAPIOutput, "wasapi/output");
+	SAVELOAD(qsWASAPIRole, "wasapi/role");
 
 	SAVELOAD(qsALSAInput, "alsa/input");
 	SAVELOAD(qsALSAOutput, "alsa/output");
@@ -972,6 +973,7 @@ void Settings::save() {
 
 	SAVELOAD(qsWASAPIInput, "wasapi/input");
 	SAVELOAD(qsWASAPIOutput, "wasapi/output");
+	SAVELOAD(qsWASAPIRole, "wasapi/role");
 
 	SAVELOAD(qsALSAInput, "alsa/input");
 	SAVELOAD(qsALSAOutput, "alsa/output");

--- a/src/mumble/Settings.h
+++ b/src/mumble/Settings.h
@@ -215,7 +215,30 @@ struct Settings {
 	QList<QVariant> qlASIOspeaker;
 
 	QString qsCoreAudioInput, qsCoreAudioOutput;
+
 	QString qsWASAPIInput, qsWASAPIOutput;
+	/// qsWASAPIRole is configured via 'wasapi/role'.
+	/// It is a string explaining Mumble's purpose for opening
+	/// the audio device. This can be used to force Windows
+	/// to not treat Mumble as a communications program
+	/// (the default).
+	///
+	/// The default is "communications". When this is set,
+	/// Windows treats Mumble as a telephony app, including
+	/// potential audio ducking.
+	///
+	/// Other values include:
+	///
+	///   "console", which should be used for games, system
+	///              notification sounds, and voice commands.
+	///
+	///   "multimedia", which should be used for music, movies,
+	///                 narration, and live music recording.
+	///
+	/// This is practically a direct mapping of the ERole enum
+	/// from Windows: https://msdn.microsoft.com/en-us/library/windows/desktop/dd370842
+	QString qsWASAPIRole;
+
 	QByteArray qbaDXInput, qbaDXOutput;
 
 	bool bExclusiveInput, bExclusiveOutput;

--- a/src/mumble/WASAPI.cpp
+++ b/src/mumble/WASAPI.cpp
@@ -26,6 +26,19 @@ public IUnknown {
 	virtual HRESULT STDMETHODCALLTYPE GetQueryInterface(IAudioSessionEnumerator **) = 0;
 };
 
+/// Convert the configured 'wasapi/role' to an ERole.
+static ERole WASAPIRoleFromSettings() {
+	QString role = g.s.qsWASAPIRole.toLower().trimmed();
+
+	if (role == QLatin1String("console")) {
+		return eConsole;
+	} else if (role == QLatin1String("multimedia")) {
+		return eMultimedia;
+	}
+
+	return eCommunications;
+}
+
 class WASAPIInputRegistrar : public AudioInputRegistrar {
 	public:
 		WASAPIInputRegistrar();
@@ -380,13 +393,13 @@ void WASAPIInput::run() {
 	}
 
 	// Open mic device.
-	pMicDevice = openNamedOrDefaultDevice(g.s.qsWASAPIInput, eCapture, eCommunications);
+	pMicDevice = openNamedOrDefaultDevice(g.s.qsWASAPIInput, eCapture, WASAPIRoleFromSettings());
 	if (!pMicDevice)
 		goto cleanup;
 
 	// Open echo capture device.
 	if (doecho) {
-		pEchoDevice = openNamedOrDefaultDevice(g.s.qsWASAPIOutput, eRender, eCommunications);
+		pEchoDevice = openNamedOrDefaultDevice(g.s.qsWASAPIOutput, eRender, WASAPIRoleFromSettings());
 		if (!pEchoDevice)
 			doecho = false;
 	}
@@ -845,7 +858,7 @@ void WASAPIOutput::run() {
 	}
 
 	// Open the output device.
-	pDevice = openNamedOrDefaultDevice(g.s.qsWASAPIOutput, eRender, eCommunications);
+	pDevice = openNamedOrDefaultDevice(g.s.qsWASAPIOutput, eRender, WASAPIRoleFromSettings());
 	if (!pDevice)
 		goto cleanup;
 


### PR DESCRIPTION
By default, Mumble will open WASAPI devices with the eCommunications role,
since we're a voice chat applicaiton.

Some users have requested this to be configurable.

This commit adds a setting, 'wasapi/role', which is a string that maps
directly to the ERole enum from WASAPI:
https://msdn.microsoft.com/en-us/library/windows/desktop/dd370842

Users can now set 'wasapi/role' to one of 'console', 'multimedia' or
'communications'.

The default is still 'communications'.