### PR TITLE
Fix travis OSX build

### DIFF
--- a/scripts/travis-ci/before_install.bash
+++ b/scripts/travis-ci/before_install.bash
@@ -57,7 +57,7 @@ if [ "${TRAVIS_OS_NAME}" == "linux" ]; then
 		exit 1
 	fi
 elif [ "${TRAVIS_OS_NAME}" == "osx" ]; then
-	brew install qt5 libogg libvorbis flac libsndfile protobuf openssl ice
+	brew update && brew install qt5 libogg libvorbis flac libsndfile protobuf openssl ice
 else
 	exit 1
 fi


### PR DESCRIPTION
Using brew to install now fails because of an incompatible ruby version.

Update brew before installing a package to work around this.

https://github.com/travis-ci/travis-ci/issues/8552