### PR TITLE
Azure Pipelines: install Qt 5.12.7 (LTS) and include AppImage updater

### DIFF
--- a/scripts/azure-pipelines/build_linux.bash
+++ b/scripts/azure-pipelines/build_linux.bash
@@ -7,6 +7,9 @@
 
 ver=$(python scripts/mumble-version.py)
 
+# Use the Qt kit installed through PPA
+source /opt/qt*/bin/qt*-env.sh || true
+
 qmake -recursive CONFIG+="release tests warnings-as-errors" DEFINES+="MUMBLE_VERSION=${ver}"
 
 make -j $(nproc)
@@ -20,9 +23,17 @@ cp release/plugins/lib* appdir/usr/lib/mumble/
 cp scripts/mumble.desktop appdir/usr/share/applications/
 cp scripts/mumble.appdata.xml appdir/usr/share/metainfo/
 cp icons/mumble.svg appdir/usr/share/icons/hicolor/scalable/apps/
+
 wget -c -nv "https://github.com/probonopd/linuxdeployqt/releases/download/continuous/linuxdeployqt-continuous-x86_64.AppImage"
 chmod a+x linuxdeployqt-continuous-x86_64.AppImage
-./linuxdeployqt-continuous-x86_64.AppImage $(find $HOME -type d -name 'appdir'| head -n 1)/usr/share/applications/*.desktop -appimage -extra-plugins=sqldrivers/libqsqlite.so
+# "-verbose=2" is required because of a bug in the tool: https://github.com/probonopd/linuxdeployqt/issues/402
+./linuxdeployqt-continuous-x86_64.AppImage appdir/usr/share/applications/*.desktop -verbose=2
+
+wget -c -nv "https://github.com/antony-jr/updatedeployqt/releases/download/continuous/updatedeployqt-continuous-x86_64.AppImage"
+chmod a+x updatedeployqt-continuous-x86_64.AppImage
+./updatedeployqt-continuous-x86_64.AppImage --config ${BUILD_SOURCESDIRECTORY} appdir
+
+./linuxdeployqt-continuous-x86_64.AppImage appdir/usr/share/applications/*.desktop -appimage -extra-plugins=sqldrivers/libqsqlite.so
 
 for f in Mumble*.AppImage; do
 	# Embed update information into AppImage

--- a/scripts/azure-pipelines/install-environment_linux.bash
+++ b/scripts/azure-pipelines/install-environment_linux.bash
@@ -5,11 +5,13 @@
 # that can be found in the LICENSE file at the root of the
 # Mumble source tree or at <https://www.mumble.info/LICENSE>.
 
+sudo add-apt-repository ppa:beineri/opt-qt-5.12.7-xenial -y
+
 sudo apt-get update
 
-sudo apt-get -y install build-essential pkg-config qt5-default qttools5-dev-tools libqt5svg5-dev \
+sudo apt-get -y install build-essential pkg-config qt512base qt512svg qt512tools qt512translations \
                         libboost-dev libssl-dev libprotobuf-dev protobuf-compiler \
-                        libcap-dev libxi-dev \
+                        libcap-dev libxi-dev libgl1-mesa-dev \
                         libasound2-dev libpulse-dev \
                         libogg-dev libsndfile1-dev libspeechd-dev \
                         libavahi-compat-libdnssd-dev libzeroc-ice-dev libg15daemon-client-dev \

--- a/updatedeployqt.json
+++ b/updatedeployqt.json
@@ -1,0 +1,11 @@
+{
+	"bridge": "AppImageUpdater",
+	"manual-update-check": {
+		"qmenu": {
+			"qobject-name": "qmHelp"
+		},
+		"qaction-to-override": {
+			"qobject-name": "qaHelpVersionCheck"
+		}
+	}
+}


### PR DESCRIPTION
Currently when we run `Help -> Check for Updates` in a continuous AppImage, we get

![](https://user-images.githubusercontent.com/2480569/59189169-f54f8600-8b68-11e9-92aa-935157d3ebdb.png)

Wouldn't it be nice if this was actually working? This PR makes it work.

This PR updates Qt to 5.12.7 (LTS) and includes the AppImageUpdaterBridge Qt Plugin by @antony-jr. It features binary delta updates, which means that going from continuous build to continuous build the user does not have to re-download the full application, but only the bits that have actually changed.

To try it, download
https://github.com/probonopd/mumble/releases/download/old/Mumble-7a563e2-x86_64.AppImage

Run it and go to `Help -> Check for Updates`. You should see

![](https://user-images.githubusercontent.com/2480569/59188853-2a0f0d80-8b68-11e9-80b0-ea512132505a.png)

Try it out and notice how fast it is.

Note that thanks to the work of @antony-jr all of this is working as a Qt plugin, without even touching any Mumble source code.