### PR TITLE
GlobalShortcutWin, MumbleApplication: add suppression support for injected Windows keyboard/mouse message events.

### DIFF
--- a/src/mumble/GlobalShortcut_win.h
+++ b/src/mumble/GlobalShortcut_win.h
@@ -112,7 +112,10 @@ class GlobalShortcutWin : public GlobalShortcutEngine {
 		/// @param  msg  The keyboard message to inject into GlobalShortcutWin.
 		///              Must be WM_KEYDOWN, WM_KEYUP, WM_SYSKEYDOWN or WM_SYSKEYUP.
 		///              Otherwise the message will be ignored.
-		void injectKeyboardMessage(MSG *msg);
+		///
+		/// @return      Returns true if the GlobalShortcut engine signalled that
+		///              the button should be suppressed. Returns false otherwise.
+		bool injectKeyboardMessage(MSG *msg);
 
 		/// Inject a native Windows mouse message into GlobalShortcutWin's
 		/// event stream. This method is meant to be called from the main thread
@@ -122,7 +125,10 @@ class GlobalShortcutWin : public GlobalShortcutEngine {
 		///              Must be WM_LBUTTONDOWN, WM_LBUTTONUP, WM_RBUTTONDOWN,
 		///              WM_RBUTTONUP, WM_MBUTTONDOWN, WM_MBUTTONUP, WM_XBUTTONDOWN
 		///              or WM_XBUTTONUP. Otherwise the message will be ignored.
-		void injectMouseMessage(MSG *msg);
+		///
+		/// @return      Returns true if the GlobalShortcut engine signalled that
+		///              the button should be suppressed. Returns false otherwise.
+		bool injectMouseMessage(MSG *msg);
 };
 
 uint qHash(const GUID &);

--- a/src/mumble/MumbleApplication.cpp
+++ b/src/mumble/MumbleApplication.cpp
@@ -62,10 +62,13 @@ bool MumbleApplication::event(QEvent *e) {
 #ifdef Q_OS_WIN
 /// gswForward forwards a native Windows keyboard/mouse message
 /// into GlobalShortcutWin's event stream.
-static void gswForward(MSG *msg) {
+///
+/// @return  Returns true if the forwarded event was suppressed
+///          by GlobalShortcutWin. Otherwise, returns false.
+static bool gswForward(MSG *msg) {
 	GlobalShortcutWin *gsw = static_cast<GlobalShortcutWin *>(GlobalShortcutEngine::engine);
 	if (gsw == NULL) {
-		return;
+		return false;
 	}
 	switch (msg->message) {
 		case WM_LBUTTONDOWN:
@@ -76,29 +79,34 @@ static void gswForward(MSG *msg) {
 		case WM_MBUTTONUP:
 		case WM_XBUTTONDOWN:
 		case WM_XBUTTONUP:
-			gsw->injectMouseMessage(msg);
-			break;
+			return gsw->injectMouseMessage(msg);
 		case WM_KEYDOWN:
 		case WM_KEYUP:
 		case WM_SYSKEYDOWN:
 		case WM_SYSKEYUP:
-			gsw->injectKeyboardMessage(msg);
-			break;
+			return gsw->injectKeyboardMessage(msg);
 	}
+	return false;
 }
 
 # if QT_VERSION >= 0x050000
 bool MumbleApplication::nativeEventFilter(const QByteArray &, void *message, long *) {
 	MSG *msg = reinterpret_cast<MSG *>(message);
 	if (QThread::currentThread() == thread()) {
-		gswForward(msg);
+		bool suppress = gswForward(msg);
+		if (suppress) {
+			return true;
+		}
 	}
 	return false;
 }
 # else
 bool MumbleApplication::winEventFilter(MSG *msg, long *result) {
 	if (QThread::currentThread() == thread()) {
-		gswForward(msg);
+		bool suppress = gswForward(msg);
+		if (suppress) {
+			return true;
+		}
 	}
 	return QApplication::winEventFilter(msg, result);
 }


### PR DESCRIPTION
This adds the ability to suppress global shortcuts injected from the main
thread. In practice, this means that Mumble will now honor suppressed keys
*inside* Mumble itself.

This is implemented by using a std::promise<bool>. The
injectKeyboardMessage and injectMouseMessage methods now
create a std::promise<bool> and a future associated with
the promise. The promise is then passed onto the GlobalShortcut
engine thread via InjectKeyboardMessageEvent and InjectMouseMessageEvent.
Once the injection events have been posted, injectKeyboardMessage
and injectMouseMessage will wait on the future, blocking the main thread
until the GlobalShortcut engine's thread sets the promise's value to
whether or not the injected event is supposed to be suppressed.

The injectKeyboardMessage and injectMouseMessage methods now return a bool
signalling whether or not the injected event is supposed to be suppressed
or not.

The gswForward method in MumbleApplication is also tweaked to return the
suppression status it receives from injectKeyboardMessage and
injectMouseMessage.

Finally, the event filters in MumbleApplication will now discard keyboard
and mouse messages when the gswForward methods returns true, which signals
that the GlobalShortcut engine told it that the injected event should be
suppressed.