### PR TITLE
GlobalShortcutWin: remove code related to the in-overlay Mumble client.

### DIFF
--- a/src/mumble/GlobalShortcut.cpp
+++ b/src/mumble/GlobalShortcut.cpp
@@ -934,9 +934,6 @@ QString GlobalShortcutEngine::buttonText(const QList<QVariant> &list) {
 	return keys.join(QLatin1String(" + "));
 }
 
-void GlobalShortcutEngine::prepareInput() {
-}
-
 GlobalShortcut::GlobalShortcut(QObject *p, int index, QString qsName, QVariant def) : QObject(p) {
 	idx = index;
 	name=qsName;

--- a/src/mumble/GlobalShortcut.h
+++ b/src/mumble/GlobalShortcut.h
@@ -258,8 +258,6 @@ class GlobalShortcutEngine : public QThread {
 		virtual void setEnabled(bool b);
 		virtual bool enabled();
 		virtual bool canDisable();
-
-		virtual void prepareInput();
 	signals:
 		void buttonPressed(bool last);
 };

--- a/src/mumble/GlobalShortcut_win.cpp
+++ b/src/mumble/GlobalShortcut_win.cpp
@@ -709,6 +709,3 @@ QString GlobalShortcutWin::buttonName(const QVariant &v) {
 bool GlobalShortcutWin::canSuppress() {
 	return bHook;
 }
-
-void GlobalShortcutWin::prepareInput() {
-}

--- a/src/mumble/GlobalShortcut_win.cpp
+++ b/src/mumble/GlobalShortcut_win.cpp
@@ -57,8 +57,6 @@ GlobalShortcutWin::GlobalShortcutWin()
 	// Hidden setting to disable hooking
 	bHook = g.qs->value(QLatin1String("winhooks"), true).toBool();
 
-	GetKeyboardState(ucKeyState);
-
 	moveToThread(this);
 	start(QThread::LowestPriority);
 }
@@ -153,7 +151,6 @@ void GlobalShortcutWin::run() {
 LRESULT CALLBACK GlobalShortcutWin::HookKeyboard(int nCode, WPARAM wParam, LPARAM lParam) {
 	GlobalShortcutWin *gsw=static_cast<GlobalShortcutWin *>(engine);
 	KBDLLHOOKSTRUCT *key=reinterpret_cast<KBDLLHOOKSTRUCT *>(lParam);
-	BYTE *ucKeyState = gsw->ucKeyState;
 
 #ifndef QT_NO_DEBUG
 	static int safety = 0;
@@ -162,73 +159,6 @@ LRESULT CALLBACK GlobalShortcutWin::HookKeyboard(int nCode, WPARAM wParam, LPARA
 #else
 	if (nCode >= 0) {
 #endif
-		UINT msg = wParam;
-		WPARAM w = key->vkCode;
-		LPARAM l = 1 | (key->scanCode << 16);
-		if (key->flags & LLKHF_EXTENDED)
-			l |= 0x1000000;
-		if (wParam == WM_KEYUP)
-			l |= 0xC0000000;
-
-		bool nomsg = false;
-
-		switch (w) {
-			case VK_LCONTROL:
-			case VK_RCONTROL:
-				if ((msg == WM_KEYDOWN) || (msg == WM_SYSKEYDOWN))
-					ucKeyState[w] |= 0x80;
-				else {
-					ucKeyState[w] &= 0x7f;
-
-					if ((ucKeyState[VK_LCONTROL] & 0x80) || (ucKeyState[VK_RCONTROL] & 0x80)) {
-						nomsg = true;
-						break;
-					}
-				}
-
-				w = VK_CONTROL;
-				break;
-			case VK_LSHIFT:
-			case VK_RSHIFT:
-				if ((msg == WM_KEYDOWN) || (msg == WM_SYSKEYDOWN))
-					ucKeyState[w] |= 0x80;
-				else {
-					ucKeyState[w] &= 0x7f;
-
-					if ((ucKeyState[VK_LSHIFT] & 0x80) || (ucKeyState[VK_RSHIFT] & 0x80)) {
-						nomsg = true;
-						break;
-					}
-				}
-
-				w = VK_SHIFT;
-				break;
-			case VK_LMENU:
-			case VK_RMENU:
-				if ((msg == WM_KEYDOWN) || (msg == WM_SYSKEYDOWN))
-					ucKeyState[w] |= 0x80;
-				else {
-					ucKeyState[w] &= 0x7f;
-
-					if ((ucKeyState[VK_LMENU] & 0x80) || (ucKeyState[VK_RMENU] & 0x80)) {
-						nomsg = true;
-						break;
-					}
-				}
-
-				w = VK_MENU;
-				break;
-			default:
-				break;
-		}
-
-		if ((msg == WM_KEYDOWN) || (msg == WM_SYSKEYDOWN)) {
-			if (ucKeyState[w] & 0x80)
-				l |= 0x40000000;
-			ucKeyState[w] |= 0x80;
-		} else if (((msg == WM_KEYUP) || (msg == WM_SYSKEYUP)) && !nomsg) {
-			ucKeyState[w] &= 0x7f;
-		}
 
 		QList<QVariant> ql;
 
@@ -284,49 +214,10 @@ LRESULT CALLBACK GlobalShortcutWin::HookKeyboard(int nCode, WPARAM wParam, LPARA
 LRESULT CALLBACK GlobalShortcutWin::HookMouse(int nCode, WPARAM wParam, LPARAM lParam) {
 	GlobalShortcutWin *gsw=static_cast<GlobalShortcutWin *>(engine);
 	MSLLHOOKSTRUCT *mouse=reinterpret_cast<MSLLHOOKSTRUCT *>(lParam);
-	BYTE *ucKeyState = gsw->ucKeyState;
 
 	if (nCode >= 0) {
 		bool suppress = false;
 		UINT msg = wParam;
-
-		switch (msg) {
-			case WM_LBUTTONDOWN:
-				ucKeyState[VK_LBUTTON] |= 0x80;
-				if (gsw->tDoubleClick.restart() < (QApplication::doubleClickInterval() * 1000ULL))
-					msg = WM_LBUTTONDBLCLK;
-				break;
-			case WM_LBUTTONUP:
-				ucKeyState[VK_LBUTTON] &= 0x7f;
-				break;
-			case WM_RBUTTONDOWN:
-				ucKeyState[VK_RBUTTON] |= 0x80;
-				break;
-			case WM_RBUTTONUP:
-				ucKeyState[VK_RBUTTON] &= 0x7f;
-				break;
-			case WM_MBUTTONDOWN:
-				ucKeyState[VK_MBUTTON] |= 0x80;
-				break;
-			case WM_MBUTTONUP:
-				ucKeyState[VK_MBUTTON] &= 0x7f;
-				break;
-			case WM_XBUTTONDOWN:
-				if ((mouse->mouseData >> 16) == XBUTTON1)
-					ucKeyState[VK_XBUTTON1] |= 0x80;
-				else if ((mouse->mouseData >> 16) == XBUTTON2)
-					ucKeyState[VK_XBUTTON2] |= 0x80;
-				break;
-			case WM_XBUTTONUP:
-				if ((mouse->mouseData >> 16) == XBUTTON1)
-					ucKeyState[VK_XBUTTON1] &= 0x7f;
-				else if ((mouse->mouseData >> 16) == XBUTTON2)
-					ucKeyState[VK_XBUTTON2] &= 0x7f;
-				break;
-			default:
-				break;
-		}
-
 		bool down = false;
 		unsigned int btn = 0;
 		switch (msg) {
@@ -820,5 +711,4 @@ bool GlobalShortcutWin::canSuppress() {
 }
 
 void GlobalShortcutWin::prepareInput() {
-	SetKeyboardState(ucKeyState);
 }

--- a/src/mumble/GlobalShortcut_win.h
+++ b/src/mumble/GlobalShortcut_win.h
@@ -91,8 +91,6 @@ class GlobalShortcutWin : public GlobalShortcutEngine {
 		~GlobalShortcutWin() Q_DECL_OVERRIDE;
 		void unacquire();
 		QString buttonName(const QVariant &) Q_DECL_OVERRIDE;
-
-		virtual void prepareInput() Q_DECL_OVERRIDE;
 };
 
 uint qHash(const GUID &);

--- a/src/mumble/GlobalShortcut_win.h
+++ b/src/mumble/GlobalShortcut_win.h
@@ -54,7 +54,6 @@ class GlobalShortcutWin : public GlobalShortcutEngine {
 		Q_OBJECT
 		Q_DISABLE_COPY(GlobalShortcutWin)
 	public:
-		BYTE ucKeyState[256];
 		LPDIRECTINPUT8 pDI;
 		QHash<GUID, InputDevice *> qhInputDevices;
 		HHOOK hhMouse, hhKeyboard;

--- a/src/mumble/MumbleApplication.cpp
+++ b/src/mumble/MumbleApplication.cpp
@@ -71,7 +71,6 @@ bool MumbleApplication::nativeEventFilter(const QByteArray &eventType, void *mes
 				case WM_KEYUP:
 				case WM_SYSKEYDOWN:
 				case WM_SYSKEYUP:
-					GlobalShortcutEngine::engine->prepareInput();
 				default:
 					break;
 			}
@@ -91,7 +90,6 @@ bool MumbleApplication::winEventFilter(MSG *msg, long *result) {
 				case WM_KEYUP:
 				case WM_SYSKEYDOWN:
 				case WM_SYSKEYUP:
-					GlobalShortcutEngine::engine->prepareInput();
 				default:
 					break;
 			}


### PR DESCRIPTION
We don't support the in-overlay Mumble client in 1.3.x because it doesn't
work correctly on Qt 5.

It's a big hack. Let's wave goodbye.