### PR TITLE
Fixed a bug/typo which prevented audio from playing on user disconnect

### DIFF
--- a/src/mumble/Settings.cpp
+++ b/src/mumble/Settings.cpp
@@ -428,7 +428,7 @@ Settings::Settings() {
 	qmMessageSounds[Log::ChannelJoin] = QLatin1String(":/UserJoinedChannel.ogg");
 	qmMessageSounds[Log::ChannelLeave] = QLatin1String(":/UserLeftChannel.ogg");
 	qmMessageSounds[Log::ChannelJoinConnect] = qmMessageSounds[Log::ChannelJoin];
-	qmMessageSounds[Log::ChannelLeaveDisconnect] = qmMessageSounds[Log::UserLeave];
+	qmMessageSounds[Log::ChannelLeaveDisconnect] = qmMessageSounds[Log::ChannelLeave];
 	qmMessageSounds[Log::YouMutedOther] = QLatin1String(":/UserMutedYouOrByYou.ogg");
 	qmMessageSounds[Log::YouMuted] = QLatin1String(":/UserMutedYouOrByYou.ogg");
 	qmMessageSounds[Log::YouKicked] = QLatin1String(":/UserKickedYouOrByYou.ogg");


### PR DESCRIPTION
Fixed a small client bug which prevented `UserLeftChannel.ogg` from playing when a user disconnected from the current channel and server.

Introduced in fc4368ad53dd1f974453e53a3c0935baa2469595.