### PR TITLE
GlobalShortcutWin: fall back to 'Unknown' for unknown DirectInput buttons.

### DIFF
--- a/src/mumble/GlobalShortcut_win.cpp
+++ b/src/mumble/GlobalShortcut_win.cpp
@@ -878,7 +878,10 @@ QString GlobalShortcutWin::buttonName(const QVariant &v) {
 	else if (id)
 		device=id->name+QLatin1String(":");
 	if (id) {
-		name=id->qhNames.value(type);
+		QString result = id->qhNames.value(type);
+		if (!result.isEmpty()) {
+			name = result;
+		}
 	}
 	return device+name;
 }


### PR DESCRIPTION
When a lookup in qhNames fails, it returns a default-constructed (null and
empty) string.

Do not update the name variable if the result of the lookup is empty.

This ensures we fall back to 'Unknown' when we encounter an unknown
button.

For now, this means that "F13-F24" are shown as K:Unknown instead of just
"K:".