### PR TITLE
Fix dangling else warning in ConnectDialog::OnSortChanged()

### DIFF
--- a/src/mumble/ConnectDialog.cpp
+++ b/src/mumble/ConnectDialog.cpp
@@ -1174,12 +1174,16 @@ void ConnectDialog::accept() {
 }
 
 void ConnectDialog::OnSortChanged(int logicalIndex, Qt::SortOrder) {
-	if (logicalIndex == 2)
-		foreach(ServerItem *si, qlItems)
-			if (si->uiPing && (si->uiPing != si->uiPingSort)) {
-				si->uiPingSort = si->uiPing;
-				si->setDatas();
-			}
+	if (logicalIndex != 2) {
+		return;
+	}
+
+	foreach(ServerItem *si, qlItems) {
+		if (si->uiPing && (si->uiPing != si->uiPingSort)) {
+			si->uiPingSort = si->uiPing;
+			si->setDatas();
+		}
+	}
 }
 
 void ConnectDialog::on_qaFavoriteAdd_triggered() {


### PR DESCRIPTION
This commit fixes a warning encountered today on FreeBSD, probably because Clang was updated and now `-Wdangling-else` is enabled by default.
```cpp
ConnectDialog.cpp:1178:3: error: add explicit braces to avoid dangling else [-Werror,-Wdangling-else]
                foreach(ServerItem *si, qlItems)
                ^
```