### PR TITLE
TestServerResolver: skip test in case the system's DNS resolver cannot be initialized

### DIFF
--- a/src/ServerResolver.h
+++ b/src/ServerResolver.h
@@ -13,6 +13,8 @@
 #include "Net.h" // for HostAddress
 #include "ServerResolverRecord.h"
 
+typedef QPair<uchar, QString> ServerResolverError;
+
 class ServerResolverPrivate;
 
 class ServerResolver : public QObject {
@@ -27,6 +29,7 @@ class ServerResolver : public QObject {
 
 		void resolve(QString hostname, quint16 port);
 		QList<ServerResolverRecord> records();
+		ServerResolverError lastError();
 
 	signals:
 		/// Resolved is fired once the ServerResolver

--- a/src/ServerResolver_nosrv.cpp
+++ b/src/ServerResolver_nosrv.cpp
@@ -18,11 +18,13 @@ class ServerResolverPrivate : public QObject {
 
 		void resolve(QString hostname, quint16 port);
 		QList<ServerResolverRecord> records();
+		ServerResolverError lastError();
 
 		QString m_origHostname;
 		quint16 m_origPort;
 
 		QList<ServerResolverRecord> m_resolved;
+		ServerResolverError m_lastError;
 
 	signals:
 		void resolved();
@@ -47,6 +49,10 @@ QList<ServerResolverRecord> ServerResolverPrivate::records() {
 	return m_resolved;
 }
 
+ServerResolverError ServerResolverPrivate::lastError() {
+	return m_lastError;
+}
+
 void ServerResolverPrivate::hostResolved(QHostInfo hostInfo) {
 	if (hostInfo.error() == QHostInfo::NoError) {
 		QList<QHostAddress> resolvedAddresses = hostInfo.addresses();
@@ -58,6 +64,8 @@ void ServerResolverPrivate::hostResolved(QHostInfo hostInfo) {
 		}
 
 		m_resolved << ServerResolverRecord(m_origHostname, m_origPort, 0, addresses);
+	} else {
+		m_lastError = ServerResolverError(hostInfo.error(), hostInfo.errorString());
 	}
 
 	emit resolved();
@@ -96,7 +104,16 @@ QList<ServerResolverRecord> ServerResolver::records() {
 	if (d) {
 		return d->records();
 	}
+
 	return QList<ServerResolverRecord>();
+}
+
+ServerResolverError ServerResolver::lastError() {
+	if (d) {
+		return d->lastError();
+	}
+
+	return ServerResolverError(QHostInfo::NoError, QString());
 }
 
 #include "ServerResolver_nosrv.moc"


### PR DESCRIPTION
This is required for tests to succeed on FreeBSD until [QTBUG-74844](https://bugreports.qt.io/browse/QTBUG-74844) is fixed:

```
QWARN  : TestServerResolver::simpleSrv() Error: "Resolver functions not found"
QWARN  : TestServerResolver::simpleSrv() Skipping test: the system's DNS resolver couldn't be initialized.
QWARN  : TestServerResolver::simpleSrv() The issue is probably related to QTBUG-74844.
PASS   : TestServerResolver::simpleSrv()
QWARN  : TestServerResolver::srvCustomPort() Error: "Resolver functions not found"
QWARN  : TestServerResolver::srvCustomPort() Skipping test: the system's DNS resolver couldn't be initialized.
QWARN  : TestServerResolver::srvCustomPort() The issue is probably related to QTBUG-74844.
PASS   : TestServerResolver::srvCustomPort()
```