### PR TITLE
SvgIcon: add new class to work around issues with SVG QIcons in Plasma/KStatusNotifierItem

### DIFF
--- a/src/mumble/MainWindow.cpp
+++ b/src/mumble/MainWindow.cpp
@@ -45,6 +45,7 @@
 #include "Settings.h"
 #include "Themes.h"
 #include "SSLCipherInfo.h"
+#include "SvgIcon.h"
 
 #ifdef Q_OS_WIN
 #include "TaskList.h"
@@ -63,37 +64,25 @@ OpenURLEvent::OpenURLEvent(QUrl u) : QEvent(static_cast<QEvent::Type>(OU_QEVENT)
 }
 
 MainWindow::MainWindow(QWidget *p) : QMainWindow(p) {
-	qiIconMuteSelf.addFile(QLatin1String("skin:muted_self.svg"));
-	qiIconMuteServer.addFile(QLatin1String("skin:muted_server.svg"));
-	qiIconMuteSuppressed.addFile(QLatin1String("skin:muted_suppressed.svg"));
-	qiIconMutePushToMute.addFile(QLatin1String("skin:muted_pushtomute.svg"));
-	qiIconDeafSelf.addFile(QLatin1String("skin:deafened_self.svg"));
-	qiIconDeafServer.addFile(QLatin1String("skin:deafened_server.svg"));
-	qiTalkingOff.addFile(QLatin1String("skin:talking_off.svg"));
-	qiTalkingOn.addFile(QLatin1String("skin:talking_on.svg"));
-	qiTalkingShout.addFile(QLatin1String("skin:talking_alt.svg"));
-	qiTalkingWhisper.addFile(QLatin1String("skin:talking_whisper.svg"));
+	SvgIcon::addSvgPixmapsToIcon(qiIconMuteSelf, QLatin1String("skin:muted_self.svg"));
+	SvgIcon::addSvgPixmapsToIcon(qiIconMuteServer, QLatin1String("skin:muted_server.svg"));
+	SvgIcon::addSvgPixmapsToIcon(qiIconMuteSuppressed, QLatin1String("skin:muted_suppressed.svg"));
+	SvgIcon::addSvgPixmapsToIcon(qiIconMutePushToMute, QLatin1String("skin:muted_pushtomute.svg"));
+	SvgIcon::addSvgPixmapsToIcon(qiIconDeafSelf, QLatin1String("skin:deafened_self.svg"));
+	SvgIcon::addSvgPixmapsToIcon(qiIconDeafServer, QLatin1String("skin:deafened_server.svg"));
+	SvgIcon::addSvgPixmapsToIcon(qiTalkingOff, QLatin1String("skin:talking_off.svg"));
+	SvgIcon::addSvgPixmapsToIcon(qiTalkingOn, QLatin1String("skin:talking_on.svg"));
+	SvgIcon::addSvgPixmapsToIcon(qiTalkingShout, QLatin1String("skin:talking_alt.svg"));
+	SvgIcon::addSvgPixmapsToIcon(qiTalkingWhisper, QLatin1String("skin:talking_whisper.svg"));
 
 #ifdef Q_OS_MAC
 	if (QFile::exists(QLatin1String("skin:mumble.icns")))
 		qiIcon.addFile(QLatin1String("skin:mumble.icns"));
 	else
-		qiIcon.addFile(QLatin1String("skin:mumble.svg"));
+		SvgIcon::addSvgPixmapsToIcon(qiIcon, QLatin1String("skin:mumble.svg"));
 #else
 	{
-		QSvgRenderer svg(QLatin1String("skin:mumble.svg"));
-		QPixmap original(512,512);
-		original.fill(Qt::transparent);
-
-		QPainter painter(&original);
-		painter.setRenderHint(QPainter::Antialiasing);
-		painter.setRenderHint(QPainter::TextAntialiasing);
-		painter.setRenderHint(QPainter::SmoothPixmapTransform);
-		painter.setRenderHint(QPainter::HighQualityAntialiasing);
-		svg.render(&painter);
-
-		for (int sz=8;sz<=256;sz+=8)
-			qiIcon.addPixmap(original.scaled(sz,sz, Qt::IgnoreAspectRatio, Qt::SmoothTransformation));
+		SvgIcon::addSvgPixmapsToIcon(qiIcon, QLatin1String("skin:mumble.svg"));
 	}
 
 	// Set application icon except on MacOSX, where the window-icon

--- a/src/mumble/SvgIcon.cpp
+++ b/src/mumble/SvgIcon.cpp
@@ -1,0 +1,40 @@
+// Copyright 2005-2018 The Mumble Developers. All rights reserved.
+// Use of this source code is governed by a BSD-style license
+// that can be found in the LICENSE file at the root of the
+// Mumble source tree or at <https://www.mumble.info/LICENSE>.
+
+#include "SvgIcon.h"
+
+#include <QSvgRenderer>
+#include <QPainter>
+
+void SvgIcon::addSvgPixmapsToIcon(QIcon &icon, QString fn) {
+	QSvgRenderer svg(fn);
+
+	QList<QSize> commonSizes;
+	commonSizes << QSize(8, 8);
+	commonSizes << QSize(16, 16);
+	commonSizes << QSize(22, 22); // Plasma notification area size
+	commonSizes << QSize(24, 24);
+	commonSizes << QSize(32, 32);
+	commonSizes << QSize(44, 44); // Plasma notification area size @x2
+	commonSizes << QSize(48, 48);
+	commonSizes << QSize(64, 64);
+	commonSizes << QSize(96, 96);
+	commonSizes << QSize(128, 128);
+	commonSizes << QSize(256, 256);
+
+	foreach (QSize size, commonSizes) {
+		QPixmap pm(size);
+		pm.fill(Qt::transparent);
+
+		QPainter p(&pm);
+		p.setRenderHint(QPainter::Antialiasing);
+		p.setRenderHint(QPainter::TextAntialiasing);
+		p.setRenderHint(QPainter::SmoothPixmapTransform);
+		p.setRenderHint(QPainter::HighQualityAntialiasing);
+		svg.render(&p);
+
+		icon.addPixmap(pm);
+	}
+}

--- a/src/mumble/SvgIcon.h
+++ b/src/mumble/SvgIcon.h
@@ -1,0 +1,26 @@
+// Copyright 2005-2018 The Mumble Developers. All rights reserved.
+// Use of this source code is governed by a BSD-style license
+// that can be found in the LICENSE file at the root of the
+// Mumble source tree or at <https://www.mumble.info/LICENSE>.
+
+#ifndef MUMBLE_MUMBLE_SVGICON_H
+#define MUMBLE_MUMBLE_SVGICON_H
+
+#include <QIcon>
+#include <QString>
+
+class SvgIcon
+{
+public:
+	/// addSvgPixmapsToIcon renders the SVG file at |fn| in various
+	/// common sizes from 8x8 up to 256x256 and adds the resulting
+	/// rasterized pixmaps to |icon|.
+	///
+	/// This method is only needed due to an odd interaction between
+	/// Qt and Plasma/KStatusNotifierItem. See
+	/// https://github.com/mumble-voip/mumble/issues/3374
+	/// for more information.
+	static void addSvgPixmapsToIcon(QIcon &icon, QString fn);
+};
+
+#endif

--- a/src/mumble/mumble.pro
+++ b/src/mumble/mumble.pro
@@ -140,7 +140,8 @@ HEADERS *= BanEditor.h \
     widgets/MUComboBox.h \
     DeveloperConsole.h \
     PathListWidget.h \
-    XMLTools.h
+    XMLTools.h \
+    SvgIcon.h
 
 SOURCES *= BanEditor.cpp \
     ACLEditor.cpp \
@@ -208,7 +209,8 @@ SOURCES *= BanEditor.cpp \
     widgets/MUComboBox.cpp \
     DeveloperConsole.cpp \
     PathListWidget.cpp \
-    XMLTools.cpp
+    XMLTools.cpp \
+    SvgIcon.cpp
 
 CONFIG(qtspeech) {
   SOURCES *= TextToSpeech.cpp


### PR DESCRIPTION
This commit adds new class SvgIcon which allows you to create a QPixmap-backed QIcon
from an SVG.

We need this to fix mumble-voip/mumble#3124.

Basically, SVG-backed QIcons returns an empty list for QIcon::availableSizes().
There is some confusion as to whether this is the expected behavior or not.
(Tracked in mumble-voip/mumble#3374).

However: Plasma/KStatusNotifierItem currently expects QIcon::availableSizes()
to return a valid list of available sizes. For our SVG icons, that is not the case.

This commit works around this by constructing a QIcon backed by pixmaps, such that
QIcon::availableSizes() returns something sensible.

This is implemented via the static method, SvgIcon::addSvgPixmapsToIcon(), which renders
SVG icon in various common sizes (including 22x22 and 44x44, the Plasma notification area
size, and its @2x size).