### PR TITLE
Fix Duplicate Certificates In Chain Viewer

### DIFF
--- a/src/mumble/ViewCert.cpp
+++ b/src/mumble/ViewCert.cpp
@@ -65,8 +65,18 @@ ViewCert::ViewCert(QList<QSslCertificate> cl, QWidget *p) : QDialog(p) {
 	qlwChain = new QListWidget(qcbChain);
 	qlwChain->setObjectName(QLatin1String("Chain"));
 
-	foreach(QSslCertificate c, qlCerts)
-		qlwChain->addItem(certificateFriendlyName(c));
+	// load certs into a set as a hacky fix to #2141
+#if QT_VERSION >= 0x050400
+	QSet<QSslCertificate> qlCertSet;
+#else
+	QList<QSslCertificate> qlCertSet;
+#endif
+	foreach(QSslCertificate c, qlCerts) {
+		if(!qlCertSet.contains(c)) {
+			qlwChain->addItem(certificateFriendlyName(c));
+			qlCertSet << c;
+		}
+	}
 	h->addWidget(qlwChain);
 
 	qcbDetails=new QGroupBox(tr("Certificate details"), this);


### PR DESCRIPTION
This PR prevents duplicate certificates from appearing in the certificate chain viewer. The fix uses a rather cautious approach (some may call it hacky) to address this issue as to avoid fiddling with the necessary "certificate chain shuffling" workaround cited in #2141 