### PR TITLE
ConnectDialog: create "Unknown" continent, never expand it automatically

### DIFF
--- a/src/mumble/mumble_en.ts
+++ b/src/mumble/mumble_en.ts
@@ -3100,7 +3100,7 @@ Are you sure you wish to replace your certificate?
 <context>
     <name>ConnectDialog</name>
     <message>
-        <location filename="ConnectDialog.cpp" line="+1134"/>
+        <location filename="ConnectDialog.cpp" line="+1142"/>
         <source>Connecting to %1</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3188,8 +3188,13 @@ Are you sure you wish to replace your certificate?
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location line="+740"/>
+        <source>Unknown</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="ConnectDialog.ui"/>
-        <location filename="ConnectDialog.cpp" line="-505"/>
+        <location filename="ConnectDialog.cpp" line="-1245"/>
         <source>Users</source>
         <translation type="unfinished"></translation>
     </message>
@@ -8048,7 +8053,7 @@ To upgrade these files to their latest versions, click the button below.</source
 <context>
     <name>ServerView</name>
     <message>
-        <location filename="ConnectDialog.cpp" line="-753"/>
+        <location filename="ConnectDialog.cpp" line="-761"/>
         <source>Favorite</source>
         <translation type="unfinished"></translation>
     </message>
@@ -8064,6 +8069,11 @@ To upgrade these files to their latest versions, click the button below.</source
     </message>
     <message>
         <location line="+7"/>
+        <source>Unknown</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+2"/>
         <source>Africa</source>
         <translation type="unfinished"></translation>
     </message>


### PR DESCRIPTION
1. There are currently two servers appearing in a non-existent continent and country because their public IP addresses are part of two blocks assigned recently which are not in our GeoIP database.

This commit adds a new continent called "Unknown" without countries, which replaces the "ghost" continent and category.

2. If the user's public IP address was not in our GeoIP database, the "Unknown" continent and country categories were expanded because the strings resulted empty.

This commit adds a check to make sure that those categories are never expanded automatically.

---

Before:
![mumble_connectdialog_unknown_continent_previous](https://user-images.githubusercontent.com/5897523/51287581-778fb000-19f8-11e9-8cbb-2c7d33e510a0.png)

After:
![mumble_connectdialog_unknown_continent](https://user-images.githubusercontent.com/5897523/51287586-7eb6be00-19f8-11e9-9016-78490e91e4af.png)