### PR TITLE
fixed setting comment to username instead of updating username

### DIFF
--- a/src/murmur/MurmurGRPCImpl.cpp
+++ b/src/murmur/MurmurGRPCImpl.cpp
@@ -2045,7 +2045,7 @@ void V1_DatabaseUserUpdate::impl(bool) {
 				QString name = u->qsName;
 				QString comment = u->qsComment;
 				if (info.contains(ServerDB::User_Name)) {
-					comment = info.value(ServerDB::User_Name);
+					name = info.value(ServerDB::User_Name);
 				}
 				if (info.contains(ServerDB::User_Comment)) {
 					comment = info.value(ServerDB::User_Comment);


### PR DESCRIPTION
when updating username of GRPC DatabaseUserUpdate() it sets the comment (if no comment is set) using setUserInfo instead of setting the name