### PR TITLE
CELT on by default.

### DIFF
--- a/src/mumble/Settings.cpp
+++ b/src/mumble/Settings.cpp
@@ -252,7 +252,7 @@ Settings::Settings() {
 	fVADmin = 0.80f;
 	fVADmax = 0.98f;
 
-	bUseOpusMusicEncoding = false;
+	bUseOpusMusicEncoding = true;
 
 	bTxAudioCue = false;
 	qsTxAudioCueOn = cqsDefaultPushClickOn;


### PR DESCRIPTION
This partially implements #3502 by setting bUseOpusMusicEncoding to default on, thus using CELT alone by default, the simplest step suggested by the issue.

As explained in the Opus docs, by restricting oneself to CELT and getting rid of the SILK layer, latency is lowered and higher quality is achieved.

As made clear by the issue description and further comments by other users, it seems pointless to keep this setting off by default. While I initially thought, based on theory, there might be a quality decrease for cases with very low bandwidth, this was unable to be reproduced in testing by me and another user with very low bandwidth and thus there seems to be virtually no drawback to turning this on in practice.

This is why at first I was going to implement this by keeping it off by default for low bandwidth users but turning it on dynamically for high bandwidth, however according to the testing results now I think it's best to just set it on by default for everyone.