### PR TITLE
Log: remove support for external images.

### DIFF
--- a/src/mumble/Log.h
+++ b/src/mumble/Log.h
@@ -67,7 +67,7 @@ class Log : public QObject {
 		QString msgName(MsgType t) const;
 		void setIgnore(MsgType t, int ignore = 1 << 30);
 		void clearIgnore();
-		static QString validHtml(const QString &html, bool allowReplacement = false, QTextCursor *tc = NULL);
+		static QString validHtml(const QString &html, QTextCursor *tc = NULL);
 		static QString imageToImg(const QByteArray &format, const QByteArray &image);
 		static QString imageToImg(QImage img);
 		static QString msgColor(const QString &text, LogColorType t);
@@ -84,14 +84,8 @@ class LogDocument : public QTextDocument {
 	public:
 		LogDocument(QObject *p = NULL);
 		QVariant loadResource(int, const QUrl &) Q_DECL_OVERRIDE;
-		void setAllowHTTPResources(bool allowHttpResources);
-		void setOnlyLoadDataURLs(bool onlyLoadDataURLs);
 	public slots:
-		void receivedHead();
 		void finished();
-	private:
-		bool m_allowHTTPResources;
-		bool m_onlyLoadDataURLs;
 };
 
 class LogDocumentResourceAddedEvent : public QEvent {

--- a/src/mumble/NetworkConfig.cpp
+++ b/src/mumble/NetworkConfig.cpp
@@ -54,7 +54,6 @@ void NetworkConfig::load(const Settings &r) {
 	qleUsername->setText(r.qsProxyUsername);
 	qlePassword->setText(r.qsProxyPassword);
 
-	loadCheckBox(qcbImageDownload, r.iMaxImageSize <= 0);
 	loadCheckBox(qcbHideOS, s.bHideOS);
 
 	loadCheckBox(qcbAutoUpdate, r.bUpdateCheck);
@@ -80,12 +79,6 @@ void NetworkConfig::save() const {
 	s.usProxyPort = qlePort->text().toUShort();
 	s.qsProxyUsername = qleUsername->text();
 	s.qsProxyPassword = qlePassword->text();
-
-	if (qcbImageDownload->isChecked()) {
-		s.iMaxImageSize = 0;
-	} else if (s.iMaxImageSize <= 0) {
-		s.iMaxImageSize = s.ciDefaultMaxImageSize;
-	}
 
 	s.bUpdateCheck=qcbAutoUpdate->isChecked();
 	s.bPluginCheck=qcbPluginUpdate->isChecked();

--- a/src/mumble/NetworkConfig.ui
+++ b/src/mumble/NetworkConfig.ui
@@ -273,29 +273,6 @@
     </widget>
    </item>
    <item>
-    <widget class="QGroupBox" name="qgbMisc">
-     <property name="title">
-      <string>Misc</string>
-     </property>
-     <layout class="QVBoxLayout" name="verticalLayout_3">
-      <item>
-       <widget class="QCheckBox" name="qcbImageDownload">
-        <property name="toolTip">
-         <string>Prevent log from downloading images</string>
-        </property>
-        <property name="whatsThis">
-         <string>&lt;b&gt;Disable image download&lt;/b&gt;&lt;br/&gt;
-Prevents the client from downloading images embedded into chat messages with the img tag.</string>
-        </property>
-        <property name="text">
-         <string>Disable image download</string>
-        </property>
-       </widget>
-      </item>
-     </layout>
-    </widget>
-   </item>
-   <item>
     <widget class="QGroupBox" name="qgbPrivacy">
      <property name="title">
       <string>Privacy</string>

--- a/src/mumble/Settings.cpp
+++ b/src/mumble/Settings.cpp
@@ -352,7 +352,6 @@ Settings::Settings() {
 	iMaxInFlightTCPPings = 2;
 	bUdpForceTcpAddr = true;
 
-	iMaxImageSize = ciDefaultMaxImageSize;
 	iMaxImageWidth = 1024; // Allow 1024x1024 resolution
 	iMaxImageHeight = 1024;
 	bSuppressIdentity = false;
@@ -682,7 +681,7 @@ void Settings::load(QSettings* settings_ptr) {
 	SAVELOAD(usProxyPort, "net/proxyport");
 	SAVELOAD(qsProxyUsername, "net/proxyusername");
 	SAVELOAD(qsProxyPassword, "net/proxypassword");
-	SAVELOAD(iMaxImageSize, "net/maximagesize");
+	DEPRECATED("net/maximagesize");
 	SAVELOAD(iMaxImageWidth, "net/maximagewidth");
 	SAVELOAD(iMaxImageHeight, "net/maximageheight");
 	SAVELOAD(qsServicePrefix, "net/serviceprefix");
@@ -1014,7 +1013,7 @@ void Settings::save() {
 	SAVELOAD(usProxyPort, "net/proxyport");
 	SAVELOAD(qsProxyUsername, "net/proxyusername");
 	SAVELOAD(qsProxyPassword, "net/proxypassword");
-	SAVELOAD(iMaxImageSize, "net/maximagesize");
+	DEPRECATED("net/maximagesize");
 	SAVELOAD(iMaxImageWidth, "net/maximagewidth");
 	SAVELOAD(iMaxImageHeight, "net/maximageheight");
 	SAVELOAD(qsServicePrefix, "net/serviceprefix");

--- a/src/mumble/Settings.h
+++ b/src/mumble/Settings.h
@@ -362,8 +362,6 @@ struct Settings {
 	// Privacy settings
 	bool bHideOS;
 
-	static const int ciDefaultMaxImageSize = 50 * 1024; // Restrict to 50KiB as a default
-	int iMaxImageSize;
 	int iMaxImageWidth;
 	int iMaxImageHeight;
 	KeyPair kpCertificate;


### PR DESCRIPTION
This change remove support for loading external images.
That is, this change ensures Mumble doesn't load images from <img> tags in text messages,
comments and channel descriptions via HTTP or HTTPS.

With this change in place, Mumble only supports images that are embedded
in the message via data URLs.