### PR TITLE
Allow users to disable UIAccess via Additional Shortcut Engines setting.

### DIFF
--- a/src/mumble/GlobalShortcut.cpp
+++ b/src/mumble/GlobalShortcut.cpp
@@ -665,6 +665,7 @@ void GlobalShortcutConfig::load(const Settings &r) {
 		qwWarningContainer->setVisible(showWarning());
 	}
 
+	qcbEnableUIAccess->setChecked(r.bEnableUIAccess);
 	qcbEnableWinHooks->setChecked(r.bEnableWinHooks);
 	qcbEnableGKey->setChecked(r.bEnableGKey);
 	qcbEnableXboxInput->setChecked(r.bEnableXboxInput);
@@ -678,6 +679,9 @@ void GlobalShortcutConfig::save() const {
 	s.qlShortcuts = qlShortcuts;
 	s.bShortcutEnable = qcbEnableGlobalShortcuts->checkState() == Qt::Checked;
 
+	bool oldUIAccess = s.bEnableUIAccess;
+	s.bEnableUIAccess = qcbEnableUIAccess->checkState() == Qt::Checked;
+
 	bool oldWinHooks = s.bEnableWinHooks;
 	s.bEnableWinHooks = qcbEnableWinHooks->checkState() == Qt::Checked;
 
@@ -687,7 +691,7 @@ void GlobalShortcutConfig::save() const {
 	bool oldXboxInput = s.bEnableXboxInput;
 	s.bEnableXboxInput = qcbEnableXboxInput->checkState() == Qt::Checked;
 
-	if (s.bEnableWinHooks != oldWinHooks || s.bEnableGKey != oldGKey || s.bEnableXboxInput != oldXboxInput) {
+	if (s.bEnableUIAccess != oldUIAccess || s.bEnableWinHooks != oldWinHooks || s.bEnableGKey != oldGKey || s.bEnableXboxInput != oldXboxInput) {
 		s.requireRestartToApply = true;
 	}
 }

--- a/src/mumble/GlobalShortcut.ui
+++ b/src/mumble/GlobalShortcut.ui
@@ -216,6 +216,18 @@
         </property>
         <layout class="QVBoxLayout" name="verticalLayout_5">
          <item>
+          <widget class="QCheckBox" name="qcbEnableUIAccess">
+           <property name="whatsThis">
+            <string>&lt;b&gt;Enable shortcuts in privileged applications&lt;/b&gt;.&lt;br /&gt;Also known as &quot;UIAccess&quot;. This allows Mumble to receive global shortcut events from programs running at high privilege levels, such as an Admin Command Prompt or older games that run with admin privileges.
+&lt;br /&gt;&lt;br /&gt;
+Without this option enabled, using Mumble's global shortcuts in privileged applications will not work. This can seem inconsistent: for example, if the Push-to-Talk button is pressed in a non-privileged program, but relesed in a privileged application, Mumble will not observe that it has been released and you will continue to talk until you press the Push-to-Talk button again.</string>
+           </property>
+           <property name="text">
+            <string>Enable shortcuts in privileged applications</string>
+           </property>
+          </widget>
+         </item>
+         <item>
           <widget class="QCheckBox" name="qcbEnableWinHooks">
            <property name="whatsThis">
             <string>&lt;b&gt;Enable Windows hooks&lt;/b&gt;.&lt;br /&gt;This enables the Windows hooks shortcut engine. Using this engine allows Mumble to suppress keypresses and mouse clicks.</string>

--- a/src/mumble/Settings.cpp
+++ b/src/mumble/Settings.cpp
@@ -402,6 +402,7 @@ Settings::Settings() {
 	bEnableXboxInput = true;
 	bEnableWinHooks = true;
 	bDirectInputVerboseLogging = false;
+	bEnableUIAccess = true;
 
 	for (int i=Log::firstMsgType; i<=Log::lastMsgType; ++i) {
 		qmMessages.insert(i, Settings::LogConsole | Settings::LogBalloon | Settings::LogTTS);
@@ -775,6 +776,7 @@ void Settings::load(QSettings* settings_ptr) {
 	SAVELOAD(bEnableXboxInput, "shortcut/windows/xbox/enable");
 	SAVELOAD(bEnableWinHooks, "winhooks");
 	SAVELOAD(bDirectInputVerboseLogging, "shortcut/windows/directinput/verboselogging");
+	SAVELOAD(bEnableUIAccess, "shortcut/windows/uiaccess/enable");
 
 	int nshorts = settings_ptr->beginReadArray(QLatin1String("shortcuts"));
 	for (int i=0; i<nshorts; i++) {
@@ -1104,6 +1106,7 @@ void Settings::save() {
 	SAVELOAD(bEnableXboxInput, "shortcut/windows/xbox/enable");
 	SAVELOAD(bEnableWinHooks, "winhooks");
 	SAVELOAD(bDirectInputVerboseLogging, "shortcut/windows/directinput/verboselogging");
+	SAVELOAD(bEnableUIAccess, "shortcut/windows/uiaccess/enable");
 
 	settings_ptr->beginWriteArray(QLatin1String("shortcuts"));
 	int idx = 0;

--- a/src/mumble/Settings.h
+++ b/src/mumble/Settings.h
@@ -268,6 +268,9 @@ struct Settings {
 	bool bEnableWinHooks;
 	/// Enable verbose logging in GlobalShortcutWin's DirectInput backend.
 	bool bDirectInputVerboseLogging;
+	/// Enable use of UIAccess (Windows's UI automation feature). This allows
+	/// Mumble greater access to global shortcuts.
+	bool bEnableUIAccess;
 	QList<Shortcut> qlShortcuts;
 
 	enum MessageLog { LogNone = 0x00, LogConsole = 0x01, LogTTS = 0x02, LogBalloon = 0x04, LogSoundfile = 0x08};

--- a/src/mumble/main.cpp
+++ b/src/mumble/main.cpp
@@ -62,6 +62,8 @@ extern void os_init();
 extern char *os_lang;
 
 #ifdef Q_OS_WIN
+// from os_early_win.cpp
+extern int os_early_init();
 // from os_win.cpp
 extern HWND mumble_mw_hwnd;
 #endif // Q_OS_WIN
@@ -72,6 +74,13 @@ extern "C" __declspec(dllexport) int main(int argc, char **argv) {
 int main(int argc, char **argv) {
 #endif
 	int res = 0;
+
+#if defined(Q_OS_WIN)
+	int ret = os_early_init();
+	if (ret != 0) {
+		return ret;
+	}
+#endif
 
 	QT_REQUIRE_VERSION(argc, argv, "4.4.0");
 

--- a/src/mumble/mumble.pro
+++ b/src/mumble/mumble.pro
@@ -374,7 +374,7 @@ win32 {
     RC_FILE = mumble.rc
   }
   HEADERS	*= GlobalShortcut_win.h Overlay_win.h TaskList.h UserLockFile.h
-  SOURCES	*= GlobalShortcut_win.cpp Overlay_win.cpp SharedMemory_win.cpp Log_win.cpp os_win.cpp TaskList.cpp WinGUIDs.cpp ../../overlay/ods.cpp UserLockFile_win.cpp
+  SOURCES	*= GlobalShortcut_win.cpp Overlay_win.cpp SharedMemory_win.cpp Log_win.cpp os_win.cpp TaskList.cpp WinGUIDs.cpp ../../overlay/ods.cpp UserLockFile_win.cpp os_early_win.cpp
 
   !CONFIG(qtspeech) {
     SOURCES *= TextToSpeech_win.cpp

--- a/src/mumble/os_early_win.cpp
+++ b/src/mumble/os_early_win.cpp
@@ -3,6 +3,158 @@
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.
 
+#include <windows.h>
+#include <shlwapi.h>
+#include <stdio.h>
+#include <sddl.h>
+
+#include <string>
+
+// Alert shows a fatal error dialog and waits for the user to click OK.
+static void Alert(LPCWSTR title, LPCWSTR msg) {
+	MessageBox(NULL, msg, title, MB_OK|MB_ICONERROR);
+}
+
+// GetExecutablePath returns the path to mumble.exe.
+static const std::wstring GetExecutablePath() {
+	wchar_t path[MAX_PATH];
+
+	if (GetModuleFileNameW(NULL, path, MAX_PATH) == 0)
+		return std::wstring();
+
+	std::wstring exe_path(path);
+	return exe_path;
+}
+
+// UIAccessDisabledViaConfig queries the configuration store, and returns
+// whether UIAccess has been disabled by the user via the
+// "shortcut/windows/uiaccess/enable" config option.
+static bool UIAccessDisabledViaConfig() {
+	// RegQueryValueEx only zero-terminates if the registry value's type is
+	// one of the Windows registry's string types. Because of this, we have
+	// to use a buffer of 7 elements in order to query for the string "false".
+	//
+	// If the value's type is string, we'll end up with "false\0\0", because we
+	// always zero-pad.
+	//
+	// But that's better than ending up in an infinite loop because we failed
+	// to zero-terminate.
+	wchar_t buf[7];
+	memset(&buf, 0, sizeof(buf));
+	DWORD sz = sizeof(buf) - 1*sizeof(wchar_t);
+
+	HKEY key = NULL;
+	bool success = (RegOpenKeyExW(HKEY_CURRENT_USER, L"Software\\Mumble\\Mumble\\shortcut\\windows\\uiaccess", NULL, KEY_READ, &key) == ERROR_SUCCESS) &&
+	               (RegQueryValueExW(key, L"enable" , NULL, NULL, (LPBYTE)&buf, &sz) == ERROR_SUCCESS);
+	if (success && _wcsicmp(buf, L"false") == 0) {
+		return true;
+	}
+
+	return false;
+}
+
+// ProcessHasUIAccess returns true if the current process has UIAccess enabled.
+static bool ProcessHasUIAccess() {
+	HANDLE token = NULL;
+	if (!OpenProcessToken(GetCurrentProcess(), TOKEN_QUERY, &token)) {
+		return false;
+	}
+
+	DWORD ui_access = 0;
+	DWORD ui_access_size = sizeof(ui_access);
+	if (!GetTokenInformation(token, TokenUIAccess, &ui_access, sizeof(ui_access), &ui_access_size)) {
+		CloseHandle(token);
+		return false;
+	}
+
+	CloseHandle(token);
+	return ui_access != 0;
+}
+
+// RelaunchWithoutUIAccessIfNecessary relaunches the process
+// without UIAccess, if necessary.
+//
+// If a relaunch of Mumble is necessary, the new process is
+// spawned and the existing process is terminated. In that
+// situation, this function will not return to the caller.
+static bool RelaunchWithoutUIAccessIfNecessary() {
+	if (!ProcessHasUIAccess()) {
+		return true;
+	}
+	if (!UIAccessDisabledViaConfig()) {
+		return true;
+	}
+
+	STARTUPINFO startup_info;
+	memset(&startup_info, 0, sizeof(startup_info));
+
+	GetStartupInfo(&startup_info);
+
+	PROCESS_INFORMATION process_info;
+	memset(&process_info, 0, sizeof(process_info));
+
+	// Store the original value of __COMPAT_LAYER so we can
+	// restore it (which may be equivalent to not setting it all)
+	// once we've been relaunched.
+	wchar_t *compat_layer_env = _wgetenv(L"__COMPAT_LAYER");
+	if (compat_layer_env == NULL) {
+		compat_layer_env = L"mumble_exe_none";
+	}
+	_wputenv_s(L"mumble_exe_prev_compat_layer", compat_layer_env);
+
+	// The only way we have found thus far to ignore the executable's
+	// manifest when calling CreateProcess, is to use the __COMPAT_LAYER
+	// environment variable.
+	//
+	// Setting this to RunAsInvoker seemingly ignores the application's
+	// manifest. RunAsInvoker is the default execution level for Windows
+	// programs.
+	_wputenv_s(L"__COMPAT_LAYER", L"RunAsInvoker");
+
+	std::wstring exe_path = GetExecutablePath();
+	if (exe_path.empty()) {
+		return false;
+	}
+
+	if (!CreateProcessW(exe_path.c_str(),
+	              GetCommandLineW(),
+	              NULL,
+	              NULL,
+	              FALSE,
+	              0,
+	              NULL,
+	              NULL,
+	              &startup_info,
+	              &process_info)) {
+		return false;
+	}
+
+	exit(0);
+}
+
+// CleanupEnvironmentVariables cleans up any
+// unnecessary environment variables.
+//
+// For now, this function cleans up any environment
+// variables set by RelaunchWithoutUIAccessIfNecessary.
+static void CleanupEnvironmentVariables() {
+	wchar_t *prev_compat_layer_env = _wgetenv(L"mumble_exe_prev_compat_layer");
+	if (prev_compat_layer_env != NULL) {
+		if (wcscmp(prev_compat_layer_env, L"mumble_exe_none") == 0) {
+			_wputenv_s(L"__COMPAT_LAYER", L"");
+		} else {
+			_wputenv_s(L"__COMPAT_LAYER", prev_compat_layer_env);
+		}
+	}
+}
+
 int os_early_init() {
+	CleanupEnvironmentVariables();
+
+	if (!RelaunchWithoutUIAccessIfNecessary()) {
+		Alert(L"Mumble Early Init Error 50", L"Unable to complete RelaunchWithoutUIAccessIfNecessary");
+		return 50;
+	}
+
 	return 0;
 }

--- a/src/mumble/os_early_win.cpp
+++ b/src/mumble/os_early_win.cpp
@@ -1,0 +1,8 @@
+// Copyright 2005-2017 The Mumble Developers. All rights reserved.
+// Use of this source code is governed by a BSD-style license
+// that can be found in the LICENSE file at the root of the
+// Mumble source tree or at <https://www.mumble.info/LICENSE>.
+
+int os_early_init() {
+	return 0;
+}


### PR DESCRIPTION
This is a continuation of PR mumble-voip/mumble#2008. This PR implements the mechanism to disable UIAccess in mumble_app.dll instead of mumble.exe -- a much cleaner architecture that keeps our mumble.exe minimal.