### PR TITLE
SSL.cpp: replace deprecated QSslSocket::systemCaCertificates() with QSslConfiguration::systemCaCertificates()

### DIFF
--- a/src/SSL.cpp
+++ b/src/SSL.cpp
@@ -214,7 +214,7 @@ void MumbleSSL::addSystemCA() {
 
 #if QT_VERSION >= 0x040800
 	// Don't perform on-demand loading of root certificates
-	QSslSocket::addDefaultCaCertificates(QSslSocket::systemCaCertificates());
+	QSslSocket::addDefaultCaCertificates(QSslConfiguration::systemCaCertificates());
 #endif
 
 #ifdef Q_OS_WIN


### PR DESCRIPTION
qt/qtbase@92cda9474245c79b635c21cd140c5d0a3a6d2e5b