### PR TITLE
WIP: Fix build directory in libraries paths list

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ sudo: required # Required for apt-get build-dep
 dist: trusty
 language: cpp
 compiler: gcc
+services: docker
 
 os:
   - linux

--- a/overlay/overlay-shared.pro
+++ b/overlay/overlay-shared.pro
@@ -32,14 +32,16 @@ LIBS *= -ld3d9 -ld3d10 -ld3d11 -ld3dcompiler -ldxgi
 CONFIG(force-x86_64-toolchain) {
   DEFINES += USE_MINHOOK
   INCLUDEPATH *= ../3rdparty/minhook-src/include
-  LIBS *= -lminhook
+  !win32-msvc* {
+    LIBS *= -L$$DESTDIR -lminhook
+  } else {
+    LIBS *= $$DESTDIR/minhook.lib
+  }
 }
 
 CONFIG(debug, debug|release) {
   DEFINES *= DEBUG
 }
-
-QMAKE_LIBDIR = $$DESTDIR $$QMAKE_LIBDIR
 
 # Override fxc binary for the x86 build.
 CONFIG(force-x86-toolchain) {

--- a/overlay_gl/overlay_gl.pro
+++ b/overlay_gl/overlay_gl.pro
@@ -54,12 +54,10 @@ macx {
   QMAKE_INFO_PLIST = overlay_gl.plist
 
   INCLUDEPATH *= ../3rdparty/mach-override-src
-  LIBS *= -lmach-override
+  LIBS *= -L$$DESTDIR -lmach-override
 }
 
 
 DESTDIR = $$DESTDIR$(DESTDIR_ADD)
-
-QMAKE_LIBDIR = $$DESTDIR $$QMAKE_LIBDIR
 
 include(../qmake/symbols.pri)

--- a/scripts/travis-ci/before_install.bash
+++ b/scripts/travis-ci/before_install.bash
@@ -22,6 +22,8 @@ if [ "${TRAVIS_OS_NAME}" == "linux" ]; then
 		sudo apt-get -qq update
 		sudo apt-get build-dep -qq mumble
 		sudo apt-get install qt5-default qttools5-dev qttools5-dev-tools qtbase5-dev qtbase5-dev-tools qttranslations5-l10n libqt5svg5-dev
+		# https://bugreports.qt.io/browse/QTBUG-38966
+		sudo echo 'DEFINES += QT_TESTCASE_BUILDDIR=$$shell_quote(\"$$OUT_PWD\")' | sudo tee /usr/lib/x86_64-linux-gnu/qt5/mkspecs/features/testlib_defines.prf
 	elif [ "${MUMBLE_QT}" == "qt5" ] && [ "${MUMBLE_HOST}" == "i686-w64-mingw32" ]; then
 		sudo dpkg --add-architecture i386
 		sudo apt-get -qq update
@@ -41,6 +43,8 @@ if [ "${TRAVIS_OS_NAME}" == "linux" ]; then
 			mxe-${MUMBLE_HOST_DEB}.static-ogg \
 			mxe-${MUMBLE_HOST_DEB}.static-vorbis \
 			mxe-${MUMBLE_HOST_DEB}.static-libsndfile
+		# https://bugreports.qt.io/browse/QTBUG-58764
+		sudo sed 's/--include $$moc_predefs.output/--include $$shell_quote($$moc_predefs.output)/' /usr/lib/mxe/usr/i686-w64-mingw32.static/qt5/mkspecs/features/moc.prf
 	elif [ "${MUMBLE_QT}" == "qt5" ] && [ "${MUMBLE_HOST}" == "x86_64-w64-mingw32" ]; then
 		sudo dpkg --add-architecture i386
 		sudo apt-get -qq update
@@ -60,6 +64,8 @@ if [ "${TRAVIS_OS_NAME}" == "linux" ]; then
 			mxe-${MUMBLE_HOST_DEB}.static-ogg \
 			mxe-${MUMBLE_HOST_DEB}.static-vorbis \
 			mxe-${MUMBLE_HOST_DEB}.static-libsndfile
+		# https://bugreports.qt.io/browse/QTBUG-58764
+		sudo sed 's/--include $$moc_predefs.output/--include $$shell_quote($$moc_predefs.output)/' /usr/lib/mxe/usr/x86_64-w64-mingw32.static/qt5/mkspecs/features/moc.prf
 	else
 		exit 1
 	fi

--- a/scripts/travis-ci/before_install.bash
+++ b/scripts/travis-ci/before_install.bash
@@ -20,10 +20,12 @@ if [ "${TRAVIS_OS_NAME}" == "linux" ]; then
 		sudo apt-get build-dep -qq mumble
 	elif [ "${MUMBLE_QT}" == "qt5" ] && [ "${MUMBLE_HOST}" == "x86_64-linux-gnu" ]; then
 		sudo apt-get -qq update
+		docker pull ubuntu:devel
+		docker run -d --name ubuntu ubuntu:devel
+		docker attach ubuntu
+		sudo apt-get -qq update
 		sudo apt-get build-dep -qq mumble
 		sudo apt-get install qt5-default qttools5-dev qttools5-dev-tools qtbase5-dev qtbase5-dev-tools qttranslations5-l10n libqt5svg5-dev
-		# https://bugreports.qt.io/browse/QTBUG-38966
-		sudo echo 'DEFINES += QT_TESTCASE_BUILDDIR=$$shell_quote(\"$$OUT_PWD\")' | sudo tee /usr/lib/x86_64-linux-gnu/qt5/mkspecs/features/testlib_defines.prf
 	elif [ "${MUMBLE_QT}" == "qt5" ] && [ "${MUMBLE_HOST}" == "i686-w64-mingw32" ]; then
 		sudo dpkg --add-architecture i386
 		sudo apt-get -qq update

--- a/scripts/travis-ci/script.bash
+++ b/scripts/travis-ci/script.bash
@@ -16,6 +16,8 @@ if [ "${TRAVIS_OS_NAME}" == "linux" ]; then
 		cd "Mumble VoIP"
 		qmake-qt4 CONFIG+="release tests g15-emulator qt4-legacy-compat ${EXTRA_CONFIG}" -recursive && make -j2 && make check
 	elif [ "${MUMBLE_QT}" == "qt5" ] && [ "${MUMBLE_HOST}" == "x86_64-linux-gnu" ]; then
+		docker start ubuntu
+		docker attach ubuntu
 		EXTRA_CONFIG=
 		if [ "${MUMBLE_NO_PCH}" == "1" ]; then
 			EXTRA_CONFIG="no-pch ${EXTRA_CONFIG}"

--- a/scripts/travis-ci/script.bash
+++ b/scripts/travis-ci/script.bash
@@ -11,12 +11,18 @@ if [ "${TRAVIS_OS_NAME}" == "linux" ]; then
 		if [ "${MUMBLE_NO_PCH}" == "1" ]; then
 			EXTRA_CONFIG="no-pch ${EXTRA_CONFIG}"
 		fi
+		cd ..
+		mv $TRAVIS_BUILD_DIR "Mumble VoIP"
+		cd "Mumble VoIP"
 		qmake-qt4 CONFIG+="release tests g15-emulator qt4-legacy-compat ${EXTRA_CONFIG}" -recursive && make -j2 && make check
 	elif [ "${MUMBLE_QT}" == "qt5" ] && [ "${MUMBLE_HOST}" == "x86_64-linux-gnu" ]; then
 		EXTRA_CONFIG=
 		if [ "${MUMBLE_NO_PCH}" == "1" ]; then
 			EXTRA_CONFIG="no-pch ${EXTRA_CONFIG}"
 		fi
+		cd ..
+		mv $TRAVIS_BUILD_DIR "Mumble VoIP"
+		cd "Mumble VoIP"
 		qmake CONFIG+="release tests g15-emulator ${EXTRA_CONFIG}" -recursive && make -j2 && make check
 	elif [ "${MUMBLE_QT}" == "qt5" ] && [ "${MUMBLE_HOST}" == "i686-w64-mingw32" ]; then
 		wget http://www.steinberg.net/sdk_downloads/asiosdk2.3.zip -P ../
@@ -28,6 +34,9 @@ if [ "${TRAVIS_OS_NAME}" == "linux" ]; then
 		if [ "${MUMBLE_NO_PCH}" == "1" ]; then
 			EXTRA_CONFIG="no-pch ${EXTRA_CONFIG}"
 		fi
+		cd ..
+		mv $TRAVIS_BUILD_DIR "Mumble VoIP"
+		cd "Mumble VoIP"
 		${MUMBLE_HOST}.static-qmake-qt5 -recursive -Wall CONFIG+="release tests warnings-as-errors g15-emulator no-overlay no-bonjour no-elevation no-ice ${EXTRA_CONFIG}"
 		make -j2
 		make check TESTRUNNER="wine"
@@ -41,6 +50,9 @@ if [ "${TRAVIS_OS_NAME}" == "linux" ]; then
 		if [ "${MUMBLE_NO_PCH}" == "1" ]; then
 			EXTRA_CONFIG="no-pch ${EXTRA_CONFIG}"
 		fi
+		cd ..
+		mv $TRAVIS_BUILD_DIR "Mumble VoIP"
+		cd "Mumble VoIP"
 		${MUMBLE_HOST}.static-qmake-qt5 -recursive -Wall CONFIG+="release tests warnings-as-errors g15-emulator no-overlay no-bonjour no-elevation no-ice ${EXTRA_CONFIG}"
 		make -j2
 		make check TESTRUNNER="wine"
@@ -53,6 +65,9 @@ elif [ "${TRAVIS_OS_NAME}" == "osx" ]; then
 	export PATH=$PATH:/usr/local/opt/qt5/bin:/usr/local/bin
 	export MUMBLE_PREFIX=/usr/local
 	export MUMBLE_ICE_PREFIX=/usr/local/opt/ice
+	cd ..
+	mv $TRAVIS_BUILD_DIR "Mumble VoIP"
+	cd "Mumble VoIP"
 	qmake CONFIG+="release tests warnings-as-errors" && make -j2 && make check
 else
 	exit 1

--- a/src/mumble.pri
+++ b/src/mumble.pri
@@ -78,7 +78,11 @@ SOURCES *= \
   SSLLocks.cpp \
   FFDHE.cpp
 
-LIBS		*= -lmumble_proto
+!win32-msvc* {
+	LIBS *= -L$$DESTDIR -lmumble_proto
+} else {
+	LIBS *= $$DESTDIR/mumble_proto.lib
+}
 
 equals(QT_MAJOR_VERSION, 4) {
 	CONFIG *= no-srv
@@ -140,5 +144,3 @@ isEqual(QT_MAJOR_VERSION, 4) {
 CONFIG(debug, debug|release) {
   CONFIG += console
 }
-
-QMAKE_LIBDIR = $$DESTDIR $$QMAKE_LIBDIR

--- a/src/mumble/mumble.pro
+++ b/src/mumble/mumble.pro
@@ -301,14 +301,22 @@ CONFIG(no-bundled-speex) {
 
 !CONFIG(no-bundled-speex) {
   INCLUDEPATH *= ../../3rdparty/speex-src/include ../../3rdparty/speex-src/libspeex ../../3rdparty/speex-build ../../3rdparty/speexdsp-src/include ../../3rdparty/speexdsp-src/libspeexdsp
-  LIBS   *= -lspeex
+  !win32-msvc* {
+    LIBS *= -L$$DESTDIR -lspeex
+  } else {
+    LIBS *= $$DESTDIR/speex.lib
+  }
 }
 
 CONFIG(sbcelt) {
   SOURCES -= CELTCodec.cpp
   SOURCES += CELTCodec_sbcelt.cpp
   INCLUDEPATH *= ../../3rdparty/celt-0.7.0-src/libcelt ../../3rdparty/sbcelt-src
-  LIBS *= -lcelt -lsbcelt
+  !win32-msvc* {
+    LIBS *= -L$$DESTDIR -lcelt -lsbcelt
+  } else {
+    LIBS *= $$DESTDIR/celt.lib $$DESTDIR/sbcelt.lib
+  }
   DEFINES *= SBCELT_PREFIX_API SBCELT_COMPAT_API USE_SBCELT
 } else {
   unix:!CONFIG(bundled-celt):system(pkg-config --atleast-version=0.7.0 celt) {
@@ -356,7 +364,11 @@ unix:!CONFIG(bundled-opus):system(pkg-config --exists opus) {
   CONFIG(opus) {
     INCLUDEPATH *= ../../3rdparty/opus-src/celt ../../3rdparty/opus-src/include ../../3rdparty/opus-src/src ../../3rdparty/opus-build/src
     DEFINES *= USE_OPUS
-    LIBS *= -lopus
+    !win32-msvc* {
+      LIBS *= -L$$DESTDIR -lopus
+    } else {
+      LIBS *= $$DESTDIR/opus.lib
+    }
     unix {
       QMAKE_CFLAGS *= "-I../../3rdparty/opus-src/celt" "-isystem  ../../3rdparty/opus-src/celt"
       QMAKE_CFLAGS *= "-I../../3rdparty/opus-src/include" "-isystem ../../3rdparty/opus-src/include"
@@ -428,7 +440,11 @@ win32 {
 
   # XInputCheck (3rdparty/xinputheck-src)
   INCLUDEPATH *= ../../3rdparty/xinputcheck-src
-  LIBS *= -lxinputcheck
+  !win32-msvc* {
+    LIBS *= -L$$DESTDIR -lxinputcheck
+  } else {
+    LIBS *= $$DESTDIR/xinputcheck.lib
+  }
 
   !CONFIG(mumble_dll) {
     !CONFIG(no-elevation) {

--- a/src/murmur/murmur.pro
+++ b/src/murmur/murmur.pro
@@ -147,7 +147,12 @@ ice {
     QMAKE_CXXFLAGS *= -fPIC
   }
 
-  LIBS *= -lmurmur_ice
+  !win32-msvc* {
+    LIBS *= -L$$DESTDIR -lmurmur_ice
+  } else {
+    LIBS *= $$DESTDIR/murmur_ice.lib
+  }
+
   INCLUDEPATH *= murmur_ice
 
   unix {


### PR DESCRIPTION
For some reason a path in `QMAKE_LIBDIR` is double-escaped (\\) if it contains whitespaces.