### PR TITLE
Use QDateTime to avoid time underflow

### DIFF
--- a/src/murmur/ServerUser.h
+++ b/src/murmur/ServerUser.h
@@ -18,7 +18,7 @@
 #include "HostAddress.h"
 
 #include <QtCore/QStringList>
-#include <QtCore/QTime>
+#include <QtCore/QDateTime>
 
 #ifdef Q_OS_WIN
 # include <winsock2.h>
@@ -67,7 +67,7 @@ class LeakyBucket {
 	private:
 		unsigned int tokensPerSec, maxTokens;
 		long currentTokens;
-		QTime lastUpdate;
+		QDateTime lastUpdate;
 
 	public:
 		// Returns true if packets should be dropped


### PR DESCRIPTION
Use `QDateTime` instead of `QTime` when tracking the last update for rate limiting purposes. This avoids the time underflow around midnight.

Further avoided backwards time updates due to DST by using UTC time instead of the local time.

And finally, if the time _does_ go backwards (due to user changing the date for example), reset the last update time to ensure it doesn't need to wait for the time to catch up to the previous update.

Fixes #3724 hopefully.