### PR TITLE
Implement new hostname resolving infrastructure

### DIFF
--- a/src/ServerAddress.cpp
+++ b/src/ServerAddress.cpp
@@ -1,0 +1,42 @@
+// Copyright 2005-2017 The Mumble Developers. All rights reserved.
+// Use of this source code is governed by a BSD-style license
+// that can be found in the LICENSE file at the root of the
+// Mumble source tree or at <https://www.mumble.info/LICENSE>.
+
+#include "murmur_pch.h"
+
+#include "ServerAddress.h"
+
+ServerAddress::ServerAddress()
+	: port(0) {}
+
+ServerAddress::ServerAddress(HostAddress host_, unsigned short port_)
+	: host(host_)
+	, port(port_) {}
+
+bool ServerAddress::isValid() const {
+	return host.isValid() && port != 0;
+}
+
+bool operator==(const ServerAddress &lhs, const ServerAddress &rhs) {
+	return lhs.host == rhs.host && lhs.port == rhs.port;
+}
+
+bool operator!=(const ServerAddress &lhs, const ServerAddress &rhs) {
+	return !operator==(lhs, rhs);
+}
+
+bool operator<(const ServerAddress &lhs, const ServerAddress &rhs) {
+	if (lhs.host < rhs.host) {
+		return true;
+	} else if (lhs.host == rhs.host) {
+		if (lhs.port < lhs.port) {
+			return true;
+		}
+	}
+	return false;
+}
+
+uint qHash(const ServerAddress &key) {
+	return qHash(key.host) ^ uint(key.port);
+}

--- a/src/ServerAddress.h
+++ b/src/ServerAddress.h
@@ -1,0 +1,48 @@
+// Copyright 2005-2017 The Mumble Developers. All rights reserved.
+// Use of this source code is governed by a BSD-style license
+// that can be found in the LICENSE file at the root of the
+// Mumble source tree or at <https://www.mumble.info/LICENSE>.
+
+#ifndef MUMBLE_SERVERADDRESS_H_
+#define MUMBLE_SERVERADDRESS_H_
+
+#include <QtCore/QString>
+
+#include "HostAddress.h"
+
+/// ServerAddress represents a server
+/// address consisting of a HostAddress
+/// and a port.
+struct ServerAddress {
+	HostAddress host;
+	unsigned short port;
+
+	/// Construct a default ServerAddress.
+	/// The default ServerAddress value is considered
+	/// invalid per the |isValid| method.
+	ServerAddress();
+
+	/// Construct a ServerAddress pointing to |host_| and |port_|.
+	ServerAddress(HostAddress host_, unsigned short port_);
+
+	/// Check whether the ServerAddress is valid.
+	/// A ServerAddress is valid if it has a valid |host|
+	/// and if its |port| > 0.
+	bool isValid() const;
+};
+
+/// Check whether the ServerAddresses |lhs| and |rhs| are equal.
+bool operator==(const ServerAddress &lhs, const ServerAddress &rhs);
+
+/// Check whether the ServerAddresses |lhs| and |rhs| are not equal.
+bool operator!=(const ServerAddress &lhs, const ServerAddress &rhs);
+
+/// Check whether ServerAddress |lhs| should be sorted before |rhs|.
+/// This is implemented such that ServerAddress can be used in QMap.
+bool operator<(const ServerAddress &lhs, const ServerAddress &rhs);
+
+/// Implementation of qHash for ServerAddress, such that ServerAddress
+/// can be used as a key in QHash, QMap, etc.
+uint qHash(const ServerAddress &key);
+
+#endif

--- a/src/ServerResolver.h
+++ b/src/ServerResolver.h
@@ -1,0 +1,40 @@
+// Copyright 2005-2017 The Mumble Developers. All rights reserved.
+// Use of this source code is governed by a BSD-style license
+// that can be found in the LICENSE file at the root of the
+// Mumble source tree or at <https://www.mumble.info/LICENSE>.
+
+#ifndef MUMBLE_MUMBLE_SERVERRESOLVER_H_
+#define MUMBLE_MUMBLE_SERVERRESOLVER_H_
+
+#include <QtCore/QObject>
+#include <QtCore/QString>
+#include <QtCore/QList>
+
+#include "Net.h" // for HostAddress
+#include "ServerResolverRecord.h"
+
+class ServerResolverPrivate;
+
+class ServerResolver : public QObject {
+	private:
+		Q_OBJECT
+		Q_DISABLE_COPY(ServerResolver)
+	public:
+		ServerResolver(QObject *parent = NULL);
+
+		QString hostname();
+		quint16 port();
+
+		void resolve(QString hostname, quint16 port);
+		QList<ServerResolverRecord> records();
+
+	signals:
+		/// Resolved is fired once the ServerResolver
+		/// has resolved the server address.
+		void resolved();
+
+	private:
+		ServerResolverPrivate *d;
+};
+
+#endif

--- a/src/ServerResolverRecord.cpp
+++ b/src/ServerResolverRecord.cpp
@@ -1,0 +1,32 @@
+// Copyright 2005-2017 The Mumble Developers. All rights reserved.
+// Use of this source code is governed by a BSD-style license
+// that can be found in the LICENSE file at the root of the
+// Mumble source tree or at <https://www.mumble.info/LICENSE>.
+
+#include "ServerResolverRecord.h"
+
+ServerResolverRecord::ServerResolverRecord() {
+}
+
+ServerResolverRecord::ServerResolverRecord(QString hostname_, quint16 port_, qint64 priority_, QList<HostAddress> addresses_)
+	: m_hostname(hostname_)
+	, m_port(port_)
+	, m_priority(priority_)
+	, m_addresses(addresses_) {
+}
+
+qint64 ServerResolverRecord::priority() {
+	return m_priority;
+}
+
+QString ServerResolverRecord::hostname() {
+	return m_hostname;
+}
+
+quint16 ServerResolverRecord::port() {
+	return m_port;
+}
+
+QList<HostAddress> ServerResolverRecord::addresses() {
+	return m_addresses;
+}

--- a/src/ServerResolverRecord.h
+++ b/src/ServerResolverRecord.h
@@ -1,0 +1,31 @@
+// Copyright 2005-2017 The Mumble Developers. All rights reserved.
+// Use of this source code is governed by a BSD-style license
+// that can be found in the LICENSE file at the root of the
+// Mumble source tree or at <https://www.mumble.info/LICENSE>.
+
+#ifndef MUMBLE_MUMBLE_SERVERRESOLVERRECORD_H_
+#define MUMBLE_MUMBLE_SERVERRESOLVERRECORD_H_
+
+#include <QtCore/QString>
+#include <QtCore/QList>
+
+#include "Net.h" // for HostAddress
+
+class ServerResolverRecord {
+	public:
+		ServerResolverRecord();
+		ServerResolverRecord(QString hostname_, quint16 port_, qint64 priority_, QList<HostAddress> addresses_);
+
+		QString hostname();
+		quint16 port();
+		qint64 priority();
+		QList<HostAddress> addresses();
+
+	protected:
+		QString m_hostname;
+		quint16 m_port;
+		qint64 m_priority;
+		QList<HostAddress> m_addresses;
+};
+
+#endif

--- a/src/ServerResolver_nosrv.cpp
+++ b/src/ServerResolver_nosrv.cpp
@@ -1,0 +1,102 @@
+// Copyright 2005-2017 The Mumble Developers. All rights reserved.
+// Use of this source code is governed by a BSD-style license
+// that can be found in the LICENSE file at the root of the
+// Mumble source tree or at <https://www.mumble.info/LICENSE>.
+
+#include "murmur_pch.h"
+
+#include "ServerResolver.h"
+
+#include <QtNetwork/QHostInfo>
+
+class ServerResolverPrivate : public QObject {
+	private:
+		Q_OBJECT
+		Q_DISABLE_COPY(ServerResolverPrivate)
+	public:
+		ServerResolverPrivate(QObject *parent);
+
+		void resolve(QString hostname, quint16 port);
+		QList<ServerResolverRecord> records();
+
+		QString m_origHostname;
+		quint16 m_origPort;
+
+		QList<ServerResolverRecord> m_resolved;
+
+	signals:
+		void resolved();
+
+	public slots:
+		void hostResolved(QHostInfo hostInfo);
+};
+
+ServerResolverPrivate::ServerResolverPrivate(QObject *parent)
+	: QObject(parent)
+	, m_origPort(0) {
+}
+
+void ServerResolverPrivate::resolve(QString hostname, quint16 port) {
+	m_origHostname = hostname;
+	m_origPort = port;
+
+	QHostInfo::lookupHost(hostname, this, SLOT(hostResolved(QHostInfo)));
+}
+
+QList<ServerResolverRecord> ServerResolverPrivate::records() {
+	return m_resolved;
+}
+
+void ServerResolverPrivate::hostResolved(QHostInfo hostInfo) {
+	if (hostInfo.error() == QHostInfo::NoError) {
+		QList<QHostAddress> resolvedAddresses = hostInfo.addresses();
+		
+		// Convert QHostAddress -> HostAddress.
+		QList<HostAddress> addresses;
+		foreach (QHostAddress ha, resolvedAddresses) {
+			addresses << HostAddress(ha);
+		}
+
+		m_resolved << ServerResolverRecord(m_origHostname, m_origPort, 0, addresses);
+	}
+
+	emit resolved();
+}
+
+ServerResolver::ServerResolver(QObject *parent)
+	: QObject(parent) {
+
+	d = new ServerResolverPrivate(this);
+}
+
+QString ServerResolver::hostname() {
+	if (d) {
+		return d->m_origHostname;
+	}
+
+	return QString();
+}
+
+quint16 ServerResolver::port() {
+	if (d) {
+		return d->m_origPort;
+	}
+
+	return 0;
+}
+
+void ServerResolver::resolve(QString hostname, quint16 port) {
+	if (d) {
+		connect(d, SIGNAL(resolved()), this, SIGNAL(resolved()));
+		d->resolve(hostname, port);
+	}
+}
+
+QList<ServerResolverRecord> ServerResolver::records() {
+	if (d) {
+		return d->records();
+	}
+	return QList<ServerResolverRecord>();
+}
+
+#include "ServerResolver_nosrv.moc"

--- a/src/ServerResolver_qt5.cpp
+++ b/src/ServerResolver_qt5.cpp
@@ -1,0 +1,162 @@
+// Copyright 2005-2017 The Mumble Developers. All rights reserved.
+// Use of this source code is governed by a BSD-style license
+// that can be found in the LICENSE file at the root of the
+// Mumble source tree or at <https://www.mumble.info/LICENSE>.
+
+#include "murmur_pch.h"
+
+#include "ServerResolver.h"
+
+#include <QtNetwork/QDnsLookup>
+#include <QtNetwork/QHostInfo>
+
+static qint64 normalizeSrvPriority(quint16 priority, quint16 weight) {
+	return static_cast<qint64>((65535U * priority) + weight);
+}
+
+class ServerResolverPrivate : public QObject {
+	private:
+		Q_OBJECT
+		Q_DISABLE_COPY(ServerResolverPrivate)
+	public:
+		ServerResolverPrivate(QObject *parent);
+
+		void resolve(QString hostname, quint16 port);
+		QList<ServerResolverRecord> records();
+
+		QString m_origHostname;
+		quint16 m_origPort;
+
+		QList<QDnsServiceRecord> m_srvQueue;
+		QMap<int, int> m_hostInfoIdToIndexMap;
+		int m_srvQueueRemain;
+
+		QList<ServerResolverRecord> m_resolved;
+
+	signals:
+		void resolved();
+
+	public slots:
+		void srvResolved();
+		void hostResolved(QHostInfo hostInfo);
+		void hostFallbackResolved(QHostInfo hostInfo);
+};
+
+ServerResolverPrivate::ServerResolverPrivate(QObject *parent)
+	: QObject(parent)
+	, m_origPort(0)
+	, m_srvQueueRemain(0) {
+}
+
+void ServerResolverPrivate::resolve(QString hostname, quint16 port) {
+	m_origHostname = hostname;
+	m_origPort = port;
+
+	QDnsLookup *resolver = new QDnsLookup(this);
+	connect(resolver, SIGNAL(finished()), this, SLOT(srvResolved()));
+	resolver->setType(QDnsLookup::SRV);
+
+	resolver->setName(QLatin1String("_mumble._tcp.") + hostname);
+	resolver->lookup();
+}
+
+QList<ServerResolverRecord> ServerResolverPrivate::records() {
+	return m_resolved;
+}
+
+void ServerResolverPrivate::srvResolved() {
+	QDnsLookup *resolver = qobject_cast<QDnsLookup *>(sender());
+
+	if (resolver->error() == QDnsLookup::NoError) {
+		m_srvQueue = resolver->serviceRecords();
+		m_srvQueueRemain = m_srvQueue.count();
+
+		for (int i = 0; i < m_srvQueue.count(); i++) {
+			QDnsServiceRecord record = m_srvQueue.at(i);
+			int hostInfoId = QHostInfo::lookupHost(record.target(), this, SLOT(hostResolved(QHostInfo)));
+			m_hostInfoIdToIndexMap[hostInfoId] = i;
+		}
+	} else {
+		QHostInfo::lookupHost(m_origHostname, this, SLOT(hostFallbackResolved(QHostInfo)));
+	}
+
+	delete resolver;
+}
+
+void ServerResolverPrivate::hostResolved(QHostInfo hostInfo) {
+	int lookupId = hostInfo.lookupId();
+	int idx = m_hostInfoIdToIndexMap[lookupId];
+	QDnsServiceRecord record = m_srvQueue.at(idx);
+
+	if (hostInfo.error() == QHostInfo::NoError) {
+		QList<QHostAddress> resolvedAddresses = hostInfo.addresses();
+		
+		// Convert QHostAddress -> HostAddress.
+		QList<HostAddress> addresses;
+		foreach (QHostAddress ha, resolvedAddresses) {
+			addresses << HostAddress(ha);
+		}
+
+		qint64 priority = normalizeSrvPriority(record.priority(), record.weight());
+		m_resolved << ServerResolverRecord(m_origHostname, m_origPort, priority, addresses);
+	}
+
+	m_srvQueueRemain -= 1;
+	if (m_srvQueueRemain == 0) {
+		emit resolved();
+	}
+}
+
+void ServerResolverPrivate::hostFallbackResolved(QHostInfo hostInfo) {
+	if (hostInfo.error() == QHostInfo::NoError) {
+		QList<QHostAddress> resolvedAddresses = hostInfo.addresses();
+		
+		// Convert QHostAddress -> HostAddress.
+		QList<HostAddress> addresses;
+		foreach (QHostAddress ha, resolvedAddresses) {
+			addresses << HostAddress(ha);
+		}
+
+		m_resolved << ServerResolverRecord(m_origHostname, m_origPort, 0, addresses);
+	}
+
+	emit resolved();
+}
+
+ServerResolver::ServerResolver(QObject *parent)
+	: QObject(parent) {
+
+	d = new ServerResolverPrivate(this);
+}
+
+QString ServerResolver::hostname() {
+	if (d) {
+		return d->m_origHostname;
+	}
+
+	return QString();
+}
+
+quint16 ServerResolver::port() {
+	if (d) {
+		return d->m_origPort;
+	}
+
+	return 0;
+}
+
+void ServerResolver::resolve(QString hostname, quint16 port) {
+	if (d) {
+		connect(d, SIGNAL(resolved()), this, SIGNAL(resolved()));
+		d->resolve(hostname, port);
+	}
+}
+
+QList<ServerResolverRecord> ServerResolver::records() {
+	if (d) {
+		return d->records();
+	}
+	return QList<ServerResolverRecord>();
+}
+
+#include "ServerResolver_qt5.moc"

--- a/src/UnresolvedServerAddress.cpp
+++ b/src/UnresolvedServerAddress.cpp
@@ -1,0 +1,43 @@
+// Copyright 2005-2017 The Mumble Developers. All rights reserved.
+// Use of this source code is governed by a BSD-style license
+// that can be found in the LICENSE file at the root of the
+// Mumble source tree or at <https://www.mumble.info/LICENSE>.
+
+#include "murmur_pch.h"
+
+#include "UnresolvedServerAddress.h"
+
+UnresolvedServerAddress::UnresolvedServerAddress()
+	: port(0) {}
+
+UnresolvedServerAddress::UnresolvedServerAddress(QString hostname_, unsigned short port_)
+	: hostname(hostname_.toLower())
+	, port(port_) {}
+
+bool UnresolvedServerAddress::isValid() const {
+	return !hostname.isEmpty() && port != 0;
+}
+
+bool operator==(const UnresolvedServerAddress &lhs, const UnresolvedServerAddress &rhs) {
+	return lhs.hostname == rhs.hostname && lhs.port == rhs.port;
+}
+
+bool operator!=(const UnresolvedServerAddress &lhs, const UnresolvedServerAddress &rhs) {
+	return !operator==(lhs, rhs);
+}
+
+bool operator<(const UnresolvedServerAddress &lhs, const UnresolvedServerAddress &rhs) {
+	if (lhs.hostname < rhs.hostname) {
+		return true;
+	}
+	if (lhs.hostname == rhs.hostname) {
+		if (lhs.port < rhs.port) {
+			return true;
+		}
+	}
+	return false;
+}
+
+uint qHash(const UnresolvedServerAddress &key) {
+	return qHash(key.hostname) ^ uint(key.port);
+}

--- a/src/UnresolvedServerAddress.h
+++ b/src/UnresolvedServerAddress.h
@@ -1,0 +1,47 @@
+// Copyright 2005-2017 The Mumble Developers. All rights reserved.
+// Use of this source code is governed by a BSD-style license
+// that can be found in the LICENSE file at the root of the
+// Mumble source tree or at <https://www.mumble.info/LICENSE>.
+
+#ifndef MUMBLE_UNRESOLVEDSERVERADDRESS_H_
+#define MUMBLE_UNRESOLVEDSERVERADDRESS_H_
+
+#include <QtCore/QString>
+
+/// UnresolvedServerAddress represents a
+/// server address consisting of a hostname
+/// and a port.
+struct UnresolvedServerAddress {
+	QString hostname;
+	unsigned short port;
+
+	/// Construct a default UnresolvedServerAddress.
+	/// The default UnresolvedServerAddress value is considered
+	/// invalid per the |isValid| method.
+	UnresolvedServerAddress();
+
+	/// Construct a UnresolvedServerAddress pointing to |hostname| and |port|.
+	/// The passed-in hostname is normalized to lowercase.
+	UnresolvedServerAddress(QString hostname, unsigned short port);
+
+	/// Check whether the UnresolvedServerAddress is valid.
+	/// An UnresolvedServerAddress is valid if it has a non-empty
+	/// |hostname| and if its |port| > 0.
+	bool isValid() const;
+};
+
+/// Check whether |lhs| and |rhs| are equal.
+bool operator==(const UnresolvedServerAddress &lhs, const UnresolvedServerAddress &rhs);
+
+/// Check whether |lhs| and |rhs| are not equal.
+bool operator!=(const UnresolvedServerAddress &lhs, const UnresolvedServerAddress &rhs);
+
+/// Check whether |lhs| is less than |rhs|.
+/// This is implemented such that UnresolvedServerAddress can be used in QMap.
+bool operator<(const UnresolvedServerAddress &lhs, const UnresolvedServerAddress &rhs);
+
+/// Implementation of qHash for UnresolvedServerAddress, such that
+/// UnresolvedServerAddress can be used as a key in QHash, QMap, etc.
+uint qHash(const UnresolvedServerAddress &key);
+
+#endif

--- a/src/mumble.pri
+++ b/src/mumble.pri
@@ -14,9 +14,19 @@ CONFIG		+= qt thread debug_and_release warn_on
 DEFINES		*= MUMBLE_VERSION_STRING=$$VERSION
 INCLUDEPATH	+= $$PWD . ../mumble_proto
 VPATH		+= $$PWD
-HEADERS		*= ACL.h Channel.h CryptState.h Connection.h Group.h HTMLFilter.h User.h Net.h OSInfo.h Timer.h SSL.h Version.h SSLCipherInfo.h SSLCipherInfoTable.h licenses.h License.h LogEmitter.h CryptographicHash.h CryptographicRandom.h PasswordGenerator.h ByteSwap.h HostAddress.cpp Ban.h EnvUtils.h UnresolvedServerAddress.h ServerAddress.h
-SOURCES 	*= ACL.cpp Group.cpp Channel.cpp Connection.cpp HTMLFilter.cpp User.cpp Timer.cpp CryptState.cpp OSInfo.cpp SSL.cpp Version.cpp SSLCipherInfo.cpp License.cpp LogEmitter.cpp CryptographicHash.cpp CryptographicRandom.cpp PasswordGenerator.cpp HostAddress.cpp Ban.cpp EnvUtils.cpp UnresolvedServerAddress.cpp ServerAddress.cpp
+HEADERS		*= ACL.h Channel.h CryptState.h Connection.h Group.h HTMLFilter.h User.h Net.h OSInfo.h Timer.h SSL.h Version.h SSLCipherInfo.h SSLCipherInfoTable.h licenses.h License.h LogEmitter.h CryptographicHash.h CryptographicRandom.h PasswordGenerator.h ByteSwap.h HostAddress.cpp Ban.h EnvUtils.h UnresolvedServerAddress.h ServerAddress.h ServerResolver.h ServerResolverRecord.h
+SOURCES 	*= ACL.cpp Group.cpp Channel.cpp Connection.cpp HTMLFilter.cpp User.cpp Timer.cpp CryptState.cpp OSInfo.cpp SSL.cpp Version.cpp SSLCipherInfo.cpp License.cpp LogEmitter.cpp CryptographicHash.cpp CryptographicRandom.cpp PasswordGenerator.cpp HostAddress.cpp Ban.cpp EnvUtils.cpp UnresolvedServerAddress.cpp ServerAddress.cpp ServerResolver_qt5.cpp ServerResolverRecord.cpp
 LIBS		*= -lmumble_proto
+
+equals(QT_MAJOR_VERSION, 4) {
+	CONFIG *= no-srv
+}
+
+CONFIG(no-srv) {
+	DEFINES += USE_NO_SRV
+	SOURCES -= ServerResolver_qt5.cpp
+	SOURCES *= ServerResolver_nosrv.cpp
+}
 
 # Add arc4random_uniform
 INCLUDEPATH *= ../../3rdparty/arc4random-src

--- a/src/mumble.pri
+++ b/src/mumble.pri
@@ -14,8 +14,8 @@ CONFIG		+= qt thread debug_and_release warn_on
 DEFINES		*= MUMBLE_VERSION_STRING=$$VERSION
 INCLUDEPATH	+= $$PWD . ../mumble_proto
 VPATH		+= $$PWD
-HEADERS		*= ACL.h Channel.h CryptState.h Connection.h Group.h HTMLFilter.h User.h Net.h OSInfo.h Timer.h SSL.h Version.h SSLCipherInfo.h SSLCipherInfoTable.h licenses.h License.h LogEmitter.h CryptographicHash.h CryptographicRandom.h PasswordGenerator.h ByteSwap.h HostAddress.cpp Ban.h EnvUtils.h UnresolvedServerAddress.h
-SOURCES 	*= ACL.cpp Group.cpp Channel.cpp Connection.cpp HTMLFilter.cpp User.cpp Timer.cpp CryptState.cpp OSInfo.cpp SSL.cpp Version.cpp SSLCipherInfo.cpp License.cpp LogEmitter.cpp CryptographicHash.cpp CryptographicRandom.cpp PasswordGenerator.cpp HostAddress.cpp Ban.cpp EnvUtils.cpp UnresolvedServerAddress.cpp
+HEADERS		*= ACL.h Channel.h CryptState.h Connection.h Group.h HTMLFilter.h User.h Net.h OSInfo.h Timer.h SSL.h Version.h SSLCipherInfo.h SSLCipherInfoTable.h licenses.h License.h LogEmitter.h CryptographicHash.h CryptographicRandom.h PasswordGenerator.h ByteSwap.h HostAddress.cpp Ban.h EnvUtils.h UnresolvedServerAddress.h ServerAddress.h
+SOURCES 	*= ACL.cpp Group.cpp Channel.cpp Connection.cpp HTMLFilter.cpp User.cpp Timer.cpp CryptState.cpp OSInfo.cpp SSL.cpp Version.cpp SSLCipherInfo.cpp License.cpp LogEmitter.cpp CryptographicHash.cpp CryptographicRandom.cpp PasswordGenerator.cpp HostAddress.cpp Ban.cpp EnvUtils.cpp UnresolvedServerAddress.cpp ServerAddress.cpp
 LIBS		*= -lmumble_proto
 
 # Add arc4random_uniform

--- a/src/mumble.pri
+++ b/src/mumble.pri
@@ -14,8 +14,8 @@ CONFIG		+= qt thread debug_and_release warn_on
 DEFINES		*= MUMBLE_VERSION_STRING=$$VERSION
 INCLUDEPATH	+= $$PWD . ../mumble_proto
 VPATH		+= $$PWD
-HEADERS		*= ACL.h Channel.h CryptState.h Connection.h Group.h HTMLFilter.h User.h Net.h OSInfo.h Timer.h SSL.h Version.h SSLCipherInfo.h SSLCipherInfoTable.h licenses.h License.h LogEmitter.h CryptographicHash.h CryptographicRandom.h PasswordGenerator.h ByteSwap.h HostAddress.cpp Ban.h EnvUtils.h
-SOURCES 	*= ACL.cpp Group.cpp Channel.cpp Connection.cpp HTMLFilter.cpp User.cpp Timer.cpp CryptState.cpp OSInfo.cpp SSL.cpp Version.cpp SSLCipherInfo.cpp License.cpp LogEmitter.cpp CryptographicHash.cpp CryptographicRandom.cpp PasswordGenerator.cpp HostAddress.cpp Ban.cpp EnvUtils.cpp
+HEADERS		*= ACL.h Channel.h CryptState.h Connection.h Group.h HTMLFilter.h User.h Net.h OSInfo.h Timer.h SSL.h Version.h SSLCipherInfo.h SSLCipherInfoTable.h licenses.h License.h LogEmitter.h CryptographicHash.h CryptographicRandom.h PasswordGenerator.h ByteSwap.h HostAddress.cpp Ban.h EnvUtils.h UnresolvedServerAddress.h
+SOURCES 	*= ACL.cpp Group.cpp Channel.cpp Connection.cpp HTMLFilter.cpp User.cpp Timer.cpp CryptState.cpp OSInfo.cpp SSL.cpp Version.cpp SSLCipherInfo.cpp License.cpp LogEmitter.cpp CryptographicHash.cpp CryptographicRandom.cpp PasswordGenerator.cpp HostAddress.cpp Ban.cpp EnvUtils.cpp UnresolvedServerAddress.cpp
 LIBS		*= -lmumble_proto
 
 # Add arc4random_uniform

--- a/src/mumble/ConnectDialog.cpp
+++ b/src/mumble/ConnectDialog.cpp
@@ -992,7 +992,7 @@ ConnectDialog::~ConnectDialog() {
 
 	foreach(ServerItem *si, qlItems) {
 		if (si->uiPing)
-			qmPingCache.insert(QPair<QString, unsigned short>(si->qsHostname, si->usPort), si->uiPing);
+			qmPingCache.insert(UnresolvedServerAddress(si->qsHostname, si->usPort), si->uiPing);
 
 		if (si->itType != ServerItem::FavoriteType)
 			continue;
@@ -1633,7 +1633,7 @@ void ConnectDialog::udpReply() {
 					si->uiBandwidth = qFromBigEndian(ping[5]);
 
 					if (! si->uiPingSort)
-						si->uiPingSort = qmPingCache.value(QPair<QString, unsigned short>(si->qsHostname, si->usPort));
+						si->uiPingSort = qmPingCache.value(UnresolvedServerAddress(si->qsHostname, si->usPort));
 
 					si->setDatas(static_cast<double>(elapsed), users, maxusers);
 					si->hideCheck();

--- a/src/mumble/ConnectDialog.cpp
+++ b/src/mumble/ConnectDialog.cpp
@@ -1480,7 +1480,7 @@ void ConnectDialog::startDns(ServerItem *si) {
 
 	if (! si->qlAddresses.isEmpty()) {
 		foreach(const QHostAddress &qha, si->qlAddresses) {
-			qhPings[qpAddress(HostAddress(qha), si->usPort)].insert(si);
+			qhPings[ServerAddress(HostAddress(qha), si->usPort)].insert(si);
 		}
 		return;
 	}
@@ -1510,7 +1510,7 @@ void ConnectDialog::stopDns(ServerItem *si) {
 	}
 
 	foreach(const QHostAddress &qha, si->qlAddresses) {
-		qpAddress addr(HostAddress(qha), si->usPort);
+		ServerAddress addr(HostAddress(qha), si->usPort);
 		if (qhPings.contains(addr)) {
 			qhPings[addr].remove(si);
 			if (qhPings[addr].isEmpty()) {
@@ -1541,12 +1541,12 @@ void ConnectDialog::lookedUp(QHostInfo info) {
 	qlDNSLookup.removeAll(host);
 	qhDNSCache.insert(host, info.addresses());
 
-	QSet<qpAddress> qs;
+	QSet<ServerAddress> qs;
 
 	foreach(ServerItem *si, qhDNSWait[host]) {
 		si->qlAddresses = info.addresses();
 		foreach(const QHostAddress &qha, info.addresses()) {
-			qpAddress addr(HostAddress(qha), si->usPort);
+			ServerAddress addr(HostAddress(qha), si->usPort);
 			qs.insert(addr);
 			qhPings[addr].insert(si);
 		}
@@ -1561,8 +1561,8 @@ void ConnectDialog::lookedUp(QHostInfo info) {
 	qhDNSWait.remove(host);
 
 	if (bAllowPing) {
-		foreach(const qpAddress &addr, qs) {
-			sendPing(addr.first.toAddress(), addr.second);
+		foreach(const ServerAddress &addr, qs) {
+			sendPing(addr.host.toAddress(), addr.port);
 		}
 	}
 }
@@ -1570,7 +1570,7 @@ void ConnectDialog::lookedUp(QHostInfo info) {
 void ConnectDialog::sendPing(const QHostAddress &host, unsigned short port) {
 	char blob[16];
 
-	qpAddress addr(HostAddress(host), port);
+	ServerAddress addr(HostAddress(host), port);
 
 	quint64 uiRand;
 	if (qhPingRand.contains(addr)) {
@@ -1610,7 +1610,7 @@ void ConnectDialog::udpReply() {
 			if (host.scopeId() == QLatin1String("0"))
 				host.setScopeId(QLatin1String(""));
 
-			qpAddress address(HostAddress(host), port);
+			ServerAddress address(HostAddress(host), port);
 
 			if (qhPings.contains(address)) {
 				quint32 *ping = reinterpret_cast<quint32 *>(blob+4);

--- a/src/mumble/ConnectDialog.h
+++ b/src/mumble/ConnectDialog.h
@@ -34,6 +34,7 @@
 #include "Net.h"
 #include "HostAddress.h"
 #include "Timer.h"
+#include "UnresolvedServerAddress.h"
 #include "ServerAddress.h"
 
 struct FavoriteServer;
@@ -251,7 +252,7 @@ class ConnectDialog : public QDialog, public Ui::ConnectDialog {
 		QHash<ServerAddress, quint64> qhPingRand;
 		QHash<ServerAddress, QSet<ServerItem *> > qhPings;
 
-		QMap<QPair<QString, unsigned short>, unsigned int> qmPingCache;
+		QMap<UnresolvedServerAddress, unsigned int> qmPingCache;
 
 		bool bIPv4;
 		bool bIPv6;

--- a/src/mumble/ConnectDialog.h
+++ b/src/mumble/ConnectDialog.h
@@ -244,10 +244,10 @@ class ConnectDialog : public QDialog, public Ui::ConnectDialog {
 
 		ServerItem *siAutoConnect;
 
-		QList<QString> qlDNSLookup;
-		QSet<QString> qsDNSActive;
-		QHash<QString, QSet<ServerItem *> > qhDNSWait;
-		QHash<QString, QList<ServerAddress> > qhDNSCache;
+		QList<UnresolvedServerAddress> qlDNSLookup;
+		QSet<UnresolvedServerAddress> qsDNSActive;
+		QHash<UnresolvedServerAddress, QSet<ServerItem *> > qhDNSWait;
+		QHash<UnresolvedServerAddress, QList<ServerAddress> > qhDNSCache;
 
 		QHash<ServerAddress, quint64> qhPingRand;
 		QHash<ServerAddress, QSet<ServerItem *> > qhPings;
@@ -290,7 +290,7 @@ class ConnectDialog : public QDialog, public Ui::ConnectDialog {
 		void fetched(QByteArray xmlData, QUrl, QMap<QString, QString>);
 
 		void udpReply();
-		void lookedUp(QHostInfo);
+		void lookedUp();
 		void timeTick();
 
 		void on_qaFavoriteAdd_triggered();

--- a/src/mumble/ConnectDialog.h
+++ b/src/mumble/ConnectDialog.h
@@ -34,11 +34,10 @@
 #include "Net.h"
 #include "HostAddress.h"
 #include "Timer.h"
+#include "ServerAddress.h"
 
 struct FavoriteServer;
 class QUdpSocket;
-
-typedef QPair<HostAddress, unsigned short> qpAddress;
 
 struct PublicInfo {
 	QString qsName;
@@ -247,8 +246,8 @@ class ConnectDialog : public QDialog, public Ui::ConnectDialog {
 		QHash<QString, QSet<ServerItem *> > qhDNSWait;
 		QHash<QString, QList<QHostAddress> > qhDNSCache;
 
-		QHash<qpAddress, quint64> qhPingRand;
-		QHash<qpAddress, QSet<ServerItem *> > qhPings;
+		QHash<ServerAddress, quint64> qhPingRand;
+		QHash<ServerAddress, QSet<ServerItem *> > qhPings;
 
 		QMap<QPair<QString, unsigned short>, unsigned int> qmPingCache;
 

--- a/src/mumble/ConnectDialog.h
+++ b/src/mumble/ConnectDialog.h
@@ -144,7 +144,9 @@ class ServerItem : public QTreeWidgetItem, public PingStats {
 		QString qsBonjourHost;
 		BonjourRecord brRecord;
 
-		QList<QHostAddress> qlAddresses;
+		/// Contains the resolved addresses for
+		/// this ServerItem.
+		QList<ServerAddress> qlAddresses;
 
 		ItemType itType;
 
@@ -244,7 +246,7 @@ class ConnectDialog : public QDialog, public Ui::ConnectDialog {
 		QList<QString> qlDNSLookup;
 		QSet<QString> qsDNSActive;
 		QHash<QString, QSet<ServerItem *> > qhDNSWait;
-		QHash<QString, QList<QHostAddress> > qhDNSCache;
+		QHash<QString, QList<ServerAddress> > qhDNSCache;
 
 		QHash<ServerAddress, quint64> qhPingRand;
 		QHash<ServerAddress, QSet<ServerItem *> > qhPings;

--- a/src/mumble/Database.cpp
+++ b/src/mumble/Database.cpp
@@ -300,21 +300,21 @@ void Database::setChannelFiltered(const QByteArray &server_cert_digest, const in
 	execQueryAndLogFailure(query);
 }
 
-QMap<QPair<QString, unsigned short>, unsigned int> Database::getPingCache() {
+QMap<UnresolvedServerAddress, unsigned int> Database::getPingCache() {
 	QSqlQuery query;
-	QMap<QPair<QString, unsigned short>, unsigned int> map;
+	QMap<UnresolvedServerAddress, unsigned int> map;
 
 	query.prepare(QLatin1String("SELECT `hostname`, `port`, `ping` FROM `pingcache`"));
 	execQueryAndLogFailure(query);
 	while (query.next()) {
-		map.insert(QPair<QString, unsigned short>(query.value(0).toString(), static_cast<unsigned short>(query.value(1).toUInt())), query.value(2).toUInt());
+		map.insert(UnresolvedServerAddress(query.value(0).toString(), static_cast<unsigned short>(query.value(1).toUInt())), query.value(2).toUInt());
 	}
 	return map;
 }
 
-void Database::setPingCache(const QMap<QPair<QString, unsigned short>, unsigned int> &map) {
+void Database::setPingCache(const QMap<UnresolvedServerAddress, unsigned int> &map) {
 	QSqlQuery query;
-	QMap<QPair<QString, unsigned short>, unsigned int>::const_iterator i;
+	QMap<UnresolvedServerAddress, unsigned int>::const_iterator i;
 
 	QSqlDatabase::database().transaction();
 
@@ -323,8 +323,8 @@ void Database::setPingCache(const QMap<QPair<QString, unsigned short>, unsigned 
 
 	query.prepare(QLatin1String("REPLACE INTO `pingcache` (`hostname`, `port`, `ping`) VALUES (?,?,?)"));
 	for (i = map.constBegin(); i != map.constEnd(); ++i) {
-		query.addBindValue(i.key().first);
-		query.addBindValue(i.key().second);
+		query.addBindValue(i.key().hostname);
+		query.addBindValue(i.key().port);
 		query.addBindValue(i.value());
 		execQueryAndLogFailure(query);
 	}

--- a/src/mumble/Database.h
+++ b/src/mumble/Database.h
@@ -7,6 +7,7 @@
 #define MUMBLE_MUMBLE_DATABASE_H_
 
 #include "Settings.h"
+#include "UnresolvedServerAddress.h"
 
 struct FavoriteServer {
 	QString qsName;
@@ -41,8 +42,8 @@ class Database : public QObject {
 		static bool isChannelFiltered(const QByteArray &server_cert_digest, const int channel_id);
 		static void setChannelFiltered(const QByteArray &server_cert_digest, const int channel_id, bool hidden);
 
-		static QMap<QPair<QString, unsigned short>, unsigned int> getPingCache();
-		static void setPingCache(const QMap<QPair<QString, unsigned short>, unsigned int> &cache);
+		static QMap<UnresolvedServerAddress, unsigned int> getPingCache();
+		static void setPingCache(const QMap<UnresolvedServerAddress, unsigned int> &cache);
 
 		static bool seenComment(const QString &hash, const QByteArray &commenthash);
 		static void setSeenComment(const QString &hash, const QByteArray &commenthash);

--- a/src/mumble/ServerHandler.cpp
+++ b/src/mumble/ServerHandler.cpp
@@ -260,6 +260,7 @@ void ServerHandler::run() {
 	qbaDigest = QByteArray();
 	bStrong = true;
 	qtsSock = new QSslSocket(this);
+	qtsSock->setPeerVerifyName(qsHostName);
 
 	if (! g.s.bSuppressIdentity && CertWizard::validateCert(g.s.kpCertificate)) {
 		qtsSock->setPrivateKey(g.s.kpCertificate.second);

--- a/src/mumble/ServerHandler.cpp
+++ b/src/mumble/ServerHandler.cpp
@@ -397,6 +397,10 @@ void ServerHandler::sendPing() {
 	if (!connection)
 		return;
 
+	if (qtsSock->state() != QAbstractSocket::ConnectedState) {
+		return;
+	}
+
 	if (g.s.iMaxInFlightTCPPings >= 0 && iInFlightTCPPings >= g.s.iMaxInFlightTCPPings) {
 		serverConnectionClosed(QAbstractSocket::UnknownSocketError, tr("Server is not responding to TCP pings"));
 		return;

--- a/src/mumble/ServerHandler.cpp
+++ b/src/mumble/ServerHandler.cpp
@@ -297,7 +297,7 @@ void ServerHandler::run() {
 #else
 	qtsSock->setProtocol(QSsl::TlsV1);
 #endif
-	qtsSock->connectToHostEncrypted(qsHostName, usPort);
+	qtsSock->connectToHost(qsHostName, usPort);
 
 	tTimestamp.restart();
 
@@ -547,6 +547,9 @@ void ServerHandler::serverConnectionStateChanged(QAbstractSocket::SocketState st
 		connect(tConnectionTimeoutTimer, SIGNAL(timeout()), this, SLOT(serverConnectionTimeoutOnConnect()));
 		tConnectionTimeoutTimer->setSingleShot(true);
 		tConnectionTimeoutTimer->start(30000);
+	} else if (state == QAbstractSocket::ConnectedState) {
+		// Start TLS handshake
+		qtsSock->startClientEncryption();
 	}
 }
 

--- a/src/mumble/ServerHandler.cpp
+++ b/src/mumble/ServerHandler.cpp
@@ -259,7 +259,7 @@ void ServerHandler::sendProtoMessage(const ::google::protobuf::Message &msg, uns
 void ServerHandler::run() {
 	qbaDigest = QByteArray();
 	bStrong = true;
-	QSslSocket *qtsSock = new QSslSocket(this);
+	qtsSock = new QSslSocket(this);
 
 	if (! g.s.bSuppressIdentity && CertWizard::validateCert(g.s.kpCertificate)) {
 		qtsSock->setPrivateKey(g.s.kpCertificate.second);

--- a/src/mumble/ServerHandler.h
+++ b/src/mumble/ServerHandler.h
@@ -37,6 +37,7 @@ class Connection;
 class Message;
 class PacketDataStream;
 class QUdpSocket;
+class QSslSocket;
 class VoiceRecorder;
 
 class ServerHandlerMessageEvent : public QEvent {
@@ -82,6 +83,7 @@ class ServerHandler : public QThread {
 		ConnectionPtr cConnection;
 		QByteArray qbaDigest;
 		boost::shared_ptr<VoiceRecorder> recorder;
+		QSslSocket *qtsSock;
 
 		unsigned int uiVersion;
 		QString qsRelease;

--- a/src/mumble/ServerHandler.h
+++ b/src/mumble/ServerHandler.h
@@ -32,6 +32,7 @@
 #include "Timer.h"
 #include "Message.h"
 #include "Mumble.pb.h"
+#include "ServerAddress.h"
 
 class Connection;
 class Message;
@@ -84,6 +85,8 @@ class ServerHandler : public QThread {
 		QByteArray qbaDigest;
 		boost::shared_ptr<VoiceRecorder> recorder;
 		QSslSocket *qtsSock;
+		QList<ServerAddress> qlAddresses;
+		ServerAddress saTargetServer;
 
 		unsigned int uiVersion;
 		QString qsRelease;
@@ -142,6 +145,7 @@ class ServerHandler : public QThread {
 		void serverConnectionClosed(QAbstractSocket::SocketError, const QString &);
 		void setSslErrors(const QList<QSslError> &);
 		void udpReady();
+		void hostnameResolved();
 	public slots:
 		void sendPing();
 };

--- a/src/tests/TestServerAddress/TestServerAddress.cpp
+++ b/src/tests/TestServerAddress/TestServerAddress.cpp
@@ -1,0 +1,101 @@
+// Copyright 2005-2017 The Mumble Developers. All rights reserved.
+// Use of this source code is governed by a BSD-style license
+// that can be found in the LICENSE file at the root of the
+// Mumble source tree or at <https://www.mumble.info/LICENSE>.
+
+#include <QtCore>
+#include <QtTest>
+
+#include <algorithm>
+
+#include "HostAddress.h"
+#include "ServerAddress.h"
+
+class TestServerAddress : public QObject {
+		Q_OBJECT
+	private slots:
+		void defaultCtor();
+		void isValid();
+		void ctor();
+		void equals();
+		void lessThan();
+		void qhash();
+};
+
+void TestServerAddress::defaultCtor() {
+	ServerAddress sa;
+	QVERIFY(sa.host == HostAddress());
+	QVERIFY(sa.port == 0);
+	QVERIFY(!sa.isValid());
+}
+
+void TestServerAddress::isValid() {
+	ServerAddress invalid1;
+	QVERIFY(!invalid1.isValid());
+
+	ServerAddress invalid2(HostAddress(), 0);
+	QVERIFY(!invalid2.isValid());
+
+	ServerAddress invalid3(HostAddress(), 64738);
+	QVERIFY(!invalid3.isValid());
+
+	ServerAddress invalid4(HostAddress(QHostAddress("127.0.0.1")), 0);
+	QVERIFY(!invalid4.isValid());
+
+	ServerAddress valid(HostAddress(QHostAddress("127.0.0.1")), 443);
+	QVERIFY(valid.isValid());
+}
+
+void TestServerAddress::ctor() {
+	ServerAddress sa(HostAddress(QHostAddress("127.0.0.1")), 443);
+	QCOMPARE(sa.host, HostAddress(QHostAddress("127.0.0.1")));
+	QCOMPARE(sa.port, static_cast<unsigned short>(443));
+}
+
+void TestServerAddress::equals() {
+	ServerAddress a1(HostAddress(QHostAddress("127.0.0.1")), 443);
+	ServerAddress a2(HostAddress(QHostAddress("127.0.0.1")), 443);
+	ServerAddress b(HostAddress(QHostAddress("127.0.0.1")), 64738);
+	ServerAddress c(HostAddress(QHostAddress("10.0.0.1")), 80);
+
+	QVERIFY(a1 == a2);
+	QVERIFY(a1 != b);
+	QVERIFY(a1 != c);
+	QVERIFY(b != c);
+}
+
+void TestServerAddress::lessThan() {
+	QList<ServerAddress> testdata;
+
+	testdata << ServerAddress();
+	testdata << ServerAddress(HostAddress(), 1);
+	testdata << ServerAddress(HostAddress(), 999);
+	testdata << ServerAddress(HostAddress(QHostAddress("0.0.0.1")), 0);
+	testdata << ServerAddress(HostAddress(QHostAddress("0.0.0.2")), 0);
+	testdata << ServerAddress(HostAddress(QHostAddress("0.0.0.2")), 1);
+	testdata << ServerAddress(HostAddress(QHostAddress("80.0.0.1")), 0);
+	testdata << ServerAddress(HostAddress(QHostAddress("80.0.0.1")), 100);
+	testdata << ServerAddress(HostAddress(QHostAddress("80.0.0.1")), 64738);
+	testdata << ServerAddress(HostAddress(QHostAddress("80.0.0.2")), 64738);
+	testdata << ServerAddress(HostAddress(QHostAddress("255.255.255.255")), 0);
+	testdata << ServerAddress(HostAddress(QHostAddress("255.255.255.255")), 65535);
+
+	QList<ServerAddress> sorted(testdata);
+	std::sort(sorted.begin(), sorted.end());
+	QVERIFY(testdata == sorted);
+}
+
+void TestServerAddress::qhash() {
+	ServerAddress a1(HostAddress(QHostAddress("127.0.0.1")), 443);
+	ServerAddress a2(HostAddress(QHostAddress("127.0.0.1")), 443);
+	ServerAddress b(HostAddress(QHostAddress("127.0.0.1")), 64738);
+	ServerAddress c(HostAddress(QHostAddress("10.0.0.1")), 80);
+
+	QVERIFY(qHash(a1) == qHash(a2));
+	QVERIFY(qHash(a1) != qHash(b));
+	QVERIFY(qHash(a1) != qHash(c));
+	QVERIFY(qHash(b) != qHash(c));
+}
+
+QTEST_MAIN(TestServerAddress)
+#include "TestServerAddress.moc"

--- a/src/tests/TestServerAddress/TestServerAddress.pro
+++ b/src/tests/TestServerAddress/TestServerAddress.pro
@@ -3,15 +3,10 @@
 # that can be found in the LICENSE file at the root of the
 # Mumble source tree or at <https://www.mumble.info/LICENSE>.
 
-TEMPLATE = subdirs
+include(../test.pri)
 
-SUBDIRS += \
-	TestCrypt \
-	TestCryptographicHash \
-	TestCryptographicRandom \
-	TestPacketDataStream \
-	TestPasswordGenerator \
-	TestTimer \
-	TestXMLTools \
-	TestUnresolvedServerAddress \
-	TestServerAddress
+QT += network
+
+TARGET = TestServerAddress
+SOURCES = TestServerAddress.cpp ServerAddress.cpp HostAddress.cpp
+HEADERS = ServerAddress.h HostAddresss.h

--- a/src/tests/TestServerResolver/TestServerResolver.cpp
+++ b/src/tests/TestServerResolver/TestServerResolver.cpp
@@ -29,8 +29,13 @@ void TestServerResolver::simpleSrv() {
 	quint16 port = 64738;
 
 	r.resolve(hostname, port);
-	
-	QVERIFY(spy.wait());
+
+	// Equivalent to QSignalSpy::wait() in Qt 5.
+	{
+		QTestEventLoop loop;
+		loop.enterLoop(5);
+	}
+
 	QCOMPARE(spy.count(), 1);
 
 	QList<ServerResolverRecord> records = r.records();
@@ -72,7 +77,12 @@ void TestServerResolver::simpleA() {
 
 	r.resolve(hostname, port);
 
-	QVERIFY(spy.wait());
+	// Equivalent to QSignalSpy::wait() in Qt 5.
+	{
+		QTestEventLoop loop;
+		loop.enterLoop(5);
+	}
+
 	QCOMPARE(spy.count(), 1);
 
 	QList<ServerResolverRecord> records = r.records();
@@ -106,7 +116,12 @@ void TestServerResolver::simpleAAAA() {
 
 	r.resolve(hostname, port);
 
-	QVERIFY(spy.wait());
+	// Equivalent to QSignalSpy::wait() in Qt 5.
+	{
+		QTestEventLoop loop;
+		loop.enterLoop(5);
+	}
+
 	QCOMPARE(spy.count(), 1);
 
 	QList<ServerResolverRecord> records = r.records();

--- a/src/tests/TestServerResolver/TestServerResolver.cpp
+++ b/src/tests/TestServerResolver/TestServerResolver.cpp
@@ -1,0 +1,115 @@
+// Copyright 2005-2017 The Mumble Developers. All rights reserved.
+// Use of this source code is governed by a BSD-style license
+// that can be found in the LICENSE file at the root of the
+// Mumble source tree or at <https://www.mumble.info/LICENSE>.
+
+#include <QtCore>
+#include <QtTest>
+#include <QSignalSpy>
+
+#include "ServerResolver.h"
+
+class TestServerResolver : public QObject {
+		Q_OBJECT
+	private slots:
+		void simpleSrv();
+		void simpleA();
+		void simpleAAAA();
+};
+
+void TestServerResolver::simpleSrv() {
+#ifdef USE_NO_SRV
+	return;
+#endif
+
+	ServerResolver r;
+	QSignalSpy spy(&r, SIGNAL(resolved()));
+
+	QString hostname = QString::fromLatin1("simple.serverresolver.mumble.info");
+	quint16 port = 64738;
+
+	r.resolve(hostname, port);
+	
+	QVERIFY(spy.wait());
+	QCOMPARE(spy.count(), 1);
+
+	QList<ServerResolverRecord> records = r.records();
+	QCOMPARE(records.size(), 1);
+
+	ServerResolverRecord record = records.at(0);
+	QCOMPARE(record.hostname(), hostname);
+	QCOMPARE(record.port(), port);
+	QCOMPARE(record.addresses().size(), 2);
+	QCOMPARE(record.priority(), 65545); // priority=1, weight=10 -> 1 * 65535 + 10
+
+	bool hasipv4 = false;
+	bool hasipv6 = false;
+
+	HostAddress v4(QHostAddress(QLatin1String("127.0.0.1")));
+	HostAddress v6(QHostAddress(QLatin1String("::1")));
+
+	foreach (HostAddress ha, record.addresses()) {
+		if (ha == v4) {
+			hasipv4 = true;
+		}
+		if (ha == v6) {
+			hasipv6 = true;
+		}
+	}
+	QVERIFY(hasipv4 && hasipv6);
+}
+
+void TestServerResolver::simpleA() {
+	ServerResolver r;
+	QSignalSpy spy(&r, SIGNAL(resolved()));
+
+	QString hostname = QString::fromLatin1("simplea.serverresolver.mumble.info");
+	quint16 port = 64738;
+
+	r.resolve(hostname, port);
+
+	QVERIFY(spy.wait());
+	QCOMPARE(spy.count(), 1);
+
+	QList<ServerResolverRecord> records = r.records();
+	QCOMPARE(records.size(), 1);
+
+	ServerResolverRecord record = records.at(0);
+	QCOMPARE(record.hostname(), hostname);
+	QCOMPARE(record.port(), port);
+	QCOMPARE(record.addresses().size(), 1);
+	QCOMPARE(record.priority(), static_cast<qint64>(0));
+
+	HostAddress want(QHostAddress(QLatin1String("127.0.0.1")));
+	HostAddress got = record.addresses().at(0);
+	QCOMPARE(want, got);
+}
+
+void TestServerResolver::simpleAAAA() {
+	ServerResolver r;
+	QSignalSpy spy(&r, SIGNAL(resolved()));
+
+	QString hostname = QString::fromLatin1("simpleaaaa.serverresolver.mumble.info");
+	quint16 port = 64738;
+
+	r.resolve(hostname, port);
+
+	QVERIFY(spy.wait());
+	QCOMPARE(spy.count(), 1);
+
+	QList<ServerResolverRecord> records = r.records();
+	QCOMPARE(records.size(), 1);
+
+	ServerResolverRecord record = records.at(0);
+	QCOMPARE(record.hostname(), hostname);
+	QCOMPARE(record.port(), port);
+	QCOMPARE(record.addresses().size(), 1);
+	QCOMPARE(record.priority(), static_cast<qint64>(0));
+
+	HostAddress want(QHostAddress(QLatin1String("::1")));
+	HostAddress got = record.addresses().at(0);
+	QCOMPARE(want, got);
+}
+
+QTEST_MAIN(TestServerResolver)
+#include "TestServerResolver.moc"

--- a/src/tests/TestServerResolver/TestServerResolver.cpp
+++ b/src/tests/TestServerResolver/TestServerResolver.cpp
@@ -39,7 +39,9 @@ void TestServerResolver::simpleSrv() {
 	ServerResolverRecord record = records.at(0);
 	QCOMPARE(record.hostname(), hostname);
 	QCOMPARE(record.port(), port);
-	QCOMPARE(record.addresses().size(), 2);
+	// Allow 1 or 2 results. The answer depends on whether
+	// the system supports IPv4, IPv6, or both.
+	QVERIFY(record.addresses().size() == 1 || record.addresses().size() == 2);
 	QCOMPARE(record.priority(), 65545); // priority=1, weight=10 -> 1 * 65535 + 10
 
 	bool hasipv4 = false;
@@ -56,7 +58,9 @@ void TestServerResolver::simpleSrv() {
 			hasipv6 = true;
 		}
 	}
-	QVERIFY(hasipv4 && hasipv6);
+
+	// Require either an IPv4 match, or an IPv6 match.
+	QVERIFY(hasipv4 || hasipv6);
 }
 
 void TestServerResolver::simpleA() {
@@ -72,6 +76,14 @@ void TestServerResolver::simpleA() {
 	QCOMPARE(spy.count(), 1);
 
 	QList<ServerResolverRecord> records = r.records();
+	// Since not all systems have IPv4 support, we have to
+	// skip this test if we get no matches. Not ideal, but
+	// at least we get some test coverage on IPv4 systems.
+	if (records.size() == 0) {
+		qWarning("Skipping test: No results returned. Assuming non-IPv4 system.");
+		return;
+	}
+
 	QCOMPARE(records.size(), 1);
 
 	ServerResolverRecord record = records.at(0);
@@ -98,6 +110,14 @@ void TestServerResolver::simpleAAAA() {
 	QCOMPARE(spy.count(), 1);
 
 	QList<ServerResolverRecord> records = r.records();
+	// Since not all systems have IPv6 support, we have to
+	// skip this test if we get no matches. Not ideal, but
+	// at least we get some test coverage on IPv6 systems.
+	if (records.size() == 0) {
+		qWarning("Skipping test: No results returned. Assuming non-IPv6 system.");
+		return;
+	}
+
 	QCOMPARE(records.size(), 1);
 
 	ServerResolverRecord record = records.at(0);

--- a/src/tests/TestServerResolver/TestServerResolver.pro
+++ b/src/tests/TestServerResolver/TestServerResolver.pro
@@ -1,0 +1,23 @@
+# Copyright 2005-2017 The Mumble Developers. All rights reserved.
+# Use of this source code is governed by a BSD-style license
+# that can be found in the LICENSE file at the root of the
+# Mumble source tree or at <https://www.mumble.info/LICENSE>.
+
+include(../test.pri)
+include(../../../qmake/qt.pri)
+
+QT *= network
+
+TARGET = TestServerResolver
+SOURCES = TestServerResolver.cpp HostAddress.cpp ServerResolver_qt5.cpp ServerResolverRecord.cpp
+HEADERS = HostAddress.h ServerResolver.h ServerResolverRecord.h
+
+isEqual(QT_MAJOR_VERSION, 4) {
+	CONFIG *= no-srv
+}
+
+CONFIG(no-srv) {
+	DEFINES += USE_NO_SRV
+	SOURCES -= ServerResolver_qt5.cpp
+	SOURCES *= ServerResolver_nosrv.cpp
+}

--- a/src/tests/TestUnresolvedServerAddress/TestUnresolvedServerAddress.cpp
+++ b/src/tests/TestUnresolvedServerAddress/TestUnresolvedServerAddress.cpp
@@ -1,0 +1,115 @@
+// Copyright 2005-2017 The Mumble Developers. All rights reserved.
+// Use of this source code is governed by a BSD-style license
+// that can be found in the LICENSE file at the root of the
+// Mumble source tree or at <https://www.mumble.info/LICENSE>.
+
+#include <QtCore>
+#include <QtTest>
+
+#include "UnresolvedServerAddress.h"
+
+class TestUnresolvedServerAddress : public QObject {
+		Q_OBJECT
+	private slots:
+		void defaultCtor();
+		void isValid();
+		void ctor();
+		void caseInsensitive();
+		void equals();
+		void lessThan();
+		void qhash();
+};
+
+void TestUnresolvedServerAddress::defaultCtor() {
+	UnresolvedServerAddress unresolved;
+	QVERIFY(unresolved.hostname.isEmpty());
+	QVERIFY(unresolved.port == 0);
+	QVERIFY(!unresolved.isValid());
+}
+
+void TestUnresolvedServerAddress::isValid() {
+	UnresolvedServerAddress invalid1;
+	QVERIFY(!invalid1.isValid());
+
+	UnresolvedServerAddress invalid2(QString(), 0);
+	QVERIFY(!invalid2.isValid());
+
+	UnresolvedServerAddress invalid3(QString(), 64738);
+	QVERIFY(!invalid3.isValid());
+
+	UnresolvedServerAddress invalid4(QLatin1String("mumble.info"), 0);
+	QVERIFY(!invalid4.isValid());
+
+	UnresolvedServerAddress valid(QLatin1String("mumble.info"), 443);
+	QVERIFY(valid.isValid());
+}
+
+void TestUnresolvedServerAddress::ctor() {
+	UnresolvedServerAddress usa(QLatin1String("mumble.info"), 443);
+	QCOMPARE(usa.hostname, QString::fromLatin1("mumble.info"));
+	QCOMPARE(usa.port, static_cast<unsigned short>(443));
+}
+
+void TestUnresolvedServerAddress::caseInsensitive() {
+	UnresolvedServerAddress a(QLatin1String("mumble.info"), 443);
+	UnresolvedServerAddress b(QLatin1String("MUMBLE.INFO"), 443);
+	UnresolvedServerAddress c(QLatin1String("MuMbLe.iNFo"), 443);
+
+	QVERIFY(a == b);
+	QVERIFY(a == c);
+}
+
+void TestUnresolvedServerAddress::equals() {
+	UnresolvedServerAddress a1(QLatin1String("mumble.info"), 443);
+	UnresolvedServerAddress a2(QLatin1String("mumble.info"), 443);
+	UnresolvedServerAddress b(QLatin1String("mumble.info"), 64738);
+	UnresolvedServerAddress c(QLatin1String("mumble.hive.no"), 80);
+
+	QVERIFY(a1 == a2);
+	QVERIFY(a1 != b);
+	QVERIFY(a1 != c);
+	QVERIFY(b != c);
+}
+
+void TestUnresolvedServerAddress::lessThan() {
+	QList<UnresolvedServerAddress> testdata;
+
+	testdata << UnresolvedServerAddress();
+	testdata << UnresolvedServerAddress(QString(), 1);
+	testdata << UnresolvedServerAddress(QString(), 999);
+	testdata << UnresolvedServerAddress(QLatin1String("aaaaa"), 0);
+	testdata << UnresolvedServerAddress(QLatin1String("baaaa"), 0);
+	testdata << UnresolvedServerAddress(QLatin1String("baaaa"), 1);
+	testdata << UnresolvedServerAddress(QLatin1String("maaaa"), 0);
+	testdata << UnresolvedServerAddress(QLatin1String("maaaa"), 100);
+	testdata << UnresolvedServerAddress(QLatin1String("maaaa"), 64738);
+	testdata << UnresolvedServerAddress(QLatin1String("naaaa"), 64738);
+	testdata << UnresolvedServerAddress(QLatin1String("zaaaa"), 0);
+	testdata << UnresolvedServerAddress(QLatin1String("zaaaa"), 65535);
+
+	QList<UnresolvedServerAddress> sorted(testdata);
+	std::sort(sorted.begin(), sorted.end());
+
+	int i = 0;
+	foreach(const UnresolvedServerAddress &unresolved, sorted) {
+		qWarning("%i -> %s:%i", i, qPrintable(unresolved.hostname), unresolved.port);
+		i += 1;
+	}
+
+	QVERIFY(testdata == sorted);
+}
+
+void TestUnresolvedServerAddress::qhash() {
+	UnresolvedServerAddress a1(QLatin1String("mumble.info"), 443);
+	UnresolvedServerAddress a2(QLatin1String("mumble.info"), 443);
+	UnresolvedServerAddress b(QLatin1String("mumble.info"), 64738);
+	UnresolvedServerAddress c(QLatin1String("mumble.hive.no"), 80);
+
+	QVERIFY(qHash(a1) == qHash(a2));
+	QVERIFY(qHash(a1) != qHash(b));
+	QVERIFY(qHash(a1) != qHash(c));
+	QVERIFY(qHash(b) != qHash(c));
+}
+
+QTEST_MAIN(TestUnresolvedServerAddress)
+#include "TestUnresolvedServerAddress.moc"

--- a/src/tests/TestUnresolvedServerAddress/TestUnresolvedServerAddress.pro
+++ b/src/tests/TestUnresolvedServerAddress/TestUnresolvedServerAddress.pro
@@ -3,14 +3,8 @@
 # that can be found in the LICENSE file at the root of the
 # Mumble source tree or at <https://www.mumble.info/LICENSE>.
 
-TEMPLATE = subdirs
+include(../test.pri)
 
-SUBDIRS += \
-	TestCrypt \
-	TestCryptographicHash \
-	TestCryptographicRandom \
-	TestPacketDataStream \
-	TestPasswordGenerator \
-	TestTimer \
-	TestXMLTools \
-	TestUnresolvedServerAddress
+TARGET = TestUnresolvedServerAddress
+SOURCES = TestUnresolvedServerAddress.cpp UnresolvedServerAddress.cpp
+HEADERS = UnresolvedServerAddress.h

--- a/src/tests/tests.pro
+++ b/src/tests/tests.pro
@@ -14,4 +14,5 @@ SUBDIRS += \
 	TestTimer \
 	TestXMLTools \
 	TestUnresolvedServerAddress \
-	TestServerAddress
+	TestServerAddress \
+	TestServerResolver


### PR DESCRIPTION
This PR implements the new hostname resolving infrastructure in Mumble. This includes support for SRV records in Mumble.

The new resolver lives in the ServerResolver class. It now allows Mumble to also resolve SRV records.

The class isn't meant to be used exclusively for SRV records. We could add an alternative later on. For example, something I've toyed with is using a ".well-known" HTTPS URL, like https://gaming.example.com/.well-known/mumble as a "server pointer". The file at /.well-known/mumble would then link to a Mumble server (maybe something as simple as mumble://my-host:64800/). However, users would be able to connect to the server via mumble://gaming.example.com/ because of the pointer file. ...Just something I've toyed around with. Not related to this PR.

The PR changes ConnectDialog and ServerHandler to use ServerResolver for resolving hostnames of Mumble servers. That's where the bulk of the code changes happen.

It also introduces some new helper types: UnresolvedServerAddress (a hostname and a port), as well as a ServerAddress (an IP address and a port). The implementation of ServerResolver in ConnectDialog and ServerHandler makes use of these new types.

This changes the Mumble client to prefer SRV record. If no SRV record is available, the old code path is taken. (A/AAAA/CNAME).

For Qt 4, Mumble will not attempt do SRV resolving, since we rely on QtNetwork's DNS resolver. SRV resolving isn't available in Qt 4.