### PR TITLE
GlobalShortcut_win: fix std::/boost:: confusion in comment.

### DIFF
--- a/src/mumble/GlobalShortcut_win.cpp
+++ b/src/mumble/GlobalShortcut_win.cpp
@@ -5,7 +5,7 @@
 
 #include "mumble_pch.hpp"
 
-// MinGW does not support boost::future/boost::promise
+// MinGW does not support std::future/std::promise
 // at present. Use Boost's implementation for now.
 #define BOOST_THREAD_VERSION 4
 #include <boost/thread.hpp>


### PR DESCRIPTION
The comment block that justifies the use of Boost in GlobalShortcut_win
accidently stated that MinGW "does not support
boost:future/boost::promise", which is incorrect.

Fix the comment to say what was intended: that MinGW doesn't
support std::future/std::promise.