### PR TITLE
Azure Pipelines: add Linux build to create and store AppImage as artifact

### DIFF
--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -20,3 +20,17 @@ jobs:
       displayName: 'Install build environment'
     - powershell: scripts/azure-pipelines/build.ps1
       displayName: 'Build'
+  - job: Linux
+    pool:
+      vmImage: 'ubuntu-16.04'
+    steps:
+    - script: git submodule --quiet update --init --recursive
+      displayName: 'Fetch submodules'
+    - script: scripts/azure-pipelines/install-environment_linux.bash
+      displayName: 'Install build environment'
+    - script: scripts/azure-pipelines/build_linux.bash
+      displayName: 'Build'
+    - task: PublishBuildArtifacts@1
+      inputs:
+        pathtoPublish: '$(Build.ArtifactStagingDirectory)'
+        artifactName: AppImage

--- a/scripts/azure-pipelines/build_linux.bash
+++ b/scripts/azure-pipelines/build_linux.bash
@@ -1,0 +1,32 @@
+#!/bin/bash -ex
+#
+# Copyright 2019 The Mumble Developers. All rights reserved.
+# Use of this source code is governed by a BSD-style license
+# that can be found in the LICENSE file at the root of the
+# Mumble source tree or at <https://www.mumble.info/LICENSE>.
+
+qmake -recursive CONFIG+="release tests warnings-as-errors" DEFINES+="MUMBLE_VERSION=${BUILD_SOURCEVERSION:0:7}"
+
+make -j $(nproc) && make check
+
+# TODO: The next few lines should be done by "make install": https://github.com/mumble-voip/mumble/issues/1029
+mkdir -p appdir/usr/bin appdir/usr/lib/mumble appdir/usr/share/metainfo/ appdir/usr/share/icons/hicolor/scalable/apps/ appdir/usr/share/applications/
+cp release/lib* appdir/usr/lib/
+cp release/mumble appdir/usr/bin
+cp release/plugins/lib* appdir/usr/lib/mumble/
+cp scripts/mumble.desktop appdir/usr/share/applications/
+cp scripts/mumble.appdata.xml appdir/usr/share/metainfo/
+cp icons/mumble.svg appdir/usr/share/icons/hicolor/scalable/apps/
+wget -c -nv "https://github.com/probonopd/linuxdeployqt/releases/download/continuous/linuxdeployqt-continuous-x86_64.AppImage"
+chmod a+x linuxdeployqt-continuous-x86_64.AppImage
+./linuxdeployqt-continuous-x86_64.AppImage $(find $HOME -type d -name 'appdir'| head -n 1)/usr/share/applications/*.desktop -appimage -extra-plugins=sqldrivers/libqsqlite.so
+
+for f in Mumble*.AppImage; do
+	# Embed update information into AppImage
+	echo -n "zsync|https://dl.mumble.info/snapshot/latest-x86_64.AppImage.zsync" | dd of=$f seek=175720 conv=notrunc oflag=seek_bytes
+
+	# Generate zsync file for AppImage
+	zsyncmake $f
+done
+
+mv Mumble*.AppImage* ${BUILD_ARTIFACTSTAGINGDIRECTORY}

--- a/scripts/azure-pipelines/install-environment_linux.bash
+++ b/scripts/azure-pipelines/install-environment_linux.bash
@@ -1,0 +1,16 @@
+#!/bin/bash -ex
+#
+# Copyright 2019 The Mumble Developers. All rights reserved.
+# Use of this source code is governed by a BSD-style license
+# that can be found in the LICENSE file at the root of the
+# Mumble source tree or at <https://www.mumble.info/LICENSE>.
+
+sudo apt-get update
+
+sudo apt-get -y install build-essential pkg-config qt5-default qttools5-dev-tools libqt5svg5-dev \
+                        libboost-dev libssl-dev libprotobuf-dev protobuf-compiler \
+                        libcap-dev libxi-dev \
+                        libjack-jackd2-dev libasound2-dev libpulse-dev \
+                        libogg-dev libsndfile1-dev libspeechd-dev \
+                        libavahi-compat-libdnssd-dev libzeroc-ice-dev libg15daemon-client-dev \
+                        zsync


### PR DESCRIPTION
This is the first step towards our new build infrastructure.