### PR TITLE
installer: revert "installer: force uninstall before install."

### DIFF
--- a/installer/Product.wxs
+++ b/installer/Product.wxs
@@ -32,7 +32,7 @@
       VersionNT > 501 OR (VersionNT = 501 AND ServicePackLevel >= 2) OR (VersionNT = 502 AND ServicePackLevel >= 1)
     </Condition>
 
-    <MajorUpgrade AllowDowngrades='no' AllowSameVersionUpgrades='yes' MigrateFeatures='yes' Schedule='afterInstallValidate' DowngradeErrorMessage='A later version of [ProductName] is already installed.' />
+    <MajorUpgrade AllowDowngrades='no' AllowSameVersionUpgrades='yes' MigrateFeatures='yes' Schedule='afterInstallExecute' DowngradeErrorMessage='A later version of [ProductName] is already installed.' />
 
     <Media Id="1" Cabinet="$(var.ProductName).cab" EmbedCab="yes" CompressionLevel="high" />
 


### PR DESCRIPTION
This reverts commit 3d4663465ea1e528a299f1939237c31a4188775c.

That commit was done because of reports that stale files from
old versions of Mumble were left behind. In particular, in
the "Versions" subdirectory.

I just tested this locally, and I can't reproduce that problem.

Reverting this commit should hopefully resolve a lot issues
such as:

mumble-voip/mumble#2901
mumble-voip/mumble#1917
mumble-voip/mumble#1845
mumble-voip/mumble#1700

Perhaps more.