### PR TITLE
Fix Xi conflict that appears when MOC files are generated and included by CMake

### DIFF
--- a/src/mumble/GlobalShortcut_unix.cpp
+++ b/src/mumble/GlobalShortcut_unix.cpp
@@ -10,7 +10,20 @@
 #include <QtCore/QFileSystemWatcher>
 #include <QtCore/QSocketNotifier>
 
-// We define a global macro called 'g'. This can lead to issues when included code uses 'g' as a type or parameter name (like protobuf 3.7 does). As such, for now, we have to make this our last include.
+#include <X11/Xlib.h>
+#include <X11/Xutil.h>
+
+#ifndef NO_XINPUT2
+# include <X11/extensions/XI2.h>
+# include <X11/extensions/XInput2.h>
+#endif
+
+#ifdef Q_OS_LINUX
+# include <linux/input.h>
+# include <fcntl.h>
+#endif
+
+// We define a global macro called 'g'. This can lead to issues when included code uses 'g' as a type or parameter name (like protobuf 3.7 does). As such, for now, we have to make this our last incl
 #include "Global.h"
 
 // We have to use a global 'diagnostic ignored' pragmas because

--- a/src/mumble/GlobalShortcut_unix.h
+++ b/src/mumble/GlobalShortcut_unix.h
@@ -11,18 +11,11 @@
 #include "Global.h"
 
 #include <X11/X.h>
-#include <X11/Xlib.h>
-#ifndef NO_XINPUT2
-#include <X11/extensions/XI2.h>
-#include <X11/extensions/XInput2.h>
-#endif
-#include <X11/Xutil.h>
-#ifdef Q_OS_LINUX
-#include <linux/input.h>
-#include <fcntl.h>
-#endif
 
 #define NUM_BUTTONS 0x2ff
+
+struct _XDisplay;
+typedef _XDisplay Display;
 
 class GlobalShortcutX : public GlobalShortcutEngine {
 	private:


### PR DESCRIPTION
Xi causes a conflict in the compiled MOC files when they are generated by CMake, because it defines a type called `Bool`:

```
In file included from mumble/build/src/mumble/mumble_autogen/EWIEGA46WW/../../../../../src/mumble/GlobalShortcut_unix.h:14,
                 from mumble/build/src/mumble/mumble_autogen/EWIEGA46WW/moc_GlobalShortcut_unix.cpp:9,
                 from mumble/build/src/mumble/mumble_autogen/mocs_compilation.cpp:26:
mumble/build/src/mumble/mumble_autogen/EWIEGA46WW/moc_Log.cpp:191:89: error: expected unqualified-id before ‘int’
  191 |     QMetaType::Void, 0x80000000 | 3, QMetaType::QString, QMetaType::QString, QMetaType::Bool, QMetaType::QString,    4,    5,    6,    7,    8,
      |                                                                                         ^~~~
mumble/build/src/mumble/mumble_autogen/EWIEGA46WW/moc_Log.cpp:191:89: error: expected ‘}’ before ‘int’
In file included from mumble/build/src/mumble/mumble_autogen/mocs_compilation.cpp:29:
mumble/build/src/mumble/mumble_autogen/EWIEGA46WW/moc_Log.cpp:171:40: note: to match this ‘{’
  171 | static const uint qt_meta_data_Log[] = {
      |                                        ^
mumble/build/src/mumble/mumble_autogen/EWIEGA46WW/moc_Log.cpp:197:1: error: expected declaration before ‘}’ token
  197 | };
      | ^
```

The conflict appears in all `moc_*` files, but I truncated the output because it was very long (the message is repeated for each file).

I didn't investigate why it doesn't happen with qmake (it's probably due to the way MOC files are included), however including less headers in an header file is an improvement anyway.