### PR TITLE
Murmur: allow certificates without full chain, but do not deem such certificates 'strong'.

### DIFF
--- a/src/murmur/Server.cpp
+++ b/src/murmur/Server.cpp
@@ -1306,6 +1306,7 @@ void Server::sslError(const QList<QSslError> &errors) {
 			case QSslError::SelfSignedCertificate:
 			case QSslError::SelfSignedCertificateInChain:
 			case QSslError::UnableToGetLocalIssuerCertificate:
+			case QSslError::UnableToVerifyFirstCertificate:
 			case QSslError::HostNameMismatch:
 			case QSslError::CertificateNotYetValid:
 			case QSslError::CertificateExpired:


### PR DESCRIPTION
As the commit message in #2336 contained some typos, it hasn't been merged. However mkrautz doesn't seem to have the time to fix them. Thus I did just that.

Note however that I really only fixed typos in the commit message. The actual coding work has been done by @mkrautz