### PR TITLE
travis-ci: unlink Python 2 files on MacOS

### DIFF
--- a/scripts/travis-ci/before_install.bash
+++ b/scripts/travis-ci/before_install.bash
@@ -64,7 +64,17 @@ if [ "${TRAVIS_OS_NAME}" == "linux" ]; then
 		exit 1
 	fi
 elif [ "${TRAVIS_OS_NAME}" == "osx" ]; then
-	brew update && brew install qt5 libogg libvorbis flac libsndfile protobuf openssl ice
+	# We install the protobuf package via brew,
+	# which depends on "python@2".
+	#
+	# The build image upgraded the installed "python",
+	# and now "python@2" conflicts with it when trying
+	# to create symlinks.
+	#
+	# We don’t use the symlinked "python" installed
+	# by default in the image, so we unlink it to allow
+	# the "python@2" package to be installed without conflict.
+	brew update && brew unlink python && brew install qt5 libogg libvorbis flac libsndfile protobuf openssl ice
 else
 	exit 1
 fi


### PR DESCRIPTION
Python's installation folder has been changed in a recent update, causing Brew to fail because there are symlinks pointing to files which were in the old one.