### PR TITLE
Prevent instability and crash due to message flood

### DIFF
--- a/src/murmur/ServerUser.cpp
+++ b/src/murmur/ServerUser.cpp
@@ -112,3 +112,61 @@ int BandwidthRecord::bandwidth() const {
 	return static_cast<int>((sum * 1000000ULL) / elapsed);
 }
 
+#if __cplusplus > 199711LL
+
+inline static
+time_point now() {
+	return std::chrono::steady_clock::now();
+}
+
+inline static
+unsigned long millisecondsBetween(time_point start, time_point end) {
+	return std::chrono::duration_cast<std::chrono::milliseconds>(end - start).count();
+}
+
+#else
+
+inline static
+time_point now() {
+	return clock();
+}
+
+inline static
+unsigned long millisecondsBetween(time_point start, time_point end) {
+	return 1000 * (end - start) / CLOCKS_PER_SEC;
+}
+
+#endif
+
+// Rate limiting: burst up to 30, 4 message per sec limit over longer time
+LeakyBucket::LeakyBucket() : tokensPerSec(4), maxTokens(30), currentTokens(0) {
+	lastUpdate = now();
+}
+
+bool LeakyBucket::ratelimit(int tokens) {
+	// First remove tokens we leaked over time
+	time_point tnow = now();
+	long ms = millisecondsBetween(lastUpdate, tnow);
+
+	long drainTokens = (ms * tokensPerSec) / 1000;
+
+	// Prevent constant starvation due to too many updates
+	if (drainTokens > 0) {
+		this->lastUpdate = tnow;
+
+		this->currentTokens -= drainTokens;
+		if (this->currentTokens < 0) {
+			this->currentTokens = 0;
+		}
+	}
+
+	// Then try to add tokens
+	bool limit = this->currentTokens > ((static_cast<long>(maxTokens)) - tokens);
+
+	// If the bucket is not overflowed, allow message and add tokens
+	if (!limit) {
+		this->currentTokens += tokens;
+	}
+
+	return limit;
+}


### PR DESCRIPTION
This patch adds a rate limiting to selected patches. The underlying rate limiter
used is the Leaky-Bucket algorithm. It allows for a burst of messages, but
limits them after a specified amount of messages within a time frame.
If the ratelimit hits the messages are simply ignored.

For now its set to a burst of 30 allowed messages and a subsequent limit of 4 messages per second, which seems to do the trick without inconveniencing normal users.

It should to some extend prevent the recent issues with bots decribed in #3505.

What was tested with the patch:

- Joining (works)
- Talking with UDP and TCP mode (works)
- Switching channels (works)
- Bringing down the server with a bot, tested with two different bots (does not work)

I'm thanking the Zom.bi community for testing and @Natenom for some insight into the problem.

I'm open to any suggestions.