### PR TITLE
Include "Global.h" after "Mumble.pb.h", to avoid a redefinition issue with protobuf 3.7

### DIFF
--- a/src/mumble/ACLEditor.cpp
+++ b/src/mumble/ACLEditor.cpp
@@ -11,10 +11,12 @@
 #include "Channel.h"
 #include "ClientUser.h"
 #include "Database.h"
-#include "Global.h"
 #include "Log.h"
 #include "ServerHandler.h"
 #include "User.h"
+
+// We define a global macro called 'g'. This can lead to issues when included code uses 'g' as a type or parameter name (like protobuf 3.7 does). As such, for now, we have to make this our last include.
+#include "Global.h"
 
 ACLGroup::ACLGroup(const QString &name) : Group(NULL, name) {
 	bInherited = false;

--- a/src/mumble/About.cpp
+++ b/src/mumble/About.cpp
@@ -7,9 +7,11 @@
 
 #include "About.h"
 
-#include "Global.h"
 #include "MainWindow.h"
 #include "License.h"
+
+// We define a global macro called 'g'. This can lead to issues when included code uses 'g' as a type or parameter name (like protobuf 3.7 does). As such, for now, we have to make this our last include.
+#include "Global.h"
 
 AboutDialog::AboutDialog(QWidget *p) : QDialog(p) {
 	setWindowTitle(tr("About Mumble"));

--- a/src/mumble/AudioOutput.cpp
+++ b/src/mumble/AudioOutput.cpp
@@ -11,13 +11,15 @@
 #include "AudioOutputSample.h"
 #include "AudioOutputSpeech.h"
 #include "User.h"
-#include "Global.h"
 #include "Message.h"
 #include "Plugins.h"
 #include "PacketDataStream.h"
 #include "ServerHandler.h"
 #include "Timer.h"
 #include "VoiceRecorder.h"
+
+// We define a global macro called 'g'. This can lead to issues when included code uses 'g' as a type or parameter name (like protobuf 3.7 does). As such, for now, we have to make this our last include.
+#include "Global.h"
 
 // Remember that we cannot use static member classes that are not pointers, as the constructor
 // for AudioOutputRegistrar() might be called before they are initialized, as the constructor

--- a/src/mumble/AudioWizard.cpp
+++ b/src/mumble/AudioWizard.cpp
@@ -9,9 +9,11 @@
 
 #include "AudioInput.h"
 #include "AudioOutputSample.h"
-#include "Global.h"
 #include "Log.h"
 #include "MainWindow.h"
+
+// We define a global macro called 'g'. This can lead to issues when included code uses 'g' as a type or parameter name (like protobuf 3.7 does). As such, for now, we have to make this our last include.
+#include "Global.h"
 
 CompletablePage::CompletablePage(QWizard *p) : QWizardPage(p) {
 	bComplete = true;

--- a/src/mumble/BanEditor.cpp
+++ b/src/mumble/BanEditor.cpp
@@ -8,9 +8,11 @@
 #include "BanEditor.h"
 
 #include "Channel.h"
-#include "Global.h"
 #include "Ban.h"
 #include "ServerHandler.h"
+
+// We define a global macro called 'g'. This can lead to issues when included code uses 'g' as a type or parameter name (like protobuf 3.7 does). As such, for now, we have to make this our last include.
+#include "Global.h"
 
 BanEditor::BanEditor(const MumbleProto::BanList &msg, QWidget *p) : QDialog(p)
 	, maskDefaultValue(32) {

--- a/src/mumble/ConnectDialog.cpp
+++ b/src/mumble/ConnectDialog.cpp
@@ -15,10 +15,12 @@
 
 #include "Channel.h"
 #include "Database.h"
-#include "Global.h"
 #include "ServerHandler.h"
 #include "WebFetch.h"
 #include "ServerResolver.h"
+
+// We define a global macro called 'g'. This can lead to issues when included code uses 'g' as a type or parameter name (like protobuf 3.7 does). As such, for now, we have to make this our last include.
+#include "Global.h"
 
 QMap<QString, QIcon> ServerItem::qmIcons;
 QList<PublicInfo> ConnectDialog::qlPublicServers;

--- a/src/mumble/CustomElements.cpp
+++ b/src/mumble/CustomElements.cpp
@@ -8,10 +8,11 @@
 #include "CustomElements.h"
 
 #include "ClientUser.h"
-#include "Global.h"
 #include "MainWindow.h"
 #include "Log.h"
 
+// We define a global macro called 'g'. This can lead to issues when included code uses 'g' as a type or parameter name (like protobuf 3.7 does). As such, for now, we have to make this our last include.
+#include "Global.h"
 
 LogTextBrowser::LogTextBrowser(QWidget *p) : QTextBrowser(p) {}
 

--- a/src/mumble/DBus.cpp
+++ b/src/mumble/DBus.cpp
@@ -9,10 +9,11 @@
 
 #include "Channel.h"
 #include "ClientUser.h"
-#include "Global.h"
 #include "MainWindow.h"
 #include "ServerHandler.h"
 
+// We define a global macro called 'g'. This can lead to issues when included code uses 'g' as a type or parameter name (like protobuf 3.7 does). As such, for now, we have to make this our last include.
+#include "Global.h"
 
 MumbleDBus::MumbleDBus(QObject *mw) : QDBusAbstractAdaptor(mw) {
 }

--- a/src/mumble/GlobalShortcut.cpp
+++ b/src/mumble/GlobalShortcut.cpp
@@ -11,8 +11,10 @@
 #include "ClientUser.h"
 #include "Channel.h"
 #include "Database.h"
-#include "Global.h"
 #include "MainWindow.h"
+
+// We define a global macro called 'g'. This can lead to issues when included code uses 'g' as a type or parameter name (like protobuf 3.7 does). As such, for now, we have to make this our last include.
+#include "Global.h"
 
 /**
  * Used to save the global, unique, platform specific GlobalShortcutEngine.

--- a/src/mumble/LCD.cpp
+++ b/src/mumble/LCD.cpp
@@ -9,9 +9,11 @@
 
 #include "ClientUser.h"
 #include "Channel.h"
-#include "Global.h"
 #include "Message.h"
 #include "ServerHandler.h"
+
+// We define a global macro called 'g'. This can lead to issues when included code uses 'g' as a type or parameter name (like protobuf 3.7 does). As such, for now, we have to make this our last include.
+#include "Global.h"
 
 QList<LCDEngineNew> *LCDEngineRegistrar::qlInitializers;
 

--- a/src/mumble/Log.cpp
+++ b/src/mumble/Log.cpp
@@ -10,12 +10,14 @@
 #include "AudioOutput.h"
 #include "AudioOutputSample.h"
 #include "Channel.h"
-#include "Global.h"
 #include "MainWindow.h"
 #include "NetworkConfig.h"
 #include "RichTextEditor.h"
 #include "ServerHandler.h"
 #include "TextToSpeech.h"
+
+// We define a global macro called 'g'. This can lead to issues when included code uses 'g' as a type or parameter name (like protobuf 3.7 does). As such, for now, we have to make this our last include.
+#include "Global.h"
 
 static ConfigWidget *LogConfigDialogNew(Settings &st) {
 	return new LogConfig(st);

--- a/src/mumble/Log_unix.cpp
+++ b/src/mumble/Log_unix.cpp
@@ -6,9 +6,11 @@
 #include "mumble_pch.hpp"
 
 #include "Log.h"
-#include "Global.h"
 #include "MainWindow.h"
 #include "Settings.h"
+
+// We define a global macro called 'g'. This can lead to issues when included code uses 'g' as a type or parameter name (like protobuf 3.7 does). As such, for now, we have to make this our last include.
+#include "Global.h"
 
 void Log::postNotification(MsgType mt, const QString &plain) {
 	// Message notification with balloon tooltips

--- a/src/mumble/LookConfig.cpp
+++ b/src/mumble/LookConfig.cpp
@@ -10,8 +10,10 @@
 
 #include "AudioInput.h"
 #include "AudioOutput.h"
-#include "Global.h"
 #include "MainWindow.h"
+
+// We define a global macro called 'g'. This can lead to issues when included code uses 'g' as a type or parameter name (like protobuf 3.7 does). As such, for now, we have to make this our last include.
+#include "Global.h"
 
 static ConfigWidget *LookConfigNew(Settings &st) {
 	return new LookConfig(st);

--- a/src/mumble/MainWindow.cpp
+++ b/src/mumble/MainWindow.cpp
@@ -22,7 +22,6 @@
 #include "ConnectDialog.h"
 #include "Database.h"
 #include "DeveloperConsole.h"
-#include "Global.h"
 #include "GlobalShortcut.h"
 #include "Log.h"
 #include "Net.h"
@@ -55,6 +54,9 @@
 #ifdef Q_OS_MAC
 #include "AppNap.h"
 #endif
+
+// We define a global macro called 'g'. This can lead to issues when included code uses 'g' as a type or parameter name (like protobuf 3.7 does). As such, for now, we have to make this our last include.
+#include "Global.h"
 
 MessageBoxEvent::MessageBoxEvent(QString m) : QEvent(static_cast<QEvent::Type>(MB_QEVENT)) {
 	msg = m;

--- a/src/mumble/Messages.cpp
+++ b/src/mumble/Messages.cpp
@@ -15,7 +15,6 @@
 #include "Connection.h"
 #include "ConnectDialog.h"
 #include "Database.h"
-#include "Global.h"
 #include "GlobalShortcut.h"
 #include "Log.h"
 #include "MainWindow.h"
@@ -29,6 +28,9 @@
 #include "VersionCheck.h"
 #include "ViewCert.h"
 #include "CryptState.h"
+
+// We define a global macro called 'g'. This can lead to issues when included code uses 'g' as a type or parameter name (like protobuf 3.7 does). As such, for now, we have to make this our last include.
+#include "Global.h"
 
 #define ACTOR_INIT \
 	ClientUser *pSrc=NULL; \

--- a/src/mumble/NetworkConfig.cpp
+++ b/src/mumble/NetworkConfig.cpp
@@ -7,9 +7,11 @@
 
 #include "NetworkConfig.h"
 
-#include "Global.h"
 #include "MainWindow.h"
 #include "OSInfo.h"
+
+// We define a global macro called 'g'. This can lead to issues when included code uses 'g' as a type or parameter name (like protobuf 3.7 does). As such, for now, we have to make this our last include.
+#include "Global.h"
 
 static ConfigWidget *NetworkConfigNew(Settings &st) {
 	return new NetworkConfig(st);

--- a/src/mumble/OSS.cpp
+++ b/src/mumble/OSS.cpp
@@ -13,8 +13,10 @@
 #include <sys/ioctl.h>
 
 #include "User.h"
-#include "Global.h"
 #include "MainWindow.h"
+
+// We define a global macro called 'g'. This can lead to issues when included code uses 'g' as a type or parameter name (like protobuf 3.7 does). As such, for now, we have to make this our last include.
+#include "Global.h"
 
 #define NBLOCKS 8
 

--- a/src/mumble/Overlay.cpp
+++ b/src/mumble/Overlay.cpp
@@ -11,7 +11,6 @@
 #include "Channel.h"
 #include "ClientUser.h"
 #include "Database.h"
-#include "Global.h"
 #include "GlobalShortcut.h"
 #include "MainWindow.h"
 #include "Message.h"
@@ -20,6 +19,9 @@
 #include "ServerHandler.h"
 #include "User.h"
 #include "WebFetch.h"
+
+// We define a global macro called 'g'. This can lead to issues when included code uses 'g' as a type or parameter name (like protobuf 3.7 does). As such, for now, we have to make this our last include.
+#include "Global.h"
 
 QString OverlayAppInfo::applicationIdentifierForPath(const QString &path) {
 #ifdef Q_OS_MAC

--- a/src/mumble/OverlayClient.cpp
+++ b/src/mumble/OverlayClient.cpp
@@ -11,7 +11,6 @@
 #include "OverlayText.h"
 #include "User.h"
 #include "Channel.h"
-#include "Global.h"
 #include "Message.h"
 #include "Database.h"
 #include "NetworkConfig.h"
@@ -19,6 +18,9 @@
 #include "MainWindow.h"
 #include "GlobalShortcut.h"
 #include "Themes.h"
+
+// We define a global macro called 'g'. This can lead to issues when included code uses 'g' as a type or parameter name (like protobuf 3.7 does). As such, for now, we have to make this our last include.
+#include "Global.h"
 
 OverlayClient::OverlayClient(QLocalSocket *socket, QObject *p)
 	: QObject(p)

--- a/src/mumble/OverlayConfig.cpp
+++ b/src/mumble/OverlayConfig.cpp
@@ -13,7 +13,6 @@
 #include "OverlayText.h"
 #include "User.h"
 #include "Channel.h"
-#include "Global.h"
 #include "Message.h"
 #include "Database.h"
 #include "NetworkConfig.h"
@@ -21,6 +20,9 @@
 #include "MainWindow.h"
 #include "GlobalShortcut.h"
 #include "PathListWidget.h"
+
+// We define a global macro called 'g'. This can lead to issues when included code uses 'g' as a type or parameter name (like protobuf 3.7 does). As such, for now, we have to make this our last include.
+#include "Global.h"
 
 #ifdef Q_OS_WIN
 #include "../../overlay/overlay_launchers.h"

--- a/src/mumble/OverlayEditor.cpp
+++ b/src/mumble/OverlayEditor.cpp
@@ -11,13 +11,15 @@
 #include "OverlayText.h"
 #include "User.h"
 #include "Channel.h"
-#include "Global.h"
 #include "Message.h"
 #include "Database.h"
 #include "NetworkConfig.h"
 #include "ServerHandler.h"
 #include "MainWindow.h"
 #include "GlobalShortcut.h"
+
+// We define a global macro called 'g'. This can lead to issues when included code uses 'g' as a type or parameter name (like protobuf 3.7 does). As such, for now, we have to make this our last include.
+#include "Global.h"
 
 OverlayEditor::OverlayEditor(QWidget *p, QGraphicsItem *qgi, OverlaySettings *osptr) :
 		QDialog(p),

--- a/src/mumble/OverlayEditorScene.cpp
+++ b/src/mumble/OverlayEditorScene.cpp
@@ -12,13 +12,15 @@
 #include "OverlayText.h"
 #include "User.h"
 #include "Channel.h"
-#include "Global.h"
 #include "Message.h"
 #include "Database.h"
 #include "NetworkConfig.h"
 #include "ServerHandler.h"
 #include "MainWindow.h"
 #include "GlobalShortcut.h"
+
+// We define a global macro called 'g'. This can lead to issues when included code uses 'g' as a type or parameter name (like protobuf 3.7 does). As such, for now, we have to make this our last include.
+#include "Global.h"
 
 OverlayEditorScene::OverlayEditorScene(const OverlaySettings &srcos, QObject *p) : QGraphicsScene(p), os(srcos) {
 	tsColor = Settings::Talking;

--- a/src/mumble/OverlayUser.cpp
+++ b/src/mumble/OverlayUser.cpp
@@ -11,13 +11,15 @@
 #include "User.h"
 #include "Channel.h"
 #include "ClientUser.h"
-#include "Global.h"
 #include "Message.h"
 #include "Database.h"
 #include "NetworkConfig.h"
 #include "ServerHandler.h"
 #include "MainWindow.h"
 #include "GlobalShortcut.h"
+
+// We define a global macro called 'g'. This can lead to issues when included code uses 'g' as a type or parameter name (like protobuf 3.7 does). As such, for now, we have to make this our last include.
+#include "Global.h"
 
 OverlayUser::OverlayUser(ClientUser *cu, unsigned int height, OverlaySettings *osptr) : OverlayGroup(), os(osptr), uiSize(height), cuUser(cu), tsColor(Settings::Passive) {
 	setup();

--- a/src/mumble/OverlayUserGroup.cpp
+++ b/src/mumble/OverlayUserGroup.cpp
@@ -14,13 +14,15 @@
 #include "User.h"
 #include "Channel.h"
 #include "ClientUser.h"
-#include "Global.h"
 #include "Message.h"
 #include "Database.h"
 #include "NetworkConfig.h"
 #include "ServerHandler.h"
 #include "MainWindow.h"
 #include "GlobalShortcut.h"
+
+// We define a global macro called 'g'. This can lead to issues when included code uses 'g' as a type or parameter name (like protobuf 3.7 does). As such, for now, we have to make this our last include.
+#include "Global.h"
 
 template <typename T>
 QRectF OverlayGroup::boundingRect() const {

--- a/src/mumble/Overlay_macx.mm
+++ b/src/mumble/Overlay_macx.mm
@@ -9,8 +9,10 @@
 #include <Carbon/Carbon.h>
 #include "OverlayConfig.h"
 #include "OverlayClient.h"
-#include "Global.h"
 #include "MainWindow.h"
+
+// We define a global macro called 'g'. This can lead to issues when included code uses 'g' as a type or parameter name (like protobuf 3.7 does). As such, for now, we have to make this our last include.
+#include "Global.h"
 
 extern "C" {
 #include <xar/xar.h>

--- a/src/mumble/Plugins.cpp
+++ b/src/mumble/Plugins.cpp
@@ -7,7 +7,6 @@
 
 #include "Plugins.h"
 
-#include "Global.h"
 #include "Log.h"
 #include "MainWindow.h"
 #include "Message.h"
@@ -15,8 +14,10 @@
 #include "../../plugins/mumble_plugin.h"
 #include "WebFetch.h"
 #include "MumbleApplication.h"
-
 #include "ManualPlugin.h"
+
+// We define a global macro called 'g'. This can lead to issues when included code uses 'g' as a type or parameter name (like protobuf 3.7 does). As such, for now, we have to make this our last include.
+#include "Global.h"
 
 static ConfigWidget *PluginConfigDialogNew(Settings &st) {
 	return new PluginConfig(st);

--- a/src/mumble/PulseAudio.cpp
+++ b/src/mumble/PulseAudio.cpp
@@ -7,11 +7,12 @@
 
 #include "PulseAudio.h"
 
-#include "Global.h"
 #include "MainWindow.h"
 #include "Timer.h"
 #include "User.h"
 
+// We define a global macro called 'g'. This can lead to issues when included code uses 'g' as a type or parameter name (like protobuf 3.7 does). As such, for now, we have to make this our last include.
+#include "Global.h"
 
 static const char *mumble_sink_input = "Mumble Speakers";
 static const char *mumble_echo = "Mumble Speakers (Echo)";

--- a/src/mumble/RichTextEditor.cpp
+++ b/src/mumble/RichTextEditor.cpp
@@ -7,10 +7,12 @@
 
 #include "RichTextEditor.h"
 
-#include "Global.h"
 #include "Log.h"
 #include "MainWindow.h"
 #include "XMLTools.h"
+
+// We define a global macro called 'g'. This can lead to issues when included code uses 'g' as a type or parameter name (like protobuf 3.7 does). As such, for now, we have to make this our last include.
+#include "Global.h"
 
 RichTextHtmlEdit::RichTextHtmlEdit(QWidget *p) : QTextEdit(p) {
 	m_document = new LogDocument(this);

--- a/src/mumble/ServerHandler.cpp
+++ b/src/mumble/ServerHandler.cpp
@@ -12,7 +12,6 @@
 #include "Cert.h"
 #include "Connection.h"
 #include "Database.h"
-#include "Global.h"
 #include "MainWindow.h"
 #include "Message.h"
 #include "NetworkConfig.h"
@@ -25,6 +24,9 @@
 #include "HostAddress.h"
 #include "ServerResolver.h"
 #include "ServerResolverRecord.h"
+
+// We define a global macro called 'g'. This can lead to issues when included code uses 'g' as a type or parameter name (like protobuf 3.7 does). As such, for now, we have to make this our last include.
+#include "Global.h"
 
 ServerHandlerMessageEvent::ServerHandlerMessageEvent(const QByteArray &msg, unsigned int mtype, bool flush) : QEvent(static_cast<QEvent::Type>(SERVERSEND_EVENT)) {
 	qbaMsg = msg;

--- a/src/mumble/SocketRPC.cpp
+++ b/src/mumble/SocketRPC.cpp
@@ -9,9 +9,11 @@
 
 #include "Channel.h"
 #include "ClientUser.h"
-#include "Global.h"
 #include "MainWindow.h"
 #include "ServerHandler.h"
+
+// We define a global macro called 'g'. This can lead to issues when included code uses 'g' as a type or parameter name (like protobuf 3.7 does). As such, for now, we have to make this our last include.
+#include "Global.h"
 
 SocketRPCClient::SocketRPCClient(QLocalSocket *s, QObject *p) : QObject(p), qlsSocket(s), qbBuffer(NULL) {
 	qlsSocket->setParent(this);

--- a/src/mumble/Themes.cpp
+++ b/src/mumble/Themes.cpp
@@ -6,9 +6,11 @@
 #include "mumble_pch.hpp"
 
 #include "Themes.h"
-#include "Global.h"
 #include "MainWindow.h"
 #include "MumbleApplication.h"
+
+// We define a global macro called 'g'. This can lead to issues when included code uses 'g' as a type or parameter name (like protobuf 3.7 does). As such, for now, we have to make this our last include.
+#include "Global.h"
 
 boost::optional<ThemeInfo::StyleInfo> Themes::getConfiguredStyle(const Settings &settings) {
 	if (settings.themeName.isEmpty() && settings.themeStyleName.isEmpty()) {

--- a/src/mumble/Tokens.cpp
+++ b/src/mumble/Tokens.cpp
@@ -8,8 +8,10 @@
 #include "Tokens.h"
 
 #include "Database.h"
-#include "Global.h"
 #include "ServerHandler.h"
+
+// We define a global macro called 'g'. This can lead to issues when included code uses 'g' as a type or parameter name (like protobuf 3.7 does). As such, for now, we have to make this our last include.
+#include "Global.h"
 
 Tokens::Tokens(QWidget *p) : QDialog(p) {
 	setupUi(this);

--- a/src/mumble/UserEdit.cpp
+++ b/src/mumble/UserEdit.cpp
@@ -10,12 +10,12 @@
 #include <QItemSelectionModel>
 
 #include "Channel.h"
-#include "Global.h"
 #include "ServerHandler.h"
 #include "User.h"
-#include "Mumble.pb.h"
 #include "UserListModel.h"
 
+// We define a global macro called 'g'. This can lead to issues when included code uses 'g' as a type or parameter name (like protobuf 3.7 does). As such, for now, we have to make this our last include.
+#include "Global.h"
 
 UserEdit::UserEdit(const MumbleProto::UserList &userList, QWidget *p)
 	: QDialog(p)

--- a/src/mumble/UserInformation.cpp
+++ b/src/mumble/UserInformation.cpp
@@ -9,10 +9,12 @@
 
 #include "Audio.h"
 #include "CELTCodec.h"
-#include "Global.h"
 #include "HostAddress.h"
 #include "ServerHandler.h"
 #include "ViewCert.h"
+
+// We define a global macro called 'g'. This can lead to issues when included code uses 'g' as a type or parameter name (like protobuf 3.7 does). As such, for now, we have to make this our last include.
+#include "Global.h"
 
 static QString decode_utf8_qssl_string(const QString &input) {
 	QString i = input;

--- a/src/mumble/UserModel.cpp
+++ b/src/mumble/UserModel.cpp
@@ -10,7 +10,6 @@
 #include "ClientUser.h"
 #include "Channel.h"
 #include "Database.h"
-#include "Global.h"
 #include "LCD.h"
 #include "Log.h"
 #include "MainWindow.h"
@@ -19,6 +18,9 @@
 #include "ServerHandler.h"
 #include "Usage.h"
 #include "User.h"
+
+// We define a global macro called 'g'. This can lead to issues when included code uses 'g' as a type or parameter name (like protobuf 3.7 does). As such, for now, we have to make this our last include.
+#include "Global.h"
 
 QHash <Channel *, ModelItem *> ModelItem::c_qhChannels;
 QHash <ClientUser *, ModelItem *> ModelItem::c_qhUsers;

--- a/src/mumble/UserView.cpp
+++ b/src/mumble/UserView.cpp
@@ -10,10 +10,12 @@
 #include "Channel.h"
 #include "ClientUser.h"
 #include "Log.h"
-#include "Global.h"
 #include "MainWindow.h"
 #include "ServerHandler.h"
 #include "UserModel.h"
+
+// We define a global macro called 'g'. This can lead to issues when included code uses 'g' as a type or parameter name (like protobuf 3.7 does). As such, for now, we have to make this our last include.
+#include "Global.h"
 
 const int UserDelegate::FLAG_ICON_DIMENSION = 16;
 const int UserDelegate::FLAG_ICON_PADDING = 1;

--- a/src/mumble/VersionCheck.cpp
+++ b/src/mumble/VersionCheck.cpp
@@ -7,9 +7,11 @@
 
 #include "VersionCheck.h"
 
-#include "Global.h"
 #include "MainWindow.h"
 #include "WebFetch.h"
+
+// We define a global macro called 'g'. This can lead to issues when included code uses 'g' as a type or parameter name (like protobuf 3.7 does). As such, for now, we have to make this our last include.
+#include "Global.h"
 
 VersionCheck::VersionCheck(bool autocheck, QObject *p, bool focus) : QObject(p) {
 	QUrl url;

--- a/src/mumble/VoiceRecorder.cpp
+++ b/src/mumble/VoiceRecorder.cpp
@@ -9,10 +9,12 @@
 
 #include "AudioOutput.h"
 #include "ClientUser.h"
-#include "Global.h"
 #include "ServerHandler.h"
 
 #include "../Timer.h"
+
+// We define a global macro called 'g'. This can lead to issues when included code uses 'g' as a type or parameter name (like protobuf 3.7 does). As such, for now, we have to make this our last include.
+#include "Global.h"
 
 VoiceRecorder::RecordBuffer::RecordBuffer(
 		int recordInfoIndex_,

--- a/src/mumble/VoiceRecorderDialog.cpp
+++ b/src/mumble/VoiceRecorderDialog.cpp
@@ -8,9 +8,11 @@
 #include "VoiceRecorderDialog.h"
 
 #include "AudioOutput.h"
-#include "Global.h"
 #include "ServerHandler.h"
 #include "VoiceRecorder.h"
+
+// We define a global macro called 'g'. This can lead to issues when included code uses 'g' as a type or parameter name (like protobuf 3.7 does). As such, for now, we have to make this our last include.
+#include "Global.h"
 
 VoiceRecorderDialog::VoiceRecorderDialog(QWidget *p) : QDialog(p), qtTimer(new QTimer(this)) {
 	qtTimer->setObjectName(QLatin1String("qtTimer"));

--- a/src/mumble/WASAPI.cpp
+++ b/src/mumble/WASAPI.cpp
@@ -8,8 +8,10 @@
 #include "WASAPI.h"
 #include "WASAPINotificationClient.h"
 
-#include "Global.h"
 #include "MainWindow.h"
+
+// We define a global macro called 'g'. This can lead to issues when included code uses 'g' as a type or parameter name (like protobuf 3.7 does). As such, for now, we have to make this our last include.
+#include "Global.h"
 
 // Now that Win7 is published, which includes public versions of these
 // interfaces, we simply inherit from those but use the "old" IIDs.

--- a/src/mumble/WASAPINotificationClient.cpp
+++ b/src/mumble/WASAPINotificationClient.cpp
@@ -5,13 +5,15 @@
 
 #include "mumble_pch.hpp"
 
-#include "Global.h"
 #include "MainWindow.h"
 
 #include "WASAPINotificationClient.h"
 
 #include <QtCore/QMutexLocker>
 #include <boost/thread/once.hpp>
+
+// We define a global macro called 'g'. This can lead to issues when included code uses 'g' as a type or parameter name (like protobuf 3.7 does). As such, for now, we have to make this our last include.
+#include "Global.h"
 
 HRESULT STDMETHODCALLTYPE WASAPINotificationClient::OnDefaultDeviceChanged(EDataFlow flow, ERole role, LPCWSTR pwstrDefaultDevice) {
 	const QString device = QString::fromWCharArray(pwstrDefaultDevice);

--- a/src/mumble/os_macx.mm
+++ b/src/mumble/os_macx.mm
@@ -5,9 +5,11 @@
 
 #include "mumble_pch.hpp"
 #include "LogEmitter.h"
-#include "Global.h"
 #include "Overlay.h"
 #include "MainWindow.h"
+
+// We define a global macro called 'g'. This can lead to issues when included code uses 'g' as a type or parameter name (like protobuf 3.7 does). As such, for now, we have to make this our last include.
+#include "Global.h"
 
 char *os_lang = NULL;
 static FILE *fConsole = NULL;


### PR DESCRIPTION
Fixes #3617.

In protobuf 3.7 `g` is used as argument name, which conflicts with our global struct:
https://github.com/mumble-voip/mumble/blob/03258363dfcc6fa9f741ced5b823ef6a50e6eca3/src/mumble/Global.h#L131


```c++
google/protobuf/stubs/strutil.h:720:47: error: 'g_global_struct' declared as a pointer to a reference of type 'const google::protobuf::strings::AlphaNum &'
                              const AlphaNum& g);
                                              ^
./Global.h:131:12: note: expanded from macro 'g'
#define g (*Global::g_global_struct)
           ^
```

The solution consists in including `Global.h` after any headers that include `Mumble.pb.h` (which in turn includes protobuf's headers).

`Mumble.pb.h` is generated by protobuf.