### PR TITLE
scripts/travis-ci: bump apt timeout in before_install.bash.

### DIFF
--- a/scripts/travis-ci/before_install.bash
+++ b/scripts/travis-ci/before_install.bash
@@ -8,6 +8,13 @@
 MUMBLE_HOST_DEB=${MUMBLE_HOST/_/-}
 
 if [ "${TRAVIS_OS_NAME}" == "linux" ]; then
+	# Bump the apt http timeout to 120 seconds.
+	# Without this, we'd regularly get timeout errors
+	# from our MXE mirror on dl.mumble.info.
+	#
+	# See mumble-voip/mumble#3312 for more information.
+	echo 'Acquire::http::Timeout "120";' | sudo tee /etc/apt/apt.conf.d/99zzztimeout
+
 	if [ "${MUMBLE_QT}" == "qt4" ] && [ "${MUMBLE_HOST}" == "x86_64-linux-gnu" ]; then
 		sudo apt-get -qq update
 		sudo apt-get build-dep -qq mumble


### PR DESCRIPTION
After switching to using a mirror of MXE on dl.mumble.info we've begun
running into timeouts from apt on Travis CI. For example:

	E: Failed to fetch https://dl.mumble.info/mirror/pkg.mxe.cc/repos/apt/debian/pool/main/m/mxe-x86-64-unknown-linux-gnu-cmake/mxe-x86-64-unknown-linux-gnu-cmake_3.5.2-20170208_amd64.deb  Operation too slow. Less than 10 bytes/sec transferred the last 10 seconds

The error is from cURL, and it means that the options CURLOPT_LOW_SPEED_LIMIT
and CURLOPT_LOW_SPEED_TIME are set quite low.
(See https://github.com/curl/curl/blob/bb0ffcc36fd46298e02f943b255ee5d6553c06dc/lib/speedcheck.c)

To fix this, we set the Acquire::http::Timeout option to 120 seconds.
This causes apt's https transport to set CURLOPT_LOW_SPEED_TIME to 120.
(See https://github.com/Debian/apt/blob/debian/wheezy/methods/https.cc#L224-L230)

Fixes mumble-voip/mumble#3312