### PR TITLE
Add JACK Audio support

### DIFF
--- a/scripts/travis-ci/before_install.bash
+++ b/scripts/travis-ci/before_install.bash
@@ -18,10 +18,12 @@ if [ "${TRAVIS_OS_NAME}" == "linux" ]; then
 	if [ "${MUMBLE_QT}" == "qt4" ] && [ "${MUMBLE_HOST}" == "x86_64-linux-gnu" ]; then
 		sudo apt-get -qq update
 		sudo apt-get build-dep -qq mumble
+		sudo apt-get install libjack-jackd2-dev
 	elif [ "${MUMBLE_QT}" == "qt5" ] && [ "${MUMBLE_HOST}" == "x86_64-linux-gnu" ]; then
 		sudo apt-get -qq update
 		sudo apt-get build-dep -qq mumble
 		sudo apt-get install qt5-default qttools5-dev qttools5-dev-tools qtbase5-dev qtbase5-dev-tools qttranslations5-l10n libqt5svg5-dev
+		sudo apt-get install libjack-jackd2-dev
 	elif [ "${MUMBLE_QT}" == "qt5" ] && [ "${MUMBLE_HOST}" == "i686-w64-mingw32" ]; then
 		sudo dpkg --add-architecture i386
 		sudo apt-get -qq update

--- a/src/mumble/JackAudio.cpp
+++ b/src/mumble/JackAudio.cpp
@@ -1,0 +1,314 @@
+/* Copyright (C) 2011, Benjamin Jemlich <pcgod@users.sourceforge.net>
+   Copyright (C) 2011, Filipe Coelho <falktx@gmail.com>
+
+   All rights reserved.
+
+   Redistribution and use in source and binary forms, with or without
+   modification, are permitted provided that the following conditions
+   are met:
+
+   - Redistributions of source code must retain the above copyright notice,
+     this list of conditions and the following disclaimer.
+   - Redistributions in binary form must reproduce the above copyright notice,
+     this list of conditions and the following disclaimer in the documentation
+     and/or other materials provided with the distribution.
+   - Neither the name of the Mumble Developers nor the names of its
+     contributors may be used to endorse or promote products derived from this
+     software without specific prior written permission.
+
+   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+   ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+   LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+   A PARTICULAR PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE FOUNDATION OR
+   CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+   EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+   PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+   PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+   LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+   NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+   SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+#include "JackAudio.h"
+#include "User.h"
+#include "Global.h"
+#include "MainWindow.h"
+#include "Timer.h"
+
+#include <cstring>
+
+static JackAudioSystem *jasys = NULL;
+
+class JackAudioInputRegistrar : public AudioInputRegistrar {
+        public:
+                JackAudioInputRegistrar();
+                virtual AudioInput *create();
+                virtual const QList<audioDevice> getDeviceChoices();
+                virtual void setDeviceChoice(const QVariant &, Settings &);
+                virtual bool canEcho(const QString &) const;
+};
+
+class JackAudioOutputRegistrar : public AudioOutputRegistrar {
+        public:
+                JackAudioOutputRegistrar();
+                virtual AudioOutput *create();
+                virtual const QList<audioDevice> getDeviceChoices();
+                virtual void setDeviceChoice(const QVariant &, Settings &);
+};
+
+class JackAudioInit : public DeferInit {
+        public:
+                JackAudioInputRegistrar *airJackAudio;
+                JackAudioOutputRegistrar *aorJackAudio;
+                void initialize() {
+                        jasys = new JackAudioSystem();
+                        jasys->init_jack();
+                        jasys->qmWait.lock();
+                        jasys->qwcWait.wait(&jasys->qmWait, 1000);
+                        jasys->qmWait.unlock();
+                        if (jasys->bJackIsGood) {
+                                airJackAudio = new JackAudioInputRegistrar();
+                                aorJackAudio = new JackAudioOutputRegistrar();
+                        } else {
+                                airJackAudio = NULL;
+                                aorJackAudio = NULL;
+                                delete jasys;
+                                jasys = NULL;
+                        }
+                };
+                void destroy() {
+                        if (airJackAudio)
+                                delete airJackAudio;
+                        if (aorJackAudio)
+                                delete aorJackAudio;
+                        if (jasys) {
+                                jasys->close_jack();
+                                delete jasys;
+                                jasys = NULL;
+                        }
+                };
+};
+
+static JackAudioInit jackinit; //unused
+
+JackAudioSystem::JackAudioSystem() {
+        bJackIsGood = false;
+        iSampleRate = 0;
+}
+
+JackAudioSystem::~JackAudioSystem() {
+}
+
+void JackAudioSystem::init_jack()
+{
+        client = jack_client_open("mumble", JackNullOption, 0);
+
+        if (client) {
+                in_port = jack_port_register(client, "input", JACK_DEFAULT_AUDIO_TYPE, JackPortIsInput, 0);
+                out_port = jack_port_register(client, "output", JACK_DEFAULT_AUDIO_TYPE, JackPortIsOutput, 0);
+                jack_set_process_callback(client, process_callback, this);
+                jack_set_sample_rate_callback(client, srate_callback, this);
+                jack_on_shutdown(client, shutdown_callback, this);
+
+                iSampleRate = jack_get_sample_rate(client);
+
+                if (jack_activate(client) || in_port == NULL || out_port == NULL) {
+                    client = NULL;
+                    return;
+                }
+
+                int port_flags;
+                unsigned i = -1;
+                const char** ports = jack_get_ports(client, 0, 0, JackPortIsPhysical);
+
+                if (ports) {
+                    while (ports[++i])
+                    {
+                        jack_port_t* port = jack_port_by_name(client, ports[i]);
+                        port_flags = jack_port_flags(port);
+
+                        if (port_flags & (JackPortIsPhysical|JackPortIsOutput) && strstr(jack_port_type(port), "audio")) {
+                            jack_connect(client, ports[i], jack_port_name(in_port));
+                        }
+                        if (port_flags & (JackPortIsPhysical|JackPortIsInput) && strstr(jack_port_type(port), "audio")) {
+                            jack_connect(client, jack_port_name(out_port), ports[i]);
+                        }
+                    }
+                }
+
+                jack_free(ports);
+
+                // If we made it this far, then everything is okay
+                qhInput.insert(QString(), tr("Hardware Ports"));
+                qhOutput.insert(QString(), tr("Hardware Ports"));
+                bJackIsGood = true;
+
+            } else {
+                bJackIsGood = false;
+                client = NULL;
+            }
+}
+
+void JackAudioSystem::close_jack()
+{
+        if (client) {
+                jack_deactivate(client);
+                jack_client_close(client);
+                client = NULL;
+        }
+}
+
+int JackAudioSystem::process_callback(jack_nframes_t nframes, void *arg)
+{
+        JackAudioSystem *jas = (JackAudioSystem*)arg;
+
+        if (jas && jas->bJackIsGood) {
+                AudioInputPtr ai = g.ai;
+                AudioOutputPtr ao = g.ao;
+                JackAudioInput *jai = (JackAudioInput*)(ai.get());
+                JackAudioOutput *jao = (JackAudioOutput*)(ao.get());
+
+                if (jai && jai->bRunning && jai->iMicChannels > 0 && !jai->isFinished()) {
+                        void* input = jack_port_get_buffer(jas->in_port, nframes);
+                        if ((float*)input != 0)
+                            jai->addMic(input, nframes);
+                }
+
+                if (jao && jao->bRunning && jao->iChannels > 0 && !jao->isFinished()) {
+                        jack_default_audio_sample_t* output = (jack_default_audio_sample_t*)jack_port_get_buffer(jas->out_port, nframes);
+                        memset(output, 0, sizeof(jack_default_audio_sample_t)*nframes); //TEST
+                        jao->mix(output, nframes);
+                }
+        }
+
+        return 0;
+}
+
+int JackAudioSystem::srate_callback(jack_nframes_t frames, void *arg)
+{
+        JackAudioSystem *jas = (JackAudioSystem*)arg;
+        jas->iSampleRate = frames;
+        return 0;
+}
+
+void JackAudioSystem::shutdown_callback(void *arg)
+{
+        JackAudioSystem *jas = (JackAudioSystem*)arg;
+        jas->bJackIsGood = false;
+}
+
+JackAudioInputRegistrar::JackAudioInputRegistrar() : AudioInputRegistrar(QLatin1String("JACK"), 10) {
+}
+
+AudioInput *JackAudioInputRegistrar::create() {
+        return new JackAudioInput();
+}
+
+const QList<audioDevice> JackAudioInputRegistrar::getDeviceChoices() {
+        QList<audioDevice> qlReturn;
+
+        QStringList qlInputDevs = jasys->qhInput.keys();
+        qSort(qlInputDevs);
+
+        foreach(const QString &dev, qlInputDevs) {
+                qlReturn << audioDevice(jasys->qhInput.value(dev), dev);
+        }
+
+        return qlReturn;
+}
+
+void JackAudioInputRegistrar::setDeviceChoice(const QVariant &choice, Settings &s) {
+        Q_UNUSED(choice);
+        Q_UNUSED(s);
+}
+
+bool JackAudioInputRegistrar::canEcho(const QString &osys) const {
+        Q_UNUSED(osys);
+        return false;
+}
+
+JackAudioOutputRegistrar::JackAudioOutputRegistrar() : AudioOutputRegistrar(QLatin1String("JACK"), 10) {
+}
+
+AudioOutput *JackAudioOutputRegistrar::create() {
+        return new JackAudioOutput();
+}
+
+const QList<audioDevice> JackAudioOutputRegistrar::getDeviceChoices() {
+        QList<audioDevice> qlReturn;
+
+        QStringList qlOutputDevs = jasys->qhOutput.keys();
+        qSort(qlOutputDevs);
+
+        foreach(const QString &dev, qlOutputDevs) {
+                qlReturn << audioDevice(jasys->qhOutput.value(dev), dev);
+        }
+
+        return qlReturn;
+}
+
+void JackAudioOutputRegistrar::setDeviceChoice(const QVariant &choice, Settings &s) {
+        Q_UNUSED(choice);
+        Q_UNUSED(s);
+}
+
+JackAudioInput::JackAudioInput() {
+        bRunning = true;
+        iMicChannels = 0;
+};
+
+JackAudioInput::~JackAudioInput() {
+        bRunning = false;
+        iMicChannels = 0;
+        qmMutex.lock();
+        qwcWait.wakeAll();
+        qmMutex.unlock();
+        wait();
+}
+
+void JackAudioInput::run() {
+        if (jasys && jasys->bJackIsGood) {
+            iMicFreq = jasys->iSampleRate;
+            iMicChannels = 1;
+            eMicFormat = SampleFloat;
+            initializeMixer();
+        }
+
+        qmMutex.lock();
+        while (bRunning)
+                qwcWait.wait(&qmMutex);
+        qmMutex.unlock();
+}
+
+JackAudioOutput::JackAudioOutput() {
+        bRunning = true;
+        iChannels = 0;
+}
+
+JackAudioOutput::~JackAudioOutput() {
+        bRunning = false;
+        iChannels = 0;
+        qmMutex.lock();
+        qwcWait.wakeAll();
+        qmMutex.unlock();
+        wait();
+}
+
+void JackAudioOutput::run() {
+        if (jasys && jasys->bJackIsGood) {
+            unsigned int chanmasks[32];
+
+            chanmasks[0] = SPEAKER_FRONT_LEFT;
+            chanmasks[1] = SPEAKER_FRONT_RIGHT;
+
+            eSampleFormat = SampleFloat;
+            iMixerFreq = jasys->iSampleRate;
+            iChannels = 1;
+            initializeMixer(chanmasks);
+        }
+
+        qmMutex.lock();
+        while (bRunning)
+                qwcWait.wait(&qmMutex);
+        qmMutex.unlock();
+}

--- a/src/mumble/JackAudio.cpp
+++ b/src/mumble/JackAudio.cpp
@@ -1,35 +1,7 @@
-/* Copyright (C) 2011, Benjamin Jemlich <pcgod@users.sourceforge.net>
-   Copyright (C) 2011, Filipe Coelho <falktx@gmail.com>
-   Copyright (C) 2015, Mikkel Krautz <mikkel@krautz.dk>
-   Copyright (C) 2018, Bernd Buschinski <b.buschinski@gmail.com>
-
-   All rights reserved.
-
-   Redistribution and use in source and binary forms, with or without
-   modification, are permitted provided that the following conditions
-   are met:
-
-   - Redistributions of source code must retain the above copyright notice,
-     this list of conditions and the following disclaimer.
-   - Redistributions in binary form must reproduce the above copyright notice,
-     this list of conditions and the following disclaimer in the documentation
-     and/or other materials provided with the distribution.
-   - Neither the name of the Mumble Developers nor the names of its
-     contributors may be used to endorse or promote products derived from this
-     software without specific prior written permission.
-
-   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
-   ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
-   LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
-   A PARTICULAR PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE FOUNDATION OR
-   CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
-   EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
-   PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
-   PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
-   LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
-   NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
-   SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*/
+// Copyright 2005-2018 The Mumble Developers. All rights reserved.
+// Use of this source code is governed by a BSD-style license
+// that can be found in the LICENSE file at the root of the
+// Mumble source tree or at <https://www.mumble.info/LICENSE>.
 
 #include "JackAudio.h"
 

--- a/src/mumble/JackAudio.cpp
+++ b/src/mumble/JackAudio.cpp
@@ -248,7 +248,7 @@ void JackAudioSystem::close_jack() {
 
 		for (unsigned i = 0; i < iOutPorts; ++i) {
 			if (out_ports[i] != NULL) {
-				err = jack_port_unregister(client, out_ports[0]);
+				err = jack_port_unregister(client, out_ports[i]);
 				if (err != 0)  {
 					qWarning("JackAudioSystem: unable to unregister out port - jack_port_unregister() returned %i", err);
 				}

--- a/src/mumble/JackAudio.cpp
+++ b/src/mumble/JackAudio.cpp
@@ -40,60 +40,60 @@
 static JackAudioSystem *jasys = NULL;
 
 class JackAudioInputRegistrar : public AudioInputRegistrar {
-        public:
-                JackAudioInputRegistrar();
-                virtual AudioInput *create();
-                virtual const QList<audioDevice> getDeviceChoices();
-                virtual void setDeviceChoice(const QVariant &, Settings &);
-                virtual bool canEcho(const QString &) const;
+	public:
+		JackAudioInputRegistrar();
+		virtual AudioInput *create();
+		virtual const QList<audioDevice> getDeviceChoices();
+		virtual void setDeviceChoice(const QVariant &, Settings &);
+		virtual bool canEcho(const QString &) const;
 };
 
 class JackAudioOutputRegistrar : public AudioOutputRegistrar {
-        public:
-                JackAudioOutputRegistrar();
-                virtual AudioOutput *create();
-                virtual const QList<audioDevice> getDeviceChoices();
-                virtual void setDeviceChoice(const QVariant &, Settings &);
+	public:
+		JackAudioOutputRegistrar();
+		virtual AudioOutput *create();
+		virtual const QList<audioDevice> getDeviceChoices();
+		virtual void setDeviceChoice(const QVariant &, Settings &);
 };
 
 class JackAudioInit : public DeferInit {
-        public:
-                JackAudioInputRegistrar *airJackAudio;
-                JackAudioOutputRegistrar *aorJackAudio;
-                void initialize() {
-                        jasys = new JackAudioSystem();
-                        jasys->init_jack();
-                        jasys->qmWait.lock();
-                        jasys->qwcWait.wait(&jasys->qmWait, 1000);
-                        jasys->qmWait.unlock();
-                        if (jasys->bJackIsGood) {
-                                airJackAudio = new JackAudioInputRegistrar();
-                                aorJackAudio = new JackAudioOutputRegistrar();
-                        } else {
-                                airJackAudio = NULL;
-                                aorJackAudio = NULL;
-                                delete jasys;
-                                jasys = NULL;
-                        }
-                };
-                void destroy() {
-                        if (airJackAudio)
-                                delete airJackAudio;
-                        if (aorJackAudio)
-                                delete aorJackAudio;
-                        if (jasys) {
-                                jasys->close_jack();
-                                delete jasys;
-                                jasys = NULL;
-                        }
-                };
+	public:
+		JackAudioInputRegistrar *airJackAudio;
+		JackAudioOutputRegistrar *aorJackAudio;
+		void initialize() {
+			jasys = new JackAudioSystem();
+			jasys->init_jack();
+			jasys->qmWait.lock();
+			jasys->qwcWait.wait(&jasys->qmWait, 1000);
+			jasys->qmWait.unlock();
+			if (jasys->bJackIsGood) {
+					airJackAudio = new JackAudioInputRegistrar();
+					aorJackAudio = new JackAudioOutputRegistrar();
+			} else {
+					airJackAudio = NULL;
+					aorJackAudio = NULL;
+					delete jasys;
+					jasys = NULL;
+			}
+		};
+		void destroy() {
+			if (airJackAudio)
+					delete airJackAudio;
+			if (aorJackAudio)
+					delete aorJackAudio;
+			if (jasys) {
+					jasys->close_jack();
+					delete jasys;
+					jasys = NULL;
+			}
+		};
 };
 
 static JackAudioInit jackinit; //unused
 
 JackAudioSystem::JackAudioSystem() {
-        bJackIsGood = false;
-        iSampleRate = 0;
+	bJackIsGood = false;
+	iSampleRate = 0;
 }
 
 JackAudioSystem::~JackAudioSystem() {
@@ -101,214 +101,214 @@ JackAudioSystem::~JackAudioSystem() {
 
 void JackAudioSystem::init_jack()
 {
-        client = jack_client_open("mumble", JackNullOption, 0);
+	client = jack_client_open("mumble", JackNullOption, 0);
 
-        if (client) {
-                in_port = jack_port_register(client, "input", JACK_DEFAULT_AUDIO_TYPE, JackPortIsInput, 0);
-                out_port = jack_port_register(client, "output", JACK_DEFAULT_AUDIO_TYPE, JackPortIsOutput, 0);
-                jack_set_process_callback(client, process_callback, this);
-                jack_set_sample_rate_callback(client, srate_callback, this);
-                jack_on_shutdown(client, shutdown_callback, this);
+	if (client) {
+		in_port = jack_port_register(client, "input", JACK_DEFAULT_AUDIO_TYPE, JackPortIsInput, 0);
+		out_port = jack_port_register(client, "output", JACK_DEFAULT_AUDIO_TYPE, JackPortIsOutput, 0);
+		jack_set_process_callback(client, process_callback, this);
+		jack_set_sample_rate_callback(client, srate_callback, this);
+		jack_on_shutdown(client, shutdown_callback, this);
 
-                iSampleRate = jack_get_sample_rate(client);
+		iSampleRate = jack_get_sample_rate(client);
 
-                if (jack_activate(client) || in_port == NULL || out_port == NULL) {
-                    client = NULL;
-                    return;
-                }
+		if (jack_activate(client) || in_port == NULL || out_port == NULL) {
+			client = NULL;
+			return;
+		}
 
-                int port_flags;
-                unsigned i = -1;
-                const char** ports = jack_get_ports(client, 0, 0, JackPortIsPhysical);
+		int port_flags;
+		unsigned i = -1;
+		const char** ports = jack_get_ports(client, 0, 0, JackPortIsPhysical);
 
-                if (ports) {
-                    while (ports[++i])
-                    {
-                        jack_port_t* port = jack_port_by_name(client, ports[i]);
-                        port_flags = jack_port_flags(port);
+		if (ports) {
+			while (ports[++i])
+			{
+				jack_port_t* port = jack_port_by_name(client, ports[i]);
+				port_flags = jack_port_flags(port);
 
-                        if (port_flags & (JackPortIsPhysical|JackPortIsOutput) && strstr(jack_port_type(port), "audio")) {
-                            jack_connect(client, ports[i], jack_port_name(in_port));
-                        }
-                        if (port_flags & (JackPortIsPhysical|JackPortIsInput) && strstr(jack_port_type(port), "audio")) {
-                            jack_connect(client, jack_port_name(out_port), ports[i]);
-                        }
-                    }
-                }
+				if (port_flags & (JackPortIsPhysical|JackPortIsOutput) && strstr(jack_port_type(port), "audio")) {
+					jack_connect(client, ports[i], jack_port_name(in_port));
+				}
+				if (port_flags & (JackPortIsPhysical|JackPortIsInput) && strstr(jack_port_type(port), "audio")) {
+					jack_connect(client, jack_port_name(out_port), ports[i]);
+				}
+			}
+		}
 
-                jack_free(ports);
+		jack_free(ports);
 
-                // If we made it this far, then everything is okay
-                qhInput.insert(QString(), tr("Hardware Ports"));
-                qhOutput.insert(QString(), tr("Hardware Ports"));
-                bJackIsGood = true;
+		// If we made it this far, then everything is okay
+		qhInput.insert(QString(), tr("Hardware Ports"));
+		qhOutput.insert(QString(), tr("Hardware Ports"));
+		bJackIsGood = true;
 
-            } else {
-                bJackIsGood = false;
-                client = NULL;
-            }
+	} else {
+		bJackIsGood = false;
+		client = NULL;
+	}
 }
 
 void JackAudioSystem::close_jack()
 {
-        if (client) {
-                jack_deactivate(client);
-                jack_client_close(client);
-                client = NULL;
-        }
+	if (client) {
+		jack_deactivate(client);
+		jack_client_close(client);
+		client = NULL;
+	}
 }
 
 int JackAudioSystem::process_callback(jack_nframes_t nframes, void *arg)
 {
-        JackAudioSystem *jas = (JackAudioSystem*)arg;
+	JackAudioSystem *jas = (JackAudioSystem*)arg;
 
-        if (jas && jas->bJackIsGood) {
-                AudioInputPtr ai = g.ai;
-                AudioOutputPtr ao = g.ao;
-                JackAudioInput *jai = (JackAudioInput*)(ai.get());
-                JackAudioOutput *jao = (JackAudioOutput*)(ao.get());
+	if (jas && jas->bJackIsGood) {
+		AudioInputPtr ai = g.ai;
+		AudioOutputPtr ao = g.ao;
+		JackAudioInput *jai = (JackAudioInput*)(ai.get());
+		JackAudioOutput *jao = (JackAudioOutput*)(ao.get());
 
-                if (jai && jai->bRunning && jai->iMicChannels > 0 && !jai->isFinished()) {
-                        void* input = jack_port_get_buffer(jas->in_port, nframes);
-                        if ((float*)input != 0)
-                            jai->addMic(input, nframes);
-                }
+		if (jai && jai->bRunning && jai->iMicChannels > 0 && !jai->isFinished()) {
+			void* input = jack_port_get_buffer(jas->in_port, nframes);
+			if ((float*)input != 0)
+				jai->addMic(input, nframes);
+		}
 
-                if (jao && jao->bRunning && jao->iChannels > 0 && !jao->isFinished()) {
-                        jack_default_audio_sample_t* output = (jack_default_audio_sample_t*)jack_port_get_buffer(jas->out_port, nframes);
-                        memset(output, 0, sizeof(jack_default_audio_sample_t)*nframes); //TEST
-                        jao->mix(output, nframes);
-                }
-        }
+		if (jao && jao->bRunning && jao->iChannels > 0 && !jao->isFinished()) {
+			jack_default_audio_sample_t* output = (jack_default_audio_sample_t*)jack_port_get_buffer(jas->out_port, nframes);
+			memset(output, 0, sizeof(jack_default_audio_sample_t)*nframes); //TEST
+			jao->mix(output, nframes);
+		}
+	}
 
-        return 0;
+	return 0;
 }
 
 int JackAudioSystem::srate_callback(jack_nframes_t frames, void *arg)
 {
-        JackAudioSystem *jas = (JackAudioSystem*)arg;
-        jas->iSampleRate = frames;
-        return 0;
+	JackAudioSystem *jas = (JackAudioSystem*)arg;
+	jas->iSampleRate = frames;
+	return 0;
 }
 
 void JackAudioSystem::shutdown_callback(void *arg)
 {
-        JackAudioSystem *jas = (JackAudioSystem*)arg;
-        jas->bJackIsGood = false;
+	JackAudioSystem *jas = (JackAudioSystem*)arg;
+	jas->bJackIsGood = false;
 }
 
 JackAudioInputRegistrar::JackAudioInputRegistrar() : AudioInputRegistrar(QLatin1String("JACK"), 10) {
 }
 
 AudioInput *JackAudioInputRegistrar::create() {
-        return new JackAudioInput();
+	return new JackAudioInput();
 }
 
 const QList<audioDevice> JackAudioInputRegistrar::getDeviceChoices() {
-        QList<audioDevice> qlReturn;
+	QList<audioDevice> qlReturn;
 
-        QStringList qlInputDevs = jasys->qhInput.keys();
-        qSort(qlInputDevs);
+	QStringList qlInputDevs = jasys->qhInput.keys();
+	qSort(qlInputDevs);
 
-        foreach(const QString &dev, qlInputDevs) {
-                qlReturn << audioDevice(jasys->qhInput.value(dev), dev);
-        }
+	foreach(const QString &dev, qlInputDevs) {
+		qlReturn << audioDevice(jasys->qhInput.value(dev), dev);
+	}
 
-        return qlReturn;
+	return qlReturn;
 }
 
 void JackAudioInputRegistrar::setDeviceChoice(const QVariant &choice, Settings &s) {
-        Q_UNUSED(choice);
-        Q_UNUSED(s);
+	Q_UNUSED(choice);
+	Q_UNUSED(s);
 }
 
 bool JackAudioInputRegistrar::canEcho(const QString &osys) const {
-        Q_UNUSED(osys);
-        return false;
+	Q_UNUSED(osys);
+	return false;
 }
 
 JackAudioOutputRegistrar::JackAudioOutputRegistrar() : AudioOutputRegistrar(QLatin1String("JACK"), 10) {
 }
 
 AudioOutput *JackAudioOutputRegistrar::create() {
-        return new JackAudioOutput();
+	return new JackAudioOutput();
 }
 
 const QList<audioDevice> JackAudioOutputRegistrar::getDeviceChoices() {
-        QList<audioDevice> qlReturn;
+	QList<audioDevice> qlReturn;
 
-        QStringList qlOutputDevs = jasys->qhOutput.keys();
-        qSort(qlOutputDevs);
+	QStringList qlOutputDevs = jasys->qhOutput.keys();
+	qSort(qlOutputDevs);
 
-        foreach(const QString &dev, qlOutputDevs) {
-                qlReturn << audioDevice(jasys->qhOutput.value(dev), dev);
-        }
+	foreach(const QString &dev, qlOutputDevs) {
+		qlReturn << audioDevice(jasys->qhOutput.value(dev), dev);
+	}
 
-        return qlReturn;
+	return qlReturn;
 }
 
 void JackAudioOutputRegistrar::setDeviceChoice(const QVariant &choice, Settings &s) {
-        Q_UNUSED(choice);
-        Q_UNUSED(s);
+	Q_UNUSED(choice);
+	Q_UNUSED(s);
 }
 
 JackAudioInput::JackAudioInput() {
-        bRunning = true;
-        iMicChannels = 0;
+	bRunning = true;
+	iMicChannels = 0;
 };
 
 JackAudioInput::~JackAudioInput() {
-        bRunning = false;
-        iMicChannels = 0;
-        qmMutex.lock();
-        qwcWait.wakeAll();
-        qmMutex.unlock();
-        wait();
+	bRunning = false;
+	iMicChannels = 0;
+	qmMutex.lock();
+	qwcWait.wakeAll();
+	qmMutex.unlock();
+	wait();
 }
 
 void JackAudioInput::run() {
-        if (jasys && jasys->bJackIsGood) {
-            iMicFreq = jasys->iSampleRate;
-            iMicChannels = 1;
-            eMicFormat = SampleFloat;
-            initializeMixer();
-        }
+	if (jasys && jasys->bJackIsGood) {
+		iMicFreq = jasys->iSampleRate;
+		iMicChannels = 1;
+		eMicFormat = SampleFloat;
+		initializeMixer();
+	}
 
-        qmMutex.lock();
-        while (bRunning)
-                qwcWait.wait(&qmMutex);
-        qmMutex.unlock();
+	qmMutex.lock();
+	while (bRunning)
+		qwcWait.wait(&qmMutex);
+	qmMutex.unlock();
 }
 
 JackAudioOutput::JackAudioOutput() {
-        bRunning = true;
-        iChannels = 0;
+	bRunning = true;
+	iChannels = 0;
 }
 
 JackAudioOutput::~JackAudioOutput() {
-        bRunning = false;
-        iChannels = 0;
-        qmMutex.lock();
-        qwcWait.wakeAll();
-        qmMutex.unlock();
-        wait();
+	bRunning = false;
+	iChannels = 0;
+	qmMutex.lock();
+	qwcWait.wakeAll();
+	qmMutex.unlock();
+	wait();
 }
 
 void JackAudioOutput::run() {
-        if (jasys && jasys->bJackIsGood) {
-            unsigned int chanmasks[32];
+	if (jasys && jasys->bJackIsGood) {
+		unsigned int chanmasks[32];
 
-            chanmasks[0] = SPEAKER_FRONT_LEFT;
-            chanmasks[1] = SPEAKER_FRONT_RIGHT;
+		chanmasks[0] = SPEAKER_FRONT_LEFT;
+		chanmasks[1] = SPEAKER_FRONT_RIGHT;
 
-            eSampleFormat = SampleFloat;
-            iMixerFreq = jasys->iSampleRate;
-            iChannels = 1;
-            initializeMixer(chanmasks);
-        }
+		eSampleFormat = SampleFloat;
+		iMixerFreq = jasys->iSampleRate;
+		iChannels = 1;
+		initializeMixer(chanmasks);
+	}
 
-        qmMutex.lock();
-        while (bRunning)
-                qwcWait.wait(&qmMutex);
-        qmMutex.unlock();
+	qmMutex.lock();
+	while (bRunning)
+		qwcWait.wait(&qmMutex);
+	qmMutex.unlock();
 }

--- a/src/mumble/JackAudio.cpp
+++ b/src/mumble/JackAudio.cpp
@@ -36,7 +36,7 @@
 #include "Global.h"
 
 
-static JackAudioSystem * jasys = NULL;
+static JackAudioSystem *jasys = NULL;
 
 // jackStatusToStringList converts a jack_status_t (a flag type
 // that can contain multiple Jack statuses) to a QStringList.
@@ -160,7 +160,6 @@ JackAudioSystem::~JackAudioSystem() {
 }
 
 void JackAudioSystem::init_jack() {
-
 	output_buffer = NULL;
 	jack_status_t status = static_cast<jack_status_t>(0);
 	int err = 0;
@@ -228,7 +227,6 @@ void JackAudioSystem::init_jack() {
 }
 
 void JackAudioSystem::close_jack() {
-
 	QMutexLocker lock(&qmWait);
 	if (client) {
 		int err = 0;
@@ -269,15 +267,14 @@ void JackAudioSystem::close_jack() {
 }
 
 
-void JackAudioSystem::auto_connect_ports()
-{
+void JackAudioSystem::auto_connect_ports() {
 	if (g.s.bJackAutoConnect == false) {
 		return;
 	}
 
 	const char **ports = NULL;
-	int const wanted_out_flags = JackPortIsPhysical | JackPortIsOutput;
-	int const wanted_in_flags = JackPortIsPhysical | JackPortIsInput;
+	const int wanted_out_flags = JackPortIsPhysical | JackPortIsOutput;
+	const int wanted_in_flags = JackPortIsPhysical | JackPortIsInput;
 	int err;
 	unsigned int connected_out_ports = 0;
 	unsigned int connected_in_ports = 0;
@@ -292,7 +289,7 @@ void JackAudioSystem::auto_connect_ports()
 				continue;
 			}
 
-			int const port_flags = jack_port_flags(port);
+			const int port_flags = jack_port_flags(port);
 
 			if ((port_flags & wanted_out_flags) == wanted_out_flags && connected_in_ports < 1) {
 				err = jack_connect(client, ports[i], jack_port_name(in_port));
@@ -316,8 +313,7 @@ void JackAudioSystem::auto_connect_ports()
 	}
 }
 
-void JackAudioSystem::activate()
-{
+void JackAudioSystem::activate() {
 	QMutexLocker lock(&qmWait);
 	if (client) {
 		if (bActive) {
@@ -337,7 +333,6 @@ void JackAudioSystem::activate()
 }
 
 int JackAudioSystem::process_callback(jack_nframes_t nframes, void *arg) {
-
 	JackAudioSystem * const jas = static_cast<JackAudioSystem*>(arg);
 
 	if (jas && jas->bJackIsGood) {
@@ -348,7 +343,7 @@ int JackAudioSystem::process_callback(jack_nframes_t nframes, void *arg) {
 
 		if (jai && jai->isRunning() && jai->iMicChannels > 0 && !jai->isFinished()) {
 			QMutexLocker(&jai->qmMutex);
-			void * input = jack_port_get_buffer(jas->in_port, nframes);
+			void *input = jack_port_get_buffer(jas->in_port, nframes);
 			if (input != NULL) {
 				jai->addMic(input, nframes);
 			}
@@ -357,7 +352,7 @@ int JackAudioSystem::process_callback(jack_nframes_t nframes, void *arg) {
 		if (jao && jao->isRunning() && jao->iChannels > 0 && !jao->isFinished()) {
 			QMutexLocker(&jao->qmMutex);
 
-			jack_default_audio_sample_t* port_buffers[JACK_MAX_OUTPUT_PORTS];
+			jack_default_audio_sample_t *port_buffers[JACK_MAX_OUTPUT_PORTS];
 			for (unsigned int i = 0; i < jao->iChannels; ++i) {
 
 				port_buffers[i] = (jack_default_audio_sample_t*)jack_port_get_buffer(jas->out_ports[i], nframes);
@@ -388,14 +383,12 @@ int JackAudioSystem::process_callback(jack_nframes_t nframes, void *arg) {
 }
 
 int JackAudioSystem::srate_callback(jack_nframes_t frames, void *arg) {
-
 	JackAudioSystem * const jas = static_cast<JackAudioSystem*>(arg);
 	jas->iSampleRate = frames;
 	return 0;
 }
 
 void JackAudioSystem::allocOutputBuffer(jack_nframes_t frames) {
-
 	iBufferSize = frames;
 	AudioOutputPtr ao = g.ao;
 	JackAudioOutput * const jao = dynamic_cast<JackAudioOutput *>(ao.get());
@@ -418,10 +411,9 @@ void JackAudioSystem::allocOutputBuffer(jack_nframes_t frames) {
 }
 
 void JackAudioSystem::setNumberOfOutPorts(unsigned int ports) {
-
 	AudioOutputPtr ao = g.ao;
 	JackAudioOutput * const jao = dynamic_cast<JackAudioOutput *>(ao.get());
-	unsigned int const oldSize = iOutPorts;
+	const unsigned int oldSize = iOutPorts;
 	int err = 0;
 
 	iOutPorts = qBound<unsigned>(1, ports, JACK_MAX_OUTPUT_PORTS);
@@ -476,19 +468,16 @@ void JackAudioSystem::setNumberOfOutPorts(unsigned int ports) {
 }
 
 unsigned int JackAudioSystem::numberOfOutPorts() const {
-
 	return iOutPorts;
 }
 
 int JackAudioSystem::buffer_size_callback(jack_nframes_t frames, void *arg) {
-
 	JackAudioSystem * const jas = static_cast<JackAudioSystem*>(arg);
 	jas->allocOutputBuffer(frames);
 	return 0;
 }
 
 void JackAudioSystem::shutdown_callback(void *arg) {
-
 	JackAudioSystem * const jas = static_cast<JackAudioSystem*>(arg);
 	jas->bJackIsGood = false;
 }
@@ -549,7 +538,6 @@ const QList<audioDevice> JackAudioOutputRegistrar::getDeviceChoices() {
 }
 
 void JackAudioOutputRegistrar::setDeviceChoice(const QVariant &choice, Settings &s) {
-
 	s.qsJackAudioOutput = choice.toString();
 	jasys->setNumberOfOutPorts(choice.toInt());
 }

--- a/src/mumble/JackAudio.h
+++ b/src/mumble/JackAudio.h
@@ -1,0 +1,97 @@
+/* Copyright (C) 2011, Benjamin Jemlich <pcgod@users.sourceforge.net>
+   Copyright (C) 2011, Filipe Coelho <falktx@gmail.com>
+
+   All rights reserved.
+
+   Redistribution and use in source and binary forms, with or without
+   modification, are permitted provided that the following conditions
+   are met:
+
+   - Redistributions of source code must retain the above copyright notice,
+     this list of conditions and the following disclaimer.
+   - Redistributions in binary form must reproduce the above copyright notice,
+     this list of conditions and the following disclaimer in the documentation
+     and/or other materials provided with the distribution.
+   - Neither the name of the Mumble Developers nor the names of its
+     contributors may be used to endorse or promote products derived from this
+     software without specific prior written permission.
+
+   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+   ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+   LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+   A PARTICULAR PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE FOUNDATION OR
+   CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+   EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+   PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+   PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+   LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+   NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+   SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+#ifndef _JACKAUDIO_H
+#define _JACKAUDIO_H
+
+#include "AudioInput.h"
+#include "AudioOutput.h"
+#include <jack/jack.h>
+
+class JackAudioOutput;
+class JackAudioInput;
+
+class JackAudioSystem : public QObject {
+        private:
+                Q_OBJECT
+                Q_DISABLE_COPY(JackAudioSystem)
+        protected:
+                jack_client_t* client;
+                jack_port_t* in_port;
+                jack_port_t* out_port;
+
+                static int process_callback(jack_nframes_t nframes, void *arg);
+                static int srate_callback(jack_nframes_t frames, void *arg);
+                static void shutdown_callback(void *arg);
+        public:
+                QHash<QString, QString> qhInput;
+                QHash<QString, QString> qhOutput;
+                bool bJackIsGood;
+                int iSampleRate;
+                QMutex qmWait;
+                QWaitCondition qwcWait;
+
+                void init_jack();
+                void close_jack();
+
+                JackAudioSystem();
+                ~JackAudioSystem();
+};
+
+class JackAudioInput : public AudioInput {
+                friend class JackAudioSystem;
+        private:
+                Q_OBJECT
+                Q_DISABLE_COPY(JackAudioInput)
+        protected:
+                QMutex qmMutex;
+                QWaitCondition qwcWait;
+        public:
+                JackAudioInput();
+                ~JackAudioInput();
+                void run();
+};
+
+class JackAudioOutput : public AudioOutput {
+                friend class JackAudioSystem;
+        private:
+                Q_OBJECT
+                Q_DISABLE_COPY(JackAudioOutput)
+        protected:
+                QMutex qmMutex;
+                QWaitCondition qwcWait;
+        public:
+                JackAudioOutput();
+                ~JackAudioOutput();
+                void run();
+};
+
+#endif

--- a/src/mumble/JackAudio.h
+++ b/src/mumble/JackAudio.h
@@ -1,5 +1,6 @@
 /* Copyright (C) 2011, Benjamin Jemlich <pcgod@users.sourceforge.net>
    Copyright (C) 2011, Filipe Coelho <falktx@gmail.com>
+   Copyright (C) 2015, Mikkel Krautz <mikkel@krautz.dk>
    Copyright (C) 2018, Bernd Buschinski <b.buschinski@gmail.com>
 
    All rights reserved.

--- a/src/mumble/JackAudio.h
+++ b/src/mumble/JackAudio.h
@@ -1,5 +1,6 @@
 /* Copyright (C) 2011, Benjamin Jemlich <pcgod@users.sourceforge.net>
    Copyright (C) 2011, Filipe Coelho <falktx@gmail.com>
+   Copyright (C) 2018, Bernd Buschinski <b.buschinski@gmail.com>
 
    All rights reserved.
 
@@ -37,6 +38,8 @@
 
 #include <jack/jack.h>
 
+#define JACK_OUTPUT_CHANNELS 2
+
 class JackAudioOutput;
 class JackAudioInput;
 
@@ -47,10 +50,12 @@ class JackAudioSystem : public QObject {
 	protected:
 		jack_client_t* client;
 		jack_port_t* in_port;
-		jack_port_t* out_port;
+		jack_port_t* out_ports[JACK_OUTPUT_CHANNELS];
+		jack_default_audio_sample_t* output_buffer;
 
 		static int process_callback(jack_nframes_t nframes, void *arg);
 		static int srate_callback(jack_nframes_t frames, void *arg);
+		static int buffer_size_callback(jack_nframes_t frames, void *arg);
 		static void shutdown_callback(void *arg);
 	public:
 		QHash<QString, QString> qhInput;
@@ -62,6 +67,8 @@ class JackAudioSystem : public QObject {
 
 		void init_jack();
 		void close_jack();
+
+		void allocate_output_buffer(jack_nframes_t frames);
 
 		JackAudioSystem();
 		~JackAudioSystem();

--- a/src/mumble/JackAudio.h
+++ b/src/mumble/JackAudio.h
@@ -38,7 +38,7 @@
 
 #include <jack/jack.h>
 
-#define JACK_OUTPUT_CHANNELS 2
+#define JACK_MAX_OUTPUT_PORTS 2
 
 class JackAudioOutput;
 class JackAudioInput;
@@ -48,11 +48,13 @@ class JackAudioSystem : public QObject {
 		Q_OBJECT
 		Q_DISABLE_COPY(JackAudioSystem)
 	protected:
-		bool active;
+		bool bActive;
 		jack_client_t* client;
 		jack_port_t* in_port;
-		jack_port_t* out_ports[JACK_OUTPUT_CHANNELS];
+		jack_port_t* out_ports[JACK_MAX_OUTPUT_PORTS];
 		jack_default_audio_sample_t* output_buffer;
+		unsigned int iOutPorts;
+		jack_nframes_t iBufferSize;
 
 		static int process_callback(jack_nframes_t nframes, void *arg);
 		static int srate_callback(jack_nframes_t frames, void *arg);
@@ -71,7 +73,10 @@ class JackAudioSystem : public QObject {
 
 		void activate();
 
-		void allocate_output_buffer(jack_nframes_t frames);
+		void allocOutputBuffer(jack_nframes_t frames);
+
+		void setNumberOfOutPorts(unsigned int ports);
+		unsigned int numberOfOutPorts() const;
 
 		JackAudioSystem();
 		~JackAudioSystem();

--- a/src/mumble/JackAudio.h
+++ b/src/mumble/JackAudio.h
@@ -50,10 +50,10 @@ class JackAudioSystem : public QObject {
 		Q_DISABLE_COPY(JackAudioSystem)
 	protected:
 		bool bActive;
-		jack_client_t* client;
-		jack_port_t* in_port;
-		jack_port_t* out_ports[JACK_MAX_OUTPUT_PORTS];
-		jack_default_audio_sample_t* output_buffer;
+		jack_client_t *client;
+		jack_port_t *in_port;
+		jack_port_t *out_ports[JACK_MAX_OUTPUT_PORTS];
+		jack_default_audio_sample_t *output_buffer;
 		unsigned int iOutPorts;
 		jack_nframes_t iBufferSize;
 

--- a/src/mumble/JackAudio.h
+++ b/src/mumble/JackAudio.h
@@ -48,6 +48,7 @@ class JackAudioSystem : public QObject {
 		Q_OBJECT
 		Q_DISABLE_COPY(JackAudioSystem)
 	protected:
+		bool active;
 		jack_client_t* client;
 		jack_port_t* in_port;
 		jack_port_t* out_ports[JACK_OUTPUT_CHANNELS];
@@ -68,6 +69,8 @@ class JackAudioSystem : public QObject {
 		void init_jack();
 		void close_jack();
 
+		void activate();
+
 		void allocate_output_buffer(jack_nframes_t frames);
 
 		JackAudioSystem();
@@ -84,8 +87,8 @@ class JackAudioInput : public AudioInput {
 		QWaitCondition qwcWait;
 	public:
 		JackAudioInput();
-		~JackAudioInput();
-		void run();
+		~JackAudioInput() Q_DECL_OVERRIDE;
+		void run() Q_DECL_OVERRIDE;
 };
 
 class JackAudioOutput : public AudioOutput {
@@ -98,8 +101,8 @@ class JackAudioOutput : public AudioOutput {
 		QWaitCondition qwcWait;
 	public:
 		JackAudioOutput();
-		~JackAudioOutput();
-		void run();
+		~JackAudioOutput() Q_DECL_OVERRIDE;
+		void run() Q_DECL_OVERRIDE;
 };
 
 #endif

--- a/src/mumble/JackAudio.h
+++ b/src/mumble/JackAudio.h
@@ -9,6 +9,8 @@
 #include "AudioInput.h"
 #include "AudioOutput.h"
 
+#include <QtCore/QWaitCondition>
+
 #include <jack/jack.h>
 
 #define JACK_MAX_OUTPUT_PORTS 2

--- a/src/mumble/JackAudio.h
+++ b/src/mumble/JackAudio.h
@@ -72,6 +72,8 @@ class JackAudioSystem : public QObject {
 		void init_jack();
 		void close_jack();
 
+		void auto_connect_ports();
+
 		void activate();
 
 		void allocOutputBuffer(jack_nframes_t frames);

--- a/src/mumble/JackAudio.h
+++ b/src/mumble/JackAudio.h
@@ -1,35 +1,7 @@
-/* Copyright (C) 2011, Benjamin Jemlich <pcgod@users.sourceforge.net>
-   Copyright (C) 2011, Filipe Coelho <falktx@gmail.com>
-   Copyright (C) 2015, Mikkel Krautz <mikkel@krautz.dk>
-   Copyright (C) 2018, Bernd Buschinski <b.buschinski@gmail.com>
-
-   All rights reserved.
-
-   Redistribution and use in source and binary forms, with or without
-   modification, are permitted provided that the following conditions
-   are met:
-
-   - Redistributions of source code must retain the above copyright notice,
-     this list of conditions and the following disclaimer.
-   - Redistributions in binary form must reproduce the above copyright notice,
-     this list of conditions and the following disclaimer in the documentation
-     and/or other materials provided with the distribution.
-   - Neither the name of the Mumble Developers nor the names of its
-     contributors may be used to endorse or promote products derived from this
-     software without specific prior written permission.
-
-   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
-   ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
-   LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
-   A PARTICULAR PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE FOUNDATION OR
-   CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
-   EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
-   PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
-   PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
-   LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
-   NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
-   SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*/
+// Copyright 2005-2018 The Mumble Developers. All rights reserved.
+// Use of this source code is governed by a BSD-style license
+// that can be found in the LICENSE file at the root of the
+// Mumble source tree or at <https://www.mumble.info/LICENSE>.
 
 #ifndef MUMBLE_MUMBLE_JACKAUDIO_H_
 #define MUMBLE_MUMBLE_JACKAUDIO_H_

--- a/src/mumble/JackAudio.h
+++ b/src/mumble/JackAudio.h
@@ -29,69 +29,70 @@
    SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 
-#ifndef _JACKAUDIO_H
-#define _JACKAUDIO_H
+#ifndef MUMBLE_MUMBLE_JACKAUDIO_H_
+#define MUMBLE_MUMBLE_JACKAUDIO_H_
 
 #include "AudioInput.h"
 #include "AudioOutput.h"
+
 #include <jack/jack.h>
 
 class JackAudioOutput;
 class JackAudioInput;
 
 class JackAudioSystem : public QObject {
-        private:
-                Q_OBJECT
-                Q_DISABLE_COPY(JackAudioSystem)
-        protected:
-                jack_client_t* client;
-                jack_port_t* in_port;
-                jack_port_t* out_port;
+	private:
+		Q_OBJECT
+		Q_DISABLE_COPY(JackAudioSystem)
+	protected:
+		jack_client_t* client;
+		jack_port_t* in_port;
+		jack_port_t* out_port;
 
-                static int process_callback(jack_nframes_t nframes, void *arg);
-                static int srate_callback(jack_nframes_t frames, void *arg);
-                static void shutdown_callback(void *arg);
-        public:
-                QHash<QString, QString> qhInput;
-                QHash<QString, QString> qhOutput;
-                bool bJackIsGood;
-                int iSampleRate;
-                QMutex qmWait;
-                QWaitCondition qwcWait;
+		static int process_callback(jack_nframes_t nframes, void *arg);
+		static int srate_callback(jack_nframes_t frames, void *arg);
+		static void shutdown_callback(void *arg);
+	public:
+		QHash<QString, QString> qhInput;
+		QHash<QString, QString> qhOutput;
+		bool bJackIsGood;
+		int iSampleRate;
+		QMutex qmWait;
+		QWaitCondition qwcWait;
 
-                void init_jack();
-                void close_jack();
+		void init_jack();
+		void close_jack();
 
-                JackAudioSystem();
-                ~JackAudioSystem();
+		JackAudioSystem();
+		~JackAudioSystem();
 };
 
 class JackAudioInput : public AudioInput {
-                friend class JackAudioSystem;
-        private:
-                Q_OBJECT
-                Q_DISABLE_COPY(JackAudioInput)
-        protected:
-                QMutex qmMutex;
-                QWaitCondition qwcWait;
-        public:
-                JackAudioInput();
-                ~JackAudioInput();
-                void run();
+	friend class JackAudioSystem;
+	private:
+		Q_OBJECT
+		Q_DISABLE_COPY(JackAudioInput)
+	protected:
+		QMutex qmMutex;
+		QWaitCondition qwcWait;
+	public:
+		JackAudioInput();
+		~JackAudioInput();
+		void run();
 };
 
 class JackAudioOutput : public AudioOutput {
-                friend class JackAudioSystem;
-        private:
-                Q_OBJECT
-                Q_DISABLE_COPY(JackAudioOutput)
-        protected:
-                QMutex qmMutex;
-                QWaitCondition qwcWait;
-        public:
-                JackAudioOutput();
-                ~JackAudioOutput();
-                void run();
+	friend class JackAudioSystem;
+	private:
+		Q_OBJECT
+		Q_DISABLE_COPY(JackAudioOutput)
+	protected:
+		QMutex qmMutex;
+		QWaitCondition qwcWait;
+	public:
+		JackAudioOutput();
+		~JackAudioOutput();
+		void run();
 };
 
 #endif

--- a/src/mumble/Settings.cpp
+++ b/src/mumble/Settings.cpp
@@ -316,6 +316,8 @@ Settings::Settings() {
 	qsALSAOutput=QLatin1String("default");
 
 	qsJackAudioOutput = QLatin1String("1");
+	bJackStartServer = true;
+	bJackAutoConnect = false;
 
 	bEcho = false;
 	bEchoMulti = true;
@@ -657,6 +659,8 @@ void Settings::load(QSettings* settings_ptr) {
 	SAVELOAD(qsPulseAudioOutput, "pulseaudio/output");
 
 	SAVELOAD(qsJackAudioOutput, "jack/output");
+	SAVELOAD(bJackStartServer, "jack/startserver");
+	SAVELOAD(bJackAutoConnect, "jack/autoconnect");
 
 	SAVELOAD(qsOSSInput, "oss/input");
 	SAVELOAD(qsOSSOutput, "oss/output");
@@ -995,6 +999,8 @@ void Settings::save() {
 	SAVELOAD(qsPulseAudioOutput, "pulseaudio/output");
 
 	SAVELOAD(qsJackAudioOutput, "jack/output");
+	SAVELOAD(bJackStartServer, "jack/startserver");
+	SAVELOAD(bJackAutoConnect, "jack/autoconnect");
 
 	SAVELOAD(qsOSSInput, "oss/input");
 	SAVELOAD(qsOSSOutput, "oss/output");

--- a/src/mumble/Settings.cpp
+++ b/src/mumble/Settings.cpp
@@ -654,6 +654,8 @@ void Settings::load(QSettings* settings_ptr) {
 	SAVELOAD(qsPulseAudioInput, "pulseaudio/input");
 	SAVELOAD(qsPulseAudioOutput, "pulseaudio/output");
 
+	SAVELOAD(qsJackAudioOutput, "jack/output");
+
 	SAVELOAD(qsOSSInput, "oss/input");
 	SAVELOAD(qsOSSOutput, "oss/output");
 
@@ -989,6 +991,8 @@ void Settings::save() {
 
 	SAVELOAD(qsPulseAudioInput, "pulseaudio/input");
 	SAVELOAD(qsPulseAudioOutput, "pulseaudio/output");
+
+	SAVELOAD(qsJackAudioOutput, "jack/output");
 
 	SAVELOAD(qsOSSInput, "oss/input");
 	SAVELOAD(qsOSSOutput, "oss/output");

--- a/src/mumble/Settings.cpp
+++ b/src/mumble/Settings.cpp
@@ -315,6 +315,8 @@ Settings::Settings() {
 	qsALSAInput=QLatin1String("default");
 	qsALSAOutput=QLatin1String("default");
 
+	qsJackAudioOutput = QLatin1String("1");
+
 	bEcho = false;
 	bEchoMulti = true;
 

--- a/src/mumble/Settings.h
+++ b/src/mumble/Settings.h
@@ -207,6 +207,7 @@ struct Settings {
 	QString qsALSAInput, qsALSAOutput;
 	QString qsPulseAudioInput, qsPulseAudioOutput;
 	QString qsJackAudioOutput;
+	bool bJackStartServer, bJackAutoConnect;
 	QString qsOSSInput, qsOSSOutput;
 	int iPortAudioInput, iPortAudioOutput;
 

--- a/src/mumble/Settings.h
+++ b/src/mumble/Settings.h
@@ -206,6 +206,7 @@ struct Settings {
 
 	QString qsALSAInput, qsALSAOutput;
 	QString qsPulseAudioInput, qsPulseAudioOutput;
+	QString qsJackAudioOutput;
 	QString qsOSSInput, qsOSSOutput;
 	int iPortAudioInput, iPortAudioOutput;
 

--- a/src/mumble/mumble.pro
+++ b/src/mumble/mumble.pro
@@ -554,10 +554,10 @@ pulseaudio {
 }
 
 jackaudio {
-       DEFINES *= USE_JACKAUDIO
-       PKGCONFIG *= jack
-       HEADERS *= JackAudio.h
-       SOURCES *= JackAudio.cpp
+  DEFINES *= USE_JACKAUDIO
+  PKGCONFIG *= jack
+  HEADERS *= JackAudio.h
+  SOURCES *= JackAudio.cpp
 }
 
 portaudio {

--- a/src/mumble/mumble.pro
+++ b/src/mumble/mumble.pro
@@ -446,10 +446,16 @@ win32 {
 
 unix {
   HAVE_PULSEAUDIO=$$system(pkg-config --modversion --silence-errors libpulse)
+  HAVE_JACKAUDIO=$$system(pkg-config --modversion --silence-errors jack)
 
   !isEmpty(HAVE_PULSEAUDIO):!CONFIG(no-pulseaudio) {
     CONFIG *= pulseaudio
   }
+
+  !isEmpty(HAVE_JACKAUDIO):!CONFIG(no-jackaudio) {
+    CONFIG *= jackaudio
+  }
+
 
   !CONFIG(no-bundled-speex) {
     QMAKE_CFLAGS *= -I../../3rdparty/speex-src/include -I../../3rdparty/speex-build
@@ -545,6 +551,13 @@ pulseaudio {
   must_pkgconfig(libpulse)
   HEADERS *= PulseAudio.h
   SOURCES *= PulseAudio.cpp
+}
+
+jackaudio {
+       DEFINES *= USE_JACKAUDIO
+       PKGCONFIG *= jack
+       HEADERS *= JackAudio.h
+       SOURCES *= JackAudio.cpp
 }
 
 portaudio {


### PR DESCRIPTION
Hello,

I took the jack patch from https://github.com/mumble-voip/mumble/pull/137 and tried to fix/advance it.

Main Changes:
- Added stereo output support
- Configurable output devices (Mono/Stereo). We can talk about the names, as strictly speaking "Mono" or "Stereo" is not an output device.
- **EDIT**: Jack port auto connect is disabled by default and can be enabled in ~/.config/Mumble/Mumble.conf 
`[jack]
autoconnect=true`
- **EDIT**: the jack server starts by default on mumble start (if not already running). This can be disabled in ~/.config/Mumble/Mumble.conf 
`[jack]
startserver=false`

Bugfixes:
- Jack input/output was always running (even if not selected) and causing crashes when interacting with a different input/output source. This fixes the crash when changing the output/input from jack to alsa and vice versa.
- Fixed possible crash on shutdown
- Fixed possible crash in case of jackd reconfiguration (for example the buffer size)


Those changes were tested with:
- jack-1.9.11_rc1 and jack-1.9.12 (-> jack2)
- switchting/mixing alsa&jack input/output source
- several runs in debug mode with ASAN support (not in this pull request)

UPDATE:
- Added autconnect (default off) and autostart (default on)
- Added more verbose error checking