### PR TITLE
Disable SRV tests  when running on Wine

### DIFF
--- a/src/PlatformCheck.cpp
+++ b/src/PlatformCheck.cpp
@@ -1,0 +1,20 @@
+// Copyright 2005-2018 The Mumble Developers. All rights reserved.
+// Use of this source code is governed by a BSD-style license
+// that can be found in the LICENSE file at the root of the
+// Mumble source tree or at <https://www.mumble.info/LICENSE>.
+
+#include "murmur_pch.h"
+
+#include <QtCore/QLibrary>
+
+#include "PlatformCheck.h"
+
+bool PlatformCheck::IsWine() {
+#ifdef Q_OS_WIN
+	void *ptr = QLibrary::resolve(QLatin1String("ntdll.dll"), "wine_get_version");
+	if (ptr != NULL) {
+		return true;
+	}
+#endif
+	return false;
+}

--- a/src/PlatformCheck.cpp
+++ b/src/PlatformCheck.cpp
@@ -11,6 +11,8 @@
 
 bool PlatformCheck::IsWine() {
 #ifdef Q_OS_WIN
+	// Detect if we're running under Wine.
+	// For more info, see https://wiki.winehq.org/Developer_FAQ#How_can_I_detect_Wine.3F
 	if (QLibrary::resolve(QLatin1String("ntdll.dll"), "wine_get_version") != NULL) {
 		return true;
 	}

--- a/src/PlatformCheck.cpp
+++ b/src/PlatformCheck.cpp
@@ -11,8 +11,7 @@
 
 bool PlatformCheck::IsWine() {
 #ifdef Q_OS_WIN
-	void *ptr = QLibrary::resolve(QLatin1String("ntdll.dll"), "wine_get_version");
-	if (ptr != NULL) {
+	if (QLibrary::resolve(QLatin1String("ntdll.dll"), "wine_get_version") != NULL) {
 		return true;
 	}
 #endif

--- a/src/PlatformCheck.h
+++ b/src/PlatformCheck.h
@@ -1,0 +1,16 @@
+// Copyright 2005-2018 The Mumble Developers. All rights reserved.
+// Use of this source code is governed by a BSD-style license
+// that can be found in the LICENSE file at the root of the
+// Mumble source tree or at <https://www.mumble.info/LICENSE>.
+
+#ifndef MUMBLE_PLATFORMCHECK_H_
+#define MUMBLE_PLATFORMCHECK_H_
+
+/// PlatformCheck performs platform checks.
+class PlatformCheck {
+	public:
+		/// IsWine returns true when running under Wine.
+		static bool IsWine();
+};
+
+#endif

--- a/src/tests/TestCrypt/TestCrypt.pro
+++ b/src/tests/TestCrypt/TestCrypt.pro
@@ -8,5 +8,5 @@ include(../test.pri)
 QT *= network
 
 TARGET = TestCrypt
-HEADERS = SSL.h SSLLocks.h Timer.h CryptState.h
-SOURCES = SSL.cpp SSLLocks.cpp TestCrypt.cpp CryptState.cpp Timer.cpp
+HEADERS *= SSL.h SSLLocks.h Timer.h CryptState.h
+SOURCES *= SSL.cpp SSLLocks.cpp TestCrypt.cpp CryptState.cpp Timer.cpp

--- a/src/tests/TestCryptographicHash/TestCryptographicHash.pro
+++ b/src/tests/TestCryptographicHash/TestCryptographicHash.pro
@@ -8,5 +8,5 @@ include(../test.pri)
 QT += network
 
 TARGET = TestCryptographicHash
-SOURCES = SSL.cpp SSLLocks.cpp TestCryptographicHash.cpp CryptographicHash.cpp
-HEADERS = SSL.h SSLLocks.h CryptographicHash.h
+SOURCES *= SSL.cpp SSLLocks.cpp TestCryptographicHash.cpp CryptographicHash.cpp
+HEADERS *= SSL.h SSLLocks.h CryptographicHash.h

--- a/src/tests/TestCryptographicRandom/TestCryptographicRandom.pro
+++ b/src/tests/TestCryptographicRandom/TestCryptographicRandom.pro
@@ -8,8 +8,8 @@ include(../test.pri)
 QT += network
 
 TARGET = TestCryptographicRandom
-SOURCES = SSL.cpp SSLLocks.cpp TestCryptographicRandom.cpp CryptographicRandom.cpp arc4random_uniform.cpp
-HEADERS = SSL.h SSLLocks.h CryptographicHash.h
+SOURCES *= SSL.cpp SSLLocks.cpp TestCryptographicRandom.cpp CryptographicRandom.cpp arc4random_uniform.cpp
+HEADERS *= SSL.h SSLLocks.h CryptographicHash.h
 
 VPATH *= ../../../3rdparty/arc4random-src
 INCLUDEPATH *= ../../../3rdparty/arc4random-src

--- a/src/tests/TestFFDHE/TestFFDHE.pro
+++ b/src/tests/TestFFDHE/TestFFDHE.pro
@@ -16,5 +16,5 @@ QT += network
 }
 
 TARGET = TestFFDHE
-SOURCES = SSL.cpp SSLLocks.cpp FFDHE.cpp TestFFDHE.cpp
-HEADERS = SSL.h SSLLocks.h FFDHE.h FFDHETable.h
+SOURCES *= SSL.cpp SSLLocks.cpp FFDHE.cpp TestFFDHE.cpp
+HEADERS *= SSL.h SSLLocks.h FFDHE.h FFDHETable.h

--- a/src/tests/TestPacketDataStream/TestPacketDataStream.pro
+++ b/src/tests/TestPacketDataStream/TestPacketDataStream.pro
@@ -8,4 +8,4 @@ include(../test.pri)
 QT *= network
 
 TARGET = TestPacketDataStream
-SOURCES = TestPacketDataStream.cpp
+SOURCES *= TestPacketDataStream.cpp

--- a/src/tests/TestPasswordGenerator/TestPasswordGenerator.pro
+++ b/src/tests/TestPasswordGenerator/TestPasswordGenerator.pro
@@ -8,8 +8,8 @@ include(../test.pri)
 QT += network
 
 TARGET = TestPasswordGenerator
-SOURCES = SSL.cpp SSLLocks.cpp TestPasswordGenerator.cpp PasswordGenerator.cpp CryptographicRandom.cpp arc4random_uniform.cpp
-HEADERS = SSL.h SSLLocks.h PasswordGenerator.h CryptographicHash.h
+SOURCES *= SSL.cpp SSLLocks.cpp TestPasswordGenerator.cpp PasswordGenerator.cpp CryptographicRandom.cpp arc4random_uniform.cpp
+HEADERS *= SSL.h SSLLocks.h PasswordGenerator.h CryptographicHash.h
 
 VPATH *= ../../../3rdparty/arc4random-src
 INCLUDEPATH *=  ../../../3rdparty/arc4random-src

--- a/src/tests/TestSSLLocks/TestSSLLocks.pro
+++ b/src/tests/TestSSLLocks/TestSSLLocks.pro
@@ -8,5 +8,5 @@ include(../test.pri)
 QT += network
 
 TARGET = TestSSLLocks
-SOURCES = SSL.cpp SSLLocks.cpp TestSSLLocks.cpp
-HEADERS = SSL.h SSLLocks.h
+SOURCES *= SSL.cpp SSLLocks.cpp TestSSLLocks.cpp
+HEADERS *= SSL.h SSLLocks.h

--- a/src/tests/TestSelfSignedCertificate/TestSelfSignedCertificate.pro
+++ b/src/tests/TestSelfSignedCertificate/TestSelfSignedCertificate.pro
@@ -9,5 +9,5 @@ include(../../../qmake/qt.pri)
 QT *= network
 
 TARGET = TestSelfSignedCertificate
-SOURCES = SSL.cpp SSLLocks.cpp TestSelfSignedCertificate.cpp SelfSignedCertificate.cpp
-HEADERS = SSL.h SSLLocks.h SelfSignedCertificate.h
+SOURCES *= SSL.cpp SSLLocks.cpp TestSelfSignedCertificate.cpp SelfSignedCertificate.cpp
+HEADERS *= SSL.h SSLLocks.h SelfSignedCertificate.h

--- a/src/tests/TestServerAddress/TestServerAddress.pro
+++ b/src/tests/TestServerAddress/TestServerAddress.pro
@@ -8,5 +8,5 @@ include(../test.pri)
 QT += network
 
 TARGET = TestServerAddress
-SOURCES = TestServerAddress.cpp ServerAddress.cpp HostAddress.cpp
-HEADERS = ServerAddress.h HostAddress.h
+SOURCES *= TestServerAddress.cpp ServerAddress.cpp HostAddress.cpp
+HEADERS *= ServerAddress.h HostAddress.h

--- a/src/tests/TestServerResolver/TestServerResolver.cpp
+++ b/src/tests/TestServerResolver/TestServerResolver.cpp
@@ -38,6 +38,7 @@ void TestServerResolver::simpleSrv() {
 #endif
 
 	// Qt 5's SRV resolver does not work in Wine.
+	// For more info, see https://bugs.winehq.org/show_bug.cgi?id=44296
 	if (PlatformCheck::IsWine()) {
 		return;
 	}
@@ -90,6 +91,7 @@ void TestServerResolver::srvCustomPort() {
 #endif
 
 	// Qt 5's SRV resolver does not work in Wine.
+	// For more info, see https://bugs.winehq.org/show_bug.cgi?id=44296
 	if (PlatformCheck::IsWine()) {
 		return;
 	}

--- a/src/tests/TestServerResolver/TestServerResolver.cpp
+++ b/src/tests/TestServerResolver/TestServerResolver.cpp
@@ -8,6 +8,7 @@
 #include <QSignalSpy>
 
 #include "ServerResolver.h"
+#include "PlatformCheck.h"
 
 void signalSpyWait(QSignalSpy &spy) {
 	// We increase the timeout from 5s to 8s because travis builds could fail otherwise (slow network response).
@@ -35,6 +36,11 @@ void TestServerResolver::simpleSrv() {
 #ifdef USE_NO_SRV
 	return;
 #endif
+
+	// Qt 5's SRV resolver does not work in Wine.
+	if (PlatformCheck::IsWine()) {
+		return;
+	}
 
 	ServerResolver r;
 	QSignalSpy spy(&r, SIGNAL(resolved()));
@@ -82,6 +88,11 @@ void TestServerResolver::srvCustomPort() {
 #ifdef USE_NO_SRV
 	return;
 #endif
+
+	// Qt 5's SRV resolver does not work in Wine.
+	if (PlatformCheck::IsWine()) {
+		return;
+	}
 
 	ServerResolver r;
 	QSignalSpy spy(&r, SIGNAL(resolved()));

--- a/src/tests/TestServerResolver/TestServerResolver.pro
+++ b/src/tests/TestServerResolver/TestServerResolver.pro
@@ -9,8 +9,8 @@ include(../../../qmake/qt.pri)
 QT *= network
 
 TARGET = TestServerResolver
-SOURCES = TestServerResolver.cpp HostAddress.cpp ServerResolver_qt5.cpp ServerResolverRecord.cpp
-HEADERS = HostAddress.h ServerResolver.h ServerResolverRecord.h
+SOURCES *= TestServerResolver.cpp HostAddress.cpp ServerResolver_qt5.cpp ServerResolverRecord.cpp
+HEADERS *= HostAddress.h ServerResolver.h ServerResolverRecord.h
 
 isEqual(QT_MAJOR_VERSION, 4) {
   CONFIG *= no-srv

--- a/src/tests/TestStdAbs/TestStdAbs.pro
+++ b/src/tests/TestStdAbs/TestStdAbs.pro
@@ -6,4 +6,4 @@
 include(../test.pri)
 
 TARGET = TestStdAbs
-SOURCES = TestStdAbs.cpp
+SOURCES *= TestStdAbs.cpp

--- a/src/tests/TestTimer/TestTimer.pro
+++ b/src/tests/TestTimer/TestTimer.pro
@@ -6,5 +6,5 @@
 include(../test.pri)
 
 TARGET = TestTimer
-SOURCES = TestTimer.cpp Timer.cpp
-HEADERS = Timer.h
+SOURCES *= TestTimer.cpp Timer.cpp
+HEADERS *= Timer.h

--- a/src/tests/TestUnresolvedServerAddress/TestUnresolvedServerAddress.pro
+++ b/src/tests/TestUnresolvedServerAddress/TestUnresolvedServerAddress.pro
@@ -6,5 +6,5 @@
 include(../test.pri)
 
 TARGET = TestUnresolvedServerAddress
-SOURCES = TestUnresolvedServerAddress.cpp UnresolvedServerAddress.cpp
-HEADERS = UnresolvedServerAddress.h
+SOURCES *= TestUnresolvedServerAddress.cpp UnresolvedServerAddress.cpp
+HEADERS *= UnresolvedServerAddress.h

--- a/src/tests/TestXMLTools/TestXMLTools.pro
+++ b/src/tests/TestXMLTools/TestXMLTools.pro
@@ -6,5 +6,5 @@
 include(../test.pri)
 
 TARGET = TestXMLTools
-HEADERS = XMLTools.h
-SOURCES = TestXMLTools.cpp XMLTools.cpp
+HEADERS *= XMLTools.h
+SOURCES *= TestXMLTools.cpp XMLTools.cpp

--- a/src/tests/test.pri
+++ b/src/tests/test.pri
@@ -27,6 +27,9 @@ LANGUAGE = C++
 VPATH *= ../.. ../../murmur ../../mumble
 INCLUDEPATH *= ../.. ../../murmur ../../mumble
 
+SOURCES += PlatformCheck.cpp
+HEADERS += PlatformCheck.h
+
 # We have to depend on OpenSSL in all tests
 # for no-pch builds to work. Our PCH headers
 # include OpenSSL, and if the headers aren't


### PR DESCRIPTION
Originally via https://github.com/mumble-voip/mumble/pull/3277.

It turns out SRV resolving is broken in Wine. So, for now, skip the tests when running on Wine.