### PR TITLE
Make Rate limiter configurable

### DIFF
--- a/scripts/murmur.ini
+++ b/scripts/murmur.ini
@@ -136,6 +136,18 @@ bandwidth=72000
 ; Maximum number of concurrent clients allowed.
 users=100
 
+; Per-user rate limiting
+;
+; These two settings allow to configure the per-user rate limiter for some
+; command messages sent from the client to the server. The messageburst setting
+; specifies an amount of messages which are allowed in short bursts. The
+; messagelimit setting specifies the number of messages per second allowed over
+; a longer period. If a user hits the rate limit, his packages are then ignored
+; for some time. Both of these settings have a minimum of 1 as setting either to
+; 0 could render the server unusable.
+messageburst=5
+messagelimit=1
+
 ; Respond to UDP ping packets.
 ;
 ; Setting to true exposes the current user count, the maximum user count, and

--- a/src/murmur/Meta.cpp
+++ b/src/murmur/Meta.cpp
@@ -74,6 +74,9 @@ MetaParams::MetaParams() {
 	qrUserName = QRegExp(QLatin1String("[-=\\w\\[\\]\\{\\}\\(\\)\\@\\|\\.]+"));
 	qrChannelName = QRegExp(QLatin1String("[ \\-=\\w\\#\\[\\]\\{\\}\\(\\)\\@\\|]+"));
 
+	iMessageLimit = 1;
+	iMessageBurst = 5;
+
 	qsCiphers = MumbleSSL::defaultOpenSSLCipherString();
 
 	qsSettings = NULL;
@@ -368,6 +371,9 @@ void MetaParams::read(QString fname) {
 
 	qrUserName = QRegExp(typeCheckedFromSettings("username", qrUserName.pattern()));
 	qrChannelName = QRegExp(typeCheckedFromSettings("channelname", qrChannelName.pattern()));
+
+	iMessageLimit = typeCheckedFromSettings("messagelimit", 1);
+	iMessageBurst = typeCheckedFromSettings("messageburst", 5);
 
 	bool bObfuscate = typeCheckedFromSettings("obfuscate", false);
 	if (bObfuscate) {

--- a/src/murmur/Meta.h
+++ b/src/murmur/Meta.h
@@ -94,6 +94,9 @@ public:
 	QRegExp qrUserName;
 	QRegExp qrChannelName;
 
+	unsigned int iMessageLimit;
+	unsigned int iMessageBurst;
+
 	QSslCertificate qscCert;
 	QSslKey qskKey;
 

--- a/src/murmur/Server.cpp
+++ b/src/murmur/Server.cpp
@@ -392,6 +392,8 @@ void Server::readParams() {
 	bForceExternalAuth = Meta::mp.bForceExternalAuth;
 	qrUserName = Meta::mp.qrUserName;
 	qrChannelName = Meta::mp.qrChannelName;
+	iMessageLimit = Meta::mp.iMessageLimit;
+	iMessageBurst = Meta::mp.iMessageBurst;
 	qvSuggestVersion = Meta::mp.qvSuggestVersion;
 	qvSuggestPositional = Meta::mp.qvSuggestPositional;
 	qvSuggestPushToTalk = Meta::mp.qvSuggestPushToTalk;
@@ -468,6 +470,15 @@ void Server::readParams() {
 
 	qrUserName=QRegExp(getConf("username", qrUserName.pattern()).toString());
 	qrChannelName=QRegExp(getConf("channelname", qrChannelName.pattern()).toString());
+
+	iMessageLimit=getConf("messagelimit", iMessageLimit).toUInt();
+	if (iMessageLimit < 1) { // Prevent disabling messages entirely
+		iMessageLimit = 1;
+	}
+	iMessageBurst=getConf("messageburst", iMessageBurst).toUInt();
+	if (iMessageBurst < 1) { // Prevent disabling messages entirely
+		iMessageBurst = 1;
+	}
 }
 
 void Server::setLiveConf(const QString &key, const QString &value) {
@@ -586,6 +597,17 @@ void Server::setLiveConf(const QString &key, const QString &value) {
 		iChannelNestingLimit = (i >= 0 && !v.isNull()) ? i : Meta::mp.iChannelNestingLimit;
 	else if (key == "channelcountlimit")
 		iChannelCountLimit = (i >= 0 && !v.isNull()) ? i : Meta::mp.iChannelCountLimit;
+	else if (key == "messagelimit") {
+		iMessageLimit = (!v.isNull()) ? v.toUInt() : Meta::mp.iMessageLimit;
+		if (iMessageLimit < 1) {
+			iMessageLimit = 1;
+		}
+	} else if (key == "messageburst") {
+		iMessageBurst = (!v.isNull()) ? v.toUInt() : Meta::mp.iMessageBurst;
+		if (iMessageBurst < 1) {
+			iMessageBurst = 1;
+		}
+	}
 }
 
 #ifdef USE_BONJOUR

--- a/src/murmur/Server.h
+++ b/src/murmur/Server.h
@@ -128,6 +128,9 @@ class Server : public QThread {
 		QRegExp qrUserName;
 		QRegExp qrChannelName;
 
+		unsigned int iMessageLimit;
+		unsigned int iMessageBurst;
+
 		QVariant qvSuggestVersion;
 		QVariant qvSuggestPositional;
 		QVariant qvSuggestPushToTalk;

--- a/src/murmur/ServerUser.cpp
+++ b/src/murmur/ServerUser.cpp
@@ -9,7 +9,7 @@
 #include "ServerUser.h"
 #include "Meta.h"
 
-ServerUser::ServerUser(Server *p, QSslSocket *socket) : Connection(p, socket), User(), s(NULL) {
+ServerUser::ServerUser(Server *p, QSslSocket *socket) : Connection(p, socket), User(), s(NULL), leakyBucket(p->iMessageLimit, p->iMessageBurst) {
 	sState = ServerUser::Connected;
 	sUdpSocket = INVALID_SOCKET;
 
@@ -139,7 +139,7 @@ unsigned long millisecondsBetween(time_point start, time_point end) {
 #endif
 
 // Rate limiting: burst up to 5, 1 message per sec limit over longer time
-LeakyBucket::LeakyBucket() : tokensPerSec(1), maxTokens(5), currentTokens(0) {
+LeakyBucket::LeakyBucket(unsigned int tokensPerSec, unsigned int maxTokens) : tokensPerSec(tokensPerSec), maxTokens(maxTokens), currentTokens(0) {
 	lastUpdate = now();
 }
 

--- a/src/murmur/ServerUser.h
+++ b/src/murmur/ServerUser.h
@@ -79,7 +79,7 @@ class LeakyBucket {
 		// Returns true if packets should be dropped
 		bool ratelimit(int tokens);
 
-		LeakyBucket();
+		LeakyBucket(unsigned int tokensPerSec, unsigned int maxTokens);
 };
 
 class ServerUser : public Connection, public User {


### PR DESCRIPTION
This makes the previously added rate limiter configurable. The change adds messagelimit and messageburst to the configuration file murmur.ini, the ServerDB as well as the ability to set these live. Because setting either of these to a value of 0 would render the Server unusable, both have a minimum of 1. The defaults are kept as before with a messagelimit of 1 and a messageburst of 5.

Though adjusting these live is entirely possible on the serverside, they currently only take effect for new connections. If they should take effect immediately for all present connections, I could add some more changes that allow that if you want.

I tested this change by printing either value on a new connection, as well as rapidly muting and unmuting myself with a messagelimit of 100 and a burstlimit of 500, without being able to get into any rate limit. Also setting either value to 0 in the murmur.ini, showed the expected 1 message per second with a maximum burst of 1 message. However this obviously felt very restricting, so I don't recommend it. :stuck_out_tongue: 

Please review the changes and tell me if I forgot something or made a mistake according to the coding style. Alternatively you can edit the change yourself if you prefer.