### PR TITLE
XMLTools: include QXmlStream headers to get proper symbols names on Qt 4.

### DIFF
--- a/src/mumble/XMLTools.h
+++ b/src/mumble/XMLTools.h
@@ -8,9 +8,8 @@
 
 #include <QObject>
 #include <QMap>
-
-class QXmlStreamReader;
-class QXmlStreamWriter;
+#include <QXmlStreamReader>
+#include <QXmlStreamWriter>
 
 class XMLTools : public QObject {
 		Q_OBJECT


### PR DESCRIPTION
Our macOS Universal build has been dead for a while. This is due to an
interaction between XMLTools.cpp, XMLTools.h and Qt 4.

In Qt 4, the QXmlStream* classes once lived in the QXml module. In Qt 4.4,
they were moved to QtCore. However, to keep binary compatibility, the symbols
from QtCore are called QCoreXmlStreamReader/QCoreXmlStreamWriter.
The qxmlstream.h header then has preprocessor defines to map
QXmlStream* to QCoreXmlStream*. For more information, see:
https://github.com/qt/qt/blob/0a2f2382541424726168804be2c90b91381608c6/src/corelib/xml/qxmlstream.h#L100-L114

This means that the pre-declared classes used in XMLTools.h:

	class QXmlStreamReader;
	class QXmlStreamWriter;

won't work with Qt 4, >= 4.4, since QXmlStreamReader and QXmlStreamWriter
don't exist in QtCore in those verions of Qt.

This commit fixes that by including the headers for QXmlStreamReader and
QXmlStreamWriter instead of pre-declaring the classes.

This causes the right symbols to be used (that is, the QCore* variants),
and fixes the macOS Universal build.