### PR TITLE
Remove DIST directive from all .pro files.

### DIFF
--- a/3rdparty/celt-0.11.0-build/celt-0.11.0-build.pro
+++ b/3rdparty/celt-0.11.0-build/celt-0.11.0-build.pro
@@ -62,8 +62,6 @@ unix {
   INCLUDEPATH += ../$$BUILDDIR
 }
 
-DIST = config.h
-
 SOURCES *= bands.c celt.c cwrs.c entcode.c entdec.c entenc.c header.c kiss_fft.c laplace.c mathops.c mdct.c modes.c pitch.c plc.c quant_bands.c rate.c vq.c
 
 CONFIG(debug, debug|release) {

--- a/3rdparty/celt-0.7.0-build/celt-0.7.0-build.pro
+++ b/3rdparty/celt-0.7.0-build/celt-0.7.0-build.pro
@@ -69,8 +69,6 @@ unix {
   INCLUDEPATH += ../$$BUILDDIR
 }
 
-DIST = config.h
-
 SOURCES *= bands.c celt.c cwrs.c entcode.c entdec.c entenc.c header.c kiss_fft.c kiss_fftr.c laplace.c mdct.c modes.c pitch.c psy.c quant_bands.c rangedec.c rangeenc.c rate.c vq.c
 
 CONFIG(debug, debug|release) {

--- a/3rdparty/opus-build/opus-build.pro
+++ b/3rdparty/opus-build/opus-build.pro
@@ -65,8 +65,6 @@ unix {
   INCLUDEPATH += ../$$BUILDDIR
 }
 
-DIST = config.h
-
 INCLUDEPATH *= \
 ../$$SOURCEDIR \
 ../$$SOURCEDIR/celt \

--- a/3rdparty/speex-build/speex-build.pro
+++ b/3rdparty/speex-build/speex-build.pro
@@ -73,8 +73,6 @@ win32 {
   INCLUDEPATH += ../speex-build
 }
 
-DIST = config.h speex.def speex/speex_config_types.h
-
 DEF_FILE = speex.def
 
 # libspeexdsp

--- a/g15helper/g15helper.pro
+++ b/g15helper/g15helper.pro
@@ -91,7 +91,6 @@ CONFIG(g15-emulator) {
     INCLUDEPATH *= $$(MUMBLE_PREFIX)/../LCDSDK/Src/
     QMAKE_LFLAGS += -framework CoreFoundation -sectcreate __TEXT __info_plist g15helper.plist
     DEFINES *= APPLE
-    DIST = g15helper.plist
   }
 }
 

--- a/macx/osax/osax.pro
+++ b/macx/osax/osax.pro
@@ -33,7 +33,6 @@ SDEF.path = Contents/Resources
 QMAKE_BUNDLE_DATA += SDEF
 
 OBJECTIVE_SOURCES = osax.m
-DIST = osax.plist MumbleOverlay.sdef
 
 CONFIG(debug, debug|release) {
   DESTDIR       = ../../debug

--- a/macx/scripts/scripts.pro
+++ b/macx/scripts/scripts.pro
@@ -1,6 +1,0 @@
-# Copyright 2005-2017 The Mumble Developers. All rights reserved.
-# Use of this source code is governed by a BSD-style license
-# that can be found in the LICENSE file at the root of the
-# Mumble source tree or at <https://www.mumble.info/LICENSE>.
-
-DIST *= DS_Store codesign-requirements.tmpl osxdist.py build-overlay-installer gendmg.pl

--- a/main.pro
+++ b/main.pro
@@ -105,6 +105,4 @@ CONFIG(tests) {
   SUBDIRS *= src/tests
 }
 
-DIST=LICENSE INSTALL README README.Linux CHANGES
-
 include(scripts/scripts.pro)

--- a/overlay/overlay-shared.pro
+++ b/overlay/overlay-shared.pro
@@ -18,7 +18,6 @@ HEADERS = ancestor.h lib.h olsettings.h excludecheck.h ods.h HardHook.h overlay_
 EFFECTS = overlay.fx
 DX11_PIXEL_SHADERS = overlay11.ps
 DX11_VERTEX_SHADERS = overlay11.vs
-DIST = overlay.h overlay.fx HardHook.h
 
 DEFINES -= UNICODE
 

--- a/plugins/plugins.pro
+++ b/plugins/plugins.pro
@@ -9,7 +9,6 @@ TEMPLATE = subdirs
 
 CONFIG += debug_and_release
 SUBDIRS = link
-DIST = plugins.pri
 
 win32 {
   SUBDIRS += aoc arma2 bf1942 bf2 bf3 bf2142 bfbc2 bfheroes bf4_x86 blacklight borderlands borderlands2 breach cod2 cod4 cod5 codmw2 codmw2so cs css dods dys etqw ffxiv tf2 gmod gtaiv gw hl2dm insurgency jc2 l4d l4d2 lol lotro ql rl sr sto ut2004 ut3 ut99 wolfet wow

--- a/scripts/scripts.pro
+++ b/scripts/scripts.pro
@@ -1,9 +1,0 @@
-# Copyright 2005-2017 The Mumble Developers. All rights reserved.
-# Use of this source code is governed by a BSD-style license
-# that can be found in the LICENSE file at the root of the
-# Mumble source tree or at <https://www.mumble.info/LICENSE>.
-
-DIST *= server/dbus/murmur.pl server/dbus/dbusauth.pl server/dbus/weblist.pl
-DIST *= server/ice/weblist.php server/ice/icedemo.php
-DIST *= murmur.ini murmur.ini.system murmur.init murmur.conf murmur.logrotate murmur-user-wrapper
-DIST *= mumble-overlay mumble.desktop mumble.protocol mumble.appdata.xml

--- a/src/mumble/mumble.pro
+++ b/src/mumble/mumble.pro
@@ -214,7 +214,6 @@ CONFIG(qtspeech) {
   SOURCES *= TextToSpeech.cpp
 }
 
-DIST  *= ../../icons/mumble.ico ../../icons/mumble.xpm murmur_pch.h mumble.plist
 RESOURCES *= mumble.qrc mumble_translations.qrc ../../themes/MumbleTheme.qrc
 # Add the various mumble_flags_XX.qrc files to RESOURCES...
 include(flags/mumble_flags.pri)

--- a/src/murmur/murmur.pro
+++ b/src/murmur/murmur.pro
@@ -19,7 +19,6 @@ FORMS =
 HEADERS *= Server.h ServerUser.h Meta.h PBKDF2.h
 SOURCES *= main.cpp Server.cpp ServerUser.cpp ServerDB.cpp Register.cpp Cert.cpp Messages.cpp Meta.cpp RPC.cpp PBKDF2.cpp
 
-DIST = DBus.h ServerDB.h ../../icons/murmur.ico Murmur.ice MurmurI.h MurmurIceWrapper.cpp murmur.plist
 PRECOMPILED_HEADER = murmur_pch.h
 
 !CONFIG(no-ice) {


### PR DESCRIPTION
We used to use DIST for referencing extra files that should be included
in our tarballs created by 'make dist'.

However, we've since migrated away relying on 'make dist' in release.pl.
Instead, we include everything, and have a list of items to exclude, such
as IETF RFC drafts distributed in 3rdparty/speex-src that do not adhere to
the Debian Free Software Guidelines.