### PR TITLE
Add qtaccessiblewidgets to PLUGINS for Qt 4 builds.

### DIFF
--- a/src/mumble/mumble.pro
+++ b/src/mumble/mumble.pro
@@ -706,10 +706,10 @@ CONFIG(static_qt_plugins) {
   !contains(TEMPLATE, .*app)|lessThan(QT_VERSION_INT, 50300) {
     QTPLUGIN += qsvg qsvgicon
 
-    # The accessiblewidgets plugin is only needed for Qt 5 versions below 5.4.
-    # In Qt 5.4, it was integrated into the QtWidgets library.
+    # For Qt 4 and Qt 5 below 5.4, we need to manually add qtaccessiblewidgets to PLUGINS.
+    # In Qt 5.4, the plugin was integrated into the QtWidgets library.
     # See QTBUG-43007 and Qt commit 4255ba40ab073a for more information.
-    isEqual(QT_MAJOR_VERSION, 5):lessThan(QT_MINOR_VERSION, 4) {
+    lessThan(QT_VERSION_INT, 50400) {
       QTPLUGIN *= qtaccessiblewidgets
     }
 


### PR DESCRIPTION
PR mumble-voip/mumble#2688 refactored the .pro file to
avoid special-casing newer versions of Qt.

However, in doing that, it also left out the qtaccessiblewidgets
from PLUGINS for Qt 4 builds.

This commit remedies that, by rewriting the comparison logic to
use integer-based Qt versions instead of complicated logic where
each part of the version (major/minor) is compared separately.

This makes the code easier to read, and fixes a link-time issue
for the macOS Universal build. Since qtaccessiblewidgets is not
on PLUGINS on Qt 4, the build doesn't link against -lqtaccessiblewidgets,
causing linking to fail.