### PR TITLE
Use Utf8 QStrings for PulseAudio

### DIFF
--- a/src/mumble/PulseAudio.cpp
+++ b/src/mumble/PulseAudio.cpp
@@ -409,12 +409,12 @@ void PulseAudioSystem::sink_callback(pa_context *, const pa_sink_info *i, int eo
 		return;
 	}
 
-	const QString name = QLatin1String(i->name);
+	const QString name = QString::fromUtf8(i->name);
 
 	pas->qhSpecMap.insert(name, i->sample_spec);
 	pas->qhChanMap.insert(name, i->channel_map);
-	pas->qhOutput.insert(name, QLatin1String(i->description));
-	pas->qhEchoMap.insert(name, QLatin1String(i->monitor_source_name));
+	pas->qhOutput.insert(name, QString::fromUtf8(i->description));
+	pas->qhEchoMap.insert(name, QString::fromUtf8(i->monitor_source_name));
 }
 
 void PulseAudioSystem::source_callback(pa_context *, const pa_source_info *i, int eol, void *userdata) {
@@ -425,19 +425,19 @@ void PulseAudioSystem::source_callback(pa_context *, const pa_source_info *i, in
 		return;
 	}
 
-	const QString name = QLatin1String(i->name);
+	const QString name = QString::fromUtf8(i->name);
 
 	pas->qhSpecMap.insert(name, i->sample_spec);
 	pas->qhChanMap.insert(name, i->channel_map);
 
-	pas->qhInput.insert(QLatin1String(i->name), QLatin1String(i->description));
+	pas->qhInput.insert(QString::fromUtf8(i->name), QString::fromUtf8(i->description));
 }
 
 void PulseAudioSystem::server_callback(pa_context *, const pa_server_info *i, void *userdata) {
 	PulseAudioSystem *pas = reinterpret_cast<PulseAudioSystem *>(userdata);
 
-	pas->qsDefaultInput = QLatin1String(i->default_source_name);
-	pas->qsDefaultOutput = QLatin1String(i->default_sink_name);
+	pas->qsDefaultInput = QString::fromUtf8(i->default_source_name);
+	pas->qsDefaultOutput = QString::fromUtf8(i->default_sink_name);
 
 	pas->bServerDone = true;
 	pas->wakeup();
@@ -647,8 +647,8 @@ void PulseAudioSystem::volume_sink_input_list_callback(pa_context *c, const pa_s
 			// create a new entry
 			PulseAttenuation patt;
 			patt.index = i->index;
-			patt.name = QLatin1String(i->name);
-			patt.stream_restore_id = QLatin1String(pa_proplist_gets(i->proplist, "module-stream-restore.id"));
+			patt.name = QString::fromUtf8(i->name);
+			patt.stream_restore_id = QString::fromUtf8(pa_proplist_gets(i->proplist, "module-stream-restore.id"));
 			patt.normal_volume = i->volume;
 
 			// calculate the attenuated volume
@@ -685,7 +685,7 @@ void PulseAudioSystem::restore_sink_input_list_callback(pa_context *c, const pa_
 
 		// otherwise, save for matching at the end of iteration
 		} else {
-			QString restore_id = QLatin1String(pa_proplist_gets(i->proplist, "module-stream-restore.id"));
+			QString restore_id = QString::fromUtf8(pa_proplist_gets(i->proplist, "module-stream-restore.id"));
 			PulseAttenuation patt;
 			patt.index = i->index;
 			patt.normal_volume = i->volume;
@@ -744,7 +744,7 @@ void PulseAudioSystem::stream_restore_read_callback(pa_context *c, const pa_ext_
 	PulseAudioSystem *pas = reinterpret_cast<PulseAudioSystem *>(userdata);
 
 	if (eol == 0) {
-		QString name = QLatin1String(i->name);
+		QString name = QString::fromUtf8(i->name);
 
 		// were we looking for this restoration?
 		if (pas->qhMissingSinks.contains(name)) {


### PR DESCRIPTION
On non-English locale systems, PulseAudio localises the sink/source names, resulting in invalid characters being rendered in the mumble audio settings widget.
![bcd3fa633ca6](https://user-images.githubusercontent.com/6003656/39034619-b150530c-447f-11e8-9633-7701ce6a2602.jpg)

Switching QStrings from Latin1 to Utf8 in PulseAudio.cpp fixes this issue.
![3affd27a86b9](https://user-images.githubusercontent.com/6003656/39034590-9578dc80-447f-11e8-90fa-6a4cadbc0c37.jpg)