### PR TITLE
Fix #3411: Threaded access to Database

### DIFF
--- a/src/mumble/ACLEditor.cpp
+++ b/src/mumble/ACLEditor.cpp
@@ -268,7 +268,7 @@ void ACLEditor::accept() {
 			const QString &descriptionText = rteChannelDescription->text();
 			mpcs.set_description(u8(descriptionText));
 			needs_update = true;
-			Database::setBlob(sha1(descriptionText), descriptionText.toUtf8());
+			g.db->setBlob(sha1(descriptionText), descriptionText.toUtf8());
 		}
 		if (pChannel->iPosition != qsbChannelPosition->value()) {
 			mpcs.set_position(qsbChannelPosition->value());

--- a/src/mumble/ConnectDialog.cpp
+++ b/src/mumble/ConnectDialog.cpp
@@ -1040,7 +1040,7 @@ ConnectDialog::ConnectDialog(QWidget *p, bool autoconnect) : QDialog(p), bAutoCo
 	}
 
 	QList<QTreeWidgetItem *> ql;
-	QList<FavoriteServer> favorites = Database::getFavorites();
+	QList<FavoriteServer> favorites = g.db->getFavorites();
 
 	foreach(const FavoriteServer &fs, favorites) {
 		ServerItem *si = new ServerItem(fs);
@@ -1089,7 +1089,7 @@ ConnectDialog::ConnectDialog(QWidget *p, bool autoconnect) : QDialog(p), bAutoCo
 	qtwServers->setCurrentItem(NULL);
 	bLastFound = false;
 
-	qmPingCache = Database::getPingCache();
+	qmPingCache = g.db->getPingCache();
 
 	if (! g.s.qbaConnectDialogGeometry.isEmpty())
 		restoreGeometry(g.s.qbaConnectDialogGeometry);
@@ -1111,8 +1111,8 @@ ConnectDialog::~ConnectDialog() {
 			continue;
 		ql << si->toFavoriteServer();
 	}
-	Database::setFavorites(ql);
-	Database::setPingCache(qmPingCache);
+	g.db->setFavorites(ql);
+	g.db->setPingCache(qmPingCache);
 
 	g.s.qbaConnectDialogHeader = qtwServers->header()->saveState();
 	g.s.qbaConnectDialogGeometry = saveGeometry();

--- a/src/mumble/Database.cpp
+++ b/src/mumble/Database.cpp
@@ -36,8 +36,8 @@ static bool execQueryAndLogFailure(QSqlQuery &query, const QString &queryString)
 }
 
 
-Database::Database() {
-	QSqlDatabase db = QSqlDatabase::addDatabase(QLatin1String("QSQLITE"));
+Database::Database(const QString &dbname) {
+	db = QSqlDatabase::addDatabase(QLatin1String("QSQLITE"), dbname);
 	QSettings qs;
 	QStringList datapaths;
 	int i;
@@ -105,7 +105,7 @@ Database::Database() {
 		f.setPermissions(f.permissions() & ~(QFile::ReadGroup | QFile::WriteGroup | QFile::ExeGroup | QFile::ReadOther | QFile::WriteOther | QFile::ExeOther));
 	}
 
-	QSqlQuery query;
+	QSqlQuery query(db);
 
 	execQueryAndLogFailure(query, QLatin1String("CREATE TABLE IF NOT EXISTS `servers` (`id` INTEGER PRIMARY KEY AUTOINCREMENT, `name` TEXT, `hostname` TEXT, `port` INTEGER DEFAULT " MUMTEXT(DEFAULT_MUMBLE_PORT) ", `username` TEXT, `password` TEXT)"));
 	query.exec(QLatin1String("ALTER TABLE `servers` ADD COLUMN `url` TEXT")); // Upgrade path, failing this query is not noteworthy
@@ -168,13 +168,13 @@ Database::Database() {
 }
 
 Database::~Database() {
-	QSqlQuery query;
+	QSqlQuery query(db);
 	execQueryAndLogFailure(query, QLatin1String("PRAGMA journal_mode = DELETE"));
 	execQueryAndLogFailure(query, QLatin1String("VACUUM"));
 }
 
 QList<FavoriteServer> Database::getFavorites() {
-	QSqlQuery query;
+	QSqlQuery query(db);
 	QList<FavoriteServer> ql;
 
 	query.prepare(QLatin1String("SELECT `name`, `hostname`, `port`, `username`, `password`, `url` FROM `servers` ORDER BY `name`"));
@@ -194,7 +194,7 @@ QList<FavoriteServer> Database::getFavorites() {
 }
 
 void Database::setFavorites(const QList<FavoriteServer> &servers) {
-	QSqlQuery query;
+	QSqlQuery query(db);
 	QSqlDatabase::database().transaction();
 
 	query.prepare(QLatin1String("DELETE FROM `servers`"));
@@ -215,7 +215,7 @@ void Database::setFavorites(const QList<FavoriteServer> &servers) {
 }
 
 bool Database::isLocalIgnored(const QString &hash) {
-	QSqlQuery query;
+	QSqlQuery query(db);
 
 	query.prepare(QLatin1String("SELECT `hash` FROM `ignored` WHERE `hash` = ?"));
 	query.addBindValue(hash);
@@ -224,7 +224,7 @@ bool Database::isLocalIgnored(const QString &hash) {
 }
 
 void Database::setLocalIgnored(const QString &hash, bool ignored) {
-	QSqlQuery query;
+	QSqlQuery query(db);
 
 	if (ignored)
 		query.prepare(QLatin1String("INSERT INTO `ignored` (`hash`) VALUES (?)"));
@@ -235,7 +235,7 @@ void Database::setLocalIgnored(const QString &hash, bool ignored) {
 }
 
 bool Database::isLocalMuted(const QString &hash) {
-	QSqlQuery query;
+	QSqlQuery query(db);
 
 	query.prepare(QLatin1String("SELECT `hash` FROM `muted` WHERE `hash` = ?"));
 	query.addBindValue(hash);
@@ -244,7 +244,7 @@ bool Database::isLocalMuted(const QString &hash) {
 }
 
 void Database::setUserLocalVolume(const QString &hash, float volume) {
-	QSqlQuery query;
+	QSqlQuery query(db);
 
 	query.prepare(QLatin1String("INSERT OR REPLACE INTO `volume` (`hash`, `volume`) VALUES (?,?)"));
 	query.addBindValue(hash);
@@ -253,7 +253,7 @@ void Database::setUserLocalVolume(const QString &hash, float volume) {
 }
 
 float Database::getUserLocalVolume(const QString &hash) {
-	QSqlQuery query;
+	QSqlQuery query(db);
 
 	query.prepare(QLatin1String("SELECT `volume` FROM `volume` WHERE `hash` = ?"));
 	query.addBindValue(hash);
@@ -265,7 +265,7 @@ float Database::getUserLocalVolume(const QString &hash) {
 }
 
 void Database::setLocalMuted(const QString &hash, bool muted) {
-	QSqlQuery query;
+	QSqlQuery query(db);
 
 	if (muted)
 		query.prepare(QLatin1String("INSERT INTO `muted` (`hash`) VALUES (?)"));
@@ -276,7 +276,7 @@ void Database::setLocalMuted(const QString &hash, bool muted) {
 }
 
 bool Database::isChannelFiltered(const QByteArray &server_cert_digest, const int channel_id) {
-	QSqlQuery query;
+	QSqlQuery query(db);
 	
 	query.prepare(QLatin1String("SELECT `channel_id` FROM `filtered_channels` WHERE `server_cert_digest` = ? AND `channel_id` = ?"));
 	query.addBindValue(server_cert_digest);
@@ -287,7 +287,7 @@ bool Database::isChannelFiltered(const QByteArray &server_cert_digest, const int
 }
 
 void Database::setChannelFiltered(const QByteArray &server_cert_digest, const int channel_id, const bool hidden) {
-	QSqlQuery query;
+	QSqlQuery query(db);
 	
 	if (hidden)
 		query.prepare(QLatin1String("INSERT INTO `filtered_channels` (`server_cert_digest`, `channel_id`) VALUES (?, ?)"));
@@ -301,7 +301,7 @@ void Database::setChannelFiltered(const QByteArray &server_cert_digest, const in
 }
 
 QMap<UnresolvedServerAddress, unsigned int> Database::getPingCache() {
-	QSqlQuery query;
+	QSqlQuery query(db);
 	QMap<UnresolvedServerAddress, unsigned int> map;
 
 	query.prepare(QLatin1String("SELECT `hostname`, `port`, `ping` FROM `pingcache`"));
@@ -313,7 +313,7 @@ QMap<UnresolvedServerAddress, unsigned int> Database::getPingCache() {
 }
 
 void Database::setPingCache(const QMap<UnresolvedServerAddress, unsigned int> &map) {
-	QSqlQuery query;
+	QSqlQuery query(db);
 	QMap<UnresolvedServerAddress, unsigned int>::const_iterator i;
 
 	QSqlDatabase::database().transaction();
@@ -333,7 +333,7 @@ void Database::setPingCache(const QMap<UnresolvedServerAddress, unsigned int> &m
 }
 
 bool Database::seenComment(const QString &hash, const QByteArray &commenthash) {
-	QSqlQuery query;
+	QSqlQuery query(db);
 
 	query.prepare(QLatin1String("SELECT COUNT(*) FROM `comments` WHERE `who` = ? AND `comment` = ?"));
 	query.addBindValue(hash);
@@ -352,7 +352,7 @@ bool Database::seenComment(const QString &hash, const QByteArray &commenthash) {
 }
 
 void Database::setSeenComment(const QString &hash, const QByteArray &commenthash) {
-	QSqlQuery query;
+	QSqlQuery query(db);
 
 	query.prepare(QLatin1String("REPLACE INTO `comments` (`who`, `comment`, `seen`) VALUES (?, ?, datetime('now'))"));
 	query.addBindValue(hash);
@@ -361,7 +361,7 @@ void Database::setSeenComment(const QString &hash, const QByteArray &commenthash
 }
 
 QByteArray Database::blob(const QByteArray &hash) {
-	QSqlQuery query;
+	QSqlQuery query(db);
 
 	query.prepare(QLatin1String("SELECT `data` FROM `blobs` WHERE `hash` = ?"));
 	query.addBindValue(hash);
@@ -382,7 +382,7 @@ void Database::setBlob(const QByteArray &hash, const QByteArray &data) {
 	if (hash.isEmpty() || data.isEmpty())
 		return;
 
-	QSqlQuery query;
+	QSqlQuery query(db);
 
 	query.prepare(QLatin1String("REPLACE INTO `blobs` (`hash`, `data`, `seen`) VALUES (?, ?, datetime('now'))"));
 	query.addBindValue(hash);
@@ -392,7 +392,7 @@ void Database::setBlob(const QByteArray &hash, const QByteArray &data) {
 
 QStringList Database::getTokens(const QByteArray &digest) {
 	QList<QString> qsl;
-	QSqlQuery query;
+	QSqlQuery query(db);
 
 	query.prepare(QLatin1String("SELECT `token` FROM `tokens` WHERE `digest` = ?"));
 	query.addBindValue(digest);
@@ -404,7 +404,7 @@ QStringList Database::getTokens(const QByteArray &digest) {
 }
 
 void Database::setTokens(const QByteArray &digest, QStringList &tokens) {
-	QSqlQuery query;
+	QSqlQuery query(db);
 
 	query.prepare(QLatin1String("DELETE FROM `tokens` WHERE `digest` = ?"));
 	query.addBindValue(digest);
@@ -420,7 +420,7 @@ void Database::setTokens(const QByteArray &digest, QStringList &tokens) {
 
 QList<Shortcut> Database::getShortcuts(const QByteArray &digest) {
 	QList<Shortcut> ql;
-	QSqlQuery query;
+	QSqlQuery query(db);
 
 	query.prepare(QLatin1String("SELECT `shortcut`,`target`,`suppress` FROM `shortcut` WHERE `digest` = ?"));
 	query.addBindValue(digest);
@@ -451,7 +451,7 @@ QList<Shortcut> Database::getShortcuts(const QByteArray &digest) {
 }
 
 bool Database::setShortcuts(const QByteArray &digest, QList<Shortcut> &shortcuts) {
-	QSqlQuery query;
+	QSqlQuery query(db);
 	bool updated = false;
 
 	query.prepare(QLatin1String("DELETE FROM `shortcut` WHERE `digest` = ?"));
@@ -493,7 +493,7 @@ bool Database::setShortcuts(const QByteArray &digest, QList<Shortcut> &shortcuts
 
 const QMap<QString, QString> Database::getFriends() {
 	QMap<QString, QString> qm;
-	QSqlQuery query;
+	QSqlQuery query(db);
 
 	query.prepare(QLatin1String("SELECT `name`, `hash` FROM `friends`"));
 	execQueryAndLogFailure(query);
@@ -503,7 +503,7 @@ const QMap<QString, QString> Database::getFriends() {
 }
 
 const QString Database::getFriend(const QString &hash) {
-	QSqlQuery query;
+	QSqlQuery query(db);
 
 	query.prepare(QLatin1String("SELECT `name` FROM `friends` WHERE `hash` = ?"));
 	query.addBindValue(hash);
@@ -514,7 +514,7 @@ const QString Database::getFriend(const QString &hash) {
 }
 
 void Database::addFriend(const QString &name, const QString &hash) {
-	QSqlQuery query;
+	QSqlQuery query(db);
 
 	query.prepare(QLatin1String("REPLACE INTO `friends` (`name`, `hash`) VALUES (?,?)"));
 	query.addBindValue(name);
@@ -523,7 +523,7 @@ void Database::addFriend(const QString &name, const QString &hash) {
 }
 
 void Database::removeFriend(const QString &hash) {
-	QSqlQuery query;
+	QSqlQuery query(db);
 
 	query.prepare(QLatin1String("DELETE FROM `friends` WHERE `hash` = ?"));
 	query.addBindValue(hash);
@@ -531,7 +531,7 @@ void Database::removeFriend(const QString &hash) {
 }
 
 const QString Database::getDigest(const QString &hostname, unsigned short port) {
-	QSqlQuery query;
+	QSqlQuery query(db);
 
 	query.prepare(QLatin1String("SELECT `digest` FROM `cert` WHERE `hostname` = ? AND `port` = ?"));
 	query.addBindValue(hostname);
@@ -544,7 +544,7 @@ const QString Database::getDigest(const QString &hostname, unsigned short port) 
 }
 
 void Database::setDigest(const QString &hostname, unsigned short port, const QString &digest) {
-	QSqlQuery query;
+	QSqlQuery query(db);
 	query.prepare(QLatin1String("REPLACE INTO `cert` (`hostname`,`port`,`digest`) VALUES (?,?,?)"));
 	query.addBindValue(hostname);
 	query.addBindValue(port);
@@ -553,7 +553,7 @@ void Database::setDigest(const QString &hostname, unsigned short port, const QSt
 }
 
 void Database::setPassword(const QString &hostname, unsigned short port, const QString &uname, const QString &pw) {
-	QSqlQuery query;
+	QSqlQuery query(db);
 	query.prepare(QLatin1String("UPDATE `servers` SET `password` = ? WHERE `hostname` = ? AND `port` = ? AND `username` = ?"));
 	query.addBindValue(pw);
 	query.addBindValue(hostname);
@@ -563,7 +563,7 @@ void Database::setPassword(const QString &hostname, unsigned short port, const Q
 }
 
 bool Database::getUdp(const QByteArray &digest) {
-	QSqlQuery query;
+	QSqlQuery query(db);
 	query.prepare(QLatin1String("SELECT COUNT(*) FROM `udp` WHERE `digest` = ? "));
 	query.addBindValue(digest);
 	execQueryAndLogFailure(query);
@@ -574,7 +574,7 @@ bool Database::getUdp(const QByteArray &digest) {
 }
 
 void Database::setUdp(const QByteArray &digest, bool udp) {
-	QSqlQuery query;
+	QSqlQuery query(db);
 	if (! udp)
 		query.prepare(QLatin1String("REPLACE INTO `udp` (`digest`) VALUES (?)"));
 	else
@@ -584,7 +584,7 @@ void Database::setUdp(const QByteArray &digest, bool udp) {
 }
 
 bool Database::fuzzyMatch(QString &name, QString &user, QString &pw, QString &hostname, unsigned short port) {
-	QSqlQuery query;
+	QSqlQuery query(db);
 	if (! user.isEmpty()) {
 		query.prepare(QLatin1String("SELECT `username`, `password`, `hostname`, `name` FROM `servers` WHERE `username` LIKE ? AND `hostname` LIKE ? AND `port`=?"));
 		query.addBindValue(user);

--- a/src/mumble/Database.h
+++ b/src/mumble/Database.h
@@ -6,6 +6,7 @@
 #ifndef MUMBLE_MUMBLE_DATABASE_H_
 #define MUMBLE_MUMBLE_DATABASE_H_
 
+#include <QSqlDatabase>
 #include "Settings.h"
 #include "UnresolvedServerAddress.h"
 
@@ -22,51 +23,54 @@ class Database : public QObject {
 	private:
 		Q_OBJECT
 		Q_DISABLE_COPY(Database)
+
+		QSqlDatabase db;
 	public:
-		Database();
+		Database(const QString &dbname);
 		~Database() Q_DECL_OVERRIDE;
-		static QList<FavoriteServer> getFavorites();
-		static void setFavorites(const QList<FavoriteServer> &servers);
-		static void setPassword(const QString &host, unsigned short port, const QString &user, const QString &pw);
-		static bool fuzzyMatch(QString &name, QString &user, QString &pw, QString &host, unsigned short port);
 
-		static bool isLocalIgnored(const QString &hash);
-		static void setLocalIgnored(const QString &hash, bool ignored);
+		QList<FavoriteServer> getFavorites();
+		void setFavorites(const QList<FavoriteServer> &servers);
+		void setPassword(const QString &host, unsigned short port, const QString &user, const QString &pw);
+		bool fuzzyMatch(QString &name, QString &user, QString &pw, QString &host, unsigned short port);
 
-		static bool isLocalMuted(const QString &hash);
-		static void setLocalMuted(const QString &hash, bool muted);
+		bool isLocalIgnored(const QString &hash);
+		void setLocalIgnored(const QString &hash, bool ignored);
 
-		static float getUserLocalVolume(const QString &hash);
-		static void setUserLocalVolume(const QString &hash, float volume);
+		bool isLocalMuted(const QString &hash);
+		void setLocalMuted(const QString &hash, bool muted);
 
-		static bool isChannelFiltered(const QByteArray &server_cert_digest, const int channel_id);
-		static void setChannelFiltered(const QByteArray &server_cert_digest, const int channel_id, bool hidden);
+		float getUserLocalVolume(const QString &hash);
+		void setUserLocalVolume(const QString &hash, float volume);
 
-		static QMap<UnresolvedServerAddress, unsigned int> getPingCache();
-		static void setPingCache(const QMap<UnresolvedServerAddress, unsigned int> &cache);
+		bool isChannelFiltered(const QByteArray &server_cert_digest, const int channel_id);
+		void setChannelFiltered(const QByteArray &server_cert_digest, const int channel_id, bool hidden);
 
-		static bool seenComment(const QString &hash, const QByteArray &commenthash);
-		static void setSeenComment(const QString &hash, const QByteArray &commenthash);
+		QMap<UnresolvedServerAddress, unsigned int> getPingCache();
+		void setPingCache(const QMap<UnresolvedServerAddress, unsigned int> &cache);
 
-		static QByteArray blob(const QByteArray &hash);
-		static void setBlob(const QByteArray &hash, const QByteArray &blob);
+		bool seenComment(const QString &hash, const QByteArray &commenthash);
+		void setSeenComment(const QString &hash, const QByteArray &commenthash);
 
-		static QStringList getTokens(const QByteArray &digest);
-		static void setTokens(const QByteArray &digest, QStringList &tokens);
+		QByteArray blob(const QByteArray &hash);
+		void setBlob(const QByteArray &hash, const QByteArray &blob);
 
-		static QList<Shortcut> getShortcuts(const QByteArray &digest);
-		static bool setShortcuts(const QByteArray &digest, QList<Shortcut> &shortcuts);
+		QStringList getTokens(const QByteArray &digest);
+		void setTokens(const QByteArray &digest, QStringList &tokens);
 
-		static void addFriend(const QString &name, const QString &hash);
-		static void removeFriend(const QString &hash);
-		static const QString getFriend(const QString &hash);
-		static const QMap<QString, QString> getFriends();
+		QList<Shortcut> getShortcuts(const QByteArray &digest);
+		bool setShortcuts(const QByteArray &digest, QList<Shortcut> &shortcuts);
 
-		static const QString getDigest(const QString &hostname, unsigned short port);
-		static void setDigest(const QString &hostname, unsigned short port, const QString &digest);
+		void addFriend(const QString &name, const QString &hash);
+		void removeFriend(const QString &hash);
+		const QString getFriend(const QString &hash);
+		const QMap<QString, QString> getFriends();
 
-		static bool getUdp(const QByteArray &digest);
-		static void setUdp(const QByteArray &digest, bool udp);
+		const QString getDigest(const QString &hostname, unsigned short port);
+		void setDigest(const QString &hostname, unsigned short port, const QString &digest);
+
+		bool getUdp(const QByteArray &digest);
+		void setUdp(const QByteArray &digest, bool udp);
 };
 
 #endif

--- a/src/mumble/Global.h
+++ b/src/mumble/Global.h
@@ -44,6 +44,9 @@ public:
 	boost::shared_ptr<ServerHandler> sh;
 	boost::shared_ptr<AudioInput> ai;
 	boost::shared_ptr<AudioOutput> ao;
+	/**
+	 * @remark Must only be accessed from the main event loop
+	 */
 	Database *db;
 	Log *l;
 	Plugins *p;

--- a/src/mumble/GlobalShortcut.cpp
+++ b/src/mumble/GlobalShortcut.cpp
@@ -188,7 +188,7 @@ ShortcutTargetDialog::ShortcutTargetDialog(const ShortcutTarget &st, QWidget *pw
 	qcbChildren->setChecked(st.bChildren);
 
 	// Insert all known friends into the possible targets list
-	const QMap<QString, QString> &friends = Database::getFriends();
+	const QMap<QString, QString> &friends = g.db->getFriends();
 	if (! friends.isEmpty()) {
 		QMap<QString, QString>::const_iterator i;
 		for (i = friends.constBegin(); i != friends.constEnd(); ++i) {
@@ -376,7 +376,7 @@ QString ShortcutTargetWidget::targetString(const ShortcutTarget &st) {
 				if (hashes.contains(hash)) {
 					name = hashes.value(hash);
 				} else {
-					name = Database::getFriend(hash);
+					name = g.db->getFriend(hash);
 					if (name.isEmpty())
 						name = QString::fromLatin1("#%1").arg(hash);
 				}

--- a/src/mumble/MainWindow.cpp
+++ b/src/mumble/MainWindow.cpp
@@ -890,7 +890,7 @@ void MainWindow::openUrl(const QUrl &url) {
 		}
 	}
 
-	Database::fuzzyMatch(name, user, pw, host, port);
+	g.db->fuzzyMatch(name, user, pw, host, port);
 
 	if (user.isEmpty()) {
 		bool ok;
@@ -1168,7 +1168,7 @@ void MainWindow::on_qaSelfComment_triggered() {
 		return;
 
 	if (! p->qbaCommentHash.isEmpty() && p->qsComment.isEmpty()) {
-		p->qsComment = QString::fromUtf8(Database::blob(p->qbaCommentHash));
+		p->qsComment = QString::fromUtf8(g.db->blob(p->qbaCommentHash));
 		if (p->qsComment.isEmpty()) {
 			pmModel->uiSessionComment = ~(p->uiSession);
 			MumbleProto::RequestBlob mprb;
@@ -1195,7 +1195,7 @@ void MainWindow::on_qaSelfComment_triggered() {
 		g.sh->sendMessage(mpus);
 
 		if (! msg.isEmpty())
-			Database::setBlob(sha1(msg), msg.toUtf8());
+			g.db->setBlob(sha1(msg), msg.toUtf8());
 	}
 	delete texm;
 }
@@ -1583,7 +1583,7 @@ void MainWindow::on_qaUserLocalMute_triggered() {
 
 	p->setLocalMute(muted);
 	if (! p->qsHash.isEmpty())
-		Database::setLocalMuted(p->qsHash, muted);
+		g.db->setLocalMuted(p->qsHash, muted);
 }
 
 void MainWindow::on_qaUserLocalIgnore_triggered() {
@@ -1595,7 +1595,7 @@ void MainWindow::on_qaUserLocalIgnore_triggered() {
 
 	p->setLocalIgnore(ignored);
 	if (! p->qsHash.isEmpty())
-		Database::setLocalIgnored(p->qsHash, ignored);
+		g.db->setLocalIgnored(p->qsHash, ignored);
 }
 
 void MainWindow::on_qaUserLocalVolume_triggered() {
@@ -1671,7 +1671,7 @@ void MainWindow::on_qaUserFriendAdd_triggered() {
 	if (!p)
 		return;
 
-	Database::addFriend(p->qsName, p->qsHash);
+	g.db->addFriend(p->qsName, p->qsHash);
 	pmModel->setFriendName(p, p->qsName);
 }
 
@@ -1684,7 +1684,7 @@ void MainWindow::on_qaUserFriendRemove_triggered() {
 	if (!p)
 		return;
 
-	Database::removeFriend(p->qsHash);
+	g.db->removeFriend(p->qsHash);
 	pmModel->setFriendName(p, QString());
 }
 
@@ -1764,7 +1764,7 @@ void MainWindow::on_qaUserCommentView_triggered() {
 		return;
 
 	if (! p->qbaCommentHash.isEmpty() && p->qsComment.isEmpty()) {
-		p->qsComment = QString::fromUtf8(Database::blob(p->qbaCommentHash));
+		p->qsComment = QString::fromUtf8(g.db->blob(p->qbaCommentHash));
 		if (p->qsComment.isEmpty()) {
 			pmModel->uiSessionComment = ~(p->uiSession);
 			MumbleProto::RequestBlob mprb;
@@ -2058,7 +2058,7 @@ void MainWindow::on_qaChannelACL_triggered() {
 	int id = c->iId;
 
 	if (! c->qbaDescHash.isEmpty() && c->qsDesc.isEmpty()) {
-		c->qsDesc = QString::fromUtf8(Database::blob(c->qbaDescHash));
+		c->qsDesc = QString::fromUtf8(g.db->blob(c->qbaDescHash));
 		if (c->qsDesc.isEmpty()) {
 			MumbleProto::RequestBlob mprb;
 			mprb.add_channel_description(id);
@@ -2850,7 +2850,7 @@ void MainWindow::serverDisconnected(QAbstractSocket::SocketError err, QString re
 	QString uname, pw, host;
 	unsigned short port;
 	g.sh->getConnectionInfo(host, port, uname, pw);
-	if (Database::setShortcuts(g.sh->qbaDigest, g.s.qlShortcuts))
+	if (g.db->setShortcuts(g.sh->qbaDigest, g.s.qlShortcuts))
 		GlobalShortcutEngine::engine->bNeedRemap = true;
 
 	if (aclEdit) {
@@ -2907,7 +2907,7 @@ void MainWindow::serverDisconnected(QAbstractSocket::SocketError err, QString re
 			QString basereason;
 			QString actual_digest = QString::fromLatin1(c.digest(QCryptographicHash::Sha1).toHex());
 			QString digests_section = tr("<li>Server certificate digest (SHA-1):\t%1</li>").arg(ViewCert::prettifyDigest(actual_digest));
-			QString expected_digest = Database::getDigest(host, port);
+			QString expected_digest = g.db->getDigest(host, port);
 			if (! expected_digest.isNull()) {
 				basereason = tr("<b>WARNING:</b> The server presented a certificate that was different from the stored one.");
 				digests_section.append(tr("<li>Expected certificate digest (SHA-1):\t%1</li>").arg(ViewCert::prettifyDigest(expected_digest)));
@@ -2935,7 +2935,7 @@ void MainWindow::serverDisconnected(QAbstractSocket::SocketError err, QString re
 					vc.exec();
 					continue;
 				} else if (res == QMessageBox::Yes) {
-					Database::setDigest(host, port, QString::fromLatin1(c.digest(QCryptographicHash::Sha1).toHex()));
+					g.db->setDigest(host, port, QString::fromLatin1(c.digest(QCryptographicHash::Sha1).toHex()));
 					qaServerDisconnect->setEnabled(true);
 					on_Reconnect_timeout();
 				}
@@ -2991,7 +2991,7 @@ void MainWindow::serverDisconnected(QAbstractSocket::SocketError err, QString re
 		}
 		if (ok && matched) {
 			if (! g.s.bSuppressIdentity)
-				Database::setPassword(host, port, uname, pw);
+				g.db->setPassword(host, port, uname, pw);
 			qaServerDisconnect->setEnabled(true);
 			g.sh->setConnectionInfo(host, port, uname, pw);
 			on_Reconnect_timeout();

--- a/src/mumble/Messages.cpp
+++ b/src/mumble/Messages.cpp
@@ -121,7 +121,7 @@ void MainWindow::msgServerSync(const MumbleProto::ServerSync &msg) {
 
 	g.sh->getConnectionInfo(host, port, uname, pw);
 
-	QList<Shortcut> sc = Database::getShortcuts(g.sh->qbaDigest);
+	QList<Shortcut> sc = g.db->getShortcuts(g.sh->qbaDigest);
 	if (! sc.isEmpty()) {
 		for (int i=0;i<sc.count(); ++i) {
 			Shortcut &s = sc[i];
@@ -279,14 +279,14 @@ void MainWindow::msgUserState(const MumbleProto::UserState &msg) {
 
 	if (msg.has_hash()) {
 		pmModel->setHash(pDst, u8(msg.hash()));
-		const QString &name = Database::getFriend(pDst->qsHash);
+		const QString &name = g.db->getFriend(pDst->qsHash);
 		if (! name.isEmpty())
 			pmModel->setFriendName(pDst, name);
-		if (Database::isLocalMuted(pDst->qsHash))
+		if (g.db->isLocalMuted(pDst->qsHash))
 			pDst->setLocalMute(true);
-		if (Database::isLocalIgnored(pDst->qsHash))
+		if (g.db->isLocalIgnored(pDst->qsHash))
 			pDst->setLocalIgnore(true);
-		pDst->fLocalVolume = Database::getUserLocalVolume(pDst->qsHash);
+		pDst->fLocalVolume = g.db->getUserLocalVolume(pDst->qsHash);
 	}
 
 	if (bNewUser)
@@ -535,7 +535,7 @@ void MainWindow::msgUserState(const MumbleProto::UserState &msg) {
 			pDst->qbaTextureHash = QByteArray();
 		} else {
 			pDst->qbaTextureHash = sha1(pDst->qbaTexture);
-			Database::setBlob(pDst->qbaTextureHash, pDst->qbaTexture);
+			g.db->setBlob(pDst->qbaTextureHash, pDst->qbaTexture);
 		}
 		g.o->verifyTexture(pDst);
 	}
@@ -590,7 +590,7 @@ void MainWindow::msgChannelState(const MumbleProto::ChannelState &msg) {
 
 			ServerHandlerPtr sh = g.sh;
 			if (sh)
-				c->bFiltered = Database::isChannelFiltered(sh->qbaDigest, c->iId);
+				c->bFiltered = g.db->isChannelFiltered(sh->qbaDigest, c->iId);
 
 		} else {
 			qWarning("Server attempted state change on nonexistent channel");
@@ -667,7 +667,7 @@ void MainWindow::msgChannelRemove(const MumbleProto::ChannelRemove &msg) {
 		if (c->bFiltered) {
 			ServerHandlerPtr sh = g.sh;
 			if (sh)
-				Database::setChannelFiltered(sh->qbaDigest, c->iId, false);
+				g.db->setChannelFiltered(sh->qbaDigest, c->iId, false);
 			c->bFiltered = false;
 		}
 		pmModel->removeChannel(c);

--- a/src/mumble/Overlay.cpp
+++ b/src/mumble/Overlay.cpp
@@ -306,7 +306,7 @@ void Overlay::verifyTexture(ClientUser *cp, bool allowupdate) {
 	allowupdate = allowupdate && self && self->cChannel->isLinked(cp->cChannel);
 
 	if (allowupdate && ! cp->qbaTextureHash.isEmpty() && cp->qbaTexture.isEmpty())
-		cp->qbaTexture = Database::blob(cp->qbaTextureHash);
+		cp->qbaTexture = g.db->blob(cp->qbaTextureHash);
 
 	if (! cp->qbaTexture.isEmpty()) {
 		bool valid = true;
@@ -439,7 +439,7 @@ void Overlay::updateOverlay() {
 
 void Overlay::requestTexture(ClientUser *cu) {
 	if (cu->qbaTexture.isEmpty() && ! qsQueried.contains(cu->uiSession)) {
-		cu->qbaTexture=Database::blob(cu->qbaTextureHash);
+		cu->qbaTexture=g.db->blob(cu->qbaTextureHash);
 		if (cu->qbaTexture.isEmpty())
 			qsQuery.insert(cu->uiSession);
 		else

--- a/src/mumble/ServerHandler.cpp
+++ b/src/mumble/ServerHandler.cpp
@@ -67,7 +67,8 @@ static HANDLE loadQoS() {
 }
 #endif
 
-ServerHandler::ServerHandler() {
+ServerHandler::ServerHandler()
+    : database(new Database(QLatin1String("ServerHandler"))) {
 	cConnection.reset();
 	qusUdp = NULL;
 	bStrong = false;
@@ -443,7 +444,7 @@ void ServerHandler::setSslErrors(const QList<QSslError> &errors) {
 #endif
 
 	bStrong = false;
-	if ((qscCert.size() > 0)  && (QString::fromLatin1(qscCert.at(0).digest(QCryptographicHash::Sha1).toHex()) == Database::getDigest(qsHostName, usPort)))
+	if ((qscCert.size() > 0)  && (QString::fromLatin1(qscCert.at(0).digest(QCryptographicHash::Sha1).toHex()) == database->getDigest(qsHostName, usPort)))
 		connection->proceedAnyway();
 	else
 		qlErrors = newErrors;
@@ -558,14 +559,14 @@ void ServerHandler::message(unsigned int msgType, const QByteArray &qbaMsg) {
 					else
 						g.mw->msgBox(tr("UDP packets cannot be received from the server. Switching to TCP mode."));
 
-					Database::setUdp(qbaDigest, false);
+					database->setUdp(qbaDigest, false);
 				}
 			} else if (!bUdp && (cs.uiRemoteGood > 3) && (cs.uiGood > 3)) {
 				bUdp = true;
 				if (! NetworkConfig::TcpModeEnabled()) {
 					g.mw->msgBox(tr("UDP packets can be sent to and received from the server. Switching back to UDP mode."));
 
-					Database::setUdp(qbaDigest, true);
+					database->setUdp(qbaDigest, true);
 				}
 			}
 		}
@@ -649,7 +650,7 @@ void ServerHandler::serverConnectionConnected() {
 	if (! qscCert.isEmpty()) {
 		const QSslCertificate &qsc = qscCert.last();
 		qbaDigest = sha1(qsc.publicKey().toDer());
-		bUdp = Database::getUdp(qbaDigest);
+		bUdp = database->getUdp(qbaDigest);
 	} else {
 		// Shouldn't reach this
 		qCritical("Server must have a certificate. Dropping connection");
@@ -676,7 +677,7 @@ void ServerHandler::serverConnectionConnected() {
 	mpa.set_username(u8(qsUserName));
 	mpa.set_password(u8(qsPassword));
 
-	QStringList tokens = Database::getTokens(qbaDigest);
+	QStringList tokens = database->getTokens(qbaDigest);
 	foreach(const QString &qs, tokens)
 		mpa.add_tokens(u8(qs));
 
@@ -907,7 +908,7 @@ void ServerHandler::setUserTexture(unsigned int uiSession, const QByteArray &qba
 	sendMessage(mpus);
 
 	if (! texture.isEmpty()) {
-		Database::setBlob(sha1(texture), texture);
+		database->setBlob(sha1(texture), texture);
 	}
 }
 

--- a/src/mumble/ServerHandler.h
+++ b/src/mumble/ServerHandler.h
@@ -35,6 +35,7 @@
 #include "ServerAddress.h"
 
 class Connection;
+class Database;
 class Message;
 class PacketDataStream;
 class QUdpSocket;
@@ -55,6 +56,8 @@ class ServerHandler : public QThread {
 	private:
 		Q_OBJECT
 		Q_DISABLE_COPY(ServerHandler)
+
+		Database *database;
 	protected:
 		QString qsHostName;
 		QString qsUserName;

--- a/src/mumble/Tokens.cpp
+++ b/src/mumble/Tokens.cpp
@@ -15,7 +15,7 @@ Tokens::Tokens(QWidget *p) : QDialog(p) {
 	setupUi(this);
 
 	qbaDigest = g.sh->qbaDigest;
-	QStringList tokens = Database::getTokens(qbaDigest);
+	QStringList tokens = g.db->getTokens(qbaDigest);
 	tokens.sort();
 	foreach(const QString &qs, tokens) {
 		QListWidgetItem *qlwi = new QListWidgetItem(qs);
@@ -33,7 +33,7 @@ void Tokens::accept() {
 		if (! text.isEmpty())
 			qsl << text;
 	}
-	Database::setTokens(qbaDigest, qsl);
+	g.db->setTokens(qbaDigest, qsl);
 	g.sh->setTokens(qsl);
 	QDialog::accept();
 }

--- a/src/mumble/UserLocalVolumeDialog.cpp
+++ b/src/mumble/UserLocalVolumeDialog.cpp
@@ -93,7 +93,7 @@ void UserLocalVolumeDialog::on_qbbUserLocalVolume_clicked(QAbstractButton *butto
 	if (button == qbbUserLocalVolume->button(QDialogButtonBox::Ok)) {
 		ClientUser *user = ClientUser::get(m_clientSession);
 		if (user && !user->qsHash.isEmpty()) {
-			Database::setUserLocalVolume(user->qsHash, user->fLocalVolume);
+			g.db->setUserLocalVolume(user->qsHash, user->fLocalVolume);
 		}
 		UserLocalVolumeDialog::close();
 	}

--- a/src/mumble/UserModel.cpp
+++ b/src/mumble/UserModel.cpp
@@ -493,7 +493,7 @@ QVariant UserModel::otherRoles(const QModelIndex &idx, int role) const {
 							QString qsImage;
 							if (! p->qbaTextureHash.isEmpty()) {
 								if (p->qbaTexture.isEmpty()) {
-									p->qbaTexture = Database::blob(p->qbaTextureHash);
+									p->qbaTexture = g.db->blob(p->qbaTextureHash);
 									if (p->qbaTexture.isEmpty()) {
 										MumbleProto::RequestBlob mprb;
 										mprb.add_session_texture(p->uiSession);
@@ -527,7 +527,7 @@ QVariant UserModel::otherRoles(const QModelIndex &idx, int role) const {
 									return p->qsName;
 							} else {
 								if (p->qsComment.isEmpty()) {
-									p->qsComment = QString::fromUtf8(Database::blob(p->qbaCommentHash));
+									p->qsComment = QString::fromUtf8(g.db->blob(p->qbaCommentHash));
 									if (p->qsComment.isEmpty()) {
 										const_cast<UserModel *>(this)->uiSessionComment = p->uiSession;
 
@@ -548,7 +548,7 @@ QVariant UserModel::otherRoles(const QModelIndex &idx, int role) const {
 								return c->qsName;
 							} else {
 								if (c->qsDesc.isEmpty()) {
-									c->qsDesc = QString::fromUtf8(Database::blob(c->qbaDescHash));
+									c->qsDesc = QString::fromUtf8(g.db->blob(c->qbaDescHash));
 									if (c->qsDesc.isEmpty()) {
 										const_cast<UserModel *>(this)->iChannelDescription = c->iId;
 
@@ -975,7 +975,7 @@ void UserModel::setComment(ClientUser *cu, const QString &comment) {
 		cu->qsComment = comment;
 
 		if (! comment.isEmpty()) {
-			Database::setBlob(cu->qbaCommentHash, cu->qsComment.toUtf8());
+			g.db->setBlob(cu->qbaCommentHash, cu->qsComment.toUtf8());
 			if (cu->uiSession == uiSessionComment) {
 				uiSessionComment = 0;
 				item->bCommentSeen = false;
@@ -994,7 +994,7 @@ void UserModel::setComment(ClientUser *cu, const QString &comment) {
 					QTimer::singleShot(0, g.mw, SLOT(on_qaUserCommentView_triggered()));
 				}
 			} else {
-				item->bCommentSeen = Database::seenComment(item->hash(), cu->qbaCommentHash);
+				item->bCommentSeen = g.db->seenComment(item->hash(), cu->qbaCommentHash);
 				newstate = item->bCommentSeen ? 2 : 1;
 			}
 		} else {
@@ -1017,7 +1017,7 @@ void UserModel::setCommentHash(ClientUser *cu, const QByteArray &hash) {
 		cu->qsComment = QString();
 		cu->qbaCommentHash = hash;
 
-		item->bCommentSeen = Database::seenComment(item->hash(), cu->qbaCommentHash);
+		item->bCommentSeen = g.db->seenComment(item->hash(), cu->qbaCommentHash);
 		newstate = item->bCommentSeen ? 2 : 1;
 
 		if (oldstate != newstate) {
@@ -1038,7 +1038,7 @@ void UserModel::setComment(Channel *c, const QString &comment) {
 		c->qsDesc = comment;
 
 		if (! comment.isEmpty()) {
-			Database::setBlob(c->qbaDescHash, c->qsDesc.toUtf8());
+			g.db->setBlob(c->qbaDescHash, c->qsDesc.toUtf8());
 
 			if (c->iId == iChannelDescription) {
 				iChannelDescription = -1;
@@ -1050,7 +1050,7 @@ void UserModel::setComment(Channel *c, const QString &comment) {
 					QToolTip::showText(QCursor::pos(), data(index(c, 0), Qt::ToolTipRole).toString(), g.mw->qtvUsers);
 				}
 			} else {
-				item->bCommentSeen = Database::seenComment(item->hash(), c->qbaDescHash);
+				item->bCommentSeen = g.db->seenComment(item->hash(), c->qbaDescHash);
 				newstate = item->bCommentSeen ? 2 : 1;
 			}
 		} else {
@@ -1073,7 +1073,7 @@ void UserModel::setCommentHash(Channel *c, const QByteArray &hash) {
 		c->qsDesc = QString();
 		c->qbaDescHash = hash;
 
-		item->bCommentSeen = Database::seenComment(item->hash(), hash);
+		item->bCommentSeen = g.db->seenComment(item->hash(), hash);
 		newstate = item->bCommentSeen ? 2 : 1;
 
 		if (oldstate != newstate) {
@@ -1095,9 +1095,9 @@ void UserModel::seenComment(const QModelIndex &idx) {
 	emit dataChanged(idx, idx);
 
 	if (item->pUser)
-		Database::setSeenComment(item->hash(), item->pUser->qbaCommentHash);
+		g.db->setSeenComment(item->hash(), item->pUser->qbaCommentHash);
 	else
-		Database::setSeenComment(item->hash(), item->cChan->qbaDescHash);
+		g.db->setSeenComment(item->hash(), item->cChan->qbaDescHash);
 }
 
 void UserModel::renameChannel(Channel *c, const QString &name) {
@@ -1306,7 +1306,7 @@ void UserModel::toggleChannelFiltered(Channel *c) {
 		c->bFiltered = !c->bFiltered;
 
 		ServerHandlerPtr sh = g.sh;
-		Database::setChannelFiltered(sh->qbaDigest, c->iId, c->bFiltered);
+		g.db->setChannelFiltered(sh->qbaDigest, c->iId, c->bFiltered);
 		idx = index(c);
 	}
 

--- a/src/mumble/main.cpp
+++ b/src/mumble/main.cpp
@@ -413,7 +413,7 @@ int main(int argc, char **argv) {
 	g.l = new Log();
 
 	// Initialize database
-	g.db = new Database();
+	g.db = new Database(QLatin1String("main"));
 
 #ifdef USE_BONJOUR
 	// Initialize bonjour
@@ -555,7 +555,7 @@ int main(int argc, char **argv) {
 	ServerHandlerPtr sh = g.sh;
 	if (sh && sh->isRunning()) {
 		url = sh->getServerURL();
-		Database::setShortcuts(g.sh->qbaDigest, g.s.qlShortcuts);
+		g.db->setShortcuts(g.sh->qbaDigest, g.s.qlShortcuts);
 	}
 
 	Audio::stop();


### PR DESCRIPTION
Qt5 documents that QSqlDatabase must not be called from varying threads.
An instance must be limited to its thread.

In Mumble the Database class handles database access.
Up to now it contained static methods and always used the global default
database instance.
We instantiate the default database connection into the Global context.
It is mostly used from the main event loop, but also from a thread in
ServerHandler.
This is broken as per specification, and Qt 5.11 seems to finally enforce
that.

To resolve this issue, we promote Database to an instantiable class,
use the created Global context class instance from the event loop,
and a distinct Database instance (and connection) from the ServerHandler
instance (and thread).

---

This replaces PR #3419.

@davidebeatrici Please not the elaborate and complete commit message.

Compared to the other PR, this PR suggests to use two explicit Database instances [and connections]. They are named, which is useful if we ever were to debug issues or errors. Identifying db connections by an arbitrary number (thread address) is not really feasible/immediately useful.

Being explicit is in most cases better than being generic. We now know who uses the database, and in which [thread] context.

This change brings us closer to the desired state of no global state. Previously we had unspecific unnamed global state (default database as per Qt). Now we use an explicit global state/instance with our Global class. If we ever manage to drop Global, this diff is at least a move in that direction.

Please note that this does not compile locally for me, but due to an unrelated non-change (somehow dirty compile workspace?). I just want to bring this out here _now_. CI can prove/disprove if it builds, or I'll check in the coming days.

WDYT?