### PR TITLE
Log: remove the notion of an invalid LogDocument.

### DIFF
--- a/src/mumble/Log.h
+++ b/src/mumble/Log.h
@@ -86,7 +86,6 @@ class LogDocument : public QTextDocument {
 		QVariant loadResource(int, const QUrl &) Q_DECL_OVERRIDE;
 		void setAllowHTTPResources(bool allowHttpResources);
 		void setOnlyLoadDataURLs(bool onlyLoadDataURLs);
-		bool isValid();
 	public slots:
 		void receivedHead();
 		void finished();


### PR DESCRIPTION
Previously, the invalid state for a LogDocument that contained images
that Mumble deemed invalid.

For example, if Mumble was configured to not download external iamges,
a LogDocument that contained references to external images would be
marked as invalid, and would not show up in the user's log. Instead,
the whole message would be shown as "[[ No valid image ]]".

With this change, Mumble will instead show the message, but replace
the images with a 'broken image' marker (currently, Qt shows a 1x1
black image.)

This makes the 'Disable image download' option in Mumble more usable.
Before, messages that contained external (i.e, HTTP/HTTPS) images would
not be shown at all. This was not desirable, since such messages could
potentially contain messages alongside the images.