### PR TITLE
Fix error when handling TCP tunneled UDP voice packets

### DIFF
--- a/src/murmur/Server.cpp
+++ b/src/murmur/Server.cpp
@@ -1456,8 +1456,8 @@ void Server::message(unsigned int uiType, const QByteArray &qbaMsg, ServerUser *
 	}
 
 	if (uiType == MessageHandler::UDPTunnel) {
-		int l = qbaMsg.size();
-		if (l < 2)
+		int len = qbaMsg.size();
+		if (len < 2)
 			return;
 
 		QReadLocker rl(&qrwlVoiceThread);
@@ -1481,7 +1481,7 @@ void Server::message(unsigned int uiType, const QByteArray &qbaMsg, ServerUser *
 			}
 
 			if (ok) {
-				processMsg(u, buffer, 1);
+				processMsg(u, buffer, len);
 			}
 		}
 


### PR DESCRIPTION
0b5579c erroneously replaced the
variable (letter) l with the integer 1.

Revert this change and use a more descriptive variable name `len`.

Fixes #3325