### PR TITLE
Add support for TLS 1.3 in the server information window

### DIFF
--- a/src/SSL.cpp
+++ b/src/SSL.cpp
@@ -264,6 +264,9 @@ QString MumbleSSL::protocolToString(QSsl::SslProtocol protocol) {
 		case QSsl::TlsV1_0: return QLatin1String("TLS 1.0");
 		case QSsl::TlsV1_1: return QLatin1String("TLS 1.1");
 		case QSsl::TlsV1_2: return QLatin1String("TLS 1.2");
+#if QT_VERSION >= 0x050C00
+		case QSsl::TlsV1_3: return QLatin1String("TLS 1.3");
+#endif
 #else
 		case QSsl::TlsV1: return  QLatin1String("TLS 1.0");
 #endif


### PR DESCRIPTION
When connecting to a server using TLS 1.3, the server information windows displays "The connection uses UnknownProtocol".
This pull request fixes that by adding a case for `QSsl::TlsV1_3` in `MumbleSSL::protocolToString(QSsl::SslProtocol protocol)`.

See https://doc.qt.io/qt-5/qssl.html#SslProtocol-enum

Before:

![mumble_unknown_protocol](https://user-images.githubusercontent.com/23304955/55678094-10b2d080-592f-11e9-82f4-f2b3799b119c.png)

After:

![mumble_tls1 3](https://user-images.githubusercontent.com/23304955/55678095-13adc100-592f-11e9-964f-a843a11aeacf.png)

