### PR TITLE
Switch client DB to sqlite synchronization mode NORMAL

### DIFF
--- a/src/mumble/Database.cpp
+++ b/src/mumble/Database.cpp
@@ -154,7 +154,7 @@ Database::Database() {
 
 	execQueryAndLogFailure(query, QLatin1String("VACUUM"));
 
-	execQueryAndLogFailure(query, QLatin1String("PRAGMA synchronous = OFF"));
+	execQueryAndLogFailure(query, QLatin1String("PRAGMA synchronous = NORMAL"));
 #ifdef Q_OS_WIN
 	// Windows can not handle TRUNCATE with multiple connections to the DB. Thus less performant DELETE.
 	execQueryAndLogFailure(query, QLatin1String("PRAGMA journal_mode = DELETE"));


### PR DESCRIPTION
In a userbase of primarily gamers system instabilities aren't
that uncommon. Without synchronization of the user-db this can
lead to corruption of our client database storing the
user-certificate. We have had various reports of such issues
over time.

The current mode was set in 2010 in commit 9fee66e8 to speed
up the client-db "even more" though it is unclear whether we
actually had performance problems that required this step.

This patch switches the client synchronization mode from OFF
to NORMAL which according to the sqlite documentation will
leave a "very small" chance for database corruption but is
than the default FULL sync mode.

This commit should partially address issue #3254 by making
database corruption much more unlikely but detecting
corruption and/or handling DB backups are further possible
approaches if this change turns out to have unacceptable
performance or we get further reports of durability issues
with the clientside DB.