### PR TITLE
WIP: GlobalShortcutWin, MumbleApplication: inject native WM_* keyboard and mouse messages into GlobalShortcutWin.

### DIFF
--- a/src/mumble/GlobalShortcut.cpp
+++ b/src/mumble/GlobalShortcut.cpp
@@ -934,9 +934,6 @@ QString GlobalShortcutEngine::buttonText(const QList<QVariant> &list) {
 	return keys.join(QLatin1String(" + "));
 }
 
-void GlobalShortcutEngine::prepareInput() {
-}
-
 GlobalShortcut::GlobalShortcut(QObject *p, int index, QString qsName, QVariant def) : QObject(p) {
 	idx = index;
 	name=qsName;

--- a/src/mumble/GlobalShortcut.h
+++ b/src/mumble/GlobalShortcut.h
@@ -258,8 +258,6 @@ class GlobalShortcutEngine : public QThread {
 		virtual void setEnabled(bool b);
 		virtual bool enabled();
 		virtual bool canDisable();
-
-		virtual void prepareInput();
 	signals:
 		void buttonPressed(bool last);
 };

--- a/src/mumble/GlobalShortcut_win.cpp
+++ b/src/mumble/GlobalShortcut_win.cpp
@@ -709,6 +709,3 @@ QString GlobalShortcutWin::buttonName(const QVariant &v) {
 bool GlobalShortcutWin::canSuppress() {
 	return bHook;
 }
-
-void GlobalShortcutWin::prepareInput() {
-}

--- a/src/mumble/GlobalShortcut_win.cpp
+++ b/src/mumble/GlobalShortcut_win.cpp
@@ -57,8 +57,6 @@ GlobalShortcutWin::GlobalShortcutWin()
 	// Hidden setting to disable hooking
 	bHook = g.qs->value(QLatin1String("winhooks"), true).toBool();
 
-	GetKeyboardState(ucKeyState);
-
 	moveToThread(this);
 	start(QThread::LowestPriority);
 }
@@ -153,7 +151,6 @@ void GlobalShortcutWin::run() {
 LRESULT CALLBACK GlobalShortcutWin::HookKeyboard(int nCode, WPARAM wParam, LPARAM lParam) {
 	GlobalShortcutWin *gsw=static_cast<GlobalShortcutWin *>(engine);
 	KBDLLHOOKSTRUCT *key=reinterpret_cast<KBDLLHOOKSTRUCT *>(lParam);
-	BYTE *ucKeyState = gsw->ucKeyState;
 
 #ifndef QT_NO_DEBUG
 	static int safety = 0;
@@ -162,73 +159,6 @@ LRESULT CALLBACK GlobalShortcutWin::HookKeyboard(int nCode, WPARAM wParam, LPARA
 #else
 	if (nCode >= 0) {
 #endif
-		UINT msg = wParam;
-		WPARAM w = key->vkCode;
-		LPARAM l = 1 | (key->scanCode << 16);
-		if (key->flags & LLKHF_EXTENDED)
-			l |= 0x1000000;
-		if (wParam == WM_KEYUP)
-			l |= 0xC0000000;
-
-		bool nomsg = false;
-
-		switch (w) {
-			case VK_LCONTROL:
-			case VK_RCONTROL:
-				if ((msg == WM_KEYDOWN) || (msg == WM_SYSKEYDOWN))
-					ucKeyState[w] |= 0x80;
-				else {
-					ucKeyState[w] &= 0x7f;
-
-					if ((ucKeyState[VK_LCONTROL] & 0x80) || (ucKeyState[VK_RCONTROL] & 0x80)) {
-						nomsg = true;
-						break;
-					}
-				}
-
-				w = VK_CONTROL;
-				break;
-			case VK_LSHIFT:
-			case VK_RSHIFT:
-				if ((msg == WM_KEYDOWN) || (msg == WM_SYSKEYDOWN))
-					ucKeyState[w] |= 0x80;
-				else {
-					ucKeyState[w] &= 0x7f;
-
-					if ((ucKeyState[VK_LSHIFT] & 0x80) || (ucKeyState[VK_RSHIFT] & 0x80)) {
-						nomsg = true;
-						break;
-					}
-				}
-
-				w = VK_SHIFT;
-				break;
-			case VK_LMENU:
-			case VK_RMENU:
-				if ((msg == WM_KEYDOWN) || (msg == WM_SYSKEYDOWN))
-					ucKeyState[w] |= 0x80;
-				else {
-					ucKeyState[w] &= 0x7f;
-
-					if ((ucKeyState[VK_LMENU] & 0x80) || (ucKeyState[VK_RMENU] & 0x80)) {
-						nomsg = true;
-						break;
-					}
-				}
-
-				w = VK_MENU;
-				break;
-			default:
-				break;
-		}
-
-		if ((msg == WM_KEYDOWN) || (msg == WM_SYSKEYDOWN)) {
-			if (ucKeyState[w] & 0x80)
-				l |= 0x40000000;
-			ucKeyState[w] |= 0x80;
-		} else if (((msg == WM_KEYUP) || (msg == WM_SYSKEYUP)) && !nomsg) {
-			ucKeyState[w] &= 0x7f;
-		}
 
 		QList<QVariant> ql;
 
@@ -284,49 +214,10 @@ LRESULT CALLBACK GlobalShortcutWin::HookKeyboard(int nCode, WPARAM wParam, LPARA
 LRESULT CALLBACK GlobalShortcutWin::HookMouse(int nCode, WPARAM wParam, LPARAM lParam) {
 	GlobalShortcutWin *gsw=static_cast<GlobalShortcutWin *>(engine);
 	MSLLHOOKSTRUCT *mouse=reinterpret_cast<MSLLHOOKSTRUCT *>(lParam);
-	BYTE *ucKeyState = gsw->ucKeyState;
 
 	if (nCode >= 0) {
-		bool suppress = false;
 		UINT msg = wParam;
-
-		switch (msg) {
-			case WM_LBUTTONDOWN:
-				ucKeyState[VK_LBUTTON] |= 0x80;
-				if (gsw->tDoubleClick.restart() < (QApplication::doubleClickInterval() * 1000ULL))
-					msg = WM_LBUTTONDBLCLK;
-				break;
-			case WM_LBUTTONUP:
-				ucKeyState[VK_LBUTTON] &= 0x7f;
-				break;
-			case WM_RBUTTONDOWN:
-				ucKeyState[VK_RBUTTON] |= 0x80;
-				break;
-			case WM_RBUTTONUP:
-				ucKeyState[VK_RBUTTON] &= 0x7f;
-				break;
-			case WM_MBUTTONDOWN:
-				ucKeyState[VK_MBUTTON] |= 0x80;
-				break;
-			case WM_MBUTTONUP:
-				ucKeyState[VK_MBUTTON] &= 0x7f;
-				break;
-			case WM_XBUTTONDOWN:
-				if ((mouse->mouseData >> 16) == XBUTTON1)
-					ucKeyState[VK_XBUTTON1] |= 0x80;
-				else if ((mouse->mouseData >> 16) == XBUTTON2)
-					ucKeyState[VK_XBUTTON2] |= 0x80;
-				break;
-			case WM_XBUTTONUP:
-				if ((mouse->mouseData >> 16) == XBUTTON1)
-					ucKeyState[VK_XBUTTON1] &= 0x7f;
-				else if ((mouse->mouseData >> 16) == XBUTTON2)
-					ucKeyState[VK_XBUTTON2] &= 0x7f;
-				break;
-			default:
-				break;
-		}
-
+		bool suppress = false;
 		bool down = false;
 		unsigned int btn = 0;
 		switch (msg) {
@@ -820,5 +711,4 @@ bool GlobalShortcutWin::canSuppress() {
 }
 
 void GlobalShortcutWin::prepareInput() {
-	SetKeyboardState(ucKeyState);
 }

--- a/src/mumble/GlobalShortcut_win.h
+++ b/src/mumble/GlobalShortcut_win.h
@@ -91,8 +91,6 @@ class GlobalShortcutWin : public GlobalShortcutEngine {
 		~GlobalShortcutWin() Q_DECL_OVERRIDE;
 		void unacquire();
 		QString buttonName(const QVariant &) Q_DECL_OVERRIDE;
-
-		virtual void prepareInput() Q_DECL_OVERRIDE;
 };
 
 uint qHash(const GUID &);

--- a/src/mumble/GlobalShortcut_win.h
+++ b/src/mumble/GlobalShortcut_win.h
@@ -54,7 +54,6 @@ class GlobalShortcutWin : public GlobalShortcutEngine {
 		Q_OBJECT
 		Q_DISABLE_COPY(GlobalShortcutWin)
 	public:
-		BYTE ucKeyState[256];
 		LPDIRECTINPUT8 pDI;
 		QHash<GUID, InputDevice *> qhInputDevices;
 		HHOOK hhMouse, hhKeyboard;

--- a/src/mumble/GlobalShortcut_win.h
+++ b/src/mumble/GlobalShortcut_win.h
@@ -79,11 +79,17 @@ class GlobalShortcutWin : public GlobalShortcutEngine {
 		static BOOL CALLBACK EnumSuitableDevicesCB(LPCDIDEVICEINSTANCE, LPDIRECTINPUTDEVICE8, DWORD, DWORD, LPVOID);
 		static BOOL CALLBACK EnumDevicesCB(LPCDIDEVICEINSTANCE, LPVOID);
 		static BOOL CALLBACK EnumDeviceObjectsCallback(LPCDIDEVICEOBJECTINSTANCE lpddoi, LPVOID pvRef);
+
 		static LRESULT CALLBACK HookKeyboard(int, WPARAM, LPARAM);
 		static LRESULT CALLBACK HookMouse(int, WPARAM, LPARAM);
 
+		static bool handleKeyMessage(DWORD scancode, DWORD vkcode, bool extended, bool up);
+		static bool handleMouseMessage(unsigned int btn, bool down);
+
 		virtual bool canSuppress() Q_DECL_OVERRIDE;
 		void run() Q_DECL_OVERRIDE;
+		bool event(QEvent *e) Q_DECL_OVERRIDE;
+
 	public slots:
 		void timeTicked();
 	public:
@@ -91,6 +97,9 @@ class GlobalShortcutWin : public GlobalShortcutEngine {
 		~GlobalShortcutWin() Q_DECL_OVERRIDE;
 		void unacquire();
 		QString buttonName(const QVariant &) Q_DECL_OVERRIDE;
+
+		void injectKeyMessage(DWORD scancode, DWORD vkcode, bool extended, bool up);
+		void injectMouseMessage(unsigned int button, bool down);
 };
 
 uint qHash(const GUID &);

--- a/src/mumble/MumbleApplication.cpp
+++ b/src/mumble/MumbleApplication.cpp
@@ -71,7 +71,6 @@ bool MumbleApplication::nativeEventFilter(const QByteArray &eventType, void *mes
 				case WM_KEYUP:
 				case WM_SYSKEYDOWN:
 				case WM_SYSKEYUP:
-					GlobalShortcutEngine::engine->prepareInput();
 				default:
 					break;
 			}
@@ -91,7 +90,6 @@ bool MumbleApplication::winEventFilter(MSG *msg, long *result) {
 				case WM_KEYUP:
 				case WM_SYSKEYDOWN:
 				case WM_SYSKEYUP:
-					GlobalShortcutEngine::engine->prepareInput();
 				default:
 					break;
 			}

--- a/src/mumble/MumbleApplication.cpp
+++ b/src/mumble/MumbleApplication.cpp
@@ -12,6 +12,10 @@
 #include "Global.h"
 #include "EnvUtils.h"
 
+#ifdef Q_OS_WIN
+# include "GlobalShortcut_win.h"
+#endif
+
 MumbleApplication *MumbleApplication::instance() {
 	return static_cast<MumbleApplication *>(QCoreApplication::instance());
 }
@@ -56,21 +60,77 @@ bool MumbleApplication::event(QEvent *e) {
 }
 
 #ifdef Q_OS_WIN
+
+static void handleWMKeyMessage(MSG *msg) {
+	GlobalShortcutWin *gsw = static_cast<GlobalShortcutWin *>(GlobalShortcutEngine::engine);
+
+	DWORD scancode = (msg->lParam >> 16) & 0xff;
+	DWORD vkcode = msg->wParam;
+	bool extended = !!(msg->lParam & 0x01000000);
+	bool up = !!(msg->lParam & 0x80000000);
+
+	gsw->injectKeyMessage(scancode, vkcode, extended, up);
+}
+
+static void handleWMMouseMessage(MSG *msg) {
+	GlobalShortcutWin *gsw = static_cast<GlobalShortcutWin *>(GlobalShortcutEngine::engine);
+
+	bool down = false;
+	unsigned int btn = 0;
+
+	switch (msg->message) {
+		case WM_LBUTTONDOWN:
+			down = true;
+		case WM_LBUTTONUP:
+			btn = 3;
+			break;
+		case WM_RBUTTONDOWN:
+			down = true;
+		case WM_RBUTTONUP:
+			btn = 4;
+			break;
+		case WM_MBUTTONDOWN:
+			down = true;
+		case WM_MBUTTONUP:
+			btn = 5;
+			break;
+		case WM_XBUTTONDOWN:
+			down = true;
+		case WM_XBUTTONUP: {
+			unsigned int offset = (msg->wParam >> 16) & 0xffff;
+			btn = 5 + offset;
+		}
+		default:
+			// Non-mouse event. Return early.
+			return;
+	}
+
+	gsw->injectMouseMessage(btn, down);
+}
+
 # if QT_VERSION >= 0x050000
-bool MumbleApplication::nativeEventFilter(const QByteArray &eventType, void *message, long *result) {
-	Q_UNUSED(eventType);
+bool MumbleApplication::nativeEventFilter(const QByteArray &, void *message, long *) {
 	MSG *msg = reinterpret_cast<MSG *>(message);
 
 	if (QThread::currentThread() == thread()) {
-		if (Global::g_global_struct && g.ocIntercept) {
+		if (Global::g_global_struct) {
 			switch (msg->message) {
-				case WM_MOUSELEAVE:
-					*result = 0;
-					return true;
+				case WM_LBUTTONDOWN:
+				case WM_LBUTTONUP:
+				case WM_RBUTTONDOWN:
+				case WM_RBUTTONUP:
+				case WM_MBUTTONDOWN:
+				case WM_MBUTTONUP:
+				case WM_XBUTTONDOWN:
+				case WM_XBUTTONUP:
+					handleWMMouseMessage(msg);
+					break;
 				case WM_KEYDOWN:
 				case WM_KEYUP:
 				case WM_SYSKEYDOWN:
 				case WM_SYSKEYUP:
+					handleWMKeyMessage(msg);
+					break;
 				default:
 					break;
 			}
@@ -81,15 +141,24 @@ bool MumbleApplication::nativeEventFilter(const QByteArray &eventType, void *mes
 # else
 bool MumbleApplication::winEventFilter(MSG *msg, long *result) {
 	if (QThread::currentThread() == thread()) {
-		if (Global::g_global_struct && g.ocIntercept) {
+		if (Global::g_global_struct) {
 			switch (msg->message) {
-				case WM_MOUSELEAVE:
-					*result = 0;
-					return true;
+				case WM_LBUTTONDOWN:
+				case WM_LBUTTONUP:
+				case WM_RBUTTONDOWN:
+				case WM_RBUTTONUP:
+				case WM_MBUTTONDOWN:
+				case WM_MBUTTONUP:
+				case WM_XBUTTONDOWN:
+				case WM_XBUTTONUP:
+					handleWMMouseMessage(msg);
+					break;
 				case WM_KEYDOWN:
 				case WM_KEYUP:
 				case WM_SYSKEYDOWN:
 				case WM_SYSKEYUP:
+					handleWMKeyMessage(msg);
+					break;
 				default:
 					break;
 			}


### PR DESCRIPTION
This should fix the problem where some keys could not be observed in
Mumble when Mumble was the program in focus. People have reported this
problem with keys F13-F24.

The reason these keys could not be observed in Mumble is that:

1) Our keyboard and mouse hook callbacks do not receive keypresses and
   mouse clicks when Mumble is on focus. We only recieve events when
   other programs are focused.

2) DirectInput does not know of F13-F24.

To remedy this situation, this commit implements a system where we feed
the native Windows keyboard and mouse events from Qt's nativeEventFilter
into GlobalShortcutWin.

Technically, we provide methods in GlobalShortcutWin that allows the
nativeEventFilter to inject keyboard and mouse evnets into it. The events
from nativeEventFilter are received on the main thread. To inject them
into GlobalShortcutWin, we inject the mouse and keyboard messages through
two QEvents: InjectKeyboardMessageEvent and InjectMouseMessageEvent.

GlobalShortcutWin implements two new public-facing methods:
injectKeyMessage and injectMouseMessage. Internally, these methods
will cause a InjectKeyboardMessageEvent or InjectMouseMessageEvent
to be sent to the GlobalShortcutWin's event handler. This is done
through QCoreApplication::postEvent(), which means that the event
is handled in the receiving object's thread.

To achieve the ability to inject these events, some of general keyboard
and mouse handling code from our hook callbacks HookKeyboard and HookMouse
have been refactored into two new methods, handleKeyMessage and
handleMouseMessage.

These new methods are used in both HookKeyboard and the event handler for
InjectKeyboardMessageEvent, as well as in HookMouse and the event handler
for InjectMouseMessageEvent.

Note: the current implementation does not implement suppression of
keyboard and mouse events coming from the nativeEventFilter. This would
require us to block the main thread until GlobalShortcutWin has time to
handle the event. This is considered future work.