### PR TITLE
Do not build tags that we create when we upload to GitHub Releases

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,3 +30,8 @@ before_install:
 
 script:
     - ./scripts/travis-ci/script.bash
+
+branches:
+  except:
+    - # Do not build tags that we create when we upload to GitHub Releases
+    - /^(?i:continuous)/


### PR DESCRIPTION
Currently each build triggers an extraneous build. This fixes it.