### PR TITLE
OpusCodec: add "libopus.so.0" (Linux) and "opus.dll" (Windows) to the library names

### DIFF
--- a/src/mumble/OpusCodec.cpp
+++ b/src/mumble/OpusCodec.cpp
@@ -28,11 +28,13 @@ OpusCodec::OpusCodec() {
 	alternatives << QString::fromLatin1("libopus.dylib");
 	alternatives << QString::fromLatin1("opus.dylib");
 #elif defined(Q_OS_UNIX)
+	alternatives << QString::fromLatin1("libopus.so.0");
 	alternatives << QString::fromLatin1("libopus0.so");
 	alternatives << QString::fromLatin1("libopus.so");
 	alternatives << QString::fromLatin1("opus.so");
 #else
 	alternatives << QString::fromLatin1("opus0.dll");
+	alternatives << QString::fromLatin1("opus.dll");
 #endif
 	foreach(const QString &lib, alternatives) {
 		qlOpus.setFileName(MumbleApplication::instance()->applicationVersionRootPath() + QLatin1String("/") + lib);


### PR DESCRIPTION
The library is called `libopus.so.0` on Ubuntu and `opus.dll` on Windows.