### PR TITLE
GlobalShortcut_win: delete poll timer inside the GlobalShortcut thread.

### DIFF
--- a/src/mumble/GlobalShortcut_win.cpp
+++ b/src/mumble/GlobalShortcut_win.cpp
@@ -113,13 +113,15 @@ void GlobalShortcutWin::run() {
 	}
 #endif
 
-	QTimer * timer = new QTimer(this);
+	QTimer *timer = new QTimer;
 	connect(timer, SIGNAL(timeout()), this, SLOT(timeTicked()));
 	timer->start(20);
 
 	setPriority(QThread::TimeCriticalPriority);
 
 	exec();
+
+	delete timer;
 
 #ifdef USE_GKEY
 	delete gkey;


### PR DESCRIPTION
Prior to this change, using Mumble on Windows would produce a warning
from Qt in the log:

    <W>2017-07-20 12:11:33.842 QObject::killTimer: Timers cannot be stopped from another thread
    <W>2017-07-20 12:11:33.842 QObject::~QObject: Timers cannot be stopped from another thread

This was because the QTimer in GlobalShortcutWin, used for polling
the various global shortcut engines, was being destroyed by the wrong
thread.

The QTimer in GlobalShortcutWin is constructed within the
GlobalShortuctWin thread. So, the QObject belongs to that thread.
However, the destructor of GlobalShortcutWin is not called in the
scope of the thread. It is called on the main thread by
GlobalShortcutEngine::remove (in GlobalShortcut.cpp) when the last
GlobalShortcut object is removed.

This change works around the problem by not parenting the QTimer
to the GlobalShortcutWin object. Instead, it explicitly deletes
the QTimer after the GlobalShortcutWin thread's event loop has
exited.

Fixes mumble-voip/mumble#3189