### PR TITLE
plugins: fix escape() warnings

### DIFF
--- a/plugins/bf1/bf1.cpp
+++ b/plugins/bf1/bf1.cpp
@@ -107,7 +107,7 @@ static int fetch(float *avatar_pos, float *avatar_front, float *avatar_top, floa
 	oidentity << "{";
 
 	// Team
-	escape(team, sizeof(server_name));
+	escape(team, sizeof(team));
 	if (strcmp(team, "") != 0) {
 		oidentity << std::endl << "\"Team\": \"" << team << "\","; // Set team name in identity.
 	}

--- a/plugins/mumble_plugin_utils.h
+++ b/plugins/mumble_plugin_utils.h
@@ -30,31 +30,29 @@ static inline std::string utf16ToUtf8(const std::wstring &wstr) {
 // string is NUL-terminated by always
 // setting the last byte of the input
 // string to the value 0.
-static void escape(char *str, size_t size) {
-    // Ensure the input string is properly NUL-terminated.
-    str[size-1] = 0;
-    char *c = str;
+static inline void escape(char *str, const size_t &size) {
+	// Ensure the input string is properly NUL-terminated.
+	str[size - 1] = 0;
+	char *c = str;
 
-    while (*c != '\0') {
-        // For JSON compatibility, the string
-        // can't contain double quotes.
-        // If a double quote is found, replace
-        // it with an ASCII space.
-        if (*c == '"') {
-            *c = ' ';
-        }
+	while (*c != '\0') {
+		// For JSON compatibility, the string
+		// can't contain double quotes.
+		// If a double quote is found, replace
+		// it with an ASCII space.
+		if (*c == '"') {
+			*c = ' ';
+		}
 
-        // Ensure the string is within printable
-        // ASCII. If not, replace the offending
-        // byte with an ASCII space.
-        if (*c < 32) {
-            *c = ' ';
-        } else if (*c > 126) {
-            *c = ' ';
-        }
+		// Ensure the string is within printable
+		// ASCII. If not, replace the offending
+		// byte with an ASCII space.
+		if (*c < 32 || *c > 126) {
+			*c = ' ';
+		}
 
-        c += 1;
-    }
+		c += 1;
+	}
 }
 
 #endif


### PR DESCRIPTION
Appeared after #3511, description in each commit.