### PR TITLE
ServerUser: use QTime instead of std::chrono and ctime

### DIFF
--- a/src/murmur/ServerUser.h
+++ b/src/murmur/ServerUser.h
@@ -7,18 +7,12 @@
 #define MUMBLE_MURMUR_SERVERUSER_H_
 
 #include <QtCore/QStringList>
+#include <QtCore/QTime>
 
 #ifdef Q_OS_UNIX
 #include <sys/socket.h>
 #else
 #include <winsock2.h>
-#endif
-
-// <chrono> was introduced in C++11
-#if __cplusplus > 199711LL
-#include <chrono>
-#else
-#include <ctime>
 #endif
 
 #include "Connection.h"
@@ -62,18 +56,12 @@ struct WhisperTarget {
 
 class Server;
 
-#if __cplusplus > 199711L
-        typedef std::chrono::time_point<std::chrono::steady_clock> time_point;
-#else
-        typedef clock_t time_point;
-#endif
-
 // Simple algorithm for rate limiting
 class LeakyBucket {
 	private:
 		unsigned int tokensPerSec, maxTokens;
 		long currentTokens;
-		time_point lastUpdate;
+		QTime lastUpdate;
 
 	public:
 		// Returns true if packets should be dropped


### PR DESCRIPTION
Fixes #3662.

The legacy implementation (with `ctime`), used when `std::chrono` is not available (C++ < 11), caused the client's messages to be permanently blocked until it reconnected.
More specifically, `millisecondsBetween()` always returned 0.

This commit replaces both implementations with a simpler one which makes use of `QTime`.

@tu-maurice