### PR TITLE
Add missing advapi32 library reference in server project

### DIFF
--- a/src/murmur/murmur.pro
+++ b/src/murmur/murmur.pro
@@ -43,7 +43,7 @@ win32 {
   RESOURCES *= murmur.qrc
   SOURCES *= Tray.cpp About.cpp
   HEADERS *= Tray.h About.h
-  LIBS *= -luser32
+  LIBS *= -luser32 -ladvapi32
   win32-msvc* {
     QMAKE_POST_LINK = $$QMAKE_POST_LINK$$escape_expand(\\n\\t)$$quote(mt.exe -nologo -updateresource:$(DESTDIR_TARGET);1 -manifest ../mumble/mumble.appcompat.manifest)
   }


### PR DESCRIPTION
`win10DisplayableVersion` in `OSInfo.cpp` makes use of the registry to
determine a user displayable windows version string.
This was introduced in 88e664710dd375dc0be42a30dc266efa5833bb4c.

The registry functions used are in the Windows API `advapi32` library.
This file was not declared for linkage yet, which leads to a linker
error.

---

Why was this not a problem yet? Will it just work when running qmake for both client and server (not using `CONFIG+=no-client`?)