### PR TITLE
Add missing ssleay32 library reference in openssl qmake configuration

### DIFF
--- a/qmake/openssl.pri
+++ b/qmake/openssl.pri
@@ -16,7 +16,7 @@ include(pkgconfig.pri)
 win32-msvc* {
 	INCLUDEPATH *= "$$OPENSSL_PATH/include"
 	QMAKE_LIBDIR *= "$$OPENSSL_PATH/lib"
-	LIBS *= -lgdi32 -llibeay32
+	LIBS *= -lgdi32 -llibeay32 -lssleay32
 }
 
 win32-g++ {


### PR DESCRIPTION
MumbleSSL (defined in SSL.h/.cpp) uses OpenSSL functions - starting with
SSL_library_init. These functions are defined in the ssleay32 library.

This library was missing, which resulted/could result in linker errors
(in specific kinds of build environments).

---

Why was this not an issue before? Does our mumble-releng buildenv do some magic/have some side effects?

It was an issue for me when building from my new vcpkg environment.