### PR TITLE
.travis.yml: remove mingw builds from allow_failures.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,10 +33,6 @@ matrix:
     - os: osx
       env: MUMBLE_QT=qt5 MUMBLE_HOST=x86_64-w64-mingw32
 
-  allow_failures:
-    - env: MUMBLE_QT=qt5 MUMBLE_HOST=i686-w64-mingw32
-    - env: MUMBLE_QT=qt5 MUMBLE_HOST=x86_64-w64-mingw32
-
 before_install:
     - ./scripts/travis-ci/before_install.bash
 


### PR DESCRIPTION
Our MinGW build was left stale due to mumble-voip/mumble#3208.

Although our current MinGW builders use Wine as their test runner
-- and were added to allow_failures exactly for that reason --
it makes more sense to get blocked from merging on build failures.
The alternative is that we actively *check* that the MinGW is not
broken, which doesn't happen in practice.

We obviously can't expect Wine to mirror the exact behavior on any
particular Windows version, but let's just look at the MinGW targets
in .travis.yml as a check for whether a) the MinGW build works on Linux,
and b) whether our tests pass using Wine.