### PR TITLE
Manual plugin UI improvement

### DIFF
--- a/src/mumble/ManualPlugin.cpp
+++ b/src/mumble/ManualPlugin.cpp
@@ -24,6 +24,9 @@ static bool bActive = true;
 static int iAzimuth = 0;
 static int iElevation = 0;
 
+static const QString defaultContext = QString::fromLatin1("Mumble");
+static const QString defaultIdentity = QString::fromLatin1("Agent47");
+
 static struct {
 	float avatar_pos[3];
 	float avatar_front[3];
@@ -72,6 +75,14 @@ Manual::Manual(QWidget *p) : QDialog(p) {
 	qsbAzimuth->setValue(iAzimuth);
 	qsbElevation->setValue(iElevation);
 	updateTopAndFront(iAzimuth, iElevation);
+
+	// Set context and identity to default values in order to
+	// a) make positional audio work out of the box (needs a context)
+	// b) make the user aware of what each field might contain
+	qleContext->setText(defaultContext);
+	qleIdentity->setText(defaultIdentity);
+	my.context = defaultContext.toStdString();
+	my.identity = defaultIdentity.toStdWString();
 }
 
 bool Manual::eventFilter(QObject *obj, QEvent *evt) {

--- a/src/mumble/ManualPlugin.cpp
+++ b/src/mumble/ManualPlugin.cpp
@@ -44,7 +44,16 @@ Manual::Manual(QWidget *p) : QDialog(p) {
 	qgvPosition->viewport()->installEventFilter(this);
 	qgvPosition->scale(1.0f, 1.0f);
 	qgsScene = new QGraphicsScene(QRectF(-5.0f, -5.0f, 10.0f, 10.0f), this);
-	qgiPosition = qgsScene->addEllipse(QRectF(-0.5f, -0.5f, 1.0f, 1.0f), QApplication::palette().text().color(), QBrush(Qt::red));
+
+	const float indicatorDiameter = 4.0f;
+	QPainterPath indicator;
+	// The center of the indicator's circle will represent the current position
+	indicator.addEllipse(QRectF(-indicatorDiameter / 2, -indicatorDiameter / 2, indicatorDiameter, indicatorDiameter));
+	// A line will indicate the indicator's orientation (azimuth)
+	indicator.moveTo(0, indicatorDiameter / 2);
+	indicator.lineTo(0,  indicatorDiameter);
+
+	qgiPosition = qgsScene->addPath(indicator);
 
 	qgvPosition->setScene(qgsScene);
 	qgvPosition->fitInView(-5.0f, -5.0f, 10.0f, 10.0f, Qt::KeepAspectRatio);
@@ -180,6 +189,8 @@ void Manual::on_buttonBox_clicked(QAbstractButton *button) {
 void Manual::updateTopAndFront(int azimuth, int elevation) {
 	iAzimuth = azimuth;
 	iElevation = elevation;
+
+	qgiPosition->setRotation(azimuth);
 
 	double azim = azimuth * M_PI / 180.;
 	double elev = elevation * M_PI / 180.;

--- a/src/mumble/ManualPlugin.cpp
+++ b/src/mumble/ManualPlugin.cpp
@@ -129,8 +129,8 @@ void Manual::on_qdsbZ_valueChanged(double d) {
 }
 
 void Manual::on_qsbAzimuth_valueChanged(int i) {
-	if (i > 180)
-		qdAzimuth->setValue(-360 + i);
+	if (i > 360)
+		qdAzimuth->setValue(i % 360);
 	else
 		qdAzimuth->setValue(i);
 

--- a/src/mumble/ManualPlugin.cpp
+++ b/src/mumble/ManualPlugin.cpp
@@ -21,7 +21,7 @@ static QPointer<Manual> mDlg = NULL;
 static bool bLinkable = false;
 static bool bActive = true;
 
-static int iAzimuth = 0;
+static int iAzimuth = 180;
 static int iElevation = 0;
 
 static const QString defaultContext = QString::fromLatin1("Mumble");

--- a/src/mumble/ManualPlugin.ui
+++ b/src/mumble/ManualPlugin.ui
@@ -65,6 +65,9 @@
             <height>100.000000000000000</height>
            </rectf>
           </property>
+          <property name="renderHints">
+           <set>QPainter::Antialiasing|QPainter::TextAntialiasing</set>
+          </property>
          </widget>
         </item>
         <item>

--- a/src/mumble/ManualPlugin.ui
+++ b/src/mumble/ManualPlugin.ui
@@ -317,24 +317,14 @@
          <property name="title">
           <string>State</string>
          </property>
-         <layout class="QHBoxLayout" name="horizontalLayout">
-          <item>
-           <widget class="QPushButton" name="qpbLinked">
-            <property name="text">
-             <string>Linked</string>
-            </property>
-            <property name="checkable">
+         <layout class="QGridLayout" name="gridLayout_4">
+          <item row="0" column="0">
+           <widget class="QCheckBox" name="qpbLinked">
+            <property name="enabled">
              <bool>true</bool>
             </property>
-            <property name="checked">
-             <bool>true</bool>
-            </property>
-           </widget>
-          </item>
-          <item>
-           <widget class="QPushButton" name="qpbActivated">
             <property name="text">
-             <string>Activated</string>
+             <string>Link</string>
             </property>
             <property name="checkable">
              <bool>true</bool>
@@ -344,14 +334,27 @@
             </property>
            </widget>
           </item>
-          <item>
-           <widget class="QPushButton" name="qpbUnhinge">
+          <item row="0" column="1">
+           <widget class="QCheckBox" name="qpbActivated">
             <property name="text">
-             <string>Unhinge</string>
+             <string>Activate</string>
+            </property>
+            <property name="checkable">
+             <bool>true</bool>
+            </property>
+            <property name="checked">
+             <bool>false</bool>
             </property>
            </widget>
           </item>
          </layout>
+        </widget>
+       </item>
+       <item>
+        <widget class="QPushButton" name="qpbUnhinge">
+         <property name="text">
+          <string>Unhinge</string>
+         </property>
         </widget>
        </item>
       </layout>
@@ -365,6 +368,9 @@
      </property>
      <property name="standardButtons">
       <set>QDialogButtonBox::Close|QDialogButtonBox::Reset</set>
+     </property>
+     <property name="centerButtons">
+      <bool>false</bool>
      </property>
     </widget>
    </item>

--- a/src/mumble/ManualPlugin.ui
+++ b/src/mumble/ManualPlugin.ui
@@ -145,6 +145,16 @@
           <string>Heading</string>
          </property>
          <layout class="QGridLayout" name="gridLayout">
+          <item row="2" column="0">
+           <widget class="QSpinBox" name="qsbAzimuth">
+            <property name="suffix">
+             <string>°</string>
+            </property>
+            <property name="maximum">
+             <number>360</number>
+            </property>
+           </widget>
+          </item>
           <item row="0" column="0">
            <widget class="QLabel" name="qlAzimuth">
             <property name="sizePolicy">
@@ -155,44 +165,6 @@
             </property>
             <property name="text">
              <string>Azimuth</string>
-            </property>
-            <property name="alignment">
-             <set>Qt::AlignCenter</set>
-            </property>
-           </widget>
-          </item>
-          <item row="1" column="0">
-           <widget class="QDial" name="qdAzimuth">
-            <property name="minimum">
-             <number>-180</number>
-            </property>
-            <property name="maximum">
-             <number>180</number>
-            </property>
-            <property name="pageStep">
-             <number>30</number>
-            </property>
-            <property name="wrapping">
-             <bool>true</bool>
-            </property>
-            <property name="notchTarget">
-             <double>6.000000000000000</double>
-            </property>
-            <property name="notchesVisible">
-             <bool>true</bool>
-            </property>
-           </widget>
-          </item>
-          <item row="0" column="1">
-           <widget class="QLabel" name="qlElevation">
-            <property name="sizePolicy">
-             <sizepolicy hsizetype="Preferred" vsizetype="Minimum">
-              <horstretch>0</horstretch>
-              <verstretch>0</verstretch>
-             </sizepolicy>
-            </property>
-            <property name="text">
-             <string>Elevation</string>
             </property>
             <property name="alignment">
              <set>Qt::AlignCenter</set>
@@ -227,16 +199,6 @@
             </property>
            </widget>
           </item>
-          <item row="2" column="0">
-           <widget class="QSpinBox" name="qsbAzimuth">
-            <property name="suffix">
-             <string>°</string>
-            </property>
-            <property name="maximum">
-             <number>360</number>
-            </property>
-           </widget>
-          </item>
           <item row="2" column="1">
            <widget class="QSpinBox" name="qsbElevation">
             <property name="suffix">
@@ -247,6 +209,44 @@
             </property>
             <property name="maximum">
              <number>90</number>
+            </property>
+           </widget>
+          </item>
+          <item row="0" column="1">
+           <widget class="QLabel" name="qlElevation">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Preferred" vsizetype="Minimum">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+            <property name="text">
+             <string>Elevation</string>
+            </property>
+            <property name="alignment">
+             <set>Qt::AlignCenter</set>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="0">
+           <widget class="QDial" name="qdAzimuth">
+            <property name="minimum">
+             <number>0</number>
+            </property>
+            <property name="maximum">
+             <number>360</number>
+            </property>
+            <property name="pageStep">
+             <number>30</number>
+            </property>
+            <property name="wrapping">
+             <bool>true</bool>
+            </property>
+            <property name="notchTarget">
+             <double>6.000000000000000</double>
+            </property>
+            <property name="notchesVisible">
+             <bool>true</bool>
             </property>
            </widget>
           </item>

--- a/src/mumble/mumble_en.ts
+++ b/src/mumble/mumble_en.ts
@@ -5543,15 +5543,15 @@ the channel&apos;s context menu.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Linked</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Activated</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Unhinge</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Link</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Activate</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -6335,7 +6335,7 @@ To upgrade these files to their latest versions, click the button below.</source
 <context>
     <name>PortAudioSystem</name>
     <message>
-        <source>Default Device</source>
+        <source>Default device</source>
         <translation type="unfinished"></translation>
     </message>
 </context>


### PR DESCRIPTION
I think the current UI of the manual placement plugin is a bit cumbersome and confusing. Thus I tweaked it to what I would consider a better UI.

The improvements I think I made are:  
1. The linked and activated status can now actually be seen (for some reason Qt ignored the checked-state of PushButtons at least on my PC making it impossible to see in the UI, whether the plugin is currently set to link or not)  
2. The unhinge-button is moved out of the state-category. As this button does not describe a state, it shouldn't be in there
3. The position view now has antialiasing enabled
4. The position indicator is bigger (now it doesn't look like some defect pixels on my screen)
5. The position indicator now also reflects the set azimuth

Here's how it is currently looking:
![Mumble_ManualPlugin_Old](https://user-images.githubusercontent.com/12751591/71324962-d6518980-24e5-11ea-8677-980462e5b987.png)

And this is with my proposed tweaks:
![Mumble_ManualPlugin_New](https://user-images.githubusercontent.com/12751591/71324969-fb45fc80-24e5-11ea-9251-88db1c271aaa.png)