### PR TITLE
MurmurGRPCImpl.cpp: remove QAtomicInt compatibility layer

### DIFF
--- a/src/murmur/MurmurGRPCImpl.cpp
+++ b/src/murmur/MurmurGRPCImpl.cpp
@@ -196,7 +196,7 @@ void ToRPC(const ::Server *srv, const ::User *u, ::MurmurRPC::User *ru) {
 	ru->set_udp_ping_msecs(su->dUDPPingAvg);
 	ru->set_tcp_ping_msecs(su->dTCPPingAvg);
 
-	ru->set_tcp_only(QAtomicIntLoad(su->aiUdpFlag) == 0);
+	ru->set_tcp_only(su->aiUdpFlag.load() == 0);
 
 	ru->set_address(su->haAddress.toStdString());
 }


### PR DESCRIPTION
I accidentally left it in 062fe2661d2457b2ae200c11709175f9d9f2b2a3 (#3602).