### PR TITLE
Remove Speex (audio codec)

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,3 @@
-[submodule "speex"]
-	path = 3rdparty/speex-src
-	url = https://github.com/mumble-voip/speex.git
 [submodule "celt-0.7.0-src"]
 	path = 3rdparty/celt-0.7.0-src
 	url = https://github.com/mumble-voip/celt-0.7.0.git

--- a/3rdparty/speex-build/speex-build.pro
+++ b/3rdparty/speex-build/speex-build.pro
@@ -1,13 +1,13 @@
 include(../../qmake/compiler.pri)
 
-!exists(../speex-src/COPYING) | !exists(../speexdsp-src/COPYING) {
-  message("The speex-src/ or speexdsp-src/ directories were not found. You need to do one of the following:")
+!exists(../speexdsp-src/COPYING) {
+  message("The speexdsp-src/ directories was not found. You need to do one of the following:")
   message("")
   message("Option 1: Use Speex Git:")
   message("git submodule init")
   message("git submodule update")
   message("")
-  message("Option 2: Use system speex and speex-dsp (v 1.2 or later):")
+  message("Option 2: Use system speex-dsp (v1.2 or later):")
   message("qmake CONFIG+=no-bundled-speex -recursive")
   message("")
   error("Aborting configuration")
@@ -20,16 +20,11 @@ CONFIG -= warn_on
 CONFIG += warn_off
 CONFIG += no_include_pwd
 
-# Enable no_batch, which disables nmake's inference rules.
-# We have to do this because we use files from two VPATHs
-# below, and nmake is unable to figure out how to handle
-# that.
-CONFIG += no_batch
-VPATH = ../speex-src/libspeex ../speexdsp-src/libspeexdsp
+VPATH = ../speexdsp-src/libspeexdsp
 
 TARGET = speex
 DEFINES += NDEBUG HAVE_CONFIG_H
-INCLUDEPATH = ../speex-src/include ../speex-src/libspeex ../speexdsp-src/include ../speexdsp-src/libspeexdsp
+INCLUDEPATH = ../speexdsp-src/include ../speexdsp-src/libspeexdsp
 
 win32 {
   INCLUDEPATH += ../speex-build/win32
@@ -68,8 +63,3 @@ DEF_FILE = speex.def
 
 # libspeexdsp
 SOURCES *= mdf.c resample.c preprocess.c jitter.c filterbank.c fftwrap.c smallft.c
-# libspeex
-SOURCES *= bits.c cb_search.c exc_10_16_table.c exc_10_32_table.c exc_20_32_table.c exc_5_256_table.c exc_5_64_table.c exc_8_128_table.c filters.c gain_table.c gain_table_lbr.c hexc_10_32_table.c hexc_table.c high_lsp_tables.c lpc.c lsp.c lsp_tables_nb.c ltp.c modes.c modes_wb.c nb_celp.c quant_lsp.c sb_celp.c scal.c speex.c speex_callbacks.c speex_header.c stereo.c vbr.c vq.c kiss_fft.c kiss_fftr.c vorbis_psy.c window.c
-
-
-

--- a/3rdparty/speex-build/speex.def
+++ b/3rdparty/speex-build/speex.def
@@ -5,66 +5,6 @@ LIBRARY speex
 EXPORTS
 ;
 ;
-;	speex.h
-;
-speex_encoder_init
-speex_encoder_destroy
-speex_encode
-speex_encode_int
-speex_encoder_ctl
-speex_decoder_init
-speex_decoder_destroy
-speex_decode
-speex_decode_int
-speex_decoder_ctl
-speex_mode_query
-speex_lib_ctl
-speex_lib_get_mode
-
-;
-;	speex_bits.h
-;
-speex_bits_init
-speex_bits_init_buffer
-speex_bits_set_bit_buffer
-speex_bits_destroy
-speex_bits_reset
-speex_bits_rewind
-speex_bits_read_from
-speex_bits_read_whole_bytes
-speex_bits_write
-speex_bits_write_whole_bytes
-speex_bits_pack
-speex_bits_unpack_signed
-speex_bits_unpack_unsigned
-speex_bits_nbytes
-speex_bits_peek_unsigned
-speex_bits_peek
-speex_bits_advance
-speex_bits_remaining
-speex_bits_insert_terminator
-
-;
-;	speex_callbacks.h
-;
-speex_inband_handler
-speex_std_mode_request_handler
-speex_std_high_mode_request_handler
-speex_std_char_handler
-speex_default_user_handler
-speex_std_low_mode_request_handler
-speex_std_vbr_request_handler
-speex_std_enh_request_handler
-speex_std_vbr_quality_request_handler
-
-;
-;	speex_header.h
-;
-speex_init_header
-speex_header_to_packet
-speex_packet_to_header
-
-;
 ;	speex_echo.h
 ;
 speex_echo_state_init
@@ -76,9 +16,6 @@ speex_echo_capture
 speex_echo_playback
 speex_echo_state_reset
 speex_echo_ctl
-speex_decorrelate_new
-speex_decorrelate
-speex_decorrelate_destroy
 
 ;
 ;	speex_jitter.h

--- a/main.pro
+++ b/main.pro
@@ -11,7 +11,7 @@ CONFIG *= ordered debug_and_release
 SUBDIRS *= src/mumble_proto
 
 !CONFIG(no-client) {
-  unix:!CONFIG(bundled-speex):system($$PKG_CONFIG --atleast-version=1.2 speexdsp):system($$PKG_CONFIG --atleast-version=1.2 speex) {
+  unix:!CONFIG(bundled-speex):system($$PKG_CONFIG --atleast-version=1.2 speexdsp) {
     CONFIG *= no-bundled-speex
   }
   !CONFIG(no-bundled-speex) {

--- a/scripts/mklic.pl
+++ b/scripts/mklic.pl
@@ -75,7 +75,7 @@ print $F "\n\n";
 my @thirdPartyLicenses = (
     ["licenseCELT", "../3rdparty/celt-0.11.0-src/COPYING", "CELT", "http://www.celt-codec.org/"],
     ["licenseOpus", "../3rdparty/opus-src/COPYING", "Opus", "http://www.opus-codec.org/"],
-    ["licenseSPEEX", "../3rdparty/speex-src/COPYING", "Speex", "http://www.speex.org/"],
+    ["licenseSPEEX", "../3rdparty/speexdsp-src/COPYING", "Speex", "http://www.speex.org/"],
     ["licenseOpenSSL", "../3rdPartyLicenses/openssl_license.txt", "OpenSSL", "http://www.openssl.org/"],
     ["licenseLibsndfile", "../3rdPartyLicenses/libsndfile_license.txt", "libsndfile", "http://www.mega-nerd.com/libsndfile/"],
     ["licenseOgg", "../3rdPartyLicenses/libogg_license.txt", "libogg", "http://www.xiph.org/"],

--- a/scripts/release.pl
+++ b/scripts/release.pl
@@ -52,13 +52,6 @@ my $exclusions = join(" --exclude=", ("",
      # Exclude the archive we are currently writing to
      "${ballname}.*",
      # Exclude files with Debian FSG licensing issues (#1230)
-     "${ballname}/3rdparty/speex-src/doc/draft-herlein-avt-rtp-speex-00.txt",
-     "${ballname}/3rdparty/speex-src/doc/draft-herlein-speex-rtp-profile-02.txt",
-     "${ballname}/3rdparty/speex-src/doc/draft-herlein-speex-rtp-profile-03.txt",
-     "${ballname}/3rdparty/speex-src/doc/draft-ietf-avt-rtp-speex-00.txt",
-     "${ballname}/3rdparty/speex-src/doc/draft-ietf-avt-rtp-speex-01-tmp.txt",
-     "${ballname}/3rdparty/speex-src/doc/draft-ietf-avt-rtp-speex-05-tmp.txt",
-     "${ballname}/3rdparty/speex-src/doc/manual.lyx",
      "${ballname}/3rdparty/celt-0.11.0-src/doc/ietf/draft-valin-celt-rtp-profile-01.txt",
      "${ballname}/3rdparty/celt-0.7.0-src/doc/ietf/draft-valin-celt-rtp-profile-01.txt"
     )

--- a/src/mumble/AudioInput.h
+++ b/src/mumble/AudioInput.h
@@ -8,7 +8,6 @@
 
 #include <boost/shared_ptr.hpp>
 #include <boost/array.hpp>
-#include <speex/speex.h>
 #include <speex/speex_echo.h>
 #include <speex/speex_preprocess.h>
 #include <speex/speex_resampler.h>

--- a/src/mumble/AudioOutputSpeech.h
+++ b/src/mumble/AudioOutputSpeech.h
@@ -7,7 +7,6 @@
 #define MUMBLE_MUMBLE_AUDIOOUTPUTSPEECH_H_
 
 #include <stdint.h>
-#include <speex/speex.h>
 #include <speex/speex_resampler.h>
 #include <speex/speex_jitter.h>
 #include <celt.h>
@@ -54,9 +53,6 @@ class AudioOutputSpeech : public AudioOutputUser {
 
 		OpusCodec *oCodec;
 		OpusDecoder *opusState;
-
-		SpeexBits sbBits;
-		void *dsSpeex;
 
 		QList<QByteArray> qlFrames;
 

--- a/src/mumble/mumble.pro
+++ b/src/mumble/mumble.pro
@@ -288,7 +288,7 @@ CONFIG(static) {
   DEFINES *= USE_MANUAL_PLUGIN
 }
 
-unix:!CONFIG(bundled-speex):system($$PKG_CONFIG --atleast-version=1.2 speexdsp):system($$PKG_CONFIG --atleast-version=1.2 speex) {
+unix:!CONFIG(bundled-speex):system($$PKG_CONFIG --atleast-version=1.2 speexdsp) {
   CONFIG *= no-bundled-speex
 }
 

--- a/src/mumble/mumble.pro
+++ b/src/mumble/mumble.pro
@@ -311,7 +311,7 @@ CONFIG(no-bundled-speex) {
 }
 
 !CONFIG(no-bundled-speex) {
-  INCLUDEPATH *= ../../3rdparty/speex-src/include ../../3rdparty/speex-src/libspeex ../../3rdparty/speex-build ../../3rdparty/speexdsp-src/include ../../3rdparty/speexdsp-src/libspeexdsp
+  INCLUDEPATH *= ../../3rdparty/speex-build ../../3rdparty/speexdsp-src/include ../../3rdparty/speexdsp-src/libspeexdsp
   LIBS   *= -lspeex
 }
 

--- a/src/mumble/mumble_pch.hpp
+++ b/src/mumble/mumble_pch.hpp
@@ -52,7 +52,6 @@
 #ifdef USE_SBCELT
 # include <sbcelt.h>
 #endif
-#include <speex/speex.h>
 #include <speex/speex_jitter.h>
 #include <speex/speex_preprocess.h>
 #include <speex/speex_echo.h>


### PR DESCRIPTION
Speex was the first audio codec we used, until it was superseded by CELT in 2009 (Mumble 1.2.0), which in turn was superseded by Opus in 2011 (Mumble 1.2.4).

We retained support for it for 10 years and we believe all active servers are currently using Opus.

This pull request removes all references to the Speex API and changes the code so that it ignores a packet if it's encoded with Speex and prints a warning in the console.

To be clear: this pull request doesn't remove anything related to the DSP functions, they are part of the SpeexDSP library: it was split from Speex when declared obsolete in favor of Opus.