### PR TITLE
Corrected error in doc

### DIFF
--- a/plugins/mumble_plugin.h
+++ b/plugins/mumble_plugin.h
@@ -129,7 +129,7 @@ typedef MumblePlugin2 *(MUMBLE_PLUGIN_CALLING_CONVENTION *mumblePlugin2Func)();
 typedef MumblePluginQt *(MUMBLE_PLUGIN_CALLING_CONVENTION *mumblePluginQtFunc)();
 
 /*
- * All plugins must implement one function called mumbleGetPlugin(), which
+ * All plugins must implement one function called getMumblePlugin(), which
  * follows the mumblePluginFunc type and returns a MumblePlugin struct.
  *
  * magic should be initialized to MUMBLE_PLUGIN_MAGIC. description is the


### PR DESCRIPTION
The doc says that the function is named `mumbleGetPlugin` whereas in the implementation it searches for a function called `getMumblePlugin`:
https://github.com/mumble-voip/mumble/blob/cb7244a6d3d9370fb47392645368cb60f409430b/src/mumble/Plugins.cpp#L312