### PR TITLE
Travis CI: disable SonarCloud scanner, incompatible with Ubuntu Bionic (18.04)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,14 +2,6 @@ sudo: required # Required for apt-get build-dep
 language: cpp
 compiler: gcc
 
-addons:
-  sonarcloud:
-    organization: "mumble-voip"
-
-cache:
-  directories:
-    - '$HOME/.sonar/cache'
-
 matrix:
   include:
     - os: linux

--- a/scripts/travis-ci/script.bash
+++ b/scripts/travis-ci/script.bash
@@ -18,17 +18,7 @@ if [ "${TRAVIS_OS_NAME}" == "linux" ]; then
 			EXTRA_CONFIG="no-pch ${EXTRA_CONFIG}"
 		fi
 		qmake CONFIG+="release tests g15-emulator ${EXTRA_CONFIG}" DEFINES+="MUMBLE_VERSION=${TRAVIS_COMMIT:0:7}" -recursive
-		if [ "${MASTER_BRANCH}" = "1" ]; then
-			# Wraps the compilation with the Build Wrapper to generate the configuration used later by the SonarQube Scanner.
-			mkdir build
-			build-wrapper-linux-x86-64 --out-dir build/sonar make -j 2
-			make check
-
-			# Run the SonarQube analysis
-			sonar-scanner
-		else
-			make -j2 && make check
-		fi
+		make -j2 && make check
 	elif [ "${MUMBLE_HOST}" == "aarch64-linux-gnu" ]; then
 		qmake CONFIG+="release tests warnings-as-errors ${EXTRA_CONFIG}" -recursive
 		make -j $(nproc)


### PR DESCRIPTION
Unfortunately `sonar-scanner` fails with the following error:
```
ERROR: Error during SonarQube Scanner execution
java.lang.IllegalStateException: The "build-wrapper-dump.json" file was found empty. Please make sure that:
  * you are using the latest version of the build-wrapper and the SonarCFamily analyzer
  * your compiler is supported
  * you are wrapping your build correctly
  * you are wrapping a full/clean build
	at com.sonar.cpp.plugin.CFamilySensor.execute(CFamilySensor.java:239)
	at org.sonar.scanner.sensor.AbstractSensorWrapper.analyse(AbstractSensorWrapper.java:48)
	at org.sonar.scanner.sensor.ModuleSensorsExecutor.execute(ModuleSensorsExecutor.java:85)
	at org.sonar.scanner.sensor.ModuleSensorsExecutor.execute(ModuleSensorsExecutor.java:62)
	at org.sonar.scanner.scan.ModuleScanContainer.doAfterStart(ModuleScanContainer.java:82)
	at org.sonar.core.platform.ComponentContainer.startComponents(ComponentContainer.java:136)
	at org.sonar.core.platform.ComponentContainer.execute(ComponentContainer.java:122)
	at org.sonar.scanner.scan.ProjectScanContainer.scan(ProjectScanContainer.java:403)
	at org.sonar.scanner.scan.ProjectScanContainer.scanRecursively(ProjectScanContainer.java:399)
	at org.sonar.scanner.scan.ProjectScanContainer.doAfterStart(ProjectScanContainer.java:362)
	at org.sonar.core.platform.ComponentContainer.startComponents(ComponentContainer.java:136)
	at org.sonar.core.platform.ComponentContainer.execute(ComponentContainer.java:122)
	at org.sonar.scanner.bootstrap.GlobalContainer.doAfterStart(GlobalContainer.java:141)
	at org.sonar.core.platform.ComponentContainer.startComponents(ComponentContainer.java:136)
	at org.sonar.core.platform.ComponentContainer.execute(ComponentContainer.java:122)
	at org.sonar.batch.bootstrapper.Batch.doExecute(Batch.java:72)
	at org.sonar.batch.bootstrapper.Batch.executeTask(Batch.java:98)
	at org.sonarsource.scanner.api.internal.batch.BatchIsolatedLauncher.execute(BatchIsolatedLauncher.java:63)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.base/java.lang.reflect.Method.invoke(Method.java:566)
	at org.sonarsource.scanner.api.internal.IsolatedLauncherProxy.invoke(IsolatedLauncherProxy.java:60)
	at com.sun.proxy.$Proxy0.execute(Unknown Source)
	at org.sonarsource.scanner.api.EmbeddedScanner.doExecute(EmbeddedScanner.java:233)
	at org.sonarsource.scanner.api.EmbeddedScanner.runAnalysis(EmbeddedScanner.java:151)
	at org.sonarsource.scanner.cli.Main.runAnalysis(Main.java:123)
	at org.sonarsource.scanner.cli.Main.execute(Main.java:77)
	at org.sonarsource.scanner.cli.Main.main(Main.java:61)
```
The file is not generated because the C/C++ plugin library fails to load:
```
ERROR: ld.so: object '/home/travis/.sonar/cache/87f7532f0609a32b83c77be7ae487f14/build-wrapper-linux-x86/libinterceptor-${PLATFORM}.so' from LD_PRELOAD cannot be preloaded (cannot open shared object file): ignored.
```