### PR TITLE
Introduce channelcountlimit to limit max channels per server

### DIFF
--- a/scripts/murmur.ini
+++ b/scripts/murmur.ini
@@ -151,6 +151,10 @@ allowping=true
 ; InnoDB will fail when operating on deeply nested channels.
 ;channelnestinglimit=10
 
+; Maximum number of channels per server. 0 for unlimited. Note that an
+; excessive number of channels will impact server performance
+;channelcountlimit=1000
+
 ; Regular expression used to validate channel names.
 ; (Note that you have to escape backslashes with \ )
 ;channelname=[ \\-=\\w\\#\\[\\]\\{\\}\\(\\)\\@\\|]+

--- a/src/Mumble.proto
+++ b/src/Mumble.proto
@@ -280,7 +280,10 @@ message PermissionDenied {
 		UserName = 8;
 		// Channel is full.
 		ChannelFull = 9;
+		// Channels are nested too deply.
 		NestingLimit = 10;
+		// Maximum channel count reached.
+		ChannelCountLimit = 11;
 	}
 	// The denied permission when type is Permission.
 	optional uint32 permission = 1;

--- a/src/mumble.pri
+++ b/src/mumble.pri
@@ -8,7 +8,7 @@ include(../qmake/qt.pri)
 include(../qmake/rcc.pri)
 include(../qmake/pkgconfig.pri)
 
-VERSION		= 1.3.1
+VERSION		= 1.3.0
 DIST		= mumble.pri Message.h PacketDataStream.h CryptState.h Timer.h Version.h OSInfo.h SSL.h
 CONFIG		+= qt thread debug_and_release warn_on
 DEFINES		*= MUMBLE_VERSION_STRING=$$VERSION

--- a/src/mumble.pri
+++ b/src/mumble.pri
@@ -8,7 +8,7 @@ include(../qmake/qt.pri)
 include(../qmake/rcc.pri)
 include(../qmake/pkgconfig.pri)
 
-VERSION		= 1.3.0
+VERSION		= 1.3.1
 DIST		= mumble.pri Message.h PacketDataStream.h CryptState.h Timer.h Version.h OSInfo.h SSL.h
 CONFIG		+= qt thread debug_and_release warn_on
 DEFINES		*= MUMBLE_VERSION_STRING=$$VERSION

--- a/src/mumble/Messages.cpp
+++ b/src/mumble/Messages.cpp
@@ -242,6 +242,10 @@ void MainWindow::msgPermissionDenied(const MumbleProto::PermissionDenied &msg) {
 				g.l->log(Log::PermissionDenied, tr("Channel nesting limit reached."));
 			}
 			break;
+		case MumbleProto::PermissionDenied_DenyType_ChannelCountLimit: {
+				g.l->log(Log::PermissionDenied, tr("Channel count limit reached. Need to delete channels before creating new ones."));
+			}
+			break;
 		default: {
 				if (msg.has_reason())
 					g.l->log(Log::PermissionDenied, tr("Denied: %1.").arg(Qt::escape(u8(msg.reason()))));

--- a/src/murmur/Messages.cpp
+++ b/src/murmur/Messages.cpp
@@ -896,6 +896,11 @@ void Server::msgChannelState(ServerUser *uSource, MumbleProto::ChannelState &msg
 		if (! p || qsName.isNull())
 			return;
 
+		if (iChannelCountLimit == 0 || qhChannels.count() >= iChannelCountLimit) {
+			PERM_DENIED_FALLBACK(ChannelCountLimit, 0x010301, QLatin1String("Channel count limit reached"));
+			return;
+		}
+		
 		ChanACL::Perm perm = msg.temporary() ? ChanACL::MakeTempChannel : ChanACL::MakeChannel;
 		if (! hasPermission(uSource, p, perm)) {
 			PERM_DENIED(uSource, p, perm);

--- a/src/murmur/Messages.cpp
+++ b/src/murmur/Messages.cpp
@@ -897,7 +897,7 @@ void Server::msgChannelState(ServerUser *uSource, MumbleProto::ChannelState &msg
 			return;
 
 		if (iChannelCountLimit != 0 && qhChannels.count() >= iChannelCountLimit) {
-			PERM_DENIED_FALLBACK(ChannelCountLimit, 0x010301, QLatin1String("Channel count limit reached"));
+			PERM_DENIED_FALLBACK(ChannelCountLimit, 0x010300, QLatin1String("Channel count limit reached"));
 			return;
 		}
 		

--- a/src/murmur/Messages.cpp
+++ b/src/murmur/Messages.cpp
@@ -896,7 +896,7 @@ void Server::msgChannelState(ServerUser *uSource, MumbleProto::ChannelState &msg
 		if (! p || qsName.isNull())
 			return;
 
-		if (iChannelCountLimit == 0 || qhChannels.count() >= iChannelCountLimit) {
+		if (iChannelCountLimit != 0 && qhChannels.count() >= iChannelCountLimit) {
 			PERM_DENIED_FALLBACK(ChannelCountLimit, 0x010301, QLatin1String("Channel count limit reached"));
 			return;
 		}

--- a/src/murmur/Meta.cpp
+++ b/src/murmur/Meta.cpp
@@ -69,6 +69,7 @@ MetaParams::MetaParams() {
 	iOpusThreshold = 100;
 
 	iChannelNestingLimit = 10;
+	iChannelCountLimit = 1000;
 
 	qrUserName = QRegExp(QLatin1String("[-=\\w\\[\\]\\{\\}\\(\\)\\@\\|\\.]+"));
 	qrChannelName = QRegExp(QLatin1String("[ \\-=\\w\\#\\[\\]\\{\\}\\(\\)\\@\\|]+"));
@@ -341,6 +342,7 @@ void MetaParams::read(QString fname) {
 	iOpusThreshold = typeCheckedFromSettings("opusthreshold", iOpusThreshold);
 
 	iChannelNestingLimit = typeCheckedFromSettings("channelnestinglimit", iChannelNestingLimit);
+	iChannelCountLimit = typeCheckedFromSettings("channelcountlimit", iChannelCountLimit);
 
 #ifdef Q_OS_UNIX
 	qsName = qsSettings->value("uname").toString();
@@ -414,6 +416,7 @@ void MetaParams::read(QString fname) {
 	qmConfig.insert(QLatin1String("suggestpushtotalk"), qvSuggestPushToTalk.isNull() ? QString() : qvSuggestPushToTalk.toString());
 	qmConfig.insert(QLatin1String("opusthreshold"), QString::number(iOpusThreshold));
 	qmConfig.insert(QLatin1String("channelnestinglimit"), QString::number(iChannelNestingLimit));
+	qmConfig.insert(QLatin1String("channelcountlimit"), QString::number(iChannelCountLimit));
 	qmConfig.insert(QLatin1String("sslCiphers"), qsCiphers);
 	qmConfig.insert(QLatin1String("sslDHParams"), QString::fromLatin1(qbaDHParams.constData()));
 }

--- a/src/murmur/Meta.h
+++ b/src/murmur/Meta.h
@@ -39,6 +39,7 @@ public:
 	int iMaxImageMessageLength;
 	int iOpusThreshold;
 	int iChannelNestingLimit;
+	int iChannelCountLimit;
 	/// If true the old SHA1 password hashing is used instead of PBKDF2
 	bool legacyPasswordHash;
 	/// Contains the default number of PBKDF2 iterations to use

--- a/src/murmur/Server.cpp
+++ b/src/murmur/Server.cpp
@@ -397,6 +397,7 @@ void Server::readParams() {
 	qvSuggestPushToTalk = Meta::mp.qvSuggestPushToTalk;
 	iOpusThreshold = Meta::mp.iOpusThreshold;
 	iChannelNestingLimit = Meta::mp.iChannelNestingLimit;
+	iChannelCountLimit = Meta::mp.iChannelCountLimit;
 
 	QString qsHost = getConf("host", QString()).toString();
 	if (! qsHost.isEmpty()) {
@@ -463,6 +464,7 @@ void Server::readParams() {
 	iOpusThreshold = getConf("opusthreshold", iOpusThreshold).toInt();
 
 	iChannelNestingLimit = getConf("channelnestinglimit", iChannelNestingLimit).toInt();
+	iChannelCountLimit = getConf("channelcountlimit", iChannelCountLimit).toInt();
 
 	qrUserName=QRegExp(getConf("username", qrUserName.pattern()).toString());
 	qrChannelName=QRegExp(getConf("channelname", qrChannelName.pattern()).toString());
@@ -582,6 +584,8 @@ void Server::setLiveConf(const QString &key, const QString &value) {
 		iOpusThreshold = (i >= 0 && !v.isNull()) ? qBound(0, i, 100) : Meta::mp.iOpusThreshold;
 	else if (key == "channelnestinglimit")
 		iChannelNestingLimit = (i >= 0 && !v.isNull()) ? i : Meta::mp.iChannelNestingLimit;
+	else if (key == "channelcountlimit")
+		iChannelCountLimit = (i >= 0 && !v.isNull()) ? i : Meta::mp.iChannelCountLimit;
 }
 
 #ifdef USE_BONJOUR

--- a/src/murmur/Server.h
+++ b/src/murmur/Server.h
@@ -171,6 +171,7 @@ class Server : public QThread {
 
 	private:
 		int iChannelNestingLimit;
+		int iChannelCountLimit;
 
 	public slots:
 		void regSslError(const QList<QSslError> &);


### PR DESCRIPTION
Having to many channels on a server can impact performance to the point
of making the instance unusably slow. This can be a problem for hosters
that allow their users unlimited channel creation.

This patch introduces a new per-server configuration parameter
channelcountlimit which can be used to configure a maximum number of
channels that may be created on each of the virtual servers. Once the
limit is reached channel creation will be rejected with permission
denied.

To allow a translated error message we have to bump the client version
to 1.3.1 to be able to use a fallback message for older clients.

As usual dbus, ice and grpc can ignore this limit. It is only enforced
against clients.

Note that I have not done extensive testing of this patch. The setting seems to work as expected when set from the ini but I did not try whether setting it on-the-fly and per-server works as expected. Also the version bump is a bit confusing considering we haven't released 1.3.0 yet. Maybe we shouldn't do that and "break" compat with the other pre-release versions? If 1.3 release is still a while away this could be backported.