### PR TITLE
Backport AudioOutput std::abs fix to 1.2.x.

### DIFF
--- a/src/mumble/AudioOutput.cpp
+++ b/src/mumble/AudioOutput.cpp
@@ -431,7 +431,7 @@ bool AudioOutput::mix(void *outbuff, unsigned int nsamp) {
 					top[2] = 0.0f;
 				}
 
-				if (std::abs<float>(front[0] * top[0] + front[1] * top[1] + front[2] * top[2]) > 0.01f) {
+				if (std::abs(front[0] * top[0] + front[1] * top[1] + front[2] * top[2]) > 0.01f) {
 					// Not perpendicular. Assume Y up and rotate 90 degrees.
 
 					float azimuth = 0.0f;


### PR DESCRIPTION
This cherry-picks commit ea861fe86743c8402bbad77d8d1dd9de8dce447e into 1.2.x to fix the std::abs issue reported in mumble-voip/mumble#3281.

In short, the commit fixes a problem where we used a (non-existant) template version of std::abs that older compilers were OK with, but newer compilers are not.