### PR TITLE
qmake/compiler.pri: target macOS 10.8 when building against Qt 5.10 or above.

### DIFF
--- a/qmake/compiler.pri
+++ b/qmake/compiler.pri
@@ -359,11 +359,18 @@ macx {
 		QMAKE_CC = $$system(xcrun -find clang)
 		QMAKE_CXX = $$system(xcrun -find clang++)
 		QMAKE_LINK = $$system(xcrun -find clang++)
-		QMAKE_MACOSX_DEPLOYMENT_TARGET = 10.7
-		QMAKE_CFLAGS += -mmacosx-version-min=10.7
-		QMAKE_CXXFLAGS += -mmacosx-version-min=10.7
-		QMAKE_OBJECTIVE_CFLAGS += -mmacosx-version-min=10.7
-		QMAKE_OBJECTIVE_CXXFLAGS += -mmacosx-version-min=10.7
+
+		# Set target macOS version to 10.8 for Qt 5.10 and above.
+		MUMBLE_TARGET_MACOS_VERSION = 10.7
+		isEqual(QT_MAJOR_VERSION, 5):greaterThan(QT_MINOR_VERSION, 9) {
+			MUMBLE_TARGET_MACOS_VERSION = 10.8
+		}
+
+		QMAKE_MACOSX_DEPLOYMENT_TARGET = $$MUMBLE_TARGET_MACOS_VERSION
+		QMAKE_CFLAGS += -mmacosx-version-min=$$MUMBLE_TARGET_MACOS_VERSION
+		QMAKE_CXXFLAGS += -mmacosx-version-min=$$MUMBLE_TARGET_MACOS_VERSION
+		QMAKE_OBJECTIVE_CFLAGS += -mmacosx-version-min=$$MUMBLE_TARGET_MACOS_VERSION
+		QMAKE_OBJECTIVE_CXXFLAGS += -mmacosx-version-min=$$MUMBLE_TARGET_MACOS_VERSION
 	} else {
 		XCODE_PATH=$$system(xcode-select -print-path)
 		CONFIG += x86 ppc no-cocoa

--- a/src/OSInfo.cpp
+++ b/src/OSInfo.cpp
@@ -17,6 +17,11 @@
 #include <sys/types.h>
 #include <sys/sysctl.h>
 #include <mach-o/arch.h>
+
+// Ignore deprecation warnings for Gestalt.
+// See mumble-voip/mumble#3290 for more information.
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+
 #endif
 
 #include "OSInfo.h"


### PR DESCRIPTION
Qt 5.10 uses features available only on macOS 10.8, such as
std::future<void>.

See the referenced issue for more information.

Fixes mumble-voip/mumble#3288