### PR TITLE
Make comparison case-insensitive in ConnectDialog.cpp

### DIFF
--- a/src/mumble/ConnectDialog.cpp
+++ b/src/mumble/ConnectDialog.cpp
@@ -776,7 +776,7 @@ void ConnectDialogEdit::validate() {
 	qlePort->setDisabled(!qsHostname.isEmpty() && qsHostname.startsWith(QLatin1Char('@')));
 
 	// For SuperUser show password edit
-	if (qsUsername == QLatin1String("SuperUser")) {
+	if (qsUsername.toLower() == QLatin1String("superuser")) {
 		qliPassword->setVisible(true);
 		qlePassword->setVisible(true);
 		qcbShowPassword->setVisible(true);


### PR DESCRIPTION
Usernames in Murmur aren't case-sensitive, but we only showed the password
field when it was entered as SuperUser, which resulted in some confusion for
users.

Hard-coded the string as lowercase, rather than leaving it and doing an
extra toLower() on it.