### PR TITLE
Default disable GKey

### DIFF
--- a/src/mumble/Settings.cpp
+++ b/src/mumble/Settings.cpp
@@ -404,7 +404,7 @@ Settings::Settings() {
 	bSuppressMacEventTapWarning = false;
 	bEnableEvdev = false;
 	bEnableXInput2 = true;
-	bEnableGKey = true;
+	bEnableGKey = false;
 	bEnableXboxInput = true;
 	bEnableWinHooks = true;
 	bDirectInputVerboseLogging = false;


### PR DESCRIPTION
We see a lot of crashes due to our GKey integration. Until we can
diagnose the underlying issue leaving GKey enabled by default is
not acceptable for the upcoming release.