### PR TITLE
Add possibility to log, before g.l is available

### DIFF
--- a/src/mumble/Audio.cpp
+++ b/src/mumble/Audio.cpp
@@ -11,8 +11,13 @@
 #ifdef USE_OPUS
 # include "OpusCodec.h"
 #endif
-#include "Global.h"
 #include "PacketDataStream.h"
+#include "Log.h"
+
+#include <QtCore/QObject>
+
+// We define a global macro called 'g'. This can lead to issues when included code uses 'g' as a type or parameter name (like protobuf 3.7 does). As such, for now, we have to make this our last include.
+#include "Global.h"
 
 class CodecInit : public DeferInit {
 	public:
@@ -32,7 +37,7 @@ void CodecInit::initialize() {
 		oCodec->report();
 		g.oCodec = oCodec;
 	} else {
-		qWarning("CodecInit: Failed to load Opus, it will not be available for encoding/decoding audio.");
+		Log::logOrDefer(Log::CriticalError, QObject::tr("CodecInit: Failed to load Opus, it will not be available for encoding/decoding audio."));
 		delete oCodec;
 	}
 #endif

--- a/src/mumble/main.cpp
+++ b/src/mumble/main.cpp
@@ -418,9 +418,6 @@ int main(int argc, char **argv) {
 	delete cr;
 #endif
 
-	// Initialize logger
-	g.l = new Log();
-
 	// Initialize database
 	g.db = new Database(QLatin1String("main"));
 
@@ -445,6 +442,12 @@ int main(int argc, char **argv) {
 	// Main Window
 	g.mw=new MainWindow(NULL);
 	g.mw->show();
+
+	// Initialize logger
+	// Log::log() needs the MainWindow to already exist. Thus creating the Log instance
+	// before the MainWindow one, does not make sense. if you need logging before this
+	// point, use Log::logOrDefer()
+	g.l = new Log();
 
 #ifdef Q_OS_WIN
 	// Set mumble_mw_hwnd in os_win.cpp.

--- a/src/mumble/main.cpp
+++ b/src/mumble/main.cpp
@@ -448,6 +448,7 @@ int main(int argc, char **argv) {
 	// before the MainWindow one, does not make sense. if you need logging before this
 	// point, use Log::logOrDefer()
 	g.l = new Log();
+	g.l->processDeferredLogs();
 
 #ifdef Q_OS_WIN
 	// Set mumble_mw_hwnd in os_win.cpp.

--- a/src/mumble/mumble_en.ts
+++ b/src/mumble/mumble_en.ts
@@ -6362,6 +6362,13 @@ To upgrade these files to their latest versions, click the button below.</source
     </message>
 </context>
 <context>
+    <name>QObject</name>
+    <message>
+        <source>CodecInit: Failed to load Opus, it will not be available for encoding/decoding audio.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>RichTextEditor</name>
     <message>
         <source>Failed to load image</source>


### PR DESCRIPTION
As of now, log messages (that is the ones that are shown in the UI) can only be created, after g.l (the global `Log` instance) has been created.
This makes it impossible to create log-messages during Mumble's startup.

This PR introduces the possibility of deferring such log-messages until the point that the `Log` instance is available, by using a static vector of deferred messages that can be processed later by the respective instance.

This framework has then been used, to fix #3672 (https://github.com/mumble-voip/mumble/issues/3672#issuecomment-524669026).

Usage-note: For deferring log messages two functions are provided. `Log::deferLog` should be used, if you know for sure, that the code is running before `g.l` is initialized. If you aren't quite sure about that, use `Log::logOrDefer` instead, which will check this for you and either logs the msg directly or defers it, depending on whether or not the `Log` instance is available.
The problem with deferred logs is that they are only ever shown to the user, if `Log::processDeferredLogs()` is called afterwards whcih at the stage of this PR is only the case right after the instantiation of `g.l`. Thus `Log::logOrDefer` will basically guarantee your message to be shown (apart maybe from some really unlucky multi-thread-timing), whereas `Log::deferLog` does not.

Another minor change this PR includes: `g.l` is no instantiated *after* `g.mw` as `Log::log` will segfault, if `g.mw` hasn't been created yet. Thus I considered it useless to instatiate the logger before the MainWindow.

TODO:
- [x] Update translations
- [x] Squash commits