### PR TITLE
Correctly handle ServerResolver errors, with dedicated signal and slot

### DIFF
--- a/src/mumble/MainWindow.h
+++ b/src/mumble/MainWindow.h
@@ -267,6 +267,7 @@ class MainWindow : public QMainWindow, public MessageHandler, public Ui::MainWin
 		void qtvUserCurrentChanged(const QModelIndex &, const QModelIndex &);
 		void serverConnected();
 		void serverDisconnected(QAbstractSocket::SocketError, QString reason);
+		void resolverError(QAbstractSocket::SocketError, QString reason);
 		void viewCertificate(bool);
 		void openUrl(const QUrl &url);
 		void context_triggered();

--- a/src/mumble/ServerHandler.cpp
+++ b/src/mumble/ServerHandler.cpp
@@ -295,6 +295,7 @@ void ServerHandler::run() {
 		int ret = exec();
 		if (ret < 0) {
 			qWarning("ServerHandler: failed to resolve hostname");
+			emit error(QAbstractSocket::HostNotFoundError, tr("Unable to resolve hostname"));
 			return;
 		}
 	}

--- a/src/mumble/ServerHandler.h
+++ b/src/mumble/ServerHandler.h
@@ -135,6 +135,7 @@ class ServerHandler : public QThread {
 		void disconnect();
 		void run() Q_DECL_OVERRIDE;
 	signals:
+		void error(QAbstractSocket::SocketError, QString reason);
 		void disconnected(QAbstractSocket::SocketError, QString reason);
 		void connected();
 		void pingRequested();


### PR DESCRIPTION
This commit adds a signal to ServerResolver and a slot to MainWindow to handle ServerHandler errors, in order to start the reconnection timer after the first connection attempt.

Fixes #3220.