### PR TITLE
AudioOutput: do not use non-existant template version of std::abs.

### DIFF
--- a/src/mumble/AudioOutput.cpp
+++ b/src/mumble/AudioOutput.cpp
@@ -437,7 +437,7 @@ bool AudioOutput::mix(void *outbuff, unsigned int nsamp) {
 					top[2] = 0.0f;
 				}
 
-				if (std::abs<float>(front[0] * top[0] + front[1] * top[1] + front[2] * top[2]) > 0.01f) {
+				if (std::abs(front[0] * top[0] + front[1] * top[1] + front[2] * top[2]) > 0.01f) {
 					// Not perpendicular. Assume Y up and rotate 90 degrees.
 
 					float azimuth = 0.0f;

--- a/src/mumble/mumble_pch.hpp
+++ b/src/mumble/mumble_pch.hpp
@@ -82,6 +82,7 @@
 #include <boost/weak_ptr.hpp>
 
 #include <algorithm>
+#include <cmath>
 
 #ifdef Q_OS_WIN
 #include "../qos2_mingw.h"

--- a/src/tests/TestStdAbs/TestStdAbs.cpp
+++ b/src/tests/TestStdAbs/TestStdAbs.cpp
@@ -1,0 +1,31 @@
+// Copyright 2005-2017 The Mumble Developers. All rights reserved.
+// Use of this source code is governed by a BSD-style license
+// that can be found in the LICENSE file at the root of the
+// Mumble source tree or at <https://www.mumble.info/LICENSE>.
+
+#include <QtCore>
+#include <QtTest>
+
+#include <cmath>
+
+/// Test the std::abs works with floats.
+/// In fixing mumble-voip/mumble#3281, I
+/// stumbled upon http://eigen.tuxfamily.org/bz/show_bug.cgi?id=619.
+/// It seems that, on some platforms, std::abs
+/// might not call through to the correct libc
+/// function.
+/// Test that it works for us.
+class TestStdAbs : public QObject {
+		Q_OBJECT
+	private slots:
+		void floatWorks();
+};
+
+void TestStdAbs::floatWorks() {
+	const float in = -1.5;
+	float out = std::abs(in);
+	QVERIFY(out > 1.2 && out < 1.8);
+}
+
+QTEST_MAIN(TestStdAbs)
+#include "TestStdAbs.moc"

--- a/src/tests/TestStdAbs/TestStdAbs.pro
+++ b/src/tests/TestStdAbs/TestStdAbs.pro
@@ -1,0 +1,9 @@
+# Copyright 2005-2017 The Mumble Developers. All rights reserved.
+# Use of this source code is governed by a BSD-style license
+# that can be found in the LICENSE file at the root of the
+# Mumble source tree or at <https://www.mumble.info/LICENSE>.
+
+include(../test.pri)
+
+TARGET = TestStdAbs
+SOURCES = TestStdAbs.cpp

--- a/src/tests/tests.pro
+++ b/src/tests/tests.pro
@@ -18,4 +18,5 @@ SUBDIRS += \
   TestServerResolver \
   TestSelfSignedCertificate \
   TestSSLLocks \
-  TestFFDHE
+  TestFFDHE \
+  TestStdAbs


### PR DESCRIPTION
This change Fixes AudioOutput to use the float overload of std::abs:

    float std::abs(float);

instead of a non-existant template version.

Fixes mumble-voip/mumble#3281

Needs-Backport: 1.2.x