### PR TITLE
GlobalShortcutWin, MumbleApplication: inject native WM_* keyboard and mouse messages into GlobalShortcutWin. 

### DIFF
--- a/src/mumble/GlobalShortcut_win.cpp
+++ b/src/mumble/GlobalShortcut_win.cpp
@@ -202,6 +202,20 @@ void GlobalShortcutWin::run() {
 	pDI->Release();
 }
 
+bool GlobalShortcutWin::event(QEvent *event) {
+	QEvent::Type type = event->type();
+	if (type == INJECTKEYBOARDMESSAGE_QEVENT) {
+		InjectKeyboardMessageEvent *ikme = static_cast<InjectKeyboardMessageEvent *>(event);
+		handleKeyboardMessage(ikme->m_scancode, ikme->m_vkcode, ikme->m_extended, ikme->m_down);
+		return true;
+	} else if (type == INJECTMOUSEMESSAGE_QEVENT) {
+		InjectMouseMessageEvent *imme = static_cast<InjectMouseMessageEvent *>(event);
+		handleMouseMessage(imme->m_btn, imme->m_down);
+		return true;
+	}
+	return GlobalShortcutEngine::event(event);
+}
+
 bool GlobalShortcutWin::handleKeyboardMessage(DWORD scancode, DWORD vkcode, bool extended, bool down) {
 	GlobalShortcutWin *gsw = static_cast<GlobalShortcutWin *>(engine);
 

--- a/src/mumble/GlobalShortcut_win.cpp
+++ b/src/mumble/GlobalShortcut_win.cpp
@@ -217,6 +217,10 @@ bool GlobalShortcutWin::event(QEvent *event) {
 }
 
 void GlobalShortcutWin::injectKeyboardMessage(MSG *msg) {
+	if (!bHook) {
+		return;
+	}
+
 	// Only allow keyboard messages.
 	switch (msg->message) {
 		case WM_KEYDOWN:
@@ -237,6 +241,10 @@ void GlobalShortcutWin::injectKeyboardMessage(MSG *msg) {
 }
 
 void GlobalShortcutWin::injectMouseMessage(MSG *msg) {
+	if (!bHook) {
+		return;
+	}
+
 	bool down = false;
 	unsigned int btn = 0;
 

--- a/src/mumble/GlobalShortcut_win.cpp
+++ b/src/mumble/GlobalShortcut_win.cpp
@@ -22,6 +22,60 @@
 // from os_win.cpp
 extern HWND mumble_mw_hwnd;
 
+/// The QEvent::Type value to use for InjectKeyboardMessageEvent.
+#define INJECTKEYBOARDMESSAGE_QEVENT (QEvent::User + 200)
+/// The QEvent::Type value to use for InjectKeyboardMouseEvent.
+#define INJECTMOUSEMESSAGE_QEVENT (QEvent::User + 201)
+
+/// InjectKeyboardMessageEvent is an event that can be sent to
+/// the GlobalShortcutWin engine to inject a native Windows keyboard
+/// event into GlobalShortcutWin's event stream.
+class InjectKeyboardMessageEvent : public QEvent {
+		Q_DISABLE_COPY(InjectKeyboardMessageEvent);
+
+	public:
+		DWORD m_scancode;
+		DWORD m_vkcode;
+		bool m_extended;
+		bool m_down;
+
+		/// Construct a new InjectKeyboardMessageEvent.
+		///
+		/// @param  scancode   The Windows scancode of the button.
+		/// @param  vkcode     The Windows virtual keycode of the button.
+		/// @param  extended   Indicates whether the button is an extended key in
+		///                    Windows nomenclature. ("[...] such as the right-hand ALT
+		///                    and CTRL keys that appear on an enhanced 101- or 102-key
+		///                    keyboard")
+		/// @param  down       The down/pressed status of the keyboard button.
+		InjectKeyboardMessageEvent(DWORD scancode, DWORD vkcode, bool extended, bool down)
+			: QEvent(static_cast<QEvent::Type>(INJECTKEYBOARDMESSAGE_QEVENT))
+			, m_scancode(scancode)
+			, m_vkcode(vkcode)
+			, m_extended(extended)
+			, m_down(down) {}
+};
+
+/// InjectMouseMessageEvent is an event that can be sent to
+/// the GlobalShortcutWin engine to inject a native Windows mouse
+/// event into GlobalShortcutWin's event stream.
+class InjectMouseMessageEvent : public QEvent {
+		Q_DISABLE_COPY(InjectMouseMessageEvent);
+
+	public:
+		unsigned int m_btn;
+		bool m_down;
+
+		/// Construct a new InjectMouseMessageEvent.
+		///
+		/// @param  btn   The DirectInput button index of the mouse event.
+		/// @param  down  The down/pressed status of the mouse button.
+		InjectMouseMessageEvent(unsigned int btn, bool down)
+			: QEvent(static_cast<QEvent::Type>(INJECTMOUSEMESSAGE_QEVENT))
+			, m_btn(btn)
+			, m_down(down) {}
+};
+
 uint qHash(const GUID &a) {
 	uint val = a.Data1 ^ a.Data2 ^ a.Data3;
 	for (int i=0;i<8;i++)

--- a/src/mumble/GlobalShortcut_win.cpp
+++ b/src/mumble/GlobalShortcut_win.cpp
@@ -218,6 +218,8 @@ LRESULT CALLBACK GlobalShortcutWin::HookMouse(int nCode, WPARAM wParam, LPARAM l
 	if (nCode >= 0) {
 		bool suppress = false;
 		UINT msg = wParam;
+		// Convert the hooked Windows mouse message into a DirectInput
+		// button index, and store the pressed state of the button.
 		bool down = false;
 		unsigned int btn = 0;
 		switch (msg) {

--- a/src/mumble/GlobalShortcut_win.h
+++ b/src/mumble/GlobalShortcut_win.h
@@ -82,6 +82,18 @@ class GlobalShortcutWin : public GlobalShortcutEngine {
 		static LRESULT CALLBACK HookKeyboard(int, WPARAM, LPARAM);
 		static LRESULT CALLBACK HookMouse(int, WPARAM, LPARAM);
 
+		/// Handle an incoming Windows keyboard message.
+		///
+		/// Returns true if the GlobalShortcut engine signals that the
+		/// button should be suppressed. Returns false otherwise.
+		static bool handleKeyboardMessage(DWORD scancode, DWORD vkcode, bool extended, bool down);
+
+		/// Handle an incoming Windows mouse message.
+		///
+		/// Returns true if the GlobalShortcut engine signals that the
+		/// button should be suppressed. Returns false otherwise.
+		static bool handleMouseMessage(unsigned int btn, bool down);
+
 		virtual bool canSuppress() Q_DECL_OVERRIDE;
 		void run() Q_DECL_OVERRIDE;
 	public slots:

--- a/src/mumble/GlobalShortcut_win.h
+++ b/src/mumble/GlobalShortcut_win.h
@@ -96,6 +96,7 @@ class GlobalShortcutWin : public GlobalShortcutEngine {
 
 		virtual bool canSuppress() Q_DECL_OVERRIDE;
 		void run() Q_DECL_OVERRIDE;
+		bool event(QEvent *e) Q_DECL_OVERRIDE;
 	public slots:
 		void timeTicked();
 	public:

--- a/src/mumble/GlobalShortcut_win.h
+++ b/src/mumble/GlobalShortcut_win.h
@@ -104,6 +104,25 @@ class GlobalShortcutWin : public GlobalShortcutEngine {
 		~GlobalShortcutWin() Q_DECL_OVERRIDE;
 		void unacquire();
 		QString buttonName(const QVariant &) Q_DECL_OVERRIDE;
+
+		/// Inject a native Windows keyboard message into GlobalShortcutWin's
+		/// event stream. This method is meant to be called from the main thread
+		/// to pass native Windows keyboard messages to GlobalShortcutWin.
+		///
+		/// @param  msg  The keyboard message to inject into GlobalShortcutWin.
+		///              Must be WM_KEYDOWN, WM_KEYUP, WM_SYSKEYDOWN or WM_SYSKEYUP.
+		///              Otherwise the message will be ignored.
+		void injectKeyboardMessage(MSG *msg);
+
+		/// Inject a native Windows mouse message into GlobalShortcutWin's
+		/// event stream. This method is meant to be called from the main thread
+		/// to pass native Windows mouse messages to GlobalShortcutWin.
+		///
+		/// @param  msg  The keyboard message to inject into GlobalShortcutWin.
+		///              Must be WM_LBUTTONDOWN, WM_LBUTTONUP, WM_RBUTTONDOWN,
+		///              WM_RBUTTONUP, WM_MBUTTONDOWN, WM_MBUTTONUP, WM_XBUTTONDOWN
+		///              or WM_XBUTTONUP. Otherwise the message will be ignored.
+		void injectMouseMessage(MSG *msg);
 };
 
 uint qHash(const GUID &);

--- a/src/mumble/MumbleApplication.cpp
+++ b/src/mumble/MumbleApplication.cpp
@@ -12,6 +12,10 @@
 #include "Global.h"
 #include "EnvUtils.h"
 
+#if defined(Q_OS_WIN)
+# include "GlobalShortcut_win.h"
+#endif
+
 MumbleApplication *MumbleApplication::instance() {
 	return static_cast<MumbleApplication *>(QCoreApplication::instance());
 }
@@ -56,44 +60,45 @@ bool MumbleApplication::event(QEvent *e) {
 }
 
 #ifdef Q_OS_WIN
-# if QT_VERSION >= 0x050000
-bool MumbleApplication::nativeEventFilter(const QByteArray &eventType, void *message, long *result) {
-	Q_UNUSED(eventType);
-	MSG *msg = reinterpret_cast<MSG *>(message);
+/// gswForward forwards a native Windows keyboard/mouse message
+/// into GlobalShortcutWin's event stream.
+static void gswForward(MSG *msg) {
+	GlobalShortcutWin *gsw = static_cast<GlobalShortcutWin *>(GlobalShortcutEngine::engine);
+	if (gsw == NULL) {
+		return;
+	}
+	switch (msg->message) {
+		case WM_LBUTTONDOWN:
+		case WM_LBUTTONUP:
+		case WM_RBUTTONDOWN:
+		case WM_RBUTTONUP:
+		case WM_MBUTTONDOWN:
+		case WM_MBUTTONUP:
+		case WM_XBUTTONDOWN:
+		case WM_XBUTTONUP:
+			gsw->injectMouseMessage(msg);
+			break;
+		case WM_KEYDOWN:
+		case WM_KEYUP:
+		case WM_SYSKEYDOWN:
+		case WM_SYSKEYUP:
+			gsw->injectKeyboardMessage(msg);
+			break;
+	}
+}
 
+# if QT_VERSION >= 0x050000
+bool MumbleApplication::nativeEventFilter(const QByteArray &, void *message, long *) {
+	MSG *msg = reinterpret_cast<MSG *>(message);
 	if (QThread::currentThread() == thread()) {
-		if (Global::g_global_struct && g.ocIntercept) {
-			switch (msg->message) {
-				case WM_MOUSELEAVE:
-					*result = 0;
-					return true;
-				case WM_KEYDOWN:
-				case WM_KEYUP:
-				case WM_SYSKEYDOWN:
-				case WM_SYSKEYUP:
-				default:
-					break;
-			}
-		}
+		gswForward(msg);
 	}
 	return false;
 }
 # else
 bool MumbleApplication::winEventFilter(MSG *msg, long *result) {
 	if (QThread::currentThread() == thread()) {
-		if (Global::g_global_struct && g.ocIntercept) {
-			switch (msg->message) {
-				case WM_MOUSELEAVE:
-					*result = 0;
-					return true;
-				case WM_KEYDOWN:
-				case WM_KEYUP:
-				case WM_SYSKEYDOWN:
-				case WM_SYSKEYUP:
-				default:
-					break;
-			}
-		}
+		gswForward(msg);
 	}
 	return QApplication::winEventFilter(msg, result);
 }


### PR DESCRIPTION
This should fix the problem where some keys could not be observed in
Mumble when Mumble was the program in focus. People have reported this
problem with keys F13-F24.

The reason these keys could not be observed in Mumble is that:

Our keyboard and mouse hook callbacks do not receive keypresses and
mouse clicks when Mumble is on focus. We only recieve events when
other programs are focused.

DirectInput does not know of F13-F24.

To remedy this situation, this commit implements a system where we feed
the native Windows keyboard and mouse events from Qt's nativeEventFilter
into GlobalShortcutWin.

Technically, we provide methods in GlobalShortcutWin that allows the
nativeEventFilter to inject keyboard and mouse evnets into it. The events
from nativeEventFilter are received on the main thread. To inject them
into GlobalShortcutWin, we inject the mouse and keyboard messages through
two QEvents: InjectKeyboardMessageEvent and InjectMouseMessageEvent.

GlobalShortcutWin implements two new public-facing methods:
injectKeyboardMessage and injectMouseMessage. Internally, these methods
will cause a InjectKeyboardMessageEvent or InjectMouseMessageEvent
to be sent to the GlobalShortcutWin's event handler. This is done
through QCoreApplication::postEvent(), which means that the event
is handled in the receiving object's thread.

To achieve the ability to inject these events, some of general keyboard
and mouse handling code from our hook callbacks HookKeyboard and HookMouse
have been refactored into two new methods, handleKeyboardMessage and
handleMouseMessage.

These new methods are used in both HookKeyboard and the event handler for
InjectKeyboardMessageEvent, as well as in HookMouse and the event handler
for InjectMouseMessageEvent.

Note: the current implementation does not implement suppression of
keyboard and mouse events coming from the nativeEventFilter. This would
require us to block the main thread until GlobalShortcutWin has time to
handle the event. This is considered future work.