### PR TITLE
ServerHandler: ensure only a single connection timeout timer is active at one time.

### DIFF
--- a/src/mumble/ServerHandler.cpp
+++ b/src/mumble/ServerHandler.cpp
@@ -302,6 +302,7 @@ void ServerHandler::run() {
 	do {
 		saTargetServer = qlAddresses.takeFirst();
 
+		tConnectionTimeoutTimer = NULL;
 		qbaDigest = QByteArray();
 		bStrong = true;
 		qtsSock = new QSslSocket(this);
@@ -393,6 +394,7 @@ void ServerHandler::run() {
 			msleep(100);
 		}
 		delete qtsSock;
+		delete tConnectionTimeoutTimer;
 	} while (shouldTryNextTargetServer && !qlAddresses.isEmpty());
 }
 


### PR DESCRIPTION
In mumble-voip/mumble#3153, it was reported that the new SRV code can
disconnect you from a server after a short while.

It turns out that we weren't being careful enough about our connection
timeout timer. A new timer was created for each connection attempt to
a server in the SRV list. In practice, this meant that 30 seconds after
each connection attempt, ServerHandler would try to tear down the
connection.

We now ensure we destroy the timer after we disconnect from a server.
This should ensure there is only one such timer active at any point in
time.

Fixes mumble-voip/mumble#3153