### PR TITLE
Add include guards for builds without dbus

### DIFF
--- a/src/mumble/Log_unix.cpp
+++ b/src/mumble/Log_unix.cpp
@@ -7,7 +7,9 @@
 #include "MainWindow.h"
 #include "Settings.h"
 
+#ifdef USE_DBUS
 #include <QtDBus/QDBusInterface>
+#endif
 
 // We define a global macro called 'g'. This can lead to issues when included code uses 'g' as a type or parameter name (like protobuf 3.7 does). As such, for now, we have to make this our last include.
 #include "Global.h"


### PR DESCRIPTION
This commit adds include guards around a QDBusInterface include added in
commit 15831dbca without the appropriate guards.