### PR TITLE
ServerHandler: do not send pings unless the TLS handshake has completed.

### DIFF
--- a/src/mumble/ServerHandler.cpp
+++ b/src/mumble/ServerHandler.cpp
@@ -461,6 +461,11 @@ void ServerHandler::sendPingInternal() {
 		return;
 	}
 
+	// Ensure the TLS handshake has completed before sending pings.
+	if (!qtsSock->isEncrypted()) {
+		return;
+	}
+
 	if (g.s.iMaxInFlightTCPPings >= 0 && iInFlightTCPPings >= g.s.iMaxInFlightTCPPings) {
 		serverConnectionClosed(QAbstractSocket::UnknownSocketError, tr("Server is not responding to TCP pings"));
 		return;


### PR DESCRIPTION
sss123next in mumble-voip/mumble#3294 reports that the current ping
timer logic causes problems with slow TLS handshakes, such as when
connecting to servers with large DH parameters.

This commit ensures pings are not sent before the TLS handshake has
completed.