### PR TITLE
Background source

### DIFF
--- a/src/mumble/AudioOutput.cpp
+++ b/src/mumble/AudioOutput.cpp
@@ -476,24 +476,21 @@ bool AudioOutput::mix(void *outbuff, unsigned int nsamp) {
 			validListener = true;
 		}
 
-        int numberOfSpeakers = qlMix.count(); // numberOfSpeakers are used for turning down background users
+		int numberOfSpeakers = qlMix.count(); // numberOfSpeakers are used for turning down background users
 
 		foreach(AudioOutputUser *aop, qlMix) {
 			const float * RESTRICT pfBuffer = aop->pfBuffer;
-            float volumeAdjustment = 1;
+			float volumeAdjustment = 1;
 
-            AudioOutputSpeech *speech = qobject_cast<AudioOutputSpeech *>(aop);
+			AudioOutputSpeech *speech = qobject_cast<AudioOutputSpeech *>(aop);
 			if (speech) {
-                const ClientUser *user = speech->p;
+				const ClientUser *user = speech->p;
 				volumeAdjustment *= user->fLocalVolume;
-
-
-                // Turn down user while others are speaking - if #BACKGROUND_SOURCE tag is added in user comment
-                if (numberOfSpeakers>1 && (std::string::npos != user->qsComment.toStdString().find("#BACKGROUND_SOURCE"))) {
-                    volumeAdjustment = 0.3;
-                }
-
-                if (prioritySpeakerActive) {
+				// Turn down user while others are speaking - if #BACKGROUND_SOURCE tag is added in user comment
+				if (numberOfSpeakers>1 && (user->qsComment.toStdString().find("#BACKGROUND_SOURCE") != std::string::npos)) {
+					volumeAdjustment = 0.2;
+				}
+				if (prioritySpeakerActive) {
 					
 					if (user->tsState != Settings::Whispering
 					    && !user->bPrioritySpeaker) {


### PR DESCRIPTION
InterCom - IFB

Added the possibility to use a user as background-source.
It´s great for intercom on top of e.g. music or a TV/Radio program. 

A Background Source/User can add a Tag #BACKGROUND_SOURCE to it´s commentfield and Mumble will turn down the backgroundSource volume when others are talking to you.

I don´t know how the community thinks about tags, but I found it the best way to implement and keeping backwards compatibility.