### PR TITLE
Introduce export and import for global shortcuts

### DIFF
--- a/src/mumble/GlobalShortcut.cpp
+++ b/src/mumble/GlobalShortcut.cpp
@@ -640,7 +640,14 @@ void GlobalShortcutConfig::on_qpbImport_clicked() {
 		return;
 	}
 	QSettings s(filePath, QSettings::IniFormat);
-	qlShortcuts = Settings::loadShortcuts(&s);
+	bool importOk = false;
+	QList<Shortcut> importedShortcuts  = Settings::loadShortcuts(&s, &importOk);
+	if (!importOk)
+	{
+		QMessageBox::warning(this, tr("Import Failure"), tr("The file could not be imported as Mumble shortcuts.\nAre you sure this is a valid Mumble shortcuts file?"));
+		return;
+	}
+	qlShortcuts = importedShortcuts;
 	reload();
 }
 

--- a/src/mumble/GlobalShortcut.cpp
+++ b/src/mumble/GlobalShortcut.cpp
@@ -631,6 +631,14 @@ void GlobalShortcutConfig::on_qpbImport_clicked() {
 	if (filePath.isEmpty()) {
 		return;
 	}
+	int userAction = QMessageBox::warning(this
+	                                      , tr("Shortcut Replacement")
+	                                      , tr("Importing the shortcuts will drop and replace all current shortcuts.\nDo you want to continue?")
+	                                      , QMessageBox::Ok | QMessageBox::Cancel
+	                                      , QMessageBox::Ok);
+	if (userAction != QMessageBox::Ok) {
+		return;
+	}
 	QSettings s(filePath, QSettings::IniFormat);
 	qlShortcuts = Settings::loadShortcuts(&s);
 	reload();

--- a/src/mumble/GlobalShortcut.cpp
+++ b/src/mumble/GlobalShortcut.cpp
@@ -625,6 +625,27 @@ void GlobalShortcutConfig::on_qpbRemove_clicked(bool) {
 	qlShortcuts.removeAt(idx);
 }
 
+void GlobalShortcutConfig::on_qpbImport_clicked() {
+	commit();
+	QString filePath = QFileDialog::getOpenFileName(this, tr("Import shortcuts"), QString(), QLatin1String("*.ini"));
+	if (filePath.isEmpty()) {
+		return;
+	}
+	QSettings s(filePath, QSettings::IniFormat);
+	qlShortcuts = g.s.loadShortcuts(&s);
+	reload();
+}
+
+void GlobalShortcutConfig::on_qpbExport_clicked() {
+	commit();
+	QString filePath = QFileDialog::getSaveFileName(this, tr("Save shortcuts"), QLatin1String("mumble-shortcuts.ini"), QLatin1String("*.ini"));
+	if (filePath.isEmpty()) {
+		return;
+	}
+	QSettings s(filePath, QSettings::IniFormat);
+	g.s.saveShortcuts(qlShortcuts, &s);
+}
+
 void GlobalShortcutConfig::on_qtwShortcuts_currentItemChanged(QTreeWidgetItem *item, QTreeWidgetItem *) {
 	qpbRemove->setEnabled(item ? true : false);
 }

--- a/src/mumble/GlobalShortcut.cpp
+++ b/src/mumble/GlobalShortcut.cpp
@@ -633,7 +633,7 @@ void GlobalShortcutConfig::on_qpbImport_clicked() {
 	}
 	const int userAction = QMessageBox::warning(this
 	                                      , tr("Shortcut Replacement")
-	                                      , tr("Importing the shortcuts will drop and replace all current shortcuts.\nDo you want to continue?")
+	                                      , tr("Importing the shortcuts will drop and replace all current shortcuts, including server specific shortcuts.\nYou may want to export the current shortcuts before importing to have a backup to come back to.\n\nDo you want to continue the import?")
 	                                      , QMessageBox::Ok | QMessageBox::Cancel
 	                                      , QMessageBox::Ok);
 	if (userAction != QMessageBox::Ok) {

--- a/src/mumble/GlobalShortcut.cpp
+++ b/src/mumble/GlobalShortcut.cpp
@@ -632,7 +632,7 @@ void GlobalShortcutConfig::on_qpbImport_clicked() {
 		return;
 	}
 	QSettings s(filePath, QSettings::IniFormat);
-	qlShortcuts = g.s.loadShortcuts(&s);
+	qlShortcuts = Settings::loadShortcuts(&s);
 	reload();
 }
 
@@ -643,7 +643,7 @@ void GlobalShortcutConfig::on_qpbExport_clicked() {
 		return;
 	}
 	QSettings s(filePath, QSettings::IniFormat);
-	g.s.saveShortcuts(qlShortcuts, &s);
+	Settings::saveShortcuts(qlShortcuts, &s);
 	s.sync();
 	if (s.status() != QSettings::NoError) {
 		QMessageBox::warning(this, tr("Export Failure"), tr("Writing the export file failed."));

--- a/src/mumble/GlobalShortcut.cpp
+++ b/src/mumble/GlobalShortcut.cpp
@@ -627,7 +627,7 @@ void GlobalShortcutConfig::on_qpbRemove_clicked(bool) {
 
 void GlobalShortcutConfig::on_qpbImport_clicked() {
 	commit();
-	QString filePath = QFileDialog::getOpenFileName(this, tr("Import shortcuts"), QString(), QLatin1String("*.ini"));
+	const QString filePath = QFileDialog::getOpenFileName(this, tr("Import shortcuts"), QString(), QLatin1String("*.ini"));
 	if (filePath.isEmpty()) {
 		return;
 	}
@@ -638,7 +638,7 @@ void GlobalShortcutConfig::on_qpbImport_clicked() {
 
 void GlobalShortcutConfig::on_qpbExport_clicked() {
 	commit();
-	QString filePath = QFileDialog::getSaveFileName(this, tr("Save shortcuts"), QLatin1String("mumble-shortcuts.ini"), QLatin1String("*.ini"));
+	const QString filePath = QFileDialog::getSaveFileName(this, tr("Save shortcuts"), QLatin1String("mumble-shortcuts.ini"), QLatin1String("*.ini"));
 	if (filePath.isEmpty()) {
 		return;
 	}

--- a/src/mumble/GlobalShortcut.cpp
+++ b/src/mumble/GlobalShortcut.cpp
@@ -631,7 +631,7 @@ void GlobalShortcutConfig::on_qpbImport_clicked() {
 	if (filePath.isEmpty()) {
 		return;
 	}
-	int userAction = QMessageBox::warning(this
+	const int userAction = QMessageBox::warning(this
 	                                      , tr("Shortcut Replacement")
 	                                      , tr("Importing the shortcuts will drop and replace all current shortcuts.\nDo you want to continue?")
 	                                      , QMessageBox::Ok | QMessageBox::Cancel

--- a/src/mumble/GlobalShortcut.cpp
+++ b/src/mumble/GlobalShortcut.cpp
@@ -644,6 +644,10 @@ void GlobalShortcutConfig::on_qpbExport_clicked() {
 	}
 	QSettings s(filePath, QSettings::IniFormat);
 	g.s.saveShortcuts(qlShortcuts, &s);
+	s.sync();
+	if (s.status() != QSettings::NoError) {
+		QMessageBox::warning(this, tr("Export Failure"), tr("Writing the export file failed."));
+	}
 }
 
 void GlobalShortcutConfig::on_qtwShortcuts_currentItemChanged(QTreeWidgetItem *item, QTreeWidgetItem *) {

--- a/src/mumble/GlobalShortcut.cpp
+++ b/src/mumble/GlobalShortcut.cpp
@@ -641,7 +641,7 @@ void GlobalShortcutConfig::on_qpbImport_clicked() {
 	}
 	QSettings s(filePath, QSettings::IniFormat);
 	bool importOk = false;
-	QList<Shortcut> importedShortcuts  = Settings::loadShortcuts(&s, &importOk);
+	QList<Shortcut> importedShortcuts  = Settings::loadShortcutsFromFile(&s, &importOk);
 	if (!importOk)
 	{
 		QMessageBox::warning(this, tr("Import Failure"), tr("The file could not be imported as Mumble shortcuts.\nAre you sure this is a valid Mumble shortcuts file?"));

--- a/src/mumble/GlobalShortcut.h
+++ b/src/mumble/GlobalShortcut.h
@@ -201,6 +201,8 @@ class GlobalShortcutConfig : public ConfigWidget, public Ui::GlobalShortcut {
 		void on_qcbEnableGlobalShortcuts_stateChanged(int);
 		void on_qpbAdd_clicked(bool);
 		void on_qpbRemove_clicked(bool);
+		void on_qpbImport_clicked();
+		void on_qpbExport_clicked();
 		void on_qtwShortcuts_currentItemChanged(QTreeWidgetItem *, QTreeWidgetItem *);
 		void on_qtwShortcuts_itemChanged(QTreeWidgetItem *, int);
 		void on_qpbOpenAccessibilityPrefs_clicked();

--- a/src/mumble/GlobalShortcut.ui
+++ b/src/mumble/GlobalShortcut.ui
@@ -207,7 +207,7 @@
         <item>
          <widget class="QPushButton" name="qpbImport">
           <property name="toolTip">
-           <string>Import shortcuts from a file, replacing the current shortcuts.</string>
+           <string>Import shortcuts from a file. Replaces the current shortcuts.</string>
           </property>
           <property name="text">
            <string>&amp;Import</string>

--- a/src/mumble/GlobalShortcut.ui
+++ b/src/mumble/GlobalShortcut.ui
@@ -204,6 +204,26 @@
           </property>
          </spacer>
         </item>
+        <item>
+         <widget class="QPushButton" name="qpbImport">
+          <property name="toolTip">
+           <string>Import shortcuts from a file, replacing the current shortcuts.</string>
+          </property>
+          <property name="text">
+           <string>&amp;Import</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QPushButton" name="qpbExport">
+          <property name="toolTip">
+           <string>Export global shortcuts to a file (does not include server specific shortcuts).</string>
+          </property>
+          <property name="text">
+           <string>&amp;Export</string>
+          </property>
+         </widget>
+        </item>
        </layout>
       </item>
       <item>

--- a/src/mumble/Settings.cpp
+++ b/src/mumble/Settings.cpp
@@ -814,7 +814,7 @@ void Settings::load(QSettings* settings_ptr) {
 QList<Shortcut> Settings::loadShortcuts(QSettings *settings_ptr) {
 	QList<Shortcut> qlShortcuts;
 	const int nshorts = settings_ptr->beginReadArray(QLatin1String("shortcuts"));
-	for (int i=0; i<nshorts; i++) {
+	for (int i = 0; i < nshorts; ++i) {
 		settings_ptr->setArrayIndex(i);
 		Shortcut s;
 

--- a/src/mumble/Settings.cpp
+++ b/src/mumble/Settings.cpp
@@ -813,19 +813,24 @@ void Settings::load(QSettings* settings_ptr) {
 	settings_ptr->endGroup();
 }
 
-QList<Shortcut> Settings::loadShortcuts(QSettings *settings_ptr, bool *ok) {
+QList<Shortcut> Settings::loadShortcutsFromFile(QSettings *settings_ptr, bool *ok) {
 	QVariant fileVersionVar = settings_ptr->value(SHORTCUTS_FILE_VERSION_FIELDNAME, QVariant::fromValue(-1));
 	bool convertOk = false;
 	int fileVersion = fileVersionVar.toInt(&convertOk);
-	QList<Shortcut> qlShortcuts;
 	if (!convertOk || fileVersion != 1)
 	{
 		if (ok != NULL)
 		{
 			*ok = false;
 		}
-		return qlShortcuts;
+		return QList<Shortcut>();
 	}
+
+	return loadShortcuts(settings_ptr, ok);
+}
+
+QList<Shortcut> Settings::loadShortcuts(QSettings *settings_ptr, bool *ok) {
+	QList<Shortcut> qlShortcuts;
 	const int nshorts = settings_ptr->beginReadArray(QLatin1String("shortcuts"));
 	for (int i = 0; i < nshorts; ++i) {
 		settings_ptr->setArrayIndex(i);
@@ -1173,9 +1178,13 @@ void Settings::save() {
 	settings_ptr->endGroup();
 }
 
-void Settings::saveShortcuts(const QList<Shortcut> &qlShortcuts, QSettings *settings_ptr) {
+void Settings::saveShortcutsToFile(const QList<Shortcut> &qlShortcuts, QSettings *settings_ptr) {
 	const int fileVersion = 1;
 	settings_ptr->setValue(SHORTCUTS_FILE_VERSION_FIELDNAME, fileVersion);
+	saveShortcuts(qlShortcuts, settings_ptr);
+}
+
+void Settings::saveShortcuts(const QList<Shortcut> &qlShortcuts, QSettings *settings_ptr) {
 	settings_ptr->beginWriteArray(QLatin1String("shortcuts"));
 	int idx = 0;
 	foreach(const Shortcut &s, qlShortcuts) {

--- a/src/mumble/Settings.cpp
+++ b/src/mumble/Settings.cpp
@@ -813,7 +813,7 @@ void Settings::load(QSettings* settings_ptr) {
 
 QList<Shortcut> Settings::loadShortcuts(QSettings *settings_ptr) {
 	QList<Shortcut> qlShortcuts;
-	int nshorts = settings_ptr->beginReadArray(QLatin1String("shortcuts"));
+	const int nshorts = settings_ptr->beginReadArray(QLatin1String("shortcuts"));
 	for (int i=0; i<nshorts; i++) {
 		settings_ptr->setArrayIndex(i);
 		Shortcut s;

--- a/src/mumble/Settings.cpp
+++ b/src/mumble/Settings.cpp
@@ -778,21 +778,7 @@ void Settings::load(QSettings* settings_ptr) {
 	SAVELOAD(bDirectInputVerboseLogging, "shortcut/windows/directinput/verboselogging");
 	SAVELOAD(bEnableUIAccess, "shortcut/windows/uiaccess/enable");
 
-	int nshorts = settings_ptr->beginReadArray(QLatin1String("shortcuts"));
-	for (int i=0; i<nshorts; i++) {
-		settings_ptr->setArrayIndex(i);
-		Shortcut s;
-
-		s.iIndex = -2;
-
-		SAVELOAD(s.iIndex, "index");
-		SAVELOAD(s.qlButtons, "keys");
-		SAVELOAD(s.bSuppress, "suppress");
-		s.qvData = settings_ptr->value(QLatin1String("data"));
-		if (s.iIndex >= -1)
-			qlShortcuts << s;
-	}
-	settings_ptr->endArray();
+	qlShortcuts = loadShortcuts(settings_ptr);
 
 	settings_ptr->beginReadArray(QLatin1String("messages"));
 	for (QMap<int, quint32>::const_iterator it = qmMessages.constBegin(); it != qmMessages.constEnd(); ++it) {
@@ -823,6 +809,26 @@ void Settings::load(QSettings* settings_ptr) {
 	settings_ptr->beginGroup(QLatin1String("overlay"));
 	os.load(settings_ptr);
 	settings_ptr->endGroup();
+}
+
+QList<Shortcut> Settings::loadShortcuts(QSettings *settings_ptr) {
+	QList<Shortcut> qlShortcuts;
+	int nshorts = settings_ptr->beginReadArray(QLatin1String("shortcuts"));
+	for (int i=0; i<nshorts; i++) {
+		settings_ptr->setArrayIndex(i);
+		Shortcut s;
+
+		s.iIndex = -2;
+
+		SAVELOAD(s.iIndex, "index");
+		SAVELOAD(s.qlButtons, "keys");
+		SAVELOAD(s.bSuppress, "suppress");
+		s.qvData = settings_ptr->value(QLatin1String("data"));
+		if (s.iIndex >= -1)
+			qlShortcuts << s;
+	}
+	settings_ptr->endArray();
+	return qlShortcuts;
 }
 
 #undef SAVELOAD
@@ -1108,18 +1114,7 @@ void Settings::save() {
 	SAVELOAD(bDirectInputVerboseLogging, "shortcut/windows/directinput/verboselogging");
 	SAVELOAD(bEnableUIAccess, "shortcut/windows/uiaccess/enable");
 
-	settings_ptr->beginWriteArray(QLatin1String("shortcuts"));
-	int idx = 0;
-	foreach(const Shortcut &s, qlShortcuts) {
-		if (! s.isServerSpecific()) {
-			settings_ptr->setArrayIndex(idx++);
-			settings_ptr->setValue(QLatin1String("index"), s.iIndex);
-			settings_ptr->setValue(QLatin1String("keys"), s.qlButtons);
-			settings_ptr->setValue(QLatin1String("suppress"), s.bSuppress);
-			settings_ptr->setValue(QLatin1String("data"), s.qvData);
-		}
-	}
-	settings_ptr->endArray();
+	saveShortcuts(qlShortcuts, settings_ptr);
 
 	settings_ptr->beginWriteArray(QLatin1String("messages"));
 	for (QMap<int, quint32>::const_iterator it = qmMessages.constBegin(); it != qmMessages.constEnd(); ++it) {
@@ -1158,4 +1153,19 @@ void Settings::save() {
 	settings_ptr->beginGroup(QLatin1String("overlay"));
 	os.save(settings_ptr);
 	settings_ptr->endGroup();
+}
+
+void Settings::saveShortcuts(const QList<Shortcut> &qlShortcuts, QSettings *settings_ptr) {
+	settings_ptr->beginWriteArray(QLatin1String("shortcuts"));
+	int idx = 0;
+	foreach(const Shortcut &s, qlShortcuts) {
+		if (! s.isServerSpecific()) {
+			settings_ptr->setArrayIndex(idx++);
+			settings_ptr->setValue(QLatin1String("index"), s.iIndex);
+			settings_ptr->setValue(QLatin1String("keys"), s.qlButtons);
+			settings_ptr->setValue(QLatin1String("suppress"), s.bSuppress);
+			settings_ptr->setValue(QLatin1String("data"), s.qvData);
+		}
+	}
+	settings_ptr->endArray();
 }

--- a/src/mumble/Settings.h
+++ b/src/mumble/Settings.h
@@ -411,7 +411,9 @@ struct Settings {
 	Settings();
 	void load();
 	void load(QSettings*);
+	QList<Shortcut> loadShortcuts(QSettings *s);
 	void save();
+	void saveShortcuts(const QList<Shortcut> &qlShortcuts, QSettings *s);
 };
 
 #endif

--- a/src/mumble/Settings.h
+++ b/src/mumble/Settings.h
@@ -419,11 +419,21 @@ struct Settings {
 	/// \param ok if passed, will hold true for a successful import, false for a failure
 	/// \return A list of shortcuts (if param ok is false of undefined contents)
 	static QList<Shortcut> loadShortcuts(QSettings *settings_ptr, bool *ok=NULL);
+	/// \brief loadShortcutsFromFile Parses the passed settings for shortcuts. The shortcuts are returned in a list.
+	/// The Parsing is guarded with a file version field to be more robust against accidental imports overwriting shortcut settings.
+	/// \param settings QSettings to load the shortcuts into
+	/// \param ok if passed, will hold true for a successful import, false for a failure
+	/// \return A list of shortcuts (if param ok is false of undefined contents)
+	static QList<Shortcut> loadShortcutsFromFile(QSettings *settings_ptr, bool *ok=NULL);
 	void save();
 	/// \brief saveShortcuts Save qlShortcuts into settings
 	/// \param qlShortcuts list of shortcuts to store
 	/// \param settings settings object to save into
 	static void saveShortcuts(const QList<Shortcut> &qlShortcuts, QSettings *settings_ptr);
+	/// \brief saveShortcutsToFile Save qlShortcuts into settings, including a file version guard field
+	/// \param qlShortcuts list of shortcuts to store
+	/// \param settings settings object to save into
+	static void saveShortcutsToFile(const QList<Shortcut> &qlShortcuts, QSettings *settings_ptr);
 };
 
 #endif

--- a/src/mumble/Settings.h
+++ b/src/mumble/Settings.h
@@ -411,9 +411,15 @@ struct Settings {
 	Settings();
 	void load();
 	void load(QSettings*);
-	QList<Shortcut> loadShortcuts(QSettings *s);
+	/// \brief loadShortcuts Parses the passed settings for shortcuts. The shortcuts are returned in a list.
+	/// \param settings QSettings to load the shortcuts into
+	/// \return A list of shortcuts
+	static QList<Shortcut> loadShortcuts(QSettings *settings_ptr);
 	void save();
-	void saveShortcuts(const QList<Shortcut> &qlShortcuts, QSettings *s);
+	/// \brief saveShortcuts Save qlShortcuts into settings
+	/// \param qlShortcuts list of shortcuts to store
+	/// \param settings settings object to save into
+	static void saveShortcuts(const QList<Shortcut> &qlShortcuts, QSettings *settings_ptr);
 };
 
 #endif

--- a/src/mumble/Settings.h
+++ b/src/mumble/Settings.h
@@ -11,6 +11,7 @@
 #include <QtCore/QPair>
 #include <QtCore/QRectF>
 #include <QtCore/QSettings>
+#include <QtCore/QString>
 #include <QtCore/QStringList>
 #include <QtGui/QColor>
 #include <QtGui/QFont>
@@ -150,6 +151,8 @@ struct Settings {
 	enum TalkState { Passive, Talking, Whispering, Shouting };
 	enum IdleAction { Nothing, Deafen, Mute };
 	typedef QPair<QList<QSslCertificate>, QSslKey> KeyPair;
+
+	static const QString SHORTCUTS_FILE_VERSION_FIELDNAME;
 
 	AudioTransmit atTransmit;
 	quint64 uiDoublePush;
@@ -413,8 +416,9 @@ struct Settings {
 	void load(QSettings*);
 	/// \brief loadShortcuts Parses the passed settings for shortcuts. The shortcuts are returned in a list.
 	/// \param settings QSettings to load the shortcuts into
-	/// \return A list of shortcuts
-	static QList<Shortcut> loadShortcuts(QSettings *settings_ptr);
+	/// \param ok if passed, will hold true for a successful import, false for a failure
+	/// \return A list of shortcuts (if param ok is false of undefined contents)
+	static QList<Shortcut> loadShortcuts(QSettings *settings_ptr, bool *ok=NULL);
 	void save();
 	/// \brief saveShortcuts Save qlShortcuts into settings
 	/// \param qlShortcuts list of shortcuts to store


### PR DESCRIPTION
This functionality ignores server specific shortcuts (shortcuts with
server specific targets).
These are stored to the database through a different mechanism.

This feature was requested on the forums in [Mumble shortcuts export/import](http://forums.mumble.info/viewtopic.php?f=4&t=3367)

![2018-01-06 15_22_10-mumble configuration](https://user-images.githubusercontent.com/93181/34640581-744e2500-f2f5-11e7-94a6-11fd2c3895f9.png)