### PR TITLE
Fixed crashing on disconnect

### DIFF
--- a/src/mumble/ServerHandler.h
+++ b/src/mumble/ServerHandler.h
@@ -137,6 +137,7 @@ class ServerHandler : public QThread {
 	signals:
 		void disconnected(QAbstractSocket::SocketError, QString reason);
 		void connected();
+		void pingRequested();
 	protected slots:
 		void message(unsigned int, const QByteArray &);
 		void serverConnectionConnected();
@@ -146,6 +147,8 @@ class ServerHandler : public QThread {
 		void setSslErrors(const QList<QSslError> &);
 		void udpReady();
 		void hostnameResolved();
+	private slots:
+		void sendPingInternal();
 	public slots:
 		void sendPing();
 };


### PR DESCRIPTION
ServerHandler::sendPing must be invoked in the ServerHandler's thread since it contains networking code.
Also there is a direct call to sendPing routine from
```c++
void MainWindow::msgServerSync(const MumbleProto::ServerSync &msg) {
        g.sh->sendPing(); // Send initial ping to establish UDP connection
```