### PR TITLE
Don't drop indices on MySQL

### DIFF
--- a/src/murmur/ServerDB.cpp
+++ b/src/murmur/ServerDB.cpp
@@ -439,31 +439,6 @@ ServerDB::ServerDB() {
 					if (key.first.startsWith(Meta::mp.qsDBPrefix))
 						ServerDB::exec(query, QString::fromLatin1("ALTER TABLE `%1` DROP FOREIGN KEY `%2`").arg(key.first).arg(key.second), true);
 				}
-
-
-				SQLPREP("SELECT TABLE_NAME, CONSTRAINT_NAME FROM INFORMATION_SCHEMA.TABLE_CONSTRAINTS WHERE TABLE_SCHEMA=? AND CONSTRAINT_TYPE='UNIQUE'");
-				query.addBindValue(Meta::mp.qsDatabase);
-				SQLEXEC();
-				while (query.next())
-					qlIndexes << qsp(query.value(0).toString(), query.value(1).toString());
-
-				foreach(const qsp &key, qlIndexes) {
-					if (key.first.startsWith(Meta::mp.qsDBPrefix))
-						ServerDB::exec(query, QString::fromLatin1("ALTER TABLE `%1` DROP INDEX `%2`").arg(key.first).arg(key.second), true);
-				}
-
-				qlIndexes.clear();
-
-				SQLPREP("SELECT DISTINCT TABLE_NAME, INDEX_NAME FROM INFORMATION_SCHEMA.STATISTICS WHERE TABLE_SCHEMA=? AND INDEX_NAME != 'PRIMARY';");
-				query.addBindValue(Meta::mp.qsDatabase);
-				SQLEXEC();
-				while (query.next())
-					qlIndexes << qsp(query.value(0).toString(), query.value(1).toString());
-
-				foreach(const qsp &key, qlIndexes) {
-					if (key.first.startsWith(Meta::mp.qsDBPrefix))
-						ServerDB::exec(query, QString::fromLatin1("ALTER TABLE `%1` DROP INDEX `%2`").arg(key.first).arg(key.second), true);
-				}
 			}
 			SQLDO("CREATE TABLE `%1servers`(`server_id` INTEGER PRIMARY KEY AUTO_INCREMENT) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_bin");
 


### PR DESCRIPTION
This is a bad idea since it tries to delete primary key indices, which fails on modern MySQL/MariaDB versions thus breaking the upgrade process in the middle. The only way to recover is to rename all tables back to their original names, pull out this code and let it upgrade again. Also it seems pointless to me since all tables and thus their indices are getting destroyed afterwards anyways.