### PR TITLE
Make client more robust against inconsistent state

### DIFF
--- a/src/mumble/Messages.cpp
+++ b/src/mumble/Messages.cpp
@@ -39,14 +39,17 @@
 
 #define VICTIM_INIT \
 	ClientUser *pDst=ClientUser::get(msg.session()); \
-	 if (! pDst) { \
+	 if (!pDst) { \
  		qWarning("MainWindow: Message for nonexistent victim %d.", msg.session()); \
 		return; \
 	}
 
 #define SELF_INIT \
-	ClientUser *pSelf = ClientUser::get(g.uiSession);
-
+	ClientUser *pSelf = ClientUser::get(g.uiSession); \
+	if (!pSelf) { \
+		qWarning("MainWindow: Received message outside of session (sid %d).", g.uiSession); \
+		return; \
+	}
 
 void MainWindow::msgAuthenticate(const MumbleProto::Authenticate &) {
 }
@@ -262,8 +265,7 @@ void MainWindow::msgUDPTunnel(const MumbleProto::UDPTunnel &) {
 
 void MainWindow::msgUserState(const MumbleProto::UserState &msg) {
 	ACTOR_INIT;
-	SELF_INIT;
-
+	ClientUser* pSelf = ClientUser::get(g.uiSession);
 	ClientUser *pDst = ClientUser::get(msg.session());
 	Channel *channel = NULL;
 


### PR DESCRIPTION
If during message handling we somehow end up in a situation
where no ClientUser is registered or g.uiSession is not set
we end up with pSelf as a null pointer. Dereferncing that
crashes the application.

Similar to other objects we retrieve for message processing
this patch modified the macro to log and bail if we encounter
this situation instead of crashing.

One drawback of this patch is that it might make state
corruption caused by client bugs less visible to us because
we no longer receive crash reports on them while the client
functionality could still be degraded severly.