### PR TITLE
Travis CI: remove macOS build, it's on Azure Pipelines

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,8 +24,6 @@ matrix:
     - os: linux
       dist: xenial
       env: MUMBLE_HOST=x86_64-w64-mingw32
-    - os: osx
-      env: MUMBLE_HOST=x86_64-apple-darwin
 
 before_install:
     - ./scripts/travis-ci/before_install.bash

--- a/scripts/travis-ci/before_install.bash
+++ b/scripts/travis-ci/before_install.bash
@@ -61,18 +61,6 @@ if [ "${TRAVIS_OS_NAME}" == "linux" ]; then
 	else
 		exit 1
 	fi
-elif [ "${TRAVIS_OS_NAME}" == "osx" ]; then
-	# We install the protobuf package via brew,
-	# which depends on "python@2".
-	#
-	# The build image upgraded the installed "python",
-	# and now "python@2" conflicts with it when trying
-	# to create symlinks.
-	#
-	# We don’t use the symlinked "python" installed
-	# by default in the image, so we unlink it to allow
-	# the "python@2" package to be installed without conflict.
-	brew update && brew unlink python && brew install qt5 libogg libvorbis flac libsndfile protobuf openssl ice
 else
 	exit 1
 fi

--- a/scripts/travis-ci/script.bash
+++ b/scripts/travis-ci/script.bash
@@ -58,14 +58,6 @@ if [ "${TRAVIS_OS_NAME}" == "linux" ]; then
 	else
 		exit 1
 	fi
-elif [ "${TRAVIS_OS_NAME}" == "osx" ]; then
-	export PKG_CONFIG_PATH=$PKG_CONFIG_PATH:/usr/local/lib/pkgconfig
-	export PKG_CONFIG_PATH=$PKG_CONFIG_PATH:/usr/local/opt/openssl/lib/pkgconfig
-	export PATH=$PATH:/usr/local/opt/qt5/bin:/usr/local/bin
-	export MUMBLE_PREFIX=/usr/local
-	export MUMBLE_ICE_PREFIX=/usr/local/opt/ice
-	qmake CONFIG+="release tests warnings-as-errors" && make -j2 && make check
-	./macx/scripts/osxdist.py
 else
 	exit 1
 fi


### PR DESCRIPTION
The macOS build on Azure Pipelines was restored in #3837.