### PR TITLE
ServerHandler, Settings: add ping interval and connection timeout duration settings.

### DIFF
--- a/src/mumble/ServerHandler.cpp
+++ b/src/mumble/ServerHandler.cpp
@@ -352,7 +352,7 @@ void ServerHandler::run() {
 		// Setup ping timer;
 		QTimer *ticker = new QTimer(this);
 		connect(ticker, SIGNAL(timeout()), this, SLOT(sendPing()));
-		ticker->start(5000);
+		ticker->start(g.s.iPingIntervalMsec);
 
 		g.mw->rtLast = MumbleProto::Reject_RejectType_None;
 
@@ -624,7 +624,7 @@ void ServerHandler::serverConnectionStateChanged(QAbstractSocket::SocketState st
 		tConnectionTimeoutTimer = new QTimer();
 		connect(tConnectionTimeoutTimer, SIGNAL(timeout()), this, SLOT(serverConnectionTimeoutOnConnect()));
 		tConnectionTimeoutTimer->setSingleShot(true);
-		tConnectionTimeoutTimer->start(30000);
+		tConnectionTimeoutTimer->start(g.s.iConnectionTimeoutDurationMsec);
 	} else if (state == QAbstractSocket::ConnectedState) {
 		// Start TLS handshake
 		qtsSock->startClientEncryption();

--- a/src/mumble/Settings.cpp
+++ b/src/mumble/Settings.cpp
@@ -351,7 +351,8 @@ Settings::Settings() {
 	usProxyPort = 0;
 	iMaxInFlightTCPPings = 2;
 	bUdpForceTcpAddr = true;
-
+	iPingIntervalMsec = 5000;
+	iConnectionTimeoutDurationMsec = 30000;
 	iMaxImageWidth = 1024; // Allow 1024x1024 resolution
 	iMaxImageHeight = 1024;
 	bSuppressIdentity = false;
@@ -687,6 +688,8 @@ void Settings::load(QSettings* settings_ptr) {
 	SAVELOAD(iMaxImageHeight, "net/maximageheight");
 	SAVELOAD(qsServicePrefix, "net/serviceprefix");
 	SAVELOAD(iMaxInFlightTCPPings, "net/maxinflighttcppings");
+	SAVELOAD(iPingIntervalMsec, "net/pingintervalmsec");
+	SAVELOAD(iConnectionTimeoutDurationMsec, "net/connectiontimeoutdurationmsec");
 	SAVELOAD(bUdpForceTcpAddr, "net/udpforcetcpaddr");
 
 	// Network settings - SSL
@@ -1020,6 +1023,8 @@ void Settings::save() {
 	SAVELOAD(iMaxImageHeight, "net/maximageheight");
 	SAVELOAD(qsServicePrefix, "net/serviceprefix");
 	SAVELOAD(iMaxInFlightTCPPings, "net/maxinflighttcppings");
+	SAVELOAD(iPingIntervalMsec, "net/pingintervalmsec");
+	SAVELOAD(iConnectionTimeoutDurationMsec, "net/connectiontimeoutdurationmsec");
 	SAVELOAD(bUdpForceTcpAddr, "net/udpforcetcpaddr");
 
 	// Network settings - SSL

--- a/src/mumble/Settings.h
+++ b/src/mumble/Settings.h
@@ -331,6 +331,19 @@ struct Settings {
 	ProxyType ptProxyType;
 	QString qsProxyHost, qsProxyUsername, qsProxyPassword;
 	unsigned short usProxyPort;
+
+	/// The ping interval in milliseconds. The Mumble client
+	/// will regularly send TCP and UDP pings to the remote
+	/// server. This setting specifies the time (in milliseconds)
+	/// between each ping message.
+	int iPingIntervalMsec;
+
+	/// The connection timeout duration in milliseconds.
+	/// If a connection is not fully established to the
+	/// server within this duration, the client will
+	/// forcefully disconnect.
+	int iConnectionTimeoutDurationMsec;
+
 	/// bUdpForceTcpAddr forces Mumble to bind its UDP
 	/// socket to the same address as its TCP
 	/// connection is using.


### PR DESCRIPTION
This PR contains two commits:

1. `Settings: implement settings for ping interval and connection timeout duration.`, which adds the necessary plumbing to the Settings class.
2. `ServerHandler: use ping interval and connection timeout duration from Settings instead of magic numbers.`, which hooks up ServerHandler to use the new values from the Settings class.