### PR TITLE
Fixed posting of empty clipboards to channel on Global Shortcut input

### DIFF
--- a/src/mumble/MainWindow.cpp
+++ b/src/mumble/MainWindow.cpp
@@ -2738,7 +2738,7 @@ void MainWindow::on_gsSendTextMessage_triggered(bool down, QVariant scdata) {
 }
 
 void MainWindow::on_gsSendClipboardTextMessage_triggered(bool down, QVariant) {
-	if (!down) {
+	if (!down || (QApplication::clipboard()->text().isEmpty())) {
 		return;
 	}
 


### PR DESCRIPTION
Fixed unexpected behavior.

Old behavior: Pressing a global shortcut for pasting clipboard content to channel while user's clipboard is empty resulted in empty messages being posted to channel.

New behavior: pressing the global shortcut for pasting clipboard content to channel while user's clipboard is empty does not post a message to channel