### PR TITLE
Allow users to specify RFC 7919 Diffie-Hellman parameters for the sslDHParams murmur.ini option

### DIFF
--- a/scripts/murmur.ini
+++ b/scripts/murmur.ini
@@ -202,9 +202,16 @@ allowping=true
 ; The sslDHParams option allows you to specify a PEM-encoded file with
 ; Diffie-Hellman parameters, which will be used as the default Diffie-
 ; Hellman parameters for all virtual servers.
-; If a file is not specified, each Murmur virtual server will auto-generate
-; its own unique set of 2048-bit Diffie-Hellman parameters on first launch.
-;sslDHParams=
+;
+; Instead of pointing sslDHParams to a file, you can also use the option
+; to specify a named set of Diffie-Hellman parameters for Murmur to use.
+; Murmur comes bundled with the Diffie-Hellman parameters from RFC 7919.
+; These parameters are available by using the following names:
+;
+; @ffdhe2048, @ffdhe3072, @ffdhe4096, @ffdhe6144, @ffdhe8192
+;
+; By default, Murmur uses @ffdhe2048.
+;sslDHParams=@ffdhe2048
 
 ; The sslCiphers option chooses the cipher suites to make available for use
 ; in SSL/TLS. This option is server-wide, and cannot be set on a

--- a/src/FFDHE.cpp
+++ b/src/FFDHE.cpp
@@ -8,6 +8,16 @@
 #include "FFDHE.h"
 #include "FFDHETable.h"
 
+QStringList FFDHE::NamedGroups() {
+	QStringList ng;
+	ng << QLatin1String("ffdhe2048");
+	ng << QLatin1String("ffdhe3072");
+	ng << QLatin1String("ffdhe4096");
+	ng << QLatin1String("ffdhe6144");
+	ng << QLatin1String("ffdhe8192");
+	return ng;
+}
+
 QByteArray FFDHE::PEMForNamedGroup(QString name) {
 	name = name.toLower();
 

--- a/src/FFDHE.h
+++ b/src/FFDHE.h
@@ -9,6 +9,10 @@
 /// FFDHE provides access to the Diffie-Hellman parameters from RFC 7919.
 class FFDHE {
 	public:
+		/// NamedGroups returns a list of the supported named
+		/// groups for PEMForNamedGroup.
+		static QStringList NamedGroups();
+
 		/// PEMForNamedGroup returns the PEM-encoded
 		/// Diffie-Hellman parameters for the RFC 7919
 		/// group with the given name, such as "ffdhe2048",

--- a/src/murmur/Meta.cpp
+++ b/src/murmur/Meta.cpp
@@ -524,7 +524,13 @@ bool MetaParams::loadSSLSettings() {
 			QString group = qsSSLDHParams.mid(1).trimmed();
 			QByteArray pem = FFDHE::PEMForNamedGroup(group);
 			if (pem.isEmpty()) {
-				qCritical("MetaParms: Diffie-Hellman parameters with name '%s' is not available in Murmur.", qPrintable(qsSSLDHParams));
+				QStringList names = FFDHE::NamedGroups();
+				QStringList atNames;
+				foreach (QString name, names) {
+					atNames << QLatin1String("@") + name;
+				}
+				QString supported = atNames.join(QLatin1String(", "));
+				qCritical("MetaParms: Diffie-Hellman parameters with name '%s' is not available. (Supported: %s)", qPrintable(qsSSLDHParams), qPrintable(supported));
 			}
 			dhparams = pem;
 		} else {

--- a/src/murmur/Meta.cpp
+++ b/src/murmur/Meta.cpp
@@ -530,7 +530,7 @@ bool MetaParams::loadSSLSettings() {
 					atNames << QLatin1String("@") + name;
 				}
 				QString supported = atNames.join(QLatin1String(", "));
-				qCritical("MetaParms: Diffie-Hellman parameters with name '%s' is not available. (Supported: %s)", qPrintable(qsSSLDHParams), qPrintable(supported));
+				qFatal("MetaParms: Diffie-Hellman parameters with name '%s' is not available. (Supported: %s)", qPrintable(qsSSLDHParams), qPrintable(supported));
 			}
 			dhparams = pem;
 		} else {
@@ -539,7 +539,7 @@ bool MetaParams::loadSSLSettings() {
 				dhparams = pem.readAll();
 				pem.close();
 			} else {
-				qCritical("MetaParams: Failed to read %s", qPrintable(qsSSLDHParams));
+				qFatal("MetaParams: Failed to read %s", qPrintable(qsSSLDHParams));
 			}
 		}
 	}
@@ -549,13 +549,13 @@ bool MetaParams::loadSSLSettings() {
 		if (qdhp.isValid()) {
 			tmpDHParams = dhparams;
 		} else {
-			qCritical("MetaParams: Unable to use specified Diffie-Hellman parameters: %s", qPrintable(qdhp.errorString()));
+			qFatal("MetaParams: Unable to use specified Diffie-Hellman parameters: %s", qPrintable(qdhp.errorString()));
 			return false;
 		}
 	}
 #else
 	if (! qsSSLDHParams.isEmpty()) {
-		qCritical("MetaParams: This version of Murmur does not support Diffie-Hellman parameters (sslDHParams). Murmur will not start unless you remove the option from your murmur.ini file.");
+		qFatal("MetaParams: This version of Murmur does not support Diffie-Hellman parameters (sslDHParams). Murmur will not start unless you remove the option from your murmur.ini file.");
 		return false;
 	}
 #endif

--- a/src/murmur/Meta.cpp
+++ b/src/murmur/Meta.cpp
@@ -429,7 +429,7 @@ bool MetaParams::loadSSLSettings() {
 	QString qsSSLCert = qsSettings->value("sslCert").toString();
 	QString qsSSLKey = qsSettings->value("sslKey").toString();
 	QString qsSSLCA = qsSettings->value("sslCA").toString();
-	QString qsSSLDHParams = qsSettings->value("sslDHParams").toString();
+	QString qsSSLDHParams = typeCheckedFromSettings(QLatin1String("sslDHParams"), QString(QLatin1String("@ffdhe2048")));
 
 	qbaPassPhrase = qsSettings->value("sslPassPhrase").toByteArray();
 

--- a/src/murmur/Meta.cpp
+++ b/src/murmur/Meta.cpp
@@ -554,7 +554,8 @@ bool MetaParams::loadSSLSettings() {
 		}
 	}
 #else
-	if (! qsSSLDHParams.isEmpty()) {
+	QString qsSSLDHParamsIniValue = qsSettings->value(QLatin1String("sslDHParams")).toString();
+	if (! qsSSLDHParamsIniValue.isEmpty()) {
 		qFatal("MetaParams: This version of Murmur does not support Diffie-Hellman parameters (sslDHParams). Murmur will not start unless you remove the option from your murmur.ini file.");
 		return false;
 	}

--- a/src/tests/TestFFDHE/TestFFDHE.cpp
+++ b/src/tests/TestFFDHE/TestFFDHE.cpp
@@ -22,6 +22,7 @@ class TestFFDHE : public QObject {
 #if defined(USE_QSSLDIFFIEHELLMANPARAMETERS)
 		void exercise_data();
 		void exercise();
+		void namedGroupsMethod();
 #endif
 };
 
@@ -51,10 +52,7 @@ void TestFFDHE::exercise_data() {
 	QTest::newRow("trailingspace") << QString(QLatin1String("ffdhe2048 ")) << false;
 }
 
-void TestFFDHE::exercise() {
-	QFETCH(QString, name);
-	QFETCH(bool, expectedToWork);
-
+static bool tryFFDHELookupByName(QString name) {
 	bool ok = true;
 
 	QByteArray pem = FFDHE::PEMForNamedGroup(name);
@@ -69,7 +67,19 @@ void TestFFDHE::exercise() {
 		}
 	}
 
-	QCOMPARE(ok, expectedToWork);
+	return ok;
+}
+
+void TestFFDHE::exercise() {
+	QFETCH(QString, name);
+	QFETCH(bool, expectedToWork);
+	QCOMPARE(tryFFDHELookupByName(name), expectedToWork);
+}
+
+void TestFFDHE::namedGroupsMethod() {
+	foreach (QString name, FFDHE::NamedGroups()) {
+		QCOMPARE(tryFFDHELookupByName(name), true);
+	}
 }
 #endif
 


### PR DESCRIPTION
This PR uses the newly introduced FFDHE class to allow users to specify RFC 7919 Diffie-Hellman parameters for the sslDHParams option in murmur.ini.

Also, this PR changes the default value for the sslDHParams option. Instead of being blank by default (which would previously cause Murmur to auto-generate Diffie-Hellman parameters for all virtual servers), we now use @ffdhe2048.

This PR depends on
mumble-voip/mumble#3183

Fixes mumble-voip/mumble#2204