### PR TITLE
scripts/travis-ci: use our own (Fastly-fronted) mirror of pkg.mxe.info.

### DIFF
--- a/scripts/travis-ci/before_install.bash
+++ b/scripts/travis-ci/before_install.bash
@@ -18,7 +18,7 @@ if [ "${TRAVIS_OS_NAME}" == "linux" ]; then
 	elif [ "${MUMBLE_QT}" == "qt5" ] && [ "${MUMBLE_HOST}" == "i686-w64-mingw32" ]; then
 		sudo dpkg --add-architecture i386
 		sudo apt-get -qq update
-		echo "deb http://pkg.mxe.cc/repos/apt/debian jessie main" | sudo tee /etc/apt/sources.list.d/mxeapt.list
+		echo "deb https://dl.mumble.info/mirror/pkg.mxe.cc/repos/apt/debian jessie main" | sudo tee /etc/apt/sources.list.d/mxeapt.list
 		sudo apt-key adv --keyserver x-hkp://keys.gnupg.net --recv-keys D43A795B73B16ABE9643FE1AFD8FFF16DB45C6AB
 		sudo apt-get -qq update
 		sudo apt-get install \
@@ -37,7 +37,7 @@ if [ "${TRAVIS_OS_NAME}" == "linux" ]; then
 	elif [ "${MUMBLE_QT}" == "qt5" ] && [ "${MUMBLE_HOST}" == "x86_64-w64-mingw32" ]; then
 		sudo dpkg --add-architecture i386
 		sudo apt-get -qq update
-		echo "deb http://pkg.mxe.cc/repos/apt/debian jessie	 main" | sudo tee /etc/apt/sources.list.d/mxeapt.list
+		echo "deb https://dl.mumble.info/mirror/pkg.mxe.cc/repos/apt/debian jessie main" | sudo tee /etc/apt/sources.list.d/mxeapt.list
 		sudo apt-key adv --keyserver x-hkp://keys.gnupg.net --recv-keys D43A795B73B16ABE9643FE1AFD8FFF16DB45C6AB
 		sudo apt-get -qq update
 		sudo apt-get install \


### PR DESCRIPTION
Our Tavis CI builds ended up taking a long time to complete.

This PR was made to try out whether mirroring pkg.mxe.cc ourselves would improve that situation.

It did.   Build times dropped from ~50 minutes to ~15 minutes.