### PR TITLE
Fix build on FreeBSD

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,9 +7,10 @@ asio/
 local/
 indent.sh
 *.pdb
-*.sln
 *.sdf
+*.sln
 *.suo
+*.swp
 *.aps
 *.vcxproj
 *.vcxproj.*

--- a/src/SSL.cpp
+++ b/src/SSL.cpp
@@ -29,8 +29,7 @@ void MumbleSSL::initialize() {
 	// If we detect that no locking callback is configured, we
 	// have to set it up ourselves to allow multi-threaded use
 	// of OpenSSL.
-	void *lockcb = reinterpret_cast<void *>(CRYPTO_get_locking_callback());
-	if (lockcb == NULL) {
+	if (CRYPTO_get_locking_callback() == NULL) {
 		SSLLocks::initialize();
 	}
 }


### PR DESCRIPTION
../SSL.cpp:32:17: error: reinterpret_cast from 'nullptr_t' to 'void *' is not allowed\

when compiled with clang version 6.0.1 (tags/RELEASE_601/final 335540) (based on LLVM 6.0.1)

While here, update gitignore with vim swp files.