### PR TITLE
Shutdown and drain gRPC completion queue on exit

### DIFF
--- a/src/murmur/MurmurGRPCImpl.cpp
+++ b/src/murmur/MurmurGRPCImpl.cpp
@@ -18,6 +18,8 @@
 #include "Channel.h"
 #include "Utils.h"
 
+#include <chrono>
+
 #include <QtCore/QStack>
 
 #include "MurmurRPC.proto.Wrapper.cpp"
@@ -138,10 +140,18 @@ MurmurRPCImpl::MurmurRPCImpl(const QString &address, std::shared_ptr<::grpc::Ser
 	m_completionQueue = builder.AddCompletionQueue();
 	m_server = builder.BuildAndStart();
 	meta->connectListener(this);
+	b_IsRunning = true;
 	start();
 }
 
 MurmurRPCImpl::~MurmurRPCImpl() {
+	void *ignored_tag;
+	bool ignored_ok;
+	b_IsRunning = false;
+	m_server->Shutdown(std::chrono::system_clock::now());
+	m_completionQueue->Shutdown();
+	while (m_completionQueue->Next(&ignored_tag, &ignored_ok))
+		;
 }
 
 // ToRPC/FromRPC methods convert data to/from grpc protocol buffer messages.
@@ -1101,7 +1111,7 @@ void MurmurRPCImpl::customEvent(QEvent *evt) {
 void MurmurRPCImpl::run() {
 	MurmurRPC::Wrapper::V1_Init(this, &m_V1Service);
 
-	while (true) {
+	while (b_IsRunning) {
 		void *tag;
 		bool ok;
 		if (!m_completionQueue->Next(&tag, &ok)) {

--- a/src/murmur/MurmurGRPCImpl.cpp
+++ b/src/murmur/MurmurGRPCImpl.cpp
@@ -140,18 +140,22 @@ MurmurRPCImpl::MurmurRPCImpl(const QString &address, std::shared_ptr<::grpc::Ser
 	m_completionQueue = builder.AddCompletionQueue();
 	m_server = builder.BuildAndStart();
 	meta->connectListener(this);
-	b_IsRunning = true;
+	m_isRunning = true;
 	start();
 }
 
 MurmurRPCImpl::~MurmurRPCImpl() {
 	void *ignored_tag;
 	bool ignored_ok;
-	b_IsRunning = false;
+	m_isRunning = false;
 	m_server->Shutdown(std::chrono::system_clock::now());
 	m_completionQueue->Shutdown();
-	while (m_completionQueue->Next(&ignored_tag, &ignored_ok))
-		;
+	while (m_completionQueue->Next(&ignored_tag, &ignored_ok)) {
+		if (ignored_tag) {
+			auto op = static_cast<boost::function<void(bool)> *>(ignored_tag);
+			delete op;
+		}
+	}
 }
 
 // ToRPC/FromRPC methods convert data to/from grpc protocol buffer messages.
@@ -1111,7 +1115,7 @@ void MurmurRPCImpl::customEvent(QEvent *evt) {
 void MurmurRPCImpl::run() {
 	MurmurRPC::Wrapper::V1_Init(this, &m_V1Service);
 
-	while (b_IsRunning) {
+	while (m_isRunning) {
 		void *tag;
 		bool ok;
 		if (!m_completionQueue->Next(&tag, &ok)) {

--- a/src/murmur/MurmurGRPCImpl.h
+++ b/src/murmur/MurmurGRPCImpl.h
@@ -40,7 +40,7 @@ namespace MurmurRPC {
 class MurmurRPCImpl : public QThread {
 		Q_OBJECT;
 		std::unique_ptr<grpc::Server> m_server;
-		volatile bool b_IsRunning;
+		volatile bool m_isRunning;
 	protected:
 		void customEvent(QEvent *evt);
 	public:

--- a/src/murmur/MurmurGRPCImpl.h
+++ b/src/murmur/MurmurGRPCImpl.h
@@ -40,6 +40,7 @@ namespace MurmurRPC {
 class MurmurRPCImpl : public QThread {
 		Q_OBJECT;
 		std::unique_ptr<grpc::Server> m_server;
+		volatile bool b_IsRunning;
 	protected:
 		void customEvent(QEvent *evt);
 	public:


### PR DESCRIPTION
This prevents a segmentation fault in next() when it tries to call back
to a deleted object when murmur is shut down.