### PR TITLE
SSL: register OpenSSL threading callbacks when we can't access Qt's OpenSSL.

### DIFF
--- a/src/SSL.cpp
+++ b/src/SSL.cpp
@@ -19,6 +19,9 @@ void MumbleSSL::initialize() {
 	QSslSocket::supportsSsl();
 }
 
+void MumbleSSL::destroy() {
+}
+
 QString MumbleSSL::defaultOpenSSLCipherString() {
 	return QLatin1String("EECDH+AESGCM:EDH+aRSA+AESGCM:DHE-RSA-AES256-SHA:DHE-RSA-AES128-SHA:AES256-SHA:AES128-SHA");
 }

--- a/src/SSL.cpp
+++ b/src/SSL.cpp
@@ -6,20 +6,37 @@
 #include "murmur_pch.h"
 
 #include "SSL.h"
+#include "SSLLocks.h"
 
 #include "Version.h"
 
 void MumbleSSL::initialize() {
+	// Let Qt initialize its copy of OpenSSL, if it's different than
+	// Mumble's. (Initialization is a side-effect of calling
+	// QSslSocket::supportsSsl()).
+	QSslSocket::supportsSsl();
+
 	// Initialize our copy of OpenSSL.
 	SSL_library_init(); // Safe to discard return value, per OpenSSL man pages.
 	SSL_load_error_strings();
 
-	// Let Qt initialize its copy of OpenSSL, if it's different than
-	// Mumble's.
-	QSslSocket::supportsSsl();
+	// Determine if a locking callback has not been set.
+	// This should be the case if there are multiple copies
+	// of OpensSSL in the address space. This is mostly due
+	// to Qt dynamically loading OpenSSL when it is not
+	// configured with -openssl-linked.
+	//
+	// If we detect that no locking callback is configured, we
+	// have to set it up ourselves to allow multi-threaded use
+	// of OpenSSL.
+	void *lockcb = reinterpret_cast<void *>(CRYPTO_get_locking_callback());
+	if (lockcb == NULL) {
+		SSLLocks::initialize();
+	}
 }
 
 void MumbleSSL::destroy() {
+	SSLLocks::destroy();
 }
 
 QString MumbleSSL::defaultOpenSSLCipherString() {

--- a/src/SSL.h
+++ b/src/SSL.h
@@ -13,6 +13,7 @@
 class MumbleSSL {
 	public:
 		static void initialize();
+		static void destroy();
 		static QString defaultOpenSSLCipherString();
 		static QList<QSslCipher> ciphersFromOpenSSLCipherString(QString cipherString);
 		static void addSystemCA();

--- a/src/SSLLocks.cpp
+++ b/src/SSLLocks.cpp
@@ -1,0 +1,85 @@
+// Copyright 2005-2017 The Mumble Developers. All rights reserved.
+// Use of this source code is governed by a BSD-style license
+// that can be found in the LICENSE file at the root of the
+// Mumble source tree or at <https://www.mumble.info/LICENSE>.
+
+#include "murmur_pch.h"
+
+#include "SSLLocks.h"
+
+static QMutex **locks = NULL;
+
+void locking_callback(int mode, int type, const char *, int) {
+	if (mode & CRYPTO_LOCK) {
+		locks[type]->lock();
+	} else {
+		locks[type]->unlock();
+	}
+}
+
+unsigned long id_callback() {
+	// OpenSSL's thread ID callback must return an unsigned long.
+	// It's therefore important that we make sure the value from
+	// Qt's QThread::currentThreadId actually makes sense to return
+	// in this case.
+	//
+	// On Windows, the return type is a DWORD. This is excellent,
+	// because on an LLP64 like 64-bit Windows, unsigned long is
+	// only 32-bits wide, just like DWORD.
+	//
+	// On macOS and embedded Linux, it's void *. And when Qt targets
+	// X11, it's unsigned long.
+	//
+	// So, in all cases, it's safe to use unsigned long.
+	//
+	// The trouble is, since the return type of QThread::currentThreadId()
+	// difers between platforms, we have to be clever about how we convert
+	// that type to an unsigned long. The way we do it here is to first convert
+	// it to an uintptr_t, since both pointer types and integer types will
+	// convert to that without the compiler complaining. Then, we convert
+	// *that* to an unsigned long. (Note that for LLP64 platforms, such as
+	// 64-bit Windows, this conversion is from a 64-bit type to a 32-bit type)
+	uintptr_t val = reinterpret_cast<uintptr_t>(QThread::currentThreadId());
+	return static_cast<unsigned long>(val);
+}
+
+void SSLLocks::initialize() {
+	int nlocks = CRYPTO_num_locks();
+
+	locks = reinterpret_cast<QMutex **>(calloc(nlocks, sizeof(QMutex *)));
+	if (locks == NULL) {
+		qFatal("SSLLocks: unable to allocate locks array");
+
+		// This initializer is called early during program
+		// execution, and the message handler that causes
+		// qFatal to terminate execution might not be registered
+		// yet. So, do exit(1) just in case.
+		exit(1);
+	}
+
+	for (int i = 0; i < nlocks; i++) {
+		locks[i] = new QMutex;
+	}
+
+	CRYPTO_set_locking_callback(locking_callback);
+	CRYPTO_set_id_callback(id_callback);
+}
+
+void SSLLocks::destroy() {
+	// If SSLLocks was never initialized, or has been destroyed already,
+	// don't try to do it again.
+	if (locks == NULL) {
+		return;
+	}
+
+	CRYPTO_set_locking_callback(NULL);
+	CRYPTO_set_id_callback(NULL);
+
+	int nlocks = CRYPTO_num_locks();
+	for (int i = 0; i < nlocks; i++) {
+		delete locks[i];
+	}
+
+	free(locks);
+	locks = NULL;
+}

--- a/src/SSLLocks.h
+++ b/src/SSLLocks.h
@@ -1,0 +1,15 @@
+// Copyright 2005-2017 The Mumble Developers. All rights reserved.
+// Use of this source code is governed by a BSD-style license
+// that can be found in the LICENSE file at the root of the
+// Mumble source tree or at <https://www.mumble.info/LICENSE>.
+
+#ifndef MUMBLE_SSLLOCKS_H_
+#define MUMBLE_SSLLOCKS_H_
+
+class SSLLocks {
+	public:
+		static void initialize();
+		static void destroy();
+};
+
+#endif

--- a/src/mumble.pri
+++ b/src/mumble.pri
@@ -14,8 +14,8 @@ CONFIG		+= qt thread debug_and_release warn_on
 DEFINES		*= MUMBLE_VERSION_STRING=$$VERSION
 INCLUDEPATH	+= $$PWD . ../mumble_proto
 VPATH		+= $$PWD
-HEADERS		*= ACL.h Channel.h CryptState.h Connection.h Group.h HTMLFilter.h User.h Net.h OSInfo.h Timer.h SSL.h Version.h SSLCipherInfo.h SSLCipherInfoTable.h licenses.h License.h LogEmitter.h CryptographicHash.h CryptographicRandom.h PasswordGenerator.h ByteSwap.h HostAddress.cpp Ban.h EnvUtils.h UnresolvedServerAddress.h ServerAddress.h ServerResolver.h ServerResolverRecord.h SelfSignedCertificate.h
-SOURCES 	*= ACL.cpp Group.cpp Channel.cpp Connection.cpp HTMLFilter.cpp User.cpp Timer.cpp CryptState.cpp OSInfo.cpp SSL.cpp Version.cpp SSLCipherInfo.cpp License.cpp LogEmitter.cpp CryptographicHash.cpp CryptographicRandom.cpp PasswordGenerator.cpp HostAddress.cpp Ban.cpp EnvUtils.cpp UnresolvedServerAddress.cpp ServerAddress.cpp ServerResolver_qt5.cpp ServerResolverRecord.cpp SelfSignedCertificate.cpp
+HEADERS		*= ACL.h Channel.h CryptState.h Connection.h Group.h HTMLFilter.h User.h Net.h OSInfo.h Timer.h SSL.h Version.h SSLCipherInfo.h SSLCipherInfoTable.h licenses.h License.h LogEmitter.h CryptographicHash.h CryptographicRandom.h PasswordGenerator.h ByteSwap.h HostAddress.cpp Ban.h EnvUtils.h UnresolvedServerAddress.h ServerAddress.h ServerResolver.h ServerResolverRecord.h SelfSignedCertificate.h SSLLocks.h
+SOURCES 	*= ACL.cpp Group.cpp Channel.cpp Connection.cpp HTMLFilter.cpp User.cpp Timer.cpp CryptState.cpp OSInfo.cpp SSL.cpp Version.cpp SSLCipherInfo.cpp License.cpp LogEmitter.cpp CryptographicHash.cpp CryptographicRandom.cpp PasswordGenerator.cpp HostAddress.cpp Ban.cpp EnvUtils.cpp UnresolvedServerAddress.cpp ServerAddress.cpp ServerResolver_qt5.cpp ServerResolverRecord.cpp SelfSignedCertificate.cpp SSLLocks.cpp
 LIBS		*= -lmumble_proto
 
 equals(QT_MAJOR_VERSION, 4) {

--- a/src/mumble/main.cpp
+++ b/src/mumble/main.cpp
@@ -600,6 +600,9 @@ int main(int argc, char **argv) {
 	// correctly.
 	userLockFile.release();
 #endif
+
+	// Tear down OpenSSL state.
+	MumbleSSL::destroy();
 	
 	// At this point termination of our process is immenent. We can safely
 	// launch another version of Mumble. The reason we do an actual

--- a/src/tests/TestCrypt/TestCrypt.cpp
+++ b/src/tests/TestCrypt/TestCrypt.cpp
@@ -9,18 +9,29 @@
 #include <QtCore>
 #include <QtTest>
 
+#include "SSL.h"
 #include "Timer.h"
 #include "CryptState.h"
 
 class TestCrypt : public QObject {
 		Q_OBJECT
 	private slots:
+		void initTestCase();
+		void cleanupTestCase();
 		void testvectors();
 		void authcrypt();
 		void ivrecovery();
 		void reverserecovery();
 		void tamper();
 };
+
+void TestCrypt::initTestCase() {
+	MumbleSSL::initialize();
+}
+
+void TestCrypt::cleanupTestCase() {
+	MumbleSSL::destroy();
+}
 
 void TestCrypt::reverserecovery() {
 	CryptState enc, dec;

--- a/src/tests/TestCrypt/TestCrypt.pro
+++ b/src/tests/TestCrypt/TestCrypt.pro
@@ -8,5 +8,5 @@ include(../test.pri)
 QT *= network
 
 TARGET = TestCrypt
-HEADERS = Timer.h CryptState.h
-SOURCES = TestCrypt.cpp CryptState.cpp Timer.cpp
+HEADERS = SSL.h SSLLocks.h Timer.h CryptState.h
+SOURCES = SSL.cpp SSLLocks.cpp TestCrypt.cpp CryptState.cpp Timer.cpp

--- a/src/tests/TestCryptographicHash/TestCryptographicHash.cpp
+++ b/src/tests/TestCryptographicHash/TestCryptographicHash.cpp
@@ -7,11 +7,16 @@
 #include <QtTest>
 #include <QLatin1String>
 
+#include "SSL.h"
+
 #include "CryptographicHash.h"
 
 class TestCryptographicHash : public QObject {
 		Q_OBJECT
 	private slots:
+		void initTestCase();
+		void cleanupTestCase();
+
 		void sha1_data();
 		void sha1();
 
@@ -22,6 +27,14 @@ class TestCryptographicHash : public QObject {
 		void multipleResultCalls();
 		void addDataAfterResult();
 };
+
+void TestCryptographicHash::initTestCase() {
+	MumbleSSL::initialize();
+}
+
+void TestCryptographicHash::cleanupTestCase() {
+	MumbleSSL::destroy();
+}
 
 /// normalizeHash removes all whitespace from the hex-encoded hash string.
 static QString normalizeHash(QString str) {

--- a/src/tests/TestCryptographicHash/TestCryptographicHash.pro
+++ b/src/tests/TestCryptographicHash/TestCryptographicHash.pro
@@ -5,6 +5,8 @@
 
 include(../test.pri)
 
+QT += network
+
 TARGET = TestCryptographicHash
-SOURCES = TestCryptographicHash.cpp CryptographicHash.cpp
-HEADERS = CryptographicHash.h
+SOURCES = SSL.cpp SSLLocks.cpp TestCryptographicHash.cpp CryptographicHash.cpp
+HEADERS = SSL.h SSLLocks.h CryptographicHash.h

--- a/src/tests/TestCryptographicRandom/TestCryptographicRandom.cpp
+++ b/src/tests/TestCryptographicRandom/TestCryptographicRandom.cpp
@@ -6,6 +6,8 @@
 #include <QtCore>
 #include <QtTest>
 
+#include "SSL.h"
+
 #include "CryptographicRandom.h"
 
 #include <stdint.h>
@@ -15,10 +17,20 @@
 class TestCryptographicRandom : public QObject {
 		Q_OBJECT
 	private slots:
+		void initTestCase();
+		void cleanupTestCase();
 		void fillBuffer();
 		void uint32();
 		void uniform();
 };
+
+void TestCryptographicRandom::initTestCase() {
+	MumbleSSL::initialize();
+}
+
+void TestCryptographicRandom::cleanupTestCase() {
+	MumbleSSL::destroy();
+}
 
 // Verify the entropy of the data returned by the random source
 // by zlib compressing it and ensuring the compressed size is at

--- a/src/tests/TestCryptographicRandom/TestCryptographicRandom.pro
+++ b/src/tests/TestCryptographicRandom/TestCryptographicRandom.pro
@@ -5,9 +5,11 @@
 
 include(../test.pri)
 
+QT += network
+
 TARGET = TestCryptographicRandom
-SOURCES = TestCryptographicRandom.cpp CryptographicRandom.cpp arc4random_uniform.cpp
-HEADERS = CryptographicHash.h
+SOURCES = SSL.cpp SSLLocks.cpp TestCryptographicRandom.cpp CryptographicRandom.cpp arc4random_uniform.cpp
+HEADERS = SSL.h SSLLocks.h CryptographicHash.h
 
 VPATH *= ../../../3rdparty/arc4random-src
 INCLUDEPATH *= ../../../3rdparty/arc4random-src

--- a/src/tests/TestPasswordGenerator/TestPasswordGenerator.cpp
+++ b/src/tests/TestPasswordGenerator/TestPasswordGenerator.cpp
@@ -6,6 +6,8 @@
 #include <QtCore>
 #include <QtTest>
 
+#include "SSL.h"
+
 #include "PasswordGenerator.h"
 
 // Get the password alphabet from PasswordGenerator.
@@ -14,8 +16,18 @@ extern QVector<QChar> mumble_password_generator_alphabet();
 class TestPasswordGenerator : public QObject {
 		Q_OBJECT
 	private slots:
+		void initTestCase();
+		void cleanupTestCase();
 		void random();
 };
+
+void TestPasswordGenerator::initTestCase() {
+	MumbleSSL::initialize();
+}
+
+void TestPasswordGenerator::cleanupTestCase() {
+	MumbleSSL::destroy();
+}
 
 void TestPasswordGenerator::random() {
 	QVector<QChar> alphabet = mumble_password_generator_alphabet();

--- a/src/tests/TestPasswordGenerator/TestPasswordGenerator.pro
+++ b/src/tests/TestPasswordGenerator/TestPasswordGenerator.pro
@@ -5,9 +5,11 @@
 
 include(../test.pri)
 
+QT += network
+
 TARGET = TestPasswordGenerator
-SOURCES = TestPasswordGenerator.cpp PasswordGenerator.cpp CryptographicRandom.cpp arc4random_uniform.cpp
-HEADERS = PasswordGenerator.h CryptographicHash.h
+SOURCES = SSL.cpp SSLLocks.cpp TestPasswordGenerator.cpp PasswordGenerator.cpp CryptographicRandom.cpp arc4random_uniform.cpp
+HEADERS = SSL.h SSLLocks.h PasswordGenerator.h CryptographicHash.h
 
 VPATH *= ../../../3rdparty/arc4random-src
 INCLUDEPATH *=  ../../../3rdparty/arc4random-src

--- a/src/tests/TestSSLLocks/TestSSLLocks.cpp
+++ b/src/tests/TestSSLLocks/TestSSLLocks.cpp
@@ -1,0 +1,106 @@
+// Copyright 2005-2017 The Mumble Developers. All rights reserved.
+// Use of this source code is governed by a BSD-style license
+// that can be found in the LICENSE file at the root of the
+// Mumble source tree or at <https://www.mumble.info/LICENSE>.
+
+#include <QtCore>
+#include <QtTest>
+
+#include "SSL.h"
+#include "QAtomicIntCompat.h"
+
+#include <openssl/rand.h>
+
+/// SSLRacer is a thread that runs operations on OpenSSL's
+/// RAND infrastructure, in an attempt to crash/segfault
+/// the test process.
+///
+/// The thread can either query OpenSSL for random bytes, or
+/// seed the RAND system. This is controlled by the |seed|
+/// parameter to the constructor.
+class SSLRacer : public QThread {
+public:
+	bool m_seed;
+	QAtomicInt *m_running;
+
+	SSLRacer(QAtomicInt *running, bool seed)
+		: m_seed(seed)
+		, m_running(running) {
+	}
+
+	void run() {
+		unsigned char buf[64];
+		while (QAtomicIntLoad(*m_running) == 1) {
+			for (int i = 0; i < 1024; i++) {
+				if (m_seed) {
+					RAND_seed(buf, sizeof(buf));
+				} else {
+					RAND_bytes(buf, sizeof(buf));
+				}
+			}
+		}
+	}
+};
+
+class TestSSLLocks : public QObject {
+		Q_OBJECT
+	private slots:
+		void initTestCase();
+		void cleanupTestCase();
+		void stress();
+};
+
+void TestSSLLocks::initTestCase() {
+	// For OpenSSL < 1.1, if you comment out this line,
+	// you'll be running OpenSSL without locking callbacks
+	// enabled. That'll make this test fail by crashing/segfaulting.
+	MumbleSSL::initialize();
+}
+
+void TestSSLLocks::cleanupTestCase() {
+	MumbleSSL::destroy();
+}
+
+/// Stress test that our locking callbacks for OpenSSL are set up and
+/// working correctly.
+///
+/// We do this by spawning a bunch of SSLStresser threads. Some of the
+/// threads will try to read random bytes in a tight loop. Other threads
+/// will, at the same time, try to add/seed random bytes to the OpenSSL
+/// RAND system.
+///
+/// The idea is that without proper locking, the data races we're causing
+/// should quite quickly cause the process to crash.
+void TestSSLLocks::stress() {
+	std::vector<SSLRacer *> racers;
+	QAtomicInt running(1);
+
+	// Spawn 24 threads in total. 12 readers, and 12 writers.
+	// Don't be too careful about cleaning up the threads. We'll either
+	// pass or crash, so the threads will be cleaned up either way.
+	int nthreads = 24;
+	for (int i = 0; i < nthreads; i++) {
+		bool seeder = i % 2;
+		SSLRacer *racer = new SSLRacer(&running, seeder);
+		racers.push_back(racer);
+		racer->start();
+	}
+
+	// Wait 2 seconds for a crash/segfault.
+	// If we don't crash within 2 seconds, we expect
+	// that our locking implementation works.
+	QTest::qSleep(2000);
+
+	// Signal to the racers that they should stop.
+	running.fetchAndStoreOrdered(0);
+
+	// Wait for all racers to complete.
+	for (size_t i = 0; i < racers.size(); i++) {
+		SSLRacer *racer = racers.at(i);
+		racer->wait();
+		delete racer;
+	}
+}
+
+QTEST_MAIN(TestSSLLocks)
+#include "TestSSLLocks.moc"

--- a/src/tests/TestSSLLocks/TestSSLLocks.pro
+++ b/src/tests/TestSSLLocks/TestSSLLocks.pro
@@ -1,0 +1,12 @@
+# Copyright 2005-2017 The Mumble Developers. All rights reserved.
+# Use of this source code is governed by a BSD-style license
+# that can be found in the LICENSE file at the root of the
+# Mumble source tree or at <https://www.mumble.info/LICENSE>.
+
+include(../test.pri)
+
+QT += network
+
+TARGET = TestSSLLocks
+SOURCES = SSL.cpp SSLLocks.cpp TestSSLLocks.cpp
+HEADERS = SSL.h SSLLocks.h

--- a/src/tests/TestSelfSignedCertificate/TestSelfSignedCertificate.cpp
+++ b/src/tests/TestSelfSignedCertificate/TestSelfSignedCertificate.cpp
@@ -6,14 +6,26 @@
 #include <QtCore>
 #include <QtTest>
 
+#include "SSL.h"
+
 #include "SelfSignedCertificate.h"
 
 class TestSelfSignedCertificate : public QObject {
 		Q_OBJECT
 	private slots:
+		void initTestCase();
+		void cleanupTestCase();
 		void exerciseClientCert();
 		void exerciseServerCert();
 };
+
+void TestSelfSignedCertificate::initTestCase() {
+	MumbleSSL::initialize();
+}
+
+void TestSelfSignedCertificate::cleanupTestCase() {
+	MumbleSSL::destroy();
+}
 
 void TestSelfSignedCertificate::exerciseClientCert() {
 	QSslCertificate cert;

--- a/src/tests/TestSelfSignedCertificate/TestSelfSignedCertificate.pro
+++ b/src/tests/TestSelfSignedCertificate/TestSelfSignedCertificate.pro
@@ -9,5 +9,5 @@ include(../../../qmake/qt.pri)
 QT *= network
 
 TARGET = TestSelfSignedCertificate
-SOURCES = TestSelfSignedCertificate.cpp SelfSignedCertificate.cpp
-HEADERS = SelfSignedCertificate.h
+SOURCES = SSL.cpp SSLLocks.cpp TestSelfSignedCertificate.cpp SelfSignedCertificate.cpp
+HEADERS = SSL.h SSLLocks.h SelfSignedCertificate.h

--- a/src/tests/tests.pro
+++ b/src/tests/tests.pro
@@ -16,4 +16,5 @@ SUBDIRS += \
 	TestUnresolvedServerAddress \
 	TestServerAddress \
 	TestServerResolver \
-	TestSelfSignedCertificate
+	TestSelfSignedCertificate \
+	TestSSLLocks


### PR DESCRIPTION
We neglected to register our own callbacks for locking and thread IDs
when we removed the restriction that we only allow one copy of OpenSSL
in the address space. (f544524)

This commit remedies that by providing our own set of callbacks for
locking and getting thread IDs to OpenSSL.

Previously, we just expected that Qt would properly initialize OpenSSL.
However, when Qt and us use separate copies of OpenSSL -- we have to do
it ourselves.