### PR TITLE
Log: remove dead m_valid code from LogDocument.

### DIFF
--- a/src/mumble/Log.cpp
+++ b/src/mumble/Log.cpp
@@ -643,7 +643,6 @@ void LogDocument::receivedHead() {
 	if (rep->url().scheme() != QLatin1String("data")) {
 		QVariant length = rep->header(QNetworkRequest::ContentLengthHeader);
 		if (length == QVariant::Invalid || length.toInt() > g.s.iMaxImageSize) {
-			m_valid = false;
 			rep->abort();
 		}
 	}

--- a/src/mumble/Log.h
+++ b/src/mumble/Log.h
@@ -91,7 +91,6 @@ class LogDocument : public QTextDocument {
 		void finished();
 	private:
 		bool m_allowHTTPResources;
-		bool m_valid;
 		bool m_onlyLoadDataURLs;
 };
 


### PR DESCRIPTION
The rest of the code was removed in mumble-voip/mumble#3157
(ab783c74330f0f630635be585bd7941d761fbfbd)

Remove the rest, since it is unused.