### PR TITLE
mumble: change title of windows which have the default one ("Form")

### DIFF
--- a/src/mumble/ASIOInput.ui
+++ b/src/mumble/ASIOInput.ui
@@ -11,7 +11,7 @@
    </rect>
   </property>
   <property name="windowTitle">
-   <string>Form</string>
+   <string>ASIO</string>
   </property>
   <layout class="QVBoxLayout">
    <item>

--- a/src/mumble/AudioInput.ui
+++ b/src/mumble/AudioInput.ui
@@ -11,7 +11,7 @@
    </rect>
   </property>
   <property name="windowTitle">
-   <string>Form</string>
+   <string>Audio input</string>
   </property>
   <layout class="QVBoxLayout">
    <item>

--- a/src/mumble/AudioOutput.ui
+++ b/src/mumble/AudioOutput.ui
@@ -11,7 +11,7 @@
    </rect>
   </property>
   <property name="windowTitle">
-   <string>Form</string>
+   <string>Audio output</string>
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
    <item>

--- a/src/mumble/LCD.ui
+++ b/src/mumble/LCD.ui
@@ -11,7 +11,7 @@
    </rect>
   </property>
   <property name="windowTitle">
-   <string>Form</string>
+   <string>LCD</string>
   </property>
   <layout class="QVBoxLayout" name="verticalLayout_2">
    <item>

--- a/src/mumble/Plugins.ui
+++ b/src/mumble/Plugins.ui
@@ -11,7 +11,7 @@
    </rect>
   </property>
   <property name="windowTitle">
-   <string>Form</string>
+   <string>Plugins</string>
   </property>
   <layout class="QVBoxLayout">
    <item>


### PR DESCRIPTION
Those windows are "integrated" into the Settings window and thus their title is not shown, but the strings appear in the translation files because they are marked as translatable.

Thanks to @deluxghost for reporting the issue.