### PR TITLE
Correct case of AGL/agl.h to allow compilation on case-sensitive filesystem

### DIFF
--- a/overlay_gl/overlay.c
+++ b/overlay_gl/overlay.c
@@ -45,7 +45,7 @@ typedef unsigned char bool;
 # include <OpenGL/OpenGL.h>
 # include <Carbon/Carbon.h>
 # include <Cocoa/Cocoa.h>
-# include <AGL/AGL.h>
+# include <AGL/agl.h>
 #
 # include <objc/objc-runtime.h>
 #


### PR DESCRIPTION
I have Mac OS installed on a case-sensitive filesystem and compilation fails without this change.