### PR TITLE
Lower bucket params

### DIFF
--- a/src/murmur/ServerUser.cpp
+++ b/src/murmur/ServerUser.cpp
@@ -138,8 +138,8 @@ unsigned long millisecondsBetween(time_point start, time_point end) {
 
 #endif
 
-// Rate limiting: burst up to 30, 4 message per sec limit over longer time
-LeakyBucket::LeakyBucket() : tokensPerSec(4), maxTokens(30), currentTokens(0) {
+// Rate limiting: burst up to 5, 1 message per sec limit over longer time
+LeakyBucket::LeakyBucket() : tokensPerSec(1), maxTokens(5), currentTokens(0) {
 	lastUpdate = now();
 }
 


### PR DESCRIPTION
I guess I was too generous with the bucket parameters. My bad.

After some more testing this evening a "1 message per second, 5 messages burst" limit is still sufficient enough to not _annoy_ people under normal circumstances.