### PR TITLE
Update translations

### DIFF
--- a/scripts/updatetranslations.sh
+++ b/scripts/updatetranslations.sh
@@ -73,7 +73,7 @@ function main
 	echo "Translation update" > $tmpfile
 	echo "" >> $tmpfile
 	
-	lupdate -no-ui-lines -disable-heuristic similartext -locations relative -no-obsolete mumble.pro -ts $file | tee -a $tmpfile || fatal "lupdate failed"
+	lupdate -no-ui-lines -disable-heuristic similartext -locations none -no-obsolete mumble.pro -ts $file | tee -a $tmpfile || fatal "lupdate failed"
 	echo
 
 	# Duplicate single numerusform entries in mumble_en.ts to work around #1195

--- a/src/mumble/main.cpp
+++ b/src/mumble/main.cpp
@@ -262,7 +262,7 @@ int main(int argc, char **argv) {
 
 	{
 		size_t reqSize;
-		if (_wgetenv_s(&reqSize, NULL, 0, L"PATH") != 0)) {
+		if (_wgetenv_s(&reqSize, NULL, 0, L"PATH") != 0) {
 			qWarning() << "Failed to get PATH. Not adding application directory to PATH. DBus bindings may not work.";
 		} else if (reqSize > 0) {
 			STACKVAR(wchar_t, buff, reqSize+1);

--- a/src/mumble/mumble_en.ts
+++ b/src/mumble/mumble_en.ts
@@ -4,109 +4,86 @@
 <context>
     <name>ACLEditor</name>
     <message>
-        <location filename="ACLEditor.cpp" line="+107"/>
         <source>Deny</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Allow</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>Allow %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-8"/>
         <source>Deny %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-84"/>
         <source>Mumble - Add channel</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+11"/>
-        <location line="+50"/>
         <source>Default server value</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-28"/>
-        <location line="+176"/>
         <source>Failed: Invalid channel</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-164"/>
         <source>Mumble - Edit %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>ID: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+46"/>
         <source>This grants the %1 privilege. If a privilege is both allowed and denied, it is denied.&lt;br /&gt;%2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+123"/>
         <source>Channel must have a name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-131"/>
         <source>This revokes the %1 privilege. If a privilege is both allowed and denied, it is denied.&lt;br /&gt;%2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="ACLEditor.ui"/>
         <source>Dialog</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Enter the channel name here.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Description</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Password</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Enter the channel password here.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Check to create a temporary channel.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Temporary</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>&lt;b&gt;Position&lt;/b&gt;&lt;br/&gt;
 This value enables you to change the way Mumble arranges the channels in the tree. A channel with a higher &lt;i&gt;Position&lt;/i&gt; value will always be placed below one with a lower value and the other way around. If the &lt;i&gt;Position&lt;/i&gt; value of two channels is equal they will get sorted alphabetically by their name.</source>
         <oldsource>&lt;b&gt;Position&lt;/b&gt;&lt;br/&gt;
@@ -114,390 +91,314 @@ This value enables you to change the way mumble arranges the channels in the tre
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Position</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>&amp;Groups</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Group</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>List of groups</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Remove selected group</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Remove</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Inherit group members from parent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Inherit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Make group inheritable to sub-channels</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Inheritable</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Group was inherited from parent channel</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Inherited</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Members</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Add</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Add member to group</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Remove member from group</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>&amp;ACL</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Active ACLs</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>List of entries</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Inherit ACL of parent?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>This sets whether or not the ACL up the chain of parent channels are applied to this object. Only those entries that are marked in the parent as &quot;Apply to sub-channels&quot; will be inherited.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Inherit ACLs</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Move entry up</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>This moves the entry up in the list. As entries are evaluated in order, this may change the effective permissions of users. You cannot move an entry above an inherited entry, if you really need that you&apos;ll have to duplicate the inherited entry.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>&amp;Up</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Move entry down</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>This moves the entry down in the list. As entries are evaluated in order, this may change the effective permissions of users.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>&amp;Down</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Add new entry</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>This adds a new entry, initially set with no permissions and applying to all.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>&amp;Add</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Remove entry</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>This removes the currently selected entry.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>&amp;Remove</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Context</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Entry should apply to this channel.</source>
         <oldsource>Entry should apply to this channel</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>This makes the entry apply to this channel.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Applies to this channel</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Entry should apply to sub-channels.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Add new group</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>&lt;b&gt;Add&lt;/b&gt;&lt;br/&gt;
 Add a new group.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Inherited members</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Contains the list of members added to the group by this channel.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Contains a list of members whose group membership will not be inherited from the parent channel.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Contains the list of members inherited by other channels.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Type in the name of a user you wish to add to the group and click Add.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Type in the name of a user you wish to remove from the group and click Add.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Exclude</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Excluded members</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>This makes the entry apply to sub-channels of this channel.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Applies to sub-channels</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Permissions</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>User/Group</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Group this entry applies to</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>User ID</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>User this entry applies to</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>This controls which user this entry applies to. Just type in the user name and hit enter to query the server for a match.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>&amp;Properties</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>&lt;b&gt;Name&lt;/b&gt;&lt;br /&gt;Enter the channel name in this field. The name has to comply with the restriction imposed by the server you are connected to.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>&lt;b&gt;Temporary&lt;/b&gt;&lt;br /&gt;
 When checked the channel created will be marked as temporary. This means when the last player leaves it the channel will be automatically deleted by the server.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>&lt;b&gt;Group&lt;/b&gt;&lt;br /&gt;
 These are all the groups currently defined for the channel. To create a new group, just type in the name and press enter.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>&lt;b&gt;Remove&lt;/b&gt;&lt;br /&gt;This removes the currently selected group. If the group was inherited, it will not be removed from the list, but all local information about the group will be cleared.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>&lt;b&gt;Inherit&lt;/b&gt;&lt;br /&gt;This inherits all the members in the group from the parent, if the group is marked as &lt;i&gt;Inheritable&lt;/i&gt; in the parent channel.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>&lt;b&gt;Inheritable&lt;/b&gt;&lt;br /&gt;This makes this group inheritable to sub-channels. If the group is non-inheritable, sub-channels are still free to create a new group with the same name.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>&lt;b&gt;Inherited&lt;/b&gt;&lt;br /&gt;This indicates that the group was inherited from the parent channel. You cannot edit this flag, it&apos;s just for information.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>&lt;b&gt;Members&lt;/b&gt;&lt;br /&gt;
 This list contains all members that were added to the group by the current channel. Be aware that this does not include members inherited by higher levels of the channel tree. These can be found in the &lt;i&gt;Inherited members&lt;/i&gt; list. To prevent this list to be inherited by lower level channels uncheck &lt;i&gt;Inheritable&lt;/i&gt; or manually add the members to the &lt;i&gt;Excluded members&lt;/i&gt; list.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>&lt;b&gt;Excluded members&lt;/b&gt;&lt;br /&gt;
 Contains a list of members whose group membership will not be inherited from the parent channel.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>&lt;b&gt;Inherited members&lt;/b&gt;&lt;br /&gt;
 Contains the list of members inherited by the current channel. Uncheck &lt;i&gt;Inherit&lt;/i&gt; to prevent inheritance from higher level channels.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>This controls which group of users this entry applies to.&lt;br /&gt;Note that the group is evaluated in the context of the channel the entry is used in. For example, the default ACL on the Root channel gives &lt;i&gt;Write&lt;/i&gt; permission to the &lt;i&gt;admin&lt;/i&gt; group. This entry, if inherited by a channel, will give a user write privileges if he belongs to the &lt;i&gt;admin&lt;/i&gt; group in that channel, even if he doesn&apos;t belong to the &lt;i&gt;admin&lt;/i&gt; group in the channel where the ACL originated.&lt;br /&gt;If a group name starts with &apos;!&apos;, its membership is negated, and if it starts with &apos;~&apos;, it is evaluated in the channel the ACL was defined in, rather than the channel the ACL is active in.&lt;br /&gt;If a group name starts with &apos;#&apos;, it is interpreted as an access token. Users must have entered whatever follows the &apos;#&apos; in their list of access tokens to match. This can be used for very simple password access to channels for non-authenticated users.&lt;br /&gt;If a group name starts with &apos;$&apos;, it will only match users whose certificate hash matches what follows the &apos;$&apos;.&lt;br /&gt;A few special predefined groups are:&lt;br /&gt;&lt;b&gt;all&lt;/b&gt; - Everyone will match.&lt;br /&gt;&lt;b&gt;auth&lt;/b&gt; - All authenticated users will match.&lt;br /&gt;&lt;b&gt;sub,a,b,c&lt;/b&gt; - User currently in a sub-channel minimum &lt;i&gt;a&lt;/i&gt; common parents, and between &lt;i&gt;b&lt;/i&gt; and &lt;i&gt;c&lt;/i&gt; channels down the chain. See the website for more extensive documentation on this one.&lt;br /&gt;&lt;b&gt;in&lt;/b&gt; - Users currently in the channel will match (convenience for &apos;&lt;i&gt;sub,0,0,0&lt;/i&gt;&apos;).&lt;br /&gt;&lt;b&gt;out&lt;/b&gt; - Users outside the channel will match (convenience for &apos;&lt;i&gt;!sub,0,0,0&lt;/i&gt;&apos;).&lt;br /&gt;Note that an entry applies to either a user or a group, not both.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>&lt;b&gt;Password&lt;/b&gt;&lt;br /&gt;This field allows you to easily set and change the password of a channel. It uses Mumble&apos;s access tokens feature in the background. Use ACLs and groups if you need more fine grained and powerful access control.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>This shows all the entries active on this channel. Entries inherited from parent channels will be shown in italics.&lt;br /&gt;ACLs are evaluated top to bottom, meaning priority increases as you move down the list.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>ID of the channel.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Maximum Users</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Maximum number of users allowed in the channel</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>&lt;b&gt;Maximum Users&lt;/b&gt;&lt;br /&gt;
 This value allows you to set the maximum number of users allowed in the channel. If the value is above zero, only that number of users will be allowed to enter the channel. If the value is zero, the maximum number of users in the channel is given by the server&apos;s default limit.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>This is the sort order for the channel.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -505,12 +406,10 @@ This value allows you to set the maximum number of users allowed in the channel.
 <context>
     <name>ALSAAudioInput</name>
     <message>
-        <location filename="ALSAAudio.cpp" line="+150"/>
         <source>Default ALSA Card</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+191"/>
         <source>Opening chosen ALSA Input failed: %1</source>
         <translation type="unfinished"></translation>
     </message>
@@ -518,12 +417,10 @@ This value allows you to set the maximum number of users allowed in the channel.
 <context>
     <name>ALSAAudioOutput</name>
     <message>
-        <location line="-190"/>
         <source>Default ALSA Card</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+328"/>
         <source>Opening chosen ALSA Output failed: %1</source>
         <translation type="unfinished"></translation>
     </message>
@@ -531,136 +428,107 @@ This value allows you to set the maximum number of users allowed in the channel.
 <context>
     <name>ASIOConfig</name>
     <message>
-        <location filename="ASIOInput.cpp" line="+213"/>
         <source>%1 (version %2)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>%1 -&gt; %2 samples buffer, with %3 sample resolution (%4 preferred) at %5 Hz</source>
         <oldsource>%1 -&gt; %2 samples buffer, with %3 sample resolution (%4 preferred) at %5Hz</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+43"/>
-        <location line="+25"/>
         <source>ASIO Initialization failed: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-21"/>
-        <location line="+25"/>
         <source>Failed to instantiate ASIO driver</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="ASIOInput.ui"/>
-        <location filename="ASIOInput.cpp" line="+37"/>
         <source>ASIO</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Device selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Device</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Device to use for microphone</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>This chooses what device to query. You still need to actually query the device and select which channels to use.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Query selected device</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>This queries the selected device for channels. Be aware that many ASIO drivers are buggy to the extreme, and querying them might cause a crash of either the application or the system.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>&amp;Query</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Configure selected device</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>This configures the selected device. Be aware that many ASIO drivers are buggy to the extreme, and querying them might cause a crash of either the application or the system.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>&amp;Configure</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Capabilities</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Driver name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Buffer size</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>This will configure the input channels for ASIO. Make sure you select at least one channel as microphone and speaker. &lt;i&gt;Microphone&lt;/i&gt; should be where your microphone is attached, and &lt;i&gt;Speaker&lt;/i&gt; should be a channel that samples &apos;&lt;i&gt;What you hear&lt;/i&gt;&apos;.&lt;br /&gt;For example, on the Audigy 2 ZS, a good selection for Microphone would be &apos;&lt;i&gt;Mic L&lt;/i&gt;&apos; while Speaker should be &apos;&lt;i&gt;Mix L&lt;/i&gt;&apos; and &apos;&lt;i&gt;Mix R&lt;/i&gt;&apos;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Configure input channels</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Channels</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Microphone</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>&lt;-</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>-&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Unused</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Speakers</source>
         <translation type="unfinished"></translation>
     </message>
@@ -668,12 +536,10 @@ This value allows you to set the maximum number of users allowed in the channel.
 <context>
     <name>ASIOInput</name>
     <message>
-        <location filename="ASIOInput.cpp" line="+74"/>
         <source>You need to select at least one microphone and one speaker source to use ASIO.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+103"/>
         <source>Opening selected ASIO device failed. No input will be done.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -681,37 +547,30 @@ This value allows you to set the maximum number of users allowed in the channel.
 <context>
     <name>AboutDialog</name>
     <message>
-        <location filename="About.cpp" line="+19"/>
         <source>About Mumble</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+35"/>
         <source>&lt;h3&gt;Mumble (%1)&lt;/h3&gt;&lt;p&gt;%3&lt;/p&gt;&lt;p&gt;&lt;b&gt;A voice-chat utility for gamers&lt;/b&gt;&lt;/p&gt;&lt;p&gt;&lt;tt&gt;&lt;a href=&quot;%2&quot;&gt;%2&lt;/a&gt;&lt;/tt&gt;&lt;/p&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>&amp;About Mumble</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>&amp;License</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>A&amp;uthors</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>&amp;Third-Party Licenses</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>OK</source>
         <translation type="unfinished"></translation>
     </message>
@@ -719,467 +578,374 @@ This value allows you to set the maximum number of users allowed in the channel.
 <context>
     <name>AudioInput</name>
     <message>
-        <location filename="AudioInput.ui"/>
         <source>Interface</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>System</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Input method for audio</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Device</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Input device for audio</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>&lt;b&gt;This is the input device to use for audio.&lt;/b&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Transmission</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>&amp;Transmit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>When to transmit your speech</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>&lt;b&gt;This sets when speech should be transmitted.&lt;/b&gt;&lt;br /&gt;&lt;i&gt;Continuous&lt;/i&gt; - All the time&lt;br /&gt;&lt;i&gt;Voice Activity&lt;/i&gt; - When you are speaking clearly.&lt;br /&gt;&lt;i&gt;Push To Talk&lt;/i&gt; - When you hold down the hotkey set under &lt;i&gt;Shortcuts&lt;/i&gt;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>DoublePush Time</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>If you press the PTT key twice in this time it will get locked.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>&lt;b&gt;DoublePush Time&lt;/b&gt;&lt;br /&gt;If you press the push-to-talk key twice during the configured interval of time it will be locked. Mumble will keep transmitting until you hit the key once more to unlock PTT again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Reset audio cue to default</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>&lt;b&gt;Reset&lt;/b&gt;&lt;br/&gt;Reset the paths for the files to their default.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Browse for on audio file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Browse for off audio file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Off</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>On</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Preview the audio cues</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Use SNR based speech detection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Signal to Noise</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>&lt;b&gt;This sets speech detection to use Amplitude.&lt;/b&gt;&lt;br /&gt;In this mode, the raw strength of the input signal is used to detect speech.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Amplitude</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Voice &amp;Hold</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>How long to keep transmitting after silence</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Silence Below</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>&lt;b&gt;This sets the trigger values for voice detection.&lt;/b&gt;&lt;br /&gt;Use this together with the Audio Statistics window to manually tune the trigger values for detecting speech. Input values below &quot;Silence Below&quot; always count as silence. Values above &quot;Speech Above&quot; always count as voice. Values in between will count as voice if you&apos;re already talking, but will not trigger a new detection.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Speech Above</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Signal values above this count as voice</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Compression</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>&amp;Quality</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Quality of compression (peak bandwidth)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>&lt;b&gt;This sets the quality of compression.&lt;/b&gt;&lt;br /&gt;This determines how much bandwidth Mumble is allowed to use for outgoing audio.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Audio per packet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>How many audio frames to send per packet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>&lt;b&gt;This selects how many audio frames should be put in one packet.&lt;/b&gt;&lt;br /&gt;Increasing this will increase the latency of your voice, but will also reduce bandwidth requirements.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>&lt;b&gt;This shows peak outgoing bandwidth used.&lt;/b&gt;&lt;br /&gt;This shows the peak amount of bandwidth sent out from your machine. Audio bitrate is the maximum bitrate (as we use VBR) for the audio data alone. Position is the bitrate used for positional information. Overhead is our framing and the IP packet headers (IP and UDP is 75% of this overhead).</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Audio Processing</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Noise Suppression</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Noise suppression</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>&lt;b&gt;This sets the amount of noise suppression to apply.&lt;/b&gt;&lt;br /&gt;The higher this value, the more aggressively stationary noise will be suppressed.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Maximum amplification of input sound</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>&lt;b&gt;Maximum amplification of input.&lt;/b&gt;&lt;br /&gt;Mumble normalizes the input volume before compressing, and this sets how much it&apos;s allowed to amplify.&lt;br /&gt;The actual level is continually updated based on your current speech pattern, but it will never go above the level specified here.&lt;br /&gt;If the &lt;i&gt;Microphone loudness&lt;/i&gt; level of the audio statistics hover around 100%, you probably want to set this to 2.0 or so, but if, like most people, you are unable to reach 100%, set this to something much higher.&lt;br /&gt;Ideally, set it so &lt;i&gt;Microphone Loudness * Amplification Factor &gt;= 100&lt;/i&gt;, even when you&apos;re speaking really soft.&lt;br /&gt;&lt;br /&gt;Note that there is no harm in setting this to maximum, but Mumble will start picking up other conversations if you leave it to auto-tune to that level.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Current speech detection chance</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Cancel echo from speakers</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Enabling this will cancel the echo from your speakers. Mixed has low CPU impact, but only works well if your speakers are equally loud and equidistant from the microphone. Multichannel echo cancellation provides much better echo cancellation, but at a higher CPU cost.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Disabled</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>&lt;b&gt;This sets speech detection to use Signal to Noise ratio.&lt;/b&gt;&lt;br /&gt;In this mode, the input is analyzed for something resembling a clear signal, and the clarity of that signal is used to trigger speech detection.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>&lt;b&gt;This shows the current speech detection settings.&lt;/b&gt;&lt;br /&gt;You can change the settings from the Settings dialog or from the Audio Wizard.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Signal values below this count as silence</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Maximum bandwidth used for sending audio</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Use Amplitude based speech detection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>&lt;b&gt;This selects how long after a perceived stop in speech transmission should continue.&lt;/b&gt;&lt;br /&gt;Set this higher if your voice breaks up when you speak (seen by a rapidly blinking voice icon next to your name).</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Exclusive mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>&lt;b&gt;This opens the device in exclusive mode.&lt;/b&gt;&lt;br /&gt;No other application will be able to use the device.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Exclusive</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>R&amp;eset</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>&amp;Browse...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>B&amp;rowse...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>&amp;Preview</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>&lt;b&gt;Preview&lt;/b&gt;&lt;br/&gt;Plays the current &lt;i&gt;on&lt;/i&gt; sound followed by the current &lt;i&gt;off&lt;/i&gt; sound.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Displays an always on top window with a push to talk button in it</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Display push to talk window</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Misc</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Audible audio cue when starting or stopping to transmit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>&lt;b&gt;This enables transmission audio cues.&lt;/b&gt;&lt;br /&gt;Setting this will give you a short audio beep when you start and stop transmitting.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Audio cue</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Gets played when starting to transmit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Gets played when stopping to transmit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Hold Time</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Time the microphone stays open after the PTT key is released</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="AudioInput.cpp" line="+603"/>
         <source>Server maximum network bandwidth is only %1 kbit/s. Audio quality auto-adjusted to %2 kbit/s (%3 ms)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="AudioInput.ui"/>
         <source>Max. Amplification</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Idle action</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>minutes do</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>nothing</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>deafen</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>mute</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>after</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Echo Cancellation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Mixed echo cancellation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Multichannel echo cancellation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>The idle action will be reversed upon any key or mouse button input</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Undo Idle action upon activity</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Apply RNNoise&apos;s noise suppression filter.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>&lt;b&gt;This applies RNNoise&apos;s noise suppression filter.&lt;/b&gt;&lt;br /&gt;RNNoise is based on machine learning and used in WebRTC.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>RNNoise</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Audio input</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>&lt;b&gt;This is the input method to use for audio.&lt;/b&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Enable Opus&apos; low-delay mode when the quality is set to &lt;b&gt;64 kb/s&lt;/b&gt; or higher. </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>If checked, Mumble will enable Opus&apos; low-delay mode when the quality is set to &lt;b&gt;64 kbit/s&lt;/b&gt; or higher. Low-delay mode decreases latency by &lt;b&gt;~15 milliseconds&lt;/b&gt; in the round trip. This mode may require an higher bitrate to preserve the same quality, in comparison with the music and VOIP modes.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Allow low delay mode</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1187,56 +953,42 @@ This value allows you to set the maximum number of users allowed in the channel.
 <context>
     <name>AudioInputDialog</name>
     <message>
-        <location filename="AudioConfigDialog.cpp" line="+79"/>
         <source>Continuous</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Voice Activity</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Push To Talk</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Audio Input</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+108"/>
-        <location line="+8"/>
-        <location line="+7"/>
         <source>%1 ms</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-9"/>
-        <location line="+7"/>
-        <location line="+20"/>
         <source>Off</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-12"/>
         <source>%1 s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>%1 kb/s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>-%1 dB</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+48"/>
         <source>%1 kbit/s (Audio %2, Position %4, Overhead %3)</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1244,339 +996,272 @@ This value allows you to set the maximum number of users allowed in the channel.
 <context>
     <name>AudioOutput</name>
     <message>
-        <location filename="AudioOutput.ui"/>
         <source>Interface</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>System</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Output method for audio</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Device</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Output device for audio</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>&lt;b&gt;This is the output device to use for audio.&lt;/b&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Positional Audio</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Audio Output</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Default &amp;Jitter Buffer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Safety margin for jitter buffer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>&lt;b&gt;This sets the minimum safety margin for the jitter buffer.&lt;/b&gt;&lt;br /&gt;All incoming audio is buffered, and the jitter buffer continually tries to push the buffer to the minimum sustainable by your network, so latency can be as low as possible. This sets the minimum buffer size to use. If the start of sentences you hear is very jittery, increase this value.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Minimum distance to user before sound volume decreases</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>This sets the minimum distance for sound calculations. The volume of other users&apos; speech will not decrease until they are at least this far away from you.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>This sets the maximum distance for sound calculations. When farther away than this, other users&apos; speech volume will not decrease any further.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>&lt;b&gt;This enables one of the loopback test modes.&lt;/b&gt;&lt;br /&gt;&lt;i&gt;None&lt;/i&gt; - Loopback disabled&lt;br /&gt;&lt;i&gt;Local&lt;/i&gt; - Emulate a local server.&lt;br /&gt;&lt;i&gt;Server&lt;/i&gt; - Request loopback from server.&lt;br /&gt;Please note than when loopback is enabled, no other users will hear your voice. This setting is not saved on application exit.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Volume</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Volume of incoming speech</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>&lt;b&gt;This adjusts the volume of incoming speech.&lt;/b&gt;&lt;br /&gt;Note that if you increase this beyond 100%, audio will be distorted.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Output Delay</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Amount of data to buffer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>The connected &quot;speakers&quot; are actually headphones</source>
         <oldsource>The connected &quot;speakers&quot; are actually headphones.</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Factor for sound volume decrease</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Bloom</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Factor for sound volume increase</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>How much should sound volume increase for sources that are really close?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Checking this indicates that you don&apos;t have speakers connected, just headphones. This is important, as speakers are usually in front of you, while headphones are directly to your left/right.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>This sets the amount of data to pre-buffer in the output buffer. Experiment with different values and set it to the lowest which doesn&apos;t cause rapid jitter in the sound.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Headphones</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Minimum Distance</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Maximum Distance</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Maximum distance, beyond which speech volume won&apos;t decrease</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Minimum Volume</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>What should the volume be at the maximum distance?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Loopback Test</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Delay Variance</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Variance in packet latency</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>&lt;b&gt;This sets the packet latency variance for loopback testing.&lt;/b&gt;&lt;br /&gt;Most audio paths contain some variable latency. This allows you to set that variance for loopback mode testing. For example, if you set this to 15ms, this will emulate a network with 20-35ms ping latency or one with 80-95ms latency. Most domestic net connections have a variance of about 5ms.</source>
         <oldsource>&lt;b&gt;This sets the packet latency variance for loopback testing.&lt;/b&gt;&lt;br /&gt;Most audio paths contain some variable latency. This allows you set that variance for loopback mode testing. For example, if you set this to 15ms, this will emulate a network with 20-35ms ping latency or one with 80-95ms latency. Most domestic net connections have a variance of about 5ms.</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Packet Loss</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Packet loss for loopback mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>&lt;b&gt;This sets the packet loss for loopback mode.&lt;/b&gt;&lt;br /&gt;This will be the ratio of packets lost. Unless your outgoing bandwidth is peaked or there&apos;s something wrong with your network connection, this will be 0%</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>&amp;Loopback</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Desired loopback mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Attenuate applications by...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Attenuation of other applications during speech</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>&lt;b&gt;Attenuate volume of other applications during speech&lt;/b&gt;&lt;br /&gt;Mumble supports decreasing the volume of other applications during incoming and/or outgoing speech. This sets the attenuation of other applications if the feature is enabled.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>If checked Mumble lowers the volume of other applications while other users talk</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>&lt;b&gt;Attenuate applications while other users talk&lt;/b&gt;&lt;br /&gt;Mumble supports decreasing the volume of other applications during incoming and/or outgoing speech. This makes mumble activate the feature while other users talk to you.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>while other users talk</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>If checked Mumble lowers the volume of other applications while you talk</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>&lt;b&gt;Attenuate applications while you talk&lt;/b&gt;&lt;br /&gt;Mumble supports decreasing the volume of other applications during incoming and/or outgoing speech. This makes mumble activate the feature while you talk.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>while you talk</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Exclusive mode, not recommended.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>&lt;b&gt;This opens the device in exclusive mode.&lt;/b&gt;&lt;br /&gt;No other application will be able to use the device.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Exclusive</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Priority Speaker</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>If checked Mumble lowers the volume of other users while you talk if you have the &quot;Priority Speaker&quot; status.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Advanced Attenuation Options</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>If checked, Mumble will only attenuate applications that are using the same output source as Mumble</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>&lt;b&gt;Attenuate only applications using the same output as Mumble&lt;/b&gt;&lt;br /&gt;If checked, applications that use a different output than Mumble will not be attenuated.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Only attenuate applications using the same output device</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>If checked, PulseAudio loopback modules will be attenuated</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>&lt;b&gt;Attenuate PulseAudio loopback modules&lt;/b&gt;&lt;br /&gt;If loopback modules are linked to Mumble&apos;s output device/sink, they will also be attenuated.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Attenuate PulseAudio loopback modules</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Audio output</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>&lt;b&gt;This is the output method to use for audio.&lt;/b&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>&lt;b&gt;Attenuate other users while talking as Priority Speaker&lt;/b&gt;&lt;br /&gt;Mumble supports decreasing the volume of other users while you talk as the &lt;i&gt;Priority Speaker&lt;/i&gt; to avoid getting disturbed. Checking this checkbox will enable this feature.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Attenuate other users while talking as Priority Speaker</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1584,44 +1269,30 @@ This value allows you to set the maximum number of users allowed in the channel.
 <context>
     <name>AudioOutputDialog</name>
     <message>
-        <location filename="AudioConfigDialog.cpp" line="+138"/>
         <source>None</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Local</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Server</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Audio Output</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+119"/>
-        <location line="+19"/>
-        <location line="+8"/>
         <source>%1 ms</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-16"/>
-        <location line="+4"/>
-        <location line="+8"/>
-        <location line="+31"/>
-        <location line="+4"/>
         <source>%1 %</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-16"/>
-        <location line="+6"/>
         <source>%1 m</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1629,17 +1300,14 @@ This value allows you to set the maximum number of users allowed in the channel.
 <context>
     <name>AudioOutputSample</name>
     <message>
-        <location filename="AudioOutputSample.cpp" line="+191"/>
         <source>Choose sound file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Invalid sound file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>The file &apos;%1&apos; cannot be used by Mumble. Please select a file with a compatible format and encoding.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1647,179 +1315,144 @@ This value allows you to set the maximum number of users allowed in the channel.
 <context>
     <name>AudioStats</name>
     <message>
-        <location filename="AudioStats.cpp" line="+366"/>
         <source>&gt;1000 ms</source>
         <oldsource>&gt;1000ms</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="AudioStats.ui"/>
         <source>Audio Statistics</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Input Levels</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Peak microphone level</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Peak power in last frame</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>This shows the peak power in the last frame (20 ms), and is the same measurement as you would usually find displayed as &quot;input power&quot;. Please disregard this and look at &lt;b&gt;Microphone power&lt;/b&gt; instead, which is much more steady and disregards outliers.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Peak speaker level</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>This shows the peak power of the speakers in the last frame (20 ms). Unless you are using a multi-channel sampling method (such as ASIO) with speaker channels configured, this will be 0. If you have such a setup configured, and this still shows 0 while you&apos;re playing audio from other programs, your setup is not working.</source>
         <oldsource>This shows the peak power in the last frame (20 ms) of the speakers. Unless you are using a multi-channel sampling method (such as ASIO) with speaker channels configured, this will be 0. If you have such a setup configured, and this still shows 0 while you&apos;re playing audio from other programs, your setup is not working.</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Peak clean level</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>This shows the peak power in the last frame (20 ms) after all processing. Ideally, this should be -96 dB when you&apos;re not talking. In reality, a sound studio should see -60 dB, and you should hopefully see somewhere around -20 dB. When you are talking, this should rise to somewhere between -5 and -10 dB.&lt;br /&gt;If you are using echo cancellation, and this rises to more than -15 dB when you&apos;re not talking, your setup is not working, and you&apos;ll annoy other users with echoes.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Signal Analysis</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Microphone power</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>How close the current input level is to ideal</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>This shows how close your current input volume is to the ideal. To adjust your microphone level, open whatever program you use to adjust the recording volume, and look at the value here while talking.&lt;br /&gt;&lt;b&gt;Talk loud, as you would when you&apos;re upset over getting fragged by a noob.&lt;/b&gt;&lt;br /&gt;Adjust the volume until this value is close to 100%, but make sure it doesn&apos;t go above. If it does go above, you are likely to get clipping in parts of your speech, which will degrade sound quality.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Signal-To-Noise ratio</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Signal-To-Noise ratio from the microphone</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>This is the Signal-To-Noise Ratio (SNR) of the microphone in the last frame (20 ms). It shows how much clearer the voice is compared to the noise.&lt;br /&gt;If this value is below 1.0, there&apos;s more noise than voice in the signal, and so quality is reduced.&lt;br /&gt;There is no upper limit to this value, but don&apos;t expect to see much above 40-50 without a sound studio.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Speech Probability</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Probability of speech</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>This is the probability that the last frame (20 ms) was speech and not environment noise.&lt;br /&gt;Voice activity transmission depends on this being right. The trick with this is that the middle of a sentence is always detected as speech; the problem is the pauses between words and the start of speech. It&apos;s hard to distinguish a sigh from a word starting with &apos;h&apos;.&lt;br /&gt;If this is in bold font, it means Mumble is currently transmitting (if you&apos;re connected).</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Configuration feedback</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Current audio bitrate</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Bitrate of last frame</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>DoublePush interval</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Time between last two Push-To-Talk presses</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Speech Detection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Current speech detection chance</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>&lt;b&gt;This shows the current speech detection settings.&lt;/b&gt;&lt;br /&gt;You can change the settings from the Settings dialog or from the Audio Wizard.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Signal and noise power spectrum</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Power spectrum of input signal and noise estimate</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>This shows the power spectrum of the current input signal (red line) and the current noise estimate (filled blue).&lt;br /&gt;All amplitudes are multiplied by 30 to show the interesting parts (how much more signal than noise is present in each waveband).&lt;br /&gt;This is probably only of interest if you&apos;re trying to fine-tune noise conditions on your microphone. Under good conditions, there should be just a tiny flutter of blue at the bottom. If the blue is more than halfway up on the graph, you have a seriously noisy environment.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Echo Analysis</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Weights of the echo canceller</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>This shows the weights of the echo canceller, with time increasing downwards and frequency increasing to the right.&lt;br /&gt;Ideally, this should be black, indicating no echo exists at all. More commonly, you&apos;ll have one or more horizontal stripes of bluish color representing time delayed echo. You should be able to see the weights updated in real time.&lt;br /&gt;Please note that as long as you have nothing to echo off, you won&apos;t see much useful data here. Play some music and things should stabilize. &lt;br /&gt;You can choose to view the real or imaginary parts of the frequency-domain weights, or alternately the computed modulus and phase. The most useful of these will likely be modulus, which is the amplitude of the echo, and shows you how much of the outgoing signal is being removed at that time step. The other viewing modes are mostly useful to people who want to tune the echo cancellation algorithms.&lt;br /&gt;Please note: If the entire image fluctuates massively while in modulus mode, the echo canceller fails to find any correlation whatsoever between the two input sources (speakers and microphone). Either you have a very long delay on the echo, or one of the input sources is configured wrong.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>This is the audio bitrate of the last compressed frame (20 ms), and as such will jump up and down as the VBR adjusts the quality. The peak bitrate can be adjusted in the Settings dialog.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1827,118 +1460,95 @@ This value allows you to set the maximum number of users allowed in the channel.
 <context>
     <name>AudioWizard</name>
     <message>
-        <location filename="AudioWizard.ui"/>
         <source>Audio Tuning Wizard</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Introduction</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Welcome to the Mumble Audio Wizard</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Finished</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Enjoy using Mumble</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Device selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Selecting the input and output device to use with Mumble.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>This is the device your microphone is connected to.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>System</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Input method for audio</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Device</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Input device to use</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>&lt;b&gt;Selects which sound card to use for audio input.&lt;/b&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Cancel echo from headset or speakers</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Use echo cancellation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>This enables echo cancellation of outgoing audio, which helps both on speakers and on headsets.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>This is the device your speakers or headphones are connected to.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Output method for audio</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Output device to use</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>&lt;b&gt;Selects which sound card to use for audio Output.&lt;/b&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Enable positional audio</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Allows positioning of sound</source>
         <oldsource>Allows positioning of sound.</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>&lt;p&gt;
 This is the audio tuning wizard for Mumble. This will help you correctly set the input levels of your sound card, and also set the correct parameters for sound processing in Mumble.
 &lt;/p&gt;
@@ -1948,22 +1558,18 @@ Please be aware that as long as this wizard is active, audio will be looped loca
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Input Device</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Output Device</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>This allows Mumble to use positional audio to place voices.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>&lt;p&gt;
 To keep latency to an absolute minimum, it&apos;s important to buffer as little audio as possible on the soundcard. However, many soundcards report that they require a much smaller buffer than what they can actually work with, so the only way to set this value is to try and fail.
 &lt;/p&gt;
@@ -1974,17 +1580,14 @@ You should hear a voice sample. Change the slider below to the lowest value whic
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Amount of data to buffer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>This sets the amount of data to pre-buffer in the output buffer. Experiment with different values and set it to the lowest which doesn&apos;t cause rapid jitter in the sound.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>&lt;p&gt;
 Open your sound control panel and go to the recording settings. Make sure the microphone is selected as active input with maximum recording volume. If there&apos;s an option to enable a &quot;Microphone boost&quot; make sure it&apos;s checked.
 &lt;/p&gt;
@@ -1995,17 +1598,14 @@ Speak loudly, as when you are annoyed or excited. Decrease the volume in the sou
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Positional Audio</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Adjusting attenuation of positional audio.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>&lt;p&gt;
 Mumble supports positional audio for some games, and will position the voice of other users relative to their position in game. Depending on their position, the volume of the voice will be changed between the speakers to simulate the direction and distance the other user is at. Such positioning depends on your speaker configuration being correct in your operating system, so a test is done here.
 &lt;/p&gt;
@@ -2016,12 +1616,10 @@ The graph below shows the position of &lt;font color=&quot;red&quot;&gt;you&lt;/
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Use headphones instead of speakers</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>&lt;p&gt;
 Congratulations. You should now be ready to enjoy a richer sound experience with Mumble.
 &lt;/p&gt;
@@ -2032,173 +1630,139 @@ Mumble is under continuous development, and the development team wants to focus 
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Use headphones</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>This ignores the OS speaker configuration and configures the positioning for headphones instead.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Volume tuning</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Tuning microphone hardware volume to optimal settings.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Now talk softly, as you would when talking late at night and you don&apos;t want to disturb anyone. Adjust the slider below so that the bar moves into green when you talk, but stays blue while you&apos;re silent.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Voice Activity Detection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Letting Mumble figure out when you&apos;re talking and when you&apos;re silent.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>This will help Mumble figure out when you are talking. The first step is selecting which data value to use.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Raw amplitude from input</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Signal-To-Noise ratio</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Next you need to adjust the following slider. The first few utterances you say should end up in the green area (definitive speech). While talking, you should stay inside the yellow (might be speech) and when you&apos;re not talking, everything should be in the red (definitively not speech).</source>
         <oldsource>Next you need to adjust the following two sliders. The first few utterances you say should end up in the green area (definitive speech). While talking, you should stay inside the yellow (might be speech) and when you&apos;re not talking, everything should be in the red (definitively not speech).</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Device tuning</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Changing hardware output delays to their minimum value.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Submit anonymous statistics to the Mumble project</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Push To Talk:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Quality &amp; Notifications</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Adjust quality and notification settings.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Quality settings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Low</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Balanced</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Notification settings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Use Text-To-Speech to read notifications and messages to you.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Disable Text-To-Speech and use sounds instead.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="AudioWizard.cpp" line="+297"/>
         <source>%1 ms</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="AudioWizard.ui"/>
         <source>Enables attenuation of other applications while users talk to you</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Attenuate applications while other users talk</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>High</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Custom</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>You already set a customized quality configuration in Mumble. Select this setting to keep it.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Enables attenuation of other applications while users talk to you. This means that as soon someone starts to speak to you in Mumble, the sound of all other applications (like audio players) will get attenuated so you can hear them more clearly.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Apply some high contrast optimizations for visually impaired users</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Use high contrast graphics</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Keep custom Text-To-Speech settings.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>&lt;p&gt;
 Open your sound control panel and go to the recording settings. Make sure the microphone is selected as active input with maximum recording volume. If there&apos;s an option to enable a &quot;Microphone boost&quot; make sure it&apos;s checked.
 &lt;/p&gt;
@@ -2217,39 +1781,32 @@ Speak loudly, as when you are annoyed or excited. Decrease the volume in the sou
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Now talk softly, as you would when talking late at night and you don&apos;t want to disturb anyone. Adjust the slider below so that the bar moves into empty zone when you talk, but stays in the striped one while you&apos;re silent.</source>
         <comment>For high contrast mode</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Next you need to adjust the following slider. The first few utterances you say should end up in the empty area (definitive speech). While talking, you should stay inside the striped (might be speech) and when you&apos;re not talking, everything should be in the crisscrossed (definitively not speech).</source>
         <comment>For high contrast mode</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>In this configuration Mumble will use a &lt;b&gt;low amount of bandwidth&lt;/b&gt;. This will inevitably result in high latency and poor quality. Choose this only if your connection cannot handle the other settings. (16kbit/s, 60ms per packet)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>This is the &lt;b&gt;recommended default&lt;/b&gt; configuration. It provides a good balance between quality, latency, and bandwidth usage. (40kbit/s, 20ms per packet)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>This configuration is only recommended for use in setups where bandwidth is not an issue, like a LAN. It provides the lowest latency supported by Mumble and &lt;b&gt;high quality&lt;/b&gt;. (72kbit/s, 10ms per packet)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>&lt;b&gt;This is the input method to use for audio.&lt;/b&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>&lt;b&gt;This is the Output method to use for audio.&lt;/b&gt;</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2257,167 +1814,134 @@ Speak loudly, as when you are annoyed or excited. Decrease the volume in the sou
 <context>
     <name>BanEditor</name>
     <message>
-        <location filename="BanEditor.ui"/>
         <source>Mumble - Edit Bans</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>&amp;Address</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>&amp;Mask</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Reason</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Start</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>End</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>User</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Hash</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>&amp;Add</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>&amp;Update</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>&amp;Remove</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Ban List</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Search field</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>This is the search field. Use it to find bans that have this username set in the username field.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Who are you looking for?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>No nickname</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>IP address</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>No IP address</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Reason for the ban</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>No reason</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Ban end date</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Ban end date. If you set the same date for start and end, the ban will be permanent (it will not expire).</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Certificate hash</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>No certificate hash</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Banned users</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>This is a list with banned users.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Use this button if you want to add a new ban.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Use this button if you want to update ban information.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Use this button if you want to remove user from the ban list.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Clear all fields</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>This button clears all fields. Use it if you want to add a new ban.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Clear</source>
         <translation type="unfinished"></translation>
     </message>
     <message numerus="yes">
-        <location filename="BanEditor.cpp" line="+177"/>
         <source>Ban List - %n Ban(s)</source>
         <translation type="unfinished">
             <numerusform></numerusform><numerusform></numerusform>
@@ -2427,32 +1951,26 @@ Speak loudly, as when you are annoyed or excited. Decrease the volume in the sou
 <context>
     <name>CertView</name>
     <message>
-        <location filename="Cert.cpp" line="+37"/>
         <source>Name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Email</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Issuer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Expiry Date</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+43"/>
         <source>(none)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Self-signed</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2460,67 +1978,54 @@ Speak loudly, as when you are annoyed or excited. Decrease the volume in the sou
 <context>
     <name>CertWizard</name>
     <message>
-        <location line="+86"/>
         <source>Unable to validate email.&lt;br /&gt;Enter a valid (or blank) email to continue.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>There was an error generating your certificate.&lt;br /&gt;Please try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Your certificate and key could not be exported to PKCS#12 format. There might be an error in your certificate.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>The file could not be opened for writing. Please use another file.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>The file&apos;s permissions could not be set. No certificate and key has been written. Please use another file.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>The file could not be written successfully. Please use another file.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>The file could not be opened for reading. Please use another file.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>The file is empty or could not be read. Please use another file.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>The file did not contain a valid certificate and key. Please use another file.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>Select file to export certificate to</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+37"/>
         <source>Select file to import certificate from</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+34"/>
         <source>Unable to import. Missing password or incompatible file type.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="main.cpp" line="+540"/>
         <source>&lt;b&gt;Certificate Expiry:&lt;/b&gt; Your certificate is about to expire. You need to renew it, or you will no longer be able to connect to servers you are registered on.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2528,163 +2033,131 @@ Speak loudly, as when you are annoyed or excited. Decrease the volume in the sou
 <context>
     <name>Certificates</name>
     <message>
-        <location filename="Cert.ui"/>
         <source>Certificate Management</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Certificate Authentication</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Authenticating to servers without using passwords</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Current certificate</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>This is the certificate Mumble currently uses.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Current Certificate</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Create a new certificate</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>This will create a new certificate.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Import certificate from file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>This will import a certificate from file.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Import a certificate</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Export Certificate</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>This will export a certificate to file.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Export current certificate</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Import Certificate</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>PKCS #12 Certificate import</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>&lt;p&gt;Mumble can import certificates stored in PKCS #12 format. This is the format used when exporting a key from Mumble, and also when exporting keys from Firefox, Internet Explorer, Opera etc.&lt;/p&gt;&lt;p&gt;If the file is password protected, you will need the password to import the certificate.&lt;/p&gt;</source>
         <oldsource>&lt;p&gt;Mumble can import certificates stored in PKCS #12 format. This is the format used when exporting a key from Mumble, and also when exporting keys from FireFox, Internet Explorer, Opera etc.&lt;/p&gt;&lt;p&gt;If the file is password protected, you will need the password to import the certificate.&lt;/p&gt;</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Import from</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Filename to import from</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>This is the filename you wish to import a certificate from.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Select file to import from</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>This opens a file selection dialog to choose a file to import a certificate from.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Open...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Password</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Password for PKCS#12 file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>This is the password for the PKCS#12 file containing your certificate.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Certificate to import</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>This is the certificate you are importing.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Certificate Details</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Replace Certificate</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Replace existing certificate with new certificate?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>&lt;p&gt;You already have a certificate stored in Mumble, and you are about to replace it.&lt;/p&gt;
 &lt;p&gt;If you are upgrading to a certificate issued to you by a trusted CA and the email addresses match your current certificate, this is completely safe, and servers you connect to will automatically recognize the strong certificate for your email address.
 &lt;/p&gt;
@@ -2697,123 +2170,99 @@ Are you sure you wish to replace your certificate?
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>This is the certificate Mumble currently uses. It will be replaced.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>New certificate</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>This is the new certificate that will replace the old one.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>New Certificate</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Make a backup of your certificate</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Export to</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Filename to export to</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>This is the filename you wish to export a certificate to.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Save As...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>This is the certificate Mumble currently uses. It will be exported.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Generate a new certificate for strong authentication</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>&lt;p&gt;Mumble will now generate a strong certificate for authentication to servers.&lt;/p&gt;&lt;p&gt;If you wish, you may provide some additional information to be stored in the certificate, which will be presented to servers when you connect. If you provide a valid email address, you can upgrade to a CA issued email certificate later on, which provides strong identification.&lt;/p&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Email</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Your email address (e.g. johndoe@mumble.info)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>This is your email address. It is strongly recommended to provide a valid email address, as this will allow you to upgrade to a strong certificate without authentication problems.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Your name (e.g. John Doe)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>This is your name, and will be filled out in the certificate. This field is entirely optional.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Finish</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Certificate-based authentication is ready for use</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Enjoy using Mumble with strong authentication.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Automatic certificate creation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>&lt;p&gt;If you ever lose your current certificate, which will happen if your computer suffers a hardware failure or you reinstall your machine, you will no longer be able to authenticate to any server you are registered on. It is therefore &lt;b&gt;mandatory&lt;/b&gt; that you make a backup of your certificate. We strongly recommend you store this backup on removable storage, such as a USB flash drive.&lt;/p&gt;
 &lt;p&gt;Note that this file will not be encrypted, and if anyone gains access to it, they will be able to impersonate you, so take good care of it.&lt;/p&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>&lt;p&gt;Mumble can use certificates to authenticate with servers. Using certificates avoids passwords, meaning you don&apos;t need to disclose any password to the remote site. It also enables very easy user registration and a client side friends list independent of servers.&lt;/p&gt;&lt;p&gt;While Mumble can work without certificates, the majority of servers will expect you to have one.&lt;/p&gt;&lt;p&gt;Creating a new certificate automatically is sufficient for most use cases. But Mumble also supports certificates representing trust in the users ownership of an email address. These certificates are issued by third parties. For more information see our &lt;a href=&quot;http://mumble.info/certificate.php&quot;&gt;user certificate documentation&lt;/a&gt;. &lt;/p&gt;</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2821,162 +2270,130 @@ Are you sure you wish to replace your certificate?
 <context>
     <name>ChanACL</name>
     <message>
-        <location filename="../ACL.cpp" line="+205"/>
         <source>None</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Traverse</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Enter</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Speak</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Mute/Deafen</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Make channel</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Make temporary</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Link channel</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-87"/>
         <source>This represents no privileges.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>This represents total access to the channel, including the ability to change group and ACL information. This privilege implies all other privileges.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>This represents the permission to traverse the channel. If a user is denied this privilege, he will be unable to access this channel and any sub-channels in any way, regardless of other permissions in the sub-channels.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>This represents the permission to join the channel. If you have a hierarchical channel structure, you might want to give everyone Traverse, but restrict Enter in the root of your hierarchy.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>This represents the permission to speak in a channel. Users without this privilege will be suppressed by the server (seen as muted), and will be unable to speak until they are unmuted by someone with the appropriate privileges.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>This represents the permission to whisper to this channel from the outside. This works exactly like the &lt;i&gt;speak&lt;/i&gt; privilege, but applies to packets spoken with the Whisper key held down. This may be used to broadcast to a hierarchy of channels without linking.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>This represents the permission to mute and deafen other users. Once muted, a user will stay muted until he is unmuted by another privileged user or reconnects to the server.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>This represents the permission to move a user to another channel or kick him from the server. To actually move the user, either the moving user must have Move privileges in the destination channel, or the user must normally be allowed to enter the channel. Users with this privilege can move users into channels the target user normally wouldn&apos;t have permission to enter.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>This represents the permission to make sub-channels. The user making the sub-channel will be added to the admin group of the sub-channel.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>This represents the permission to make a temporary subchannel. The user making the sub-channel will be added to the admin group of the sub-channel. Temporary channels are not stored and disappear when the last user leaves.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>This represents the permission to link channels. Users in linked channels hear each other, as long as the speaking user has the &lt;i&gt;speak&lt;/i&gt; privilege in the channel of the listener. You need the link privilege in both channels to create a link, but just in either channel to remove it.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>This represents the permission to write text messages to other users in this channel.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>This represents the permission to forcibly remove users from the server.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>This represents the permission to permanently remove users from the server.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>This represents the permission to register and unregister users on the server.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>This represents the permission to register oneself on the server.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+31"/>
         <source>Whisper</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Move</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Text message</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Kick</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Ban</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Register User</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Register Self</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-28"/>
         <source>Write ACL</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2984,13 +2401,11 @@ Are you sure you wish to replace your certificate?
 <context>
     <name>ChatbarTextEdit</name>
     <message>
-        <location filename="CustomElements.cpp" line="+89"/>
         <source>Paste and &amp;Send</source>
         <oldsource>Paste and send</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>&lt;center&gt;Type chat message here&lt;/center&gt;</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2998,52 +2413,42 @@ Are you sure you wish to replace your certificate?
 <context>
     <name>ClientUser</name>
     <message>
-        <location filename="ClientUser.cpp" line="+108"/>
         <source>Friend</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Authenticated</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Priority speaker</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Recording</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Muted (server)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Deafened (server)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Local Ignore (Text messages)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Local Mute</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Muted (self)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Deafened (self)</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3051,58 +2456,47 @@ Are you sure you wish to replace your certificate?
 <context>
     <name>ConfigDialog</name>
     <message>
-        <location filename="ConfigDialog.cpp" line="+32"/>
         <source>Accept changes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>This button will accept current settings and return to the application.&lt;br /&gt;The settings will be stored to disk when you leave the application.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Reject changes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>This button will reject all changes and return to the application.&lt;br /&gt;The settings will be reset to the previous positions.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Apply changes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>This button will immediately apply all changes.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Undo changes for current page</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>This button will revert any changes done on the current page to the most recent applied settings.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Restore defaults for current page</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>This button will restore the defaults for the settings on the current page. Other pages will not be changed.&lt;br /&gt;To restore all settings to their defaults, you will have to use this button on every page.</source>
         <oldsource>This button will restore the settings for the current page only to their defaults. Other pages will not be changed.&lt;br /&gt;To restore all settings to their defaults, you will have to use this button on every page.</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="ConfigDialog.ui"/>
         <source>Mumble Configuration</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3110,203 +2504,158 @@ Are you sure you wish to replace your certificate?
 <context>
     <name>ConnectDialog</name>
     <message>
-        <location filename="ConnectDialog.cpp" line="+1163"/>
         <source>Connecting to %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-699"/>
-        <location line="+699"/>
         <source>Enter username</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-699"/>
         <source>Adding host %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="ConnectDialog.ui"/>
-        <location filename="ConnectDialog.cpp" line="+71"/>
         <source>Servername</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="ConnectDialog.cpp" line="+1"/>
         <source>Hostname</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Bonjour name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Port</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Addresses</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Website</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Packet loss</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Ping (80%)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
-        <location line="+2"/>
         <source>%1 ms</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Ping (95%)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Bandwidth</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>%1 kbit/s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+430"/>
         <source>&amp;Connect</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+76"/>
         <source>&amp;Filters</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+740"/>
         <source>Unknown</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="ConnectDialog.ui"/>
-        <location filename="ConnectDialog.cpp" line="-1245"/>
         <source>Users</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="ConnectDialog.cpp" line="+1"/>
         <source>Version</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1221"/>
         <source>Failed to fetch server list</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="ConnectDialog.ui"/>
         <source>Mumble Server Connect</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Ping</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Remove from Favorites</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Add custom server</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Show all servers that respond to ping</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Show all servers with users</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Show all servers</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>&amp;Copy</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Copy favorite link to clipboard</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>&amp;Paste</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Paste favorite from clipboard</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
-        <location filename="ConnectDialog.cpp" line="-784"/>
         <source>&amp;Edit...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
-        <location filename="ConnectDialog.cpp" line="-7"/>
         <source>&amp;Add New...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Add to &amp;Favorites</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Open &amp;Webpage</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Show &amp;Reachable</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Show &amp;Populated</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Show &amp;All</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3314,28 +2663,23 @@ Are you sure you wish to replace your certificate?
 <context>
     <name>ConnectDialogEdit</name>
     <message>
-        <location filename="ConnectDialogEdit.ui"/>
         <source>Edit Server</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Name of the server</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>A&amp;ddress</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Internet address of the server.</source>
         <oldsource>Internet address of the server. </oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>&lt;b&gt;Address&lt;/b&gt;&lt;br/&gt;
 Internet address of the server. This can be a normal hostname, an IPv4/IPv6 address or a Bonjour service identifier. Bonjour service identifiers have to be prefixed with a &apos;@&apos; to be recognized by Mumble.</source>
         <oldsource>&lt;b&gt;Address&lt;/b&gt;&lt;/br&gt;
@@ -3343,115 +2687,94 @@ Internet address of the server. This can be a normal hostname, an ipv4/6 address
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>&amp;Port</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Port on which the server is listening</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>&lt;b&gt;Port&lt;/b&gt;&lt;br/&gt;
 Port on which the server is listening. If the server is identified by a Bonjour service identifier this field will be ignored.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>&amp;Username</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Username to send to the server</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>&lt;b&gt;Username&lt;/b&gt;&lt;br/&gt;
 Username to send to the server. Be aware that the server can impose restrictions on how a username might look like. Also your username could already be taken by another user.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Label</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="ConnectDialog.cpp" line="-192"/>
         <source>Add Server</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>You are currently connected to a server.
 Do you want to fill the dialog with the connection data of this server?
 Host: %1 Port: %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+45"/>
         <source>You have an URL in your clipboard.
 Do you want to fill the dialog with this data?
 Host: %1 Port: %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="ConnectDialogEdit.ui"/>
         <source>Password</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Password to send to the server</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>&lt;b&gt;Password&lt;/b&gt;&lt;br/&gt;
 Password to be sent to the server on connect. This password is needed when connecting as &lt;i&gt;SuperUser&lt;/i&gt; or to a server using password authentication. If not entered here the password will be queried on connect.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Show password</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>&lt;b&gt;Label&lt;/b&gt;&lt;br/&gt;
 Label of the server. This is what the server will be named like in your server list and can be chosen freely.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Local server label</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>127.0.0.1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>64738</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Your username</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Your password</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>&amp;Fill</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3459,7 +2782,6 @@ Label of the server. This is what the server will be named like in your server l
 <context>
     <name>CoreAudioSystem</name>
     <message>
-        <location filename="CoreAudio.cpp" line="+66"/>
         <source>Default Device</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3467,69 +2789,55 @@ Label of the server. This is what the server will be named like in your server l
 <context>
     <name>CrashReporter</name>
     <message>
-        <location filename="CrashReporter.cpp" line="+20"/>
         <source>Mumble Crash Report</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>&lt;p&gt;&lt;b&gt;We&apos;re terribly sorry, but it seems Mumble has crashed. Do you want to send a crash report to the Mumble developers?&lt;/b&gt;&lt;/p&gt;&lt;p&gt;The crash report contains a partial copy of Mumble&apos;s memory at the time it crashed, and will help the developers fix the problem.&lt;/p&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Email address (optional)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Please describe briefly, in English, what you were doing at the time of the crash</source>
         <oldsource>Please briefly describe what you were doing at the time of the crash</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Send Report</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Don&apos;t send report</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+24"/>
         <source>Crash upload successful</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Thank you for helping make Mumble better!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
-        <location line="+2"/>
         <source>Crash upload failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-2"/>
         <source>We&apos;re really sorry, but it appears the crash upload has failed with error %1 %2. Please inform a developer.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>This really isn&apos;t funny, but apparently there&apos;s a bug in the crash reporting code, and we&apos;ve failed to upload the report. You may inform a developer about error %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+101"/>
         <source>Uploading crash report</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Abort upload</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3537,13 +2845,11 @@ Label of the server. This is what the server will be named like in your server l
 <context>
     <name>Database</name>
     <message>
-        <location filename="Database.cpp" line="+96"/>
         <source>Mumble failed to initialize a database in any
 of the possible locations.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>The database &apos;%1&apos; is read-only. Mumble cannot store server settings (i.e. SSL certificates) until you fix this problem.</source>
         <oldsource>The database &apos;%1&apos; is read-only. Mumble can not store server settings (ie. SSL certificates) until you fix this problem.</oldsource>
         <translation type="unfinished"></translation>
@@ -3552,7 +2858,6 @@ of the possible locations.</source>
 <context>
     <name>DeveloperConsole</name>
     <message>
-        <location filename="DeveloperConsole.cpp" line="+33"/>
         <source>Developer Console</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3560,7 +2865,6 @@ of the possible locations.</source>
 <context>
     <name>DockTitleBar</name>
     <message>
-        <location filename="CustomElements.cpp" line="+189"/>
         <source>Drag here</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3568,134 +2872,108 @@ of the possible locations.</source>
 <context>
     <name>GlobalShortcut</name>
     <message>
-        <location filename="GlobalShortcut.ui"/>
         <source>Shortcuts</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>List of configured shortcuts</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Function</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Data</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Shortcut</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Suppress</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Add new shortcut</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>This will add a new global shortcut</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>&amp;Add</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Remove selected shortcut</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>This will permanently remove a selected shortcut.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>&amp;Remove</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Mumble can currently only use mouse buttons and keyboard modifier keys (Alt, Ctrl, Cmd, etc.) for global shortcuts.&lt;/p&gt;&lt;p&gt;If you want more flexibility, you can enable &lt;span style=&quot; font-style:italic;&quot;&gt;Access for assistive devices&lt;/span&gt; in the system&apos;s Accessibility preferences. However, please note that this change also potentially allows malicious programs to read what is typed on your keyboard.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Open Accessibility Preferences</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Skip</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Enable Global Shortcuts</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>&lt;b&gt;Additional Shortcut Engines&lt;/b&gt;&lt;br /&gt;This section allows you to configure the use of additional GlobalShortcut engines.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Additional Shortcut Engines</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>&lt;b&gt;Enable Windows hooks&lt;/b&gt;.&lt;br /&gt;This enables the Windows hooks shortcut engine. Using this engine allows Mumble to suppress keypresses and mouse clicks.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Enable Windows hooks</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>&lt;b&gt;Enable GKey&lt;/b&gt;.&lt;br /&gt;This setting enables support for the GKey shortcut engine, for &quot;G&quot;-keys found on Logitech keyboards.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Enable GKey</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>&lt;b&gt;Enable XInput&lt;/b&gt;&lt;br /&gt;This setting enables support for the XInput shortcut engine, for Xbox compatible controllers.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Enable XInput</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>&lt;b&gt;Enable shortcuts in privileged applications&lt;/b&gt;.&lt;br /&gt;Also known as &quot;UIAccess&quot;. This allows Mumble to receive global shortcut events from programs running at high privilege levels, such as an Admin Command Prompt or older games that run with admin privileges.
 &lt;br /&gt;&lt;br /&gt;
 Without this option enabled, using Mumble&apos;s global shortcuts in privileged applications will not work. This can seem inconsistent: for example, if the Push-to-Talk button is pressed in a non-privileged program, but released in a privileged application, Mumble will not observe that it has been released and you will continue to talk until you press the Push-to-Talk button again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Enable shortcuts in privileged applications</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3703,33 +2981,27 @@ Without this option enabled, using Mumble&apos;s global shortcuts in privileged 
 <context>
     <name>GlobalShortcutConfig</name>
     <message>
-        <location filename="GlobalShortcut.cpp" line="+558"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Mumble can currently only use mouse buttons and keyboard modifier keys (Alt, Ctrl, Cmd, etc.) for global shortcuts.&lt;/p&gt;&lt;p&gt;If you want more flexibility, you can add Mumble as a trusted accessibility program in the Security &amp; Privacy section of your Mac&apos;s System Preferences.&lt;/p&gt;&lt;p&gt;In the Security &amp; Privacy preference pane, change to the Privacy tab. Then choose Accessibility (near the bottom) in the list to the left. Finally, add Mumble to the list of trusted accessibility programs.&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+120"/>
         <source>Shortcuts</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+72"/>
         <source>Shortcut button combination.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>&lt;b&gt;This is the global shortcut key combination.&lt;/b&gt;&lt;br /&gt;Click this field and then press the desired key/button combo to rebind. Double-click to clear.</source>
         <oldsource>&lt;b&gt;This is the global shortcut key combination.&lt;/b&gt;&lt;br /&gt;Double-click this field and then the desired key/button combo to rebind.</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Suppress keys from other applications</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>&lt;b&gt;This hides the button presses from other applications.&lt;/b&gt;&lt;br /&gt;Enabling this will hide the button (or the last button of a multi-button combo) from other applications. Note that not all buttons can be suppressed.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3737,82 +3009,66 @@ Without this option enabled, using Mumble&apos;s global shortcuts in privileged 
 <context>
     <name>GlobalShortcutTarget</name>
     <message>
-        <location filename="GlobalShortcutTarget.ui"/>
         <source>Whisper Target</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Whisper to list of Users</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Channel Target</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Restrict to Group</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>If specified, only members of this group will receive the whisper.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>List of users</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Add</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Remove</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Modifiers</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Do not send positional audio information when using this whisper shortcut.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Ignore positional audio</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Shout to Linked channels</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Shout to subchannels</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Shout to Channel</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>The whisper will also be transmitted to linked channels.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>The whisper will also be sent to the subchannels of the channel target.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3820,7 +3076,6 @@ Without this option enabled, using Mumble&apos;s global shortcuts in privileged 
 <context>
     <name>GlobalShortcutX</name>
     <message>
-        <location filename="GlobalShortcut_unix.cpp" line="+357"/>
         <source>Mouse %1</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3828,17 +3083,14 @@ Without this option enabled, using Mumble&apos;s global shortcuts in privileged 
 <context>
     <name>JackAudioSystem</name>
     <message>
-        <location filename="JackAudio.cpp" line="+128"/>
         <source>Hardware Ports</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Mono</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Stereo</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3846,7 +3098,6 @@ Without this option enabled, using Mumble&apos;s global shortcuts in privileged 
 <context>
     <name>LCD</name>
     <message>
-        <location filename="LCD.cpp" line="+270"/>
         <source>Not connected</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3854,28 +3105,22 @@ Without this option enabled, using Mumble&apos;s global shortcuts in privileged 
 <context>
     <name>LCDConfig</name>
     <message>
-        <location line="-171"/>
         <source>Enable this device</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="LCD.ui"/>
-        <location filename="LCD.cpp" line="+5"/>
         <source>LCD</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Devices</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>&lt;p&gt;This is the list of available LCD devices on your system.  It lists devices by name, but also includes the size of the display. Mumble supports outputting to several LCD devices at a time.&lt;/p&gt;
 &lt;h3&gt;Size:&lt;/h3&gt;
 &lt;p&gt;
@@ -3885,39 +3130,32 @@ This field describes the size of an LCD device. The size is given either in pixe
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Size</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Enabled</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Views</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Minimum Column Width</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>&lt;p&gt;This option decides the minimum width a column in the User View.&lt;/p&gt;
 &lt;p&gt;If too many people are speaking at once, the User View will split itself into columns. You can use this option to pick a compromise between number of users shown on the LCD, and width of user names.&lt;/p&gt;
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>This setting decides the width of column splitter.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Splitter Width</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3925,733 +3163,596 @@ This field describes the size of an LCD device. The size is given either in pixe
 <context>
     <name>Log</name>
     <message>
-        <location filename="Log.cpp" line="+236"/>
         <source>Debug</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Critical</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Warning</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Information</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
-        <source>Server Connected</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Server Disconnected</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+7"/>
         <source>Other self-muted/deafened</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
-        <source>Permission Denied</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Text Message</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="-13"/>
-        <source>User Joined Server</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>User Left Server</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
         <source>User recording state changed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>User kicked (you or by you)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>User kicked</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>You self-muted</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>User muted (you)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>User muted (by you)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>User muted (other)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
-        <source>User Joined Channel</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>User Left Channel</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+3"/>
         <source>You self-unmuted</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>You self-deafened</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>You self-undeafened</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>User renamed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
-        <source>You Joined Channel</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>You Joined Channel (moved)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+1"/>
         <source>User connected and entered channel</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>User left channel and disconnected</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Private text message</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+59"/>
         <source>the server</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+110"/>
         <source>[[ Invalid size ]]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>[[ Text object too large to display ]]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+46"/>
         <source>[Date changed to %1]
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+82"/>
         <source>link to %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>FTP link to %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>player link</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>channel link</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1 link</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Server connected</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Server disconnected</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>User joined server</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>User left server</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>User joined channel</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>User left channel</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Permission denied</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Text message</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>You joined channel</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>You joined channel (moved)</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>LogConfig</name>
     <message>
-        <location line="-511"/>
         <source>Toggle console for %1 events</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Toggle pop-up notifications for %1 events</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Toggle Text-To-Speech for %1 events</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-10"/>
         <source>Click here to toggle sound notification for %1 events</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1"/>
         <source>Toggle window highlight (if not active) for %1 events</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Path to sound file used for sound notifications in the case of %1 events&lt;br /&gt;Single click to play&lt;br /&gt;Double-click to change</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Click here to toggle console output for %1 events.&lt;br /&gt;If checked, this option makes Mumble output all %1 events in its message log.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Click here to toggle pop-up notifications for %1 events.&lt;br /&gt;If checked, a notification pop-up will be created by Mumble for every %1 event.</source>
         <oldsource>Click here to toggle pop-up notifications for %1 events.&lt;br /&gt;If checked, a notification pop-up will be created by mumble for every %1 event.</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Click here to toggle window highlight for %1 events.&lt;br /&gt;If checked, Mumble&apos;s window will be highlighted for every %1 event, if not active.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Path to sound file used for sound notifications in the case of %1 events.&lt;br /&gt;Single click to play&lt;br /&gt;Double-click to change&lt;br /&gt;Ensure that sound notifications for these events are enabled or this field will not have any effect.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Click here to toggle Text-To-Speech for %1 events.&lt;br /&gt;If checked, Mumble uses Text-To-Speech to read %1 events out loud to you. Text-To-Speech is also able to read the contents of the event which is not true for sound files. Text-To-Speech and sound files cannot be used at the same time.</source>
         <oldsource>Click here to toggle sound notification for %1 events.&lt;br /&gt;If checked, Mumble uses a soundfile predefined by you to indicate %1 events. Soundfiles and Text-To-Speech cannot be used at the same time.</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-5"/>
         <source>Click here to toggle sound notification for %1 events.&lt;br /&gt;If checked, Mumble uses a sound file predefined by you to indicate %1 events. Sound files and Text-To-Speech cannot be used at the same time.</source>
         <oldsource>Path to soundfile used for sound notifications in the case of %1 events.&lt;br /&gt;Single click to play&lt;br /&gt;Doubleclick to change&lt;br /&gt;Be sure that sound notifications for these events are enabled or this field will not have any effect.</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="Log.ui"/>
         <source>Messages</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Message</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Console</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Notification</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Text-To-Speech</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Soundfile</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Path</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Text To Speech</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Volume</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Volume of Text-To-Speech Engine</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>&lt;b&gt;This is the volume used for the speech synthesis.&lt;/b&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Length threshold</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Message length threshold for Text-To-Speech Engine</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>&lt;b&gt;This is the length threshold used for the Text-To-Speech Engine.&lt;/b&gt;&lt;br /&gt;Messages longer than this limit will not be read aloud in their full length.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source> Characters</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Whisper</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>If checked you will only hear whispers from users you added to your friend list.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Only accept whispers from friends</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>If enabled text messages you send will be read back to you with TTS</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Read back own messages</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Chat Log</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Maximum chat length</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Unlimited</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source> Lines</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Highlight</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>If enabled, TTS will not dictate the message scope.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Omit Message Scope</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>If enabled, TTS will not dictate the message author.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Omit Message Author</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>If checked the time at the beginning of a message will be displayed in the 24-hour format.
+
+The setting only applies for new messages, the already shown ones will retain the previous time format.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Use 24-hour clock</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>LookConfig</name>
     <message>
-        <location filename="LookConfig.cpp" line="+34"/>
         <source>System default</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+21"/>
-        <location line="+51"/>
         <source>None</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-50"/>
         <source>Only with users</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>All</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
-        <location line="+4"/>
         <source>Ask</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-3"/>
-        <location line="+4"/>
         <source>Do Nothing</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-3"/>
-        <location line="+4"/>
         <source>Move</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>&lt;a href=&quot;%1&quot;&gt;Browse&lt;/a&gt;</source>
         <extracomment>This link is located next to the theme heading in the ui config and opens the user theme directory</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>User Interface</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="LookConfig.ui"/>
         <source>This sets which channels to automatically expand. &lt;i&gt;None&lt;/i&gt; and &lt;i&gt;All&lt;/i&gt; will expand no or all channels, while &lt;i&gt;Only with users&lt;/i&gt; will expand and collapse channels as users join and leave them.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>List users above subchannels (requires restart).</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>&lt;b&gt;If set, users will be shown above subchannels in the channel view.&lt;/b&gt;&lt;br /&gt;A restart of Mumble is required to see the change.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Users above Channels</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>&lt;b&gt;If set, will verify you want to quit if connected.&lt;/b&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Show number of users in each channel</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Show channel user count</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Language</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Language to use (requires restart)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>&lt;b&gt;This sets which language Mumble should use.&lt;/b&gt;&lt;br /&gt;You have to restart Mumble to use the new language.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Look and Feel</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Layout</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Classic</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Stacked</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Hybrid</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Custom</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>This changes the behavior when moving channels.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>This sets the behavior of channel drags; it can be used to prevent accidental dragging. &lt;i&gt;Move&lt;/i&gt; moves the channel without prompting. &lt;i&gt;Do Nothing&lt;/i&gt; does nothing and prints an error message. &lt;i&gt;Ask&lt;/i&gt; uses a message box to confirm if you really wanted to move the channel.</source>
         <oldsource>This sets the behavior of channel drags; it can be used to prevent accidental dragging. &lt;i&gt;Move Channel&lt;/i&gt; moves the channel without prompting. &lt;i&gt;Do Nothing&lt;/i&gt; does nothing and prints an error message. &lt;i&gt;Ask&lt;/i&gt; uses a message box to confirm if you really wanted to move the channel.</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Expand</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>When to automatically expand channels</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Channel Dragging</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Ask whether to close or minimize when quitting Mumble.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Ask on quit while connected</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Always On Top</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>&lt;b&gt;If set, minimizing the Mumble main window will cause it to be hidden and accessible only from the tray. Otherwise, it will be minimized as a window normally would.&lt;/b&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Hide in tray when minimized</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Hide the main Mumble window in the tray when it is minimized.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>This setting controls when the application will be always on top.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Never</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Always</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>In minimal view</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>In normal view</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Displays talking status in system tray</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Show talking status in tray icon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>This setting controls in which situations the application will stay always on top. If you select &lt;i&gt;Never&lt;/i&gt; the application will not stay on top. &lt;i&gt;Always&lt;/i&gt; will always keep the application on top. &lt;i&gt;In minimal view&lt;/i&gt; / &lt;i&gt;In normal view&lt;/i&gt; will only keep the application always on top when minimal view is activated / deactivated.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Show context menu in menu bar</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Apply some high contrast optimizations for visually impaired users</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Optimize for high contrast</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Application</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Adds user and channel context menus into the menu bar</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Tray Icon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Channel Tree</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Use selected item as the chat bar target</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Filter automatically hides empty channels</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Show transmit mode dropdown in toolbar</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Theme</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Theme to use to style the user interface</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>&lt;b&gt;Configures which theme the Mumble user interface should be styled with&lt;/b&gt;&lt;br /&gt;Mumble will pick up themes from certain directories and display them in this list. The one you select will be used to customize the visual appearance of Mumble. This includes colors, icons and more.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>User Dragging</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>This changes the behavior when moving users.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>This sets the behavior of user drags; it can be used to prevent accidental dragging. &lt;i&gt;Move&lt;/i&gt; moves the user without prompting. &lt;i&gt;Do Nothing&lt;/i&gt; does nothing and prints an error message. &lt;i&gt;Ask&lt;/i&gt; uses a message box to confirm if you really wanted to move the user.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>&lt;b&gt;Enable Developer menu&lt;/b&gt;&lt;br /&gt;This enables the &quot;Developer&quot;-menu in Mumble. This menu is used for developer-specific features, such as the Developer Console.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Enable Developer menu</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>When in custom layout mode, checking this disables rearranging.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Lock layout</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4659,1738 +3760,1368 @@ This field describes the size of an LCD device. The size is given either in pixe
 <context>
     <name>MainWindow</name>
     <message>
-        <location filename="MainWindow.cpp" line="+127"/>
-        <location line="+2744"/>
         <source>Root</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-2684"/>
         <source>Push-to-Talk</source>
         <comment>Global Shortcut</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Push and hold this button to send voice.</source>
         <comment>Global Shortcut</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>This configures the push-to-talk button, and as long as you hold this button down, you will transmit voice.</source>
         <comment>Global Shortcut</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Reset Audio Processor</source>
         <comment>Global Shortcut</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Unlink Plugin</source>
         <comment>Global Shortcut</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Push-to-Mute</source>
         <comment>Global Shortcut</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Join Channel</source>
         <comment>Global Shortcut</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Toggle Overlay</source>
         <comment>Global Shortcut</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Toggle state of in-game overlay.</source>
         <comment>Global Shortcut</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Toggle Minimal</source>
         <comment>Global Shortcut</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Volume Up (+10%)</source>
         <comment>Global Shortcut</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Volume Down (-10%)</source>
         <comment>Global Shortcut</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="MainWindow.ui"/>
         <source>Mumble</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="MainWindow.cpp" line="+4"/>
-        <location line="+168"/>
-        <location line="+2669"/>
         <source>Mumble -- %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-2797"/>
         <source>&amp;Window</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
-        <location line="+185"/>
         <source>Minimize</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-185"/>
         <source>Ctrl+M</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+184"/>
         <source>Close</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1"/>
         <source>Mumble is currently connected to a server. Do you want to Close or Minimize it?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-261"/>
         <source>Mute Self</source>
         <comment>Global Shortcut</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Set self-mute status.</source>
         <comment>Global Shortcut</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>This will set or toggle your muted status. If you turn this off, you will also disable self-deafen.</source>
         <comment>Global Shortcut</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Deafen Self</source>
         <comment>Global Shortcut</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Set self-deafen status.</source>
         <comment>Global Shortcut</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>This will set or toggle your deafened status. If you turn this on, you will also enable self-mute.</source>
         <comment>Global Shortcut</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+31"/>
         <source>Whisper/Shout</source>
         <oldsource>Whisper</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+88"/>
-        <location line="+2834"/>
         <source>&lt;center&gt;Not connected&lt;/center&gt;</source>
         <oldsource>Not connected</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-2386"/>
         <source>Clear</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+73"/>
         <source>Opening URL %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>File does not exist</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>File is not a configuration file.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Settings merged from file.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>URL scheme is not &apos;mumble&apos;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>This version of Mumble can&apos;t handle URLs for Mumble version %1.%2.%3</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+36"/>
         <source>Connecting to %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Enter username</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
-        <location line="+221"/>
         <source>Connecting to server %1.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Reconnecting.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+76"/>
-        <location line="+1498"/>
-        <location line="+22"/>
         <source>Transmit Mode set to Continuous</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1419"/>
         <source>&lt;p&gt;%1 (%2)&lt;br /&gt;%3&lt;/p&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+69"/>
         <source>&lt;h2&gt;Voice channel&lt;/h2&gt;&lt;p&gt;Encrypted with 128 bit OCB-AES128&lt;br /&gt;%1 ms average latency (%4 deviation)&lt;/p&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-180"/>
-        <location line="+449"/>
         <source>Register yourself as %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-449"/>
-        <location line="+449"/>
         <source>&lt;p&gt;You are about to register yourself on this server. This action cannot be undone, and your username cannot be changed once this is done. You will forever be known as &apos;%1&apos; on this server.&lt;/p&gt;&lt;p&gt;Are you sure you want to register yourself?&lt;/p&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-343"/>
         <source>&lt;h2&gt;Version&lt;/h2&gt;&lt;p&gt;Protocol %1&lt;/p&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&lt;p&gt;No build information or OS version available&lt;/p&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>The connection is encrypted and authenticated using %1 and uses %2 as the key exchange mechanism (%3)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>The connection is encrypted using %1, with %2 for message authentication and %3 as the key exchange mechanism (%4)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>The connection is secured by the cipher suite that OpenSSL identifies as %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>&lt;p&gt;The connection provides perfect forward secrecy&lt;/p&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>&lt;p&gt;The connection does not provide perfect forward secrecy&lt;/p&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>&lt;h2&gt;Control channel&lt;/h2&gt;&lt;p&gt;The connection uses %1&lt;/p&gt;%2%3&lt;p&gt;%4 ms average latency (%5 deviation)&lt;/p&gt;&lt;p&gt;Remote host %6 (port %7)&lt;/p&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>Voice channel is sent over control channel</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+273"/>
         <source>Register user %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>&lt;p&gt;You are about to register %1 on the server. This action cannot be undone, the username cannot be changed, and as a registered user, %1 will have access to the server even if you change the server password.&lt;/p&gt;&lt;p&gt;From this point on, %1 will be authenticated with the certificate currently in use.&lt;/p&gt;&lt;p&gt;Are you sure you want to register %1?&lt;/p&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+40"/>
         <source>Kicking user %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Banning user %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+61"/>
         <source>View comment on user %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+76"/>
-        <location line="+270"/>
-        <location line="+641"/>
         <source>Message to channel %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+65"/>
         <source>Connected.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+112"/>
         <source>&lt;li&gt;Expected certificate digest (SHA-1):	%1&lt;/li&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Server presented a certificate which failed verification.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>&lt;p&gt;%1&lt;/p&gt;&lt;ul&gt;%2&lt;/ul&gt;&lt;p&gt;The specific errors with this certificate are:&lt;/p&gt;&lt;ol&gt;%3&lt;/ol&gt;&lt;p&gt;Do you wish to accept this certificate anyway?&lt;br /&gt;(It will also be stored so you won&apos;t be asked this again.)&lt;/p&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+24"/>
         <source>SSL Version mismatch</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+67"/>
         <source>Server connection failed.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+86"/>
         <source>&lt;center&gt;Type message to channel &apos;%1&apos; here&lt;/center&gt;</source>
         <oldsource>Type message to channel &apos;%1&apos; here</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&lt;center&gt;Type message to user &apos;%1&apos; here&lt;/center&gt;</source>
         <oldsource>Type message to user &apos;%1&apos; here</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+101"/>
         <source>Choose image file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
-        <location line="+17"/>
-        <location line="+9"/>
         <source>Failed to load image</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-26"/>
         <source>Could not open file for reading.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+17"/>
-        <location line="+9"/>
         <source>Image format not recognized.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-3152"/>
         <source>&amp;User</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>&amp;Channel</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+65"/>
-        <location line="+26"/>
         <source>Use in conjunction with Whisper to.</source>
         <comment>Global Shortcut</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-21"/>
         <source>This will switch the states of the in-game overlay.</source>
         <comment>Global Shortcut</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Link Channel</source>
         <comment>Global Shortcut</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Cycle Transmit Mode</source>
         <comment>Global Shortcut</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Set Transmit Mode to Push-To-Talk</source>
         <comment>Global Shortcut</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Set Transmit Mode to Continuous</source>
         <comment>Global Shortcut</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Set Transmit Mode to VAD</source>
         <comment>Global Shortcut</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Send Text Message</source>
         <comment>Global Shortcut</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Send Clipboard Text Message</source>
         <comment>Global Shortcut</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>This will send your Clipboard content to the channel you are currently in.</source>
         <comment>Global Shortcut</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+88"/>
         <source>Continuous</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Voice Activity</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Push-to-Talk</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+49"/>
         <source>Mumble - Minimal View -- %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+62"/>
         <source>Cancel</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+305"/>
         <source>Save Image As...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Save Image File</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Could not save image: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+418"/>
         <source>Change your comment</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+41"/>
-        <location line="+1485"/>
-        <location line="+40"/>
         <source>Transmit Mode set to Voice Activity</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1520"/>
-        <location line="+1484"/>
-        <location line="+16"/>
         <source>Transmit Mode set to Push-to-Talk</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1348"/>
         <source>&lt;p&gt;Connected users: %1/%2&lt;/p&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>UDP Statistics</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>To Server</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>From Server</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Good</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Late</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Lost</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Resync</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>&lt;h2&gt;Audio bandwidth&lt;/h2&gt;&lt;p&gt;Maximum %1 kbit/s&lt;br /&gt;Current %2 kbit/s&lt;br /&gt;Codec: %3&lt;/p&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Mumble Server Information</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
-        <location line="+1554"/>
         <source>&amp;View Certificate</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1260"/>
-        <location line="+19"/>
         <source>Enter reason</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Sending message to %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location line="+103"/>
-        <location line="+4"/>
-        <location line="+266"/>
-        <location line="+641"/>
         <source>To %1: %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1014"/>
-        <location line="+107"/>
         <source>Message to %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-64"/>
         <source>Are you sure you want to reset the comment of user %1?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>Are you sure you want to reset the avatar of user %1?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+232"/>
         <source>Are you sure you want to delete %1 and all its sub-channels?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+71"/>
         <source>Sending message to channel %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Message to tree %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>To %1 (Tree): %2</source>
         <oldsource>(Tree) %1: %2</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+173"/>
         <source>Unmuted and undeafened.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Unmuted.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Muted.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+31"/>
         <source>Muted and deafened.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Deafened.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Undeafened.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+47"/>
         <source>Restart Mumble?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Some settings will only apply after a restart of Mumble. Restart Mumble now?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+51"/>
         <source>About Qt</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+499"/>
         <source>SSL Verification failed: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>&lt;li&gt;Server certificate digest (SHA-1):	%1&lt;/li&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&lt;b&gt;WARNING:&lt;/b&gt; The server presented a certificate that was different from the stored one.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+34"/>
         <source>This server is using an older encryption standard, and is no longer supported by modern versions of Mumble.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
-        <location line="+59"/>
         <source>Server connection failed: %1.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-57"/>
         <source>Disconnected from server.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+11"/>
-        <location filename="Messages.cpp" line="+71"/>
         <source>Invalid username</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>You connected with an invalid username, please try another one.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
-        <location filename="Messages.cpp" line="+3"/>
         <source>Username in use</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>That username is already in use, please try another username.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
-        <location filename="Messages.cpp" line="+3"/>
         <source>Wrong certificate or password</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Wrong certificate or password for registered user. If you are
 certain this user is protected by a password please retry.
 Otherwise abort and check your certificate and username.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
-        <location filename="Messages.cpp" line="+3"/>
         <source>Wrong password</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Wrong server password for unregistered user account, please try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-2269"/>
-        <location line="+2487"/>
         <source>Images (*.png *.jpg *.jpeg)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="MainWindow.ui"/>
         <source>C&amp;onfigure</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>&amp;Help</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Log</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>This shows all recent activity. Connecting to servers, errors and information messages all show up here.&lt;br /&gt;To configure exactly which messages show up here, use the &lt;b&gt;Settings&lt;/b&gt; command from the menu.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>&amp;Quit Mumble</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Closes the program</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Exits the application.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Ctrl+Q</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Open the server connection dialog</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>&amp;Disconnect</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Disconnect from server</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Disconnects you from the server.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Show information about the server connection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>This will show extended information about the connection to the server.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>&amp;Mute</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>&amp;Deafen</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>&amp;Local Mute</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Send a Text Message</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Sends a text message to another user.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Add new channel</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>This adds a new sub-channel to the currently selected channel.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Remove channel</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>This removes a channel and all sub-channels.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Edit Groups and ACL for channel</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>This opens the Group and ACL dialog for the channel, to control permissions.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>&amp;Link</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Link your channel to another channel</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>This is the chatbar&lt;br /&gt;If you enter text here and then press enter the text is sent to the user or channel that was selected. If nothing is selected the message is sent to your current channel.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Chatbar</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Shows a dialog of registered servers, and also allows quick-connect.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Kick user (with reason)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Kick selected user off server. You&apos;ll be asked to specify a reason.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Mute user</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Mute or unmute user on server. Unmuting a deafened user will also undeafen them.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Kick and ban user (with reason)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Kick and ban selected user from server. You&apos;ll be asked to specify a reason.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Deafen user</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Deafen or undeafen user on server. Deafening a user will also mute them.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Mute user locally</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Mute or unmute user locally. Use this on other users in the same room.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>This links your current channel to the selected channel. If users in a channel have permission to speak in the other channel, users can now hear each other. This is a permanent link, and will last until manually unlinked or the server is restarted. Please see the shortcuts for push-to-link.</source>
         <oldsource>This links your current channel to the selected channel. If they have permission to speak in the other channel, users can now hear each other. This is a permanent link, and will last until manually unlinked or the server is restarted. Please see the shortcuts for push-to-link.</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>&amp;Unlink</source>
         <comment>Channel</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Unlink your channel from another channel</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>This unlinks your current channel from the selected channel.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Unlinks your channel from all linked channels.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>This unlinks your current channel (not the selected one) from all linked channels.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>&amp;Reset</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Reset audio preprocessor</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>This will reset the audio preprocessor, including noise cancellation, automatic gain and voice activity detection. If something suddenly worsens the audio environment (like dropping the microphone) and it was temporary, use this to avoid having to wait for the preprocessor to readjust.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>&amp;Mute Self</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Mute yourself</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Mute or unmute yourself. When muted, you will not send any data to the server. Unmuting while deafened will also undeafen.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>&amp;Deafen Self</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Deafen yourself</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Deafen or undeafen yourself. When deafened, you will not hear anything. Deafening yourself will also mute.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>&amp;Text-To-Speech</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Toggle Text-To-Speech</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Enable or disable the text-to-speech engine. Only messages enabled for TTS in the Configuration dialog will actually be spoken.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Display audio statistics</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Pops up a small dialog with information about your current audio input.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Forcibly unlink plugin</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>This forces the current plugin to unlink, which is handy if it is reading completely wrong data.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Configure Mumble</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Allows you to change most settings for Mumble.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Start the audio configuration wizard</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>This will guide you through the process of configuring your audio hardware.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>&amp;What&apos;s This?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Enter What&apos;s This? mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Click this to enter &quot;What&apos;s This?&quot; mode. Your cursor will turn into a question mark. Click on any button, menu choice or area to show a description of what it is.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Information about Mumble</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Shows a small dialog with information and license for Mumble.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Information about Speex</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Shows a small dialog with information about Speex.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Information about Qt</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Shows a small dialog with information about Qt.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Check for &amp;Updates</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Check for new version of Mumble</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Connects to the Mumble webpage to check if a new version is available, and notifies you with an appropriate download URL if this is the case.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Sends a text message to all users in a channel.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Configure certificates for strong authentication</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>This starts the wizard for creating, importing and exporting certificates for authentication against servers.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Register user on server</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>This will permanently register the user on the server.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Add &amp;Friend</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Adds a user as your friend.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>This will add the user as a friend, so you can recognize him on this and other servers.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>&amp;Remove Friend</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Removes a user from your friends.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>This will remove a user from your friends list.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>&amp;Update Friend</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Update name of your friend.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Your friend uses a different name than what is in your database. This will update the name.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Edit registered users list</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>This opens the editor for registered users, which allow you to change their name or unregister them.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Add or remove text-based access tokens</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>&amp;Minimal View</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Toggle minimal window modes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>This will toggle minimal mode, where the log window and menu is hidden.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="Messages.cpp" line="+416"/>
         <source>You muted and deafened %1.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>You unmuted and undeafened %1.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>You undeafened %1.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>You suppressed %1.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>%1 muted and deafened by %2.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1 unmuted and undeafened by %2.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>%1 undeafened by %2.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>%1 suppressed by %2.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-208"/>
         <source>%1 moved to %2.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>%1 moved to %2 by %3.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-2"/>
         <source>%1 moved in from %2 by %3.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+48"/>
         <source>%1 is now muted and deafened.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-304"/>
         <source>Your account information can not be verified currently. Please try again later</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+20"/>
-        <location line="+55"/>
         <source>Welcome message: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-17"/>
         <source>Mumble: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+42"/>
         <source>You were denied %1 privileges in %2.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>%3 was denied %1 privileges in %2.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Denied: Cannot modify SuperUser.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Denied: Invalid channel name.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Denied: Text message too long.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Denied: Operation not permitted in temporary channel.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>You need a certificate to perform this operation.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1 does not have a certificate.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Invalid username: %1.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Invalid username.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Channel is full.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Channel nesting limit reached.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Channel count limit reached. Need to delete channels before creating new ones.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Permission denied.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+42"/>
         <source>%1 connected and entered channel.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1 connected.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+91"/>
         <source>%1 is now muted.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1 is now unmuted.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>Recording started</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Recording stopped</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>%1 started recording.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1 stopped recording.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>You revoked your priority speaker status.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>You assumed priority speaker status.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>%1 revoked your priority speaker status.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1 gave you priority speaker status.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>You revoked priority speaker status for %1.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>You gave priority speaker status to %1.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>%1 revoked own priority speaker status.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1 assumed priority speaker status.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>%1 revoked priority speaker status for %2.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1 gave priority speaker status to %2.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>You were unmuted and undeafened by %1.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>You were muted by %1.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>You were undeafened by %1.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>You were suppressed.</source>
         <oldsource>You were suppressed by %1.</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>You were unsuppressed.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>You were unsuppressed by %1.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-169"/>
         <source>You joined %1.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
-        <location line="+2"/>
         <source>You moved %1 to %2.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>%1 is recording</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>%1 renamed to %2 by %3.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+236"/>
         <source>%1 disconnected.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+116"/>
-        <location line="+1"/>
         <source>Server</source>
         <comment>message from</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>(Tree) </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>(Channel) </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>(Private) </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
-        <location line="+2"/>
-        <location line="+2"/>
-        <location line="+5"/>
         <source>%2%1: %3</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+151"/>
         <source>Failed to load Opus, it will not be available for audio encoding/decoding.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+58"/>
         <source>The server requests minimum client version %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>The server requests positional audio be enabled.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>The server requests positional audio be disabled.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>The server requests Push-to-Talk be enabled.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>The server requests Push-to-Talk be disabled.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-484"/>
         <source>You were unmuted by %1.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+29"/>
         <source>You muted %1.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>You unsuppressed %1.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-14"/>
         <source>You unmuted %1.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>%1 muted by %2.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>%1 unsuppressed by %2.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-14"/>
         <source>%1 unmuted by %2.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+387"/>
         <source>Unable to find matching CELT codecs with other clients. You will not be able to talk to all users.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-453"/>
         <source>You were muted and deafened by %1.</source>
         <oldsource>You were deafened by %1.</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+120"/>
         <source>You were kicked from the server by %1: %2.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>%3 was kicked from the server by %1: %2.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-7"/>
         <source>You were kicked and banned from the server by %1: %2.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>%3 was kicked and banned from the server by %1: %2.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-266"/>
         <source>You were moved to %1 by %2.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>%1 entered channel.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-243"/>
         <source>Server connection rejected: %1.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+162"/>
         <source>Denied: %1.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+110"/>
         <source>%1 renamed to %2.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+231"/>
         <source>%1 left channel and disconnected.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+144"/>
         <source>Message from %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="UserModel.cpp" line="+1398"/>
         <source>You have User Dragging set to &quot;Do Nothing&quot; so the user wasn&apos;t moved.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>You have Channel Dragging set to &quot;Do Nothing&quot; so the channel wasn&apos;t moved.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Unknown Channel Drag mode in UserModel::dropMimeData.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="main.cpp" line="-354"/>
         <source>Remote controlling Mumble:
 
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-26"/>
         <source>Usage: mumble [options] [&lt;url&gt;]
 
 &lt;url&gt; specifies a URL to connect to after startup instead of showing
@@ -6419,7 +5150,6 @@ Valid options are:
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+30"/>
         <source>Usage: mumble rpc &lt;action&gt; [options]
 
 It is possible to remote control a running instance of Mumble by using
@@ -6443,172 +5173,138 @@ Valid actions are:
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>Invocation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>Error: No RPC command specified</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>RPC</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+227"/>
         <source>Welcome to Mumble.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+76"/>
         <source>Skipping version check in debug mode.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="MainWindow.ui"/>
         <source>Hide Frame</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Toggle showing frame on minimal window</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>This will toggle whether the minimal window should have a frame for moving and resizing.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>&amp;Unlink All</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Reset the comment of the selected user.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>&amp;Join Channel</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>View comment in editor</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Query server for connection information for user</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>S&amp;erver</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>&amp;Self</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>&amp;Unlink Plugins</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Register yourself on the server</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Change your avatar image on this server</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>&amp;Remove Avatar</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Remove currently defined avatar image.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Icon Toolbar</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Change your own comment</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Recording</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Priority Speaker</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>&amp;Copy URL</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Copies a link to this channel to the clipboard.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Ignore Messages</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Locally ignore user&apos;s text chat messages.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Silently drops all text messages from the user.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Edit ban list on server</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>This lets you edit the server-side IP ban list.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>&amp;Filter on/off</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Toggle the channel filter (Ctrl+F)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Enable or disable the filtering of select channels.
 By default all empty channels will be filtered.
 You can mark additional channels for filtering from
@@ -6616,295 +5312,245 @@ the channel&apos;s context menu.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Ctrl+F</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>&amp;Hide Channel when Filtering</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Reset the avatar of the selected user.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Locally adjust the user&apos;s speech volume.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Opens a dialog with a volume slider. Use this on other users in the same room.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="MainWindow.cpp" line="-3116"/>
         <source>&amp;Developer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="MainWindow.ui"/>
         <source>&amp;Hide Mumble</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Hides the main Mumble window.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Hides the main Mumble window. Restore by clicking on the tray icon or starting Mumble again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Show the Developer Console</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Shows the Mumble Developer Console, where Mumble&apos;s log output can be inspected.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>&amp;Connect...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>&amp;Ban list...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>&amp;Information...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>&amp;Kick...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>&amp;Ban...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Local Volume Adjustment...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Send &amp;Message...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>&amp;Add...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>&amp;Remove...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>&amp;Edit...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Audio S&amp;tatistics...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>&amp;Settings...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>&amp;Audio Wizard...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Developer &amp;Console...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>&amp;About...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>About &amp;Speex...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>About &amp;Qt...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>&amp;Certificate Wizard...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>&amp;Register...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Registered &amp;Users...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Change &amp;Avatar...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>&amp;Access Tokens...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Reset &amp;Comment...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Reset &amp;Avatar...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>View Comment...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>&amp;Change Comment...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>R&amp;egister...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Show</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Shows the main Mumble window.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Server sync protocol violation. No user profile received.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Protocol violation. Server sent remove for occupied channel.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>Manual</name>
     <message>
-        <location filename="ManualPlugin.ui"/>
         <source>Manual Mumble Positional Audio</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Position</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>X</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Y</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Z</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>m</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Heading</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Azimuth</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Elevation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>°</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Meta data</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Context</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Identity</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Set</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>State</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Linked</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Activated</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Unhinge</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6912,254 +5558,204 @@ the channel&apos;s context menu.</source>
 <context>
     <name>NetworkConfig</name>
     <message>
-        <location filename="NetworkConfig.cpp" line="+33"/>
         <source>Network</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+36"/>
         <source>Updates are mandatory when using snapshot releases.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="NetworkConfig.ui"/>
         <source>Connection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Use TCP compatibility mode</source>
         <oldsource>Use TCP compatability mode</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>&lt;b&gt;Enable TCP compatibility mode&lt;/b&gt;.&lt;br /&gt;This will make Mumble use only TCP when communicating with the server. This will increase overhead and cause lost packets to produce noticeable pauses in communication, so this should only be used if you are unable to use the default (which uses UDP for voice and TCP for control).</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Reconnect when disconnected</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>&lt;b&gt;Reconnect when disconnected&lt;/b&gt;.&lt;br /&gt;This will make Mumble try to automatically reconnect after 10 seconds if your server connection fails.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Reconnect automatically</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Proxy</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Type</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Type of proxy to connect through</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Direct connection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>HTTP(S) proxy</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>SOCKS5 proxy</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Hostname</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Hostname of the proxy</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Force TCP mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Enable QoS to prioritize packets</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>This will enable QoS, which will attempt to prioritize voice packets over other traffic.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Use Quality of Service</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Don&apos;t send certificate to server and don&apos;t save passwords. (Not saved).</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>&lt;b&gt;This will suppress identity information from the client.&lt;/b&gt;&lt;p&gt;The client will not identify itself with a certificate, even if defined, and will not cache passwords for connections. This is primarily a test-option and is not saved.&lt;/p&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Suppress certificate and password storage</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>&lt;b&gt;Type of proxy to connect through.&lt;/b&gt;&lt;br /&gt;This makes Mumble connect through a proxy for all outgoing connections. Note: Proxy tunneling forces Mumble into TCP compatibility mode, causing all voice data to be sent via the control channel.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>&lt;b&gt;Hostname of the proxy.&lt;/b&gt;&lt;br /&gt;This field specifies the hostname of the proxy you wish to tunnel network traffic through.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Port</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Port number of the proxy</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>&lt;b&gt;Port number of the proxy.&lt;/b&gt;&lt;br /&gt;This field specifies the port number that the proxy expects connections on.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Username</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Username for proxy authentication</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>&lt;b&gt;Username for proxy authentication.&lt;/b&gt;&lt;br /&gt;This specifies the username you use for authenticating yourself with the proxy. In case the proxy does not use authentication, or you want to connect anonymously, simply leave this field blank.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Password</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Password for proxy authentication</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>&lt;b&gt;Password for proxy authentication.&lt;/b&gt;&lt;br /&gt;This specifies the password you use for authenticating yourself with the proxy. In case the proxy does not use authentication, or you want to connect anonymously, simply leave this field blank.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Mumble services</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Check for new releases of Mumble automatically.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>This will check for new releases of Mumble every time you start the program, and notify you if one is available.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Check for application updates on startup</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Check for new releases of plugins automatically.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>This will check for new releases of plugins every time you start the program, and download them automatically.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>&lt;b&gt;Submit anonymous statistics.&lt;/b&gt;&lt;br /&gt;Mumble has a small development team, and as such needs to focus its development where it is needed most. By submitting a bit of statistics you help the project determine where to focus development.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Submit anonymous statistics to the Mumble project</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Submit anonymous statistics</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Reconnect to last used server when starting Mumble</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Reconnect to last server on startup</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Download plugin and overlay updates on startup</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Privacy</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Prevent OS information being sent to Mumble servers and web servers</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>&lt;b&gt;Don&apos;t send OS information to servers&lt;/b&gt;&lt;br/&gt;
 Prevents the client from sending potentially identifying information about the operating system to the Mumble server and web servers.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Do not send OS information to Mumble servers and web servers</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7167,37 +5763,26 @@ Prevents the client from sending potentially identifying information about the o
 <context>
     <name>Overlay</name>
     <message>
-        <location filename="OverlayEditorScene.cpp" line="+104"/>
-        <location filename="OverlayUser.cpp" line="+132"/>
         <source>Silent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
-        <location filename="OverlayUser.cpp" line="+3"/>
         <source>Talking</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
-        <location filename="OverlayUser.cpp" line="+3"/>
         <source>Whisper</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
-        <location filename="OverlayUser.cpp" line="+3"/>
         <source>Shout</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+17"/>
-        <location filename="OverlayUser.cpp" line="-110"/>
         <source>Channel</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="Overlay.cpp" line="+223"/>
         <source>Failed to create communication with overlay at %2: %1. No overlay will be available.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7205,77 +5790,62 @@ Prevents the client from sending potentially identifying information about the o
 <context>
     <name>OverlayClient</name>
     <message>
-        <location filename="OverlayUserGroup.cpp" line="+82"/>
         <source>Filter</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Only talking</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Talking and recently active</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>All in current channel</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>All in linked channels</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Always show yourself</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Configure recently active time (%1 seconds)...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Columns</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Sort</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Alphabetically</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Last state change</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Edit...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Reset Zoom</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+41"/>
         <source>Configure recently active time</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Amount of seconds users remain active after talking:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7283,244 +5853,193 @@ Prevents the client from sending potentially identifying information about the o
 <context>
     <name>OverlayConfig</name>
     <message>
-        <location filename="OverlayConfig.cpp" line="+88"/>
         <source>To move the users, drag the little red dot.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>To resize the users, mouse wheel over a user.</source>
         <oldsource>To resize the users, mousewheel over a user.</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>For more options, right click a user.</source>
         <oldsource>For more options, rightclick a user.</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+72"/>
         <source>Launcher Filter</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+254"/>
         <source>Overlay</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+190"/>
-        <location line="+60"/>
-        <location line="+76"/>
         <source>Choose executable</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-134"/>
-        <location line="+60"/>
-        <location line="+76"/>
         <source>Choose application</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-41"/>
         <source>Choose path</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+132"/>
         <source>Load Overlay Presets</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
-        <location line="+36"/>
         <source>Mumble overlay presets (*.mumblelay)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-2"/>
         <source>Save Overlay Presets</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="Overlay.ui"/>
         <source>Options</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Enable overlay.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Enable Overlay</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>This sets whether the overlay is enabled or not. This setting is only checked when applications are started, so make sure Mumble is running and this option is on before you start the application.&lt;br /&gt;Please note that if you start Mumble after starting the application, or if you disable the overlay while the application is running, there is no safe way to restart the overlay without also restarting the application.</source>
         <oldsource>This sets whether the overlay is enabled or not. This setting is only checked when applications are started, so make sure Mumble is running and this option is on before you start the application.&lt;br /&gt;Please note that if you start the application after starting Mumble, or if you disable the overlay while running, there is no safe way to restart the overlay without also restarting the application.</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Layout</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="OverlayConfig.cpp" line="-707"/>
         <source>Blacklist</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1"/>
         <source>Whitelist</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="Overlay.ui"/>
         <source>Uninstall Overlay</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Overlay Installation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Mumble has detected that you do not have the Mumble Overlay installed.
 
 Click the button below to install the overlay.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Install Mumble Overlay</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Overlay Upgrade</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Mumble has detected an old version of the overlay support files installed on your computer.
 
 To upgrade these files to their latest versions, click the button below.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Upgrade Mumble Overlay</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Display a frame counter in the overlay</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Show FPS counter</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Load an overlay preset from file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Load…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Save your overlay settings to file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Save…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Set the overlay font.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Set the overlay text color.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Color</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Remove</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Font</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>FPS and Clock Display</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Display a clock in the overlay showing the current local time (system time).</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Show Clock</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Overlay Exceptions</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Overlay Exception Mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Allowed launchers</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Add</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Allowed programs</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Allowed paths</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Blacklisted programs</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7528,117 +6047,94 @@ To upgrade these files to their latest versions, click the button below.</source
 <context>
     <name>OverlayEditor</name>
     <message>
-        <location filename="OverlayEditor.ui"/>
         <source>State</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>User is not talking</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Passive</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>User is talking in your channel or a linked channel</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Talking</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>User is whispering to you privately</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Private Whisper</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>User is shouting to your channel</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Channel Whisper</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Zoom</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Zoom Factor</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Enabled Elements</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>User avatar, chosen by each user</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Avatar</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>User&apos;s name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Username</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Name of user&apos;s channel, if outside your current channel</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Channel</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Muted or deafened</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Mute state</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Bounding box, automatically shrunk to minimum size to contain all visible elements</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Bounding box</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Overlay Editor</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7646,119 +6142,94 @@ To upgrade these files to their latest versions, click the button below.</source
 <context>
     <name>OverlayEditorScene</name>
     <message>
-        <location filename="OverlayEditorScene.cpp" line="+397"/>
         <source>Layout preset</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Large square avatar</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Avatar and Name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>User Opacity</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
-        <location line="+31"/>
         <source>%1%</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-5"/>
         <source>Object Opacity</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Alignment</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>Left</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
-        <location line="+18"/>
         <source>Center</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-13"/>
         <source>Right</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Top</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Bottom</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Color...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Font...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Bounding box</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Pen width</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Padding</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Pen color</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Fill color</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+87"/>
         <source>Pick pen color</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Pick fill color</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Pick color</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>Pick font</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7766,93 +6237,74 @@ To upgrade these files to their latest versions, click the button below.</source
 <context>
     <name>PluginConfig</name>
     <message>
-        <location filename="Plugins.ui"/>
-        <location filename="Plugins.cpp" line="+88"/>
         <source>Plugins</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="Plugins.cpp" line="+54"/>
         <source>Plugin has no configure function.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Plugin has no about function.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="Plugins.ui"/>
         <source>Options</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Enable plugins and transmit positional information</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>This allows plugins for supported games to fetch your in-game position and transmit it with each voice packet. This enables other users to hear your voice in-game from the direction your character is in relation to their own.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Link to Game and Transmit Position</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Reloads all plugins</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>This rescans and reloads plugins. Use this if you just added or changed a plugin to the plugins directory.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>&amp;Reload plugins</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Information about plugin</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>This shows a small information message about the plugin.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>&amp;About</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Show configuration page of plugin</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>This shows the configuration page of the plugin, if any.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>&amp;Configure</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Enabled</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7860,28 +6312,22 @@ To upgrade these files to their latest versions, click the button below.</source
 <context>
     <name>Plugins</name>
     <message>
-        <location filename="Plugins.cpp" line="+440"/>
         <source>Skipping plugin update in debug mode.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+168"/>
-        <location line="+6"/>
         <source>Downloaded new or updated plugin to %1.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Failed to install new plugin to %1.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-344"/>
         <source>%1 lost link.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+123"/>
         <source>%1 linked.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7889,7 +6335,6 @@ To upgrade these files to their latest versions, click the button below.</source
 <context>
     <name>PortAudioSystem</name>
     <message>
-        <location filename="PAAudio.cpp" line="+278"/>
         <source>Default Device</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7897,12 +6342,10 @@ To upgrade these files to their latest versions, click the button below.</source
 <context>
     <name>PulseAudioSystem</name>
     <message>
-        <location filename="PulseAudio.cpp" line="+789"/>
         <source>Default Input</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Default Output</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7910,12 +6353,10 @@ To upgrade these files to their latest versions, click the button below.</source
 <context>
     <name>QApplication</name>
     <message>
-        <location filename="main.cpp" line="+127"/>
         <source>Failed to restart mumble</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Mumble failed to restart itself. Please restart it manually.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7923,82 +6364,66 @@ To upgrade these files to their latest versions, click the button below.</source
 <context>
     <name>RichTextEditor</name>
     <message>
-        <location filename="RichTextEditor.cpp" line="+245"/>
         <source>Failed to load image</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Image file too large to embed in document. Please use images smaller than %1 kB.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+81"/>
         <source>Message is too long.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="RichTextEditor.ui"/>
         <source>Display</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Source Text</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>&amp;Bold</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Ctrl+B</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>&amp;Italic</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Italic</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Ctrl+I</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Underline</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Ctrl+U</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Color</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Insert Link</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Ctrl+L</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Insert Image</source>
         <translation type="unfinished"></translation>
     </message>
@@ -8006,17 +6431,14 @@ To upgrade these files to their latest versions, click the button below.</source
 <context>
     <name>RichTextEditorLink</name>
     <message>
-        <location filename="RichTextEditorLink.ui"/>
         <source>Add Link</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>URL</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Text</source>
         <translation type="unfinished"></translation>
     </message>
@@ -8024,37 +6446,30 @@ To upgrade these files to their latest versions, click the button below.</source
 <context>
     <name>ServerHandler</name>
     <message>
-        <location filename="ServerHandler.cpp" line="+334"/>
         <source>Unable to resolve hostname</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+175"/>
         <source>Server is not responding to TCP pings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+84"/>
         <source>UDP packets cannot be sent to or received from the server. Switching to TCP mode.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>UDP packets cannot be sent to the server. Switching to TCP mode.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>UDP packets cannot be received from the server. Switching to TCP mode.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>UDP packets can be sent to and received from the server. Switching back to UDP mode.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+53"/>
         <source>Connection timed out</source>
         <translation type="unfinished"></translation>
     </message>
@@ -8062,52 +6477,42 @@ To upgrade these files to their latest versions, click the button below.</source
 <context>
     <name>ServerView</name>
     <message>
-        <location filename="ConnectDialog.cpp" line="-761"/>
         <source>Favorite</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>LAN</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Public Internet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Unknown</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Africa</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Asia</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>North America</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>South America</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Europe</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Oceania</source>
         <translation type="unfinished"></translation>
     </message>
@@ -8115,7 +6520,6 @@ To upgrade these files to their latest versions, click the button below.</source
 <context>
     <name>ShortcutActionWidget</name>
     <message>
-        <location filename="GlobalShortcut.cpp" line="-635"/>
         <source>Unassigned</source>
         <translation type="unfinished"></translation>
     </message>
@@ -8123,22 +6527,18 @@ To upgrade these files to their latest versions, click the button below.</source
 <context>
     <name>ShortcutDelegate</name>
     <message>
-        <location line="+373"/>
         <source>On</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Off</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Toggle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Unassigned</source>
         <translation type="unfinished"></translation>
     </message>
@@ -8146,7 +6546,6 @@ To upgrade these files to their latest versions, click the button below.</source
 <context>
     <name>ShortcutKeyWidget</name>
     <message>
-        <location line="-447"/>
         <source>Press Shortcut</source>
         <translation type="unfinished"></translation>
     </message>
@@ -8154,23 +6553,18 @@ To upgrade these files to their latest versions, click the button below.</source
 <context>
     <name>ShortcutTargetDialog</name>
     <message>
-        <location line="+203"/>
         <source>Root</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Parent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Current</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
-        <location line="+6"/>
         <source>Subchannel #%1</source>
         <translation type="unfinished"></translation>
     </message>
@@ -8178,43 +6572,34 @@ To upgrade these files to their latest versions, click the button below.</source
 <context>
     <name>ShortcutTargetWidget</name>
     <message>
-        <location line="+85"/>
         <source>...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+41"/>
         <source>, </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Root</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Parent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Current</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
-        <location line="+2"/>
         <source>Subchannel #%1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Invalid</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Empty</source>
         <oldsource>&lt;Empty&gt;</oldsource>
         <translation type="unfinished"></translation>
@@ -8223,17 +6608,14 @@ To upgrade these files to their latest versions, click the button below.</source
 <context>
     <name>ShortcutToggleWidget</name>
     <message>
-        <location line="-271"/>
         <source>Off</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Toggle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>On</source>
         <translation type="unfinished"></translation>
     </message>
@@ -8241,17 +6623,14 @@ To upgrade these files to their latest versions, click the button below.</source
 <context>
     <name>TextMessage</name>
     <message>
-        <location filename="TextMessage.h" line="+20"/>
         <source>Enter text</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="TextMessage.ui"/>
         <source>If checked the message is recursively sent to all subchannels</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Send recursively to subchannels</source>
         <translation type="unfinished"></translation>
     </message>
@@ -8259,22 +6638,18 @@ To upgrade these files to their latest versions, click the button below.</source
 <context>
     <name>Tokens</name>
     <message>
-        <location filename="Tokens.cpp" line="+42"/>
         <source>Empty Token</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="Tokens.ui"/>
         <source>Mumble - Access Tokens</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>List of access tokens on current server</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>&lt;b&gt;This is an editable list of access tokens on the connected server.&lt;/b&gt;
 &lt;br /&gt;
 An access token is a text string, which can be used as a password for very simple access management on channels. Mumble will remember the tokens you&apos;ve used and resend them to the server next time you reconnect, so you don&apos;t have to enter these every time.
@@ -8282,22 +6657,18 @@ An access token is a text string, which can be used as a password for very simpl
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Add a token</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>&amp;Add</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Remove a token</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>&amp;Remove</source>
         <translation type="unfinished"></translation>
     </message>
@@ -8305,54 +6676,42 @@ An access token is a text string, which can be used as a password for very simpl
 <context>
     <name>UserEdit</name>
     <message>
-        <location filename="UserEdit.ui"/>
         <source>Registered Users</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
-        <location filename="UserEdit.cpp" line="+102"/>
         <source>Remove</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
-        <location filename="UserEdit.cpp" line="-7"/>
         <source>Rename</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Who are you looking for?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Days</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Weeks</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Months</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Years</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Inactive for</source>
         <translation type="unfinished"></translation>
     </message>
     <message numerus="yes">
-        <location filename="UserEdit.cpp" line="-68"/>
         <source>Registered users: %n account(s)</source>
         <translation type="unfinished">
             <numerusform></numerusform><numerusform></numerusform>
@@ -8362,192 +6721,153 @@ An access token is a text string, which can be used as a password for very simpl
 <context>
     <name>UserInformation</name>
     <message>
-        <location filename="UserInformation.ui"/>
         <source>User Information</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Connection Information</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Version</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>OS</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Certificate</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>IP Address</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>CELT Versions</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Details...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Ping Statistics</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Pings received</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Average ping</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>TCP (Control)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>UDP (Voice)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>UDP Network statistics</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Good</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Late</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Lost</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Resync</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>From Client</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>To Client</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Connection time</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="UserInformation.cpp" line="+85"/>
         <source>%1w</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1d</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1h</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1m</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>%1s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+33"/>
-        <location line="+39"/>
         <source>, </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-13"/>
-        <location line="+1"/>
         <source>%1 (%2)</source>
         <oldsource>%1.%2.%3 (%4)</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Supported</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Not Supported</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-123"/>
         <source>Not Reported</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+164"/>
         <source>%1 online (%2 idle)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1 online</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>%1 kbit/s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="UserInformation.ui"/>
         <source>Bandwidth</source>
         <comment>GroupBox</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Bandwidth</source>
         <comment>Label</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Ping deviation</source>
         <translation type="unfinished"></translation>
     </message>
@@ -8555,32 +6875,26 @@ An access token is a text string, which can be used as a password for very simpl
 <context>
     <name>UserListModel</name>
     <message>
-        <location filename="UserListModel.cpp" line="+63"/>
         <source>Nick</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Inactive days</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Last channel</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+29"/>
         <source>Last seen: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Never</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Channel ID: %1</source>
         <translation type="unfinished"></translation>
     </message>
@@ -8588,27 +6902,22 @@ An access token is a text string, which can be used as a password for very simpl
 <context>
     <name>UserLocalVolumeDialog</name>
     <message>
-        <location filename="UserLocalVolumeDialog.ui"/>
         <source>Local volume for other users</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>&lt;b&gt;Adjust the volume of other users locally&lt;/b&gt;&lt;br /&gt;Mumble supports adjusting the volume of other users locally.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="UserLocalVolumeDialog.cpp" line="+58"/>
         <source>Adjusting local volume for %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="UserLocalVolumeDialog.ui"/>
         <source> dB</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Use the slider or the text box to change the volume of the user.&lt;/p&gt;&lt;p&gt;&lt;span style=&quot;font-weight:600;&quot;&gt;Attention!&lt;/span&gt;&lt;/p&gt;&lt;p&gt;Increasing the volume of a user too much can permanently damage your hearing. It may also increase the background noise of the user.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
@@ -8616,159 +6925,127 @@ An access token is a text string, which can be used as a password for very simpl
 <context>
     <name>UserModel</name>
     <message>
-        <location filename="UserModel.cpp" line="-836"/>
         <source>This is a user connected to the server. The icon to the left of the user indicates whether or not they are talking:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Talking to your channel.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Shouting directly to your channel.</source>
         <oldsource>Whispering directly to your channel.</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Whispering directly to you.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Not talking.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>This is a channel on the server. The icon indicates the state of the channel:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Your current channel.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>A channel that is linked with your channel. Linked channels can talk to each other.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>A channel on the server that you are not linked to.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>This shows the flags the user has on the server, if any:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>On your friend list</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Authenticated user</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Muted (manually muted by self)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Muted (manually muted by admin)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Muted (not allowed to speak in current channel)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Muted (muted by you, only on your machine)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Muted (push-to-mute)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Deafened (by self)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Deafened (by admin)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>User has a new comment set (click to show)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>User has a comment set, which you&apos;ve already seen. (click to show)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Ignoring Text Messages</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>This shows the flags the channel has, if any:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Channel has a new comment set (click to show)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Channel has a comment set, which you&apos;ve already seen. (click to show)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Channel will be hidden when filtering is enabled</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Flags</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+726"/>
         <source>Are you sure you want to drag this user?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>Are you sure you want to drag this channel?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+94"/>
-        <location line="+20"/>
         <source>Cannot perform this movement automatically, please reset the numeric sorting indicators or adjust it manually.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -8776,38 +7053,31 @@ An access token is a text string, which can be used as a password for very simpl
 <context>
     <name>VersionCheck</name>
     <message>
-        <location filename="VersionCheck.cpp" line="+132"/>
         <source>Upgrade Mumble</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>A new version of Mumble has been detected and automatically downloaded. It is recommended that you either upgrade to this version, or downgrade to the latest stable release. Do you want to launch the installer now?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Failed to launch snapshot installer.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Corrupt download of new version detected. Automatically removed.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Downloading new snapshot from %1 to %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Failed to write new version to disk.</source>
         <oldsource>Failed to write new version to disc.</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Mumble failed to retrieve version information from the central server.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -8815,112 +7085,86 @@ An access token is a text string, which can be used as a password for very simpl
 <context>
     <name>ViewCert</name>
     <message>
-        <location filename="ViewCert.cpp" line="+63"/>
         <source>Certificate Chain Details</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Certificate chain</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Certificate details</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+36"/>
-        <location line="+40"/>
         <source>Common Name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-39"/>
-        <location line="+40"/>
         <source>Organization</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-39"/>
         <source>Subunit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+40"/>
         <source>Country</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-39"/>
-        <location line="+40"/>
         <source>Locality</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-39"/>
-        <location line="+40"/>
         <source>State</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-39"/>
         <source>Valid from: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Valid to: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Serial: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Public Key: %1 bits %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>RSA</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>DSA</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Digest (SHA-1): %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Digest (SHA-256): %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Email: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>DNS: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Issued by:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Unit Name</source>
         <translation type="unfinished"></translation>
     </message>
@@ -8928,32 +7172,26 @@ An access token is a text string, which can be used as a password for very simpl
 <context>
     <name>VoiceRecorder</name>
     <message>
-        <location filename="VoiceRecorder.cpp" line="+264"/>
         <source>Recorder failed to create directory &apos;%1&apos;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Recorder failed to open file &apos;%1&apos;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+166"/>
         <source>.wav - Uncompressed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>.ogg (Vorbis) - Compressed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>.au - Uncompressed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>.flac - Lossless compressed</source>
         <translation type="unfinished"></translation>
     </message>
@@ -8961,139 +7199,107 @@ An access token is a text string, which can be used as a password for very simpl
 <context>
     <name>VoiceRecorderDialog</name>
     <message>
-        <location filename="VoiceRecorderDialog.ui"/>
-        <location filename="VoiceRecorderDialog.cpp" line="+112"/>
-        <location line="+8"/>
-        <location line="+10"/>
-        <location line="+9"/>
-        <location line="+141"/>
         <source>Recorder</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Control</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>00:00:00</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>&amp;Start</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
-        <location filename="VoiceRecorderDialog.cpp" line="-21"/>
         <source>S&amp;top</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Multichannel</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Output</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Output format</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Target directory</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Filename</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>&amp;Browse...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="VoiceRecorderDialog.cpp" line="-210"/>
         <source>Valid variables are:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Inserts the user&apos;s name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Inserts the current date</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Inserts the current time</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Inserts the hostname</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Recorder still running</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Closing the recorder without stopping it will discard unwritten audio. Do you really want to close the recorder?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+33"/>
         <source>Unable to start recording. Not connected to a server.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>The server you are currently connected to is version 1.2.2 or older. For privacy reasons, recording on servers of versions older than 1.2.3 is not possible.
 Please contact your server administrator for further information.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>There is already a recorder active for this server.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Please select a recording format.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+73"/>
         <source>Stopping</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Select target directory</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="VoiceRecorderDialog.ui"/>
         <source>Downmix</source>
         <translation type="unfinished"></translation>
     </message>
@@ -9101,7 +7307,6 @@ Please contact your server administrator for further information.</source>
 <context>
     <name>WASAPIInput</name>
     <message>
-        <location filename="WASAPI.cpp" line="+462"/>
         <source>Access to the microphone was denied. Please check that your operating system&apos;s microphone settings allow Mumble to use the microphone.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -9109,7 +7314,6 @@ Please contact your server administrator for further information.</source>
 <context>
     <name>WASAPISystem</name>
     <message>
-        <location line="-219"/>
         <source>Default Device</source>
         <translation type="unfinished"></translation>
     </message>
@@ -9117,12 +7321,10 @@ Please contact your server administrator for further information.</source>
 <context>
     <name>qwPTTButtonWidget</name>
     <message>
-        <location filename="PTTButtonWidget.ui"/>
         <source>Mumble PTT</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location/>
         <source>Push to talk</source>
         <translation type="unfinished"></translation>
     </message>


### PR DESCRIPTION
This updates translations and fixes a typo lupdate complained about in main.cpp . The funny churn in mumble_en.ts comes from alphabetical ordering changes due to some words no longer being capitalized.

As discussed we also drop the location lines for source files. They produce a lot of churn in our diffs for translation updates and in the PRs from transifex and there seems to be no real gain to keeping them (can always grep for the source string).