### PR TITLE
src/murmur: remove CONFIG(ermine), use CONFIG(buildenv) instead.

### DIFF
--- a/src/murmur/murmur.pro
+++ b/src/murmur/murmur.pro
@@ -59,7 +59,7 @@ unix {
     QMAKE_LFLAGS *= -static
   }
 
-  CONFIG(ermine) {
+  !macx:CONFIG(buildenv) {
     QMAKE_LFLAGS *= -Wl,-rpath,$$(MUMBLE_PREFIX)/lib:$$(MUMBLE_ICE_PREFIX)/lib
   }
 
@@ -116,7 +116,7 @@ ice {
 		QMAKE_LIBDIR *= $$(MUMBLE_PREFIX)/Ice-3.4.2/lib/
 	}
 
-	CONFIG(ermine) {
+	unix:!macx:CONFIG(buildenv) {
 		INCLUDEPATH *= $$(MUMBLE_ICE_PREFIX)/include/
 		QMAKE_LIBDIR *= $$(MUMBLE_ICE_PREFIX)/lib/
 	}

--- a/src/murmur/murmur_ice/murmur_ice.pro
+++ b/src/murmur/murmur_ice/murmur_ice.pro
@@ -51,7 +51,7 @@ macx {
 	slice.commands = $$MUMBLE_ICE_PREFIX/bin/slice2cpp --checksum -I$$MUMBLE_ICE_PREFIX/slice/ -I$$MUMBLE_ICE_PREFIX/share/slice/ ../Murmur.ice
 }
 
-CONFIG(ermine) {
+unix:!macx:CONFIG(buildenv) {
 	INCLUDEPATH *= $$(MUMBLE_ICE_PREFIX)/include/
 	slice.commands = $$(MUMBLE_ICE_PREFIX)/bin/slice2cpp --checksum -I$$(MUMBLE_ICE_PREFIX)/slice/ ../Murmur.ice
 }


### PR DESCRIPTION
CONFIG(ermine) was used before we had CONFIG(buildenv).
All CONFIG(ermine) does is to try and use Ice from our build
environment.