### PR TITLE
ConnectDialog: re-arrange lookedUp() code to avoid recursive runloop problem.

### DIFF
--- a/src/mumble/ConnectDialog.cpp
+++ b/src/mumble/ConnectDialog.cpp
@@ -1569,23 +1569,26 @@ void ConnectDialog::lookedUp() {
 		}
 	}
 
-	foreach(ServerItem *si, qhDNSWait[unresolved]) {
+	QSet<ServerItem *> waiting = qhDNSWait[unresolved];
+	foreach(ServerItem *si, waiting) {
 		foreach (const ServerAddress &addr, qs) {
 			qhPings[addr].insert(si);
 		}
 
 		si->qlAddresses = qs.toList();
+	}
 
+	qlDNSLookup.removeAll(unresolved);
+	qhDNSCache.insert(unresolved, qs.toList());
+	qhDNSWait.remove(unresolved);
+
+	foreach(ServerItem *si, waiting) {
 		if (si == qtwServers->currentItem()) {
 			on_qtwServers_currentItemChanged(si, si);
 			if (si == siAutoConnect)
 				accept();
 		}
 	}
-
-	qlDNSLookup.removeAll(unresolved);
-	qhDNSCache.insert(unresolved, qs.toList());
-	qhDNSWait.remove(unresolved);
 
 	if (bAllowPing) {
 		foreach(const ServerAddress &addr, qs) {


### PR DESCRIPTION
This ensures that we apply all globally visible state from the lookedUp()
method before we attempt to auto-connect.

The previous block of code would, when auto-connect is enabled, call
accept() to perform the auto-connect. In case the selected ServerItem
has no username set, accept() will trigger a dialog box to appear asking
the user to input their desired username. Unfortunately, showing this
dialog causes Mumble to enter the event loop before the lookedUp()
method anticipated it to be entered. The point at which the auto-connect
happens, is before the lookedUp() method has had time to update the
global state of the ConnectDialog to reflect the successful host lookup.
In practice, this meant that the auto-connect would be triggered many,
many times in a row. In this scenario, Mumble would open a new username
dialog box for each auto-connect attempt. This would cause Mumble to
become unresponsive, because Mumble would spawn infinitely many username
dialog boxes.

The code of the lookedUp() method was re-arranged in
4d6e28e6dec7c812f77ad542a61e3ac600daf3ea, which introduced this problem.

Fixes mumble-voip/mumble#3191