### PR TITLE
ServerHandler.cpp: Remove "Qt::QueuedConnection" attribute for connection between "readyRead()" and "udpReady()"

### DIFF
--- a/src/mumble/ServerHandler.cpp
+++ b/src/mumble/ServerHandler.cpp
@@ -707,7 +707,7 @@ void ServerHandler::serverConnectionConnected() {
 			}
 		}
 
-		connect(qusUdp, SIGNAL(readyRead()), this, SLOT(udpReady()), Qt::QueuedConnection);
+		connect(qusUdp, SIGNAL(readyRead()), this, SLOT(udpReady()));
 
 		if (g.s.bQoS) {
 


### PR DESCRIPTION
It causes Mumble's UDP system to not work properly on Linux, probably because udpRead() is never called.

Fixes issue #3256.