### PR TITLE
Set custom build folders globally, with support for shadow builds

### DIFF
--- a/3rdparty/celt-0.11.0-build/celt-0.11.0-build.pro
+++ b/3rdparty/celt-0.11.0-build/celt-0.11.0-build.pro
@@ -64,13 +64,11 @@ unix {
 
 SOURCES *= bands.c celt.c cwrs.c entcode.c entdec.c entenc.c header.c kiss_fft.c laplace.c mathops.c mdct.c modes.c pitch.c plc.c quant_bands.c rate.c vq.c
 
-CONFIG(debug, debug|release) {
-  CONFIG += console
-  DESTDIR = ../../debug
-}
-
-CONFIG(release, debug|release) {
-  DESTDIR = ../../release
-}
+# TARGET is the same in both versions of CELT, thus we have to specify
+# a separated folder to prevent objects collision between the two.
+OBJECTS_DIR = $$OBJECTS_ROOT/celt-0.11.0-build
+MOC_DIR = $$MOC_ROOT/celt-0.11.0-build
+RCC_DIR = $$RCC_ROOT/celt-0.11.0-build
+UI_DIR = $$UI_ROOT/celt-0.11.0-build
 
 include(../../qmake/symbols.pri)

--- a/3rdparty/celt-0.7.0-build/celt-0.7.0-build.pro
+++ b/3rdparty/celt-0.7.0-build/celt-0.7.0-build.pro
@@ -71,13 +71,11 @@ unix {
 
 SOURCES *= bands.c celt.c cwrs.c entcode.c entdec.c entenc.c header.c kiss_fft.c kiss_fftr.c laplace.c mdct.c modes.c pitch.c psy.c quant_bands.c rangedec.c rangeenc.c rate.c vq.c
 
-CONFIG(debug, debug|release) {
-  CONFIG += console
-  DESTDIR = ../../debug
-}
-
-CONFIG(release, debug|release) {
-  DESTDIR = ../../release
-}
+# TARGET is the same in both versions of CELT, thus we have to specify
+# a separated folder to prevent objects collision between the two.
+OBJECTS_DIR = $$OBJECTS_ROOT/celt-0.7.0-build
+MOC_DIR = $$MOC_ROOT/celt-0.7.0-build
+RCC_DIR = $$RCC_ROOT/celt-0.7.0-build
+UI_DIR = $$UI_ROOT/celt-0.7.0-build
 
 include(../../qmake/symbols.pri)

--- a/3rdparty/mach-override-build/mach-override-build.pro
+++ b/3rdparty/mach-override-build/mach-override-build.pro
@@ -8,15 +8,6 @@ SOURCEDIR=$$replace(BUILDDIR,-build,-src)
   error("Aborting configuration")
 }
 
-CONFIG(debug, debug|release) {
-  CONFIG += console
-  DESTDIR = ../../debug
-}
-
-CONFIG(release, debug|release) {
-  DESTDIR = ../../release
-}
-
 TEMPLATE = lib
 CONFIG -= qt
 CONFIG += debug_and_release

--- a/3rdparty/minhook-build/minhook-build.pro
+++ b/3rdparty/minhook-build/minhook-build.pro
@@ -9,15 +9,6 @@ SOURCEDIR=$$replace(BUILDDIR,-build,-src)
   error("Aborting configuration")
 }
 
-CONFIG(debug, debug|release) {
-  CONFIG += console
-  DESTDIR = ../../debug
-}
-
-CONFIG(release, debug|release) {
-  DESTDIR = ../../release
-}
-
 TEMPLATE = lib
 CONFIG -= qt
 CONFIG += debug_and_release

--- a/3rdparty/opus-build/opus-build.pro
+++ b/3rdparty/opus-build/opus-build.pro
@@ -259,14 +259,4 @@ src/analysis.c \
 src/mlp.c \
 src/mlp_data.c
 
-
-CONFIG(debug, debug|release) {
-  CONFIG += console
-  DESTDIR = ../../debug
-}
-
-CONFIG(release, debug|release) {
-  DESTDIR = ../../release
-}
-
 include(../../qmake/symbols.pri)

--- a/3rdparty/sbcelt-helper-build/sbcelt-helper-build.pro
+++ b/3rdparty/sbcelt-helper-build/sbcelt-helper-build.pro
@@ -1,4 +1,4 @@
-include (../../qmake/compiler.pri)
+include(../../qmake/compiler.pri)
 
 BUILDDIR=$$basename(PWD)
 SOURCEDIR=$$replace(BUILDDIR,-helper-build,-src)
@@ -67,13 +67,8 @@ macx {
   SOURCES *= ../lib/futex-stub.c sbcelt-sandbox-darwin.c pdeath-kqueue.c
 }
 
-CONFIG(release, debug|release) {
-  DESTDIR = ../../release
-}
-
 CONFIG(debug, debug|release) {
   DEFINES *= USE_LOGFILE
-  DESTDIR = ../../debug/
 }
 
 include(../../qmake/symbols.pri)

--- a/3rdparty/sbcelt-lib-build/sbcelt-lib-build.pro
+++ b/3rdparty/sbcelt-lib-build/sbcelt-lib-build.pro
@@ -52,13 +52,4 @@ macx {
   SOURCES *= futex-stub.c closefrom.c
 }
 
-CONFIG(debug, debug|release) {
-  CONFIG += console
-  DESTDIR = ../../debug
-}
-
-CONFIG(release, debug|release) {
-  DESTDIR = ../../release
-}
-
 include(../../qmake/symbols.pri)

--- a/3rdparty/speex-build/speex-build.pro
+++ b/3rdparty/speex-build/speex-build.pro
@@ -13,15 +13,6 @@ include(../../qmake/compiler.pri)
   error("Aborting configuration")
 }
 
-CONFIG(debug, debug|release) {
-  CONFIG += console
-  DESTDIR = ../../debug
-}
-
-CONFIG(release, debug|release) {
-  DESTDIR = ../../release
-}
-
 TEMPLATE = lib
 CONFIG -= qt
 CONFIG += debug_and_release

--- a/3rdparty/xinputcheck-build/xinputcheck-build.pro
+++ b/3rdparty/xinputcheck-build/xinputcheck-build.pro
@@ -15,13 +15,4 @@ INCLUDEPATH = ../$$SOURCEDIR
 
 SOURCES *= xinputcheck.cpp
 
-CONFIG(debug, debug|release) {
-  CONFIG += console
-  DESTDIR = ../../debug
-}
-
-CONFIG(release, debug|release) {
-  DESTDIR = ../../release
-}
-
 include(../../qmake/symbols.pri)

--- a/g15helper/g15helper.pro
+++ b/g15helper/g15helper.pro
@@ -94,13 +94,8 @@ CONFIG(g15-emulator) {
   }
 }
 
-CONFIG(release, debug|release) {
-  DESTDIR = ../release
-}
-
 CONFIG(debug, debug|release) {
   DEFINES *= USE_LOGFILE
-  DESTDIR = ../debug/
 }
 
 include(../qmake/symbols.pri)

--- a/macx/compat/compat.pro
+++ b/macx/compat/compat.pro
@@ -31,12 +31,4 @@ TARGET = Mumble.compat
 OBJECTIVE_SOURCES = compat.m
 QMAKE_LFLAGS += -framework ApplicationServices -framework Cocoa -framework AppKit
 
-CONFIG(debug, debug|release) {
-  DESTDIR       = ../../debug
-}
-
-CONFIG(release, debug|release) {
-  DESTDIR       = ../../release
-}
-
 include(../../qmake/symbols.pri)

--- a/macx/osax/osax.pro
+++ b/macx/osax/osax.pro
@@ -34,12 +34,4 @@ QMAKE_BUNDLE_DATA += SDEF
 
 OBJECTIVE_SOURCES = osax.m
 
-CONFIG(debug, debug|release) {
-  DESTDIR       = ../../debug
-}
-
-CONFIG(release, debug|release) {
-  DESTDIR       = ../../release
-}
-
 include(../../qmake/symbols.pri)

--- a/overlay/overlay-shared.pro
+++ b/overlay/overlay-shared.pro
@@ -11,7 +11,6 @@ TEMPLATE = lib
 CONFIG -= qt
 CONFIG *= dll shared debug_and_release warn_on
 CONFIG -= embed_manifest_dll
-TARGET = mumble_ol
 RC_FILE = mumble_ol.rc
 SOURCES = ancestor.cpp lib.cpp olsettings.cpp excludecheck.cpp d3d9.cpp dxgi.cpp d3d10.cpp d3d11.cpp ods.cpp opengl.cpp HardHook.cpp D11StateBlock.cpp
 HEADERS = ancestor.h lib.h olsettings.h excludecheck.h ods.h HardHook.h overlay_blacklist.h D11StateBlock.h ../3rdparty/GL/glext.h
@@ -36,16 +35,11 @@ CONFIG(force-x86_64-toolchain) {
   LIBS *= -lminhook
 }
 
-CONFIG(release, debug|release) {
-  DESTDIR = ../release
-  QMAKE_LIBDIR = ../release $$QMAKE_LIBDIR
-}
-
 CONFIG(debug, debug|release) {
-  DESTDIR = ../debug
-  QMAKE_LIBDIR = ../debug $$QMAKE_LIBDIR
   DEFINES *= DEBUG
 }
+
+QMAKE_LIBDIR = $$DESTDIR $$QMAKE_LIBDIR
 
 # Override fxc binary for the x86 build.
 CONFIG(force-x86-toolchain) {

--- a/overlay/overlay.pro
+++ b/overlay/overlay.pro
@@ -4,4 +4,6 @@
 # Mumble source tree or at <https://www.mumble.info/LICENSE>.
 
 CONFIG += force-x86-toolchain
+TARGET = mumble_ol
+
 include(overlay-shared.pro)

--- a/overlay/overlay_exe/overlay_exe-shared.pro
+++ b/overlay/overlay_exe/overlay_exe-shared.pro
@@ -8,7 +8,6 @@ include(../../qmake/compiler.pri)
 TEMPLATE = app
 CONFIG -= qt
 CONFIG += debug_and_release
-TARGET = mumble_ol_helper
 
 win32 {
   DEFINES += WIN32 _WIN32
@@ -32,12 +31,10 @@ QMAKE_POST_LINK = $$QMAKE_POST_LINK$$escape_expand(\\n\\t)$$quote(mt.exe -nologo
 CONFIG(debug, debug|release) {
   CONFIG += console
   DEFINES *= DEBUG
-  DESTDIR = ../../debug
 }
 
 CONFIG(release, debug|release) {
   DEFINES *= NDEBUG
-  DESTDIR = ../../release
 }
 
 include(../../qmake/symbols.pri)

--- a/overlay/overlay_exe/overlay_exe.pro
+++ b/overlay/overlay_exe/overlay_exe.pro
@@ -4,4 +4,6 @@
 # Mumble source tree or at <https://www.mumble.info/LICENSE>.
 
 CONFIG += force-x86-toolchain
+TARGET = mumble_ol_helper
+
 include(overlay_exe-shared.pro)

--- a/overlay_gl/overlay_gl.pro
+++ b/overlay_gl/overlay_gl.pro
@@ -57,14 +57,9 @@ macx {
   LIBS *= -lmach-override
 }
 
-CONFIG(debug, debug|release) {
-  QMAKE_LIBDIR = ../debug$(DESTDIR_ADD) $$QMAKE_LIBDIR
-  DESTDIR = ../debug$(DESTDIR_ADD)
-}
 
-CONFIG(release, debug|release) {
-  QMAKE_LIBDIR = ../release$(DESTDIR_ADD) $$QMAKE_LIBDIR
-  DESTDIR = ../release$(DESTDIR_ADD)
-}
+DESTDIR = $$DESTDIR$(DESTDIR_ADD)
+
+QMAKE_LIBDIR = $$DESTDIR $$QMAKE_LIBDIR
 
 include(../qmake/symbols.pri)

--- a/overlay_winx64/overlay_exe_winx64/overlay_exe_winx64.pro
+++ b/overlay_winx64/overlay_exe_winx64/overlay_exe_winx64.pro
@@ -5,5 +5,6 @@
 
 CONFIG += force-x86_64-toolchain
 VPATH = ../../overlay/overlay_exe
-include(../../overlay/overlay_exe/overlay_exe-shared.pro)
 TARGET = mumble_ol_helper_x64
+
+include(../../overlay/overlay_exe/overlay_exe-shared.pro)

--- a/overlay_winx64/overlay_winx64.pro
+++ b/overlay_winx64/overlay_winx64.pro
@@ -5,5 +5,6 @@
 
 CONFIG += force-x86_64-toolchain
 VPATH = ../overlay
-include(../overlay/overlay-shared.pro)
 TARGET = mumble_ol_x64
+
+include(../overlay/overlay-shared.pro)

--- a/plugins/plugins.pri
+++ b/plugins/plugins.pri
@@ -16,13 +16,6 @@ CONFIG(static) {
 	CONFIG += qt_dynamic_lookup
 }
 
-CONFIG(debug, debug|release) {
-  CONFIG += console
-  DESTDIR       = ../../debug/plugins
-}
-
-CONFIG(release, debug|release) {
-  DESTDIR       = ../../release/plugins
-}
+DESTDIR = $$DESTDIR/plugins
 
 include(../qmake/symbols.pri)

--- a/qmake/builddir.pri
+++ b/qmake/builddir.pri
@@ -1,0 +1,58 @@
+# Copyright 2005-2018 The Mumble Developers. All rights reserved.
+# Use of this source code is governed by a BSD-style license
+# that can be found in the LICENSE file at the root of the
+# Mumble source tree or at <https://www.mumble.info/LICENSE>.
+
+# Globally use "/debug" or "/release" as build directory,
+# if it's not a shadow build, otherwise use the shadowed directory.
+#
+# https://wiki.qt.io/QMake-top-level-srcdir-and-builddir
+
+# Since this file is in the "qmake" directory,
+# "$$PWD/.." is the top of the source tree.
+#
+# clean_path() is used to clean the path.
+# It's not available on Qt 4.
+greaterThan(QT_MAJOR_VERSION, 4) {
+  TOP_SRCDIR = $$clean_path($$PWD/..)
+}
+
+# In case absolute_path() doesn't return anything.
+isEmpty(TOP_SRCDIR) {
+  TOP_SRCDIR = $$PWD/..
+}
+
+# shadowed() is used to retrieve the shadowed build path.
+# It's not available on Qt 4.
+greaterThan(QT_MAJOR_VERSION, 4) {
+  TOP_BUILDDIR = $$shadowed($$TOP_SRCDIR)
+}
+
+# In case shadowed() doesn't return anything.
+isEmpty(TOP_BUILDDIR) {
+  TOP_BUILDDIR = $$TOP_SRCDIR
+}
+
+# If the build and source paths are equal,
+# it's not a shadow build.
+equals(TOP_BUILDDIR, $$TOP_SRCDIR) {
+  CONFIG(debug, debug|release) {
+    DESTDIR = $$TOP_BUILDDIR/debug
+  }
+
+  CONFIG(release, debug|release) {
+    DESTDIR = $$TOP_BUILDDIR/release
+  }
+} else {
+  DESTDIR = $$TOP_BUILDDIR
+}
+
+OBJECTS_ROOT = $$DESTDIR/.obj
+MOC_ROOT = $$DESTDIR/.moc
+RCC_ROOT = $$DESTDIR/.qrc
+UI_ROOT = $$DESTDIR/.ui
+
+OBJECTS_DIR = $$OBJECTS_ROOT/$$TARGET
+MOC_DIR = $$MOC_ROOT/$$TARGET
+RCC_DIR = $$RCC_ROOT/$$TARGET
+UI_DIR = $$UI_ROOT/$$TARGET

--- a/qmake/compiler.pri
+++ b/qmake/compiler.pri
@@ -6,8 +6,9 @@
 include(qt.pri)
 include(uname.pri)
 include(buildenv.pri)
+include(builddir.pri)
 include(cplusplus.pri)
- 
+
 CONFIG *= warn_on
 
 # Enable zlib compression for assets

--- a/qmake/symbols.pri
+++ b/qmake/symbols.pri
@@ -4,13 +4,7 @@
 # Mumble source tree or at <https://www.mumble.info/LICENSE>.
 
 CONFIG(symbols):macx {
-	CONFIG(debug, debug|release) {
-		DSYM_DESTDIR = $${PWD}/debug
-	}
-
-	CONFIG(release, debug|release) {
-		DSYM_DESTDIR = $${PWD}/release
-	}
+	DSYM_DESTDIR = $${DESTDIR}
 
 	contains(TEMPLATE, 'app') {
 		DSYM_TARGET_FULLPATH = ${TARGET}

--- a/src/mumble.pri
+++ b/src/mumble.pri
@@ -139,11 +139,6 @@ isEqual(QT_MAJOR_VERSION, 4) {
 
 CONFIG(debug, debug|release) {
   CONFIG += console
-  QMAKE_LIBDIR = ../../debug $$QMAKE_LIBDIR
-  DESTDIR	= ../../debug
 }
 
-CONFIG(release, debug|release) {
-  QMAKE_LIBDIR = ../../release $$QMAKE_LIBDIR
-  DESTDIR	= ../../release
-}
+QMAKE_LIBDIR = $$DESTDIR $$QMAKE_LIBDIR

--- a/src/mumble_exe/mumble_exe.pro
+++ b/src/mumble_exe/mumble_exe.pro
@@ -47,12 +47,10 @@ win32-msvc* {
 CONFIG(debug, debug|release) {
   CONFIG += console
   DEFINES *= DEBUG
-  DESTDIR = ../../debug
 }
 
 CONFIG(release, debug|release) {
   DEFINES *= NDEBUG
-  DESTDIR = ../../release
 }
 
 include(../../qmake/symbols.pri)

--- a/src/mumble_proto/mumble_proto.pro
+++ b/src/mumble_proto/mumble_proto.pro
@@ -38,12 +38,4 @@ QMAKE_EXTRA_COMPILERS *= pb pbh
   CONFIG += warn_off
 }
 
-CONFIG(debug, debug|release) {
-  DESTDIR = ../../debug
-}
-
-CONFIG(release, debug|release) {
-  DESTDIR = ../../release
-}
-
 include(../../qmake/symbols.pri)

--- a/src/murmur/murmur_grpc/murmur_grpc.pro
+++ b/src/murmur/murmur_grpc/murmur_grpc.pro
@@ -52,12 +52,4 @@ unix {
   QMAKE_CXXFLAGS *= -std=c++11
 }
 
-CONFIG(debug, debug|release) {
-  DESTDIR = ../../../debug
-}
-
-CONFIG(release, debug|release) {
-  DESTDIR = ../../../release
-}
-
 include(../../../qmake/symbols.pri)

--- a/src/murmur/murmur_ice/murmur_ice.pro
+++ b/src/murmur/murmur_ice/murmur_ice.pro
@@ -73,12 +73,4 @@ macx:CONFIG(static) {
     CONFIG += warn_off
 }
 
-CONFIG(debug, debug|release) {
-  DESTDIR = ../../../debug
-}
-
-CONFIG(release, debug|release) {
-  DESTDIR = ../../../release
-}
-
 include(../../../qmake/symbols.pri)

--- a/src/tests/test.pri
+++ b/src/tests/test.pri
@@ -35,3 +35,5 @@ HEADERS += PlatformCheck.h
 # include OpenSSL, and if the headers aren't
 # in the include path, the build will break.
 include(../../qmake/openssl.pri)
+
+DESTDIR = $$DESTDIR/tests


### PR DESCRIPTION
This pull request sets all build artifacts to be stored in a single build directory in the root of the source tree (either "release" or "debug").

Previously, that build folder was set in in every component's project file, rather than in one of the global project files (such as "compiler.pri").

Every build file (aside from the binary) was created in the component's project directory rather than in the build one.

Also, the tests binaries were being created inside their project folder, meaning that Git showed these files as "added" rather than "untracked".

In addition to that, there was a problem with the shadow builds: binaries being in our build directory and other artifacts in the shadowed one.

This pull request sets custom folders in "compiler.pri" for as many types of build file as possible, making use of the $$shadowed (http://doc.qt.io/qt-5/qmake-function-reference.html#shadowed-path) function to retrieve the path to the shadow build directory (in case it's a shadow build).

Since that function is not available on Qt 4 and the method described on Qt's Wiki (https://wiki.qt.io/QMake-top-level-srcdir-and-builddir) sounds more like a workaround than a solution, we use our custom build folders even if it's a shadow build.