### PR TITLE
plugins: move common functions and variables from OS-specific headers to mumble_plugin_main.h

### DIFF
--- a/plugins/aoc/aoc.cpp
+++ b/plugins/aoc/aoc.cpp
@@ -3,7 +3,7 @@
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.
 
-#include "../mumble_plugin_win32.h"
+#include "../mumble_plugin_main.h"
 
 using namespace std;
 

--- a/plugins/arma2/arma2.cpp
+++ b/plugins/arma2/arma2.cpp
@@ -3,7 +3,7 @@
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.
 
-#include "../mumble_plugin_win32.h"
+#include "../mumble_plugin_main.h"
 
 procptr_t posptr, frontptr, topptr;
 

--- a/plugins/bf1/bf1.cpp
+++ b/plugins/bf1/bf1.cpp
@@ -3,7 +3,7 @@
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.
 
-#include "../mumble_plugin_win32.h" // Include standard plugin header.
+#include "../mumble_plugin_main.h" // Include standard plugin header.
 #include "../mumble_plugin_utils.h" // Include plugin header for special functions, like "escape".
 
 static int fetch(float *avatar_pos, float *avatar_front, float *avatar_top, float *camera_pos, float *camera_front, float *camera_top, std::string &context, std::wstring &identity) {

--- a/plugins/bf1942/bf1942.cpp
+++ b/plugins/bf1942/bf1942.cpp
@@ -3,7 +3,7 @@
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.
 
-#include "../mumble_plugin_win32.h"
+#include "../mumble_plugin_main.h"
 
 procptr_t faceptr, topptr;
 //BYTE *stateptr;

--- a/plugins/bf2/bf2.cpp
+++ b/plugins/bf2/bf2.cpp
@@ -3,7 +3,8 @@
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.
 
-#include "../mumble_plugin_win32.h"
+#include "../mumble_plugin_main.h"
+
 using namespace std;
 
 

--- a/plugins/bf2142/bf2142.cpp
+++ b/plugins/bf2142/bf2142.cpp
@@ -3,7 +3,7 @@
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.
 
-#include "../mumble_plugin_win32.h" // Include standard plugin header.
+#include "../mumble_plugin_main.h" // Include standard plugin header.
 #include "../mumble_plugin_utils.h" // Include plugin header for special functions, like "escape".
 
 // Variable to contain module's addresses

--- a/plugins/bf3/bf3.cpp
+++ b/plugins/bf3/bf3.cpp
@@ -36,7 +36,8 @@
    SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 
-#include "../mumble_plugin_win32.h"
+#include "../mumble_plugin_main.h"
+
 static bool ptr_chain_valid = false;
 
 // Magic ptrs

--- a/plugins/bf4/bf4.cpp
+++ b/plugins/bf4/bf4.cpp
@@ -3,7 +3,7 @@
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.
 
-#include "../mumble_plugin_win32.h" // Include standard plugin header.
+#include "../mumble_plugin_main.h" // Include standard plugin header.
 #include "../mumble_plugin_utils.h" // Include plugin header for special functions, like "escape".
 
 static int fetch(float *avatar_pos, float *avatar_front, float *avatar_top, float *camera_pos, float *camera_front, float *camera_top, std::string &context, std::wstring &identity) {

--- a/plugins/bf4_x86/bf4_x86.cpp
+++ b/plugins/bf4_x86/bf4_x86.cpp
@@ -3,7 +3,7 @@
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.
 
-#include "../mumble_plugin_win32.h" // Include standard plugin header.
+#include "../mumble_plugin_main.h" // Include standard plugin header.
 #include "../mumble_plugin_utils.h" // Include plugin header for special functions, like "escape".
 
 static int fetch(float *avatar_pos, float *avatar_front, float *avatar_top, float *camera_pos, float *camera_front, float *camera_top, std::string &context, std::wstring &identity) {

--- a/plugins/bfbc2/bfbc2.cpp
+++ b/plugins/bfbc2/bfbc2.cpp
@@ -3,7 +3,7 @@
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.
 
-#include "../mumble_plugin_win32.h"
+#include "../mumble_plugin_main.h"
 
 bool is_steam = false;
 

--- a/plugins/bfheroes/bfheroes.cpp
+++ b/plugins/bfheroes/bfheroes.cpp
@@ -3,7 +3,7 @@
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.
 
-#include "../mumble_plugin_win32.h"
+#include "../mumble_plugin_main.h"
 
 procptr_t posptr, faceptr, topptr, stateptr;
 

--- a/plugins/blacklight/blacklight.cpp
+++ b/plugins/blacklight/blacklight.cpp
@@ -34,7 +34,7 @@
    SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 
-#include "../mumble_plugin_win32.h"
+#include "../mumble_plugin_main.h"
 
 /* 
 	Arrays of bytes to find addresses accessed by respective functions so we don't have to blindly search for addresses after every update

--- a/plugins/borderlands/borderlands.cpp
+++ b/plugins/borderlands/borderlands.cpp
@@ -34,7 +34,7 @@
    SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 
-#include "../mumble_plugin_win32.h"
+#include "../mumble_plugin_main.h"
 
 procptr_t posptr, frontptr, topptr, contextptraddress, stateaddress, loginaddress;
 

--- a/plugins/borderlands2/borderlands2.cpp
+++ b/plugins/borderlands2/borderlands2.cpp
@@ -35,7 +35,8 @@
    SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */ 
 
-#include "../mumble_plugin_win32.h"
+#include "../mumble_plugin_main.h"
+
 #include <algorithm>
 
 procptr_t vects_ptr;

--- a/plugins/breach/breach.cpp
+++ b/plugins/breach/breach.cpp
@@ -34,7 +34,7 @@
    SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 
-#include "../mumble_plugin_win32.h"
+#include "../mumble_plugin_main.h"
 
 procptr_t posptr, frontptr, topptr;
 

--- a/plugins/cod2/cod2.cpp
+++ b/plugins/cod2/cod2.cpp
@@ -3,7 +3,7 @@
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.
 
-#include "../mumble_plugin_win32.h"
+#include "../mumble_plugin_main.h"
 
 static int fetch(float *avatar_pos, float *avatar_front, float *avatar_top, float *camera_pos, float *camera_front, float *camera_top, std::string &, std::wstring &) {
 	float viewHor, viewVer;

--- a/plugins/cod4/cod4.cpp
+++ b/plugins/cod4/cod4.cpp
@@ -3,7 +3,7 @@
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.
 
-#include "../mumble_plugin_win32.h"
+#include "../mumble_plugin_main.h"
 
 using namespace std;
 

--- a/plugins/cod5/cod5.cpp
+++ b/plugins/cod5/cod5.cpp
@@ -3,7 +3,7 @@
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.
 
-#include "../mumble_plugin_win32.h"
+#include "../mumble_plugin_main.h"
 
 static int fetch(float *avatar_pos, float *avatar_front, float *avatar_top, float *camera_pos, float *camera_front, float *camera_top, std::string &, std::wstring &) {
 	float viewHor, viewVer;

--- a/plugins/codmw2/codmw2.cpp
+++ b/plugins/codmw2/codmw2.cpp
@@ -3,7 +3,7 @@
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.
 
-#include "../mumble_plugin_win32.h"
+#include "../mumble_plugin_main.h"
 
 static int fetch(float *avatar_pos, float *avatar_front, float *avatar_top, float *camera_pos, float *camera_front, float *camera_top, std::string &, std::wstring &) {
 	float viewHor, viewVer;

--- a/plugins/codmw2so/codmw2so.cpp
+++ b/plugins/codmw2so/codmw2so.cpp
@@ -35,7 +35,7 @@
    SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 
-#include "../mumble_plugin_win32.h"
+#include "../mumble_plugin_main.h"
 
 static int fetch(float *avatar_pos, float *avatar_front, float *avatar_top, float *camera_pos, float *camera_front, float *camera_top, std::string &, std::wstring &) {
 	float viewHor, viewVer;

--- a/plugins/cs/cs.cpp
+++ b/plugins/cs/cs.cpp
@@ -35,7 +35,7 @@
    SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 
-#include "../mumble_plugin_win32.h"
+#include "../mumble_plugin_main.h"
 
 using namespace std;
 

--- a/plugins/dys/dys.cpp
+++ b/plugins/dys/dys.cpp
@@ -3,7 +3,7 @@
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.
 
-#include "../mumble_plugin_win32.h"
+#include "../mumble_plugin_main.h"
 
 using namespace std;
 

--- a/plugins/etqw/etqw.cpp
+++ b/plugins/etqw/etqw.cpp
@@ -3,7 +3,7 @@
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.
 
-#include "../mumble_plugin_win32.h"
+#include "../mumble_plugin_main.h"
 
 using namespace std;
 

--- a/plugins/ffxiv/ffxiv.cpp
+++ b/plugins/ffxiv/ffxiv.cpp
@@ -3,9 +3,9 @@
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.
 
-#include "../mumble_plugin_win32.h" // Include standard plugin header.
-
+#include "../mumble_plugin_main.h" // Include standard plugin header.
 #include "../mumble_plugin_utils.h" // Include plugin header for special functions, like "escape".
+
 #include <cmath>
 
 // Offset values can be obtained from:

--- a/plugins/gmod/gmod.cpp
+++ b/plugins/gmod/gmod.cpp
@@ -3,7 +3,7 @@
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.
 
-#include "../mumble_plugin_win32.h"
+#include "../mumble_plugin_main.h"
 
 using namespace std;
 

--- a/plugins/gtaiv/gtaiv.cpp
+++ b/plugins/gtaiv/gtaiv.cpp
@@ -34,7 +34,7 @@
    SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 
-#include "../mumble_plugin_win32.h"
+#include "../mumble_plugin_main.h"
 
 static unsigned int playerid;
 static procptr_t base_address;

--- a/plugins/gtav/gtav.cpp
+++ b/plugins/gtav/gtav.cpp
@@ -3,8 +3,9 @@
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.
 
-#include "../mumble_plugin_win32.h" // Include standard plugin header.
+#include "../mumble_plugin_main.h" // Include standard plugin header.
 #include "../mumble_plugin_utils.h" // Include plugin header for special functions, like "escape".
+
 #include <algorithm> // Include algorithm header for the game version detector
 
 static int fetch(float *avatar_pos, float *avatar_front, float *avatar_top, float *camera_pos, float *camera_front, float *camera_top, std::string &context, std::wstring &identity) {

--- a/plugins/gw/gw.cpp
+++ b/plugins/gw/gw.cpp
@@ -34,7 +34,7 @@
    SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 
-#include "../mumble_plugin_win32.h"
+#include "../mumble_plugin_main.h"
 
 /*
 	Arrays of bytes to find addresses accessed by respective functions so we don't have to blindly search for addresses after every update

--- a/plugins/insurgency/insurgency.cpp
+++ b/plugins/insurgency/insurgency.cpp
@@ -3,7 +3,7 @@
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.
 
-#include "../mumble_plugin_win32.h"
+#include "../mumble_plugin_main.h"
 
 using namespace std;
 

--- a/plugins/jc2/jc2.cpp
+++ b/plugins/jc2/jc2.cpp
@@ -35,7 +35,7 @@
    SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 
-#include "../mumble_plugin_win32.h"
+#include "../mumble_plugin_main.h"
 
 const unsigned int off_character_manager = 0xD8FB24;
 const unsigned int off_local_player = 0x3570;

--- a/plugins/l4d/l4d.cpp
+++ b/plugins/l4d/l4d.cpp
@@ -3,7 +3,7 @@
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.
 
-#include "../mumble_plugin_win32.h" // Include standard plugin header.
+#include "../mumble_plugin_main.h" // Include standard plugin header.
 #include "../mumble_plugin_utils.h" // Include plugin header for special functions, like "escape".
 
 static procptr_t steamclient, engine; // Variables to contain modules addresses

--- a/plugins/l4d2/l4d2.cpp
+++ b/plugins/l4d2/l4d2.cpp
@@ -3,12 +3,7 @@
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.
 
-#ifdef WIN32
-#include "../mumble_plugin_win32.h" // Include standard plugin header.
-#else
-#include "../mumble_plugin_linux.h" // Include standard plugin header.
-#endif
-
+#include "../mumble_plugin_main.h" // Include standard plugin header.
 #include "../mumble_plugin_utils.h" // Include plugin header for special functions, like "escape".
 
 // Variables to contain modules addresses

--- a/plugins/lol/lol.cpp
+++ b/plugins/lol/lol.cpp
@@ -34,7 +34,7 @@
    SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */ 
 
-#include "../mumble_plugin_win32.h"
+#include "../mumble_plugin_main.h"
 
 /*
 	Arrays of bytes to find addresses accessed by respective functions so we don't have to blindly search for addresses after every update

--- a/plugins/lotro/lotro.cpp
+++ b/plugins/lotro/lotro.cpp
@@ -34,7 +34,7 @@
    SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 
-#include "../mumble_plugin_win32.h"
+#include "../mumble_plugin_main.h"
 
 static int fetch(float *avatar_pos, float *avatar_front, float *avatar_top, float *camera_pos, float *camera_front, float *camera_top, std::string &context, std::wstring &) {
 	for (int i=0;i<3;i++)

--- a/plugins/mumble_plugin.h
+++ b/plugins/mumble_plugin.h
@@ -6,7 +6,10 @@
 #ifndef MUMBLE_MUMBLE_PLUGIN_H_
 #define MUMBLE_MUMBLE_PLUGIN_H_
 
-typedef unsigned long long procptr_t;
+#include <stdint.h>
+
+typedef uint32_t procid_t;
+typedef uint64_t procptr_t;
 
 #define LENGTH_OF(array) (sizeof(array) / sizeof((array)[0]))
 

--- a/plugins/mumble_plugin_linux.h
+++ b/plugins/mumble_plugin_linux.h
@@ -6,6 +6,10 @@
 #ifndef MUMBLE_PLUGIN_LINUX_H_
 #define MUMBLE_PLUGIN_LINUX_H_
 
+# ifndef MUMBLE_PLUGIN_MAIN_H_
+#  error "Include mumble_plugin_main.h instead of mumble_plugin_linux.h"
+# endif
+
 #include <sys/uio.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -15,8 +19,6 @@
 #include <iostream>
 #include <fstream>
 #include <sstream>
-
-#include "mumble_plugin.h"
 
 static inline std::string readAll(const std::string &fn) {
 	std::ifstream ifs;
@@ -168,7 +170,7 @@ static inline procptr_t getModuleAddr(const procid_t &pid, const wchar_t *modnam
 			if (pathname.size() > lastSlash + 1) {
 				std::string basename = pathname.substr(lastSlash + 1);
 				if (basename == modnameNonWide) {
-					unsigned long addr = strtoul(baseaddr.c_str(), NULL, 16);
+					unsigned long addr = strtoul(baseaddr.c_str(), nullptr, 16);
 					return addr;
 				}
 			}
@@ -192,7 +194,7 @@ static inline bool peekProc(const procptr_t &addr, void *dest, const size_t &len
 	return (nread != -1 && static_cast<size_t>(nread) == in.iov_len);
 }
 
-static bool inline initialize(const std::multimap<std::wstring, unsigned long long int> &pids, const wchar_t *procname, const wchar_t *modname = NULL) {
+static bool inline initialize(const std::multimap<std::wstring, unsigned long long int> &pids, const wchar_t *procname, const wchar_t *modname = nullptr) {
 	pModule = 0;
 
 	if (! pids.empty()) {

--- a/plugins/mumble_plugin_linux.h
+++ b/plugins/mumble_plugin_linux.h
@@ -18,11 +18,7 @@
 
 #include "mumble_plugin.h"
 
-pid_t pPid;
-int is64Bit;
-static procptr_t pModule;
-
-static inline std::string readAll(std::string fn) {
+static inline std::string readAll(const std::string &fn) {
 	std::ifstream ifs;
 	ifs.open(fn.c_str(), std::ifstream::binary);
 
@@ -42,7 +38,7 @@ static inline std::string readAll(std::string fn) {
 
 // This function returns 0 if the process is 32-bit and 1 if it's 64-bit.
 // In case of failure, it returns -1.
-static inline int checkProcessIs64Bit(const pid_t pid)
+static inline int checkProcessIs64Bit(const procid_t &pid)
 {
 	// We can know the process architecture by looking at its ELF header.
 	char elf[5];
@@ -74,7 +70,7 @@ static inline int checkProcessIs64Bit(const pid_t pid)
 	return elf[4] != 1;
 }
 
-static inline procptr_t getModuleAddr(pid_t pid, const wchar_t *modname) {
+static inline procptr_t getModuleAddr(const procid_t &pid, const wchar_t *modname) {
 	std::wstring modnameWide(modname);
 	std::string modnameNonWide(modnameWide.begin(), modnameWide.end());
 
@@ -182,13 +178,9 @@ static inline procptr_t getModuleAddr(pid_t pid, const wchar_t *modname) {
 	return 0;
 }
 
-static inline procptr_t getModuleAddr(const wchar_t *modname) {
-	return getModuleAddr(pPid, modname);
-}
-
-static inline bool peekProc(procptr_t base, void *dest, size_t len) {
+static inline bool peekProc(const procptr_t &addr, void *dest, const size_t &len) {
 	struct iovec in;
-	in.iov_base = reinterpret_cast<void *>(base); // Address from target process
+	in.iov_base = reinterpret_cast<void *>(addr); // Address from target process
 	in.iov_len = len; // Length
 
 	struct iovec out;
@@ -198,31 +190,6 @@ static inline bool peekProc(procptr_t base, void *dest, size_t len) {
 	ssize_t nread = process_vm_readv(pPid, &out, 1, &in, 1, 0);
 
 	return (nread != -1 && static_cast<size_t>(nread) == in.iov_len);
-}
-
-template<class T>
-bool peekProc(procptr_t base, T &dest) {
-	struct iovec in;
-	in.iov_base = reinterpret_cast<void *>(base); // Address from target process
-	in.iov_len = sizeof(T); // Length
-
-	struct iovec out;
-	out.iov_base = &dest;
-	out.iov_len = sizeof(T);
-
-	ssize_t nread = process_vm_readv(pPid, &out, 1, &in, 1, 0);
-
-	return (nread != -1 && static_cast<size_t>(nread) == in.iov_len);
-}
-
-static inline procptr_t peekProcPtr(procptr_t base) {
-	procptr_t v = 0;
-
-	if (!peekProc(base, &v, is64Bit ? 8 : 4)) {
-		return 0;
-	}
-
-	return v;
 }
 
 static bool inline initialize(const std::multimap<std::wstring, unsigned long long int> &pids, const wchar_t *procname, const wchar_t *modname = NULL) {

--- a/plugins/mumble_plugin_main.h
+++ b/plugins/mumble_plugin_main.h
@@ -1,15 +1,23 @@
-// Copyright 2005-2019 The Mumble Developers. All rights reserved.
+// Copyright 2019 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.
+
+// This is the main header for process/OS stuff; it's included in most plugins
+// because values can rarely be retrieved without accessing the process' memory.
+//
+// Various functions are provided for common tasks when reading from memory.
+// The most important are getModuleAddr() and peekProc(); the first returns the
+// base address of a module (e.g. shared library), the latter reads memory at the
+// specified address and stores it in a variable.
 
 #ifndef MUMBLE_PLUGIN_MAIN_H_
 #define MUMBLE_PLUGIN_MAIN_H_
 
 #include "mumble_plugin.h"
 
-static procid_t pPid;
 static bool is64Bit;
+static procid_t pPid;
 static procptr_t pModule;
 
 static inline bool peekProc(const procptr_t &addr, void *dest, const size_t &len);

--- a/plugins/mumble_plugin_main.h
+++ b/plugins/mumble_plugin_main.h
@@ -1,0 +1,43 @@
+// Copyright 2005-2019 The Mumble Developers. All rights reserved.
+// Use of this source code is governed by a BSD-style license
+// that can be found in the LICENSE file at the root of the
+// Mumble source tree or at <https://www.mumble.info/LICENSE>.
+
+#ifndef MUMBLE_PLUGIN_MAIN_H_
+#define MUMBLE_PLUGIN_MAIN_H_
+
+#include "mumble_plugin.h"
+
+static procid_t pPid;
+static bool is64Bit;
+static procptr_t pModule;
+
+static inline bool peekProc(const procptr_t &addr, void *dest, const size_t &len);
+static inline procptr_t getModuleAddr(const procid_t &pid, const wchar_t *modname);
+
+static inline procptr_t getModuleAddr(const wchar_t *modname) {
+	return getModuleAddr(pPid, modname);
+}
+
+template<class T>
+static inline bool peekProc(const procptr_t &addr, T &dest) {
+	return peekProc(addr, &dest, sizeof(T));
+}
+
+static inline procptr_t peekProcPtr(const procptr_t &addr) {
+	procptr_t v = 0;
+
+	if (!peekProc(addr, &v, is64Bit ? 8 : 4)) {
+		return 0;
+	}
+
+	return v;
+}
+
+#ifdef WIN32
+# include "../mumble_plugin_win32.h"
+#else
+# include "../mumble_plugin_linux.h"
+#endif
+
+#endif

--- a/plugins/mumble_plugin_win32.h
+++ b/plugins/mumble_plugin_win32.h
@@ -6,7 +6,9 @@
 #ifndef MUMBLE_MUMBLE_PLUGIN_WIN32_H_
 #define MUMBLE_MUMBLE_PLUGIN_WIN32_H_
 
-#include "mumble_plugin_main.h"
+# ifndef MUMBLE_PLUGIN_MAIN_H_
+#  error "Include mumble_plugin_main.h instead of mumble_plugin_win32.h"
+# endif
 
 #define _USE_MATH_DEFINES
 #include <stdio.h>
@@ -98,8 +100,8 @@ static inline bool peekProc(const procptr_t &addr, void *dest, const size_t &len
 	return (ok && (r == len));
 }
 
-static bool inline initialize(const std::multimap<std::wstring, unsigned long long int> &pids, const wchar_t *procname, const wchar_t *modname = NULL) {
-	hProcess = NULL;
+static bool inline initialize(const std::multimap<std::wstring, unsigned long long int> &pids, const wchar_t *procname, const wchar_t *modname = nullptr) {
+	hProcess = nullptr;
 	pModule = 0;
 
 	if (!pids.empty()) {
@@ -145,7 +147,7 @@ static bool inline initialize(const std::multimap<std::wstring, unsigned long lo
 static void generic_unlock() {
 	if (hProcess) {
 		CloseHandle(hProcess);
-		hProcess = NULL;
+		hProcess = nullptr;
 		pModule = 0;
 		pPid = 0;
 	}

--- a/plugins/ql/ql.cpp
+++ b/plugins/ql/ql.cpp
@@ -3,7 +3,7 @@
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.
 
-#include "../mumble_plugin_win32.h" // Include standard plugin header.
+#include "../mumble_plugin_main.h" // Include standard plugin header.
 #include "../mumble_plugin_utils.h" // Include plugin header for special functions, like "escape".
 
 static int fetch(float *avatar_pos, float *avatar_front, float *avatar_top, float *camera_pos, float *camera_front, float *camera_top, std::string &context, std::wstring &identity) {

--- a/plugins/rl/rl.cpp
+++ b/plugins/rl/rl.cpp
@@ -3,11 +3,7 @@
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.
 
-#ifdef WIN32
-#include "../mumble_plugin_win32.h"
-#else
-#include "../mumble_plugin_linux.h"
-#endif
+#include "../mumble_plugin_main.h"
 
 #ifdef WIN32
 // Memory offsets

--- a/plugins/sr/sr.cpp
+++ b/plugins/sr/sr.cpp
@@ -35,7 +35,7 @@
    
 */ 
 
-#include "../mumble_plugin_win32.h"
+#include "../mumble_plugin_main.h"
 
 static int fetch(float *avatar_pos, float *avatar_front, float *avatar_top, float *camera_pos, float *camera_front, float *camera_top, std::string &/*context*/, std::wstring &/*identity*/) {
 	for (int i=0;i<3;i++)

--- a/plugins/ut2004/ut2004.cpp
+++ b/plugins/ut2004/ut2004.cpp
@@ -3,7 +3,7 @@
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.
 
-#include "../mumble_plugin_win32.h"
+#include "../mumble_plugin_main.h"
 
 using namespace std;
 

--- a/plugins/ut3/ut3.cpp
+++ b/plugins/ut3/ut3.cpp
@@ -3,7 +3,7 @@
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.
 
-#include "../mumble_plugin_win32.h"
+#include "../mumble_plugin_main.h"
 
 using namespace std;
 

--- a/plugins/ut99/ut99.cpp
+++ b/plugins/ut99/ut99.cpp
@@ -34,7 +34,7 @@
    SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 
-#include "../mumble_plugin_win32.h"
+#include "../mumble_plugin_main.h"
 
 procptr_t posptr;
 procptr_t frtptr;

--- a/plugins/wolfet/wolfet.cpp
+++ b/plugins/wolfet/wolfet.cpp
@@ -47,7 +47,7 @@
 		Increasing when turning left.
 */
 
-#include "../mumble_plugin_win32.h"
+#include "../mumble_plugin_main.h"
 
 static int fetch(float *avatar_pos, float *avatar_front, float *avatar_top, float *camera_pos, float *camera_front, float *camera_top, std::string &context, std::wstring &) {
 	float viewHor, viewVer;

--- a/plugins/wow/wow.cpp
+++ b/plugins/wow/wow.cpp
@@ -3,7 +3,7 @@
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.
 
-#include "../mumble_plugin_win32.h" // Include standard plugin header.
+#include "../mumble_plugin_main.h" // Include standard plugin header.
 #include "../mumble_plugin_utils.h" // Include plugin header for special functions, like "escape".
 
 static int fetch(float *avatar_pos, float *avatar_front, float *avatar_top, float *camera_pos, float *camera_front, float *camera_top, std::string &context, std::wstring &identity) {

--- a/plugins/wow_x64/wow_x64.cpp
+++ b/plugins/wow_x64/wow_x64.cpp
@@ -3,7 +3,7 @@
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.
 
-#include "../mumble_plugin_win32.h" // Include standard plugin header.
+#include "../mumble_plugin_main.h" // Include standard plugin header.
 #include "../mumble_plugin_utils.h" // Include plugin header for special functions, like "escape".
 
 static int fetch(float *avatar_pos, float *avatar_front, float *avatar_top, float *camera_pos, float *camera_front, float *camera_top, std::string &context, std::wstring &identity) {


### PR DESCRIPTION
This is in preparation for the new Source Engine plugin (for #3493) which will add a few common functions.

This commit also improves the functions arguments so that they are passed by reference and marked as `const` (when possible).

A new data type called `procid_t` is created, intended to be a replacement for `pid_t` (Linux) and `DWORD` (Windows).