### PR TITLE
Replace deprecated qSort() with std::sort()

### DIFF
--- a/src/mumble/ALSAAudio.cpp
+++ b/src/mumble/ALSAAudio.cpp
@@ -91,7 +91,7 @@ const QList<audioDevice> ALSAAudioInputRegistrar::getDeviceChoices() {
 	QList<audioDevice> qlReturn;
 
 	QStringList qlInputDevs = cards->qhInput.keys();
-	qSort(qlInputDevs);
+	std::sort(qlInputDevs.begin(), qlInputDevs.end());
 
 	if (qlInputDevs.contains(g.s.qsALSAInput)) {
 		qlInputDevs.removeAll(g.s.qsALSAInput);
@@ -125,7 +125,7 @@ const QList<audioDevice> ALSAAudioOutputRegistrar::getDeviceChoices() {
 	QList<audioDevice> qlReturn;
 
 	QStringList qlOutputDevs = cards->qhOutput.keys();
-	qSort(qlOutputDevs);
+	std::sort(qlOutputDevs.begin(), qlOutputDevs.end());
 
 	if (qlOutputDevs.contains(g.s.qsALSAOutput)) {
 		qlOutputDevs.removeAll(g.s.qsALSAOutput);

--- a/src/mumble/GlobalShortcut_win.cpp
+++ b/src/mumble/GlobalShortcut_win.cpp
@@ -559,7 +559,7 @@ BOOL GlobalShortcutWin::EnumDevicesCB(LPCDIDEVICEINSTANCE pdidi, LPVOID pContext
 
 	if (id->qhNames.count() > 0) {
 		QList<DWORD> types = id->qhNames.keys();
-		qSort(types);
+		std::sort(types.begin(), types.end());
 
 		int nbuttons = types.count();
 		STACKVAR(DIOBJECTDATAFORMAT, rgodf, nbuttons);

--- a/src/mumble/JackAudio.cpp
+++ b/src/mumble/JackAudio.cpp
@@ -502,7 +502,7 @@ const QList<audioDevice> JackAudioInputRegistrar::getDeviceChoices() {
 	QList<audioDevice> qlReturn;
 
 	QStringList qlInputDevs = jasys->qhInput.keys();
-	qSort(qlInputDevs);
+	std::sort(qlInputDevs.begin(), qlInputDevs.end());
 
 	foreach(const QString &dev, qlInputDevs) {
 		qlReturn << audioDevice(jasys->qhInput.value(dev), dev);
@@ -532,7 +532,7 @@ const QList<audioDevice> JackAudioOutputRegistrar::getDeviceChoices() {
 	QList<audioDevice> qlReturn;
 
 	QStringList qlOutputDevs = jasys->qhOutput.keys();
-	qSort(qlOutputDevs);
+	std::sort(qlOutputDevs.begin(), qlOutputDevs.end());
 
 	if (qlOutputDevs.contains(g.s.qsJackAudioOutput)) {
 		qlOutputDevs.removeAll(g.s.qsJackAudioOutput);

--- a/src/mumble/OSS.cpp
+++ b/src/mumble/OSS.cpp
@@ -72,7 +72,7 @@ const QList<audioDevice> OSSInputRegistrar::getDeviceChoices() {
 	QList<audioDevice> qlReturn;
 
 	QStringList qlInputDevs = cards->qhInput.keys();
-	qSort(qlInputDevs);
+	std::sort(qlInputDevs.begin(), qlInputDevs.end());
 
 	if (qlInputDevs.contains(g.s.qsOSSInput)) {
 		qlInputDevs.removeAll(g.s.qsOSSInput);
@@ -105,7 +105,7 @@ const QList<audioDevice> OSSOutputRegistrar::getDeviceChoices() {
 	QList<audioDevice> qlReturn;
 
 	QStringList qlOutputDevs = cards->qhOutput.keys();
-	qSort(qlOutputDevs);
+	std::sort(qlOutputDevs.begin(), qlOutputDevs.end());
 
 	if (qlOutputDevs.contains(g.s.qsOSSOutput)) {
 		qlOutputDevs.removeAll(g.s.qsOSSOutput);

--- a/src/mumble/PulseAudio.cpp
+++ b/src/mumble/PulseAudio.cpp
@@ -843,7 +843,7 @@ const QList<audioDevice> PulseAudioInputRegistrar::getDeviceChoices() {
 	QList<audioDevice> qlReturn;
 
 	QStringList qlInputDevs = pasys->qhInput.keys();
-	qSort(qlInputDevs);
+	std::sort(qlInputDevs.begin(), qlInputDevs.end());
 
 	if (qlInputDevs.contains(g.s.qsPulseAudioInput)) {
 		qlInputDevs.removeAll(g.s.qsPulseAudioInput);
@@ -876,7 +876,7 @@ const QList<audioDevice> PulseAudioOutputRegistrar::getDeviceChoices() {
 	QList<audioDevice> qlReturn;
 
 	QStringList qlOutputDevs = pasys->qhOutput.keys();
-	qSort(qlOutputDevs);
+	std::sort(qlOutputDevs.begin(), qlOutputDevs.end());
 
 	if (qlOutputDevs.contains(g.s.qsPulseAudioOutput)) {
 		qlOutputDevs.removeAll(g.s.qsPulseAudioOutput);

--- a/src/mumble/WASAPI.cpp
+++ b/src/mumble/WASAPI.cpp
@@ -279,7 +279,7 @@ const QList<audioDevice> WASAPISystem::mapToDevice(const QHash<QString, QString>
 	QList<audioDevice> qlReturn;
 
 	QStringList qlDevices = devs.keys();
-	qSort(qlDevices);
+	std::sort(qlDevices.begin(), qlDevices.end());
 
 	if (qlDevices.contains(match)) {
 		qlDevices.removeAll(match);

--- a/src/murmur/MurmurGRPCImpl.cpp
+++ b/src/murmur/MurmurGRPCImpl.cpp
@@ -1700,7 +1700,7 @@ void V1_TreeQuery::impl(bool) {
 		ToRPC(server, currentChannel, currentTree->mutable_channel());
 
 		QList< ::User *> users = currentChannel->qlUsers;
-		qSort(users.begin(), users.end(), [] (const ::User *a, const ::User *b) -> bool {
+		std::sort(users.begin(), users.end(), [] (const ::User *a, const ::User *b) -> bool {
 			return ::User::lessThan(a, b);
 		});
 		foreach(const ::User *u, users) {
@@ -1709,7 +1709,7 @@ void V1_TreeQuery::impl(bool) {
 		}
 
 		QList< ::Channel *> channels = currentChannel->qlChannels;
-		qSort(channels.begin(), channels.end(), [] (const ::Channel *a, const ::Channel *b) -> bool {
+		std::sort(channels.begin(), channels.end(), [] (const ::Channel *a, const ::Channel *b) -> bool {
 			return ::Channel::lessThan(a, b);
 		});
 		foreach(const ::Channel *subChannel, channels) {


### PR DESCRIPTION
qt/qtbase@5957f245c6c77c98d7e90d614c9fe2cdbfe7e8e6

I accidentally forgot to search for "qSort" in files when I created 3132f993d83820d72124ffbb6fc4fd3810d36b8e.

This pull request replaces the `qSort()` instances I missed.