### PR TITLE
Use QSslSocket for Ca Certs on Qt5 < 5.5

### DIFF
--- a/src/SSL.cpp
+++ b/src/SSL.cpp
@@ -212,9 +212,11 @@ void MumbleSSL::addSystemCA() {
 	QSslSocket::setDefaultCaCertificates(ql);
 #endif // NO_SYSTEM_CA_OVERRIDE
 
-#if QT_VERSION >= 0x040800
 	// Don't perform on-demand loading of root certificates
+#if QT_VERSION >= 0x050500
 	QSslSocket::addDefaultCaCertificates(QSslConfiguration::systemCaCertificates());
+#elif QT_VERSION >= 0x040800
+	QSslSocket::addDefaultCaCertificates(QSslSocket::systemCaCertificates());
 #endif
 
 #ifdef Q_OS_WIN


### PR DESCRIPTION
Fixes regression caused by 3cd2984e8a, as mentioned in the IRC room.