### PR TITLE
Create OpusCodec class, similar to CeltCodec, in order to load Opus' functions from a shared library

### DIFF
--- a/3rdparty/opus-build/opus-build.pro
+++ b/3rdparty/opus-build/opus-build.pro
@@ -45,19 +45,6 @@ win32 {
 }
 
 unix {
-  CONFIG += staticlib
-  CONFIG(sbcelt) {
-    # Before Opus 1.1 we used to be able to build Opus
-    # as C++ code to get C++ name mangling for free,
-    # allowing us to statically build both libcelt
-    # and libopus into the same binary while avoiding
-    # symbol clashes between the two libraries.
-    #
-    # Stock Opus 1.1 doesn't build in C++ mode, so error
-    # out for now.
-    error(Mumble cannot be built in SBCELT mode with Opus 1.1 - aborting build.)
-  }
-
   contains(QMAKE_CFLAGS, -ffast-math) {
     DEFINES += FLOAT_APPROX
   }

--- a/src/mumble/AudioInput.h
+++ b/src/mumble/AudioInput.h
@@ -23,6 +23,7 @@
 
 class AudioInput;
 class CELTCodec;
+class OpusCodec;
 struct CELTEncoder;
 struct OpusEncoder;
 typedef boost::shared_ptr<AudioInput> AudioInputPtr;
@@ -72,6 +73,7 @@ class AudioInput : public QThread {
 		inMixerFunc chooseMixer(const unsigned int nchan, SampleFormat sf, quint64 mask);
 		void resetAudioProcessor();
 
+		OpusCodec *oCodec;
 		OpusEncoder *opusState;
 		bool selectCodec();
 		

--- a/src/mumble/AudioOutputSpeech.h
+++ b/src/mumble/AudioOutputSpeech.h
@@ -18,6 +18,7 @@
 #include "Message.h"
 
 class CELTCodec;
+class OpusCodec;
 class ClientUser;
 struct OpusDecoder;
 
@@ -51,6 +52,7 @@ class AudioOutputSpeech : public AudioOutputUser {
 		CELTCodec *cCodec;
 		CELTDecoder *cdDecoder;
 
+		OpusCodec *oCodec;
 		OpusDecoder *opusState;
 
 		SpeexBits sbBits;

--- a/src/mumble/Global.h
+++ b/src/mumble/Global.h
@@ -29,6 +29,7 @@ class LCD;
 class BonjourClient;
 class OverlayClient;
 class CELTCodec;
+class OpusCodec;
 class LogEmitter;
 class DeveloperConsole;
 
@@ -74,6 +75,7 @@ public:
 	int iAudioBandwidth;
 	QDir qdBasePath;
 	QMap<int, CELTCodec *> qmCodecs;
+	OpusCodec *oCodec;
 	int iCodecAlpha, iCodecBeta;
 	bool bPreferAlpha;
 	bool bOpus;

--- a/src/mumble/MainWindow.cpp
+++ b/src/mumble/MainWindow.cpp
@@ -15,6 +15,7 @@
 #include "AudioWizard.h"
 #include "BanEditor.h"
 #include "CELTCodec.h"
+#include "OpusCodec.h"
 #include "Cert.h"
 #include "Channel.h"
 #include "Connection.h"

--- a/src/mumble/OpusCodec.cpp
+++ b/src/mumble/OpusCodec.cpp
@@ -1,0 +1,92 @@
+// Copyright 2005-2018 The Mumble Developers. All rights reserved.
+// Use of this source code is governed by a BSD-style license
+// that can be found in the LICENSE file at the root of the
+// Mumble source tree or at <https://www.mumble.info/LICENSE>.
+
+#include "mumble_pch.hpp"
+
+#include "OpusCodec.h"
+
+#include "Audio.h"
+#include "Version.h"
+#include "MumbleApplication.h"
+
+#ifdef Q_CC_GNU
+#define RESOLVE(var) { var = reinterpret_cast<__typeof__(var)>(qlOpus.resolve(#var)); bValid = bValid && (var != NULL); }
+#else
+#define RESOLVE(var) { * reinterpret_cast<void **>(&var) = static_cast<void *>(qlOpus.resolve(#var)); bValid = bValid && (var != NULL); }
+#endif
+
+OpusCodec::OpusCodec() {
+	bValid = false;
+	qlOpus.setLoadHints(QLibrary::ResolveAllSymbolsHint);
+
+	QStringList alternatives;
+#if defined(Q_OS_MAC)
+	alternatives << QString::fromLatin1("libopus0.dylib");
+	alternatives << QString::fromLatin1("opus0.dylib");
+	alternatives << QString::fromLatin1("libopus.dylib");
+	alternatives << QString::fromLatin1("opus.dylib");
+#elif defined(Q_OS_UNIX)
+	alternatives << QString::fromLatin1("libopus0.so");
+	alternatives << QString::fromLatin1("libopus.so");
+	alternatives << QString::fromLatin1("opus.so");
+#else
+	alternatives << QString::fromLatin1("opus0.dll");
+#endif
+	foreach(const QString &lib, alternatives) {
+		qlOpus.setFileName(MumbleApplication::instance()->applicationVersionRootPath() + QLatin1String("/") + lib);
+		if (qlOpus.load()) {
+			bValid = true;
+			break;
+		}
+
+#ifdef Q_OS_MAC
+		qlOpus.setFileName(QApplication::instance()->applicationDirPath() + QLatin1String("/../Codecs/") + lib);
+		if (qlOpus.load()) {
+			bValid = true;
+			break;
+		}
+#endif
+
+#ifdef PLUGIN_PATH
+		qlOpus.setFileName(QLatin1String(MUMTEXT(PLUGIN_PATH) "/") + lib);
+		if (qlOpus.load()) {
+			bValid = true;
+			break;
+		}
+#endif
+
+		qlOpus.setFileName(lib);
+		if (qlOpus.load()) {
+			bValid = true;
+			break;
+		}
+	}
+
+	RESOLVE(opus_get_version_string);
+
+	RESOLVE(opus_encode);
+	RESOLVE(opus_decode_float);
+
+	RESOLVE(opus_encoder_create);
+	RESOLVE(opus_encoder_ctl);
+	RESOLVE(opus_encoder_destroy);
+	RESOLVE(opus_decoder_create);
+	RESOLVE(opus_decoder_destroy);
+
+	RESOLVE(opus_packet_get_nb_frames);
+	RESOLVE(opus_packet_get_samples_per_frame);
+}
+
+OpusCodec::~OpusCodec() {
+	qlOpus.unload();
+}
+
+bool OpusCodec::isValid() const {
+	return bValid;
+}
+
+void OpusCodec::report() const {
+	qDebug("%s from %s", opus_get_version_string(), qPrintable(qlOpus.fileName()));
+}

--- a/src/mumble/OpusCodec.h
+++ b/src/mumble/OpusCodec.h
@@ -1,0 +1,46 @@
+// Copyright 2005-2018 The Mumble Developers. All rights reserved.
+// Use of this source code is governed by a BSD-style license
+// that can be found in the LICENSE file at the root of the
+// Mumble source tree or at <https://www.mumble.info/LICENSE>.
+
+#ifndef MUMBLE_MUMBLE_OPUSCODEC_H_
+#define MUMBLE_MUMBLE_OPUSCODEC_H_
+
+#include <opus.h>
+
+#include <QtCore/QLibrary>
+
+#ifndef Q_OS_WIN
+#define __cdecl
+#endif
+
+/// Loads Opus from a shared library and acts as a wrapper for its functions.
+class OpusCodec {
+	private:
+		Q_DISABLE_COPY(OpusCodec)
+	protected:
+		QLibrary qlOpus;
+		bool bValid;
+	public:
+		OpusCodec();
+		virtual ~OpusCodec();
+
+		bool isValid() const;
+		void report() const;
+
+		const char *(__cdecl *opus_get_version_string)();
+
+		OpusEncoder *(__cdecl *opus_encoder_create)(opus_int32 Fs, int channels, int application, int *error);
+		int (__cdecl *opus_encoder_ctl)(OpusEncoder *st, int request, ...);
+		void (__cdecl *opus_encoder_destroy)(OpusEncoder *st);
+		OpusDecoder *(__cdecl *opus_decoder_create)(opus_int32 Fs, int channels, int *error);
+		void (__cdecl *opus_decoder_destroy)(OpusDecoder *st);
+
+		int (__cdecl *opus_encode)(OpusEncoder *st, const opus_int16 *pcm, int frame_size, unsigned char *compressed, int nbCompressedBytes);
+		int (__cdecl *opus_decode_float)(OpusDecoder *st, const unsigned char *data, opus_int32 len, float *pcm, int frame_size, int decode_fec);
+
+		int (__cdecl *opus_packet_get_nb_frames)(const unsigned char packet[], opus_int32 len);
+		int (__cdecl *opus_packet_get_samples_per_frame)(const unsigned char *data, opus_int32 Fs);
+};
+
+#endif  // OPUSCODEC_H_

--- a/src/mumble/mumble.pro
+++ b/src/mumble/mumble.pro
@@ -360,7 +360,6 @@ unix:!CONFIG(bundled-opus):system(pkg-config --exists opus) {
   CONFIG(opus) {
     INCLUDEPATH *= ../../3rdparty/opus-src/celt ../../3rdparty/opus-src/include ../../3rdparty/opus-src/src ../../3rdparty/opus-build/src
     DEFINES *= USE_OPUS
-    LIBS *= -lopus
     unix {
       QMAKE_CFLAGS *= "-I../../3rdparty/opus-src/celt" "-isystem  ../../3rdparty/opus-src/celt"
       QMAKE_CFLAGS *= "-I../../3rdparty/opus-src/include" "-isystem ../../3rdparty/opus-src/include"

--- a/src/mumble/mumble.pro
+++ b/src/mumble/mumble.pro
@@ -86,6 +86,7 @@ HEADERS *= BanEditor.h \
     AudioOutputSpeech.h \
     AudioOutputUser.h \
     CELTCodec.h \
+    OpusCodec.h \
     CustomElements.h \
     MainWindow.h \
     ServerHandler.h \
@@ -156,6 +157,7 @@ SOURCES *= BanEditor.cpp \
     AudioOutputUser.cpp \
     main.cpp \
     CELTCodec.cpp \
+    OpusCodec.cpp \
     CustomElements.cpp \
     MainWindow.cpp \
     ServerHandler.cpp \


### PR DESCRIPTION
In the past we already encountered a problem where we couldn't link statically to both Opus and CELT at the same time, because there are multiple symbols (functions) shared across the two libraries, as Opus is the successor of CELT.

Initially this was solved by building Opus in C++ mode. which provides name mangling for the symbols, but since version 1.1 this isn't possible anymore:
https://github.com/mumble-voip/mumble/blob/c19ac8c0b0f934d2ff206858d7cb66352d6eb418/3rdparty/opus-build/opus-build.pro#L50-L57

We currently build Opus as static library and CELT as shared, loading it through the `CELTCodec` class.

#3427 adds support for RNNoise, an advanced noise suppression library, which has some functions shared with Opus, resulting in a linker error.

This pull request adds a new class called `OpusCodec`, similar to `CELTCodec`, in order to load Opus' functions from a shared library, so that we can link statically to RNNoise.