### PR TITLE
XMLTools: remove unused default argument 'opstyle' in recurseParse().

### DIFF
--- a/src/mumble/XMLTools.h
+++ b/src/mumble/XMLTools.h
@@ -22,7 +22,7 @@ class XMLTools : public QObject {
 		static void recurseParse(QXmlStreamReader &reader,
 		                         QXmlStreamWriter &writer,
 		                         int &paragraphs,
-		                         const QMap<QString, QString> &opstyle = QMap<QString, QString>(),
+		                         const QMap<QString, QString> &opstyle,
 		                         const int close = 0, bool ignore = true);
 
 		/* Iterate XML and remove close-followed-by-open.

--- a/src/tests/TestXMLTools/TestXMLTools.cpp
+++ b/src/tests/TestXMLTools/TestXMLTools.cpp
@@ -54,7 +54,8 @@ QString TestXMLTools::doParse(QString input) {
 	QXmlStreamWriter writerOut(&outBuf);
 	outBuf.open(QIODevice::WriteOnly);
 	int paragraphs = 0;
-	XMLTools::recurseParse(reader, writerOut, paragraphs);
+	QMap<QString, QString> pstyle;
+	XMLTools::recurseParse(reader, writerOut, paragraphs, pstyle);
 	outBuf.close();
 	return QString(outBuf.data());
 }


### PR DESCRIPTION
This fixes the build on our OS X Universal builder.
Our legacy OS X Universal builder's gcc 4.2 seems to
misparse this.

There are no users of this default argument, and it's an
internal API. We can change it as we wish.

Fixes mumble-voip/mumble#3336