### PR TITLE
Travis CI: transform Linux x86_64 build into ARM64

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,8 +13,9 @@ cache:
 matrix:
   include:
     - os: linux
+      arch: arm64
       dist: xenial
-      env: MUMBLE_HOST=x86_64-linux-gnu
+      env: MUMBLE_HOST=aarch64-linux-gnu
     - os: linux
       dist: xenial
       env: MUMBLE_HOST=x86_64-linux-gnu MUMBLE_NO_PCH=1

--- a/scripts/travis-ci/before_install.bash
+++ b/scripts/travis-ci/before_install.bash
@@ -20,6 +20,14 @@ if [ "${TRAVIS_OS_NAME}" == "linux" ]; then
 		sudo apt-get build-dep -qq mumble
 		sudo apt-get install libqt5sql5 libqt5sql5-sqlite qt5-default qttools5-dev qttools5-dev-tools qtbase5-dev qtbase5-dev-tools qttranslations5-l10n libqt5svg5-dev
 		sudo apt-get install libjack-jackd2-dev
+	elif [ "${MUMBLE_HOST}" == "aarch64-linux-gnu" ]; then
+		sudo apt-get -qq update
+		sudo apt-get -y install build-essential pkg-config qt5-default qttools5-dev-tools libqt5svg5-dev \
+                                libboost-dev libssl-dev libprotobuf-dev protobuf-compiler \
+                                libcap-dev libxi-dev \
+                                libjack-jackd2-dev libasound2-dev libpulse-dev \
+                                libogg-dev libsndfile1-dev libspeechd-dev \
+                                libavahi-compat-libdnssd-dev libzeroc-ice-dev libg15daemon-client-dev
 	elif [ "${MUMBLE_HOST}" == "i686-w64-mingw32" ]; then
 		sudo dpkg --add-architecture i386
 		sudo apt-get -qq update

--- a/scripts/travis-ci/script.bash
+++ b/scripts/travis-ci/script.bash
@@ -18,7 +18,7 @@ if [ "${TRAVIS_OS_NAME}" == "linux" ]; then
 			EXTRA_CONFIG="no-pch ${EXTRA_CONFIG}"
 		fi
 		qmake CONFIG+="release tests g15-emulator ${EXTRA_CONFIG}" DEFINES+="MUMBLE_VERSION=${TRAVIS_COMMIT:0:7}" -recursive
-		if [ "${MUMBLE_NO_PCH}" == "1" ] && [ "${MASTER_BRANCH}" = "1" ]; then
+		if [ "${MASTER_BRANCH}" = "1" ]; then
 			# Wraps the compilation with the Build Wrapper to generate the configuration used later by the SonarQube Scanner.
 			mkdir build
 			build-wrapper-linux-x86-64 --out-dir build/sonar make -j 2
@@ -29,6 +29,9 @@ if [ "${TRAVIS_OS_NAME}" == "linux" ]; then
 		else
 			make -j2 && make check
 		fi
+	elif [ "${MUMBLE_HOST}" == "aarch64-linux-gnu" ]; then
+		qmake CONFIG+="release tests warnings-as-errors ${EXTRA_CONFIG}" -recursive
+		make -j $(nproc)
 	elif [ "${MUMBLE_HOST}" == "i686-w64-mingw32" ]; then
 		wget http://www.steinberg.net/sdk_downloads/asiosdk2.3.zip -P ../
 		unzip ../asiosdk2.3.zip -d ../


### PR DESCRIPTION
Travis CI announced support for ARM64 builds a few days ago: https://blog.travis-ci.com/2019-10-07-multi-cpu-architecture-support

We already have a Linux x86_64 build on Azure Pipelines, which also generates an AppImage.

This commit changes the architecture for the build we have on Travis CI, so that it's not redundant anymore (and becomes useful).

The "no-pch" build is not changed because the only differences consist in the PCH header not being used and the SonarQube Scanner being executed.

Also, we don't want to use an ARM64 builder unnecessarily.

We don't use `make check` because of #3845.