### PR TITLE
ServerHandler: avoid leaking ServerResolver in ::run().

### DIFF
--- a/src/mumble/ServerHandler.cpp
+++ b/src/mumble/ServerHandler.cpp
@@ -287,9 +287,9 @@ void ServerHandler::hostnameResolved() {
 void ServerHandler::run() {
 	// Resolve the hostname...
 	{
-		ServerResolver *sr = new ServerResolver();
-		QObject::connect(sr, SIGNAL(resolved()), this, SLOT(hostnameResolved()));
-		sr->resolve(qsHostName, usPort);
+		ServerResolver sr;
+		QObject::connect(&sr, SIGNAL(resolved()), this, SLOT(hostnameResolved()));
+		sr.resolve(qsHostName, usPort);
 		int ret = exec();
 		if (ret < 0) {
 			qWarning("ServerHandler: failed to resolve hostname");


### PR DESCRIPTION
This changes the ServerResolver used in the ServerHandler thread to be
properly cleaned up after we've performed name resolution.