### PR TITLE
Azure Pipelines: add macOS build

### DIFF
--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -20,3 +20,13 @@ jobs:
       displayName: 'Install build environment'
     - powershell: scripts/azure-pipelines/build.ps1
       displayName: 'Build'
+  - job: macOS
+    pool:
+      vmImage: 'macOS-10.13'
+    steps:
+    - script: git submodule --quiet update --init --recursive
+      displayName: 'Fetch submodules'
+    - script: scripts/azure-pipelines/install-environment_macos.bash
+      displayName: 'Install build environment'
+    - script: scripts/azure-pipelines/build_macos.bash
+      displayName: 'Build'

--- a/scripts/azure-pipelines/build_macos.bash
+++ b/scripts/azure-pipelines/build_macos.bash
@@ -1,0 +1,14 @@
+#!/bin/bash -ex
+#
+# Copyright 2019 The Mumble Developers. All rights reserved.
+# Use of this source code is governed by a BSD-style license
+# that can be found in the LICENSE file at the root of the
+# Mumble source tree or at <https://www.mumble.info/LICENSE>.
+
+export PKG_CONFIG_PATH=$PKG_CONFIG_PATH:/usr/local/lib/pkgconfig
+export PKG_CONFIG_PATH=$PKG_CONFIG_PATH:/usr/local/opt/openssl/lib/pkgconfig
+export PATH=$PATH:/usr/local/opt/qt5/bin:/usr/local/bin
+export MUMBLE_PREFIX=/usr/local
+export MUMBLE_ICE_PREFIX=/usr/local/opt/ice
+
+qmake -recursive CONFIG+="release tests warnings-as-errors" && make -j $(sysctl -n hw.ncpu) && make check

--- a/scripts/azure-pipelines/install-environment_macos.bash
+++ b/scripts/azure-pipelines/install-environment_macos.bash
@@ -1,0 +1,8 @@
+#!/bin/bash -ex
+#
+# Copyright 2019 The Mumble Developers. All rights reserved.
+# Use of this source code is governed by a BSD-style license
+# that can be found in the LICENSE file at the root of the
+# Mumble source tree or at <https://www.mumble.info/LICENSE>.
+
+brew update && brew install pkg-config qt5 boost libogg libvorbis flac libsndfile protobuf openssl ice


### PR DESCRIPTION
This should lower the overall CI completion time, because the macOS build seems to always take a while to start on Travis CI.

The macOS build will be removed from Travis CI in a dedicated pull request.