### PR TITLE
CI: Fix Azure Pipelines build failing

### DIFF
--- a/scripts/azure-pipelines/build.ps1
+++ b/scripts/azure-pipelines/build.ps1
@@ -7,25 +7,28 @@
 #
 # Predefined variables:
 #
-#  AGENT_BUILDDIRECTORY       - Predefined variable.
-#                               The local path on the agent where all folders
+#  AGENT_BUILDDIRECTORY       - The local path on the agent where all folders
 #                               for a given build pipeline are created
-#                               (e.g. "D:\a\1")
-#  BUILD_SOURCESDIRECTORY     - Predefined variable.
-#                               The local path on the agent where the
+#                               (e.g. "c:\agent_work\1").
+#  BUILD_SOURCESDIRECTORY     - The local path on the agent where the
 #                               repository is downloaded.
-#                               (e.g. "D:\a\1\s")
+#                               (e.g. "c:\agent_work\1\s").
+#  AGENT_TOOLSDIRECTORY       - The directory used by tasks such as
+#                               Node Tool Installer and Use Python Version
+#                               to switch between multiple versions of a tool.
+#                               We store our build environment there, in the
+#                               folder specified by MUMBLE_ENVIRONMENT_DIR.
 #
 # Defined in the visual designer on Azure Pipelines:
 #
-#  MUMBLE_ENVIRONMENT_DIR     - The local path where the build environment
-#                               is stored (e.g. "C:\MumbleBuild").
+#  MUMBLE_ENVIRONMENT_DIR     - Folder where the build environment will be stored
+#                               (e.g. "MumbleBuild").
 #  MUMBLE_ENVIRONMENT_VERSION - Full build environment version
 #                               (e.g. win64-static-no-ltcg-1.3.x-2017-02-02-ec94ddb-790).
 #                               Must match .7z and extracted folder name.
 #  MUMBLE_BUILDSCRIPT         - Path to required build script cmd file. Relative to build
 #                               environment's "mumble-releng\buildscripts" path.
-#                               (e.g. "1.3.x/buildenv-win64-static.cmd")
+#                               (e.g. "1.3.x/buildenv-win64-static.cmd").
 #
 # Defined in the YAML configuration:
 #
@@ -34,7 +37,7 @@
 
 $MUMBLE_BUILD_DIR = $env:AGENT_BUILDDIRECTORY
 $MUMBLE_SOURCE_DIR = $env:BUILD_SOURCESDIRECTORY
-$MUMBLE_BUILDENV_DIR = Join-Path $env:MUMBLE_ENVIRONMENT_DIR $env:MUMBLE_ENVIRONMENT_VERSION
+$MUMBLE_BUILDENV_DIR = Join-Path (Join-Path $env:AGENT_TOOLSDIRECTORY $env:MUMBLE_ENVIRONMENT_DIR) $env:MUMBLE_ENVIRONMENT_VERSION
 $MUMBLE_BUILDSCRIPT = Join-Path $MUMBLE_BUILDENV_DIR "mumble-releng\buildscripts\$env:MUMBLE_BUILDSCRIPT"
 
 $env:MUMBLE_EXTRA_QMAKE_CONFIG_FLAGS = ""

--- a/scripts/azure-pipelines/install-environment.ps1
+++ b/scripts/azure-pipelines/install-environment.ps1
@@ -2,10 +2,20 @@
 # into our Azure Pipelines VM before we attempt to build. If the
 # environment archive is already present, this script will just extract it.
 #
-# Configuration variables (defined in the visual designer on Azure Pipelines) used from environment:
+# Below is a list of configuration variables used from environment.
 #
-#  MUMBLE_ENVIRONMENT_DIR     - The local path where the build environment
-#                               will be stored (e.g. "C:\MumbleBuild").
+# Predefined variables:
+#
+#  AGENT_TOOLSDIRECTORY       - The directory used by tasks such as
+#                               Node Tool Installer and Use Python Version
+#                               to switch between multiple versions of a tool.
+#                               We store our build environment there, in the
+#                               folder specified by MUMBLE_ENVIRONMENT_DIR.
+#
+# Defined in the visual designer on Azure Pipelines:
+#
+#  MUMBLE_ENVIRONMENT_DIR     - Folder where the build environment will be stored
+#                               (e.g. "MumbleBuild").
 #  MUMBLE_ENVIRONMENT_SOURCE  - Build environment web source folder URL
 #                               (e.g. https://somehost/folder).
 #  MUMBLE_ENVIRONMENT_VERSION - Full build environment version
@@ -15,8 +25,8 @@
 
 $MUMBLE_ENVIRONMENT_VERSION = $env:MUMBLE_ENVIRONMENT_VERSION
 $MUMBLE_ENVIRONMENT_SOURCE = $env:MUMBLE_ENVIRONMENT_SOURCE
-$MUMBLE_ENVIRONMENT_DIR = $env:MUMBLE_ENVIRONMENT_DIR
-$MUMBLE_ENVIRONMENT_STORE = Join-Path $MUMBLE_ENVIRONMENT_DIR "\cache"
+$MUMBLE_ENVIRONMENT_PATH = Join-Path $env:AGENT_TOOLSDIRECTORY $env:MUMBLE_ENVIRONMENT_DIR
+$MUMBLE_ENVIRONMENT_STORE = Join-Path $MUMBLE_ENVIRONMENT_PATH "cache"
 
 if (-Not (Test-Path $MUMBLE_ENVIRONMENT_STORE)) {
     New-Item $MUMBLE_ENVIRONMENT_STORE -ItemType Directory | Out-Null
@@ -30,9 +40,13 @@ if (-Not (Test-Path $env_7z)) {
     Invoke-WebRequest -Uri $env_url -OutFile $env_7z
 }
 
-if (-Not (Test-Path (Join-Path $MUMBLE_ENVIRONMENT_DIR $MUMBLE_ENVIRONMENT_VERSION))) {
-    Write-Host "Extracting build environment to $MUMBLE_ENVIRONMENT_DIR..."
-    & C:\ProgramData\chocolatey\bin\7z.exe x $env_7z -o"$MUMBLE_ENVIRONMENT_DIR"
+if (-Not (Test-Path (Join-Path $MUMBLE_ENVIRONMENT_PATH $MUMBLE_ENVIRONMENT_VERSION))) {
+    Write-Host "Extracting build environment to $MUMBLE_ENVIRONMENT_PATH..."
+    & C:\ProgramData\chocolatey\bin\7z.exe x $env_7z -o"$MUMBLE_ENVIRONMENT_PATH"
 }
 
-Get-ChildItem -Path $MUMBLE_ENVIRONMENT_DIR
+Get-ChildItem -Path $MUMBLE_ENVIRONMENT_PATH
+
+# We have to create a symlink because unfortunately C:\MumbleBuild is hardcoded
+# in our environment (e.g. qmake's configuration files' path).
+New-Item -Path C:\MumbleBuild -ItemType SymbolicLink -Value $MUMBLE_ENVIRONMENT_PATH


### PR DESCRIPTION
This is a cherry-pick of c7c4fba6 which landed in master.

Recent builds have failed because there is not enough space in `C:\` after installing the build environment, which we used to extract in `C:\MumbleBuild`.

This commit changes the PowerShell scripts so that our environment directory (e.g. `MumbleBuild`) is created in the proper directory (Agent.ToolsDirectory's value, e.g. `D:\a\_tool\`) instead of `C:\`.

`C:\MumbleBuild` is still required because our build environment's qmake expects its configuration files to be there (hardcoded). The environment installation script creates a symbolic link to solve the problem.