### PR TITLE
Overlay_win: properly terminate our overlay helper processes.

### DIFF
--- a/src/mumble/Overlay_win.cpp
+++ b/src/mumble/Overlay_win.cpp
@@ -133,6 +133,18 @@ OverlayPrivateWin::~OverlayPrivateWin() {
 		qFatal("OverlayPrivateWin: unable to close Mumble process handle.");
 		return;
 	}
+
+	// Remove all signals, so they don't
+	// interfere with our calls to waitForFinished
+	// below.
+	m_helper_process->disconnect();
+	m_helper64_process->disconnect();
+
+	m_helper_process->terminate();
+	m_helper64_process->terminate();
+
+	m_helper_process->waitForFinished();
+	m_helper64_process->waitForFinished();
 }
 
 void OverlayPrivateWin::startHelper(QProcess *helper) {


### PR DESCRIPTION
This gets rid of the errors in the Mumble log about destroying
QProcess instances while they're still running.