### PR TITLE
Add Cirrus CI for continuous integration (FreeBSD)

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,0 +1,11 @@
+freebsd_instance:
+  image: freebsd-12-0-release-amd64
+
+freebsd_task:
+  update_script: pkg update && pkg upgrade -y
+  install_script: pkg install -y git pkgconf gmake qt5-qmake qt5-l10n qt5-buildtools qt5-linguisttools qt5-testlib qt5-core qt5-gui qt5-network qt5-sql qt5-svg qt5-widgets qt5-xml boost-libs opus libsndfile protobuf ice avahi-libdns speech-dispatcher python
+  fetch_submodules_script: git submodule --quiet update --init --recursive
+  build_script:
+  - qmake -recursive CONFIG+="release tests warnings-as-errors no-alsa no-jackaudio no-pulseaudio"
+  - gmake -j $(sysctl -n hw.ncpu)
+  check_script: gmake check


### PR DESCRIPTION
Cirrus CI released support for FreeBSD on their CI service in December: https://www.freebsd.org/news/newsflash.html#event20181211:01