### PR TITLE
Renamed AudioOutputUser::needSamples

### DIFF
--- a/src/mumble/AudioOutput.cpp
+++ b/src/mumble/AudioOutput.cpp
@@ -376,7 +376,7 @@ bool AudioOutput::mix(void *outbuff, unsigned int nsamp) {
 	QMultiHash<const ClientUser *, AudioOutputUser *>::const_iterator it = qmOutputs.constBegin();
 	while (it != qmOutputs.constEnd()) {
 		AudioOutputUser *aop = it.value();
-		if (! aop->needSamples(nsamp)) {
+		if (! aop->prepareSampleBuffer(nsamp)) {
 			qlDel.append(aop);
 		} else {
 			qlMix.append(aop);

--- a/src/mumble/AudioOutputSample.cpp
+++ b/src/mumble/AudioOutputSample.cpp
@@ -197,7 +197,7 @@ QString AudioOutputSample::browseForSndfile(QString defaultpath) {
 	return file;
 }
 
-bool AudioOutputSample::needSamples(unsigned int snum) {
+bool AudioOutputSample::prepareSampleBuffer(unsigned int snum) {
 	// Forward the buffer
 	for (unsigned int i=iLastConsume;i<iBufferFilled;++i)
 		pfBuffer[i-iLastConsume]=pfBuffer[i];

--- a/src/mumble/AudioOutputSample.h
+++ b/src/mumble/AudioOutputSample.h
@@ -59,7 +59,7 @@ class AudioOutputSample : public AudioOutputUser {
 	public:
 		static SoundFile* loadSndfile(const QString &filename);
 		static QString browseForSndfile(QString defaultpath=QString());
-		virtual bool needSamples(unsigned int snum) Q_DECL_OVERRIDE;
+		virtual bool prepareSampleBuffer(unsigned int snum) Q_DECL_OVERRIDE;
 		AudioOutputSample(const QString &name, SoundFile *psndfile, bool repeat, unsigned int freq);
 		~AudioOutputSample() Q_DECL_OVERRIDE;
 };

--- a/src/mumble/AudioOutputSpeech.cpp
+++ b/src/mumble/AudioOutputSpeech.cpp
@@ -166,7 +166,7 @@ void AudioOutputSpeech::addFrameToBuffer(const QByteArray &qbaPacket, unsigned i
 	}
 }
 
-bool AudioOutputSpeech::needSamples(unsigned int snum) {
+bool AudioOutputSpeech::prepareSampleBuffer(unsigned int snum) {
 	for (unsigned int i=iLastConsume;i<iBufferFilled;++i)
 		pfBuffer[i-iLastConsume]=pfBuffer[i];
 	iBufferFilled -= iLastConsume;
@@ -317,7 +317,7 @@ bool AudioOutputSpeech::needSamples(unsigned int snum) {
 					for (unsigned int i=0;i<iFrameSize;++i)
 						pOut[i] *= (1.0f / 32767.f);
 				} else {
-					qWarning("AudioOutputSpeech: encountered unknown message type %li in needSamples().", static_cast<long>(umtType));
+					qWarning("AudioOutputSpeech: encountered unknown message type %li in prepareSampleBuffer().", static_cast<long>(umtType));
 				}
 
 				bool update = true;

--- a/src/mumble/AudioOutputSpeech.h
+++ b/src/mumble/AudioOutputSpeech.h
@@ -66,7 +66,7 @@ class AudioOutputSpeech : public AudioOutputUser {
 		int iMissedFrames;
 		ClientUser *p;
 
-		virtual bool needSamples(unsigned int snum) Q_DECL_OVERRIDE;
+		virtual bool prepareSampleBuffer(unsigned int snum) Q_DECL_OVERRIDE;
 
 		void addFrameToBuffer(const QByteArray &, unsigned int iBaseSeq);
 		AudioOutputSpeech(ClientUser *, unsigned int freq, MessageHandler::UDPMessageType type);

--- a/src/mumble/AudioOutputUser.h
+++ b/src/mumble/AudioOutputUser.h
@@ -22,7 +22,7 @@ class AudioOutputUser : public QObject {
 		float *pfBuffer;
 		float *pfVolume;
 		float fPos[3];
-		virtual bool needSamples(unsigned int snum) = 0;
+		virtual bool prepareSampleBuffer(unsigned int snum) = 0;
 };
 
 #endif  // AUDIOOUTPUTUSER_H_


### PR DESCRIPTION
Fixes #3786

I went for `prepareSampleBuffer` as my name of choice.

Before the rename:
```
find -type f \( -iname "*.h" -o -iname "*.cpp" -o -name "*.pro" \) -exec fgrep -n needSamples {} /dev/null \;
./src/mumble/AudioOutputSpeech.h:69:            virtual bool needSamples(unsigned int snum) Q_DECL_OVERRIDE;
./src/mumble/AudioOutput.cpp:379:               if (! aop->needSamples(nsamp)) {
./src/mumble/AudioOutputSample.cpp:200:bool AudioOutputSample::needSamples(unsigned int snum) {
./src/mumble/AudioOutputUser.h:25:              virtual bool needSamples(unsigned int snum) = 0;
./src/mumble/AudioOutputSample.h:62:            virtual bool needSamples(unsigned int snum) Q_DECL_OVERRIDE;
./src/mumble/AudioOutputSpeech.cpp:169:bool AudioOutputSpeech::needSamples(unsigned int snum) {
./src/mumble/AudioOutputSpeech.cpp:320:                                 qWarning("AudioOutputSpeech: encountered unknown message type %li in needSamples().", static_cast<long>(umtType));
```

After:
```
find -type f \( -iname "*.h" -o -iname "*.cpp" -o -name "*.pro" \) -exec fgrep -n prepareSampleBuffer {} /dev/null \;
./src/mumble/AudioOutputSpeech.h:69:            virtual bool prepareSampleBuffer(unsigned int snum) Q_DECL_OVERRIDE;
./src/mumble/AudioOutput.cpp:379:               if (! aop->prepareSampleBuffer(nsamp)) {
./src/mumble/AudioOutputSample.cpp:200:bool AudioOutputSample::prepareSampleBuffer(unsigned int snum) {
./src/mumble/AudioOutputUser.h:25:              virtual bool prepareSampleBuffer(unsigned int snum) = 0;
./src/mumble/AudioOutputSample.h:62:            virtual bool prepareSampleBuffer(unsigned int snum) Q_DECL_OVERRIDE;
./src/mumble/AudioOutputSpeech.cpp:169:bool AudioOutputSpeech::prepareSampleBuffer(unsigned int snum) {
./src/mumble/AudioOutputSpeech.cpp:320:                                 qWarning("AudioOutputSpeech: encountered unknown message type %li in prepareSampleBuffer().", static_cast<long>(umtType));
```

It also still compiles just fine and in a very quick test I can join a server and hear another client in my channel. To me that indicates that the renaming didn't break anything