### PR TITLE
Global: fix migrateDataDir() not migrating the data directory

### DIFF
--- a/src/mumble/Global.cpp
+++ b/src/mumble/Global.cpp
@@ -48,7 +48,6 @@ static void migrateDataDir() {
 
 	if (!QFile::exists(newdir) && QFile::exists(olddir)) {
 		QDir d;
-		d.mkpath(newdir + QLatin1String("/.."));
 		if (d.rename(olddir, newdir)) {
 			qWarning("Migrated application data directory from '%s' to '%s'",
 			         qPrintable(olddir), qPrintable(newdir));


### PR DESCRIPTION
Fixes #1702.

---

`rename()` was failing because it doesn't expect the new directory to exist.

From Qt's documentation (http://doc.qt.io/qt-5/qdir.html#rename):
> On most file systems, rename() fails only if _oldName_ does not exist, or if a file with the new name already exists.