### PR TITLE
GRPC: fix deadlock in removeChannel

### DIFF
--- a/src/murmur/MurmurGRPCImpl.cpp
+++ b/src/murmur/MurmurGRPCImpl.cpp
@@ -1528,10 +1528,7 @@ void V1_ChannelRemove::impl(bool) {
 		throw ::grpc::Status(::grpc::INVALID_ARGUMENT, "cannot remove the root channel");
 	}
 
-	{
-		QWriteLocker wl(&server->qrwlVoiceThread);
-		server->removeChannel(channel);
-	}
+	server->removeChannel(channel);
 
 	end();
 }


### PR DESCRIPTION
`Server::removeChannel` already acquires the voice thread lock where necessary, doing so before calling it will result in a dead lock.