### PR TITLE
Minimize window on tray icon click

### DIFF
--- a/src/mumble/MainWindow.cpp
+++ b/src/mumble/MainWindow.cpp
@@ -3113,7 +3113,11 @@ void MainWindow::on_Icon_activated(QSystemTrayIcon::ActivationReason reason) {
 		case QSystemTrayIcon::Trigger:
 		case QSystemTrayIcon::DoubleClick:
 		case QSystemTrayIcon::MiddleClick:
+		if (isMinimized()) {
 			showRaiseWindow();
+		} else {
+			showMinimized();
+		}
 		default: break;
 	}
 }


### PR DESCRIPTION
Closes #3680.

This pull request changes `MainWindow::on_Icon_activated()` so that it minimizes Mumble's window if it's not already.

Previously, no action occurred when clicking on the tray icon while the window was shown.