### PR TITLE
travis-ci: switch to Xenial for Qt 5 builds, improve matrix, update MXE mirror

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,37 +1,29 @@
 sudo: required # Required for apt-get build-dep
-dist: trusty
 language: cpp
 compiler: gcc
 
-os:
-  - linux
-  - osx
-
-env:
-  - MUMBLE_QT=qt4 MUMBLE_HOST=x86_64-linux-gnu
-  - MUMBLE_QT=qt4 MUMBLE_HOST=x86_64-linux-gnu MUMBLE_NO_PCH=1
-  - MUMBLE_QT=qt5 MUMBLE_HOST=x86_64-linux-gnu
-  - MUMBLE_QT=qt5 MUMBLE_HOST=x86_64-linux-gnu MUMBLE_NO_PCH=1
-  - MUMBLE_QT=qt5 MUMBLE_HOST=i686-w64-mingw32
-  - MUMBLE_QT=qt5 MUMBLE_HOST=x86_64-w64-mingw32
-  - MUMBLE_QT=qt5 MUMBLE_HOST=x86_64-apple-darwin
-
 matrix:
-  exclude:
+  include:
     - os: linux
-      env: MUMBLE_QT=qt5 MUMBLE_HOST=x86_64-apple-darwin
-    - os: osx
+      dist: trusty
       env: MUMBLE_QT=qt4 MUMBLE_HOST=x86_64-linux-gnu
-    - os: osx
+    - os: linux
+      dist: trusty
       env: MUMBLE_QT=qt4 MUMBLE_HOST=x86_64-linux-gnu MUMBLE_NO_PCH=1
-    - os: osx
+    - os: linux
+      dist: xenial
       env: MUMBLE_QT=qt5 MUMBLE_HOST=x86_64-linux-gnu
-    - os: osx
+    - os: linux
+      dist: xenial
       env: MUMBLE_QT=qt5 MUMBLE_HOST=x86_64-linux-gnu MUMBLE_NO_PCH=1
-    - os: osx
+    - os: linux
+      dist: xenial
       env: MUMBLE_QT=qt5 MUMBLE_HOST=i686-w64-mingw32
-    - os: osx
+    - os: linux
+      dist: xenial
       env: MUMBLE_QT=qt5 MUMBLE_HOST=x86_64-w64-mingw32
+    - os: osx
+      env: MUMBLE_QT=qt5 MUMBLE_HOST=x86_64-apple-darwin
 
 before_install:
     - ./scripts/travis-ci/before_install.bash

--- a/scripts/travis-ci/before_install.bash
+++ b/scripts/travis-ci/before_install.bash
@@ -27,8 +27,8 @@ if [ "${TRAVIS_OS_NAME}" == "linux" ]; then
 	elif [ "${MUMBLE_QT}" == "qt5" ] && [ "${MUMBLE_HOST}" == "i686-w64-mingw32" ]; then
 		sudo dpkg --add-architecture i386
 		sudo apt-get -qq update
-		echo "deb https://dl.mumble.info/mirror/pkg.mxe.cc/repos/apt/debian jessie main" | sudo tee /etc/apt/sources.list.d/mxeapt.list
-		sudo apt-key adv --keyserver x-hkp://keys.gnupg.net --recv-keys D43A795B73B16ABE9643FE1AFD8FFF16DB45C6AB
+		echo "deb https://dl.mumble.info/mirror/mirror.mxe.cc/repos/apt xenial main" | sudo tee /etc/apt/sources.list.d/mxe.list
+		sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 86B72ED9
 		sudo apt-get -qq update
 		sudo apt-get install \
 			wine \
@@ -46,8 +46,8 @@ if [ "${TRAVIS_OS_NAME}" == "linux" ]; then
 	elif [ "${MUMBLE_QT}" == "qt5" ] && [ "${MUMBLE_HOST}" == "x86_64-w64-mingw32" ]; then
 		sudo dpkg --add-architecture i386
 		sudo apt-get -qq update
-		echo "deb https://dl.mumble.info/mirror/pkg.mxe.cc/repos/apt/debian jessie main" | sudo tee /etc/apt/sources.list.d/mxeapt.list
-		sudo apt-key adv --keyserver x-hkp://keys.gnupg.net --recv-keys D43A795B73B16ABE9643FE1AFD8FFF16DB45C6AB
+		echo "deb https://dl.mumble.info/mirror/mirror.mxe.cc/repos/apt xenial main" | sudo tee /etc/apt/sources.list.d/mxe.list
+		sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 86B72ED9
 		sudo apt-get -qq update
 		sudo apt-get install \
 			wine \

--- a/scripts/travis-ci/script.bash
+++ b/scripts/travis-ci/script.bash
@@ -23,7 +23,7 @@ if [ "${TRAVIS_OS_NAME}" == "linux" ]; then
 		unzip ../asiosdk2.3.zip -d ../
 		mv ../ASIOSDK2.3 3rdparty/asio
 		PATH=$PATH:/usr/lib/mxe/usr/bin
-		export MUMBLE_PROTOC=/usr/lib/mxe/usr/x86_64-unknown-linux-gnu/bin/protoc
+		export MUMBLE_PROTOC=/usr/lib/mxe/usr/x86_64-pc-linux-gnu/bin/protoc
 		EXTRA_CONFIG=
 		if [ "${MUMBLE_NO_PCH}" == "1" ]; then
 			EXTRA_CONFIG="no-pch ${EXTRA_CONFIG}"
@@ -36,7 +36,7 @@ if [ "${TRAVIS_OS_NAME}" == "linux" ]; then
 		unzip ../asiosdk2.3.zip -d ../
 		mv ../ASIOSDK2.3 3rdparty/asio
 		PATH=$PATH:/usr/lib/mxe/usr/bin
-		export MUMBLE_PROTOC=/usr/lib/mxe/usr/x86_64-unknown-linux-gnu/bin/protoc
+		export MUMBLE_PROTOC=/usr/lib/mxe/usr/x86_64-pc-linux-gnu/bin/protoc
 		EXTRA_CONFIG=
 		if [ "${MUMBLE_NO_PCH}" == "1" ]; then
 			EXTRA_CONFIG="no-pch ${EXTRA_CONFIG}"


### PR DESCRIPTION
Ubuntu Xenial is available on Travis CI since November: https://blog.travis-ci.com/2018-11-08-xenial-release

Regarding MXE's APT repository: mxe/mxe/issues/2253