### PR TITLE
Try to fix channel limit override by subchan delete

### DIFF
--- a/src/murmur/Server.cpp
+++ b/src/murmur/Server.cpp
@@ -1626,7 +1626,7 @@ void Server::removeChannel(Channel *chan, Channel *dest) {
 		}
 
 		Channel *target = dest;
-		while (target->cParent && ! hasPermission(static_cast<ServerUser *>(p), target, ChanACL::Enter))
+		while (target->cParent && (! hasPermission(static_cast<ServerUser *>(p), target, ChanACL::Enter) || isChannelFull(target, static_cast<ServerUser *>(p))))
 			target = target->cParent;
 
 		MumbleProto::UserState mpus;


### PR DESCRIPTION
Try to remove the ability to join a full channel by
creating a sub channel, then joining it
and removing it (discovered by @Natenom).

Check `isChannelFull` in addition to existing
`hasPermissions` `ChanACL::Enter` check.