### PR TITLE
AudioInput: Use celt 0.11 API for VBR bitrates

### DIFF
--- a/src/mumble/AudioInput.cpp
+++ b/src/mumble/AudioInput.cpp
@@ -771,7 +771,12 @@ int AudioInput::encodeCELTFrame(short *psSource, EncodingOutputBuffer& buffer) {
 
 	cCodec->celt_encoder_ctl(ceEncoder, CELT_SET_PREDICTION(0));
 
+#ifdef CELT_SET_VBR_RATE
 	cCodec->celt_encoder_ctl(ceEncoder, CELT_SET_VBR_RATE(iAudioQuality));
+#else
+	cCodec->celt_encoder_ctl(ceEncoder, CELT_SET_BITRATE(iAudioQuality));
+	cCodec->celt_encoder_ctl(ceEncoder, CELT_SET_VBR(1));
+#endif
 	len = cCodec->encode(ceEncoder, psSource, &buffer[0], qMin<int>(iAudioQuality / (8 * 100), static_cast<int>(buffer.size())));
 	iBitrate = len * 100 * 8;
 


### PR DESCRIPTION
This commit allows packagers to unbundle celt from the distribution and use the system-wide celt. It's tested against celt-0.11 but probably works with celt-0.7 also. I've used ifdef's to guard for both cases.

Closes: https://github.com/mumble-voip/mumble/issues/3519
Signed-off-by: Kai Krakow <kai@kaishome.de>