### PR TITLE
Add setting to toggle 24-hour time format for the chat

### DIFF
--- a/src/mumble/Log.cpp
+++ b/src/mumble/Log.cpp
@@ -104,6 +104,7 @@ void LogConfig::load(const Settings &r) {
 	}
 
 	qsbMaxBlocks->setValue(r.iMaxLogBlocks);
+	qcb24HourClock->setChecked(r.bLog24HourClock);
 
 #ifdef USE_NO_TTS
 	qtwMessages->hideColumn(ColTTS);
@@ -140,6 +141,7 @@ void LogConfig::save() const {
 		s.qmMessageSounds[mt] = i->text(ColStaticSoundPath);
 	}
 	s.iMaxLogBlocks = qsbMaxBlocks->value();
+	s.bLog24HourClock = qcb24HourClock->isChecked();
 
 #ifndef USE_NO_TTS
 	s.iTTSVolume=qsVolume->value();
@@ -493,7 +495,10 @@ void Log::log(MsgType mt, const QString &console, const QString &terse, bool own
 		} else if (! g.mw->qteLog->document()->isEmpty()) {
 			tc.insertBlock();
 		}
-		tc.insertHtml(Log::msgColor(QString::fromLatin1("[%1] ").arg(dt.time().toString().toHtmlEscaped()), Log::Time));
+
+		const QString timeString = dt.time().toString(QLatin1String(g.s.bLog24HourClock ? "HH:mm:ss" : "hh:mm:ss AP"));
+		tc.insertHtml(Log::msgColor(QString::fromLatin1("[%1] ").arg(timeString.toHtmlEscaped()), Log::Time));
+
 		validHtml(console, &tc);
 		tc.movePosition(QTextCursor::End);
 		g.mw->qteLog->setTextCursor(tc);

--- a/src/mumble/Log.ui
+++ b/src/mumble/Log.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>446</width>
-    <height>334</height>
+    <width>554</width>
+    <height>405</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -240,6 +240,18 @@
          </size>
         </property>
        </spacer>
+      </item>
+      <item row="1" column="0">
+       <widget class="QCheckBox" name="qcb24HourClock">
+        <property name="toolTip">
+         <string>If checked the time at the beginning of a message will be displayed in the 24-hour format.
+
+The setting only applies for new messages, the already shown ones will retain the previous time format.</string>
+        </property>
+        <property name="text">
+         <string>Use 24-hour clock</string>
+        </property>
+       </widget>
       </item>
      </layout>
     </widget>

--- a/src/mumble/Settings.cpp
+++ b/src/mumble/Settings.cpp
@@ -399,6 +399,7 @@ Settings::Settings() {
 	requireRestartToApply = false;
 
 	iMaxLogBlocks = 0;
+	bLog24HourClock = true;
 
 	bShortcutEnable = true;
 	bSuppressMacEventTapWarning = false;
@@ -753,6 +754,7 @@ void Settings::load(QSettings* settings_ptr) {
 	SAVELOAD(bShowTransmitModeComboBox, "ui/transmitmodecombobox");
 	SAVELOAD(bHighContrast, "ui/HighContrast");
 	SAVELOAD(iMaxLogBlocks, "ui/MaxLogBlocks");
+	SAVELOAD(bLog24HourClock, "ui/24HourClock");
 
 	// PTT Button window
 	SAVELOAD(bShowPTTButtonWindow, "ui/showpttbuttonwindow");
@@ -1089,6 +1091,7 @@ void Settings::save() {
 	SAVELOAD(bShowTransmitModeComboBox, "ui/transmitmodecombobox");
 	SAVELOAD(bHighContrast, "ui/HighContrast");
 	SAVELOAD(iMaxLogBlocks, "ui/MaxLogBlocks");
+	SAVELOAD(bLog24HourClock, "ui/24HourClock");
 
 	// PTT Button window
 	SAVELOAD(bShowPTTButtonWindow, "ui/showpttbuttonwindow");

--- a/src/mumble/Settings.h
+++ b/src/mumble/Settings.h
@@ -278,6 +278,7 @@ struct Settings {
 
 	enum MessageLog { LogNone = 0x00, LogConsole = 0x01, LogTTS = 0x02, LogBalloon = 0x04, LogSoundfile = 0x08, LogHighlight = 0x10 };
 	int iMaxLogBlocks;
+	bool bLog24HourClock;
 	QMap<int, QString> qmMessageSounds;
 	QMap<int, quint32> qmMessages;
 


### PR DESCRIPTION
By default `QTime` uses the 24-hour time format when converting to a string.

This commit adds a setting (a checkbox) which allows users to toggle the format.

The setting only applies for new messages, the already shown ones will retain the previous time format.

![](https://user-images.githubusercontent.com/5897523/66183087-cad58b80-e677-11e9-828f-ac3c6be4483a.png)

---

Fixes #3823.