### PR TITLE
Disable winhooks if screen reader is active

### DIFF
--- a/src/mumble/GlobalShortcut_win.h
+++ b/src/mumble/GlobalShortcut_win.h
@@ -129,6 +129,9 @@ class GlobalShortcutWin : public GlobalShortcutEngine {
 		/// @return      Returns true if the GlobalShortcut engine signalled that
 		///              the button should be suppressed. Returns false otherwise.
 		bool injectMouseMessage(MSG *msg);
+
+	private:
+		bool areScreenReadersActive();
 };
 
 uint qHash(const GUID &);


### PR DESCRIPTION
This PR adds a detection mechanism that, while primitive, prevents windows hooking when a screen reader is found to be running when Mumble is executed. This is accomplished by enumerating the process list and checking for a (currently hardcoded) set of (only two right now) screen reader binaries. I know that NVDA (denoted by image name nvda.exe) is affected when Mumble loads winhooks, but I don't know if JAWS (denoted with image name jfw.exe) is. Rather than add every screen reader I know of to this list, I feel it might be better to just add them when we come across them.
Note: I have not built this code yet. I am working on automating the build process since I am unable to do it on my local machine at this time, so expect errors. (I tried not to make any, but you know...) Also, I did my best to mantain formatting, though it wasn't easy. :)