### PR TITLE
Only invoke Q_IMPORT_PLUGIN(qico) on Windows.

### DIFF
--- a/src/mumble/main.cpp
+++ b/src/mumble/main.cpp
@@ -42,7 +42,9 @@
 
 #if defined(USE_STATIC_QT_PLUGINS) && QT_VERSION < 0x050000
 Q_IMPORT_PLUGIN(qtaccessiblewidgets)
-Q_IMPORT_PLUGIN(qico)
+# ifdef Q_OS_WIN
+   Q_IMPORT_PLUGIN(qico)
+# endif
 Q_IMPORT_PLUGIN(qsvg)
 Q_IMPORT_PLUGIN(qsvgicon)
 # ifdef Q_OS_MAC


### PR DESCRIPTION
This fixes a link-time issue for the macOS Universal build.
It only happens there because it's the only Qt 4 static build
we have a build machine for.

The problem is that commit 7a450721f2a76048a57f1ebf9d7d9e89d4bd3db0
changed mumble.pro to only include qico for Windows.

That commit did not update main.cpp to not invoke Q_IMPORT_PLUGIN(qico)
for non-Windows platforms.

This commit fixes that, and hopefully allows the macOS Universal build
to link properly.