### PR TITLE
Allow Prefilling Add Server Dialog With HTTP URLs

### DIFF
--- a/src/mumble/ConnectDialog.cpp
+++ b/src/mumble/ConnectDialog.cpp
@@ -385,10 +385,23 @@ ServerItem *ServerItem::fromMimeData(const QMimeData *mime, bool default_name, Q
 		}
 	}
 
-	return fromUrl(url, default_name, p);
+	if (default_name) {
+#if QT_VERSION >= 0x050000
+		QUrlQuery query(url);
+		if (! query.hasQueryItem(QLatin1String("title"))) {
+			query.addQueryItem(QLatin1String("title"), url.host());
+		}
+#else
+		if (! url.hasQueryItem(QLatin1String("title"))) {
+			url.addQueryItem(QLatin1String("title"), url.host());
+		}
+#endif
+	}
+
+	return fromUrl(url, p);
 }
 
-ServerItem *ServerItem::fromUrl(QUrl url, bool default_name, QWidget *p) {
+ServerItem *ServerItem::fromUrl(QUrl url, QWidget *p) {
 	if (! url.isValid() || (url.scheme() != QLatin1String("mumble"))) {
 		return NULL;
 	}
@@ -411,17 +424,11 @@ ServerItem *ServerItem::fromUrl(QUrl url, bool default_name, QWidget *p) {
 	}
 
 #if QT_VERSION >= 0x050000
-	if (! query.hasQueryItem(QLatin1String("title")) && default_name)
-		query.addQueryItem(QLatin1String("title"), url.host());
-
 	ServerItem *si = new ServerItem(query.queryItemValue(QLatin1String("title")), url.host(), static_cast<unsigned short>(url.port(DEFAULT_MUMBLE_PORT)), url.userName(), url.password());
 
 	if (query.hasQueryItem(QLatin1String("url")))
 		si->qsUrl = query.queryItemValue(QLatin1String("url"));
 #else
-	if (! url.hasQueryItem(QLatin1String("title")) && default_name)
-		url.addQueryItem(QLatin1String("title"), url.host());
-
 	ServerItem *si = new ServerItem(url.queryItemValue(QLatin1String("title")), url.host(), static_cast<unsigned short>(url.port(DEFAULT_MUMBLE_PORT)), url.userName(), url.password());
 
 	if (url.hasQueryItem(QLatin1String("url")))

--- a/src/mumble/ConnectDialog.cpp
+++ b/src/mumble/ConnectDialog.cpp
@@ -385,12 +385,17 @@ ServerItem *ServerItem::fromMimeData(const QMimeData *mime, bool default_name, Q
 		}
 	}
 
+	return fromUrl(url, default_name, p);
+}
+
+ServerItem *ServerItem::fromUrl(QUrl url, bool default_name, QWidget *p) {
+	if (! url.isValid() || (url.scheme() != QLatin1String("mumble"))) {
+		return NULL;
+	}
+
 #if QT_VERSION >= 0x050000
 	QUrlQuery query(url);
 #endif
-
-	if (! url.isValid() || (url.scheme() != QLatin1String("mumble")))
-		return NULL;
 
 	if (url.userName().isEmpty()) {
 		if (g.s.qsUsername.isEmpty()) {

--- a/src/mumble/ConnectDialog.cpp
+++ b/src/mumble/ConnectDialog.cpp
@@ -767,8 +767,6 @@ ConnectDialogEdit::ConnectDialogEdit(QWidget *parent) : QDialog(parent) {
 	setWindowTitle(tr("Add Server"));
 	init();
 
-	connect(QApplication::clipboard(), SIGNAL(dataChanged()), this, SLOT(updateFromClipboard()));
-
 	if (!updateFromClipboard()) {
 		// If connected to a server assume the user wants to add it
 		if (g.sh && g.sh->isRunning()) {

--- a/src/mumble/ConnectDialog.cpp
+++ b/src/mumble/ConnectDialog.cpp
@@ -813,7 +813,7 @@ ConnectDialogEdit::~ConnectDialogEdit() {
 	delete m_si;
 }
 
-void ConnectDialogEdit::showNotice(const QString & text) {
+void ConnectDialogEdit::showNotice(const QString &text) {
 	QLabel *label = qwInlineNotice->findChild<QLabel *>(QLatin1String("qlPasteNotice"));
 	Q_ASSERT(label);
 	label->setText(text);

--- a/src/mumble/ConnectDialog.cpp
+++ b/src/mumble/ConnectDialog.cpp
@@ -378,6 +378,7 @@ ServerItem *ServerItem::fromMimeData(const QMimeData *mime, bool default_name, Q
 
 			url = QUrl::fromEncoded(qba, QUrl::StrictMode);
 			if (! url.isValid()) {
+				// Windows internet shortcut files (.url) are an ini with an URL value
 				QSettings qs(qsFile, QSettings::IniFormat);
 				url = QUrl::fromEncoded(qs.value(QLatin1String("InternetShortcut/URL")).toByteArray(), QUrl::StrictMode);
 			}

--- a/src/mumble/ConnectDialog.h
+++ b/src/mumble/ConnectDialog.h
@@ -176,7 +176,7 @@ class ServerItem : public QTreeWidgetItem, public PingStats {
 		///
 		static ServerItem *fromMimeData(const QMimeData *mime, bool default_name = true, QWidget *p = NULL);
 		/// Create a ServerItem from a mumble:// URL
-		static ServerItem *fromUrl(QUrl url, bool default_name, QWidget *p);
+		static ServerItem *fromUrl(QUrl url, QWidget *p);
 
 		void addServerItem(ServerItem *child);
 

--- a/src/mumble/ConnectDialog.h
+++ b/src/mumble/ConnectDialog.h
@@ -198,6 +198,8 @@ class ConnectDialogEdit : public QDialog, protected Ui::ConnectDialogEdit {
 	private:
 		Q_OBJECT
 		Q_DISABLE_COPY(ConnectDialogEdit)
+
+		void init();
 	protected:
 		bool bOk;
 		bool bCustomLabel;
@@ -212,12 +214,14 @@ class ConnectDialogEdit : public QDialog, protected Ui::ConnectDialogEdit {
 		QString qsName, qsHostname, qsUsername, qsPassword;
 		unsigned short usPort;
 		ConnectDialogEdit(QWidget *parent,
-		                  const QString &name = QString(),
-		                  const QString &host = QString(),
-		                  const QString &user = QString(),
-		                  unsigned short port = DEFAULT_MUMBLE_PORT,
-		                  const QString &password = QString(),
-		                  bool add = false);
+		                  const QString &name,
+		                  const QString &host,
+		                  const QString &user,
+		                  unsigned short port,
+		                  const QString &password);
+		/// Add a new Server
+		/// Prefills from clipboard content or the connected to server if available
+		ConnectDialogEdit(QWidget *parent);
 };
 
 class ConnectDialog : public QDialog, public Ui::ConnectDialog {

--- a/src/mumble/ConnectDialog.h
+++ b/src/mumble/ConnectDialog.h
@@ -214,6 +214,7 @@ class ConnectDialogEdit : public QDialog, protected Ui::ConnectDialogEdit {
 		void on_qcbShowPassword_toggled(bool);
 		void on_qleName_textEdited(const QString&);
 		void on_qleServer_textEdited(const QString&);
+		bool updateFromClipboard();
 	public:
 		QString qsName, qsHostname, qsUsername, qsPassword;
 		unsigned short usPort;

--- a/src/mumble/ConnectDialog.h
+++ b/src/mumble/ConnectDialog.h
@@ -214,6 +214,7 @@ class ConnectDialogEdit : public QDialog, protected Ui::ConnectDialogEdit {
 		void on_qcbShowPassword_toggled(bool);
 		void on_qleName_textEdited(const QString&);
 		void on_qleServer_textEdited(const QString&);
+		void showNotice(const QString & text);
 		bool updateFromClipboard();
 	public:
 		QString qsName, qsHostname, qsUsername, qsPassword;

--- a/src/mumble/ConnectDialog.h
+++ b/src/mumble/ConnectDialog.h
@@ -174,7 +174,7 @@ class ServerItem : public QTreeWidgetItem, public PingStats {
 		/// @param p Parent widget to use in case the user has to be queried
 		/// @return Server item or NULL if mime data invalid.
 		///
-		static ServerItem *fromMimeData(const QMimeData *mime, bool default_name = true, QWidget *p = NULL);
+		static ServerItem *fromMimeData(const QMimeData *mime, bool default_name = true, QWidget *p = NULL, bool convertHttpUrls=false);
 		/// Create a ServerItem from a mumble:// URL
 		static ServerItem *fromUrl(QUrl url, QWidget *p);
 
@@ -203,10 +203,14 @@ class ConnectDialogEdit : public QDialog, protected Ui::ConnectDialogEdit {
 	protected:
 		bool bOk;
 		bool bCustomLabel;
+		ServerItem *m_si;
+
 	public slots:
 		void validate();
 		void accept();
 
+		void on_qbFill_clicked();
+		void on_qbDiscard_clicked();
 		void on_qcbShowPassword_toggled(bool);
 		void on_qleName_textEdited(const QString&);
 		void on_qleServer_textEdited(const QString&);
@@ -222,6 +226,7 @@ class ConnectDialogEdit : public QDialog, protected Ui::ConnectDialogEdit {
 		/// Add a new Server
 		/// Prefills from clipboard content or the connected to server if available
 		ConnectDialogEdit(QWidget *parent);
+		virtual ~ConnectDialogEdit();
 };
 
 class ConnectDialog : public QDialog, public Ui::ConnectDialog {

--- a/src/mumble/ConnectDialog.h
+++ b/src/mumble/ConnectDialog.h
@@ -175,6 +175,8 @@ class ServerItem : public QTreeWidgetItem, public PingStats {
 		/// @return Server item or NULL if mime data invalid.
 		///
 		static ServerItem *fromMimeData(const QMimeData *mime, bool default_name = true, QWidget *p = NULL);
+		/// Create a ServerItem from a mumble:// URL
+		static ServerItem *fromUrl(QUrl url, bool default_name, QWidget *p);
 
 		void addServerItem(ServerItem *child);
 

--- a/src/mumble/ConnectDialog.h
+++ b/src/mumble/ConnectDialog.h
@@ -214,7 +214,7 @@ class ConnectDialogEdit : public QDialog, protected Ui::ConnectDialogEdit {
 		void on_qcbShowPassword_toggled(bool);
 		void on_qleName_textEdited(const QString&);
 		void on_qleServer_textEdited(const QString&);
-		void showNotice(const QString & text);
+		void showNotice(const QString &text);
 		bool updateFromClipboard();
 	public:
 		QString qsName, qsHostname, qsUsername, qsPassword;

--- a/src/mumble/ConnectDialogEdit.ui
+++ b/src/mumble/ConnectDialogEdit.ui
@@ -7,11 +7,11 @@
     <x>0</x>
     <y>0</y>
     <width>430</width>
-    <height>241</height>
+    <height>272</height>
    </rect>
   </property>
   <property name="sizePolicy">
-   <sizepolicy hsizetype="Preferred" vsizetype="MinimumExpanding">
+   <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
     <horstretch>0</horstretch>
     <verstretch>0</verstretch>
    </sizepolicy>
@@ -27,7 +27,13 @@
   </property>
   <layout class="QGridLayout" name="gridLayout">
    <item row="1" column="0" colspan="2">
-    <widget class="QWidget" name="qwPasteNotice" native="true">
+    <widget class="QWidget" name="qwInlineNotice" native="true">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
      <layout class="QHBoxLayout" name="horizontalLayout">
       <item>
        <widget class="QLabel" name="qlPasteNotice">
@@ -232,8 +238,8 @@ Label of the server. This is what the server will be named like in your server l
    <slot>accept()</slot>
    <hints>
     <hint type="sourcelabel">
-     <x>112</x>
-     <y>123</y>
+     <x>175</x>
+     <y>231</y>
     </hint>
     <hint type="destinationlabel">
      <x>50</x>
@@ -248,8 +254,8 @@ Label of the server. This is what the server will be named like in your server l
    <slot>reject()</slot>
    <hints>
     <hint type="sourcelabel">
-     <x>191</x>
-     <y>128</y>
+     <x>254</x>
+     <y>231</y>
     </hint>
     <hint type="destinationlabel">
      <x>224</x>

--- a/src/mumble/ConnectDialogEdit.ui
+++ b/src/mumble/ConnectDialogEdit.ui
@@ -83,6 +83,9 @@ Port on which the server is listening. If the server is identified by a Bonjour 
      <property name="text">
       <string>Password</string>
      </property>
+     <property name="buddy">
+      <cstring>qlePassword</cstring>
+     </property>
     </widget>
    </item>
    <item row="4" column="1">

--- a/src/mumble/ConnectDialogEdit.ui
+++ b/src/mumble/ConnectDialogEdit.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>265</width>
-    <height>197</height>
+    <width>430</width>
+    <height>241</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -16,11 +16,66 @@
     <verstretch>0</verstretch>
    </sizepolicy>
   </property>
+  <property name="minimumSize">
+   <size>
+    <width>430</width>
+    <height>0</height>
+   </size>
+  </property>
   <property name="windowTitle">
    <string>Edit Server</string>
   </property>
   <layout class="QGridLayout" name="gridLayout">
-   <item row="1" column="0">
+   <item row="1" column="0" colspan="2">
+    <widget class="QWidget" name="qwPasteNotice" native="true">
+     <layout class="QHBoxLayout" name="horizontalLayout">
+      <item>
+       <widget class="QLabel" name="qlPasteNotice">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="wordWrap">
+         <bool>true</bool>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <layout class="QVBoxLayout" name="qlActions">
+        <item>
+         <widget class="QPushButton" name="qbFill">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="text">
+           <string>✓ &amp;Fill</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QPushButton" name="qbDiscard">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="text">
+           <string notr="true">🗙 &amp;Ignore</string>
+          </property>
+         </widget>
+        </item>
+       </layout>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item row="2" column="0">
     <widget class="QLabel" name="qliServer">
      <property name="text">
       <string>A&amp;ddress</string>
@@ -30,7 +85,7 @@
      </property>
     </widget>
    </item>
-   <item row="1" column="1">
+   <item row="2" column="1">
     <widget class="QLineEdit" name="qleServer">
      <property name="toolTip">
       <string>Internet address of the server.</string>
@@ -44,7 +99,7 @@ Internet address of the server. This can be a normal hostname, an IPv4/IPv6 addr
      </property>
     </widget>
    </item>
-   <item row="2" column="0">
+   <item row="3" column="0">
     <widget class="QLabel" name="qliPort">
      <property name="text">
       <string>&amp;Port</string>
@@ -54,7 +109,7 @@ Internet address of the server. This can be a normal hostname, an IPv4/IPv6 addr
      </property>
     </widget>
    </item>
-   <item row="2" column="1">
+   <item row="3" column="1">
     <widget class="QLineEdit" name="qlePort">
      <property name="toolTip">
       <string>Port on which the server is listening</string>
@@ -68,7 +123,7 @@ Port on which the server is listening. If the server is identified by a Bonjour 
      </property>
     </widget>
    </item>
-   <item row="4" column="0">
+   <item row="5" column="0">
     <widget class="QLabel" name="qliUsername">
      <property name="text">
       <string>&amp;Username</string>
@@ -78,7 +133,7 @@ Port on which the server is listening. If the server is identified by a Bonjour 
      </property>
     </widget>
    </item>
-   <item row="5" column="0">
+   <item row="6" column="0">
     <widget class="QLabel" name="qliPassword">
      <property name="text">
       <string>Password</string>
@@ -88,7 +143,7 @@ Port on which the server is listening. If the server is identified by a Bonjour 
      </property>
     </widget>
    </item>
-   <item row="4" column="1">
+   <item row="5" column="1">
     <widget class="QLineEdit" name="qleUsername">
      <property name="toolTip">
       <string>Username to send to the server</string>
@@ -102,14 +157,14 @@ Username to send to the server. Be aware that the server can impose restrictions
      </property>
     </widget>
    </item>
-   <item row="8" column="1">
+   <item row="9" column="1">
     <widget class="QDialogButtonBox" name="qdbbButtonBox">
      <property name="standardButtons">
       <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
      </property>
     </widget>
    </item>
-   <item row="5" column="1">
+   <item row="6" column="1">
     <widget class="QLineEdit" name="qlePassword">
      <property name="toolTip">
       <string>Password to send to the server</string>
@@ -123,7 +178,7 @@ Password to be sent to the server on connect. This password is needed when conne
      </property>
     </widget>
    </item>
-   <item row="7" column="1">
+   <item row="8" column="1">
     <widget class="QCheckBox" name="qcbShowPassword">
      <property name="toolTip">
       <string/>
@@ -133,7 +188,7 @@ Password to be sent to the server on connect. This password is needed when conne
      </property>
     </widget>
    </item>
-   <item row="6" column="0">
+   <item row="7" column="0">
     <widget class="QLabel" name="qliName">
      <property name="text">
       <string>Label</string>
@@ -143,7 +198,7 @@ Password to be sent to the server on connect. This password is needed when conne
      </property>
     </widget>
    </item>
-   <item row="6" column="1">
+   <item row="7" column="1">
     <widget class="QLineEdit" name="qleName">
      <property name="toolTip">
       <string>Name of the server</string>

--- a/src/mumble/ConnectDialogEdit.ui
+++ b/src/mumble/ConnectDialogEdit.ui
@@ -38,10 +38,13 @@
       <item>
        <widget class="QLabel" name="qlPasteNotice">
         <property name="sizePolicy">
-         <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
-          <horstretch>0</horstretch>
+         <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+          <horstretch>4</horstretch>
           <verstretch>0</verstretch>
          </sizepolicy>
+        </property>
+        <property name="alignment">
+         <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
         </property>
         <property name="wordWrap">
          <bool>true</bool>
@@ -49,34 +52,54 @@
        </widget>
       </item>
       <item>
-       <layout class="QVBoxLayout" name="qlActions">
-        <item>
-         <widget class="QPushButton" name="qbFill">
-          <property name="sizePolicy">
-           <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-            <horstretch>0</horstretch>
-            <verstretch>0</verstretch>
-           </sizepolicy>
-          </property>
-          <property name="text">
-           <string>✓ &amp;Fill</string>
-          </property>
-         </widget>
-        </item>
-        <item>
-         <widget class="QPushButton" name="qbDiscard">
-          <property name="sizePolicy">
-           <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-            <horstretch>0</horstretch>
-            <verstretch>0</verstretch>
-           </sizepolicy>
-          </property>
-          <property name="text">
-           <string notr="true">🗙 &amp;Ignore</string>
-          </property>
-         </widget>
-        </item>
-       </layout>
+       <widget class="QWidget" name="qwActions" native="true">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+          <horstretch>1</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <layout class="QVBoxLayout" name="qlActions">
+         <property name="leftMargin">
+          <number>0</number>
+         </property>
+         <property name="topMargin">
+          <number>0</number>
+         </property>
+         <property name="rightMargin">
+          <number>0</number>
+         </property>
+         <property name="bottomMargin">
+          <number>0</number>
+         </property>
+         <item>
+          <widget class="QPushButton" name="qbFill">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="text">
+            <string>&amp;Fill</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QPushButton" name="qbDiscard">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="text">
+            <string notr="true">&amp;Ignore</string>
+           </property>
+          </widget>
+         </item>
+        </layout>
+       </widget>
       </item>
      </layout>
     </widget>

--- a/src/mumble/Themes.cpp
+++ b/src/mumble/Themes.cpp
@@ -155,5 +155,5 @@ bool Themes::readStylesheet(const QString &stylesheetFn, QString &stylesheetCont
 }
 
 QString Themes::getDefaultStylesheet() {
-	return QLatin1String(".log-channel{text-decoration:none;}.log-user{text-decoration:none;}p{margin:0;}#qwMacWarning{background-color:#FFFEDC;border-radius:5px;border:1px solid #B5B59E;}");
+	return QLatin1String(".log-channel{text-decoration:none;}.log-user{text-decoration:none;}p{margin:0;}#qwMacWarning,#qwInlineNotice{background-color:#FFFEDC;border-radius:5px;border:1px solid #B5B59E;}");
 }


### PR DESCRIPTION
The commits in this PR restructure the ConnectDialogEdit code and implement suggesting to the user to fill the dialog form from the clipboard (if clipboard data is available). Implements #3143 

---
Outdated

![2017-07-18 01_42_33-add server](https://user-images.githubusercontent.com/93181/28294504-fa566a04-6b5a-11e7-979e-c9bd050aa681.png)

TODO:
* [x] Use existing themeable color/style
* [x] Fix/Need layout auto-adjustment on show/hide
* [x] Implement fill suggestion for current connected to server (fallback if no clipboard data)
* [ ] Prevent vertical resizability

@mkrautz @davidebeatrici @hacst what do you think about this new UI element (as per screenshot)?

Also makes sense for prefilling with the current connected to server instead of autofilling like we currently do, right? (Even though we can not have invalid/wrong data there like for HTTP URLs.)