### PR TITLE
Client authentication for gRPC

### DIFF
--- a/scripts/murmur.ini
+++ b/scripts/murmur.ini
@@ -86,8 +86,14 @@ icesecretwrite=
 ;grpc="127.0.0.1:50051"
 ; Specifying both a certificate and key file below will cause gRPC to use
 ; secured, TLS connections.
+; When using secured connections you need to also set the list of authorized
+; clients. grpcauthorized is a space delimited list of SHA256 fingerprints
+; for authorized client certificates.
+; Get this from the command line:
+; openssl x509 -in cert.pem -SHA256 -noout -fingerprint
 ;grpccert=""
 ;grpckey=""
+;grpcauthorized=""
 
 ; How many login attempts do we tolerate from one IP
 ; inside a given timeframe before we ban the connection?

--- a/src/murmur/Meta.cpp
+++ b/src/murmur/Meta.cpp
@@ -303,6 +303,7 @@ void MetaParams::read(QString fname) {
 	qsGRPCAddress = typeCheckedFromSettings("grpc", qsGRPCAddress);
 	qsGRPCCert = typeCheckedFromSettings("grpccert", qsGRPCCert);
 	qsGRPCKey = typeCheckedFromSettings("grpckey", qsGRPCKey);
+	qsGRPCAuthorized = typeCheckedFromSettings("grpcauthorized", qsGRPCAuthorized);
 
 	iLogDays = typeCheckedFromSettings("logdays", iLogDays);
 

--- a/src/murmur/Meta.h
+++ b/src/murmur/Meta.h
@@ -84,6 +84,7 @@ public:
 	QString qsGRPCAddress;
 	QString qsGRPCCert;
 	QString qsGRPCKey;
+	QString qsGRPCAuthorized;
 
 	QString qsRegName;
 	QString qsRegPassword;

--- a/src/murmur/MurmurGRPCImpl.h
+++ b/src/murmur/MurmurGRPCImpl.h
@@ -22,8 +22,10 @@
 #include <atomic>
 
 #include <QMultiHash>
+#include <QSet>
 
 #include <grpc++/grpc++.h>
+#include <grpc++/security/auth_context.h>
 
 class RPCCall;
 
@@ -36,6 +38,15 @@ namespace MurmurRPC {
 		class V1_TextMessageFilter;
 	}
 }
+
+class MurmurRPCAuthenticator : public ::grpc_impl::AuthMetadataProcessor {
+	public:
+		MurmurRPCAuthenticator();
+		grpc::Status Process(const InputMetadata&, ::grpc::AuthContext*, OutputMetadata*, OutputMetadata*);
+		bool IsBlocking() const;
+	protected:
+		QSet<QByteArray> m_gRPCUsers;
+};
 
 class MurmurRPCImpl : public QThread {
 		Q_OBJECT;


### PR DESCRIPTION
This adds client authentication using TLS certificates when it is
enabled in gRPC. This just the basic feature right now. You either have
access or you do not.

Access is granted by putting the certificate digests of the authorized
users into the murmur.ini file. It's a simple configuration for the moment, but the authentication class would be easily able to be extended to have more fine-grained control.

This should solve also feature request #3496. It allows the gRPC port to be safely opened up to the internet as anybody without a valid certificate won't get much past the handshake. It also doesn't interfere with people who are using the unsecured connection types over a loopback device or a UNIX domain socket.

If anybody wants to test this, since I don't think there are many gRPC enabled clients, and I'm unaware of any that support client certificates, you can [my fork of murmur-cli](https://github.com/McKayJT/murmur-cli) that I have added client certificate support to. 