### PR TITLE
Initialize siInfo.format

### DIFF
--- a/src/mumble/AudioOutputSample.cpp
+++ b/src/mumble/AudioOutputSample.cpp
@@ -15,6 +15,7 @@ SoundFile::SoundFile(const QString &fname) {
 	siInfo.samplerate = 0;
 	siInfo.sections = 0;
 	siInfo.seekable = 0;
+	siInfo.format = 0;
 
 	sfFile = NULL;
 


### PR DESCRIPTION
siInfo.format was used uninitialized when siInfo was passed to libsndfile
so better initialize it to 0.

==11511== Conditional jump or move depends on uninitialised value(s)
==11511==    at 0x667CB97: psf_open_file (sndfile.c:2935)
==11511==    by 0x1B4527: SoundFile::SoundFile(QString const&) (AudioOutputSample.cpp:52)
==11511==    by 0x1B4BA6: AudioOutputSample::loadSndfile(QString const&) (AudioOutputSample.cpp:188)
==11511==    by 0x1B388E: AudioOutput::playSample(QString const&, bool) (AudioOutput.cpp:222)
==11511==    by 0x190EFB: Log::log(Log::MsgType, QString const&, QString const&, bool) (Log.cpp:486)
==11511==    by 0x1C7627: MainWindow::serverConnected() (MainWindow.cpp:2330)