### PR TITLE
fixed (g++) warning about implicit fallthrough

### DIFF
--- a/src/mumble/PulseAudio.cpp
+++ b/src/mumble/PulseAudio.cpp
@@ -202,9 +202,8 @@ void PulseAudioSystem::eventCallback(pa_mainloop_api *api, pa_defer_event *) {
 						pasOutput = pa_stream_new(pacContext, mumble_sink_input, &pss, (pss.channels == 1) ? NULL : &pcm);
 						pa_stream_set_state_callback(pasOutput, stream_callback, this);
 						pa_stream_set_write_callback(pasOutput, write_callback, this);
-
-						// Fallthrough
 					}
+					// Fallthrough
 				case PA_STREAM_UNCONNECTED:
 					do_start = true;
 					break;
@@ -271,10 +270,8 @@ void PulseAudioSystem::eventCallback(pa_mainloop_api *api, pa_defer_event *) {
 						pasInput = pa_stream_new(pacContext, "Microphone", &pss, NULL);
 						pa_stream_set_state_callback(pasInput, stream_callback, this);
 						pa_stream_set_read_callback(pasInput, read_callback, this);
-
-						// Fallthrough
 					}
-
+					// Fallthrough
 				case PA_STREAM_UNCONNECTED:
 					do_start = true;
 					break;
@@ -336,9 +333,8 @@ void PulseAudioSystem::eventCallback(pa_mainloop_api *api, pa_defer_event *) {
 						pasSpeaker = pa_stream_new(pacContext, mumble_echo, &pss, (pss.channels == 1) ? NULL : &pcm);
 						pa_stream_set_state_callback(pasSpeaker, stream_callback, this);
 						pa_stream_set_read_callback(pasSpeaker, read_callback, this);
-
-						// Fallthrough
 					}
+					// Fallthrough
 				case PA_STREAM_UNCONNECTED:
 					do_start = true;
 					break;


### PR DESCRIPTION
When compiling Mumble on Linux (g++) I get some warnings about implicit fallthrough in `PulseAudio.cpp`. According to [this question](https://stackoverflow.com/questions/45129741/gcc-7-wimplicit-fallthrough-warnings-and-portable-way-to-clear-them) on SO this can be fixed by placing a comment about it right before the following `case`-statement so I went to do that. It turns out there have already been comments about this, just in the wrong places. Thus this PR will merely move those comments in order to silence the warnings.