### PR TITLE
Fix #3162: Travis builds could fail with timeout

### DIFF
--- a/src/tests/TestServerResolver/TestServerResolver.cpp
+++ b/src/tests/TestServerResolver/TestServerResolver.cpp
@@ -9,6 +9,13 @@
 
 #include "ServerResolver.h"
 
+// Equivalent to QSignalSpy::wait() in Qt 5.
+// We increased the timeout from 5s to 8s because travis builds could fail otherwise.
+void signalSpyWait() {
+	QTestEventLoop loop;
+	loop.enterLoop(8);
+}
+
 class TestServerResolver : public QObject {
 		Q_OBJECT
 	private slots:
@@ -30,11 +37,7 @@ void TestServerResolver::simpleSrv() {
 
 	r.resolve(hostname, port);
 
-	// Equivalent to QSignalSpy::wait() in Qt 5.
-	{
-		QTestEventLoop loop;
-		loop.enterLoop(5);
-	}
+	signalSpyWait();
 
 	QCOMPARE(spy.count(), 1);
 
@@ -77,11 +80,7 @@ void TestServerResolver::simpleA() {
 
 	r.resolve(hostname, port);
 
-	// Equivalent to QSignalSpy::wait() in Qt 5.
-	{
-		QTestEventLoop loop;
-		loop.enterLoop(5);
-	}
+	signalSpyWait();
 
 	QCOMPARE(spy.count(), 1);
 
@@ -116,11 +115,7 @@ void TestServerResolver::simpleAAAA() {
 
 	r.resolve(hostname, port);
 
-	// Equivalent to QSignalSpy::wait() in Qt 5.
-	{
-		QTestEventLoop loop;
-		loop.enterLoop(5);
-	}
+	signalSpyWait();
 
 	QCOMPARE(spy.count(), 1);
 

--- a/src/tests/TestServerResolver/TestServerResolver.cpp
+++ b/src/tests/TestServerResolver/TestServerResolver.cpp
@@ -9,11 +9,16 @@
 
 #include "ServerResolver.h"
 
-// Equivalent to QSignalSpy::wait() in Qt 5.
-// We increased the timeout from 5s to 8s because travis builds could fail otherwise.
-void signalSpyWait() {
+void signalSpyWait(QSignalSpy &spy) {
+	// We increase the timeout from 5s to 8s because travis builds could fail otherwise (slow network response).
+	const int signalTimeoutS = 8;
+#if QT_VERSION >= 0x050000
+	spy.wait(signalTimeoutS * 1000);
+#else
+	// Equivalent to QSignalSpy::wait() in Qt 5, except we do not return early on a spied on signal result.
 	QTestEventLoop loop;
-	loop.enterLoop(8);
+	loop.enterLoop(signalTimeoutS);
+#endif
 }
 
 class TestServerResolver : public QObject {
@@ -37,7 +42,7 @@ void TestServerResolver::simpleSrv() {
 
 	r.resolve(hostname, port);
 
-	signalSpyWait();
+	signalSpyWait(spy);
 
 	QCOMPARE(spy.count(), 1);
 
@@ -80,7 +85,7 @@ void TestServerResolver::simpleA() {
 
 	r.resolve(hostname, port);
 
-	signalSpyWait();
+	signalSpyWait(spy);
 
 	QCOMPARE(spy.count(), 1);
 
@@ -115,7 +120,7 @@ void TestServerResolver::simpleAAAA() {
 
 	r.resolve(hostname, port);
 
-	signalSpyWait();
+	signalSpyWait(spy);
 
 	QCOMPARE(spy.count(), 1);
 


### PR DESCRIPTION
Unfortunately QHostInfo::lookupHost is a static method, so we can’t
mock it. As a result, the test TestServerResolver is dependent on the
network. Travis builds could fail with network timeouts. Hence, we
increase the 5s timeout to 10s.