### PR TITLE
Disable hiding when system tray not present

### DIFF
--- a/src/mumble/MainWindow.cpp
+++ b/src/mumble/MainWindow.cpp
@@ -1246,7 +1246,8 @@ void MainWindow::on_qmServer_aboutToShow() {
 	// Don't add qaHide on macOS.
 	// There is no way to bring the window back (no 'tray' for Mumble on macOS),
 	// and the system has built-in hide functionality via Cmd-H.
-	qmServer->addAction(qaHide);
+	if (qstiIcon->isSystemTrayAvailable())
+		qmServer->addAction(qaHide);
 #endif
 	qmServer->addAction(qaQuit);
 

--- a/src/mumble/Settings.cpp
+++ b/src/mumble/Settings.cpp
@@ -295,7 +295,7 @@ Settings::Settings() {
 	bHideInTray = (winVer < QSysInfo::WV_WINDOWS7);
 #else
 	const bool isUnityDesktop = QProcessEnvironment::systemEnvironment().value(QLatin1String("XDG_CURRENT_DESKTOP")) == QLatin1String("Unity");
-	bHideInTray = !isUnityDesktop;
+	bHideInTray = !isUnityDesktop && QSystemTrayIcon::isSystemTrayAvailable();
 #endif
 	bStateInTray = true;
 	bUsage = true;


### PR DESCRIPTION
In environments where the system tray is not present (in my case, a tiling window manager on GNU/Linux) the application can still be hidden which causes it to become totally invisible and inaccessible while still running. This patch fixes that, by hiding the "Hide Mumble" menu item as well as making the application exit on window close when the system tray is not available.