### PR TITLE
Backport gRPC fixes

### DIFF
--- a/src/murmur/MurmurGRPCImpl.cpp
+++ b/src/murmur/MurmurGRPCImpl.cpp
@@ -18,6 +18,11 @@
 #include "ServerUser.h"
 #include "Server.h"
 #include "Channel.h"
+#include "Utils.h"
+
+#include <chrono>
+
+#include <QtCore/QStack>
 
 #include "MurmurRPC.proto.Wrapper.cpp"
 
@@ -139,10 +144,18 @@ MurmurRPCImpl::MurmurRPCImpl(const QString &address, std::shared_ptr<::grpc::Ser
 	m_completionQueue = builder.AddCompletionQueue();
 	m_server = builder.BuildAndStart();
 	meta->connectListener(this);
+	b_IsRunning = true;
 	start();
 }
 
 MurmurRPCImpl::~MurmurRPCImpl() {
+	void *ignored_tag;
+	bool ignored_ok;
+	b_IsRunning = false;
+	m_server->Shutdown(std::chrono::system_clock::now());
+	m_completionQueue->Shutdown();
+	while (m_completionQueue->Next(&ignored_tag, &ignored_ok))
+		;
 }
 
 // ToRPC/FromRPC methods convert data to/from grpc protocol buffer messages.
@@ -1102,7 +1115,7 @@ void MurmurRPCImpl::customEvent(QEvent *evt) {
 void MurmurRPCImpl::run() {
 	MurmurRPC::Wrapper::V1_Init(this, &m_V1Service);
 
-	while (true) {
+	while (b_IsRunning) {
 		void *tag;
 		bool ok;
 		if (!m_completionQueue->Next(&tag, &ok)) {

--- a/src/murmur/MurmurGRPCImpl.cpp
+++ b/src/murmur/MurmurGRPCImpl.cpp
@@ -144,18 +144,22 @@ MurmurRPCImpl::MurmurRPCImpl(const QString &address, std::shared_ptr<::grpc::Ser
 	m_completionQueue = builder.AddCompletionQueue();
 	m_server = builder.BuildAndStart();
 	meta->connectListener(this);
-	b_IsRunning = true;
+	m_isRunning = true;
 	start();
 }
 
 MurmurRPCImpl::~MurmurRPCImpl() {
 	void *ignored_tag;
 	bool ignored_ok;
-	b_IsRunning = false;
+	m_isRunning = false;
 	m_server->Shutdown(std::chrono::system_clock::now());
 	m_completionQueue->Shutdown();
-	while (m_completionQueue->Next(&ignored_tag, &ignored_ok))
-		;
+	while (m_completionQueue->Next(&ignored_tag, &ignored_ok)) {
+		if (ignored_tag) {
+			auto op = static_cast<boost::function<void(bool)> *>(ignored_tag);
+			delete op;
+		}
+	}
 }
 
 // ToRPC/FromRPC methods convert data to/from grpc protocol buffer messages.
@@ -1115,7 +1119,7 @@ void MurmurRPCImpl::customEvent(QEvent *evt) {
 void MurmurRPCImpl::run() {
 	MurmurRPC::Wrapper::V1_Init(this, &m_V1Service);
 
-	while (b_IsRunning) {
+	while (m_isRunning) {
 		void *tag;
 		bool ok;
 		if (!m_completionQueue->Next(&tag, &ok)) {

--- a/src/murmur/MurmurGRPCImpl.h
+++ b/src/murmur/MurmurGRPCImpl.h
@@ -36,7 +36,7 @@ namespace MurmurRPC {
 class MurmurRPCImpl : public QThread {
 		Q_OBJECT;
 		std::unique_ptr<grpc::Server> m_server;
-		volatile bool b_IsRunning;
+		volatile bool m_isRunning;
 	protected:
 		void customEvent(QEvent *evt);
 	public:

--- a/src/murmur/MurmurGRPCImpl.h
+++ b/src/murmur/MurmurGRPCImpl.h
@@ -36,6 +36,7 @@ namespace MurmurRPC {
 class MurmurRPCImpl : public QThread {
 		Q_OBJECT;
 		std::unique_ptr<grpc::Server> m_server;
+		volatile bool b_IsRunning;
 	protected:
 		void customEvent(QEvent *evt);
 	public:


### PR DESCRIPTION
This fixes a segfault when stopping Murmur with gRPC enabled, probably worth having on the stable branch