### PR TITLE
ServerHandler: fix broken hostname validation.

### DIFF
--- a/src/mumble/ServerHandler.cpp
+++ b/src/mumble/ServerHandler.cpp
@@ -305,6 +305,7 @@ void ServerHandler::run() {
 		qbaDigest = QByteArray();
 		bStrong = true;
 		qtsSock = new QSslSocket(this);
+		qtsSock->setPeerVerifyName(qsHostName);
 
 		if (! g.s.bSuppressIdentity && CertWizard::validateCert(g.s.kpCertificate)) {
 			qtsSock->setPrivateKey(g.s.kpCertificate.second);


### PR DESCRIPTION
The call to QSslSocket::setPeerVerifyName() was accidently removed
in edd95a87a979c20cedb6872f21a8c1c354df3fd6.

Re-add it.