### PR TITLE
Change tab-size to 4 in Doxygen

### DIFF
--- a/Doxyfile
+++ b/Doxyfile
@@ -193,7 +193,7 @@ SEPARATE_MEMBER_PAGES  = NO
 # The TAB_SIZE tag can be used to set the number of spaces in a tab. 
 # Doxygen uses this value to replace tabs by spaces in code fragments.
 
-TAB_SIZE               = 8
+TAB_SIZE               = 4
 
 # This tag can be used to specify a number of aliases that acts 
 # as commands in the documentation. An alias has the form "name=value". 


### PR DESCRIPTION
Currently the tab-size is set to 8 which isn't what one would expect in most cases. Thus I changed it to be 4 which from my experience is what people would expect a tab to look like.