### PR TITLE
Fix for #3755, check if Screen::screenAt(p) is nullptr

### DIFF
--- a/src/mumble/MainWindow.cpp
+++ b/src/mumble/MainWindow.cpp
@@ -3076,24 +3076,27 @@ void MainWindow::trayAboutToShow() {
 		p = QCursor::pos();
 	}
 
-	QRect qr = Screen::screenAt(p)->geometry();
+	QScreen *screen = Screen::screenAt(p);
+	if(screen != nullptr){
+		QRect qr = screen->geometry();
 
-	if (p.y() < (qr.height() / 2))
-		top = true;
+		if (p.y() < (qr.height() / 2))
+			top = true;
 
-	qmTray->clear();
-	if (top) {
-		qmTray->addAction(qaQuit);
-		qmTray->addAction(qaShow);
-		qmTray->addSeparator();
-		qmTray->addAction(qaAudioDeaf);
-		qmTray->addAction(qaAudioMute);
-	} else {
-		qmTray->addAction(qaAudioMute);
-		qmTray->addAction(qaAudioDeaf);
-		qmTray->addSeparator();
-		qmTray->addAction(qaShow);
-		qmTray->addAction(qaQuit);
+		qmTray->clear();
+		if (top) {
+			qmTray->addAction(qaQuit);
+			qmTray->addAction(qaShow);
+			qmTray->addSeparator();
+			qmTray->addAction(qaAudioDeaf);
+			qmTray->addAction(qaAudioMute);
+		} else {
+			qmTray->addAction(qaAudioMute);
+			qmTray->addAction(qaAudioDeaf);
+			qmTray->addSeparator();
+			qmTray->addAction(qaShow);
+			qmTray->addAction(qaQuit);
+		}
 	}
 }
 


### PR DESCRIPTION
check if Screen::screenAt(p) is not nullptr in MainWindow.cpp,
MainWindow::trayAboutToShow(). If screen == nullptr, do nothing more.

This is a work around / fix for #3755, on my machine everything works after adding this check (the tray works too as always).

I'm not an C++/QT expert so maybe that is not a good solution - in that case just tell me and close the PR.

Thanks!