### PR TITLE
Fix deprecated QSslSocket::setDefaultCaCertificates

### DIFF
--- a/src/mumble/main.cpp
+++ b/src/mumble/main.cpp
@@ -604,10 +604,8 @@ int main(int argc, char **argv) {
 	Global::g_global_struct = NULL;
 
 #ifndef QT_NO_DEBUG
-	// Hide Qt memory leak.
-	QSslSocket::setDefaultCaCertificates(QList<QSslCertificate>());
-	// Release global protobuf memory allocations.
 #if (GOOGLE_PROTOBUF_VERSION >= 2001000)
+	// Release global protobuf memory allocations.
 	google::protobuf::ShutdownProtobufLibrary();
 #endif
 #endif


### PR DESCRIPTION
removed redundant workaround for https://bugreports.qt.io/browse/QTBUG-6504 in debug-mode

Fixes #3840 