### PR TITLE
installer: only use WiX toolset from MUMBLE_PREFIX if the MUMBLE_PREFIX env var is set.

### DIFF
--- a/installer/MumbleInstall.wixproj
+++ b/installer/MumbleInstall.wixproj
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <PropertyGroup>
+  <PropertyGroup Condition=" '$(MUMBLE_PREFIX)' != '' ">
     <WixToolPath>$(MUMBLE_PREFIX)\wix\</WixToolPath>
     <WixTargetsPath>$(WixToolPath)Wix.targets</WixTargetsPath>
     <WixTasksPath>$(WixToolPath)wixtasks.dll</WixTasksPath>


### PR DESCRIPTION
This should allow building the installer with Visual Studio.

Thanks to @sregister for the bugreport.