### PR TITLE
installer: copy rnnoise.dll

### DIFF
--- a/installer/Files.wxs
+++ b/installer/Files.wxs
@@ -66,6 +66,12 @@
         </Component>
       <?endif ?>
 
+      <?ifdef RNN ?>
+        <Component Id="rnnoise.dll">
+          <File Source="$(var.SourceDir)\release\rnnoise.dll" KeyPath="yes" />
+        </Component>
+      <?endif ?>    
+          
       <?ifdef RedistDirVC14 ?>
       <Component Id="msvcp140.dll">
         <File Source="$(var.RedistDirVC14)\msvcp140.dll" KeyPath="yes" />

--- a/installer/Product.wxs
+++ b/installer/Product.wxs
@@ -131,6 +131,9 @@
       <?ifdef G15 ?>
         <ComponentRef Id="mumble_g15_helper.exe" />
       <?endif ?>
+      <?ifdef RNN ?>
+        <ComponentRef Id="rnnoise.dll" />
+      <?endif ?>
 
       <?ifdef RedistDirVC14 ?>
         <ComponentRef Id="msvcp140.dll" />

--- a/installer/Settings.wxi
+++ b/installer/Settings.wxi
@@ -129,6 +129,10 @@
   <?ifndef env.MumbleNoG15 ?>
     <?define G15 = true ?> 
   <?endif ?>
+  
+  <?ifndef env.MumbleNoRNNoise ?>
+    <?define RNN = true ?>
+  <?endif ?>
 
   <?ifdef env.MumbleVersionSubDir ?>
     <?define VersionSubDir = "$(env.MumbleVersionSubDir)" ?>


### PR DESCRIPTION
Fixes #3477.

The file copy can be disabled with the MumbleNoRNNoise environment variable.