### PR TITLE
Bump version to 1.4.0

### DIFF
--- a/g15helper/g15helper.plist
+++ b/g15helper/g15helper.plist
@@ -13,7 +13,7 @@
 	<key>CFBundleSignature</key>
 	<string>G15H</string>
 	<key>CFBundleVersion</key>
-	<string>1.3.0</string>
+	<string>1.4.0</string>
 	<key>NSHumanReadableCopyright</key>
 	<string>Copyright (c) 2005-2019 The Mumble Developers</string>
 </dict>

--- a/g15helper/g15helper.rc
+++ b/g15helper/g15helper.rc
@@ -20,8 +20,8 @@ IDI_ICON1               ICON    DISCARDABLE     "../icons/g15helper.ico"
 #endif
 
 VS_VERSION_INFO VERSIONINFO
-	FILEVERSION		1,3,0,0
-	PRODUCTVERSION	1,3,0,0
+	FILEVERSION		1,4,0,0
+	PRODUCTVERSION	1,4,0,0
 	FILEFLAGSMASK	VS_FFI_FILEFLAGSMASK
 	FILEFLAGS		(VER_DEBUG|VER_RELEASE)
 	FILEOS			VOS_NT_WINDOWS32
@@ -34,8 +34,8 @@ VS_VERSION_INFO VERSIONINFO
 			BEGIN
 				VALUE "CompanyName", "The Mumble Developers"
 				VALUE "FileDescription", "Mumble G15 LCD Helper"
-				VALUE "FileVersion", "1.3.0"
-				VALUE "ProductVersion", "1.3.0"
+				VALUE "FileVersion", "1.4.0"
+				VALUE "ProductVersion", "1.4.0"
 				VALUE "LegalCopyright", "Copyright (c) 2005-2019 The Mumble Developers"
 				VALUE "OriginalFilename", "mumble-g15-helper.exe"
 				VALUE "ProductName", "Mumble G15 LCD Helper"

--- a/installer/Settings.wxi
+++ b/installer/Settings.wxi
@@ -2,7 +2,7 @@
 <Include>
   <?define ProductName = "Mumble" ?>
   <?define ProductManufacturer = "The Mumble Developers" ?>
-  <?define ProductVersion = "1.3.0" ?>
+  <?define ProductVersion = "1.4.0" ?>
 
   <?if $(sys.BUILDARCH) = "x86" ?>
     <?define ProductUpgradeCode = "B0EEFCC7-8A9c-4471-AB10-CBD35BE3161D" ?>

--- a/macx/common.pri
+++ b/macx/common.pri
@@ -5,7 +5,7 @@
 
 # Common OSX overlay settings.
 
-VERSION = 1.3.0
+VERSION = 1.4.0
 
 DEFINES *= VERSION=\\\"$$VERSION\\\"
 

--- a/macx/osax/osax.plist
+++ b/macx/osax/osax.plist
@@ -13,7 +13,7 @@
 	<key>CFBundlePackageType</key>
 	<string>osax</string>
 	<key>CFbundleVersion</key>
-	<string>1.3.0</string>
+	<string>1.4.0</string>
 	<key>CFBundleSignature</key>
 	<string>MUOL</string>
 	<key>CSResourcesFileMapped</key>

--- a/overlay/mumble_ol.rc
+++ b/overlay/mumble_ol.rc
@@ -18,8 +18,8 @@
 #endif
 
 VS_VERSION_INFO VERSIONINFO
-	FILEVERSION		1,3,0,0
-	PRODUCTVERSION	1,3,0,0
+	FILEVERSION		1,4,0,0
+	PRODUCTVERSION	1,4,0,0
 	FILEFLAGSMASK	VS_FFI_FILEFLAGSMASK
 	FILEFLAGS		(VER_DEBUG|VER_RELEASE)
 	FILEOS			VOS_NT_WINDOWS32
@@ -32,8 +32,8 @@ VS_VERSION_INFO VERSIONINFO
 			BEGIN
 				VALUE "CompanyName", "The Mumble Developers"
 				VALUE "FileDescription", "Mumble - Low-latency VoIP client"
-				VALUE "FileVersion", "1.3.0"
-				VALUE "ProductVersion", "1.3.0"
+				VALUE "FileVersion", "1.4.0"
+				VALUE "ProductVersion", "1.4.0"
 				VALUE "LegalCopyright", "Copyright (c) 2005-2019 The Mumble Developers"
 				VALUE "OriginalFilename", "mumble_ol.dll"
 				VALUE "ProductName", "Mumble"

--- a/overlay/overlay-shared.pro
+++ b/overlay/overlay-shared.pro
@@ -5,7 +5,7 @@
 
 include (../qmake/compiler.pri)
 
-VERSION = 1.3.0
+VERSION = 1.4.0
 TARGET_EXT = .dll
 TEMPLATE = lib
 CONFIG -= qt

--- a/overlay/overlay_exe/overlay_exe.rc
+++ b/overlay/overlay_exe/overlay_exe.rc
@@ -18,8 +18,8 @@
 #endif
 
 VS_VERSION_INFO VERSIONINFO
-	FILEVERSION		1,3,0,0
-	PRODUCTVERSION	1,3,0,0
+	FILEVERSION		1,4,0,0
+	PRODUCTVERSION	1,4,0,0
 	FILEFLAGSMASK	VS_FFI_FILEFLAGSMASK
 	FILEFLAGS		(VER_DEBUG|VER_RELEASE)
 	FILEOS			VOS_NT_WINDOWS32
@@ -32,8 +32,8 @@ VS_VERSION_INFO VERSIONINFO
 			BEGIN
 				VALUE "CompanyName", "The Mumble Developers"
 				VALUE "FileDescription", "Mumble - Low-latency VoIP client"
-				VALUE "FileVersion", "1.3.0"
-				VALUE "ProductVersion", "1.3.0"
+				VALUE "FileVersion", "1.4.0"
+				VALUE "ProductVersion", "1.4.0"
 				VALUE "LegalCopyright", "Copyright (c) 2005-2019 The Mumble Developers"
 				VALUE "OriginalFilename", "mumble_ol_helper.exe"
 				VALUE "ProductName", "Mumble"

--- a/overlay_gl/overlay_gl.pro
+++ b/overlay_gl/overlay_gl.pro
@@ -10,7 +10,7 @@ include(../qmake/compiler.pri)
 TEMPLATE = lib
 CONFIG -= qt gui
 CONFIG *= debug_and_release
-VERSION = 1.3.0
+VERSION = 1.4.0
 SOURCES = overlay.c
 
 CONFIG(static) {

--- a/overlay_winx64/mumble_ol.rc
+++ b/overlay_winx64/mumble_ol.rc
@@ -18,8 +18,8 @@
 #endif
 
 VS_VERSION_INFO VERSIONINFO
-	FILEVERSION		1,3,0,0
-	PRODUCTVERSION	1,3,0,0
+	FILEVERSION		1,4,0,0
+	PRODUCTVERSION	1,4,0,0
 	FILEFLAGSMASK	VS_FFI_FILEFLAGSMASK
 	FILEFLAGS		(VER_DEBUG|VER_RELEASE)
 	FILEOS			VOS_NT_WINDOWS32
@@ -32,8 +32,8 @@ VS_VERSION_INFO VERSIONINFO
 			BEGIN
 				VALUE "CompanyName", "The Mumble Developers"
 				VALUE "FileDescription", "Mumble - Low-latency VoIP client"
-				VALUE "FileVersion", "1.3.0"
-				VALUE "ProductVersion", "1.3.0"
+				VALUE "FileVersion", "1.4.0"
+				VALUE "ProductVersion", "1.4.0"
 				VALUE "LegalCopyright", "Copyright (c) 2005-2019 The Mumble Developers"
 				VALUE "OriginalFilename", "mumble_ol_x64.dll"
 				VALUE "ProductName", "Mumble"

--- a/overlay_winx64/overlay_exe_winx64/overlay_exe.rc
+++ b/overlay_winx64/overlay_exe_winx64/overlay_exe.rc
@@ -18,8 +18,8 @@
 #endif
 
 VS_VERSION_INFO VERSIONINFO
-	FILEVERSION		1,3,0,0
-	PRODUCTVERSION	1,3,0,0
+	FILEVERSION		1,4,0,0
+	PRODUCTVERSION	1,4,0,0
 	FILEFLAGSMASK	VS_FFI_FILEFLAGSMASK
 	FILEFLAGS		(VER_DEBUG|VER_RELEASE)
 	FILEOS			VOS_NT_WINDOWS32
@@ -32,8 +32,8 @@ VS_VERSION_INFO VERSIONINFO
 			BEGIN
 				VALUE "CompanyName", "The Mumble Developers"
 				VALUE "FileDescription", "Mumble - Low-latency VoIP client"
-				VALUE "FileVersion", "1.3.0"
-				VALUE "ProductVersion", "1.3.0"
+				VALUE "FileVersion", "1.4.0"
+				VALUE "ProductVersion", "1.4.0"
 				VALUE "LegalCopyright", "Copyright (c) 2005-2019 The Mumble Developers"
 				VALUE "OriginalFilename", "mumble_ol_helper_x64.exe"
 				VALUE "ProductName", "Mumble"

--- a/src/mumble.pri
+++ b/src/mumble.pri
@@ -8,7 +8,7 @@ include(../qmake/qt.pri)
 include(../qmake/rcc.pri)
 include(../qmake/pkgconfig.pri)
 
-VERSION		= 1.3.0
+VERSION		= 1.4.0
 DIST		= mumble.pri Message.h PacketDataStream.h CryptState.h Timer.h Version.h OSInfo.h SSL.h
 CONFIG		+= qt thread debug_and_release warn_on
 DEFINES		*= MUMBLE_VERSION_STRING=$$VERSION

--- a/src/mumble/mumble.plist
+++ b/src/mumble/mumble.plist
@@ -26,7 +26,7 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>1.3.0</string>
+	<string>1.4.0</string>
 	<key>NSHumanReadableCopyright</key>
 	<string>Copyright (c) 2005-2019 The Mumble Developers</string>
 	<key>NSPrincipalClass</key>

--- a/src/mumble/mumble.rc
+++ b/src/mumble/mumble.rc
@@ -20,8 +20,8 @@ IDI_ICON1               ICON    DISCARDABLE     "../../icons/mumble.ico"
 #endif
 
 VS_VERSION_INFO VERSIONINFO
-	FILEVERSION		1,3,0,0
-	PRODUCTVERSION	1,3,0,0
+	FILEVERSION		1,4,0,0
+	PRODUCTVERSION	1,4,0,0
 	FILEFLAGSMASK	VS_FFI_FILEFLAGSMASK
 	FILEFLAGS		(VER_DEBUG|VER_RELEASE)
 	FILEOS			VOS_NT_WINDOWS32
@@ -34,8 +34,8 @@ VS_VERSION_INFO VERSIONINFO
 			BEGIN
 				VALUE "CompanyName", "The Mumble Developers"
 				VALUE "FileDescription", "Mumble - Low-latency VoIP client"
-				VALUE "FileVersion", "1.3.0"
-				VALUE "ProductVersion", "1.3.0"
+				VALUE "FileVersion", "1.4.0"
+				VALUE "ProductVersion", "1.4.0"
 				VALUE "LegalCopyright", "Copyright (c) 2005-2019 The Mumble Developers"
 				VALUE "OriginalFilename", "mumble.exe"
 				VALUE "ProductName", "Mumble"

--- a/src/mumble/mumble_dll.rc
+++ b/src/mumble/mumble_dll.rc
@@ -18,8 +18,8 @@
 #endif
 
 VS_VERSION_INFO VERSIONINFO
-	FILEVERSION		1,3,0,0
-	PRODUCTVERSION	1,3,0,0
+	FILEVERSION		1,4,0,0
+	PRODUCTVERSION	1,4,0,0
 	FILEFLAGSMASK	VS_FFI_FILEFLAGSMASK
 	FILEFLAGS		(VER_DEBUG|VER_RELEASE)
 	FILEOS			VOS_NT_WINDOWS32
@@ -32,8 +32,8 @@ VS_VERSION_INFO VERSIONINFO
 			BEGIN
 				VALUE "CompanyName", "The Mumble Developers"
 				VALUE "FileDescription", "Mumble - Low-latency VoIP client"
-				VALUE "FileVersion", "1.3.0"
-				VALUE "ProductVersion", "1.3.0"
+				VALUE "FileVersion", "1.4.0"
+				VALUE "ProductVersion", "1.4.0"
 				VALUE "LegalCopyright", "Copyright (c) 2005-2019 The Mumble Developers"
 				VALUE "OriginalFilename", "mumble_app.dll"
 				VALUE "ProductName", "Mumble"

--- a/src/murmur/murmur.plist
+++ b/src/murmur/murmur.plist
@@ -13,7 +13,7 @@
 	<key>CFBundleSignature</key>
 	<string>MMUR</string>
 	<key>CFBundleVersion</key>
-	<string>1.3.0</string>
+	<string>1.4.0</string>
 	<key>NSHumanReadableCopyright</key>
 	<string>Copyright (c) 2005-2019 The Mumble Developers</string>
 </dict>

--- a/src/murmur/murmur.rc
+++ b/src/murmur/murmur.rc
@@ -20,8 +20,8 @@ IDI_ICON1               ICON    DISCARDABLE     "../../icons/murmur.ico"
 #endif
 
 VS_VERSION_INFO VERSIONINFO
-	FILEVERSION		1,3,0,0
-	PRODUCTVERSION	1,3,0,0
+	FILEVERSION		1,4,0,0
+	PRODUCTVERSION	1,4,0,0
 	FILEFLAGSMASK	VS_FFI_FILEFLAGSMASK
 	FILEFLAGS		(VER_DEBUG|VER_RELEASE)
 	FILEOS			VOS_NT_WINDOWS32
@@ -34,8 +34,8 @@ VS_VERSION_INFO VERSIONINFO
 			BEGIN
 				VALUE "CompanyName", "The Mumble Developers"
 				VALUE "FileDescription", "Murmur - Low-latency VoIP server"
-				VALUE "FileVersion", "1.3.0"
-				VALUE "ProductVersion", "1.3.0"
+				VALUE "FileVersion", "1.4.0"
+				VALUE "ProductVersion", "1.4.0"
 				VALUE "LegalCopyright", "Copyright (c) 2005-2019 The Mumble Developers"
 				VALUE "OriginalFilename", "murmur.exe"
 				VALUE "ProductName", "Mumble"


### PR DESCRIPTION
1.3.0 has been released. master now represents the current state of
development towards the next feature release 1.4.0.

Bugfixes for 1.3 will happen in the 1.3.x branch.

Compared to earlier version bumps we bump a lot more files because of
we produce more artifacts; overlay process, dll and exe split, etc.

This should have happened right after the 1.3.x branch was split off.

Fixes #3761

Waiting on response from xPoke in that ticket concerning theme version. That will have to be landed first, and then this PR updated with the landed commit in mumble-theme.

Feel free to already review independent of xPoke response.

As the mumble-theme commit did not land yet checking out this PR will not work (for others than me who has the commit locally).