### PR TITLE
Fix QPalette::Background is deprecated

### DIFF
--- a/src/mumble/AudioStats.cpp
+++ b/src/mumble/AudioStats.cpp
@@ -210,7 +210,7 @@ void AudioNoiseWidget::paintEvent(QPaintEvent *) {
 	QPainter paint(this);
 	QPalette pal;
 
-	paint.fillRect(rect(), pal.color(QPalette::Background));
+	paint.fillRect(rect(), pal.color(QPalette::Window));
 
 	AudioInputPtr ai = g.ai;
 	if (ai.get() == NULL || ! ai->sppPreprocess)


### PR DESCRIPTION
I just had a [build](https://cirrus-ci.com/task/5107295804981248?command=build#L598) failing because `AudioStats.cpp` is using `QPalette::Background` which apparently has been declared deprecated. The Qt docs advise to use `QPalette::Window` instead (see https://doc.qt.io/qt-5/qpalette.html) so I went ahead and changed the code accordingly.