### PR TITLE
JackAudio: change disconnect_ports() so that it uses stored ports instead of retrieving them using jack_get_ports()

### DIFF
--- a/src/mumble/JackAudio.cpp
+++ b/src/mumble/JackAudio.cpp
@@ -252,20 +252,21 @@ void JackAudioSystem::disconnect_ports() {
 		return;
 	}
 
-	const char **ports = jack_get_ports(client, 0, "audio", JackPortIsPhysical);
+	// Disconnect the input port
+	if (in_port != NULL) {
+		int err = jack_port_disconnect(client, in_port);
+		if (err != 0)  {
+			qWarning("JackAudioSystem: unable to disconnect in port - jack_port_disconnect() returned %i", err);
+		}
+	}
 
-	if (ports != NULL) {
-		int i = 0;
-		while (ports[i] != NULL) {
-			jack_port_t * const port = jack_port_by_name(client, ports[i]);
-			if (port == NULL)  {
-				qWarning("JackAudioSystem: jack_port_by_name() returned an invalid port - skipping it");
-				continue;
+	// Disconnect the output ports
+	for (unsigned int i = 0; i < iOutPorts; ++i) {
+		if (out_ports[i] != NULL) {
+			int err = jack_port_disconnect(client, out_ports[i]);
+			if (err != 0)  {
+				qWarning("JackAudioSystem: unable to disconnect out port - jack_port_disconnect() returned %i", err);
 			}
-
-			jack_port_disconnect(client, port);
-
-			++i;
 		}
 	}
 }


### PR DESCRIPTION
`jack_get_ports()` returns all the ports registered on the JACK server, unless a name pattern is specified, which means that Mumble disconnected ports registered by other clients.

This commit changes `disconnect_ports()` so that it disconnects the ports which are stored in our internal variables, making it faster.

Fixes #3489.