### PR TITLE
TaskList.cpp: fix compilation error with MinGW when PCH is disabled

### DIFF
--- a/src/mumble/TaskList.cpp
+++ b/src/mumble/TaskList.cpp
@@ -7,6 +7,8 @@
 
 #include "MumbleApplication.h"
 
+#include "win.h"
+
 #include <QtCore/QFileInfo>
 #include <QtCore/QSettings>
 #include <QtCore/QString>


### PR DESCRIPTION
Fixes the following error:
```cpp
TaskList.cpp:77:20: error: 'SHARD_LINK' was not declared in this scope
  SHAddToRecentDocs(SHARD_LINK, link);
                    ^
```

`SHARD_LINK` is only defined when `NTDDI_VERSION` is at least `NTDDI_WIN7` (`0x06010000`).

We handle the logic for MinGW in "win.h", this commit fixes the error by including it.