### PR TITLE
.lgtm.yml: Prepare for Ubuntu 19.10

### DIFF
--- a/.lgtm.yml
+++ b/.lgtm.yml
@@ -6,4 +6,4 @@ extraction:
       - "libqt5svg5-dev"
     configure:
       command:
-      - "qmake -recursive CONFIG+='release tests g15-emulator'"
+      - "qmake -recursive CONFIG+='release tests no-g15'"


### PR DESCRIPTION
We'll soon upgrade the lgtm.com build environment to Ubuntu 19.10, where  `libg15daemon-client-dev` is no longer available, which makes the build fail because it can't find `g15daemon_client.h`. Adding `no-g15` makes  the build succeed.