### PR TITLE
ServerHandler: Use the SRV resolved port for UDP connections

### DIFF
--- a/src/mumble/ServerHandler.cpp
+++ b/src/mumble/ServerHandler.cpp
@@ -188,7 +188,7 @@ void ServerHandler::udpReady() {
 		quint16 senderPort;
 		qusUdp->readDatagram(encrypted, qMin(2048U, buflen), &senderAddr, &senderPort);
 
-		if (!(HostAddress(senderAddr) == HostAddress(qhaRemote)) || (senderPort != usPort))
+		if (!(HostAddress(senderAddr) == HostAddress(qhaRemote)) || (senderPort != usResolvedPort))
 			continue;
 
 		ConnectionPtr connection(cConnection);
@@ -276,7 +276,7 @@ void ServerHandler::sendMessage(const char *data, int len, bool force) {
 		QApplication::postEvent(this, new ServerHandlerMessageEvent(qba, MessageHandler::UDPTunnel, true));
 	} else {
 		connection->csCrypt.encrypt(reinterpret_cast<const unsigned char *>(data), crypto, len);
-		qusUdp->writeDatagram(reinterpret_cast<const char *>(crypto), len + 4, qhaRemote, usPort);
+		qusUdp->writeDatagram(reinterpret_cast<const char *>(crypto), len + 4, qhaRemote, usResolvedPort);
 	}
 }
 
@@ -733,6 +733,7 @@ void ServerHandler::serverConnectionConnected() {
 
 		qhaRemote = connection->peerAddress();
 		qhaLocal = connection->localAddress();
+		usResolvedPort = connection->peerPort();
 		if (qhaLocal.isNull()) {
 			qFatal("ServerHandler: qhaLocal is unexpectedly a null addr");
 		}

--- a/src/mumble/ServerHandler.h
+++ b/src/mumble/ServerHandler.h
@@ -65,6 +65,7 @@ class ServerHandler : public QThread {
 		QString qsUserName;
 		QString qsPassword;
 		unsigned short usPort;
+		unsigned short usResolvedPort;
 		bool bUdp;
 		bool bStrong;
 


### PR DESCRIPTION
This is basically the same thing as in #3267, but for the UDP/voice connection.

Currently if you have murmur running on port 2 (and your SRV `_mumble._tcp.` record matches that), but the connect dialog says port 1, Mumble will do server pings and the TCP/control channel over port 2, but the voice channel sends data over port 1, causing it to fallback to TCP tunneling.