### PR TITLE
Murmur: fix Denial of Service vulnerability in msgChannelState()

### DIFF
--- a/src/murmur/Messages.cpp
+++ b/src/murmur/Messages.cpp
@@ -1062,6 +1062,13 @@ void Server::msgChannelState(ServerUser *uSource, MumbleProto::ChannelState &msg
 			}
 		}
 
+		if (msg.has_max_users()) {
+			if (! hasPermission(uSource, c, ChanACL::Write)) {
+				PERM_DENIED(uSource, c, ChanACL::Write);
+				return;
+			}
+		}
+
 		// All permission checks done -- the update is good.
 
 		if (p) {


### PR DESCRIPTION
Fixes #3585.

---

The vulnerability was kindly reported by the [zom.bi](https://zom.bi) community, who also provided a patch, which is applied in this commit.

Thank you very much for your support!