### PR TITLE
Do not link the Linux overlay with '-z now'.

### DIFF
--- a/overlay_gl/overlay_gl.pro
+++ b/overlay_gl/overlay_gl.pro
@@ -10,6 +10,10 @@ SOURCES = overlay.c
 LIBS *= -lrt -ldl
 QMAKE_CFLAGS *= -fvisibility=hidden $(CFLAGS_ADD)
 QMAKE_LFLAGS -= -Wl,--no-undefined
+
+QMAKE_LFLAGS -= -Wl,-z,now
+QMAKE_LFLAGS += -Wl,-z,lazy
+
 QMAKE_LFLAGS *= $(LFLAGS_ADD)
 equals(QMAKE_LINK,g++) {
   message(Overriding linker)


### PR DESCRIPTION
Linking the overlay library with '-z now' requires all target
processes to have libGL symbols in them at load time.
If it doesn't, the program will not start at all.

Instead, explicitly use '-z lazy' to defer libGL symbol resolution
until first use, which is never for non-libGL users.

[This is a backport of 859da4dabec070959b5c06f8d32512990d7ec9c2
 from the master branch.]