### PR TITLE
Implement & auto-select Opus' low delay mode

### DIFF
--- a/src/mumble/AudioConfigDialog.cpp
+++ b/src/mumble/AudioConfigDialog.cpp
@@ -132,6 +132,7 @@ void AudioInputDialog::load(const Settings &r) {
 	loadCheckBox(qcbPushWindow, r.bShowPTTButtonWindow);
 	loadCheckBox(qcbPushClick, r.bTxAudioCue);
 	loadSlider(qsQuality, r.iQuality);
+	loadCheckBox(qcbAllowLowDelay, r.bAllowLowDelay);
 	if (r.iNoiseSuppress != 0)
 		loadSlider(qsNoise, - r.iNoiseSuppress);
 	else
@@ -160,6 +161,7 @@ void AudioInputDialog::load(const Settings &r) {
 
 void AudioInputDialog::save() const {
 	s.iQuality = qsQuality->value();
+	s.bAllowLowDelay = qcbAllowLowDelay->isChecked();
 	s.iNoiseSuppress = (qsNoise->value() == 14) ? 0 : - qsNoise->value();
 	s.bDenoise = qcbDenoise->isChecked();
 	s.iMinLoudness = 18000 - qsAmp->value() + 2000;

--- a/src/mumble/AudioInput.h
+++ b/src/mumble/AudioInput.h
@@ -112,6 +112,7 @@ class AudioInput : public QThread {
 
 		/// Encoded audio rate in bit/s
 		int iAudioQuality;
+		bool bAllowLowDelay;
 		/// Number of 10ms audio "frames" per packet (!= frames in packet)
 		int iAudioFrames;
 
@@ -142,7 +143,7 @@ class AudioInput : public QThread {
 
 		void initializeMixer();
 
-		static void adjustBandwidth(int bitspersec, int &bitrate, int &frames);
+		static void adjustBandwidth(int bitspersec, int &bitrate, int &frames, bool &allowLowDelay);
 	signals:
 		void doDeaf();
 		void doMute();

--- a/src/mumble/AudioInput.ui
+++ b/src/mumble/AudioInput.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>569</width>
-    <height>764</height>
+    <width>588</width>
+    <height>794</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -295,6 +295,71 @@
         </widget>
         <widget class="QWidget" name="qwVAD">
          <layout class="QGridLayout">
+          <item row="1" column="2">
+           <widget class="QLabel" name="qlTransmitHold">
+            <property name="minimumSize">
+             <size>
+              <width>40</width>
+              <height>0</height>
+             </size>
+            </property>
+            <property name="text">
+             <string/>
+            </property>
+           </widget>
+          </item>
+          <item row="3" column="0">
+           <widget class="QLabel" name="qliTransmitMin">
+            <property name="text">
+             <string>Silence Below</string>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="1">
+           <widget class="QSlider" name="qsTransmitHold">
+            <property name="toolTip">
+             <string>How long to keep transmitting after silence</string>
+            </property>
+            <property name="whatsThis">
+             <string>&lt;b&gt;This selects how long after a perceived stop in speech transmission should continue.&lt;/b&gt;&lt;br /&gt;Set this higher if your voice breaks up when you speak (seen by a rapidly blinking voice icon next to your name).</string>
+            </property>
+            <property name="minimum">
+             <number>20</number>
+            </property>
+            <property name="maximum">
+             <number>250</number>
+            </property>
+            <property name="orientation">
+             <enum>Qt::Horizontal</enum>
+            </property>
+           </widget>
+          </item>
+          <item row="2" column="1">
+           <widget class="AudioBar" name="abSpeech" native="true">
+            <property name="maximumSize">
+             <size>
+              <width>16777215</width>
+              <height>10</height>
+             </size>
+            </property>
+            <property name="toolTip">
+             <string>Current speech detection chance</string>
+            </property>
+            <property name="whatsThis">
+             <string>&lt;b&gt;This shows the current speech detection settings.&lt;/b&gt;&lt;br /&gt;You can change the settings from the Settings dialog or from the Audio Wizard.</string>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="0">
+           <widget class="QLabel" name="qliTransmitHold">
+            <property name="text">
+             <string>Voice &amp;Hold</string>
+            </property>
+            <property name="buddy">
+             <cstring>qsTransmitHold</cstring>
+            </property>
+           </widget>
+          </item>
           <item row="0" column="0" colspan="3">
            <layout class="QHBoxLayout">
             <item>
@@ -325,68 +390,10 @@
             </item>
            </layout>
           </item>
-          <item row="1" column="0">
-           <widget class="QLabel" name="qliTransmitHold">
+          <item row="4" column="0">
+           <widget class="QLabel" name="qliTransmitMax">
             <property name="text">
-             <string>Voice &amp;Hold</string>
-            </property>
-            <property name="buddy">
-             <cstring>qsTransmitHold</cstring>
-            </property>
-           </widget>
-          </item>
-          <item row="1" column="1">
-           <widget class="QSlider" name="qsTransmitHold">
-            <property name="toolTip">
-             <string>How long to keep transmitting after silence</string>
-            </property>
-            <property name="whatsThis">
-             <string>&lt;b&gt;This selects how long after a perceived stop in speech transmission should continue.&lt;/b&gt;&lt;br /&gt;Set this higher if your voice breaks up when you speak (seen by a rapidly blinking voice icon next to your name).</string>
-            </property>
-            <property name="minimum">
-             <number>20</number>
-            </property>
-            <property name="maximum">
-             <number>250</number>
-            </property>
-            <property name="orientation">
-             <enum>Qt::Horizontal</enum>
-            </property>
-           </widget>
-          </item>
-          <item row="1" column="2">
-           <widget class="QLabel" name="qlTransmitHold">
-            <property name="minimumSize">
-             <size>
-              <width>40</width>
-              <height>0</height>
-             </size>
-            </property>
-            <property name="text">
-             <string/>
-            </property>
-           </widget>
-          </item>
-          <item row="2" column="1">
-           <widget class="AudioBar" name="abSpeech" native="true">
-            <property name="maximumSize">
-             <size>
-              <width>16777215</width>
-              <height>10</height>
-             </size>
-            </property>
-            <property name="toolTip">
-             <string>Current speech detection chance</string>
-            </property>
-            <property name="whatsThis">
-             <string>&lt;b&gt;This shows the current speech detection settings.&lt;/b&gt;&lt;br /&gt;You can change the settings from the Settings dialog or from the Audio Wizard.</string>
-            </property>
-           </widget>
-          </item>
-          <item row="3" column="0">
-           <widget class="QLabel" name="qliTransmitMin">
-            <property name="text">
-             <string>Silence Below</string>
+             <string>Speech Above</string>
             </property>
            </widget>
           </item>
@@ -412,13 +419,6 @@
             </property>
             <property name="orientation">
              <enum>Qt::Horizontal</enum>
-            </property>
-           </widget>
-          </item>
-          <item row="4" column="0">
-           <widget class="QLabel" name="qliTransmitMax">
-            <property name="text">
-             <string>Speech Above</string>
             </property>
            </widget>
           </item>
@@ -461,57 +461,6 @@
       <string>Compression</string>
      </property>
      <layout class="QGridLayout">
-      <item row="0" column="0">
-       <widget class="QLabel" name="qliQuality">
-        <property name="text">
-         <string>&amp;Quality</string>
-        </property>
-        <property name="buddy">
-         <cstring>qsQuality</cstring>
-        </property>
-       </widget>
-      </item>
-      <item row="0" column="1">
-       <widget class="QSlider" name="qsQuality">
-        <property name="toolTip">
-         <string>Quality of compression (peak bandwidth)</string>
-        </property>
-        <property name="whatsThis">
-         <string>&lt;b&gt;This sets the quality of compression.&lt;/b&gt;&lt;br /&gt;This determines how much bandwidth Mumble is allowed to use for outgoing audio.</string>
-        </property>
-        <property name="minimum">
-         <number>8000</number>
-        </property>
-        <property name="maximum">
-         <number>96000</number>
-        </property>
-        <property name="singleStep">
-         <number>1000</number>
-        </property>
-        <property name="pageStep">
-         <number>5000</number>
-        </property>
-        <property name="value">
-         <number>32000</number>
-        </property>
-        <property name="orientation">
-         <enum>Qt::Horizontal</enum>
-        </property>
-       </widget>
-      </item>
-      <item row="0" column="2">
-       <widget class="QLabel" name="qlQuality">
-        <property name="minimumSize">
-         <size>
-          <width>30</width>
-          <height>0</height>
-         </size>
-        </property>
-        <property name="text">
-         <string/>
-        </property>
-       </widget>
-      </item>
       <item row="1" column="0">
        <widget class="QLabel" name="qliFrames">
         <property name="text">
@@ -544,6 +493,19 @@
         </property>
        </widget>
       </item>
+      <item row="0" column="2">
+       <widget class="QLabel" name="qlQuality">
+        <property name="minimumSize">
+         <size>
+          <width>30</width>
+          <height>0</height>
+         </size>
+        </property>
+        <property name="text">
+         <string/>
+        </property>
+       </widget>
+      </item>
       <item row="1" column="2">
        <widget class="QLabel" name="qlFrames">
         <property name="minimumSize">
@@ -557,7 +519,35 @@
         </property>
        </widget>
       </item>
-      <item row="2" column="0" colspan="3">
+      <item row="0" column="1">
+       <widget class="QSlider" name="qsQuality">
+        <property name="toolTip">
+         <string>Quality of compression (peak bandwidth)</string>
+        </property>
+        <property name="whatsThis">
+         <string>&lt;b&gt;This sets the quality of compression.&lt;/b&gt;&lt;br /&gt;This determines how much bandwidth Mumble is allowed to use for outgoing audio.</string>
+        </property>
+        <property name="minimum">
+         <number>8000</number>
+        </property>
+        <property name="maximum">
+         <number>192000</number>
+        </property>
+        <property name="singleStep">
+         <number>1000</number>
+        </property>
+        <property name="pageStep">
+         <number>5000</number>
+        </property>
+        <property name="value">
+         <number>32000</number>
+        </property>
+        <property name="orientation">
+         <enum>Qt::Horizontal</enum>
+        </property>
+       </widget>
+      </item>
+      <item row="3" column="0" colspan="3">
        <widget class="QLabel" name="qlBitrate">
         <property name="font">
          <font>
@@ -575,6 +565,29 @@
         </property>
         <property name="alignment">
          <set>Qt::AlignCenter</set>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="0">
+       <widget class="QLabel" name="qliQuality">
+        <property name="text">
+         <string>&amp;Quality</string>
+        </property>
+        <property name="buddy">
+         <cstring>qsQuality</cstring>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="0" colspan="2">
+       <widget class="QCheckBox" name="qcbAllowLowDelay">
+        <property name="toolTip">
+         <string>Enable Opus' low-delay mode when the quality is set to &lt;b&gt;64 kb/s&lt;/b&gt; or higher. </string>
+        </property>
+        <property name="whatsThis">
+         <string>If checked, Mumble will enable Opus' low-delay mode when the quality is set to &lt;b&gt;64 kbit/s&lt;/b&gt; or higher. Low-delay mode decreases latency by &lt;b&gt;~15 milliseconds&lt;/b&gt; in the round trip. This mode may require an higher bitrate to preserve the same quality, in comparison with the music and VOIP modes.</string>
+        </property>
+        <property name="text">
+         <string>Allow low delay mode</string>
         </property>
        </widget>
       </item>

--- a/src/mumble/Settings.cpp
+++ b/src/mumble/Settings.cpp
@@ -250,6 +250,7 @@ Settings::Settings() {
 	iFramesPerPacket = 2;
 	iNoiseSuppress = -30;
 	bDenoise = false;
+	bAllowLowDelay = true;
 	uiAudioInputChannelMask = 0xffffffffffffffffULL;
 
 	// Idle auto actions
@@ -260,8 +261,6 @@ Settings::Settings() {
 	vsVAD = Amplitude;
 	fVADmin = 0.80f;
 	fVADmax = 0.98f;
-
-	bUseOpusMusicEncoding = true;
 
 	bTxAudioCue = false;
 	qsTxAudioCueOn = cqsDefaultPushClickOn;
@@ -629,6 +628,7 @@ void Settings::load(QSettings* settings_ptr) {
 	SAVELOAD(fVADmax, "audio/vadmax");
 	SAVELOAD(iNoiseSuppress, "audio/noisesupress");
 	SAVELOAD(bDenoise, "audio/denoise");
+	SAVELOAD(bAllowLowDelay, "audio/allowlowdelay");
 	SAVELOAD(uiAudioInputChannelMask, "audio/inputchannelmask");
 	SAVELOAD(iVoiceHold, "audio/voicehold");
 	SAVELOAD(iOutputDelay, "audio/outputdelay");
@@ -652,8 +652,6 @@ void Settings::load(QSettings* settings_ptr) {
 	SAVELOAD(qsAudioOutput, "audio/output");
 	SAVELOAD(bWhisperFriends, "audio/whisperfriends");
 	SAVELOAD(bTransmitPosition, "audio/postransmit");
-
-	SAVELOAD(bUseOpusMusicEncoding, "codec/opus/encoder/music");
 
 	SAVELOAD(iJitterBufferSize, "net/jitterbuffer");
 	SAVELOAD(iFramesPerPacket, "net/framesperpacket");
@@ -972,6 +970,7 @@ void Settings::save() {
 	SAVELOAD(fVADmax, "audio/vadmax");
 	SAVELOAD(iNoiseSuppress, "audio/noisesupress");
 	SAVELOAD(bDenoise, "audio/denoise");
+	SAVELOAD(bAllowLowDelay, "audio/allowlowdelay");
 	SAVELOAD(uiAudioInputChannelMask, "audio/inputchannelmask");
 	SAVELOAD(iVoiceHold, "audio/voicehold");
 	SAVELOAD(iOutputDelay, "audio/outputdelay");
@@ -995,8 +994,6 @@ void Settings::save() {
 	SAVELOAD(qsAudioOutput, "audio/output");
 	SAVELOAD(bWhisperFriends, "audio/whisperfriends");
 	SAVELOAD(bTransmitPosition, "audio/postransmit");
-
-	SAVELOAD(bUseOpusMusicEncoding, "codec/opus/encoder/music");
 
 	SAVELOAD(iJitterBufferSize, "net/jitterbuffer");
 	SAVELOAD(iFramesPerPacket, "net/framesperpacket");

--- a/src/mumble/Settings.h
+++ b/src/mumble/Settings.h
@@ -185,6 +185,7 @@ struct Settings {
 	QString qsTTSLanguage;
 	int iQuality, iMinLoudness, iVoiceHold, iJitterBufferSize;
 	int iNoiseSuppress;
+	bool bAllowLowDelay;
 	bool bDenoise;
 	quint64 uiAudioInputChannelMask;
 
@@ -205,7 +206,6 @@ struct Settings {
 	bool bOnlyAttenuateSameOutput;
 	bool bAttenuateLoopbacks;
 	int iOutputDelay;
-	bool bUseOpusMusicEncoding;
 
 	QString qsALSAInput, qsALSAOutput;
 	QString qsPulseAudioInput, qsPulseAudioOutput;


### PR DESCRIPTION
This pull request implements Opus' low delay mode selection, which should result in a big decrease in latency.
The `bUseOpusMusicEncoding` option has been removed, because now the Opus mode is selected depending on the bitrate. The automatic selection aims to decrease the latency while maintaining acceptable quality.
The exact values may have to be tuned further for a smarter auto-selection because the low delay mode, while causing a strong decrease in latency, requires an higher bitrate to maintain the same quality; in order to compensate, the maximum bitrate in the UI has been increased to **192 kbit/s**.

The automatic selection sets:
- Low-delay mode when the bitrate is **>= 64 kbit/s**.
- Music mode when the bitrate is **>= 32 kbit/s**.
- VOIP mode when the bitrate is **< 32 kbit/s**.