### PR TITLE
Fix SRV port bugs in ServerResolver and ConnectDialog 

### DIFF
--- a/src/ServerResolver_qt5.cpp
+++ b/src/ServerResolver_qt5.cpp
@@ -98,7 +98,7 @@ void ServerResolverPrivate::hostResolved(QHostInfo hostInfo) {
 		}
 
 		qint64 priority = normalizeSrvPriority(record.priority(), record.weight());
-		m_resolved << ServerResolverRecord(m_origHostname, m_origPort, priority, addresses);
+		m_resolved << ServerResolverRecord(m_origHostname, record.port(), priority, addresses);
 	}
 
 	m_srvQueueRemain -= 1;

--- a/src/mumble/ConnectDialog.cpp
+++ b/src/mumble/ConnectDialog.cpp
@@ -1645,7 +1645,7 @@ void ConnectDialog::lookedUp() {
 	QSet<ServerAddress> qs;
 	foreach (ServerResolverRecord record, sr->records()) {
 		foreach(const HostAddress &ha, record.addresses()) {
-			qs.insert(ServerAddress(ha, sr->port()));
+			qs.insert(ServerAddress(ha, record.port()));
 		}
 	}
 


### PR DESCRIPTION
This PR includes two fixes for SRV port issues.

The first fix is for ServerResolver.  The Qt 5 (SRV) version had a bug where resolved ServerResolverRecords would be created with `m_origPort`. In practice, this meant that Mumble would *always* use the port specified in the ConnectDialog record for the server. Typically, this would be 64738, the default port.

The second fix is somewhat related to the first. The ConnectDialog had a bug where it would use `ServerResolver::port()` instead of `ServerResolverRecord::port()` when constructing the list of resolved addresses for a ConnectDialog entry. Unfortunately, `ServerResolver::port()` is the "original port". That is, the port specified in the ConnectDialog entry. Once again, this meant that Mumble would display the wrong port to user: the one from the ConnectDialog entry instead of the resolved port. Typically, this would be the default port (64738).

Fixes mumble-voip/mumble#3267