### PR TITLE
OverlaySettings: disable overlay by default

### DIFF
--- a/src/mumble/Settings.cpp
+++ b/src/mumble/Settings.cpp
@@ -95,7 +95,7 @@ const QString Settings::cqsDefaultPushClickOn = QLatin1String(":/on.ogg");
 const QString Settings::cqsDefaultPushClickOff = QLatin1String(":/off.ogg");
 
 OverlaySettings::OverlaySettings() {
-	bEnable = true;
+	bEnable = false;
 
 	fX = 1.0f;
 	fY = 0.0f;


### PR DESCRIPTION
Requested in #3515.

When a game process is detected, the overlay is injected into it.

If a user doesn't like the overlay and starts Mumble for the first time, he's forced to disable it and then restart the game to make it disappear.