### PR TITLE
[BUILD] ZeroC Ice 3.7 compatibility

### DIFF
--- a/src/murmur/murmur.pro
+++ b/src/murmur/murmur.pro
@@ -90,7 +90,7 @@ ice {
 	} else {
 		# check Ice version, 3.7 merged IceUtil into Ice
 		ICE_VERSION = $$system(slice2cpp --version 2>&1)
-		ICE_MAJOR_VERSION = $$section(ICE_VERSION, ., 0, 0))
+		ICE_MAJOR_VERSION = $$section(ICE_VERSION, ., 0, 0)
 		ICE_MINOR_VERSION = $$section(ICE_VERSION, ., 1, 1)
 
 		!equals(ICE_MAJOR_VERSION, 3) {

--- a/src/murmur/murmur.pro
+++ b/src/murmur/murmur.pro
@@ -88,7 +88,16 @@ ice {
 	win32:CONFIG(debug, debug|release) {
 		LIBS *= -lIceD -lIceUtilD
 	} else {
-		LIBS *= -lIce -lIceUtil
+		# check Ice version, 3.7 merged IceUtil into Ice
+		ICE_VERSION = $$system(slice2cpp --version 2>&1)
+		ICE_MAJOR_VERSION = $$section(ICE_VERSION, ., 0, 0))
+		ICE_MINOR_VERSION = $$section(ICE_VERSION, ., 1, 1)
+
+		lessThan(ICE_MAJOR_VERSION, 3) | lessThan(ICE_MINOR_VERSION, 7) {
+			LIBS *= -lIce -lIceUtil
+		} else {
+			LIBS *= -lIce 
+		}
 	}
 	DEFINES *= USE_ICE
 

--- a/src/murmur/murmur.pro
+++ b/src/murmur/murmur.pro
@@ -93,12 +93,18 @@ ice {
 		ICE_MAJOR_VERSION = $$section(ICE_VERSION, ., 0, 0))
 		ICE_MINOR_VERSION = $$section(ICE_VERSION, ., 1, 1)
 
-		lessThan(ICE_MAJOR_VERSION, 3) | lessThan(ICE_MINOR_VERSION, 7) {
-			LIBS *= -lIce -lIceUtil
-		} else {
-			LIBS *= -lIce 
+		!equals(ICE_MAJOR_VERSION, 3) {
+     			error("Unsupported Ice version")
+		}
+		lessThan(ICE_MINOR_VERSION, 7) {
+    			# Ice < 3.7
+    			LIBS *= -lIce -lIceUtil
+		}  else {
+    			# Ice 3.7+
+    			LIBS *= -lIce
 		}
 	}
+
 	DEFINES *= USE_ICE
 
 	win32 {

--- a/src/murmur/murmur_ice/murmur_ice.pro
+++ b/src/murmur/murmur_ice/murmur_ice.pro
@@ -16,7 +16,7 @@ win32 {
 	!isEmpty(ICE_VERSION) {
 		EXTRA_SLICEFLAGS = -I/usr/share/Ice-$$ICE_VERSION/slice/
 	}
-	slice.commands = slice2cpp --checksum -I/usr/local/share/Ice -I/usr/share/Ice/slice -I/usr/share/slice $$EXTRA_SLICEFLAGS ${QMAKE_FILE_NAME}
+	slice.commands = slice2cpp --checksum -I/usr/local/share/Ice -I/usr/share/Ice/slice -I/usr/share/ice/slice -I/usr/share/slice $$EXTRA_SLICEFLAGS ${QMAKE_FILE_NAME}
 }
 slice.input = SLICEFILES
 slice.CONFIG *= no_link explicit_dependencies


### PR DESCRIPTION
Fixes #3210 

Ice 3.7 seems to have changed some folder's capital case around (Ice -> ice), added an include path to fix that.

Besides that IceUtil merged into Ice, added some logic to select the correct linking params.

Didn't test actual running with ice enabled in settings, it compiles and murmur runs without problems. Also I couldn't test it with 3.6, since I don't have 3.6 installed on any of my machines anymore.

Please be free to suggest improvements, I didn't wrote any qmake stuff before.

More Ice 3.7 stuff: https://doc.zeroc.com/display/Ice37/Upgrading+your+Application+from+Ice+3.6