### PR TITLE
Add Azure Pipelines for continuous integration (Windows)

### DIFF
--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -1,0 +1,22 @@
+jobs:
+  - job: Windows
+    strategy:
+      matrix:
+        MSVC_2015:
+          MUMBLE_QT: qt5
+          MUMBLE_HOST: x86_64-pc-windows-msvc
+        MSVC_2015_NO_PCH:
+          MUMBLE_QT: qt5
+          MUMBLE_HOST: x86_64-pc-windows-msvc
+          MUMBLE_NO_PCH: 1
+    steps:
+    - script: git submodule --quiet update --init --recursive
+      displayName: 'Fetch submodules'
+    - powershell: |
+        Set-ExecutionPolicy Bypass -Scope Process -Force; iex ((New-Object System.Net.WebClient).DownloadString('https://chocolatey.org/install.ps1'))
+        choco install 7zip.install -y
+      displayName: 'Install 7-Zip via Chocolatey'
+    - powershell: scripts/azure-pipelines/install-environment.ps1
+      displayName: 'Install build environment'
+    - powershell: scripts/azure-pipelines/build.ps1
+      displayName: 'Build'

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 Mumble - A voice chat utility for gamers
 =======================================
 
+[![Build Status](https://dev.azure.com/Mumble-VoIP/Mumble/_apis/build/status/Mumble-CI?branchName=master)](https://dev.azure.com/Mumble-VoIP/Mumble/_build/latest?definitionId=1?branchName=master)
+
 > *http://mumble.info/*  
 > *#mumble on freenode*
 

--- a/scripts/azure-pipelines/build.ps1
+++ b/scripts/azure-pipelines/build.ps1
@@ -1,0 +1,60 @@
+﻿# Builds Mumble using the specified build script.
+# The path to the script is relative to the build environment's root.
+# The configuration we build with is adjusted to be close to
+# our release builds.
+#
+# Below is a list of configuration variables used from environment.
+#
+# Predefined variables:
+#
+#  AGENT_BUILDDIRECTORY       - Predefined variable.
+#                               The local path on the agent where all folders
+#                               for a given build pipeline are created
+#                               (e.g. "D:\a\1")
+#  BUILD_SOURCESDIRECTORY     - Predefined variable.
+#                               The local path on the agent where the
+#                               repository is downloaded.
+#                               (e.g. "D:\a\1\s")
+#
+# Defined in the visual designer on Azure Pipelines:
+#
+#  MUMBLE_ENVIRONMENT_DIR     - The local path where the build environment
+#                               is stored (e.g. "C:\MumbleBuild").
+#  MUMBLE_ENVIRONMENT_VERSION - Full build environment version
+#                               (e.g. win64-static-no-ltcg-1.3.x-2017-02-02-ec94ddb-790).
+#                               Must match .7z and extracted folder name.
+#  MUMBLE_BUILDSCRIPT         - Path to required build script cmd file. Relative to build
+#                               environment's "mumble-releng\buildscripts" path.
+#                               (e.g. "1.3.x/buildenv-win64-static.cmd")
+#
+# Defined in the YAML configuration:
+#
+#  MUMBLE_NO_PCH              - Indicates whether the build should not use PCH.
+#
+
+$MUMBLE_BUILD_DIR = $env:AGENT_BUILDDIRECTORY
+$MUMBLE_SOURCE_DIR = $env:BUILD_SOURCESDIRECTORY
+$MUMBLE_BUILDENV_DIR = Join-Path $env:MUMBLE_ENVIRONMENT_DIR $env:MUMBLE_ENVIRONMENT_VERSION
+$MUMBLE_BUILDSCRIPT = Join-Path $MUMBLE_BUILDENV_DIR "mumble-releng\buildscripts\$env:MUMBLE_BUILDSCRIPT"
+
+$env:MUMBLE_EXTRA_QMAKE_CONFIG_FLAGS = ""
+
+# We do not sign the Azure Pipelines CI builds, so we must disable
+# uiaccess elevation. Also no intermediary signing is wanted.
+$env:MUMBLE_EXTRA_QMAKE_CONFIG_FLAGS = $env:MUMBLE_EXTRA_QMAKE_CONFIG_FLAGS + " no-elevation"
+
+# If "MUMBLE_NO_PCH" is enabled, pass "no-pch".
+if ($env:MUMBLE_NO_PCH -eq 1) {
+	$env:MUMBLE_EXTRA_QMAKE_CONFIG_FLAGS = $env:MUMBLE_EXTRA_QMAKE_CONFIG_FLAGS + " no-pch"
+}
+
+# Use jom to take advantage of the multiple cores we get on the builder.
+$env:MUMBLE_NMAKE = "jom"
+$env:MUMBLE_SKIP_COLLECT_SYMBOLS = "1"
+$env:MUMBLE_SKIP_INTERNAL_SIGNING = "1"
+$env:MUMBLE_BUILDENV_DIR = $MUMBLE_BUILDENV_DIR
+
+Get-ChildItem -Path $MUMBLE_BUILD_DIR
+
+& $MUMBLE_BUILDSCRIPT
+exit $lastexitcode

--- a/scripts/azure-pipelines/install-environment.ps1
+++ b/scripts/azure-pipelines/install-environment.ps1
@@ -1,0 +1,38 @@
+# Ensures we have downloaded and extracted a build environment
+# into our Azure Pipelines VM before we attempt to build. If the
+# environment archive is already present, this script will just extract it.
+#
+# Configuration variables (defined in the visual designer on Azure Pipelines) used from environment:
+#
+#  MUMBLE_ENVIRONMENT_DIR     - The local path where the build environment
+#                               will be stored (e.g. "C:\MumbleBuild").
+#  MUMBLE_ENVIRONMENT_SOURCE  - Build environment web source folder URL
+#                               (e.g. https://somehost/folder).
+#  MUMBLE_ENVIRONMENT_VERSION - Full build environment version
+#                               (e.g. win64-static-no-ltcg-1.3.x-2017-02-02-ec94ddb-790).
+#                               Must match .7z and extracted folder name.
+#
+
+$MUMBLE_ENVIRONMENT_VERSION = $env:MUMBLE_ENVIRONMENT_VERSION
+$MUMBLE_ENVIRONMENT_SOURCE = $env:MUMBLE_ENVIRONMENT_SOURCE
+$MUMBLE_ENVIRONMENT_DIR = $env:MUMBLE_ENVIRONMENT_DIR
+$MUMBLE_ENVIRONMENT_STORE = Join-Path $MUMBLE_ENVIRONMENT_DIR "\cache"
+
+if (-Not (Test-Path $MUMBLE_ENVIRONMENT_STORE)) {
+    New-Item $MUMBLE_ENVIRONMENT_STORE -ItemType Directory | Out-Null
+ }
+
+$env_7z = Join-Path $MUMBLE_ENVIRONMENT_STORE "$MUMBLE_ENVIRONMENT_VERSION.7z";
+
+if (-Not (Test-Path $env_7z)) {
+    Write-Host "Environment not cached. Downloading..."
+    $env_url = "$MUMBLE_ENVIRONMENT_SOURCE/$MUMBLE_ENVIRONMENT_VERSION.7z"
+    Invoke-WebRequest -Uri $env_url -OutFile $env_7z
+}
+
+if (-Not (Test-Path (Join-Path $MUMBLE_ENVIRONMENT_DIR $MUMBLE_ENVIRONMENT_VERSION))) {
+    Write-Host "Extracting build environment to $MUMBLE_ENVIRONMENT_DIR..."
+    & C:\ProgramData\chocolatey\bin\7z.exe x $env_7z -o"$MUMBLE_ENVIRONMENT_DIR"
+}
+
+Get-ChildItem -Path $MUMBLE_ENVIRONMENT_DIR


### PR DESCRIPTION
Azure Pipelines offers many advantages over AppVeyor, with the biggest one being a maximum of 10 parallel builds for open-source projects, drastically reducing the builds completion time.

A pipeline takes about the same time to build on the two CI infrastructures, however the caching feature is currently only available on AppVeyor, meaning that on Azure Pipelines the compressed environment is downloaded for each build consuming about 10 minutes.

This means that we'll save at least 10 minutes per pipeline compared to AppVeyor once the feature is added to Azure Pipelines: https://github.com/Microsoft/azure-pipelines-tasks/issues/9190