### PR TITLE
Settings: enable JACK auto-connect option by default

### DIFF
--- a/src/mumble/Settings.cpp
+++ b/src/mumble/Settings.cpp
@@ -317,7 +317,7 @@ Settings::Settings() {
 
 	qsJackAudioOutput = QLatin1String("1");
 	bJackStartServer = true;
-	bJackAutoConnect = false;
+	bJackAutoConnect = true;
 
 	bEcho = false;
 	bEchoMulti = true;


### PR DESCRIPTION
JACK should be ready to be used with little to no interaction required by the user, especially because the setting has to be changed by manually editing the configuration file.