### PR TITLE
AudioWizard: fix speech sample path

### DIFF
--- a/src/mumble/AudioWizard.cpp
+++ b/src/mumble/AudioWizard.cpp
@@ -358,7 +358,7 @@ void AudioWizard::playChord() {
 	AudioOutputPtr ao = g.ao;
 	if (! ao || aosSource || bInit)
 		return;
-	aosSource = ao->playSample(QLatin1String("skin:wb_male.oga"), true);
+	aosSource = ao->playSample(QLatin1String(":/wb_male.oga"), true);
 }
 
 void AudioWizard::restartAudio() {


### PR DESCRIPTION
The sample is not part of the "skin" namespace since #3475.

https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=921268