### PR TITLE
Make client robust against server dropping occupied channel

### DIFF
--- a/src/mumble/Messages.cpp
+++ b/src/mumble/Messages.cpp
@@ -695,7 +695,11 @@ void MainWindow::msgChannelRemove(const MumbleProto::ChannelRemove &msg) {
 				g.db->setChannelFiltered(sh->qbaDigest, c->iId, false);
 			c->bFiltered = false;
 		}
-		pmModel->removeChannel(c);
+		if (!pmModel->removeChannel(c, true)) {
+			g.l->log(Log::CriticalError, tr("Protocol violation. Server sent remove for occupied channel."));
+			g.sh->disconnect();
+			return;
+		}
 	}
 }
 

--- a/src/mumble/UserModel.cpp
+++ b/src/mumble/UserModel.cpp
@@ -1161,12 +1161,12 @@ Channel *UserModel::addChannel(int id, Channel *p, const QString &name) {
 	return c;
 }
 
-void UserModel::removeChannel(Channel *c) {
-	ModelItem *item, *i;
+bool UserModel::removeChannel(Channel *c, const bool onlyIfUnoccupied) {
+	const ModelItem *item = ModelItem::c_qhChannels.value(c);
+	
+	if (onlyIfUnoccupied && item->iUsers !=0) return false; // Checks full hierarchy
 
-	item=ModelItem::c_qhChannels.value(c);
-
-	foreach(i, item->qlChildren) {
+	foreach(const ModelItem *i, item->qlChildren) {
 		if (i->pUser)
 			removeUser(i->pUser);
 		else
@@ -1176,7 +1176,7 @@ void UserModel::removeChannel(Channel *c) {
 	Channel *p = c->cParent;
 
 	if (! p)
-		return;
+		return true;
 
 	ModelItem *citem = ModelItem::c_qhChannels.value(p);
 
@@ -1192,6 +1192,7 @@ void UserModel::removeChannel(Channel *c) {
 
 	delete item;
 	delete c;
+	return true;
 }
 
 void UserModel::moveChannel(Channel *c, Channel *p) {

--- a/src/mumble/UserModel.h
+++ b/src/mumble/UserModel.h
@@ -30,6 +30,7 @@ public:
 	ModelItem *parent;
 	QList<ModelItem *> qlChildren;
 	QList<ModelItem *> qlHiddenChildren;
+	/// Number of users in this channel (recursive)
 	int iUsers;
 
 	static QHash <Channel *, ModelItem *> c_qhChannels;
@@ -126,7 +127,7 @@ class UserModel : public QAbstractItemModel {
 		void setCommentHash(Channel *c, const QByteArray &hash);
 
 		void removeUser(ClientUser *p);
-		void removeChannel(Channel *c);
+		bool removeChannel(Channel *c, const bool onlyIfUnoccupied = false);
 
 		void linkChannels(Channel *c, QList<Channel *> links);
 		void unlinkChannels(Channel *c, QList<Channel *> links);


### PR DESCRIPTION
While this should not occur the client did not properly
consider what would happen if a server send a ChannelRemove
without first moving all users out. Allowing this operation
to happen will bring our UserModel into an undefined state
where users (even ourselves) might have been dropped while
the server still considers them.

With this patch we now detect that case and disconnect ourselves
from the broken server instead of breaking our state.