### PR TITLE
overlay_gl: linux: only assume absolute dynamic entries on glibc.

### DIFF
--- a/overlay_gl/init_unix.c
+++ b/overlay_gl/init_unix.c
@@ -152,19 +152,24 @@ static int find_odlsym() {
 		int nchains = 0;
 		ElfW(Sym) *symtab = NULL;
 		const char *strtab = NULL;
+#if defined(__GLIBC__)
+		const ElfW(Addr) base = 0;
+#else
+		const ElfW(Addr) base = lm->l_addr;
+#endif
 
 		ElfW(Dyn) *dyn = lm->l_ld;
 
 		while (dyn->d_tag) {
 			switch (dyn->d_tag) {
 				case DT_HASH:
-					nchains = *(int *)(dyn->d_un.d_ptr + 4);
+					nchains = *(int *)(base + dyn->d_un.d_ptr + 4);
 					break;
 				case DT_STRTAB:
-					strtab = (const char *) dyn->d_un.d_ptr;
+					strtab = (const char *)(base + dyn->d_un.d_ptr);
 					break;
 				case DT_SYMTAB:
-					symtab = (ElfW(Sym) *) dyn->d_un.d_ptr;
+					symtab = (ElfW(Sym) *)(base + dyn->d_un.d_ptr);
 					break;
 			}
 			dyn ++;


### PR DESCRIPTION
This fixes a crash in libmumble's library constructor when built against
the musl libc.

The code that locates libc's `dlsym(3)` relied on addresses in dynamic
entries in the link map returned by `dlopen(3)` to always be absolute.
This seems to be specific to glibc though, so add a glibc feature test.