### PR TITLE
SelfSignedCertificate: fix automatic certificate generator

### DIFF
--- a/src/SelfSignedCertificate.cpp
+++ b/src/SelfSignedCertificate.cpp
@@ -214,6 +214,7 @@ bool SelfSignedCertificate::generate(CertificateType certificateType, QString cl
 		qscCert = QSslCertificate(crt, QSsl::Der);
 		if (qscCert.isNull()) {
 			ok = false;
+			goto out;
 		}
 	}
 
@@ -235,6 +236,7 @@ bool SelfSignedCertificate::generate(CertificateType certificateType, QString cl
 		qskKey = QSslKey(key, QSsl::Rsa, QSsl::Der);
 		if (qskKey.isNull()) {
 			ok = false;
+			goto out;
 		}
 	}
 

--- a/src/SelfSignedCertificate.cpp
+++ b/src/SelfSignedCertificate.cpp
@@ -28,7 +28,7 @@ static int add_ext(X509 * crt, int nid, char *value) {
 	return 1;
 }
 
-bool SelfSignedCertificate::generate(QString clientCertName, QString clientCertEmail, QSslCertificate &qscCert, QSslKey &qskKey) {
+bool SelfSignedCertificate::generate(CertificateType certificateType, QString clientCertName, QString clientCertEmail, QSslCertificate &qscCert, QSslKey &qskKey) {
 	bool ok = true;
 	X509 *x509 = NULL;
 	EVP_PKEY *pkey = NULL;
@@ -39,7 +39,7 @@ bool SelfSignedCertificate::generate(QString clientCertName, QString clientCertE
 	ASN1_TIME *notBefore = NULL;
 	ASN1_TIME *notAfter = NULL;
 	QString commonName;
-	bool isServerCert = clientCertName.isEmpty() && clientCertEmail.isEmpty();
+	bool isServerCert = certificateType == CertificateTypeServerCertificate;
 
 	if (CRYPTO_mem_ctrl(CRYPTO_MEM_CHECK_ON) == -1) {
 		ok = false;
@@ -262,19 +262,9 @@ out:
 }
 
 bool SelfSignedCertificate::generateMumbleCertificate(QString name, QString email, QSslCertificate &qscCert, QSslKey &qskKey) {
-	if (name.trimmed().isEmpty()) {
-		qscCert = QSslCertificate();
-		qskKey = QSslKey();
-		return false;
-	}
-	if (email.trimmed().isEmpty()) {
-		qscCert = QSslCertificate();
-		qskKey = QSslKey();
-		return false;
-	}
-	return SelfSignedCertificate::generate(name, email, qscCert, qskKey);
+	return SelfSignedCertificate::generate(CertificateTypeClientCertificate, name, email, qscCert, qskKey);
 }
 
 bool SelfSignedCertificate::generateMurmurV2Certificate(QSslCertificate &qscCert, QSslKey &qskKey) {
-	return SelfSignedCertificate::generate(QString(), QString(), qscCert, qskKey);
+	return SelfSignedCertificate::generate(CertificateTypeServerCertificate, QString(), QString(), qscCert, qskKey);
 }

--- a/src/SelfSignedCertificate.cpp
+++ b/src/SelfSignedCertificate.cpp
@@ -185,9 +185,11 @@ bool SelfSignedCertificate::generate(CertificateType certificateType, QString cl
 	}
 
 	if (!isServerCert) {
-		if (add_ext(x509, NID_subject_alt_name, QString::fromLatin1("email:%1").arg(clientCertEmail).toUtf8().data()) == 0) {
-			ok = false;
-			goto out;
+		if (!clientCertEmail.trimmed().isEmpty()) {
+			if (add_ext(x509, NID_subject_alt_name, QString::fromLatin1("email:%1").arg(clientCertEmail).toUtf8().data()) == 0) {
+				ok = false;
+				goto out;
+			}
 		}
 	}
 

--- a/src/SelfSignedCertificate.h
+++ b/src/SelfSignedCertificate.h
@@ -10,9 +10,11 @@
 #include <QtNetwork/QSslCertificate>
 #include <QtNetwork/QSslKey>
 
+enum CertificateType { CertificateTypeServerCertificate, CertificateTypeClientCertificate };
+
 class SelfSignedCertificate {
 private:
-	static bool generate(QString clientCertName, QString clientCertEmail, QSslCertificate &qscCert, QSslKey &qskKey);
+	static bool generate(CertificateType certificateType, QString clientCertName, QString clientCertEmail, QSslCertificate &qscCert, QSslKey &qskKey);
 
 public:
 	static bool generateMumbleCertificate(QString name, QString email, QSslCertificate &qscCert, QSslKey &qskKey);

--- a/src/tests/TestSelfSignedCertificate/TestSelfSignedCertificate.cpp
+++ b/src/tests/TestSelfSignedCertificate/TestSelfSignedCertificate.cpp
@@ -41,6 +41,20 @@ void TestSelfSignedCertificate::exerciseClientCert() {
 	QCOMPARE(ok, true);
 	QCOMPARE(cert.isNull(), false);
 	QCOMPARE(key.isNull(), false);
+
+	// Test that users can create certificates without an email
+	// address set.
+	ok = SelfSignedCertificate::generateMumbleCertificate(QLatin1String("John Doe"), QString(), cert, key);
+	QCOMPARE(ok, true);
+	QCOMPARE(cert.isNull(), false);
+	QCOMPARE(key.isNull(), false);
+
+	// Test that it's possible to create a client certificate with
+	// both a name and an email.
+	ok = SelfSignedCertificate::generateMumbleCertificate(QLatin1String("John Doe"), QLatin1String("john@doe.family"), cert, key);
+	QCOMPARE(ok, true);
+	QCOMPARE(cert.isNull(), false);
+	QCOMPARE(key.isNull(), false);
 }
 
 void TestSelfSignedCertificate::exerciseServerCert() {

--- a/src/tests/TestSelfSignedCertificate/TestSelfSignedCertificate.cpp
+++ b/src/tests/TestSelfSignedCertificate/TestSelfSignedCertificate.cpp
@@ -34,12 +34,12 @@ void TestSelfSignedCertificate::exerciseClientCert() {
 	bool ok = SelfSignedCertificate::generateMumbleCertificate(QLatin1String("Test"), QLatin1String("test@test.test"), cert, key);
 	QCOMPARE(ok, true);
 	QCOMPARE(cert.isNull(), false);
-	QCOMPARE(cert.isNull(), false);
+	QCOMPARE(key.isNull(), false);
 
 	ok = SelfSignedCertificate::generateMumbleCertificate(QString(), QString(), cert, key);
 	QCOMPARE(ok, false);
 	QCOMPARE(cert.isNull(), true);
-	QCOMPARE(cert.isNull(), true);
+	QCOMPARE(key.isNull(), true);
 }
 
 void TestSelfSignedCertificate::exerciseServerCert() {
@@ -49,7 +49,7 @@ void TestSelfSignedCertificate::exerciseServerCert() {
 	bool ok = SelfSignedCertificate::generateMurmurV2Certificate(cert, key);
 	QCOMPARE(ok, true);
 	QCOMPARE(cert.isNull(), false);
-	QCOMPARE(cert.isNull(), false);
+	QCOMPARE(key.isNull(), false);
 }
 
 QTEST_MAIN(TestSelfSignedCertificate)

--- a/src/tests/TestSelfSignedCertificate/TestSelfSignedCertificate.cpp
+++ b/src/tests/TestSelfSignedCertificate/TestSelfSignedCertificate.cpp
@@ -36,10 +36,11 @@ void TestSelfSignedCertificate::exerciseClientCert() {
 	QCOMPARE(cert.isNull(), false);
 	QCOMPARE(key.isNull(), false);
 
+	// Test that certificates are auto-generated correctly
 	ok = SelfSignedCertificate::generateMumbleCertificate(QString(), QString(), cert, key);
-	QCOMPARE(ok, false);
-	QCOMPARE(cert.isNull(), true);
-	QCOMPARE(key.isNull(), true);
+	QCOMPARE(ok, true);
+	QCOMPARE(cert.isNull(), false);
+	QCOMPARE(key.isNull(), false);
 }
 
 void TestSelfSignedCertificate::exerciseServerCert() {


### PR DESCRIPTION
Previously, the generator was choosing the certificate type (server or client) basing on the presence of the name and email, which broke it.

This PR also includes various other small fixes.

Fixes mumble-voip/mumble#3284.