### PR TITLE
scripts/mkini-win32.bat: perform LF -> CRLF conversion.

### DIFF
--- a/scripts/mkini-win32.bat
+++ b/scripts/mkini-win32.bat
@@ -3,4 +3,12 @@
 :: that can be found in the LICENSE file at the root of the
 :: Mumble source tree or at <https://www.mumble.info/LICENSE>.
 
-copy murmur.ini murmur.ini.win32
+:: Copy murmur.ini to murmur.ini.win32, and convert
+:: LF -> CRLF so Windows users can edit murmur.ini in
+:: Notepad.
+::
+:: Note that the 'more' command also expands tabs
+:: to spaces. This isn't a problem right now, since
+:: we don't use tabs in murmur.ini -- and even if
+:: we did, they wouldn't be significant.
+type murmur.ini | more /p > murmur.ini.win32


### PR DESCRIPTION
This ensures that murmur.ini on Windows installations has
Windows-style line endings, allowing admins to use Notepad
to edit the file.

Fixes mumble-voip/mumble#3101