### PR TITLE
Add option to omit scope in TTS messages

### DIFF
--- a/src/mumble/Log.cpp
+++ b/src/mumble/Log.cpp
@@ -114,6 +114,9 @@ void LogConfig::load(const Settings &r) {
 	loadSlider(qsVolume, r.iTTSVolume);
 	qsbThreshold->setValue(r.iTTSThreshold);
 	qcbReadBackOwn->setChecked(r.bTTSMessageReadBack);
+	qcbNoScope->setChecked(r.bTTSNoScope);
+	qcbNoAuthor->setChecked(r.bTTSNoAuthor);
+
 #endif
 	qcbWhisperFriends->setChecked(r.bWhisperFriends);
 }
@@ -145,6 +148,8 @@ void LogConfig::save() const {
 	s.iTTSVolume=qsVolume->value();
 	s.iTTSThreshold=qsbThreshold->value();
 	s.bTTSMessageReadBack = qcbReadBackOwn->isChecked();
+	s.bTTSNoScope = qcbNoScope->isChecked();
+	s.bTTSNoAuthor = qcbNoAuthor->isChecked();
 #endif
 	s.bWhisperFriends = qcbWhisperFriends->isChecked();
 }
@@ -451,7 +456,7 @@ QString Log::validHtml(const QString &html, QTextCursor *tc) {
 	}
 }
 
-void Log::log(MsgType mt, const QString &console, const QString &terse, bool ownMessage) {
+void Log::log(MsgType mt, const QString &console, const QString &terse, bool ownMessage, const QString &overrideTTS) {
 	QDateTime dt = QDateTime::currentDateTime();
 
 	int ignore = qmIgnore.value(mt);
@@ -536,6 +541,11 @@ void Log::log(MsgType mt, const QString &console, const QString &terse, bool own
 	// Message notification with Text-To-Speech
 	if (g.s.bDeaf || !g.s.bTTS || !(flags & Settings::LogTTS)) {
 		return;
+	}
+
+	// If overrideTTS is a valid string use its contents as message
+	if (!overrideTTS.isNull()) {
+		plain = overrideTTS;
 	}
 
 	// Apply simplifications to spoken text

--- a/src/mumble/Log.h
+++ b/src/mumble/Log.h
@@ -74,7 +74,7 @@ class Log : public QObject {
 		static QString formatClientUser(ClientUser *cu, LogColorType t, const QString &displayName=QString());
 		static QString formatChannel(::Channel *c);
 	public slots:
-		void log(MsgType t, const QString &console, const QString &terse=QString(), bool ownMessage = false);
+		void log(MsgType t, const QString &console, const QString &terse=QString(), bool ownMessage = false, const QString &overrideTTS=QString());
 };
 
 class LogDocument : public QTextDocument {

--- a/src/mumble/Log.ui
+++ b/src/mumble/Log.ui
@@ -154,6 +154,26 @@
         </property>
        </widget>
       </item>
+      <item row="2" column="0">
+       <widget class="QCheckBox" name="qcbNoScope">
+        <property name="toolTip">
+         <string>If enabled, TTS will not dictate the message scope.</string>
+        </property>
+        <property name="text">
+         <string>Omit Message Scope</string>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="1">
+       <widget class="QCheckBox" name="qcbNoAuthor">
+        <property name="toolTip">
+         <string>If enabled, TTS will not dictate the message author.</string>
+        </property>
+        <property name="text">
+         <string>Omit Message Author</string>
+        </property>
+       </widget>
+      </item>
      </layout>
     </widget>
    </item>

--- a/src/mumble/Messages.cpp
+++ b/src/mumble/Messages.cpp
@@ -703,6 +703,7 @@ void MainWindow::msgChannelRemove(const MumbleProto::ChannelRemove &msg) {
 void MainWindow::msgTextMessage(const MumbleProto::TextMessage &msg) {
 	ACTOR_INIT;
 	QString target;
+	QString overrideTTS = QString();
 
 	// Silently drop the message if this user is set to "ignore"
 	if (pSrc && pSrc->bLocalIgnore)
@@ -721,9 +722,22 @@ void MainWindow::msgTextMessage(const MumbleProto::TextMessage &msg) {
 		privateMessage = true;
 	}
 
+	// If NoScope or NoAuthor is selected generate a new string to pass to TTS
+	if (g.s.bTTSNoScope || g.s.bTTSNoAuthor) {
+		if (g.s.bTTSNoScope && g.s.bTTSNoAuthor) {
+			overrideTTS += tr("%2%1: %3").arg(QString()).arg(QString()).arg(u8(msg.message()));
+		} else if (g.s.bTTSNoAuthor) {
+			overrideTTS += tr("%2%1: %3").arg(QString()).arg(target).arg(u8(msg.message()));
+		} else if (g.s.bTTSNoScope) {
+			overrideTTS += tr("%2%1: %3").arg(name).arg(QString()).arg(u8(msg.message()));
+		}
+	}
+
 	g.l->log(privateMessage ? Log::PrivateTextMessage : Log::TextMessage,
 	         tr("%2%1: %3").arg(name).arg(target).arg(u8(msg.message())),
-	         tr("Message from %1").arg(plainName));
+	         tr("Message from %1").arg(plainName),
+	         false,
+	         overrideTTS.isNull() ? QString() : overrideTTS);
 }
 
 void MainWindow::msgACL(const MumbleProto::ACL &msg) {

--- a/src/mumble/Settings.cpp
+++ b/src/mumble/Settings.cpp
@@ -224,6 +224,8 @@ Settings::Settings() {
 	bMute = bDeaf = false;
 	bTTS = true;
 	bTTSMessageReadBack = false;
+	bTTSNoScope = false;
+	bTTSNoAuthor = false;
 	iTTSVolume = 75;
 	iTTSThreshold = 250;
 	qsTTSLanguage = QString();
@@ -684,6 +686,8 @@ void Settings::load(QSettings* settings_ptr) {
 	SAVELOAD(iTTSVolume, "tts/volume");
 	SAVELOAD(iTTSThreshold, "tts/threshold");
 	SAVELOAD(bTTSMessageReadBack, "tts/readback");
+	SAVELOAD(bTTSNoScope, "tts/noscope");
+	SAVELOAD(bTTSNoAuthor, "tts/noauthor");
 	SAVELOAD(qsTTSLanguage, "tts/language");
 
 	// Network settings
@@ -1025,6 +1029,8 @@ void Settings::save() {
 	SAVELOAD(iTTSVolume, "tts/volume");
 	SAVELOAD(iTTSThreshold, "tts/threshold");
 	SAVELOAD(bTTSMessageReadBack, "tts/readback");
+	SAVELOAD(bTTSNoScope, "tts/noscope");
+	SAVELOAD(bTTSNoAuthor, "tts/noauthor");
 	SAVELOAD(qsTTSLanguage, "tts/language");
 
 	// Network settings

--- a/src/mumble/Settings.h
+++ b/src/mumble/Settings.h
@@ -171,6 +171,8 @@ struct Settings {
 	bool bUserTop;
 	bool bWhisperFriends;
 	bool bTTSMessageReadBack;
+	bool bTTSNoScope;
+	bool bTTSNoAuthor;
 	int iTTSVolume, iTTSThreshold;
 	/// The Text-to-Speech language to use. This setting overrides
 	/// the default language for the Text-to-Speech engine, which


### PR DESCRIPTION
When a user sends a message to the log, the TTS engine
will play "Channel <username> <message>". When omit scope
box is selected, the phrase "Channel" is omitted from the TTS
engine which allows for the users message to quickly be spoken
for all clients. There is also an option not say the username.

Addresses: https://github.com/mumble-voip/mumble/issues/3676
