### PR TITLE
Fix log spacing and typos when setting up the PBKDF2 iteration count

### DIFF
--- a/src/murmur/ServerDB.cpp
+++ b/src/murmur/ServerDB.cpp
@@ -55,28 +55,28 @@ void ServerDB::loadOrSetupMetaPKBDF2IterationsCount(QSqlQuery &query) {
 	if (!Meta::mp.legacyPasswordHash) {
 		if (Meta::mp.kdfIterations <= 0) {
 			// Configuration doesn't specify an override, load from db
-			
+
 			SQLDO("SELECT `value` FROM `%1meta` WHERE `keystring` = 'pbkdf2_iterations'");
 			if (query.next()) {
 				Meta::mp.kdfIterations = query.value(0).toInt();
 			}
-			
+
 			if (Meta::mp.kdfIterations <= 0) {
 				// Didn't get a valid iteration count from DB, overwrite
 				Meta::mp.kdfIterations = PBKDF2::benchmark();
-				
-				qWarning() << "Performed initial PBKDF2 benchmark. Will use " << Meta::mp.kdfIterations << " iterations as default";
-				
+
+				qWarning() << "Performed initial PBKDF2 benchmark. Will use" << Meta::mp.kdfIterations << "iterations as default";
+
 				SQLPREP("INSERT INTO `%1meta` (`keystring`, `value`) VALUES('pbkdf2_iterations',?)");
 				query.addBindValue(Meta::mp.kdfIterations);
 				SQLEXEC();
 			}
 		}
-		
+
 		if (Meta::mp.kdfIterations < PBKDF2::BENCHMARK_MINIMUM_ITERATION_COUNT) {
-			qWarning() << "Configured default PBKDF2 iteration count of " << Meta::mp.kdfIterations << " is below minimum recommended value of " << PBKDF2::BENCHMARK_MINIMUM_ITERATION_COUNT << " and could be insecure.";
+			qWarning() << "Configured default PBKDF2 iteration count of" << Meta::mp.kdfIterations << "is below minimum recommended value of" << PBKDF2::BENCHMARK_MINIMUM_ITERATION_COUNT << "and could be insecure.";
 		}
-	}	
+	}
 }
 
 ServerDB::ServerDB() {

--- a/src/murmur/ServerDB.cpp
+++ b/src/murmur/ServerDB.cpp
@@ -51,7 +51,7 @@ QSqlDatabase *ServerDB::db = NULL;
 Timer ServerDB::tLogClean;
 QString ServerDB::qsUpgradeSuffix;
 
-void ServerDB::loadOrSetupMetaPKBDF2IterationsCount(QSqlQuery &query) {
+void ServerDB::loadOrSetupMetaPBKDF2IterationCount(QSqlQuery &query) {
 	if (!Meta::mp.legacyPasswordHash) {
 		if (Meta::mp.kdfIterations <= 0) {
 			// Configuration doesn't specify an override, load from db
@@ -212,8 +212,8 @@ ServerDB::ServerDB() {
 
 	if (query.next())
 		version = query.value(0).toInt();
-	
-	loadOrSetupMetaPKBDF2IterationsCount(query);
+
+	loadOrSetupMetaPBKDF2IterationCount(query);
 
 	if (version < 6) {
 		if (version > 0) {

--- a/src/murmur/ServerDB.h
+++ b/src/murmur/ServerDB.h
@@ -48,7 +48,7 @@ class ServerDB {
 		ServerDB(const ServerDB &);
 		
 	private:
-		static void loadOrSetupMetaPKBDF2IterationsCount(QSqlQuery &query);
+		static void loadOrSetupMetaPBKDF2IterationCount(QSqlQuery &query);
 		static void writeSUPW(int srvnum, const QString &pwHash, const QString &saltHash, const QVariant &kdfIterations);
 };
 


### PR DESCRIPTION
The Qt logging functions already insert spaces between each item when using the stream insertion operator, so no need to insert them manually.

I also fixed the name of the method (PKBDF2 should be PBKDF2).