### PR TITLE
Improve channel password handling

### DIFF
--- a/src/ACL.cpp
+++ b/src/ACL.cpp
@@ -238,3 +238,18 @@ QString ChanACL::permName(Perm p) {
 	}
 	return QString();
 }
+
+bool ChanACL::isPassword() const {
+	// A password is an ACL that applies to a group of the form '#<something>'
+	// AND grants 'Enter'
+	// AND grants 'Speak', 'Whisper', 'TextMessage', 'LinkChannel' and potentially Traverse but NOTHING else
+	// AND does not deny anything.
+	// Furthermore the ACL must apply directly to the channel and may not be inherited.
+	return this->qsGroup.startsWith(QLatin1Char('#'))
+		&& this->bApplyHere
+		&& !this->bInherited
+		&& (this->pAllow & ChanACL::Enter)
+		&& (this->pAllow == (ChanACL::Enter | ChanACL::Speak | ChanACL::Whisper | ChanACL::TextMessage | ChanACL::LinkChannel) || // Backwards compat with old behaviour that didn't deny traverse
+			this->pAllow == (ChanACL::Enter | ChanACL::Speak | ChanACL::Whisper | ChanACL::TextMessage | ChanACL::LinkChannel | ChanACL::Traverse))
+		&& this->pDeny == ChanACL::None;
+}

--- a/src/ACL.h
+++ b/src/ACL.h
@@ -59,6 +59,10 @@ class ChanACL : public QObject {
 		Permissions pDeny;
 
 		ChanACL(Channel *c);
+
+		/// @returns Whether the given ChanACL represents a password. 
+		bool isPassword() const;
+
 #ifdef MURMUR
 		static bool hasPermission(ServerUser *p, Channel *c, QFlags<Perm> perm, ACLCache *cache);
 		static QFlags<Perm> effectivePermissions(ServerUser *p, Channel *c, ACLCache *cache);

--- a/src/Channel.cpp
+++ b/src/Channel.cpp
@@ -28,6 +28,9 @@ Channel::Channel(int id, const QString &name, QObject *p) : QObject(p) {
 #ifdef MUMBLE
 	uiPermissions = 0;
 	bFiltered = false;
+
+	hasEnterRestrictions.store(false);
+	localUserCanEnter.store(true);
 #endif
 }
 

--- a/src/Channel.h
+++ b/src/Channel.h
@@ -13,6 +13,10 @@
 #include <QtCore/QSet>
 #include <QtCore/QString>
 
+#ifdef MUMBLE
+	#include <atomic>
+#endif
+
 class User;
 class Group;
 class ChanACL;
@@ -37,6 +41,16 @@ class Channel : public QObject {
 		QList<User *> qlUsers;
 		QHash<QString, Group *> qhGroups;
 		QList<ChanACL *> qlACL;
+
+#ifdef MUMBLE
+		/// A flag indicating whether this channel has enter restrictions (ACL denying ENTER) in place
+		std::atomic<bool> hasEnterRestrictions;
+		/// A flag indicating whether the local user is currently able to enter this channel. In theory this should
+		/// represent the correct access state (apart from the time it takes to synchronize ACL changes from the server
+		/// to the client), but in the end, it's the server who decides whether the user can enter. This flag is only
+		/// meant for UI purposes and should not be used influence actual behaviour.
+		std::atomic<bool> localUserCanEnter;
+#endif
 
 		QSet<Channel *> qsPermLinks;
 		QHash<Channel *, int> qhLinks;

--- a/src/Mumble.proto
+++ b/src/Mumble.proto
@@ -146,6 +146,10 @@ message ChannelState {
 	// the maximum number of users allowed in the channel is given by the
 	// server's "usersperchannel" setting.
 	optional uint32 max_users = 11;
+	// Whether this channel has enter restrictions (ACL denying ENTER) set
+	optional bool is_enter_restricted = 12;
+	// Whether the receiver of this msg is considered to be able to enter this channel
+	optional bool can_enter = 13;
 }
 
 // Used to communicate user leaving or being kicked. May be sent by the client

--- a/src/mumble/ACLEditor.cpp
+++ b/src/mumble/ACLEditor.cpp
@@ -649,17 +649,10 @@ void ACLEditor::on_qtwTab_currentChanged(int index) {
 }
 
 void ACLEditor::updatePasswordField() {
+	// Search for an ACL that represents the current password
 	pcaPassword = NULL;
 	foreach(ChanACL *acl, qlACLs) {
-		// Check for sth that applies to '#<something>' AND grants 'Enter' AND may grant 'Speak', 'Whisper',
-		// 'TextMessage', 'Link' but NOTHING else AND does not deny anything, then '<something>' is the password.
-		if (acl->qsGroup.startsWith(QLatin1Char('#')) &&
-		        acl->bApplyHere &&
-		        !acl->bInherited &&
-		        (acl->pAllow & ChanACL::Enter) &&
-		        (acl->pAllow == (ChanACL::Enter | ChanACL::Speak | ChanACL::Whisper | ChanACL::TextMessage | ChanACL::LinkChannel) || // Backwards compat with old behaviour that didn't deny traverse
-		         acl->pAllow == (ChanACL::Enter | ChanACL::Speak | ChanACL::Whisper | ChanACL::TextMessage | ChanACL::LinkChannel | ChanACL::Traverse)) &&
-		        acl->pDeny == ChanACL::None) {
+		if (acl->isPassword()) {
 			pcaPassword = acl;
 		}
 	}

--- a/src/mumble/Messages.cpp
+++ b/src/mumble/Messages.cpp
@@ -214,11 +214,17 @@ void MainWindow::msgPermissionDenied(const MumbleProto::PermissionDenied &msg) {
 				Channel *c = Channel::get(msg.channel_id());
 				if (! c)
 					return;
-				QString pname = ChanACL::permName(static_cast<ChanACL::Permissions>(msg.permission()));
-				if (pDst == pSelf)
-					g.l->log(Log::PermissionDenied, tr("You were denied %1 privileges in %2.").arg(Log::msgColor(pname, Log::Privilege)).arg(Log::formatChannel(c)));
-				else
-					g.l->log(Log::PermissionDenied, tr("%3 was denied %1 privileges in %2.").arg(Log::msgColor(pname, Log::Privilege)).arg(Log::formatChannel(c)).arg(Log::formatClientUser(pDst, Log::Target)));
+				ChanACL::Permissions permission = static_cast<ChanACL::Permissions>(msg.permission());
+				QString pname = ChanACL::permName(permission);
+
+				if ((permission == ChanACL::Perm::Enter) && c->hasEnterRestrictions.load()) {
+					g.l->log(Log::PermissionDenied, tr("Unable to %1 into %2 - Adding the respective access (password) token might grant you access.").arg(Log::msgColor(pname, Log::Privilege)).arg(Log::formatChannel(c)));
+				} else {
+					if (pDst == pSelf)
+						g.l->log(Log::PermissionDenied, tr("You were denied %1 privileges in %2.").arg(Log::msgColor(pname, Log::Privilege)).arg(Log::formatChannel(c)));
+					else
+						g.l->log(Log::PermissionDenied, tr("%3 was denied %1 privileges in %2.").arg(Log::msgColor(pname, Log::Privilege)).arg(Log::formatChannel(c)).arg(Log::formatClientUser(pDst, Log::Target)));
+				}
 			}
 			break;
 		case MumbleProto::PermissionDenied_DenyType_SuperUser: {

--- a/src/mumble/Messages.cpp
+++ b/src/mumble/Messages.cpp
@@ -736,6 +736,24 @@ void MainWindow::msgChannelState(const MumbleProto::ChannelState &msg) {
 	if (msg.has_max_users()) {
 		c->uiMaxUsers = msg.max_users();
 	}
+
+	bool updateUI = false;
+
+	if (msg.has_is_enter_restricted()) {
+		c->hasEnterRestrictions.store(msg.is_enter_restricted());
+		updateUI = true;
+	}
+
+	if (msg.has_can_enter()) {
+		c->localUserCanEnter.store(msg.can_enter());
+		updateUI = true;
+	}
+
+	if (updateUI) {
+		// Passing nullptr to this function will make it do not much except fire a dataChanged event
+		// which leads to the UI being updated (reflecting the changes that just took effect).
+		this->pmModel->toggleChannelFiltered(nullptr);
+	}
 }
 
 void MainWindow::msgChannelRemove(const MumbleProto::ChannelRemove &msg) {

--- a/src/mumble/UserModel.cpp
+++ b/src/mumble/UserModel.cpp
@@ -218,6 +218,8 @@ UserModel::UserModel(QObject *p) : QAbstractItemModel(p) {
 	qiComment=QIcon(QLatin1String("skin:comment.svg"));
 	qiCommentSeen=QIcon(QLatin1String("skin:comment_seen.svg"));
 	qiFilter=QIcon(QLatin1String("skin:filter.svg"));
+	qiLock_locked=QIcon(QLatin1String("skin:lock_locked.svg"));
+	qiLock_unlocked=QIcon(QLatin1String("skin:lock_unlocked.svg"));
 
 	ModelItem::bUsersTop = g.s.bUserTop;
 
@@ -443,6 +445,14 @@ QVariant UserModel::data(const QModelIndex &idx, int role) const {
 				if (c->bFiltered)
 					l << (qiFilter);
 
+				// Show a lock icon for enter restricted channels
+				if (c->hasEnterRestrictions.load()) {
+					if (c->localUserCanEnter.load()) {
+						l << qiLock_unlocked;
+					} else {
+						l << qiLock_locked;
+					}
+				}
 				return l;
 			case Qt::FontRole:
 				if (g.uiSession) {

--- a/src/mumble/UserModel.h
+++ b/src/mumble/UserModel.h
@@ -72,6 +72,7 @@ class UserModel : public QAbstractItemModel {
 		QIcon qiAuthenticated, qiChannel, qiLinkedChannel, qiActiveChannel;
 		QIcon qiFriend;
 		QIcon qiComment, qiCommentSeen, qiFilter;
+		QIcon qiLock_locked, qiLock_unlocked;
 		ModelItem *miRoot;
 		QSet<Channel *> qsLinked;
 		QMap<QString, ClientUser *> qmHashes;

--- a/src/murmur/Messages.cpp
+++ b/src/murmur/Messages.cpp
@@ -136,6 +136,21 @@ class TemporaryAccessTokenHelper {
 		}
 };
 
+/// Checks whether the given channel has restrictions affecting the ENTER privilege
+///
+/// @param c A pointer to the Channel that should be checked
+/// @return Whether the provided channel has an ACL denying ENTER
+bool isChannelEnterRestricted(Channel *c) {
+	// A channel is enter restricted if there's an ACL denying enter privileges
+	foreach(ChanACL *acl, c->qlACL) {
+		if (acl->pDeny & ChanACL::Enter) {
+			return true;
+		}
+	}
+
+	return false;
+}
+
 void Server::msgAuthenticate(ServerUser *uSource, MumbleProto::Authenticate &msg) {
 	if ((msg.tokens_size() > 0) || (uSource->sState == ServerUser::Authenticated)) {
 		QStringList qsl;
@@ -146,6 +161,16 @@ void Server::msgAuthenticate(ServerUser *uSource, MumbleProto::Authenticate &msg
 			uSource->qslAccessTokens = qsl;
 		}
 		clearACLCache(uSource);
+
+		// Send back updated enter states of all channels
+		MumbleProto::ChannelState mpcs;
+		foreach(Channel *chan, qhChannels) {
+			mpcs.set_channel_id(chan->iId);
+			mpcs.set_can_enter(ChanACL::hasPermission(uSource, chan, ChanACL::Enter, &acCache));
+			// As no ACLs have changed, we don't need to update the is_access_restricted message field
+
+			sendMessage(uSource, mpcs);
+		}
 	}
 	MSG_SETUP(ServerUser::Connected);
 
@@ -321,6 +346,10 @@ void Server::msgAuthenticate(ServerUser *uSource, MumbleProto::Authenticate &msg
 			mpcs.set_description(u8(c->qsDesc));
 
 		mpcs.set_max_users(c->uiMaxUsers);
+
+		// Include info about enter restrictions of this channel
+		mpcs.set_is_enter_restricted(isChannelEnterRestricted(c));
+		mpcs.set_can_enter(ChanACL::hasPermission(uSource, c, ChanACL::Enter, &acCache));
 
 		sendMessage(uSource, mpcs);
 
@@ -1490,6 +1519,16 @@ void Server::msgACL(ServerUser *uSource, MumbleProto::ACL &msg) {
 
 		updateChannel(c);
 		log(uSource, QString("Updated ACL in channel %1").arg(*c));
+
+		// Send refreshed enter states of this channel to all clients
+		MumbleProto::ChannelState mpcs;
+		mpcs.set_channel_id(c->iId);
+		foreach(ServerUser *user, qhUsers) {
+			mpcs.set_is_enter_restricted(isChannelEnterRestricted(c));
+			mpcs.set_can_enter(ChanACL::hasPermission(user, c, ChanACL::Enter, &acCache));
+
+			sendMessage(uSource, mpcs);
+		}
 	}
 }
 

--- a/themes/Classic/lock_locked.svg
+++ b/themes/Classic/lock_locked.svg
@@ -1,0 +1,171 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+<svg xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://web.resource.org/cc/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:svg="http://www.w3.org/2000/svg" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:sodipodi="http://inkscape.sourceforge.net/DTD/sodipodi-0.dtd" xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape" width="48px" height="48px" id="svg1381" sodipodi:version="0.32" inkscape:version="0.43+devel" sodipodi:docbase="/home/jimmac/src/cvs/tango-icon-theme/scalable/status" sodipodi:docname="locked.svg">
+  <defs id="defs1383">
+    <linearGradient id="linearGradient7613">
+      <stop style="stop-color:#ffffff;stop-opacity:0;" offset="0" id="stop7615"/>
+      <stop style="stop-color:#ffffff;stop-opacity:1;" offset="1" id="stop7617"/>
+    </linearGradient>
+    <linearGradient inkscape:collect="always" id="linearGradient7601">
+      <stop style="stop-color:#ffffff;stop-opacity:1;" offset="0" id="stop7603"/>
+      <stop style="stop-color:#ffffff;stop-opacity:0;" offset="1" id="stop7605"/>
+    </linearGradient>
+    <linearGradient id="linearGradient5820">
+      <stop id="stop6704" offset="0" style="stop-color:#000000;stop-opacity:0;"/>
+      <stop style="stop-color:#000000;stop-opacity:0;" offset="0.60799319" id="stop6706"/>
+      <stop style="stop-color:#000000;stop-opacity:1;" offset="1" id="stop5824"/>
+    </linearGradient>
+    <linearGradient id="linearGradient4135">
+      <stop style="stop-color:#896d00;stop-opacity:1.0000000;" offset="0.0000000" id="stop4137"/>
+      <stop style="stop-color:#a18000;stop-opacity:0;" offset="1" id="stop4139"/>
+    </linearGradient>
+    <linearGradient id="linearGradient3505">
+      <stop style="stop-color:#ffec41;stop-opacity:1.0000000;" offset="0" id="stop3509"/>
+      <stop id="stop3513" offset="1" style="stop-color:#c3af00;stop-opacity:1;"/>
+    </linearGradient>
+    <linearGradient y2="6.0396547" x2="16.198252" y1="9.6635771" x1="19.250618" gradientTransform="translate(0,-1.926279)" gradientUnits="userSpaceOnUse" id="linearGradient1394" xlink:href="#linearGradient11335" inkscape:collect="always"/>
+    <linearGradient y2="17.470011" x2="27.192274" y1="2.9136841" x1="10.650842" gradientTransform="translate(0,-1.926279)" gradientUnits="userSpaceOnUse" id="linearGradient1392" xlink:href="#linearGradient10591" inkscape:collect="always"/>
+    <linearGradient y2="26.024691" x2="27.824219" y1="22.739454" x1="27.812500" gradientTransform="matrix(1.230769,0,0,0.32409,-5.538462,32.89774)" gradientUnits="userSpaceOnUse" id="linearGradient2324" xlink:href="#linearGradient5741" inkscape:collect="always"/>
+    <linearGradient y2="26.024691" x2="27.824219" y1="22.739454" x1="27.812500" gradientTransform="matrix(1.230769,0,0,0.32409,-5.538462,30.89774)" gradientUnits="userSpaceOnUse" id="linearGradient2322" xlink:href="#linearGradient5741" inkscape:collect="always"/>
+    <linearGradient y2="26.024691" x2="27.824219" y1="22.739454" x1="27.812500" gradientTransform="matrix(1.230769,0,0,0.32409,-5.538462,28.89774)" gradientUnits="userSpaceOnUse" id="linearGradient2320" xlink:href="#linearGradient5741" inkscape:collect="always"/>
+    <linearGradient y2="26.024691" x2="27.824219" y1="22.739454" x1="27.812500" gradientTransform="matrix(1.230769,0,0,0.32409,-5.538462,26.89774)" gradientUnits="userSpaceOnUse" id="linearGradient2318" xlink:href="#linearGradient5741" inkscape:collect="always"/>
+    <linearGradient y2="26.024691" x2="27.824219" y1="22.739454" x1="27.812500" gradientTransform="matrix(1.230769,0,0,0.32409,-5.538462,24.89774)" gradientUnits="userSpaceOnUse" id="linearGradient2316" xlink:href="#linearGradient5741" inkscape:collect="always"/>
+    <linearGradient y2="26.024691" x2="27.824219" y1="22.739454" x1="27.812500" gradientTransform="matrix(1.230769,0,0,0.32409,-5.538462,22.89774)" gradientUnits="userSpaceOnUse" id="linearGradient2314" xlink:href="#linearGradient5741" inkscape:collect="always"/>
+    <linearGradient y2="26.024691" x2="27.824219" y1="22.739454" x1="27.812500" gradientTransform="matrix(1.230769,0,0,0.32409,-5.538462,20.89774)" gradientUnits="userSpaceOnUse" id="linearGradient2312" xlink:href="#linearGradient5741" inkscape:collect="always"/>
+    <linearGradient y2="26.024691" x2="27.824219" y1="22.739454" x1="27.812500" gradientTransform="matrix(1.230769,0,0,0.32409,-5.538462,18.89774)" gradientUnits="userSpaceOnUse" id="linearGradient2310" xlink:href="#linearGradient5741" inkscape:collect="always"/>
+    <linearGradient y2="26.024691" x2="27.824219" y1="22.739454" x1="27.812500" gradientTransform="matrix(1.230769,0,0,0.32409,-5.538462,16.89774)" gradientUnits="userSpaceOnUse" id="linearGradient2308" xlink:href="#linearGradient5741" inkscape:collect="always"/>
+    <linearGradient y2="26.024691" x2="27.824219" y1="22.739454" x1="27.812500" gradientTransform="matrix(1.230769,0,0,0.32409,-5.538462,14.89774)" gradientUnits="userSpaceOnUse" id="linearGradient2306" xlink:href="#linearGradient5741" inkscape:collect="always"/>
+    <linearGradient id="linearGradient9845">
+      <stop id="stop9847" offset="0" style="stop-color:#ffffff;stop-opacity:1;"/>
+      <stop id="stop9849" offset="1.0000000" style="stop-color:#ffffff;stop-opacity:0.49484536;"/>
+    </linearGradient>
+    <linearGradient id="linearGradient10591">
+      <stop id="stop10593" offset="0.0000000" style="stop-color:#cad0c6;stop-opacity:1.0000000;"/>
+      <stop style="stop-color:#eaece9;stop-opacity:1.0000000;" offset="0.50000000" id="stop10599"/>
+      <stop id="stop10595" offset="1.0000000" style="stop-color:#c5cbc0;stop-opacity:1.0000000;"/>
+    </linearGradient>
+    <linearGradient id="linearGradient11327">
+      <stop id="stop11329" offset="0" style="stop-color:#7d6400;stop-opacity:1;"/>
+      <stop id="stop11331" offset="1.0000000" style="stop-color:#be9700;stop-opacity:1.0000000;"/>
+    </linearGradient>
+    <linearGradient id="linearGradient11335">
+      <stop id="stop11337" offset="0" style="stop-color:#6f716d;stop-opacity:1;"/>
+      <stop id="stop11339" offset="1.0000000" style="stop-color:#9ea09c;stop-opacity:1.0000000;"/>
+    </linearGradient>
+    <linearGradient id="linearGradient12071" inkscape:collect="always">
+      <stop id="stop12073" offset="0" style="stop-color:#ffffff;stop-opacity:1;"/>
+      <stop id="stop12075" offset="1" style="stop-color:#ffffff;stop-opacity:0;"/>
+    </linearGradient>
+    <linearGradient id="linearGradient5741">
+      <stop id="stop5743" offset="0.0000000" style="stop-color:#896d00;stop-opacity:1.0000000;"/>
+      <stop id="stop5745" offset="1.0000000" style="stop-color:#a18000;stop-opacity:0.26804122;"/>
+    </linearGradient>
+    <linearGradient id="linearGradient2092">
+      <stop style="stop-color:#ead200;stop-opacity:0.71341461;" offset="0" id="stop2094"/>
+      <stop id="stop2098" offset="0.20999999" style="stop-color:#ffec41;stop-opacity:1.0000000;"/>
+      <stop style="stop-color:#e2cc00;stop-opacity:1;" offset="0.83999997" id="stop2293"/>
+      <stop style="stop-color:#c3af00;stop-opacity:1;" offset="1" id="stop2100"/>
+    </linearGradient>
+    <radialGradient gradientUnits="userSpaceOnUse" gradientTransform="matrix(1,0,0,0.651376,4.756609e-15,10.75754)" r="15.571428" fy="30.857143" fx="22.571428" cy="30.857143" cx="22.571428" id="radialGradient3564" xlink:href="#linearGradient3558" inkscape:collect="always"/>
+    <linearGradient id="linearGradient3558" inkscape:collect="always">
+      <stop id="stop3560" offset="0" style="stop-color:#000000;stop-opacity:1;"/>
+      <stop id="stop3562" offset="1" style="stop-color:#000000;stop-opacity:0;"/>
+    </linearGradient>
+    <linearGradient id="linearGradient2298" inkscape:collect="always">
+      <stop id="stop2300" offset="0" style="stop-color:#ffffff;stop-opacity:1;"/>
+      <stop id="stop2302" offset="1" style="stop-color:#ffffff;stop-opacity:0;"/>
+    </linearGradient>
+    <radialGradient inkscape:collect="always" xlink:href="#linearGradient2298" id="radialGradient1572" gradientUnits="userSpaceOnUse" gradientTransform="matrix(2.531089,-2.901827e-16,6.080015e-9,2.860549,-19.66786,-16.33929)" cx="12.845672" cy="13.342374" fx="12.845672" fy="13.342374" r="17"/>
+    <linearGradient inkscape:collect="always" xlink:href="#linearGradient9845" id="linearGradient1575" gradientUnits="userSpaceOnUse" gradientTransform="matrix(0.999112,0,0,1.095802,3.642141e-2,-4.139733)" x1="10.907269" y1="25.002281" x2="30.875446" y2="36.127281"/>
+    <linearGradient inkscape:collect="always" xlink:href="#linearGradient2092" id="linearGradient1578" gradientUnits="userSpaceOnUse" gradientTransform="matrix(1,0,0,1.089878,0,-5.10979)" x1="6.7268200" y1="32.161697" x2="40.938126" y2="32.161697"/>
+    <linearGradient inkscape:collect="always" xlink:href="#linearGradient11327" id="linearGradient1580" gradientUnits="userSpaceOnUse" gradientTransform="matrix(1,0,0,1.089878,0,-3.986899)" x1="31.630468" y1="41.791817" x2="8.6713638" y2="25.793524"/>
+    <linearGradient inkscape:collect="always" xlink:href="#linearGradient3505" id="linearGradient1591" x1="24.875" y1="21" x2="24.75" y2="17" gradientUnits="userSpaceOnUse" gradientTransform="translate(0,1)"/>
+    <linearGradient inkscape:collect="always" xlink:href="#linearGradient12071" id="linearGradient1387" gradientUnits="userSpaceOnUse" gradientTransform="matrix(1,0,0,0.951923,0,1.975963)" x1="21.941509" y1="21.550869" x2="21.941509" y2="18.037588"/>
+    <linearGradient inkscape:collect="always" xlink:href="#linearGradient5741" id="linearGradient1411" gradientUnits="userSpaceOnUse" gradientTransform="matrix(1.230769,0,0,0.32409,-5.538462,14.89774)" x1="27.812500" y1="22.739454" x2="27.824219" y2="26.024691"/>
+    <linearGradient inkscape:collect="always" xlink:href="#linearGradient5741" id="linearGradient1413" gradientUnits="userSpaceOnUse" gradientTransform="matrix(1.230769,0,0,0.32409,-5.538462,16.89774)" x1="27.812500" y1="22.739454" x2="27.824219" y2="26.024691"/>
+    <linearGradient inkscape:collect="always" xlink:href="#linearGradient5741" id="linearGradient1415" gradientUnits="userSpaceOnUse" gradientTransform="matrix(1.230769,0,0,0.32409,-5.538462,18.89774)" x1="27.812500" y1="22.739454" x2="27.824219" y2="26.024691"/>
+    <linearGradient inkscape:collect="always" xlink:href="#linearGradient5741" id="linearGradient1417" gradientUnits="userSpaceOnUse" gradientTransform="matrix(1.230769,0,0,0.32409,-5.538462,20.89774)" x1="27.812500" y1="22.739454" x2="27.824219" y2="26.024691"/>
+    <linearGradient inkscape:collect="always" xlink:href="#linearGradient5741" id="linearGradient1419" gradientUnits="userSpaceOnUse" gradientTransform="matrix(1.230769,0,0,0.32409,-5.538462,22.89774)" x1="27.812500" y1="22.739454" x2="27.824219" y2="26.024691"/>
+    <linearGradient inkscape:collect="always" xlink:href="#linearGradient5741" id="linearGradient1421" gradientUnits="userSpaceOnUse" gradientTransform="matrix(1.230769,0,0,0.32409,-5.538462,24.89774)" x1="27.812500" y1="22.739454" x2="27.824219" y2="26.024691"/>
+    <linearGradient inkscape:collect="always" xlink:href="#linearGradient5741" id="linearGradient1423" gradientUnits="userSpaceOnUse" gradientTransform="matrix(1.230769,0,0,0.32409,-5.538462,26.89774)" x1="27.812500" y1="22.739454" x2="27.824219" y2="26.024691"/>
+    <linearGradient inkscape:collect="always" xlink:href="#linearGradient5741" id="linearGradient1425" gradientUnits="userSpaceOnUse" gradientTransform="matrix(1.230769,0,0,0.32409,-5.538462,28.89774)" x1="27.812500" y1="22.739454" x2="27.824219" y2="26.024691"/>
+    <linearGradient inkscape:collect="always" xlink:href="#linearGradient5741" id="linearGradient1427" gradientUnits="userSpaceOnUse" gradientTransform="matrix(1.230769,0,0,0.32409,-5.538462,30.89774)" x1="27.812500" y1="22.739454" x2="27.824219" y2="26.024691"/>
+    <linearGradient inkscape:collect="always" xlink:href="#linearGradient5741" id="linearGradient1429" gradientUnits="userSpaceOnUse" gradientTransform="matrix(1.230769,0,0,0.32409,-5.538462,32.89774)" x1="27.812500" y1="22.739454" x2="27.824219" y2="26.024691"/>
+    <linearGradient inkscape:collect="always" xlink:href="#linearGradient5741" id="linearGradient2307" gradientUnits="userSpaceOnUse" gradientTransform="matrix(1.312358,0,1.799061e-17,0.32409,-1.156393,5.669486)" x1="27.812500" y1="22.739454" x2="27.824219" y2="26.024691"/>
+    <linearGradient inkscape:collect="always" xlink:href="#linearGradient5741" id="linearGradient2311" gradientUnits="userSpaceOnUse" gradientTransform="matrix(1.312358,0,1.799061e-17,0.32409,-1.156393,3.669486)" x1="27.812500" y1="22.739454" x2="27.824219" y2="26.024691"/>
+    <linearGradient inkscape:collect="always" xlink:href="#linearGradient5741" id="linearGradient2315" gradientUnits="userSpaceOnUse" gradientTransform="matrix(1.312358,0,1.799061e-17,0.32409,-1.156393,1.669487)" x1="27.812500" y1="22.739454" x2="27.824219" y2="26.024691"/>
+    <linearGradient inkscape:collect="always" xlink:href="#linearGradient5741" id="linearGradient2319" gradientUnits="userSpaceOnUse" gradientTransform="matrix(1.312358,0,1.799061e-17,0.32409,-1.156393,-0.330512)" x1="27.812500" y1="22.739454" x2="27.824219" y2="26.024691"/>
+    <linearGradient inkscape:collect="always" xlink:href="#linearGradient5741" id="linearGradient2323" gradientUnits="userSpaceOnUse" gradientTransform="matrix(1.312358,0,1.799061e-17,0.32409,-1.156393,-2.330512)" x1="27.812500" y1="22.739454" x2="27.824219" y2="26.024691"/>
+    <linearGradient inkscape:collect="always" xlink:href="#linearGradient5741" id="linearGradient2326" gradientUnits="userSpaceOnUse" gradientTransform="matrix(1.312358,0,1.799061e-17,0.32409,-1.156393,-4.330511)" x1="27.812500" y1="22.739454" x2="27.824219" y2="26.024691"/>
+    <linearGradient inkscape:collect="always" xlink:href="#linearGradient5741" id="linearGradient2329" gradientUnits="userSpaceOnUse" gradientTransform="matrix(1.312358,0,1.799061e-17,0.32409,-1.156393,-6.33051)" x1="27.812500" y1="22.739454" x2="27.824219" y2="26.024691"/>
+    <linearGradient inkscape:collect="always" xlink:href="#linearGradient5741" id="linearGradient2332" gradientUnits="userSpaceOnUse" gradientTransform="matrix(1.312358,0,1.799061e-17,0.32409,-1.156393,-8.330509)" x1="27.812500" y1="22.739454" x2="27.824219" y2="26.024691"/>
+    <linearGradient inkscape:collect="always" xlink:href="#linearGradient5741" id="linearGradient2335" gradientUnits="userSpaceOnUse" gradientTransform="matrix(1.312358,0,1.799061e-17,0.32409,-1.156393,-10.33051)" x1="27.812500" y1="22.739454" x2="27.824219" y2="26.024691"/>
+    <linearGradient inkscape:collect="always" xlink:href="#linearGradient5741" id="linearGradient2338" gradientUnits="userSpaceOnUse" gradientTransform="matrix(1.312358,0,1.799061e-17,0.32409,-1.156393,-12.33051)" x1="27.812500" y1="22.739454" x2="27.824219" y2="26.024691"/>
+    <linearGradient inkscape:collect="always" xlink:href="#linearGradient7601" id="linearGradient7607" x1="16.529249" y1="-0.3973901" x2="14.614914" y2="12.436604" gradientUnits="userSpaceOnUse"/>
+    <radialGradient inkscape:collect="always" xlink:href="#linearGradient7613" id="radialGradient7611" cx="30.996042" cy="13.156409" fx="30.996042" fy="13.156409" r="1.000184" gradientTransform="matrix(-5.31617e-7,14.96898,-8.276676,3.968832e-4,143.8949,-454.2723)" gradientUnits="userSpaceOnUse"/>
+    <radialGradient inkscape:collect="always" xlink:href="#linearGradient9845" id="radialGradient7619" cx="12.184196" cy="8.5463438" fx="12.184196" fy="8.5463438" r="3.6037733" gradientTransform="matrix(-0.441342,3.786965,-3.285907,-0.382939,47.91818,-38.4483)" gradientUnits="userSpaceOnUse"/>
+  </defs>
+  <sodipodi:namedview id="base" pagecolor="#ffffff" bordercolor="#666666" borderopacity="1.0" inkscape:pageopacity="0.0" inkscape:pageshadow="2" inkscape:zoom="1" inkscape:cx="23.553558" inkscape:cy="21.779338" inkscape:current-layer="layer1" showgrid="false" inkscape:grid-bbox="true" inkscape:document-units="px" gridspacingx="0.5px" gridspacingy="0.5px" showguides="true" inkscape:guide-bbox="true" gridempspacing="2" fill="#c4a000" inkscape:window-width="872" inkscape:window-height="663" inkscape:window-x="545" inkscape:window-y="200" showborder="false" inkscape:showpageshadow="false"/>
+  <metadata id="metadata1386">
+    <rdf:RDF>
+      <cc:Work rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
+        <dc:title>Lock</dc:title>
+        <dc:date/>
+        <dc:creator>
+          <cc:Agent>
+            <dc:title>Andreas Nilsson</dc:title>
+          </cc:Agent>
+        </dc:creator>
+        <dc:subject>
+          <rdf:Bag>
+            <rdf:li>lock</rdf:li>
+            <rdf:li>key</rdf:li>
+            <rdf:li>secure</rdf:li>
+          </rdf:Bag>
+        </dc:subject>
+        <dc:contributor>
+          <cc:Agent>
+            <dc:title>Jakub Steiner, 
+Lapo Calamandrei</dc:title>
+          </cc:Agent>
+        </dc:contributor>
+        <cc:license rdf:resource="http://creativecommons.org/licenses/by-sa/2.0/"/>
+      </cc:Work>
+      <cc:License rdf:about="http://creativecommons.org/licenses/by-sa/2.0/">
+        <cc:permits rdf:resource="http://web.resource.org/cc/Reproduction"/>
+        <cc:permits rdf:resource="http://web.resource.org/cc/Distribution"/>
+        <cc:requires rdf:resource="http://web.resource.org/cc/Notice"/>
+        <cc:requires rdf:resource="http://web.resource.org/cc/Attribution"/>
+        <cc:permits rdf:resource="http://web.resource.org/cc/DerivativeWorks"/>
+        <cc:requires rdf:resource="http://web.resource.org/cc/ShareAlike"/>
+      </cc:License>
+    </rdf:RDF>
+  </metadata>
+  <g id="layer1" inkscape:label="Layer 1" inkscape:groupmode="layer">
+    <path inkscape:r_cy="true" inkscape:r_cx="true" sodipodi:type="arc" style="opacity:0.47368421;color:#000000;fill:url(#radialGradient3564);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;marker:none;marker-start:none;marker-mid:none;marker-end:none;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;visibility:visible;display:inline;overflow:visible" id="path3556" sodipodi:cx="22.571428" sodipodi:cy="30.857143" sodipodi:rx="15.571428" sodipodi:ry="10.142858" d="M 38.142857 30.857143 A 15.571428 10.142858 0 1 1  7,30.857143 A 15.571428 10.142858 0 1 1  38.142857 30.857143 z" transform="matrix(1.440225,0,0,0.419014,-8.581573,29.82043)"/>
+    <rect style="fill:url(#linearGradient1578);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient1580);stroke-width:0.99999946;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" id="rect1314" width="34.993771" height="27.009277" x="6.5" y="17.5" rx="2.2349751" ry="2.2570534" inkscape:r_cx="true" inkscape:r_cy="true"/>
+    <rect style="fill:none;fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient1575);stroke-width:1.00000012;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.60109289" id="rect6903" width="33.000904" height="25.006882" x="7.5" y="18.5" rx="1.288511" ry="1.288511" inkscape:r_cx="true" inkscape:r_cy="true"/>
+    <g inkscape:r_cy="true" inkscape:r_cx="true" id="g2281" style="opacity:1" transform="matrix(1.066291,0,0,1,-1.59099,0)">
+      <rect inkscape:r_cy="true" inkscape:r_cx="true" ry="0" rx="0" y="23" x="8" height="0.97227097" width="32" id="rect5013" style="opacity:0.5;fill:url(#linearGradient2306);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"/>
+      <rect inkscape:r_cy="true" inkscape:r_cx="true" style="opacity:0.5;fill:url(#linearGradient2308);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" id="rect2245" width="32" height="0.97227097" x="8" y="25" rx="0" ry="0"/>
+      <rect inkscape:r_cy="true" inkscape:r_cx="true" ry="0" rx="0" y="27" x="8" height="0.97227097" width="32" id="rect2249" style="opacity:0.5;fill:url(#linearGradient2310);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"/>
+      <rect inkscape:r_cy="true" inkscape:r_cx="true" style="opacity:0.5;fill:url(#linearGradient2312);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" id="rect2253" width="32" height="0.97227097" x="8" y="29" rx="0" ry="0"/>
+      <rect inkscape:r_cy="true" inkscape:r_cx="true" ry="0" rx="0" y="31" x="8" height="0.97227097" width="32" id="rect2257" style="opacity:0.5;fill:url(#linearGradient2314);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"/>
+      <rect inkscape:r_cy="true" inkscape:r_cx="true" style="opacity:0.5;fill:url(#linearGradient2316);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" id="rect2261" width="32" height="0.97227097" x="8" y="33" rx="0" ry="0"/>
+      <rect inkscape:r_cy="true" inkscape:r_cx="true" ry="0" rx="0" y="35" x="8" height="0.97227097" width="32" id="rect2265" style="opacity:0.5;fill:url(#linearGradient2318);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"/>
+      <rect inkscape:r_cy="true" inkscape:r_cx="true" style="opacity:0.5;fill:url(#linearGradient2320);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" id="rect2269" width="32" height="0.97227097" x="8" y="37" rx="0" ry="0"/>
+      <rect inkscape:r_cy="true" inkscape:r_cx="true" ry="0" rx="0" y="39" x="8" height="0.97227097" width="32" id="rect2273" style="opacity:0.5;fill:url(#linearGradient2322);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"/>
+      <rect inkscape:r_cy="true" inkscape:r_cx="true" style="opacity:0.5;fill:url(#linearGradient2324);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" id="rect2277" width="32" height="0.97227097" x="8" y="41" rx="0" ry="0"/>
+    </g>
+    <rect style="color:#000000;fill:url(#linearGradient1591);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;marker:none;marker-start:none;marker-mid:none;marker-end:none;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;visibility:visible;display:inline;overflow:visible" id="rect1460" width="34" height="4" x="7" y="18" inkscape:r_cx="true" inkscape:r_cy="true" rx="1.7146454" ry="1.6610726"/>
+    <path inkscape:r_cy="true" inkscape:r_cx="true" style="opacity:0.40659341;fill:url(#radialGradient1572);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dashoffset:0;stroke-opacity:0.60109289" d="M 39.022894,21.954401 L 8.9789228,21.954401 C 7.4608208,21.962502 6.9982278,22.594587 6.9826028,24.335226 L 6.9826028,35.180882 C 12.330783,39.937562 24.775283,30.210883 40.982603,35.180882 L 40.982603,24.314186 C 40.969992,22.533917 40.441755,21.968139 39.022894,21.954401 z " id="rect8390" sodipodi:nodetypes="ccccccc"/>
+    <g id="g1387" inkscape:r_cx="true" inkscape:r_cy="true" transform="translate(-2.086163e-7,-0.987405)">
+      <path inkscape:r_cy="true" inkscape:r_cx="true" sodipodi:nodetypes="cczcccczccc" id="path2086" d="M 10.5,20.234846 L 10.5,13 C 10.5,5.1298666 15.897609,1.3910066 24.020027,1.4892921 C 32.18664,1.5875777 37.5,5.0372782 37.5,13 L 37.5,20.234846 C 37.416053,21.938431 32.536612,21.932149 32.5,20.234846 L 32.5,15 C 32.5,13 33.138264,6.528147 24.077241,6.528147 C 14.953718,6.528147 15.489989,13.039885 15.52268,14.992026 L 15.52268,20.268524 C 15.3125,21.859846 10.5,21.797346 10.5,20.234846 z " style="fill:url(#linearGradient1392);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient1394);stroke-width:0.99999958;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+      <path inkscape:r_cy="true" inkscape:r_cx="true" sodipodi:nodetypes="ccsccc" id="rect11343" d="M 11.496849,13.160018 C 11.745273,8.7621798 12.91305,4.7080565 18.456117,3.1987817 C 20.036661,5.0232133 13.557817,5.1195438 13.458448,11.481749 C 13.458448,11.481749 13.480108,19.46426 13.480108,19.46426 C 13.245273,20.052648 11.559349,20.070825 11.496849,19.414575 L 11.496849,13.160018 z " style="fill:url(#radialGradient7619);fill-opacity:1.0;fill-rule:evenodd;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dashoffset:0;stroke-opacity:1"/>
+      <path style="fill:url(#radialGradient7611);fill-opacity:1.0;fill-rule:evenodd;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dashoffset:0;stroke-opacity:1" d="M 33.500368,9.7120694 L 35.500368,9.7120694 L 35.500368,19.347482 C 35.437868,20.472482 33.469118,19.878732 33.500368,19.347482 L 33.500368,9.7120694 z " id="rect1345" sodipodi:nodetypes="ccccc" inkscape:r_cx="true" inkscape:r_cy="true"/>
+    </g>
+    <rect style="color:#000000;fill:none;fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient1387);stroke-width:1;stroke-linecap:round;stroke-linejoin:round;marker:none;marker-start:none;marker-mid:none;marker-end:none;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;visibility:visible;display:inline;overflow:visible" id="rect1593" width="33" height="2.8557696" x="7.5" y="18.634619" inkscape:r_cx="true" inkscape:r_cy="true" rx="1.2001942" ry="1.0968477"/>
+  </g>
+</svg>

--- a/themes/Classic/lock_unlocked.svg
+++ b/themes/Classic/lock_unlocked.svg
@@ -1,0 +1,183 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+<svg xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://web.resource.org/cc/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:svg="http://www.w3.org/2000/svg" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:sodipodi="http://inkscape.sourceforge.net/DTD/sodipodi-0.dtd" xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape" width="48px" height="48px" id="svg1381" sodipodi:version="0.32" inkscape:version="0.43+devel" sodipodi:docbase="/home/jimmac/src/cvs/tango-icon-theme/scalable/status" sodipodi:docname="unlocked.svg">
+  <defs id="defs1383">
+    <linearGradient inkscape:collect="always" id="linearGradient2983">
+      <stop style="stop-color:#000000;stop-opacity:1;" offset="0" id="stop2985"/>
+      <stop style="stop-color:#000000;stop-opacity:0;" offset="1" id="stop2987"/>
+    </linearGradient>
+    <linearGradient inkscape:collect="always" id="linearGradient2901">
+      <stop style="stop-color:#000000;stop-opacity:1;" offset="0" id="stop2903"/>
+      <stop style="stop-color:#000000;stop-opacity:0;" offset="1" id="stop2905"/>
+    </linearGradient>
+    <linearGradient id="linearGradient7613">
+      <stop style="stop-color:#ffffff;stop-opacity:0;" offset="0" id="stop7615"/>
+      <stop style="stop-color:#ffffff;stop-opacity:1;" offset="1" id="stop7617"/>
+    </linearGradient>
+    <linearGradient inkscape:collect="always" id="linearGradient7601">
+      <stop style="stop-color:#ffffff;stop-opacity:1;" offset="0" id="stop7603"/>
+      <stop style="stop-color:#ffffff;stop-opacity:0;" offset="1" id="stop7605"/>
+    </linearGradient>
+    <linearGradient id="linearGradient5820">
+      <stop id="stop6704" offset="0" style="stop-color:#000000;stop-opacity:0;"/>
+      <stop style="stop-color:#000000;stop-opacity:0;" offset="0.60799319" id="stop6706"/>
+      <stop style="stop-color:#000000;stop-opacity:1;" offset="1" id="stop5824"/>
+    </linearGradient>
+    <linearGradient id="linearGradient4135">
+      <stop style="stop-color:#896d00;stop-opacity:1.0000000;" offset="0.0000000" id="stop4137"/>
+      <stop style="stop-color:#a18000;stop-opacity:0;" offset="1" id="stop4139"/>
+    </linearGradient>
+    <linearGradient id="linearGradient3505">
+      <stop style="stop-color:#ffec41;stop-opacity:1.0000000;" offset="0" id="stop3509"/>
+      <stop id="stop3513" offset="1" style="stop-color:#c3af00;stop-opacity:1;"/>
+    </linearGradient>
+    <linearGradient y2="6.0396547" x2="16.198252" y1="9.6635771" x1="19.250618" gradientTransform="translate(0,-1.926279)" gradientUnits="userSpaceOnUse" id="linearGradient1394" xlink:href="#linearGradient11335" inkscape:collect="always"/>
+    <linearGradient y2="17.470011" x2="27.192274" y1="2.9136841" x1="10.650842" gradientTransform="translate(0,-1.926279)" gradientUnits="userSpaceOnUse" id="linearGradient1392" xlink:href="#linearGradient10591" inkscape:collect="always"/>
+    <linearGradient y2="26.024691" x2="27.824219" y1="22.739454" x1="27.812500" gradientTransform="matrix(1.230769,0,0,0.32409,-5.538462,32.89774)" gradientUnits="userSpaceOnUse" id="linearGradient2324" xlink:href="#linearGradient5741" inkscape:collect="always"/>
+    <linearGradient y2="26.024691" x2="27.824219" y1="22.739454" x1="27.812500" gradientTransform="matrix(1.230769,0,0,0.32409,-5.538462,30.89774)" gradientUnits="userSpaceOnUse" id="linearGradient2322" xlink:href="#linearGradient5741" inkscape:collect="always"/>
+    <linearGradient y2="26.024691" x2="27.824219" y1="22.739454" x1="27.812500" gradientTransform="matrix(1.230769,0,0,0.32409,-5.538462,28.89774)" gradientUnits="userSpaceOnUse" id="linearGradient2320" xlink:href="#linearGradient5741" inkscape:collect="always"/>
+    <linearGradient y2="26.024691" x2="27.824219" y1="22.739454" x1="27.812500" gradientTransform="matrix(1.230769,0,0,0.32409,-5.538462,26.89774)" gradientUnits="userSpaceOnUse" id="linearGradient2318" xlink:href="#linearGradient5741" inkscape:collect="always"/>
+    <linearGradient y2="26.024691" x2="27.824219" y1="22.739454" x1="27.812500" gradientTransform="matrix(1.230769,0,0,0.32409,-5.538462,24.89774)" gradientUnits="userSpaceOnUse" id="linearGradient2316" xlink:href="#linearGradient5741" inkscape:collect="always"/>
+    <linearGradient y2="26.024691" x2="27.824219" y1="22.739454" x1="27.812500" gradientTransform="matrix(1.230769,0,0,0.32409,-5.538462,22.89774)" gradientUnits="userSpaceOnUse" id="linearGradient2314" xlink:href="#linearGradient5741" inkscape:collect="always"/>
+    <linearGradient y2="26.024691" x2="27.824219" y1="22.739454" x1="27.812500" gradientTransform="matrix(1.230769,0,0,0.32409,-5.538462,20.89774)" gradientUnits="userSpaceOnUse" id="linearGradient2312" xlink:href="#linearGradient5741" inkscape:collect="always"/>
+    <linearGradient y2="26.024691" x2="27.824219" y1="22.739454" x1="27.812500" gradientTransform="matrix(1.230769,0,0,0.32409,-5.538462,18.89774)" gradientUnits="userSpaceOnUse" id="linearGradient2310" xlink:href="#linearGradient5741" inkscape:collect="always"/>
+    <linearGradient y2="26.024691" x2="27.824219" y1="22.739454" x1="27.812500" gradientTransform="matrix(1.230769,0,0,0.32409,-5.538462,16.89774)" gradientUnits="userSpaceOnUse" id="linearGradient2308" xlink:href="#linearGradient5741" inkscape:collect="always"/>
+    <linearGradient y2="26.024691" x2="27.824219" y1="22.739454" x1="27.812500" gradientTransform="matrix(1.230769,0,0,0.32409,-5.538462,14.89774)" gradientUnits="userSpaceOnUse" id="linearGradient2306" xlink:href="#linearGradient5741" inkscape:collect="always"/>
+    <linearGradient id="linearGradient9845">
+      <stop id="stop9847" offset="0" style="stop-color:#ffffff;stop-opacity:1;"/>
+      <stop id="stop9849" offset="1.0000000" style="stop-color:#ffffff;stop-opacity:0.49484536;"/>
+    </linearGradient>
+    <linearGradient id="linearGradient10591">
+      <stop id="stop10593" offset="0.0000000" style="stop-color:#cad0c6;stop-opacity:1.0000000;"/>
+      <stop style="stop-color:#eaece9;stop-opacity:1.0000000;" offset="0.50000000" id="stop10599"/>
+      <stop id="stop10595" offset="1.0000000" style="stop-color:#c5cbc0;stop-opacity:1.0000000;"/>
+    </linearGradient>
+    <linearGradient id="linearGradient11327">
+      <stop id="stop11329" offset="0" style="stop-color:#7d6400;stop-opacity:1;"/>
+      <stop id="stop11331" offset="1.0000000" style="stop-color:#be9700;stop-opacity:1.0000000;"/>
+    </linearGradient>
+    <linearGradient id="linearGradient11335">
+      <stop id="stop11337" offset="0" style="stop-color:#6f716d;stop-opacity:1;"/>
+      <stop id="stop11339" offset="1.0000000" style="stop-color:#9ea09c;stop-opacity:1.0000000;"/>
+    </linearGradient>
+    <linearGradient id="linearGradient12071" inkscape:collect="always">
+      <stop id="stop12073" offset="0" style="stop-color:#ffffff;stop-opacity:1;"/>
+      <stop id="stop12075" offset="1" style="stop-color:#ffffff;stop-opacity:0;"/>
+    </linearGradient>
+    <linearGradient id="linearGradient5741">
+      <stop id="stop5743" offset="0.0000000" style="stop-color:#896d00;stop-opacity:1.0000000;"/>
+      <stop id="stop5745" offset="1.0000000" style="stop-color:#a18000;stop-opacity:0.26804122;"/>
+    </linearGradient>
+    <linearGradient id="linearGradient2092">
+      <stop style="stop-color:#ead200;stop-opacity:0.71341461;" offset="0" id="stop2094"/>
+      <stop id="stop2098" offset="0.20999999" style="stop-color:#ffec41;stop-opacity:1.0000000;"/>
+      <stop style="stop-color:#e2cc00;stop-opacity:1;" offset="0.83999997" id="stop2293"/>
+      <stop style="stop-color:#c3af00;stop-opacity:1;" offset="1" id="stop2100"/>
+    </linearGradient>
+    <radialGradient gradientUnits="userSpaceOnUse" gradientTransform="matrix(1,0,0,0.651376,4.756609e-15,10.75754)" r="15.571428" fy="30.857143" fx="22.571428" cy="30.857143" cx="22.571428" id="radialGradient3564" xlink:href="#linearGradient3558" inkscape:collect="always"/>
+    <linearGradient id="linearGradient3558" inkscape:collect="always">
+      <stop id="stop3560" offset="0" style="stop-color:#000000;stop-opacity:1;"/>
+      <stop id="stop3562" offset="1" style="stop-color:#000000;stop-opacity:0;"/>
+    </linearGradient>
+    <linearGradient id="linearGradient2298" inkscape:collect="always">
+      <stop id="stop2300" offset="0" style="stop-color:#ffffff;stop-opacity:1;"/>
+      <stop id="stop2302" offset="1" style="stop-color:#ffffff;stop-opacity:0;"/>
+    </linearGradient>
+    <radialGradient inkscape:collect="always" xlink:href="#linearGradient2298" id="radialGradient1572" gradientUnits="userSpaceOnUse" gradientTransform="matrix(2.531089,-2.901827e-16,6.080015e-9,2.860549,-19.66786,-16.33929)" cx="12.845672" cy="13.342374" fx="12.845672" fy="13.342374" r="17"/>
+    <linearGradient inkscape:collect="always" xlink:href="#linearGradient9845" id="linearGradient1575" gradientUnits="userSpaceOnUse" gradientTransform="matrix(0.999112,0,0,1.095802,3.642141e-2,-4.139733)" x1="10.907269" y1="25.002281" x2="30.875446" y2="36.127281"/>
+    <linearGradient inkscape:collect="always" xlink:href="#linearGradient2092" id="linearGradient1578" gradientUnits="userSpaceOnUse" gradientTransform="matrix(1,0,0,1.089878,0,-5.10979)" x1="6.7268200" y1="32.161697" x2="40.938126" y2="32.161697"/>
+    <linearGradient inkscape:collect="always" xlink:href="#linearGradient11327" id="linearGradient1580" gradientUnits="userSpaceOnUse" gradientTransform="matrix(1,0,0,1.089878,0,-3.986899)" x1="31.630468" y1="41.791817" x2="8.6713638" y2="25.793524"/>
+    <linearGradient inkscape:collect="always" xlink:href="#linearGradient3505" id="linearGradient1591" x1="24.875" y1="21" x2="24.75" y2="17" gradientUnits="userSpaceOnUse" gradientTransform="translate(0,1)"/>
+    <linearGradient inkscape:collect="always" xlink:href="#linearGradient12071" id="linearGradient1387" gradientUnits="userSpaceOnUse" gradientTransform="matrix(1,0,0,0.951923,0,1.975963)" x1="21.941509" y1="21.550869" x2="21.941509" y2="18.037588"/>
+    <linearGradient inkscape:collect="always" xlink:href="#linearGradient5741" id="linearGradient1411" gradientUnits="userSpaceOnUse" gradientTransform="matrix(1.230769,0,0,0.32409,-5.538462,14.89774)" x1="27.812500" y1="22.739454" x2="27.824219" y2="26.024691"/>
+    <linearGradient inkscape:collect="always" xlink:href="#linearGradient5741" id="linearGradient1413" gradientUnits="userSpaceOnUse" gradientTransform="matrix(1.230769,0,0,0.32409,-5.538462,16.89774)" x1="27.812500" y1="22.739454" x2="27.824219" y2="26.024691"/>
+    <linearGradient inkscape:collect="always" xlink:href="#linearGradient5741" id="linearGradient1415" gradientUnits="userSpaceOnUse" gradientTransform="matrix(1.230769,0,0,0.32409,-5.538462,18.89774)" x1="27.812500" y1="22.739454" x2="27.824219" y2="26.024691"/>
+    <linearGradient inkscape:collect="always" xlink:href="#linearGradient5741" id="linearGradient1417" gradientUnits="userSpaceOnUse" gradientTransform="matrix(1.230769,0,0,0.32409,-5.538462,20.89774)" x1="27.812500" y1="22.739454" x2="27.824219" y2="26.024691"/>
+    <linearGradient inkscape:collect="always" xlink:href="#linearGradient5741" id="linearGradient1419" gradientUnits="userSpaceOnUse" gradientTransform="matrix(1.230769,0,0,0.32409,-5.538462,22.89774)" x1="27.812500" y1="22.739454" x2="27.824219" y2="26.024691"/>
+    <linearGradient inkscape:collect="always" xlink:href="#linearGradient5741" id="linearGradient1421" gradientUnits="userSpaceOnUse" gradientTransform="matrix(1.230769,0,0,0.32409,-5.538462,24.89774)" x1="27.812500" y1="22.739454" x2="27.824219" y2="26.024691"/>
+    <linearGradient inkscape:collect="always" xlink:href="#linearGradient5741" id="linearGradient1423" gradientUnits="userSpaceOnUse" gradientTransform="matrix(1.230769,0,0,0.32409,-5.538462,26.89774)" x1="27.812500" y1="22.739454" x2="27.824219" y2="26.024691"/>
+    <linearGradient inkscape:collect="always" xlink:href="#linearGradient5741" id="linearGradient1425" gradientUnits="userSpaceOnUse" gradientTransform="matrix(1.230769,0,0,0.32409,-5.538462,28.89774)" x1="27.812500" y1="22.739454" x2="27.824219" y2="26.024691"/>
+    <linearGradient inkscape:collect="always" xlink:href="#linearGradient5741" id="linearGradient1427" gradientUnits="userSpaceOnUse" gradientTransform="matrix(1.230769,0,0,0.32409,-5.538462,30.89774)" x1="27.812500" y1="22.739454" x2="27.824219" y2="26.024691"/>
+    <linearGradient inkscape:collect="always" xlink:href="#linearGradient5741" id="linearGradient1429" gradientUnits="userSpaceOnUse" gradientTransform="matrix(1.230769,0,0,0.32409,-5.538462,32.89774)" x1="27.812500" y1="22.739454" x2="27.824219" y2="26.024691"/>
+    <linearGradient inkscape:collect="always" xlink:href="#linearGradient5741" id="linearGradient2307" gradientUnits="userSpaceOnUse" gradientTransform="matrix(1.312358,0,1.799061e-17,0.32409,-1.156393,5.669486)" x1="27.812500" y1="22.739454" x2="27.824219" y2="26.024691"/>
+    <linearGradient inkscape:collect="always" xlink:href="#linearGradient5741" id="linearGradient2311" gradientUnits="userSpaceOnUse" gradientTransform="matrix(1.312358,0,1.799061e-17,0.32409,-1.156393,3.669486)" x1="27.812500" y1="22.739454" x2="27.824219" y2="26.024691"/>
+    <linearGradient inkscape:collect="always" xlink:href="#linearGradient5741" id="linearGradient2315" gradientUnits="userSpaceOnUse" gradientTransform="matrix(1.312358,0,1.799061e-17,0.32409,-1.156393,1.669487)" x1="27.812500" y1="22.739454" x2="27.824219" y2="26.024691"/>
+    <linearGradient inkscape:collect="always" xlink:href="#linearGradient5741" id="linearGradient2319" gradientUnits="userSpaceOnUse" gradientTransform="matrix(1.312358,0,1.799061e-17,0.32409,-1.156393,-0.330512)" x1="27.812500" y1="22.739454" x2="27.824219" y2="26.024691"/>
+    <linearGradient inkscape:collect="always" xlink:href="#linearGradient5741" id="linearGradient2323" gradientUnits="userSpaceOnUse" gradientTransform="matrix(1.312358,0,1.799061e-17,0.32409,-1.156393,-2.330512)" x1="27.812500" y1="22.739454" x2="27.824219" y2="26.024691"/>
+    <linearGradient inkscape:collect="always" xlink:href="#linearGradient5741" id="linearGradient2326" gradientUnits="userSpaceOnUse" gradientTransform="matrix(1.312358,0,1.799061e-17,0.32409,-1.156393,-4.330511)" x1="27.812500" y1="22.739454" x2="27.824219" y2="26.024691"/>
+    <linearGradient inkscape:collect="always" xlink:href="#linearGradient5741" id="linearGradient2329" gradientUnits="userSpaceOnUse" gradientTransform="matrix(1.312358,0,1.799061e-17,0.32409,-1.156393,-6.33051)" x1="27.812500" y1="22.739454" x2="27.824219" y2="26.024691"/>
+    <linearGradient inkscape:collect="always" xlink:href="#linearGradient5741" id="linearGradient2332" gradientUnits="userSpaceOnUse" gradientTransform="matrix(1.312358,0,1.799061e-17,0.32409,-1.156393,-8.330509)" x1="27.812500" y1="22.739454" x2="27.824219" y2="26.024691"/>
+    <linearGradient inkscape:collect="always" xlink:href="#linearGradient5741" id="linearGradient2335" gradientUnits="userSpaceOnUse" gradientTransform="matrix(1.312358,0,1.799061e-17,0.32409,-1.156393,-10.33051)" x1="27.812500" y1="22.739454" x2="27.824219" y2="26.024691"/>
+    <linearGradient inkscape:collect="always" xlink:href="#linearGradient5741" id="linearGradient2338" gradientUnits="userSpaceOnUse" gradientTransform="matrix(1.312358,0,1.799061e-17,0.32409,-1.156393,-12.33051)" x1="27.812500" y1="22.739454" x2="27.824219" y2="26.024691"/>
+    <linearGradient inkscape:collect="always" xlink:href="#linearGradient7601" id="linearGradient7607" x1="16.529249" y1="-0.3973901" x2="14.614914" y2="12.436604" gradientUnits="userSpaceOnUse"/>
+    <radialGradient inkscape:collect="always" xlink:href="#linearGradient7613" id="radialGradient7611" cx="30.996042" cy="13.156409" fx="30.996042" fy="13.156409" r="1.000184" gradientTransform="matrix(-5.31617e-7,14.96898,-8.276676,3.968832e-4,143.8949,-454.2723)" gradientUnits="userSpaceOnUse"/>
+    <radialGradient inkscape:collect="always" xlink:href="#linearGradient9845" id="radialGradient7619" cx="12.184196" cy="8.5463438" fx="12.184196" fy="8.5463438" r="3.6037733" gradientTransform="matrix(-0.441342,3.786965,-3.285907,-0.382939,51.92133,-44.11008)" gradientUnits="userSpaceOnUse"/>
+    <linearGradient inkscape:collect="always" xlink:href="#linearGradient2901" id="linearGradient2907" x1="36.5625" y1="20.625" x2="36.5625" y2="17" gradientUnits="userSpaceOnUse"/>
+    <linearGradient inkscape:collect="always" xlink:href="#linearGradient2983" id="linearGradient2989" x1="25.178555" y1="21.294252" x2="31.640839" y2="19.060417" gradientUnits="userSpaceOnUse"/>
+  </defs>
+  <sodipodi:namedview id="base" pagecolor="#ffffff" bordercolor="#666666" borderopacity="0.19607843" inkscape:pageopacity="0.0" inkscape:pageshadow="2" inkscape:zoom="11.313708" inkscape:cx="26.388884" inkscape:cy="28.431207" inkscape:current-layer="layer1" showgrid="false" inkscape:grid-bbox="true" inkscape:document-units="px" gridspacingx="0.5px" gridspacingy="0.5px" showguides="true" inkscape:guide-bbox="true" gridempspacing="2" fill="#c4a000" inkscape:window-width="872" inkscape:window-height="663" inkscape:window-x="181" inkscape:window-y="404" showborder="true" inkscape:showpageshadow="false"/>
+  <metadata id="metadata1386">
+    <rdf:RDF>
+      <cc:Work rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
+        <dc:title>Lock</dc:title>
+        <dc:date/>
+        <dc:creator>
+          <cc:Agent>
+            <dc:title>Andreas Nilsson</dc:title>
+          </cc:Agent>
+        </dc:creator>
+        <dc:subject>
+          <rdf:Bag>
+            <rdf:li>lock</rdf:li>
+            <rdf:li>key</rdf:li>
+            <rdf:li>secure</rdf:li>
+          </rdf:Bag>
+        </dc:subject>
+        <dc:contributor>
+          <cc:Agent>
+            <dc:title>Jakub Steiner, 
+Lapo Calamandrei</dc:title>
+          </cc:Agent>
+        </dc:contributor>
+        <cc:license rdf:resource="http://creativecommons.org/licenses/by-sa/2.0/"/>
+      </cc:Work>
+      <cc:License rdf:about="http://creativecommons.org/licenses/by-sa/2.0/">
+        <cc:permits rdf:resource="http://web.resource.org/cc/Reproduction"/>
+        <cc:permits rdf:resource="http://web.resource.org/cc/Distribution"/>
+        <cc:requires rdf:resource="http://web.resource.org/cc/Notice"/>
+        <cc:requires rdf:resource="http://web.resource.org/cc/Attribution"/>
+        <cc:permits rdf:resource="http://web.resource.org/cc/DerivativeWorks"/>
+        <cc:requires rdf:resource="http://web.resource.org/cc/ShareAlike"/>
+      </cc:License>
+    </rdf:RDF>
+  </metadata>
+  <g id="layer1" inkscape:label="Layer 1" inkscape:groupmode="layer">
+    <path inkscape:r_cy="true" inkscape:r_cx="true" sodipodi:type="arc" style="opacity:0.47368421;color:#000000;fill:url(#radialGradient3564);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;marker:none;marker-start:none;marker-mid:none;marker-end:none;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;visibility:visible;display:inline;overflow:visible" id="path3556" sodipodi:cx="22.571428" sodipodi:cy="30.857143" sodipodi:rx="15.571428" sodipodi:ry="10.142858" d="M 38.142857 30.857143 A 15.571428 10.142858 0 1 1  7,30.857143 A 15.571428 10.142858 0 1 1  38.142857 30.857143 z" transform="matrix(1.440225,0,0,0.419014,-8.581573,29.82043)"/>
+    <rect style="fill:url(#linearGradient1578);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient1580);stroke-width:0.99999946;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" id="rect1314" width="34.993771" height="27.009277" x="6.5" y="17.5" rx="2.2349751" ry="2.2570534" inkscape:r_cx="true" inkscape:r_cy="true"/>
+    <rect style="fill:none;fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient1575);stroke-width:1.00000012;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.60109289" id="rect6903" width="33.000904" height="25.006882" x="7.5" y="18.5" rx="1.288511" ry="1.288511" inkscape:r_cx="true" inkscape:r_cy="true"/>
+    <g inkscape:r_cy="true" inkscape:r_cx="true" id="g2281" style="opacity:1" transform="matrix(1.066291,0,0,1,-1.59099,0)">
+      <rect inkscape:r_cy="true" inkscape:r_cx="true" ry="0" rx="0" y="23" x="8" height="0.97227097" width="32" id="rect5013" style="opacity:0.5;fill:url(#linearGradient2306);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"/>
+      <rect inkscape:r_cy="true" inkscape:r_cx="true" style="opacity:0.5;fill:url(#linearGradient2308);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" id="rect2245" width="32" height="0.97227097" x="8" y="25" rx="0" ry="0"/>
+      <rect inkscape:r_cy="true" inkscape:r_cx="true" ry="0" rx="0" y="27" x="8" height="0.97227097" width="32" id="rect2249" style="opacity:0.5;fill:url(#linearGradient2310);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"/>
+      <rect inkscape:r_cy="true" inkscape:r_cx="true" style="opacity:0.5;fill:url(#linearGradient2312);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" id="rect2253" width="32" height="0.97227097" x="8" y="29" rx="0" ry="0"/>
+      <rect inkscape:r_cy="true" inkscape:r_cx="true" ry="0" rx="0" y="31" x="8" height="0.97227097" width="32" id="rect2257" style="opacity:0.5;fill:url(#linearGradient2314);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"/>
+      <rect inkscape:r_cy="true" inkscape:r_cx="true" style="opacity:0.5;fill:url(#linearGradient2316);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" id="rect2261" width="32" height="0.97227097" x="8" y="33" rx="0" ry="0"/>
+      <rect inkscape:r_cy="true" inkscape:r_cx="true" ry="0" rx="0" y="35" x="8" height="0.97227097" width="32" id="rect2265" style="opacity:0.5;fill:url(#linearGradient2318);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"/>
+      <rect inkscape:r_cy="true" inkscape:r_cx="true" style="opacity:0.5;fill:url(#linearGradient2320);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" id="rect2269" width="32" height="0.97227097" x="8" y="37" rx="0" ry="0"/>
+      <rect inkscape:r_cy="true" inkscape:r_cx="true" ry="0" rx="0" y="39" x="8" height="0.97227097" width="32" id="rect2273" style="opacity:0.5;fill:url(#linearGradient2322);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"/>
+      <rect inkscape:r_cy="true" inkscape:r_cx="true" style="opacity:0.5;fill:url(#linearGradient2324);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" id="rect2277" width="32" height="0.97227097" x="8" y="41" rx="0" ry="0"/>
+    </g>
+    <rect style="color:#000000;fill:url(#linearGradient1591);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;marker:none;marker-start:none;marker-mid:none;marker-end:none;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;visibility:visible;display:inline;overflow:visible" id="rect1460" width="34" height="4" x="7" y="18" inkscape:r_cx="true" inkscape:r_cy="true" rx="1.7146454" ry="1.6610726"/>
+    <path inkscape:r_cy="true" inkscape:r_cx="true" style="opacity:0.40659341;fill:url(#radialGradient1572);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dashoffset:0;stroke-opacity:0.60109289" d="M 39.022894,21.954401 L 8.9789228,21.954401 C 7.4608208,21.962502 6.9982278,22.594587 6.9826028,24.335226 L 6.9826028,35.180882 C 12.330783,39.937562 24.775283,30.210883 40.982603,35.180882 L 40.982603,24.314186 C 40.969992,22.533917 40.441755,21.968139 39.022894,21.954401 z " id="rect8390" sodipodi:nodetypes="ccccccc"/>
+    <path style="opacity:0.08888889;color:#000000;fill:url(#linearGradient2989);fill-opacity:1.0;fill-rule:nonzero;stroke:none;stroke-width:3;stroke-linecap:round;stroke-linejoin:round;marker:none;marker-start:none;marker-mid:none;marker-end:none;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;visibility:visible;display:block;overflow:visible" d="M 25.102292,22.013826 L 25.102292,31.648156 C 25.19068,32.885592 23.577593,33.902058 22.0087,33.769476 C 20.439806,33.636893 18.649942,32.708816 18.826719,31.736544 L 18.826719,21.925437 C 21.584031,19.181878 27.366441,18.478261 33.14344,19.517758 C 29.930431,20.226867 25.487523,20.652153 25.102292,22.013826 z " id="path2909" inkscape:r_cx="true" inkscape:r_cy="true" sodipodi:nodetypes="ccscccc"/>
+    <rect style="color:#000000;fill:none;fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient1387);stroke-width:1;stroke-linecap:round;stroke-linejoin:round;marker:none;marker-start:none;marker-mid:none;marker-end:none;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;visibility:visible;display:inline;overflow:visible" id="rect1593" width="33" height="2.8557696" x="7.5" y="18.634619" inkscape:r_cx="true" inkscape:r_cy="true" rx="1.2001942" ry="1.0968477"/>
+    <g id="g1387" inkscape:r_cx="true" inkscape:r_cy="true" transform="matrix(1,-0.535714,0,1,1,17.36974)">
+      <path inkscape:r_cy="true" inkscape:r_cx="true" sodipodi:nodetypes="ccccczcccczccc" id="path2086" d="M 14.625,19.194666 L 14.5,17.773114 C 16.082652,18.703615 17.401837,18.604506 18,18.023112 L 14.5,15.523113 L 14.5,6.892856 C 14.378104,-1.0416346 18.139338,-3.204022 24.395027,-1.9348152 C 30.571757,-0.6816282 37.5,7.6479326 37.5,13.625 L 37.5,21.859846 C 37.416053,23.563431 32.536612,20.932149 32.5,19.234846 L 32.5,11.375 C 32.5,9.497501 29.9793,4.8322283 25.452241,4.0147537 C 20.953737,3.2024354 20.52268,6.1233627 20.52268,9.2955955 L 20.58518,22.355576 C 20.875,24.589755 14.625,21.644953 14.625,19.194666 z " style="fill:url(#linearGradient1392);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient1394);stroke-width:0.99999958;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"/>
+      <path inkscape:r_cy="true" inkscape:r_cx="true" sodipodi:nodetypes="ccsccc" id="rect11343" d="M 15.375,6.4312763 C 15.375,-0.36155329 19.541201,-1.7769638 24.209268,-0.9004962 C 21.664812,-0.66088485 17.560968,0.27026655 17.586599,6.5119359 C 17.586599,6.5119359 17.483259,14.552483 17.483259,14.552483 C 17.435924,16.116317 15.5625,14.784048 15.5,13.377798 L 15.375,6.4312763 z " style="fill:url(#radialGradient7619);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dashoffset:0;stroke-opacity:1"/>
+      <path style="fill:url(#radialGradient7611);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dashoffset:0;stroke-opacity:1" d="M 33.500368,9.7120694 L 35.500368,9.7120694 L 35.500368,19.347482 C 35.437868,20.472482 33.469118,19.878732 33.500368,19.347482 L 33.500368,9.7120694 z " id="rect1345" sodipodi:nodetypes="ccccc" inkscape:r_cx="true" inkscape:r_cy="true"/>
+    </g>
+    <path sodipodi:type="arc" style="opacity:1;color:#000000;fill:url(#linearGradient2907);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:3;stroke-linecap:round;stroke-linejoin:round;marker:none;marker-start:none;marker-mid:none;marker-end:none;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;visibility:visible;display:block;overflow:visible" id="path2899" sodipodi:cx="36.5625" sodipodi:cy="19.375" sodipodi:rx="2.8125" sodipodi:ry="1.25" d="M 39.375 19.375 A 2.8125 1.25 0 1 1  33.75,19.375 A 2.8125 1.25 0 1 1  39.375 19.375 z" inkscape:r_cx="true" inkscape:r_cy="true" transform="translate(-24.25,-0.125)"/>
+  </g>
+</svg>

--- a/themes/ClassicTheme.qrc
+++ b/themes/ClassicTheme.qrc
@@ -30,6 +30,8 @@
     <file alias="layout_custom.svg">Classic/layout_custom.svg</file>
     <file alias="layout_hybrid.svg">Classic/layout_hybrid.svg</file>
     <file alias="layout_stacked.svg">Classic/layout_stacked.svg</file>
+    <file alias="lock_locked.svg">Classic/lock_locked.svg</file>
+    <file alias="lock_unlocked.svg">Classic/lock_unlocked.svg</file>
     <file alias="muted_local.svg">Classic/muted_local.svg</file>
     <file alias="muted_self.svg">Classic/muted_self.svg</file>
     <file alias="muted_server.svg">Classic/muted_server.svg</file>

--- a/themes/MumbleTheme.qrc
+++ b/themes/MumbleTheme.qrc
@@ -31,6 +31,8 @@
     <file alias="layout_stacked.svg">Mumble/layout_stacked.svg</file>
     <file alias="Dark.qss">Mumble/Dark.qss</file>
     <file alias="Lite.qss">Mumble/Lite.qss</file>
+	<file alias="lock_locked.svg">Mumble/lock_locked.svg</file>
+	<file alias="lock_unlocked.svg">Mumble/lock_unlocked.svg</file>
     <file alias="mumble.ico">Mumble/mumble.ico</file>
     <file alias="mumble.osx.png">Mumble/mumble.osx.png</file>
     <file alias="mumble.png">Mumble/mumble.png</file>


### PR DESCRIPTION
This is aimed to fix #3857 and to fix #3856

Changes of this PR:
- Add 2 fields to the `MumbleProto::channelState` msg indicating whether a channel is protected by ACLs denying ENTER privilege and whether the user the message is being sent to has the permissions to enter the channel
- Implement the backend to process the abovementioned fields (Mumble + Murmur)
- Added the equivalents of those message-fields as fields in the channel class inside the Mumble-client
- UI: Show lock-icon if channel is access-restricted (locked lock for the case in which the local user can't enter the respective channel and unlocked lock for the case in which the local user has the necessary privileges to enter the channel noetheless)
- UI (kinda): Changed permission denied message for ENTER or MOVE requests, if the channel has access-restrictions (the message now states that a missing password/access token might be the cause for the denial)