### PR TITLE
ServerResolver: treat SRV lookups that return NOERROR but no records as errors.

### DIFF
--- a/src/ServerResolver_qt5.cpp
+++ b/src/ServerResolver_qt5.cpp
@@ -67,10 +67,10 @@ QList<ServerResolverRecord> ServerResolverPrivate::records() {
 void ServerResolverPrivate::srvResolved() {
 	QDnsLookup *resolver = qobject_cast<QDnsLookup *>(sender());
 
-	if (resolver->error() == QDnsLookup::NoError) {
-		m_srvQueue = resolver->serviceRecords();
-		m_srvQueueRemain = m_srvQueue.count();
+	m_srvQueue = resolver->serviceRecords();
+	m_srvQueueRemain = m_srvQueue.count();
 
+	if (resolver->error() == QDnsLookup::NoError && m_srvQueueRemain > 0) {
 		for (int i = 0; i < m_srvQueue.count(); i++) {
 			QDnsServiceRecord record = m_srvQueue.at(i);
 			int hostInfoId = QHostInfo::lookupHost(record.target(), this, SLOT(hostResolved(QHostInfo)));


### PR DESCRIPTION
This seems like a very sensible change. If no SRV records are retrieved,
treat the situation as an error, and fall back to a regular A/AAAA/CNAME
lookup.

Fixes mumble-voip/mumble#3163