### PR TITLE
fix build without Opus

### DIFF
--- a/src/mumble/Audio.cpp
+++ b/src/mumble/Audio.cpp
@@ -8,7 +8,9 @@
 #include "AudioInput.h"
 #include "AudioOutput.h"
 #include "CELTCodec.h"
-#include "OpusCodec.h"
+#ifdef USE_OPUS
+# include "OpusCodec.h"
+#endif
 #include "Global.h"
 #include "PacketDataStream.h"
 

--- a/src/mumble/AudioInput.cpp
+++ b/src/mumble/AudioInput.cpp
@@ -7,7 +7,9 @@
 
 #include "AudioOutput.h"
 #include "CELTCodec.h"
-#include "OpusCodec.h"
+#ifdef USE_OPUS
+# include "OpusCodec.h"
+#endif
 #include "ServerHandler.h"
 #include "MainWindow.h"
 #include "User.h"

--- a/src/mumble/AudioOutputSpeech.cpp
+++ b/src/mumble/AudioOutputSpeech.cpp
@@ -17,7 +17,9 @@
 
 #include "Audio.h"
 #include "CELTCodec.h"
-#include "OpusCodec.h"
+#ifdef USE_OPUS
+# include "OpusCodec.h"
+#endif
 #include "ClientUser.h"
 #include "Global.h"
 #include "PacketDataStream.h"

--- a/src/mumble/MainWindow.cpp
+++ b/src/mumble/MainWindow.cpp
@@ -13,7 +13,9 @@
 #include "AudioWizard.h"
 #include "BanEditor.h"
 #include "CELTCodec.h"
-#include "OpusCodec.h"
+#ifdef USE_OPUS
+# include "OpusCodec.h"
+#endif
 #include "Cert.h"
 #include "Channel.h"
 #include "Connection.h"

--- a/src/mumble/mumble.pro
+++ b/src/mumble/mumble.pro
@@ -86,7 +86,6 @@ HEADERS *= BanEditor.h \
     AudioOutputSpeech.h \
     AudioOutputUser.h \
     CELTCodec.h \
-    OpusCodec.h \
     CustomElements.h \
     MainWindow.h \
     ServerHandler.h \
@@ -158,7 +157,6 @@ SOURCES *= BanEditor.cpp \
     AudioOutputUser.cpp \
     main.cpp \
     CELTCodec.cpp \
-    OpusCodec.cpp \
     CustomElements.cpp \
     MainWindow.cpp \
     ServerHandler.cpp \
@@ -359,6 +357,8 @@ CONFIG(no-vorbis-recording) {
 unix:!CONFIG(bundled-opus):system($$PKG_CONFIG --exists opus) {
   must_pkgconfig(opus)
   DEFINES *= USE_OPUS
+  HEADERS *= OpusCodec.h
+  SOURCES *= OpusCodec.cpp
 } else {
   !CONFIG(no-opus) {
     CONFIG *= opus
@@ -367,6 +367,8 @@ unix:!CONFIG(bundled-opus):system($$PKG_CONFIG --exists opus) {
   CONFIG(opus) {
     INCLUDEPATH *= ../../3rdparty/opus-src/celt ../../3rdparty/opus-src/include ../../3rdparty/opus-src/src ../../3rdparty/opus-build/src
     DEFINES *= USE_OPUS
+    HEADERS *= OpusCodec.h
+    SOURCES *= OpusCodec.cpp
     unix {
       QMAKE_CFLAGS *= "-I../../3rdparty/opus-src/celt" "-isystem  ../../3rdparty/opus-src/celt"
       QMAKE_CFLAGS *= "-I../../3rdparty/opus-src/include" "-isystem ../../3rdparty/opus-src/include"


### PR DESCRIPTION
Adds few missing checks where Opus is included even if not building with it and also modifies the qmake project file to not always build OpusCodec.

Build tested with Linux and MXE, latter runtime tested on Windows.