### PR TITLE
Fix dangling else warning in Server::msgACL()

### DIFF
--- a/src/murmur/Messages.cpp
+++ b/src/murmur/Messages.cpp
@@ -1326,11 +1326,12 @@ void Server::msgACL(ServerUser *uSource, MumbleProto::ACL &msg) {
 					group->add_remove(id);
 				}
 			}
-			if (pg)
+			if (pg) {
 				foreach(int id, pg->members()) {
 					qsId.insert(id);
 					group->add_inherited_members(id);
 				}
+			}
 		}
 
 		sendMessage(uSource, msg);


### PR DESCRIPTION
This pull request fixes a warning encountered today on FreeBSD, probably because Clang was updated and now `-Wdangling-else` is enabled by default.

```cpp
Messages.cpp:1330:5: error: add explicit braces to avoid dangling else [-Werror,-Wdangling-else]
                                foreach(int id, pg->members()) {
                                ^
```