### PR TITLE
Register.cpp: replace deprecated QSslSocket::defaultCaCertificates()

### DIFF
--- a/src/murmur/Register.cpp
+++ b/src/murmur/Register.cpp
@@ -98,7 +98,7 @@ void Server::update() {
 
 	/* Work around bug in QSslConfiguration */
 	QList<QSslCertificate> calist = ssl.caCertificates();
-	calist << QSslSocket::defaultCaCertificates();
+	calist << QSslConfiguration::defaultConfiguration().caCertificates();
 	calist << Meta::mp.qlCA;
 	calist << Meta::mp.qlIntermediates;
 	calist << qscCert;


### PR DESCRIPTION
qt/qtbase@92cda94