### PR TITLE
Fix Travis OSX build, Support Ice 3.7

### DIFF
--- a/src/murmur/MurmurIce.cpp
+++ b/src/murmur/MurmurIce.cpp
@@ -252,7 +252,11 @@ MurmurIce::MurmurIce() {
 		}
 		adapter = communicator->createObjectAdapterWithEndpoints("Murmur", qPrintable(meta->mp.qsIceEndpoint));
 		MetaPtr m = new MetaI;
+#if ICE_INT_VERSION >= 30700
+		MetaPrx mprx = MetaPrx::uncheckedCast(adapter->add(m, Ice::stringToIdentity("Meta")));
+#else
 		MetaPrx mprx = MetaPrx::uncheckedCast(adapter->add(m, communicator->stringToIdentity("Meta")));
+#endif
 		adapter->addServantLocator(new ServerLocator(), "s");
 
 		iopServer = new ServerI;
@@ -264,7 +268,11 @@ MurmurIce::MurmurIce() {
 
 		meta->connectListener(this);
 	} catch (Ice::Exception &e) {
+#if ICE_INT_VERSION >= 30700
+		qCritical("MurmurIce: Initialization failed: %s", qPrintable(u8(e.ice_id())));
+#else
 		qCritical("MurmurIce: Initialization failed: %s", qPrintable(u8(e.ice_name())));
+#endif
 	}
 }
 

--- a/src/murmur/murmur_ice/murmur_ice.pro
+++ b/src/murmur/murmur_ice/murmur_ice.pro
@@ -48,7 +48,7 @@ macx {
       MUMBLE_ICE_PREFIX = $$(MUMBLE_PREFIX)/Ice-3.4.2
   }
   INCLUDEPATH *= $$MUMBLE_ICE_PREFIX/include/
-  slice.commands = $$MUMBLE_ICE_PREFIX/bin/slice2cpp --checksum -I$$MUMBLE_ICE_PREFIX/slice/ -I$$MUMBLE_ICE_PREFIX/share/slice/ ../Murmur.ice
+  slice.commands = $$MUMBLE_ICE_PREFIX/bin/slice2cpp --checksum -I$$MUMBLE_ICE_PREFIX/slice/ -I$$MUMBLE_ICE_PREFIX/share/slice/ -I$$MUMBLE_ICE_PREFIX/share/ice/slice ../Murmur.ice
 }
 
 unix:!macx:CONFIG(buildenv) {


### PR DESCRIPTION
Our OSX build uses brew to install dependencies, amongst which is Ice.

The brew keg (package) `ice` was updated from 3.6 to 3.7.
With the update, the slice file path changed to `/usr/local/opt/ice/share/ice/slice`
(where `/usr/local/opt/<keg-name>` is the symlinked path to the currently installed keg (=package) files.

* Use `share/ice/slice` as a possible subpath for slice file inclusion when running slice2cpp to compile Ice cpp files.
* Replace method calls that were marked obsolete in Ice 3.7.