### PR TITLE
Updated UI String to be consistent with others

### DIFF
--- a/src/mumble/AudioOutput.ui
+++ b/src/mumble/AudioOutput.ui
@@ -383,10 +383,10 @@
          <string>If checked Mumble lowers the volume of other users while you talk if you have the &quot;Priority Speaker&quot; status.</string>
         </property>
         <property name="whatsThis">
-         <string>&lt;b&gt;Attenuate other users while talking as Priority Speaker.&lt;/b&gt;&lt;br /&gt;Mumble supports decreasing the volume of other users while you talk as the &lt;i&gt;Priority Speaker&lt;/i&gt; to avoid getting disturbed. Checking this checkbox will enable this feature.</string>
+         <string>&lt;b&gt;Attenuate other users while talking as Priority Speaker&lt;/b&gt;&lt;br /&gt;Mumble supports decreasing the volume of other users while you talk as the &lt;i&gt;Priority Speaker&lt;/i&gt; to avoid getting disturbed. Checking this checkbox will enable this feature.</string>
         </property>
         <property name="text">
-         <string>Attenuate other users while talking as Priority Speaker.</string>
+         <string>Attenuate other users while talking as Priority Speaker</string>
         </property>
        </widget>
       </item>


### PR DESCRIPTION
Original:
Attenuate other users while talking as Priority Speaker.
Update:
Attenuate other users while talking as Priority Speaker

This was a minor fix to an issue: https://github.com/mumble-voip/mumble/issues/3665