### PR TITLE
Murmur.ice: add missing value to UserInfo

### DIFF
--- a/src/murmur/Murmur.ice
+++ b/src/murmur/Murmur.ice
@@ -223,7 +223,7 @@ module Murmur
 	sequence<Tree> TreeList;
 
 	enum ChannelInfo { ChannelDescription, ChannelPosition };
-	enum UserInfo { UserName, UserEmail, UserComment, UserHash, UserPassword, UserLastActive };
+	enum UserInfo { UserName, UserEmail, UserComment, UserHash, UserPassword, UserLastActive, UserKDFIterations };
 
 	dictionary<int, User> UserMap;
 	dictionary<int, Channel> ChannelMap;


### PR DESCRIPTION
Mumble.com kindly reported that the `getRegistration()` Ice method fails with an `enumerator out of range` error, due to a missing value in the `UserInfo` enum.

The value was added to Murmur in 813aceb854949a863e095930423d8d49793e4be8 and then renamed and moved in 5131d9e3036bb7de94967dd026f2c7f4ec91645d.