### PR TITLE
PulseAudio: don't send empty data into the stream if audio output is not enabled

### DIFF
--- a/src/mumble/PulseAudio.cpp
+++ b/src/mumble/PulseAudio.cpp
@@ -529,13 +529,7 @@ void PulseAudioSystem::write_callback(pa_stream *s, size_t bytes, void *userdata
 	AudioOutputPtr ao = g.ao;
 	PulseAudioOutput *pao = dynamic_cast<PulseAudioOutput *>(ao.get());
 
-	unsigned char buffer[bytes];
-
 	if (! pao) {
-		// Transitioning, but most likely transitions back, so just zero.
-		memset(buffer, 0, bytes);
-		pa_stream_write(s, buffer, bytes, NULL, 0, PA_SEEK_RELATIVE);
-		pas->wakeup();
 		return;
 	}
 
@@ -600,6 +594,7 @@ void PulseAudioSystem::write_callback(pa_stream *s, size_t bytes, void *userdata
 	const unsigned int samples = static_cast<unsigned int>(bytes) / iSampleSize;
 	bool oldAttenuation = pas->bAttenuating;
 
+	unsigned char buffer[bytes];
 	// do we have some mixed output?
 	if (pao->mix(buffer, samples)) {
 		// attenuate if instructed to or it's in settings


### PR DESCRIPTION
https://maemo.org/api_refs/5.0/5.0-final/pulseaudio/paplay_8c-example.html

In the example the stream writer callback does nothing and returns in case there is no data to send. 

Our code, instead, creates a buffer, fills it with zeroes and writes it to the stream if audio output is not enabled.

This pull request changes the callback function's code so that it returns immediately in such case.

The change has been tested by setting an underflow callback function (using `pa_stream_set_underflow_callback()`) and checking whether underflows occurred.

---

Fixes #1246.