### PR TITLE
FEAT: Improve OSInfo so that architecture and OS are properly reported

### DIFF
--- a/src/OSInfo.h
+++ b/src/OSInfo.h
@@ -1,4 +1,4 @@
-// Copyright 2005-2020 The Mumble Developers. All rights reserved.
+// Copyright 2005-2021 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.
@@ -15,10 +15,30 @@ class QHostAddress;
 
 class OSInfo {
 public:
+	/// If \p build is false, returns the operating system architecture.
+	/// If \p build is true, returns the build architecture.
+	static QString getArchitecture(const bool build);
+
+	/// Returns an hash generated from the primary network interface's MAC address.
 	static QString getMacHash(const QList< QHostAddress > & = QList< QHostAddress >());
+
+	/// Returns the operating system's basename.
+	/// Examples: "Windows", "Linux", "macOS", "FreeBSD", "Unknown", etc.
 	static QString getOS();
+
+	/// Returns the complete operating system version.
+	///
+	/// Examples:
+	/// "Windows 10 Enterprise 2009 19042.804 [x64]"
+	/// "Debian GNU/Linux bullseye/sid [x64]"
+	///
+	/// The architecture is not explicitly added when \p appendArch is false.
+	static QString getOSDisplayableVersion(const bool appendArch = true);
+
+	/// Returns the operating system's version.
+	/// Examples: "10.0.19042.1", "10.16.0 20C69"
 	static QString getOSVersion();
-	static QString getOSDisplayableVersion();
+
 	static void fillXml(QDomDocument &doc, QDomElement &root, const QString &os = OSInfo::getOS(),
 						const QString &osver          = OSInfo::getOSVersion(),
 						const QList< QHostAddress > & = QList< QHostAddress >());


### PR DESCRIPTION
Fixes #3554.

As `/etc/os-release` is considered the standard on Linux distributions which make use of `systemd`, we should try to read the version from that file prior to using other methods (currently `lsb_release` and `uname()`).