### PR TITLE
JackAudio: fix segmentation fault, revamp initialization logic

### DIFF
--- a/src/mumble/JackAudio.h
+++ b/src/mumble/JackAudio.h
@@ -48,9 +48,7 @@ class JackAudioSystem : public QObject {
 		int iSampleRate;
 		unsigned int iOutPorts;
 		QMutex qmWait;
-
-		void init_jack();
-		void close_jack();
+		QWaitCondition qwcWait;
 
 		void activate();
 
@@ -61,6 +59,7 @@ class JackAudioSystem : public QObject {
 		void destroyOutput();
 
 		JackAudioSystem();
+		~JackAudioSystem();
 };
 
 class JackAudioInput : public AudioInput {


### PR DESCRIPTION
Fixes #3682.

The crash happens when an invalid client is passed to `jack_port_register()`.

This pull request changes `JackAudioInit::initialize()` so that it aborts the initialization process in case the client cannot be opened (e.g. when the server cannot be started due to permission issues).

`bJackIsGood` was set to true by `init_jack()`, which was called by `initializeInput()` and `initializeOutput()`. In order to be able to check whether the client is correctly initialized (`bJackIsGood == true`) before making the backend available to the rest of the program (e.g. settings window), this pull request merged `init_jack()` with `JackAudioSystem()` and `destroy_jack()` with `~JackAudioSystem()`.

The downside to moving the client initialization into the constructor is that it stays open (but not active) even when JACK is not used as backend, which is what currently happens with the PulseAudio backend.

In future we will improve the way audio backends are handled and fix the issue.