### PR TITLE
WIP: A new way to gRPC

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -25,3 +25,6 @@
 [submodule "3rdparty/mp11"]
 	path = 3rdparty/mp11
 	url = https://github.com/boostorg/mp11.git
+[submodule "3rdparty/callable_traits"]
+	path = 3rdparty/callable_traits
+	url = https://github.com/boostorg/callable_traits.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -22,3 +22,6 @@
 [submodule "themes/Mumble"]
 	path = themes/Mumble
 	url = https://github.com/mumble-voip/mumble-theme.git
+[submodule "3rdparty/mp11"]
+	path = 3rdparty/mp11
+	url = https://github.com/boostorg/mp11.git

--- a/qmake/compiler.pri
+++ b/qmake/compiler.pri
@@ -292,9 +292,9 @@ unix:!macx {
 	}
 
 	CONFIG(debug, debug|release) {
-		QMAKE_CFLAGS *= -fstack-protector #-fPIE
-		QMAKE_CXXFLAGS *= -fstack-protector #-fPIE
-	#	QMAKE_LFLAGS *= -pie
+		QMAKE_CFLAGS *= -fstack-protector -fPIE
+		QMAKE_CXXFLAGS *= -fstack-protector -fPIE
+		QMAKE_LFLAGS *= -pie
 		QMAKE_LFLAGS *= -Wl,--no-add-needed
 	}
 

--- a/qmake/compiler.pri
+++ b/qmake/compiler.pri
@@ -7,7 +7,7 @@ include(qt.pri)
 include(uname.pri)
 include(buildenv.pri)
 include(builddir.pri)
-include(cplusplus.pri)
+#include(cplusplus.pri) lets not mangle the version of c++ we want
 include(pkgconfig.pri)
 
 CONFIG *= warn_on
@@ -256,6 +256,12 @@ unix|win32-g++ {
 		QMAKE_LFLAGS *= -fprofile-generate
 	}
 
+	CONFIG(tcmalloc) {
+		QMAKE_CFLAGS *= -fno-builtin-malloc -fno-builtin-calloc -fno-builtin-realloc -fno-builtin-free
+		QMAKE_CXXFLAGS *= -fno-builtin-malloc -fno-builtin-calloc -fno-builtin-realloc -fno-builtin-free
+		LIBS += -ltcmalloc
+	}
+
 	CONFIG(optimize) {
 		QMAKE_CFLAGS *= -O3 -march=native -ffast-math -ftree-vectorize -fprofile-use
 		QMAKE_CXXFLAGS *= -O3 -march=native -ffast-math -ftree-vectorize -fprofile-use
@@ -292,8 +298,8 @@ unix:!macx {
 	}
 
 	CONFIG(debug, debug|release) {
-		QMAKE_CFLAGS *= -fstack-protector -fPIE
-		QMAKE_CXXFLAGS *= -fstack-protector -fPIE
+		QMAKE_CFLAGS *= -fstack-protector -Og -fPIE
+		QMAKE_CXXFLAGS *= -fstack-protector -Og -fPIE
 		QMAKE_LFLAGS *= -pie
 		QMAKE_LFLAGS *= -Wl,--no-add-needed
 	}
@@ -324,6 +330,12 @@ unix:!macx {
 	}
 
 	QMAKE_LFLAGS *= -Wl,-z,relro -Wl,-z,now
+
+	CONFIG(LTO) {
+		QMAKE_CFLAGS += $$QMAKE_CFLAGS_LTCG
+		QMAKE_CXXFLAGS += $$QMAKE_CXXFLAGS_LTCG
+		QMAKE_LFLAGS *= $$QMAKE_LFLAGS_LTCG
+	}
 
 	CONFIG(symbols) {
 		QMAKE_CFLAGS *= -g

--- a/qmake/compiler.pri
+++ b/qmake/compiler.pri
@@ -292,9 +292,9 @@ unix:!macx {
 	}
 
 	CONFIG(debug, debug|release) {
-		QMAKE_CFLAGS *= -fstack-protector -fPIE
-		QMAKE_CXXFLAGS *= -fstack-protector -fPIE
-		QMAKE_LFLAGS *= -pie
+		QMAKE_CFLAGS *= -fstack-protector #-fPIE
+		QMAKE_CXXFLAGS *= -fstack-protector #-fPIE
+	#	QMAKE_LFLAGS *= -pie
 		QMAKE_LFLAGS *= -Wl,--no-add-needed
 	}
 

--- a/qmake/compiler.pri
+++ b/qmake/compiler.pri
@@ -260,6 +260,7 @@ unix|win32-g++ {
 		QMAKE_CFLAGS *= -fno-builtin-malloc -fno-builtin-calloc -fno-builtin-realloc -fno-builtin-free
 		QMAKE_CXXFLAGS *= -fno-builtin-malloc -fno-builtin-calloc -fno-builtin-realloc -fno-builtin-free
 		LIBS += -ltcmalloc
+		CONFIG *= lto
 	}
 
 	CONFIG(optimize) {
@@ -331,7 +332,7 @@ unix:!macx {
 
 	QMAKE_LFLAGS *= -Wl,-z,relro -Wl,-z,now
 
-	CONFIG(LTO) {
+	CONFIG(lto) {
 		QMAKE_CFLAGS += $$QMAKE_CFLAGS_LTCG
 		QMAKE_CXXFLAGS += $$QMAKE_CXXFLAGS_LTCG
 		QMAKE_LFLAGS *= $$QMAKE_LFLAGS_LTCG

--- a/qmake/compiler.pri
+++ b/qmake/compiler.pri
@@ -299,8 +299,8 @@ unix:!macx {
 	}
 
 	CONFIG(debug, debug|release) {
-		QMAKE_CFLAGS *= -fstack-protector -Og -fPIE
-		QMAKE_CXXFLAGS *= -fstack-protector -Og -fPIE
+		QMAKE_CFLAGS *= -fstack-protector -fPIE
+		QMAKE_CXXFLAGS *= -fstack-protector -fPIE
 		QMAKE_LFLAGS *= -pie
 		QMAKE_LFLAGS *= -Wl,--no-add-needed
 	}

--- a/scripts/azure-pipelines/build_linux.bash
+++ b/scripts/azure-pipelines/build_linux.bash
@@ -5,9 +5,10 @@
 # that can be found in the LICENSE file at the root of the
 # Mumble source tree or at <https://www.mumble.info/LICENSE>.
 
+
 ver=$(python scripts/mumble-version.py)
 
-qmake -recursive CONFIG+="release tests warnings-as-errors" DEFINES+="MUMBLE_VERSION=${ver}"
+qmake -recursive CONFIG+="c++11 release tests warnings-as-errors" DEFINES+="MUMBLE_VERSION=${ver}"
 
 make -j $(nproc)
 make check

--- a/scripts/azure-pipelines/install-environment_linux.bash
+++ b/scripts/azure-pipelines/install-environment_linux.bash
@@ -7,10 +7,20 @@
 
 sudo apt-get update
 
-sudo apt-get -y install build-essential pkg-config qt5-default qttools5-dev-tools libqt5svg5-dev \
+sudo apt-get -y install build-essential pkg-config g++-5 qt5-default qttools5-dev-tools libqt5svg5-dev \
                         libboost-dev libssl-dev libprotobuf-dev protobuf-compiler \
                         libcap-dev libxi-dev \
                         libasound2-dev libpulse-dev \
                         libogg-dev libsndfile1-dev libspeechd-dev \
                         libavahi-compat-libdnssd-dev libzeroc-ice-dev libg15daemon-client-dev \
                         zsync
+
+sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-5 20
+
+sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-5 20
+
+sudo update-alternatives --set cc /usr/bin/gcc
+sudo update-alternatives --set c++ /usr/bin/g++
+sudo update-alternatives --set g++ "/usr/bin/g++-5"
+sudo update-alternatives --set gcc "/usr/bin/gcc-5"
+

--- a/scripts/travis-ci/before_install.bash
+++ b/scripts/travis-ci/before_install.bash
@@ -18,7 +18,8 @@ if [ "${TRAVIS_OS_NAME}" == "linux" ]; then
 	if [ "${MUMBLE_HOST}" == "x86_64-linux-gnu" ] || [ "${MUMBLE_HOST}" == "aarch64-linux-gnu" ]; then
 		sudo apt-get -qq update
 		sudo apt-get -y install build-essential pkg-config qt5-default qttools5-dev-tools qttranslations5-l10n \
-                                libqt5svg5-dev libboost-dev libssl-dev libprotobuf-dev protobuf-compiler \
+                                libqt5svg5-dev libboost-dev libboost-context-dev libboost-fiber-dev \
+                                libssl-dev libprotobuf-dev protobuf-compiler \
                                 libcap-dev libxi-dev \
                                 libasound2-dev libpulse-dev \
                                 libogg-dev libsndfile1-dev libspeechd-dev \

--- a/src/Utils.h
+++ b/src/Utils.h
@@ -26,4 +26,10 @@
 # define ZeroMemory(ptr,len) memset(ptr, 0, len)
 #endif
 
+#ifdef USE_GRPC
+# include <QDebug>
+# include <string>
+QDebug operator<<(QDebug dbg, const std::string& s);
+#endif
+
 #endif // MUMBLE_UTILS_H_

--- a/src/Utils.h
+++ b/src/Utils.h
@@ -29,7 +29,7 @@
 #ifdef USE_GRPC
 # include <QDebug>
 # include <string>
-# include <grpcpp/support/string_ref.h>
+# include <grpc++/support/string_ref.h>
 QDebug operator<<(QDebug dbg, const std::string& s);
 QDebug operator<<(QDebug dbg, const grpc::string_ref& s);
 #endif

--- a/src/Utils.h
+++ b/src/Utils.h
@@ -29,7 +29,9 @@
 #ifdef USE_GRPC
 # include <QDebug>
 # include <string>
+# include <grpcpp/support/string_ref.h>
 QDebug operator<<(QDebug dbg, const std::string& s);
+QDebug operator<<(QDebug dbg, const grpc::string_ref& s);
 #endif
 
 #endif // MUMBLE_UTILS_H_

--- a/src/murmur/GRPCContainer.h
+++ b/src/murmur/GRPCContainer.h
@@ -34,6 +34,11 @@ namespace MurmurRPC {
 			namespace mp11 = boost::mp11;
 
 			namespace Detail {
+				/// \brief Helper key-extractor for a tuple.
+				///
+				/// Only exists because std::get<tuple> cannot be called as
+				/// a global function in older versions of c++
+				///
 				template<typename Value, int idx>
 				struct tuple_extractor {
 					using const_lref_t = boost::add_lvalue_reference_t<
@@ -49,6 +54,10 @@ namespace MurmurRPC {
 					}
 				};
 
+				///
+				/// helper template to determine the return type of
+				/// weakContainer::getLockedRange()
+				///
 				template<typename Adapter, typename Pred, typename It>
 				struct range_type_it {
 					using pred_t = boost::decay_t<Pred>;
@@ -66,6 +75,10 @@ namespace MurmurRPC {
 				template<typename Adapter, typename Pred, typename It>
 					using range_type_it_t = typename range_type_it<Adapter, Pred, It>::type;
 
+				///
+				/// helper template to determine return type of
+				/// weakContainer::getLockedIdx()
+				///
 				template<typename Adapter, typename Pred, typename Idx>
 				struct range_type_idx {
 					using idx_t = boost::decay_t<Idx>;
@@ -76,6 +89,10 @@ namespace MurmurRPC {
 				template<typename Adapter, typename Pred, typename Idx>
 					using range_type_idx_t = typename range_type_idx<Adapter, Pred, Idx>::type;
 
+				///
+				/// helper template to determine return type of
+				/// weakContainer::getLocked()
+				///
 				template<typename Adapter, typename Pred, typename Functor, typename Container>
 				struct range_type_func {
 					using container_lref_t = boost::add_lvalue_reference_t<
@@ -95,10 +112,11 @@ namespace MurmurRPC {
 					using range_type_func_t = typename range_type_func<Adapter, Pred, Functor, Container>::type;
 			} //end Detail
 
-			struct server {};
-			struct rpcid {};
-			struct serveraction {};
+			struct server {}; ///< used in weakContainer as an index tag
+			struct rpcid {}; ///< used in weakContainer as an index tag
+			struct serveraction {}; ///< used in weakContainer as an index tag
 
+			/// \brief Configuration template for weakContainer to resemble a std::map
 			template<typename T>
 			struct mapConfig {
 				typedef std::tuple<int, uint32_t, std::weak_ptr<T>> value_type;
@@ -116,6 +134,7 @@ namespace MurmurRPC {
 					>;
 			};
 
+			/// \brief Configuration template for weakContainer to resemble std::multimap
 			template<typename T>
 			struct multiMapConfig {
 				typedef std::tuple<int, uint32_t, std::weak_ptr<T>> value_type;
@@ -133,6 +152,10 @@ namespace MurmurRPC {
 					>;
 			};
 
+			/// \brief Configuration template for weakContainer used by contextActionEvents.
+			///
+			/// Resembles a std::unordered_map with the key being a std::pair<int, std::string>
+			///
 			template<typename T>
 			struct contextActionConfig {
 				typedef std::tuple<int, std::string, uint32_t, std::weak_ptr<T>> value_type;
@@ -155,6 +178,7 @@ namespace MurmurRPC {
 			};
 
 
+			/// \brief Configuration template for weakContainer to resemble std::set
 			template<typename T>
 			struct setConfig {
 
@@ -169,26 +193,73 @@ namespace MurmurRPC {
 					>;
 			};
 
+			/// \brief Wrapper class for a boost::multi_index container.
+			///
+			/// Allows the container to be safely
+			/// used across threads and without having to know many details about
+			/// how boost::multi_index works.
+			///
+			/// Takes a configuration parameter as a template argument to generate
+			/// the type of container we are going to emulate, as well as the
+			/// actual values being stored in the container.
+			///
+			/// A typical configuration has is indexed on two items. One is the
+			/// index that RPCCall users call in order to look up the std::weak_ptr
+			/// that they need for a particular call. The second index is on
+			/// the id of the RPCCall itself. This allows an RPCCall object to find
+			/// itself in a container and remove itself when it is done. This would
+			/// would be very hard to do without the second index as it would have
+			/// to iterate through the entire container, and without the RPCId being
+			/// stored, all it could look against would be a std::weak_ptr which is
+			/// not a comparable object.
+			///
+			/// All the current configuration store std::tuples with the indexable
+			/// items in the front, and the std::weak_ptr at the end. The current
+			/// implementation assumes this layout in order to be able to generate
+			/// 'safe' iterable ranges.
+			///
+			/// \tparam C configuration struct defining the container attributes
 			template<typename C>
 			class weakContainer {
 
 			public:
-				typedef typename C::value_type value_type;
-				typedef typename C::locked_type locked_type;
+				using value_type = typename C::value_type; ///< typename for what is being stored
 
-				weakContainer() = default;
-				~weakContainer() = default;
-				weakContainer(const weakContainer&) = delete;
-				weakContainer& operator=(const weakContainer&) = delete;
+				/// \brief typename for a modified tuple that has a std::shared_ptr at the end instead
+				/// of a std::weak_ptr
+				using locked_type = typename C::locked_type;
+
+				weakContainer() = default; ///< defaulted constructor
+				~weakContainer() = default; ///< defaulted deleteter
+				weakContainer(const weakContainer&) = delete; ///< non-copyable
+				weakContainer& operator=(const weakContainer&) = delete; ///< non-copyable
 
 			private:
 				using container_t = mi::multi_index_container<value_type, typename C::indices>;
 
 				container_t container;
+
+				///
+				/// mutex used to prevent data races between fibers and threads using the
+				/// container. It is recursive because many methods force this mutex
+				/// to be held and it would be very easy to deadlock
+				///
 				boost::fibers::recursive_mutex m_Mtx;
 
+				/// \brief Helper class used by the boost Range library.
+				///
+				/// It takes in a tuple
+				/// stored by the container, copies everything except the end. It then calls
+				/// lock() on the std::weak_ptr, resulting in a std::shared_ptr to the RPCCall
+				/// or a std::shared_ptr holding nullptr. Then it puts it back together,
+				/// resulting in a tuple just like the original except now that it holds
+				/// a std::shared_ptr the RPCCall object cannot be deleted while iterating.
+				///
+				/// Thank boost::mp11 for this. Without it it would be near impossible to
+				/// make this happen with one struct that works for every single container.
+				///
 				struct locked_adapter {
-					typedef locked_type result_type;
+					using result_type = locked_type;
 
 					template<class Tp1, class Tp2, std::size_t... I>
 					constexpr static Tp1 make_head(Tp2&& tp2, mp11::index_sequence<I...>) {
@@ -208,6 +279,11 @@ namespace MurmurRPC {
 					}
 				};
 
+				/// \brief Helper class used by boost Range library.
+				///
+				/// Filters a range of 'locked'
+				/// types so that the ones where the std::shared_ptr is nullptr are removed
+				///
 				struct locked_filter {
 					template<typename... types>
 					bool operator()(const std::tuple<types...>& tup) const {
@@ -216,6 +292,14 @@ namespace MurmurRPC {
 					}
 				};
 
+				/// \brief Helper class used as a 'deleter' when accessing the container.
+				///
+				/// Non-const indices are only given out as std::unique_ptr with this deleter, which
+				/// means that having any access to modify the container forces you to
+				/// hold the lock.
+				///
+				/// By hiding the mutex lock this way it can be a private member variable.
+				///
 				struct lock_holder{
 					std::unique_lock<boost::fibers::recursive_mutex> lock;
 
@@ -248,6 +332,12 @@ namespace MurmurRPC {
 					}
 				};
 
+				///
+				/// takes an lref to an index in the container, and turns it into a
+				/// std::unique_ptr with locked_filter as the deleter. While this could
+				/// be used to hold onto the mutex forever, the nature of std::unique_ptr
+				/// makes it very hard to do so without intent.
+				///
 				template<typename Idx>
 				typename std::unique_ptr<Idx, decltype(lock_holder())>
 				makeUniqueIdx(Idx& index) {
@@ -257,6 +347,11 @@ namespace MurmurRPC {
 						);
 				}
 
+				///
+				/// helper function to convert a pair of iterators into a
+				/// range from boost Range that can be safely iterated over
+				/// without holding the lock on the container.
+				///
 				template<typename It>
 				auto getLockedRange(const std::pair<It, It>& rng)
 					-> Detail::range_type_it_t<
@@ -266,13 +361,35 @@ namespace MurmurRPC {
 
 			public:
 
-				typedef typename container_t::iterator iterator;
+				using iterator = typename container_t::iterator;
 
+				///
+				/// uses a user-provided functor that returns a iterator pair
+				/// from the container to make a 'safe' range that can be iterated
+				/// over without either holding the mutex for the container or without
+				/// having check for deleted RPCCalls.
+				///
+				/// \param func a functor that takes in a const lref to this container,
+				/// and returns an iterator pair of the range it wants to go over.
+				///
+				/// \return a transformed range where all RPCCall pointers are converted to
+				/// std::shared_ptr, none of those pointers are null, and no iterator can
+				/// be invalidated.
+				///
 				template<typename Functor>
 				auto getLocked(Functor&& func) -> Detail::range_type_func_t<
 						decltype(locked_adapter()), decltype(locked_filter()),
 						Functor, decltype(*this)>;
 
+				///
+				/// gets a 'safe' range for an index on this container which
+				/// can be iterated over without any invalidation of the iterators and
+				/// all RPCCall pointers are non-nullptr std::shared_ptr
+				///
+				/// \param Idx a reference to the 'tag' of the index you wish to get
+				///
+				/// \return transformed range which can be safely iterated over
+				///
 				template<typename Idx>
 				auto getLockedIndex(const Idx&)
 					-> Detail::range_type_idx_t<
@@ -281,38 +398,86 @@ namespace MurmurRPC {
 						decltype(mi::get<Idx>(container))
 						>;
 
+				/// \brief Only available if the container has an index on a serverId.
+				///
+				/// This will get the container mutex, then return to you a smart
+				/// pointer that you can use as if this was a std::map or std::multimap
+				/// depending on configuration.
+				///
+				/// \return a std::unique_ptr to that has an interface as if it
+				/// was a standard container.
+				///
 				template<typename Q = server>
 				auto getServerPtr() -> decltype(makeUniqueIdx(mi::get<Q>(container))) {
 
 					return makeUniqueIdx(mi::get<Q>(container));
 				}
 
+				/// \brief Only available if container has index on a serverId.
+				///
+				/// \return const lreference that can be used like a standard container
+				///
 				template<typename Q = server>
 				auto getServerIndex() const -> decltype(mi::get<Q>(container)) {
 
 					return mi::get<Q>(container);
 				}
 
+				/// \brief Available in all configurations.
+				///
+				/// Locks the container mutex then returns a smart pointer.
+				///
+				/// \return std::unique_ptr that can be used as if it was pointing to a std::set
+				/// or std::multiset depending on configuration
+				///
 				template<typename Q = rpcid>
 				auto getRPCIdPtr() -> decltype(makeUniqueIdx(mi::get<Q>(container))) {
 					return makeUniqueIdx(mi::get<Q>(container));
 				}
 
+				/// Available in all configurations.
+				///
+				/// Gets a const lreference the rpcId index.
+				///
+				/// \return const lreference that acts like std::set or std::multiset
+				///
 				template<typename Q = rpcid>
 				auto getRPCIdIndex() const -> decltype(mi::get<Q>(container)) {
 					return mi::get<Q>(container);
 				}
 
+				/// Only for contextAction configurations.
+				///
+				/// Locks the container mutex, and returns a smart pointer that has
+				/// an interface like a std::unordered_map keyed on
+				/// std::pair<int, std::string> (serverId and the name of the contextaction)
+				///
+				/// \return std::unique_ptr with a std::unordered_map like interface
+				///
 				template<typename Q = serveraction>
 				auto getActionPtr() -> decltype(makeUniqueIdx(mi::get<Q>(container))) {
 					return makeUniqueIdx(mi::get<Q>(container));
 				}
 
+				/// \brief Only for contextAction configurations.
+				///
+				/// \return const lreference to what appears to be a std::unordered_map
+				///
 				template<typename Q = serveraction>
 				auto getActionIndex() const -> decltype(mi::get<Q>(container)) {
 					return mi::get<Q>(container);
 				}
 
+				/// \brief Used to put new items into the container.
+				///
+				/// While new items can be inserted through the indices this is the way most
+				/// items are expected to be inserted. It will hold the mutex during
+				/// insertion.
+				///
+				/// \return std::pair<iterator, bool> where iterator is iterator
+				/// deferencable to the item inserted, and bool indicates success or failure
+				/// (if you tried to insert a duplicate item into a map/set-like index)
+				///
 				template<typename ... Args>
 				std::pair<iterator, bool> emplace(Args&& ... args) {
 					std::lock_guard<decltype(m_Mtx)> lk(m_Mtx);

--- a/src/murmur/GRPCContainer.h
+++ b/src/murmur/GRPCContainer.h
@@ -9,7 +9,7 @@
 #include <QDebug>
 
 #include <boost/container/slist.hpp>
-#include <boost/container_hash/hash.hpp>
+//#include <boost/container_hash/hash.hpp>
 #include <boost/fiber/all.hpp>
 #include <boost/mp11.hpp>
 #include <boost/mp11/mpl.hpp>

--- a/src/murmur/GRPCContainer.h
+++ b/src/murmur/GRPCContainer.h
@@ -1,0 +1,278 @@
+// Copyright 2005-2019 The Mumble Developers. All rights reserved.
+// Use of this source code is governed by a BSD-style license
+// that can be found in the LICENSE file at the root of the
+// Mumble source tree or at <https://www.mumble.info/LICENSE>.
+
+#ifndef MUMBLE_MURMUR_GRPCONTAINER_H
+#define MUMBLE_MURMUR_GRPCONTAINER_H
+
+#include <boost/mp11.hpp>
+#include <boost/mp11/mpl.hpp>
+#include <boost/container_hash/hash.hpp>
+#include <boost/multi_index_container.hpp>
+#include <boost/multi_index/ordered_index.hpp>
+#include <boost/multi_index/hashed_index.hpp>
+#include <boost/multi_index/key_extractors.hpp>
+#include <boost/range.hpp>
+#include <boost/range/adaptors.hpp>
+#include <boost/range/algorithm/remove_if.hpp>
+#include <boost/range/sub_range.hpp>
+#include <boost/fiber/all.hpp>
+
+#include <tuple>
+#include <type_traits>
+#include <memory>
+#include <mutex>
+
+namespace MurmurRPC {
+	namespace Wrapper {
+		namespace Container {
+
+			struct server {};
+			struct rpcid {};
+			struct serveraction {};
+
+			namespace mi = boost::multi_index;
+
+			template<typename T>
+			struct mapConfig {
+				typedef std::tuple<int, uint32_t, std::weak_ptr<T>> value_type;
+				typedef std::tuple<int, uint32_t, std::shared_ptr<T>> locked_type;
+
+				using indices = std::tuple<
+						mi::ordered_unique<
+							mi::tag<server>,
+							mi::global_fun<
+								const value_type&,
+								const int&,
+								static_cast<const int& (*)(const value_type&)>(std::get<0>)
+							>
+						>,
+						mi::ordered_unique<
+							mi::tag<rpcid>,
+							mi::global_fun<
+								const value_type&,
+								const uint32_t&,
+								static_cast<const uint32_t& (*)(const value_type&)>(std::get<1>)
+							>
+						>
+					>;
+			};
+
+			template<typename T>
+			struct multiMapConfig {
+				typedef std::tuple<int, uint32_t, std::weak_ptr<T>> value_type;
+				typedef std::tuple<int, uint32_t, std::shared_ptr<T>> locked_type;
+
+				using indices = std::tuple<
+						mi::ordered_non_unique<
+							mi::tag<server>,
+							mi::global_fun<
+								const value_type&,
+								const int&,
+								static_cast<const int& (*)(const value_type&)>(std::get<0>)
+							>
+						>,
+						mi::ordered_non_unique<
+							mi::tag<rpcid>,
+							mi::global_fun<
+								const value_type&,
+								const uint32_t&,
+								static_cast<const uint32_t& (*)(const value_type&)>(std::get<1>)
+							>
+						>
+					>;
+			};
+
+			template<typename T>
+			struct contextActionConfig {
+				typedef std::tuple<int, std::string, uint32_t, std::weak_ptr<T>> value_type;
+				typedef std::tuple<int, std::string, uint32_t, std::shared_ptr<T>> locked_type;
+
+				using indices = std::tuple<
+						mi::hashed_non_unique<
+							mi::tag<serveraction>,
+							mi::composite_key<
+								value_type,
+								mi::global_fun<
+									const value_type&,
+									const int&,
+									static_cast<const int& (*)(const value_type&)>(std::get<0>)
+								>,
+								mi::global_fun<
+									const value_type&,
+									const std::string&,
+									static_cast<const std::string& (*)(const value_type&)>(std::get<1>)
+								>
+							>
+						>,
+						mi::ordered_non_unique<
+							mi::tag<rpcid>,
+							mi::global_fun<
+								const value_type &,
+								const uint32_t&,
+								static_cast<const uint32_t& (*)(const value_type&)>(std::get<2>)
+							>
+						>
+					>;
+			};
+
+
+			template<typename T>
+			struct setConfig {
+
+				typedef std::tuple<uint32_t, std::weak_ptr<T>> value_type;
+				typedef std::tuple<uint32_t, std::shared_ptr<T>> locked_type;
+
+				using indices = std::tuple<
+					mi::ordered_unique<
+							mi::tag<rpcid>,
+							mi::global_fun<
+								const value_type&,
+								const uint32_t&,
+								static_cast<const uint32_t& (*)(const value_type&)>(std::get<0>)
+							>
+						>
+					>;
+			};
+
+			template<typename C>
+			class weakContainer {
+
+			public:
+				typedef typename C::value_type value_type;
+				typedef typename C::locked_type locked_type;
+
+				weakContainer() = default;
+				~weakContainer() = default;
+				weakContainer(const weakContainer&) = delete;
+				weakContainer& operator=(const weakContainer&) = delete;
+
+			private:
+				using container_t = mi::multi_index_container<value_type, typename C::indices>;
+
+				container_t container;
+				boost::fibers::recursive_mutex m_Mtx;
+
+				struct locked_adapter {
+					typedef locked_type result_type;
+
+					template<class ...T>
+					locked_type operator()(std::tuple<T...> const & arg) const {
+						static_assert(std::is_same<std::remove_cv_t<std::remove_reference_t<decltype(arg)>>, value_type>::value, "arg is not value_type!");
+						namespace mp11 = boost::mp11;
+						using L1 = std::tuple<T...>;
+						using head_t = mp11::mp_pop_back<L1>;
+						auto head = head_t();
+						using head_idx = mp11::mp_iota<mp11::mp_size<head_t>>;
+						mp11::mp_for_each<head_idx>([&head, &arg](auto i){
+									std::get<i>(head) = std::get<i>(arg);
+								});
+						mp11::mp_back<locked_type> tail = (std::get<sizeof...(T) - 1>(arg)).lock();
+					    return std::tuple_cat(std::move(head), std::make_tuple(tail));
+					}
+				};
+
+				struct locked_filter {
+					template<typename... types>
+					bool operator()(const std::tuple<types...>& tup) const {
+						static_assert(std::is_same<std::remove_cv_t<std::remove_reference_t<decltype(tup)>>, locked_type>::value, "arg is not locked_type!");
+						return std::get<(sizeof...(types) - 1)>(tup) == nullptr;
+					}
+				};
+
+				struct lock_holder{
+					std::unique_lock<boost::fibers::recursive_mutex> lock;
+
+					lock_holder(boost::fibers::recursive_mutex& mtx) : lock(mtx, std::defer_lock) {
+						lock.lock();
+					}
+
+					lock_holder() = default;
+
+					lock_holder(lock_holder&& other) noexcept {
+						std::swap(this->lock, other.lock);
+					}
+					lock_holder& operator=(lock_holder&& other) noexcept {
+						std::swap(this->lock, other.lock);
+					}
+
+					lock_holder(const lock_holder&) = delete;
+
+					lock_holder& operator=(const lock_holder&) = delete;
+
+					~lock_holder() noexcept {
+						if (lock.owns_lock()) {
+							lock.unlock();
+						}
+					}
+
+					template<typename T>
+					void operator()(T* t) {
+						(void) t;
+					}
+				};
+
+				template<typename Idx>
+				typename std::unique_ptr<Idx, decltype(lock_holder())>
+				makeUniqueIdx(Idx& index) {
+					return std::unique_ptr<Idx, lock_holder>(std::addressof(index),
+							lock_holder(this->m_Mtx));
+				}
+
+				template<typename It>
+				auto getLockedRange(const std::pair<It, It>& rng);
+
+			public:
+
+				typedef typename container_t::iterator iterator;
+
+				template<typename Functor>
+				auto getLocked(Functor&& func);
+
+				template<typename Idx>
+				auto getLockedIndex(const Idx&);
+
+				template<typename Q = server>
+				auto getServerPtr() -> decltype(makeUniqueIdx(mi::get<Q>(container))) {
+
+					return makeUniqueIdx(mi::get<Q>(container));
+				}
+
+				template<typename Q = server>
+				auto getServerIndex() const -> decltype(mi::get<Q>(container)) {
+
+					return mi::get<Q>(container);
+				}
+
+				template<typename Q = rpcid>
+				auto getRPCIdPtr() -> decltype(makeUniqueIdx(mi::get<Q>(container))) {
+					return makeUniqueIdx(mi::get<Q>(container));
+				}
+
+				template<typename Q = rpcid>
+				auto getRPCIdIndex() const -> decltype(mi::get<Q>(container)) {
+					return mi::get<Q>(container);
+				}
+
+				template<typename Q = serveraction>
+				auto getActionPtr() -> decltype(makeUniqueIdx(mi::get<Q>(container))) {
+					return makeUniqueIdx(mi::get<Q>(container));
+				}
+
+				template<typename Q = serveraction>
+				auto getActionIndex() const -> decltype(mi::get<Q>(container)) {
+					return mi::get<Q>(container);
+				}
+
+				template<typename ... Args>
+				std::pair<iterator, bool> emplace(Args&& ... args) {
+					auto lk = std::lock_guard(m_Mtx);
+					return container.emplace(std::forward<Args>(args)...);
+				}
+
+			};
+		} //end Container
+	} // wrapper
+}//MurmurRPC
+#endif

--- a/src/murmur/GRPCall.h
+++ b/src/murmur/GRPCall.h
@@ -1,0 +1,661 @@
+// Copyright 2005-2019 The Mumble Developers. All rights reserved.
+// Use of this source code is governed by a BSD-style license
+// that can be found in the LICENSE file at the root of the
+// Mumble source tree or at <https://www.mumble.info/LICENSE>.
+
+#ifndef MUMBLE_MURMUR_GRPCALL_H
+#define MUMBLE_MURMUR_GRPCALL_H
+
+#include <QtCore/QCoreApplication>
+#include <QRandomGenerator>
+
+#include <boost/fiber/all.hpp>
+#include <boost/callable_traits/return_type.hpp>
+#include <boost/callable_traits/args.hpp>
+#include <boost/callable_traits/function_type.hpp>
+#include <boost/type_traits/is_detected.hpp>
+#include <boost/mp11.hpp>
+
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wunused-parameter"
+#include "MurmurRPC.grpc.pb.h"
+#pragma GCC diagnostic pop
+
+#include "Server.h"
+#include "murmur_grpc/FiberScheduler.h"
+
+#include <atomic>
+#include <chrono>
+#include <functional>
+#include <type_traits>
+#include <queue>
+#include <tuple>
+#include <utility>
+
+class MurmurRPCImpl;
+
+namespace MurmurRPC {
+	namespace Wrapper {
+		namespace Detail {
+			// class designed to 'delete' rpc
+			// objects.
+			struct rpc_deleter {
+				typedef void result_type;
+
+				template<typename T, typename Q = decltype(std::declval<T>().m_alive)>
+				void operator()(T* p) const noexcept {
+					if (p == nullptr) {
+						return;
+					}
+					p->m_alive.store(false, std::memory_order_release);
+					return;
+				}
+			};
+
+			struct qtimer_deleter {
+				typedef void result_type;
+
+				template<typename T>
+				void operator()(T* p) const noexcept {
+					if (p == nullptr) {
+						return;
+					}
+					p->deleteLater();
+					return;
+				}
+			};
+
+			//tag types for RPC policy objects
+			using Unary_t = std::integral_constant<int, 1>;
+			using ClientStream_t = std::integral_constant<int, 2>;
+			using ServerStream_t = std::integral_constant<int, 3>;
+			using BidiStream_t = std::integral_constant<int, 4>;
+
+			struct Unary {
+				typedef Unary_t rpctype;
+			};
+			struct ClientStream {
+				typedef ClientStream_t rpctype;
+			};
+			struct ServerStream {
+				typedef ServerStream_t rpctype;
+			};
+			struct BidiStream {
+				typedef BidiStream_t rpctype;
+			};
+
+			namespace bf = boost::fibers;
+			namespace ct = boost::callable_traits;
+
+			template<typename Stream, typename In, typename Out>
+			struct work_queue {
+				bf::mutex m_busyMtx;
+				bf::fiber m_worker;
+				bf::condition_variable m_doWork;
+				std::atomic<bool> m_isWorking{false};
+				std::queue<bf::packaged_task<void()>> m_workQueue;
+				Stream stream;
+
+				work_queue(::grpc::ServerContext *ctx) : stream(ctx){
+				}
+				~work_queue() = default;
+
+				template<typename Functor>
+				bf::future<ct::return_type_t<Functor>> queueWork(Functor && func) {
+					static_assert(std::tuple_size<ct::args_t<Functor>>::value == 0,
+							"queueWork needs R() signature");
+
+					bf::packaged_task< ct::return_type_t<Functor> () > task(func);
+					auto future = task.get_future();
+					{
+						std::unique_lock< bf::mutex > l(m_busyMtx);
+						m_workQueue.emplace(std::move(task));
+					}
+					m_doWork.notify_one();
+					return future;
+				}
+
+				void createWorker() {
+					m_isWorking.store(true);
+					bf::fiber f([&] {
+						while(m_isWorking) {
+							bf::packaged_task<void ()> task;
+							{
+								std::unique_lock<bf::mutex> l(m_busyMtx);
+								if (m_workQueue.empty()) {
+									m_doWork.wait(l, [&](){return !m_workQueue.empty() || !m_isWorking.load();});
+									if (!m_isWorking.load()) {
+										//drain work queue my just resetting everything
+										while (!m_workQueue.empty()) {
+											if (m_workQueue.front().valid()) {
+												m_workQueue.front().reset();
+											}
+											m_workQueue.pop();
+										}
+										return;
+									}
+								}
+								task = std::move(m_workQueue.front());
+								m_workQueue.pop();
+							}
+							if (task.valid()) {
+								task();
+							}
+						}
+					});
+					m_worker = std::move(f);
+					return;
+				}
+
+				void cancel() {
+					m_isWorking.store(false);
+				}
+
+				void done(bool) {
+					m_isWorking.store(false);
+					m_doWork.notify_one();
+					if (m_worker.joinable()) {
+						m_worker.join();
+					}
+				}
+
+				bool writePrivate (const Out& message) {
+					bf::promise<bool> okPromise;
+					bf::future<bool> okFuture(okPromise.get_future());
+					auto l = [okPromise = std::move(okPromise), &message](bool ok) mutable {
+							okPromise.set_value(ok);
+					};
+					auto cb = ::boost::function<void(bool)>(std::ref(l));
+					stream.Write(message, std::addressof(cb));
+					auto ret = okFuture.get();
+					return ret;
+				}
+
+				std::pair< bool, In > readPrivate() {
+					In request;
+					bf::promise<bool> okPromise;
+					bf::future<bool> okFuture(okPromise.get_future());
+
+					auto l = [okPromise=std::move(okPromise)](bool ok) mutable {
+									okPromise.set_value(ok);
+								};
+					auto cb = ::boost::function<void(bool)>(std::ref(l));
+					stream.Read(&request, std::addressof(cb));
+					auto ret = okFuture.get();
+					return std::make_pair(ret, request);
+				}
+
+				void error(const ::grpc::Status& err) {
+					stream.Finish(err, nullptr);
+				}
+			};
+
+			template<typename RPCType, template<typename...> class StreamType, typename In, typename Out>
+			struct rpcImpl {};
+
+			template<template<typename...> class StreamType, typename In, typename Out>
+			struct rpcImpl<Unary_t, StreamType, In, Out>
+			{
+				typedef StreamType<Out> Stream;
+
+				In m_Request{};
+				Stream stream;
+
+				void error(const ::grpc::Status &err) {
+					stream.FinishWithError(err, nullptr);
+				}
+
+				void end(const Out& msg) {
+					stream.Finish(msg, ::grpc::Status::OK, nullptr);
+				}
+
+				void start() {};
+				void cancel() {};
+				void done(bool) {};
+
+				rpcImpl(::grpc::ServerContext *ctx) : stream(ctx) {
+				};
+			};
+
+			template<template<typename...> class StreamType, typename In, typename Out>
+			struct rpcImpl<ServerStream_t, StreamType, In, Out> :
+					private work_queue<StreamType<Out>, In, Out> {
+				typedef work_queue<StreamType<Out>, In, Out> queue;
+
+				In m_Request{};
+				Out m_Response{};
+				using queue::stream;
+
+				using queue::done;
+				using queue::cancel;
+				using queue::error;
+				using queue::createWorker;
+
+				template<typename Functor>
+				void Write(const Out &msg, Functor && fn) {
+					static_assert(std::is_same<ct::function_type_t<Functor>, void(bool)>{},
+							"Write(msg, cb)) expects void(bool) for cb");
+
+					(void) this->queueWork([this, msg, fn = std::move(fn)]() mutable -> void {
+								auto ok = this->writePrivate(msg);
+								static_cast<std::function<void(bool)>>(std::ref(fn))(ok);
+							});
+				}
+
+				rpcImpl(::grpc::ServerContext *ctx) : work_queue<StreamType<Out>, In, Out>(ctx) {
+				};
+			};
+
+			template<template<typename...> class StreamType, typename In, typename Out>
+			struct rpcImpl<BidiStream_t, StreamType, In, Out> :
+					private work_queue<StreamType<Out, In>, In, Out> {
+				typedef work_queue<StreamType<Out, In>, In, Out> queue;
+
+				using queue::stream;
+
+				using queue::done;
+				using queue::cancel;
+				using queue::error;
+				using queue::createWorker;
+
+				bf::future<bool> write(const Out &message) {
+					return this->queueWork([&]() -> bool { return this->writePrivate(message); });
+				}
+
+				bf::future<std::pair< bool, In >> read() {
+					return this->queueWork([&]() -> std::pair< bool, In > { return this->readPrivate(); });
+				}
+
+				bf::future<std::pair< bool, In>> writeRead(const Out &message) {
+					return this->queueWork([&]() -> std::pair<bool, In > {
+						bool ok = this->writePrivate(message);
+						if (!ok) {
+							In m;
+							return std::make_pair(false, m);
+						}
+						return this->readPrivate();
+					});
+				}
+
+				rpcImpl(::grpc::ServerContext *ctx) : work_queue<StreamType<Out, In>, In, Out>(ctx) {
+				};
+			};
+		} //end Detail
+
+		namespace bf = boost::fibers;
+		namespace ct = boost::callable_traits;
+		using Detail::Unary_t;
+		using Detail::ClientStream_t;
+		using Detail::ServerStream_t;
+		using Detail::BidiStream_t;
+
+		template<typename Derived, typename RPCType = typename Derived::RPCType> class RPCCall : private Derived {
+			friend Detail::rpc_deleter;
+			friend Derived;
+
+		public:
+			typedef typename Derived::InType InType;
+			typedef typename Derived::OutType OutType;
+			typedef typename Derived::Service ServiceType;
+			using Derived::impl;
+
+		private:
+			std::atomic<bool> m_isCancelled;
+			std::atomic_flag m_finished;
+			std::atomic<bool> m_alive;
+			std::shared_ptr<RPCCall<Derived>> m_this;
+
+		protected:
+			uint32_t m_RPCid;
+			::MurmurRPCImpl *rpc;
+			ServiceType *service;
+			::grpc::ServerContext context;
+			Detail::rpcImpl<RPCType, Derived::template StreamType, InType, OutType> impl_detail;
+			typedef decltype(impl_detail) ImplType;
+
+		private:
+
+			boost::function<void(bool)> m_DoneFunction;
+
+			void* getDoneFunctionAddr() { return std::addressof(m_DoneFunction); }
+
+			boost::function<void(bool)> m_HandleFunction;
+
+			void* getHandleFunctionAddr() { return std::addressof(m_HandleFunction); }
+
+			bool tryDelete() {
+				if(m_alive.load(std::memory_order_acquire)) {
+					qDebug("worker %u still alive, but needs deleted", m_RPCid);
+					return false;
+				}
+				delete this;
+				return true;
+			}
+
+			void finish() {
+				if (m_finished.test_and_set()) {
+					qDebug("finished called more than once id %u", m_RPCid);
+					return;
+				}
+				qDebug("attempting to delete id %u", m_RPCid);
+
+				// the first delete always fails....
+				// but without this in place, it deletes me before i'm ready
+				bf::barrier b(2);
+				(void) bf::fiber([this, &b](){
+					b.wait();
+					while (!this->tryDelete()) {
+						::boost::this_fiber::sleep_for(std::chrono::milliseconds(100));
+					}
+				}).detach();
+				b.wait();
+				m_this.reset();
+			}
+
+			void done(bool ok) {
+				if (context.IsCancelled()) {
+					m_isCancelled.store(true, std::memory_order_release);
+					impl_detail.cancel();
+				}
+				impl_detail.done(ok);
+				this->finish();
+			}
+
+			template<typename Functor>
+			void launchInEventLoop(Functor&& fn) {
+				static_assert(std::is_same<ct::function_type_t<Functor>, void()>{},
+							"launchInEventLoop(Fn) expects void() for fn");
+
+				boost::fibers::fiber f([ptr = this->getSharedPtr(), func = std::move(fn)](){
+					try {
+						func();
+					} catch (::grpc::Status &ex) {
+						if (!ptr->isCancelled()) {
+							ptr->error(ex);
+						}
+					}
+				});
+				auto& props( f.properties<MurmurRPC::Scheduler::grpc_props>() );
+				props.run_in_main(true);
+				f.detach();
+			}
+
+			template<typename X = RPCType, std::enable_if_t<std::is_same<X, Unary_t>::value>* = nullptr>
+			void handle(bool ok);
+
+			template<typename X = RPCType, std::enable_if_t<std::is_same<X, ServerStream_t>::value>* = nullptr>
+			void handle(bool ok);
+
+			template<typename X = RPCType, std::enable_if_t<std::is_same<X, BidiStream_t>::value>* = nullptr>
+			void handle(bool ok);
+
+		protected:
+			template<typename RFn,
+				std::enable_if_t<(std::tuple_size<std::add_const_t<ct::args_t<RFn>>>::value == 7)>* = nullptr>
+			static void addCQHandler(ServiceType* svc, MurmurRPCImpl* rpc, RFn requestFn, void *handleFn,
+					RPCCall<Derived> *call);
+
+			template<typename RFn,
+				std::enable_if_t<(std::tuple_size<std::add_const_t<ct::args_t<RFn>>>::value == 6)>* = nullptr>
+			static void addCQHandler(ServiceType* svc, MurmurRPCImpl* rpc, RFn requestFn, void *handleFn,
+					RPCCall<Derived> *call);
+
+			explicit RPCCall(MurmurRPCImpl *rpcImpl, ServiceType *svc) :
+				m_isCancelled(false),
+				m_alive(true),
+				m_this(static_cast<RPCCall<Derived> *>(this), Detail::rpc_deleter()),
+				m_RPCid(QRandomGenerator::global()->generate()),
+				rpc(rpcImpl),
+				service(svc),
+				impl_detail(&context) {
+					m_finished.clear();
+					this->m_DoneFunction = boost::function<void(bool)>([this](bool ok){ this->done(ok); });
+					this->m_HandleFunction = boost::function<void(bool)>([this](bool ok){ this->handle(ok); });
+			}
+
+			~RPCCall() {
+				qDebug("deleted worker %u", getId());
+			}
+
+			std::shared_ptr<RPCCall<Derived>> getSharedPtr() const {
+				return m_this;
+			}
+
+		public:
+			//universal functions
+			uint32_t getId() {
+				return m_RPCid;
+			}
+
+			bool isCancelled() {
+				return m_isCancelled.load(std::memory_order_acquire);
+			}
+
+			void error(const ::grpc::Status &err) {
+				impl_detail.error(err);
+			}
+
+			std::weak_ptr<RPCCall<Derived>> getWeakPtr() const {
+				return m_this;
+			}
+
+			//unary streams
+			template<typename Impl = ImplType>
+			auto end(const OutType &message = OutType())
+					-> decltype(std::declval<Impl>().end(OutType())) {
+				impl_detail.end(message);
+			}
+
+			// functions for client streams
+			template<typename Impl = ImplType, typename Functor>
+			auto Write(const OutType& msg, Functor&& func)
+					-> decltype(std::declval<Impl>().Write(OutType(), std::declval<Functor>())) {
+				return impl_detail.Write(msg, std::forward<Functor>(func));
+			}
+
+			// stream-stream functions
+			template<typename MsgType>
+			auto write(MsgType message) {
+				return impl_detail.queueWork([&]() -> bool { return impl_detail.writePrivate(message); });
+			}
+
+			template<typename Impl = ImplType>
+			auto read() -> decltype(std::declval<Impl>().read()) {
+				return impl_detail.read();
+			}
+
+			template<typename Impl = ImplType>
+			auto writeRead(const OutType& message) -> decltype(std::declval<Impl>().writeRead(OutType())) {
+				return impl_detail.writeRead(message);
+			}
+
+			static void create(MurmurRPCImpl *rpc, ServiceType *service) {
+				auto call = new RPCCall<Derived>(rpc, service);
+				auto doneFn = call->getDoneFunctionAddr();
+				call->context.AsyncNotifyWhenDone(doneFn);
+				auto handleFn = call->getHandleFunctionAddr();
+				auto requestFn = Derived::getRequestFn();
+				addCQHandler(service, rpc, requestFn, handleFn, call);
+			}
+		};
+} //end Wrapper
+} //end MurmurRPC
+
+#include "MurmurRPC.proto.Wrapper.cpp"
+
+/*
+class RPCExecEvent : public ExecEvent {
+public:
+	boost::function<void(grpc::Status&)> error;
+
+	template<typename T>
+	RPCExecEvent(boost::function<void()> fn, MurmurRPC::Wrapper::RPCCall<T>& rpc_call) : ExecEvent(fn) {
+		auto weak = rpc_call.getWeakPtr();
+		error = [weak](::grpc::Status& err){
+			auto c = weak.lock();
+			if(c != nullptr && !c->isCancelled()) {
+				c->error(err);
+			}
+		};
+	}
+
+private:
+	RPCExecEvent(const RPCExecEvent&) = delete;
+	RPCExecEvent &operator=(const RPCExecEvent&) = delete;
+};
+*/
+
+#endif
+
+#ifdef MUMBLE_MURMUR_GRPC_WRAPPER_IMPL
+#ifndef MUMBLE_MURMUR_GRPC_WRAPPER_IMPL_HH_
+#define MUMBLE_MURMUR_GRPC_WRAPPER_IMPL_HH_
+
+
+
+namespace MurmurRPC {
+	namespace Wrapper {
+
+		using Detail::Unary_t;
+		using Detail::ClientStream_t;
+		using Detail::ServerStream_t;
+		using Detail::BidiStream_t;
+
+		namespace ct = boost::callable_traits;
+
+		template<typename Derived, typename RPCType>
+		template<typename RFn, std::enable_if_t<(std::tuple_size<std::add_const_t<ct::args_t<RFn>>>::value == 7)>*>
+		void RPCCall<Derived, RPCType>::addCQHandler(ServiceType* svc, MurmurRPCImpl* rpc,
+					RFn requestFn, void *handleFn, RPCCall<Derived> *call) {
+				(svc->*requestFn)(&call->context, &call->impl_detail.m_Request, &call->impl_detail.stream, rpc->m_completionQueue.get(), rpc->m_completionQueue.get(), handleFn);
+		}
+
+		template<typename Derived, typename RPCType>
+		template<typename RFn, std::enable_if_t<(std::tuple_size<std::add_const_t<ct::args_t<RFn>>>::value == 6)>*>
+		void RPCCall<Derived, RPCType>::addCQHandler(ServiceType* svc, MurmurRPCImpl* rpc,
+					RFn requestFn, void *handleFn, RPCCall<Derived> *call) {
+			(svc->*requestFn)(&call->context, &call->impl_detail.stream, rpc->m_completionQueue.get(),
+					rpc->m_completionQueue.get(), handleFn);
+		}
+
+		/*
+		template<typename Derived, typename RPCType>
+		template<typename X, std::enable_if_t<std::is_same<X, Unary_t>::value>*>
+		void RPCCall<Derived, RPCType>::handle(bool ok) {
+			RPCCall<Derived>::create(this->rpc, this->service);
+			auto weak_ptr = this->getWeakPtr();
+			auto ie = new RPCExecEvent([this, weak_ptr, ok](){
+				auto ptr = weak_ptr.lock();
+				if (ptr == nullptr) { return; }
+				ptr->impl(this->getSharedPtr(), this->impl_detail.m_Request);
+			}, *this);
+			QCoreApplication::instance()->postEvent(rpc, ie);
+		}
+		*/
+
+		template<typename Derived, typename RPCType>
+		template<typename X, std::enable_if_t<std::is_same<X, Unary_t>::value>*>
+		void RPCCall<Derived, RPCType>::handle(bool ok) {
+			RPCCall<Derived>::create(this->rpc, this->service);
+			auto ptr = this->getSharedPtr();
+			this->launchInEventLoop([this, ptr, ok](){
+					ptr->impl(ptr, this->impl_detail.m_Request);
+			});
+		}
+
+		/*
+		template<typename Derived, typename RPCType>
+		template<typename X, std::enable_if_t<std::is_same<X, ServerStream_t>::value>*>
+		void RPCCall<Derived, RPCType>::handle(bool ok) {
+			RPCCall<Derived>::create(this->rpc, this->service);
+			auto weak_ptr = this->getWeakPtr();
+			auto ie = new RPCExecEvent([this, weak_ptr, ok](){
+				auto ptr = weak_ptr.lock();
+				if (ptr == nullptr) { return; }
+				ptr->impl(this->getSharedPtr(), this->impl_detail.m_Request);
+			}, *this);
+			QCoreApplication::instance()->postEvent(rpc, ie);
+			impl_detail.createWorker();
+		}
+		*/
+
+		template<typename Derived, typename RPCType>
+		template<typename X, std::enable_if_t<std::is_same<X, ServerStream_t>::value>*>
+		void RPCCall<Derived, RPCType>::handle(bool ok) {
+			RPCCall<Derived>::create(this->rpc, this->service);
+			auto ptr = this->getSharedPtr();
+			this->launchInEventLoop([this, ptr, ok](){
+				ptr->impl(ptr, this->impl_detail.m_Request);
+			});
+			impl_detail.createWorker();
+		}
+
+		/*
+		template<typename Derived, typename RPCType>
+		template<typename X, std::enable_if_t<std::is_same<X, BidiStream_t>::value>*>
+		void RPCCall<Derived, RPCType>::handle(bool ok) {
+			RPCCall<Derived>::create(this->rpc, this->service);
+			auto weak_ptr = this->getWeakPtr();
+			auto ie = new RPCExecEvent([this, weak_ptr, ok](){
+				auto ptr = weak_ptr.lock();
+				if (ptr == nullptr) { return; }
+				ptr->impl(this->getSharedPtr());
+			}, *this);
+			QCoreApplication::instance()->postEvent(rpc, ie);
+			impl_detail.createWorker();
+		}
+		*/
+
+		template<typename Derived, typename RPCType>
+		template<typename X, std::enable_if_t<std::is_same<X, BidiStream_t>::value>*>
+		void RPCCall<Derived, RPCType>::handle(bool ok) {
+			RPCCall<Derived>::create(this->rpc, this->service);
+			auto ptr = this->getSharedPtr();
+			this->launchInEventLoop([this, ptr, ok](){
+				ptr->impl(ptr);
+			});
+			impl_detail.createWorker();
+		}
+	} //end Wrapper
+} //end MurmurRPC
+
+namespace MurmurRPC {
+	namespace Wrapper {
+	namespace Container {
+
+		namespace mp11 = boost::mp11;
+
+		template<typename C>
+		template<typename It>
+		auto weakContainer<C>::getLockedRange(const std::pair<It, It>& rng) {
+			auto range = ::boost::iterator_range<It>(rng.first, rng.second);
+			auto locked = ::boost::adaptors::transform(range, locked_adapter());
+			return ::boost::remove_if<::boost::return_begin_found>(locked, locked_filter());
+		}
+
+		template<typename C>
+		template<typename Idx>
+		auto weakContainer<C>::getLockedIndex(const Idx&) {
+			auto lk = std::lock_guard(m_Mtx);
+			const auto& idx = mi::get<Idx>(container);
+			return getLockedRange(std::make_pair(idx.cbegin(), idx.cend()));
+		}
+
+		template<typename C>
+		template<typename Functor>
+		auto weakContainer<C>::getLocked(Functor&& func) {
+			using return_type = std::decay_t<decltype(std::declval<Functor>()(*this))>;
+			using voids = mp11::mp_transform<mp11::mp_void, return_type>;
+			static_assert(std::is_same<voids, std::pair<void, void>>::value && 
+					mp11::mp_same<return_type>::value , "func must have signature std::pair<Iter, Iter>(&Container)");
+			auto lk = std::lock_guard(m_Mtx);
+			const auto& range = func(*this);
+			return this->getLockedRange(range);
+		}
+	}
+}}
+
+#include "MurmurRPC.proto.Wrapper.cpp"
+
+#endif
+#endif

--- a/src/murmur/GRPCall.h
+++ b/src/murmur/GRPCall.h
@@ -7,7 +7,6 @@
 #define MUMBLE_MURMUR_GRPCALL_H
 
 #include <QDebug>
-//#include <QRandomGenerator>
 #include <QtCore/QCoreApplication>
 
 #include <boost/callable_traits/args.hpp>
@@ -693,9 +692,7 @@ namespace MurmurRPC {
 				};
 			};
 
-			static std::random_device r;
-			static std::seed_seq seed{r(), r(), r(), r(), r(), r(), r(), r()};
-			static std::mt19937 mt_rand(seed);
+			uint32_t mt_random();
 
 			/// \brief param number for completion queue call with message to be read in
 			///
@@ -990,7 +987,7 @@ namespace MurmurRPC {
 				m_isCancelled(false),
 				m_alive(true),
 				m_this(static_cast<RPCCall<Derived> *>(this), Detail::rpc_deleter()),
-				m_RPCid(Detail::mt_rand()),
+				m_RPCid(Detail::mt_random()),
 				rpc(rpcImpl),
 				service(svc),
 				impl_detail(&context) {

--- a/src/murmur/GRPCall.h
+++ b/src/murmur/GRPCall.h
@@ -37,8 +37,11 @@ class MurmurRPCImpl;
 namespace MurmurRPC {
 	namespace Wrapper {
 		namespace Detail {
-			// class designed to 'delete' rpc
-			// objects.
+
+			/// \brief Custom deleter for RPCCall objects.
+			///
+			/// Instead of deleting the objects, just sets RPCCall::m_alive to false
+			///
 			struct rpc_deleter {
 				typedef void result_type;
 
@@ -52,8 +55,14 @@ namespace MurmurRPC {
 				}
 			};
 
+			/// \brief Custom deleter for QTimer.
+			///
+			/// If you try to delete a QTimer allocated with new, you will
+			/// find it throws an exception. This deleter just calls the
+			/// method to delete the timer on the next event loop run
+			///
 			struct qtimer_deleter {
-				typedef void result_type;
+				using result_type = void;
 
 				template<typename T>
 				void operator()(T* p) const noexcept {
@@ -72,21 +81,32 @@ namespace MurmurRPC {
 			using BidiStream_t = std::integral_constant<int, 4>;
 
 			struct Unary {
-				typedef Unary_t rpctype;
+				using rpctype = Unary_t;
 			};
 			struct ClientStream {
-				typedef ClientStream_t rpctype;
+				using rpctype = ClientStream_t;
 			};
 			struct ServerStream {
-				typedef ServerStream_t rpctype;
+				using rpctype = ServerStream_t;
 			};
 			struct BidiStream {
-				typedef BidiStream_t rpctype;
+				using rpctype = BidiStream_t;
 			};
 
 			namespace bf = boost::fibers;
 			namespace ct = boost::callable_traits;
 
+			/// \brief Helper class to implement a work queue running in a seperate fiber.
+			///
+			/// This class takes in arbitrary functions, packages them
+			/// into `boost::fibers::packaged_task<>`, and then returns a
+			/// future to wait on. It then runs each function in the order
+			/// recieved.
+			///
+			/// \tparam Stream typename of the steram object used for communications
+			/// \tparam In typename of the protobuf messages that will be recieved
+			/// \tparam Out typename of the protobuf messages that will be sent
+			///
 			template<typename Stream, typename In, typename Out>
 			struct work_queue {
 				bf::mutex m_busyMtx;
@@ -96,12 +116,32 @@ namespace MurmurRPC {
 				std::queue<bf::packaged_task<void()>> m_workQueue;
 				Stream stream;
 
+				/// \brief Constructor.
+				///
+				/// You cannot send messages until createWorker() has been called
+				///
+				/// \param [in] ctx a `grpc::ServerContext` to create the stream with
+				///
 				work_queue(::grpc::ServerContext *ctx) : stream(ctx){
 				}
+
 				~work_queue() = default;
 
+				/// \brief Queues a function to be run in the work queue
+				///
+				/// queueWork takes any arbitrary functor (llambda, function object,
+				/// function ponter) puts it into a `boost::fibers::packaged_task<>` and returns
+				/// the `boost::fibers::future<>` that is associated with the outcome
+				/// of the functor.
+				///
+				/// It then queues the work to be done in the worker fiber.
+				///
+				/// \param func [in] a *MoveConstructable* functor with no arguments
+				/// \return a `boost::fibers::future<R>` where `R` is the return value
+				/// of the functor that was given
+				///
 				template<typename Functor>
-				bf::future<ct::return_type_t<Functor>> queueWork(Functor && func) {
+				auto queueWork(Functor&& func) -> bf::future<ct::return_type_t<Functor>> {
 					static_assert(std::tuple_size<ct::args_t<Functor>>::value == 0,
 							"queueWork needs R() signature");
 
@@ -115,7 +155,25 @@ namespace MurmurRPC {
 					return future;
 				}
 
-				void createWorker() {
+				/// \brief Initializes the work queue.
+				///
+				/// createWorker spawns a new fiber in the current thread that
+				/// is responsible for running the tasks. When there are no tasks,
+				/// it will wait on a condition variable until queueWork(Functor&& func)
+				/// is called.
+				///
+				/// cancel() may be called to cancel the processing of work early, but
+				/// does not remove any jobs from the queue, nor alert the worker fiber
+				/// that anything has happened.
+				///
+				/// done(bool) cancels the processing of work, alerts the worker fiber to
+				/// return from sleeping, and if the fiber is still joinable, join
+				/// the fiber.
+				///
+				/// The worker fiber is stored in \ref m_worker. Since this fiber is not
+				/// detached it is critical to call done(bool) before destroying the object.
+				///
+				auto createWorker() -> void {
 					m_isWorking.store(true);
 					bf::fiber f([&] {
 						while(m_isWorking) {
@@ -147,10 +205,17 @@ namespace MurmurRPC {
 					return;
 				}
 
+				/// cancels processing of work, but does not wake up the worker fiber
 				void cancel() {
 					m_isWorking.store(false);
 				}
 
+				/// \brief cancels processing of work, then joins the worker fiber
+				///
+				/// This function must be called before destroying the object, as
+				/// if the worker fiber is still joinable when destroyed,
+				/// `std::terminate` will be called.
+				///
 				void done(bool) {
 					m_isWorking.store(false);
 					m_doWork.notify_one();
@@ -159,6 +224,18 @@ namespace MurmurRPC {
 					}
 				}
 
+				/// \brief implementation detail not to be called outside the framework
+				///
+				/// This is one of the core functions used to communicate with the
+				/// gRPC framework. It takes a message to be written, calls
+				/// the write function, and then blocks until the completion queue
+				/// calls the callback with a `bool` to indicate sucesss.
+				///
+				/// \param [in] message a const lref to the protobuf message to write.
+				/// this function does not take ownership of the written message.
+				/// \return `true` or `false` depending on what the completion queue
+				/// returns when the callback sent to be called
+				///
 				bool writePrivate (const Out& message) {
 					bf::promise<bool> okPromise;
 					bf::future<bool> okFuture(okPromise.get_future());
@@ -166,18 +243,27 @@ namespace MurmurRPC {
 					auto l = std::bind([](bf::promise<bool>& okPromise, bool ok) -> void {
 							okPromise.set_value(ok);
 					}, std::move(okPromise), std::placeholders::_1);
-					boost::function<void(bool)> cb = std::ref(l);
+					std::function<void(bool)> cb = std::ref(l);
 #else
 					auto l = [okPromise = std::move(okPromise)](bool ok) mutable {
 							okPromise.set_value(ok);
 					};
-					auto cb = boost::function<void(bool)>(std::ref(l));
+					auto cb = std::function<void(bool)>(std::ref(l));
 #endif
 					stream.Write(message, std::addressof(cb));
 					auto ret = okFuture.get();
 					return ret;
 				}
 
+				/// \brief implementation detail not to be called outside the framework
+				///
+				/// This is one of the core functions used to communicate with the
+				/// gRPC framework. It reads a message from the stream, blocking
+				/// until it has been recieved.
+				///
+				/// \return `std::pair<bool, Message>` where bool is the sucess code
+				/// and message is either blank or the recieved message
+				///
 				std::pair< bool, In > readPrivate() {
 					In request;
 					bf::promise<bool> okPromise;
@@ -187,18 +273,23 @@ namespace MurmurRPC {
 					auto l = std::bind([](bf::promise<bool>& okPromise, bool ok) -> void {
 							okPromise.set_value(ok);
 					}, std::move(okPromise), std::placeholders::_1);
-					boost::function<void(bool)> cb = std::ref(l);
+					std::function<void(bool)> cb = std::ref(l);
 #else
 					auto l = [okPromise = std::move(okPromise)](bool ok) mutable {
 							okPromise.set_value(ok);
 					};
-					auto cb = boost::function<void(bool)>(std::ref(l));
+					auto cb = std::function<void(bool)>(std::ref(l));
 #endif
 					stream.Read(&request, std::addressof(cb));
 					auto ret = okFuture.get();
 					return std::make_pair(ret, request);
 				}
 
+				/// \brief implementation detail not to be called outside the framework
+				///
+				/// finishes the stream with the given error code and
+				/// returns without waiting
+				///
 				void error(const ::grpc::Status& err) {
 					stream.Finish(err, nullptr);
 				}
@@ -207,6 +298,15 @@ namespace MurmurRPC {
 			template<typename RPCType, template<typename...> class StreamType, typename In, typename Out>
 			struct rpcImpl {};
 
+			/// \brief implentation detail for unary streams
+			///
+			/// This is the helper class for unary streams where a message
+			/// is recieved and either a message is sent out or an error is sent out
+			///
+			/// \tparam StreamType template for creating the stream object
+			/// \tparam In typename of the incoming protobuf messages
+			/// \tparam Out typename of the outgoing protobuf messages
+			///
 			template<template<typename...> class StreamType, typename In, typename Out>
 			struct rpcImpl<Unary_t, StreamType, In, Out>
 			{
@@ -215,26 +315,55 @@ namespace MurmurRPC {
 				In m_Request{};
 				Stream stream;
 
+				/// \brief Request the stream be finished with an error code, then returns
+				///
+				/// \param err the error code to be sent
+				///
 				void error(const ::grpc::Status &err) {
 					stream.FinishWithError(err, nullptr);
 				}
 
+				/// \brief Requests an output message to be written, then returns
+				///
+				/// \param msg const lref to the output message. Ownership
+				/// is not taken of the message and it can destroyed after
+				/// this returns
+				///
 				void end(const Out& msg) {
 					stream.Finish(msg, ::grpc::Status::OK, nullptr);
 				}
 
+				/// does nothing, but needed to satisfy interface
 				void start() {};
+
+
+				/// does nothing, but needed to satisfy interface
 				void cancel() {};
+
+				/// does nothing, but needed to satisfy interface
 				void done(bool) {};
 
+				/// \brief Constructor.
+				///
+				/// \param ctx the grpc::ServerContext to create the stream
+				///
 				rpcImpl(::grpc::ServerContext *ctx) : stream(ctx) {
 				};
 			};
 
+			/// \brief Helper class for streams where there is one request, and many output messages
+			///
+			/// This class depends on \ref work_queue
+			/// for most of its implementation.
+			///
+			/// \tparam StreamType template of the stream object used for writing
+			/// \tparam In typename of the incoming protobuf messages
+			/// \tparam Out typename of the outgoing protobuf messages
+			///
 			template<template<typename...> class StreamType, typename In, typename Out>
 			struct rpcImpl<ServerStream_t, StreamType, In, Out> :
 					private work_queue<StreamType<Out>, In, Out> {
-				typedef work_queue<StreamType<Out>, In, Out> queue;
+				using queue = work_queue<StreamType<Out>, In, Out>;
 
 				In m_Request{};
 				Out m_Response{};
@@ -245,6 +374,23 @@ namespace MurmurRPC {
 				using queue::error;
 				using queue::createWorker;
 
+				/// \brief Requests write of message and returns immediately.
+				/// fn is called on completion of write.
+				///
+				/// This is the main function used by ServerStream type RPC calls. It asks
+				/// for a message to be written and returns immediately, afterward it calls a
+				/// user-defined functor with the success or error of the write. This functor
+				/// will be called in the thread of the work queue.
+				///
+				/// Since no two calls to the gRPC Write function at the same time are allowed,
+				/// the work queue is used to ensure that they do not overlap.
+				///
+				/// \param [in] msg protobuff message to be written. Ownership is not taken
+				/// \param [in] fn a *MoveConstructable* functor of signature `void(bool)` to
+				/// be called after the write has been completed. Ownership is taken of this
+				/// functor and it cannot be used after this call. It is expected to be stack
+				/// allocated.
+				///
 				template<typename Functor>
 				void Write(const Out &msg, Functor && fn) {
 					static_assert(std::is_same<ct::function_type_t<Functor>, void(bool)>{},
@@ -270,30 +416,111 @@ namespace MurmurRPC {
 #endif
 				}
 
+				/// \brief Constructor.
+				///
+				/// \param ctx the grpc::ServerContext used to create the communication stream
+				///
 				rpcImpl(::grpc::ServerContext *ctx) : work_queue<StreamType<Out>, In, Out>(ctx) {
 				};
 			};
 
+			/// \brief helper class for bidirectional stream RPC calls
+			///
+			/// Most of the implementation of this class is in \ref work_queue
+			///
+			/// This is the helper for bidirectional streams, where both the server
+			/// and client will be sending messages back and forth, such as
+			/// textMessageFilter. As such, it exposes much more of the boost::fibers
+			/// implementation that is used by all RPC types.
+			///
+			/// \tparam StreamType template of the stream type that will be used for messages
+			/// \tparam In typename of the incoming protobuf messages
+			/// \tparam Out typename out outgoing prototobuf messages
+			///
 			template<template<typename...> class StreamType, typename In, typename Out>
 			struct rpcImpl<BidiStream_t, StreamType, In, Out> :
 					private work_queue<StreamType<Out, In>, In, Out> {
-				typedef work_queue<StreamType<Out, In>, In, Out> queue;
+
+				using queue = work_queue<StreamType<Out, In>, In, Out>;
 
 				using queue::stream;
 
+				/// see \ref work_queue::done()
 				using queue::done;
+
+				/// see \ref work_queue::cancel()
 				using queue::cancel;
+
+				/// see \ref work_queue::error()
 				using queue::error;
+
+				/// see \ref work_queue::createWorker()
 				using queue::createWorker;
 
-				bf::future<bool> write(const Out &message) {
+				/// \brief Asks message to be written.
+				///
+				/// It enqueues a message to be written into the work queue. Since no
+				/// two messages can be written at the same time if the futures are not requested
+				/// in the order in which they were recieved a single same fiber, deadlock can result.
+				///
+				/// Futures can be requested out of order as long as different fibers request them;
+				/// they will just be woken up in the same order in which the writes were requested.
+				///
+				/// Calling `get()` or `wait()` on the returned future will block that fiber until
+				/// the write has been completed. If an exception was encountered or the promise was
+				/// destroyed `get()` will throw an exception. See the `boost::fibers` documentation
+				/// for more details
+				///
+				/// \param [in] message the message to be written. Ownership is not taken and it can
+				/// be destroyed after this call
+				/// \return `boost::fibers::future<bool>` that will contain the result of the write.
+				///
+				bf::future<bool> write(const Out& message) {
 					return this->queueWork([&]() -> bool { return this->writePrivate(message); });
 				}
 
+				/// \brief Asks message to be read.
+				///
+				/// It enqueues a read request in the work queue. It will then
+				/// return immediately with a future that will both have the success of the read
+				/// and the read message or a blank message.
+				///
+				/// See write() for more info and some warnings about reading futures.
+				///
+				/// \return `boost::future<std::pair<bool,Message>>` with the bool being the success
+				/// and the message being the read message or a blank one on failure.
+				///
 				bf::future<std::pair< bool, In >> read() {
 					return this->queueWork([&]() -> std::pair< bool, In > { return this->readPrivate(); });
 				}
 
+				/// \brief Asks for write of message and read of response, atomically.
+				///
+				/// This helper makes sure that if you want the response to your
+				/// outgoing message, no other call to read() will intervene.
+				///
+				/// It enqueues a task that both writes a message and reads a response. Due to the
+				/// nature of the the gRPC and the work queue, just calling write()
+				/// waiting on the result, and afterward calling read() would not promise that the
+				/// read message was the reply to your outgoing one. This is because read() could
+				/// be called during your wait for the write, and gRPC reads whatever message comes
+				/// next. Even calling write() and then calling read() and
+				/// waiting on the futures in order would not be safe the RPC object can
+				/// be called by multiple threads, as there could be a read() call put in before
+				/// yours.
+				///
+				/// By making the write and read both one task, it ensures that read reply
+				/// is the next message recieved after the write is completed. Similar to 
+				/// read() it returns a future with the result of the read and the read message.
+				///
+				/// See write() for warnings about reading futures.
+				///
+				/// \param message the protobuf message to be written. Ownership is not taken
+				/// and it can be destroyed after this returns.
+				/// \return `boost::fibers::future<std::pair<bool,Message>>` if the first item
+				/// in the pair is false, either the write or read failed, and the message is blank.
+				/// There is not a way to determine if the write or the read was the failure
+				///
 				bf::future<std::pair< bool, In>> writeRead(const Out &message) {
 					return this->queueWork([&]() -> std::pair<bool, In > {
 						bool ok = this->writePrivate(message);
@@ -305,6 +532,10 @@ namespace MurmurRPC {
 					});
 				}
 
+				/// \brief Constructor.
+				///
+				/// \param ctx grpc::ServerContext to be used to create the stream write/read
+				///
 				rpcImpl(::grpc::ServerContext *ctx) : work_queue<StreamType<Out, In>, In, Out>(ctx) {
 				};
 			};
@@ -317,40 +548,88 @@ namespace MurmurRPC {
 		using Detail::ServerStream_t;
 		using Detail::BidiStream_t;
 
+		/// \brief RPCCall class template. Makes concrete RPCCall objects that can be used.
+		///
+		/// This class template uses the Derived type to generate an RPCall object that
+		/// abstracts away the gRPC interface being used. Clients are expected to use
+		/// `std::shared_ptr` and `std::weak_ptr` for calling members and container storange
+		/// as the lifecycle of the class is determined by gRPC itself.
+		///
+		/// To ensure that we can erase ourself safely, we hold onto \ref m_this which
+		/// is a shared pointer with a special deleter that tells us we are safe to delete.
+		/// All other smart pointers to this are created from this pointer, which means that
+		/// each one of them shares our custom deleter. By using smart pointers both as the
+		/// only way to access the object we use `std::smart_ptr` as our own reference counter.
+		///
+		/// Derived is expected to model \link codegen.h one of serveral types of structs.\endlink
+		///
+		/// \tparam Derived a struct generated by the gRPC codegen which has the
+		/// type definitions and a few static implementation function that
+		/// control behavior when a new service request is recieved that need to
+		/// be written by the implementor of the call.
+		///
 		template<typename Derived, typename RPCType = typename Derived::RPCType> class RPCCall : private Derived {
 			friend Detail::rpc_deleter;
 			friend Derived;
 
 		public:
-			typedef typename Derived::InType InType;
-			typedef typename Derived::OutType OutType;
-			typedef typename Derived::Service ServiceType;
-			using Derived::impl;
+			using InType = typename Derived::InType; ///< typedef for incoming protobuf message type
+			using OutType =  typename Derived::OutType; ///< typedef for outgoing protobuf message type
+			using ServiceType = typename Derived::Service; ///< typedef for the service we implement, always MurmurRPC::V1::AsyncService at present
+
 
 		private:
-			std::atomic<bool> m_isCancelled;
-			std::atomic_flag m_finished;
+			std::atomic<bool> m_isCancelled; ///< flag indicating we were cancelled
+			std::atomic_flag m_finished; ///< used to prevent double calls to finish, likely unneeded in current design
+
+			/// The custom deleter of \ref m_this sets this to true when it was supposed to delete us
 			std::atomic<bool> m_alive;
+
+			/// \brief `std::shared_ptr` with customized deleter.
+			///
+			/// This should be the source of all smart pointers to this object, all
+			/// of them will then share the same deleter. The deleter simply sets
+			/// #m_alive to false, letting us know there are no more references left.
+			///
 			std::shared_ptr<RPCCall<Derived>> m_this;
 
-		protected:
-			uint32_t m_RPCid;
-			::MurmurRPCImpl *rpc;
-			ServiceType *service;
-			::grpc::ServerContext context;
+			uint32_t m_RPCid; ///< unique id for this object, used for lookup in containers
+			::MurmurRPCImpl *rpc; ///< ptr to MurmurRPCImpl that we are in
+			ServiceType *service; ///< ptr to the Service we are in
+			::grpc::ServerContext context; ///< the unique context for our call
+
+			///
+			/// This is helper where most of our implementation determined by the
+			/// type of stream exist.
+			///
+			/// see:
+			/// * \ref Detail::rpcImpl<Unary_t,StreamType,In,Out> "rpcImpl<Unary_t>"
+			/// * \ref Detail::rpcImpl<ServerStream_t,StreamType,In,Out> "rpcImpl<ServerStream_t>
+			/// * \ref Detail::rpcImpl<BidiStream_t,StreamType,In,Out> "rpcImpl<BidiStream_t>"
+			///
 			Detail::rpcImpl<RPCType, Derived::template StreamType, InType, OutType> impl_detail;
-			typedef decltype(impl_detail) ImplType;
+			using ImplType = decltype(impl_detail);
 
-		private:
+			std::function<void(bool)> m_DoneFunction = [this](bool ok){ this->done(ok);};
 
-			boost::function<void(bool)> m_DoneFunction;
-
+			/// \brief Gets the address of the callback used when gRPC tells us we are done
+			/// and can be deleted
 			void* getDoneFunctionAddr() { return std::addressof(m_DoneFunction); }
 
-			boost::function<void(bool)> m_HandleFunction;
+			std::function<void(bool)> m_HandleFunction = [this](bool ok){ this->handle(ok); };
 
+			/// Gets the address of the function used to handle request for a new service
 			void* getHandleFunctionAddr() { return std::addressof(m_HandleFunction); }
 
+			/// brings Derived's implementation method into this class
+			using Derived::impl;
+
+			///
+			/// Attempts to delete ourself, but will return failure if other objects
+			/// still contain valid references to us.
+			///
+			/// \return sucess or failure of deletion
+			///
 			bool tryDelete() {
 				if(m_alive.load(std::memory_order_acquire)) {
 					qDebug("worker %u still alive, but needs deleted", m_RPCid);
@@ -360,6 +639,14 @@ namespace MurmurRPC {
 				return true;
 			}
 
+			///
+			/// this is essentially the destructor for the object. After gRPC lets us know
+			/// that we are done, this is the last method called. It spawns a new
+			/// fiber that will repeatedly call tryDelete() until it succeeds
+			/// after all references are gone. It then resets \ref m_this so no new
+			/// valid pointers can be obtained. After all other copies of \ref m_this
+			/// are also deleted, we can safely `delete this`
+			///
 			void finish() {
 				if (m_finished.test_and_set()) {
 					qDebug("finished called more than once id %u", m_RPCid);
@@ -373,13 +660,19 @@ namespace MurmurRPC {
 				(void) bf::fiber([this, &b](){
 					b.wait();
 					while (!this->tryDelete()) {
-						::boost::this_fiber::sleep_for(std::chrono::milliseconds(100));
+						boost::this_fiber::sleep_for(std::chrono::milliseconds(100));
 					}
 				}).detach();
 				b.wait();
 				m_this.reset();
 			}
 
+			///
+			/// called by gRPC when this object is either finished or cancelled.
+			/// sets m_isCancelled if we are cancelled. Then it calls the user-defined
+			/// function, calls the impl_detail.done() and finally calls finish() to
+			/// destroy ourself
+			///
 			void done(bool ok) {
 				if (context.IsCancelled()) {
 					m_isCancelled.store(true, std::memory_order_release);
@@ -389,6 +682,20 @@ namespace MurmurRPC {
 				this->finish();
 			}
 
+			/// \brief Helper function to run some functor in the main event loop of murmur.
+			///
+			/// This replaces the RPCExecEvent callback that was used in
+			/// the old method. At the moment, only the Derived::impl() method is
+			/// called here. To match the old interface, those functions can throw
+			/// `grpc::Status` like it was an exception to indicate an error.
+			///
+			/// If an `grpc::Status` is caught, if the service was not cancelled, it is
+			/// used to call error() which will notify gRPC of the failure and close
+			/// the connection.
+			///
+			/// \param fn a *MoveConstructable* function with signature `void()` to be
+			/// run in the main murmur event loop. Ownership will be taken of the function.
+			///
 			template<typename Functor>
 			void launchInEventLoop(Functor&& fn) {
 				static_assert(std::is_same<ct::function_type_t<Functor>, void()>{},
@@ -421,6 +728,27 @@ namespace MurmurRPC {
 				f.detach();
 			}
 
+			/// \brief function called by gRPC when a new service is requested.
+			///
+			/// Creates a new identical
+			/// RPCall to handle the next new service request. It then acts somewhat differently
+			/// depending on the type of service.
+			///
+			/// For unary services, the incoming message has already been read in. It then calls
+			/// Derived::impl() in the main event loop with the message and a pointer to us for the end(). 
+			///
+			/// For server stream services, in request message has already been read in. This
+			/// will then request to call Derived::impl() in the main event loop with the message
+			/// and a pointer to us. The typical implementation just checks the validity of the request,
+			/// and then adds a `std::weak_ptr`, along with some other information into a container
+			/// of listening RPC clients. When that call finishes, the work queue is started so that
+			/// outgoing messages can be written.
+			///
+			/// For bidirectional streams, message has not been read in. It requests Detail::impl() be
+			/// called in the main loop and starts the work queue for writes and reads. The typical
+			/// implementation reads in the message, checks validity, then adds a `std::weak_ptr` along
+			/// with other details to a container of listeners.
+			///
 			template<typename X = RPCType, boost::enable_if_t<std::is_same<X, Unary_t>::value>* = nullptr>
 			void handle(bool ok);
 
@@ -430,7 +758,15 @@ namespace MurmurRPC {
 			template<typename X = RPCType, boost::enable_if_t<std::is_same<X, BidiStream_t>::value>* = nullptr>
 			void handle(bool ok);
 
-		protected:
+			/// \brief Helper to add ourself to the completion queue.
+			///
+			/// We need to request to be added to the
+			/// queue at startup and whenever a new service is requested (to replace the old one).
+			///
+			/// This function has a template with two different calls as the call to add to the queue
+			/// has a slightly different signature for Bidirectional streams than for Unary and Server
+			/// streams.
+			///
 			template<typename RFn,
 				boost::enable_if_t<(std::tuple_size<boost::add_const_t<ct::args_t<RFn>>>::value == 7)>* = nullptr>
 			static void addCQHandler(ServiceType* svc, MurmurRPCImpl* rpc, RFn requestFn, void *handleFn,
@@ -441,6 +777,12 @@ namespace MurmurRPC {
 			static void addCQHandler(ServiceType* svc, MurmurRPCImpl* rpc, RFn requestFn, void *handleFn,
 					RPCCall<Derived> *call);
 
+			/// \brief Constructor.
+			///
+			/// Only to be called in create(). Setups up our flags,
+			/// m_this, generates a random number to be used as an id, and creates
+			/// the impl_detail object which has most of the code used by outside classes
+			///
 			explicit RPCCall(MurmurRPCImpl *rpcImpl, ServiceType *svc) :
 				m_isCancelled(false),
 				m_alive(true),
@@ -450,8 +792,6 @@ namespace MurmurRPC {
 				service(svc),
 				impl_detail(&context) {
 					m_finished.clear();
-					this->m_DoneFunction = boost::function<void(bool)>([this](bool ok){ this->done(ok); });
-					this->m_HandleFunction = boost::function<void(bool)>([this](bool ok){ this->handle(ok); });
 			}
 
 			~RPCCall() {
@@ -463,54 +803,105 @@ namespace MurmurRPC {
 			}
 
 		public:
-			//universal functions
+			/// \brief Gets the unique id associated with this RPCCall.
+			///
+			/// Used in containers as they contain `std::weak_ptr` which you can't compare against.
+			///
 			uint32_t getId() {
 				return m_RPCid;
 			}
 
+			/// \brief Checks if this call has been cancelled.
+			///
+			/// Normally this would be done by the client disconnecting
+			///
 			bool isCancelled() {
 				return m_isCancelled.load(std::memory_order_acquire);
 			}
 
+			/// \brief Cancels the stream with an error code
+			///
+			/// \param err grpc::Status with the error in it
+			///
 			void error(const ::grpc::Status &err) {
 				impl_detail.error(err);
 			}
 
+			/// \brief Gets a `std::weak_ptr` copied from \ref m_this.
+			///
+			/// This can be used to store an identifier for
+			/// a listener in event containers. Since it does not have ownership, and
+			/// we can delete ourself at any time gRPC asks us to, others
+			/// accessing the container will never be left holding onto a bad reference.
+			///
 			std::weak_ptr<RPCCall<Derived>> getWeakPtr() const {
 				return m_this;
 			}
 
-			//unary streams
+			/// \brief only available for unary streams
+			///
+			/// Called at the end of the `Detail::impl()` function to send the outgoing request.
+			///
+			/// This is somewhat bad design as if `impl()` fails to call this or
+			/// throw an exception we are left dangling until we get cancelled due
+			/// to a timeout. This is a likely non-method in the future.
+			///
 			template<typename Impl = ImplType>
 			auto end(const OutType &message = OutType())
 					-> decltype(std::declval<Impl>().end(OutType())) {
 				impl_detail.end(message);
 			}
 
-			// functions for client streams
+			/// \brief only for server stream types.
+			///
+			/// \copydoc Detail::rpcImpl<ServerStream_t,StreamType,In,Out>::Write()
+			///
 			template<typename Impl = ImplType, typename Functor>
 			auto Write(const OutType& msg, Functor&& func)
 					-> decltype(std::declval<Impl>().Write(OutType(), std::declval<Functor>())) {
 				return impl_detail.Write(msg, std::forward<Functor>(func));
 			}
 
-			// stream-stream functions
+			/// \brief only for bidirection streams.
+			///
+			/// \copydoc Detail::rpcImpl<BidiStream_t,StreamType,In,Out>::write()
+			///
 			template<typename Impl = ImplType, typename MsgType>
 			auto write(MsgType message)
 				-> decltype(std::declval<Impl>().queueWork(std::declval<bool(*)()>())) {
 				return impl_detail.queueWork([&]() -> bool { return impl_detail.writePrivate(message); });
 			}
 
+			/// \brief only for bidirection streams
+			///
+			/// \copydoc Detail::rpcImpl<BidiStream_t,StreamType,In,Out>::read()
+			///
 			template<typename Impl = ImplType>
 			auto read() -> decltype(std::declval<Impl>().read()) {
 				return impl_detail.read();
 			}
 
+			/// \brief only for bidirection streams
+			///
+			/// \copydoc Detail::rpcImpl<BidiStream_t,StreamType,In,Out>::writeRead()
+			///
 			template<typename Impl = ImplType>
 			auto writeRead(const OutType& message) -> decltype(std::declval<Impl>().writeRead(OutType())) {
 				return impl_detail.writeRead(message);
 			}
 
+			///
+			/// This method should be called only one time during initialization
+			/// to create the service. It is also called to create new services
+			/// when old ones get taken.
+			///
+			/// It creates a new service, sets up the callbacks for both
+			/// the function to handle a request and completion, and uses
+			/// them to add this to the completion queue.
+			///
+			/// \param rpc pointer to MururGRPCImpl
+			/// \param service pointer to ServiceType, likely MurmurRPC::V1::AsyncService
+			///
 			static void create(MurmurRPCImpl *rpc, ServiceType *service) {
 				auto call = new RPCCall<Derived>(rpc, service);
 				auto doneFn = call->getDoneFunctionAddr();

--- a/src/murmur/GRPCall.h
+++ b/src/murmur/GRPCall.h
@@ -483,28 +483,6 @@ namespace MurmurRPC {
 
 #include "MurmurRPC.proto.Wrapper.cpp"
 
-/*
-class RPCExecEvent : public ExecEvent {
-public:
-	boost::function<void(grpc::Status&)> error;
-
-	template<typename T>
-	RPCExecEvent(boost::function<void()> fn, MurmurRPC::Wrapper::RPCCall<T>& rpc_call) : ExecEvent(fn) {
-		auto weak = rpc_call.getWeakPtr();
-		error = [weak](::grpc::Status& err){
-			auto c = weak.lock();
-			if(c != nullptr && !c->isCancelled()) {
-				c->error(err);
-			}
-		};
-	}
-
-private:
-	RPCExecEvent(const RPCExecEvent&) = delete;
-	RPCExecEvent &operator=(const RPCExecEvent&) = delete;
-};
-*/
-
 #endif
 
 #ifdef MUMBLE_MURMUR_GRPC_WRAPPER_IMPL
@@ -538,21 +516,6 @@ namespace MurmurRPC {
 					rpc->m_completionQueue.get(), handleFn);
 		}
 
-		/*
-		template<typename Derived, typename RPCType>
-		template<typename X, std::enable_if_t<std::is_same<X, Unary_t>::value>*>
-		void RPCCall<Derived, RPCType>::handle(bool ok) {
-			RPCCall<Derived>::create(this->rpc, this->service);
-			auto weak_ptr = this->getWeakPtr();
-			auto ie = new RPCExecEvent([this, weak_ptr, ok](){
-				auto ptr = weak_ptr.lock();
-				if (ptr == nullptr) { return; }
-				ptr->impl(this->getSharedPtr(), this->impl_detail.m_Request);
-			}, *this);
-			QCoreApplication::instance()->postEvent(rpc, ie);
-		}
-		*/
-
 		template<typename Derived, typename RPCType>
 		template<typename X, std::enable_if_t<std::is_same<X, Unary_t>::value>*>
 		void RPCCall<Derived, RPCType>::handle(bool ok) {
@@ -562,22 +525,6 @@ namespace MurmurRPC {
 					ptr->impl(ptr, this->impl_detail.m_Request);
 			});
 		}
-
-		/*
-		template<typename Derived, typename RPCType>
-		template<typename X, std::enable_if_t<std::is_same<X, ServerStream_t>::value>*>
-		void RPCCall<Derived, RPCType>::handle(bool ok) {
-			RPCCall<Derived>::create(this->rpc, this->service);
-			auto weak_ptr = this->getWeakPtr();
-			auto ie = new RPCExecEvent([this, weak_ptr, ok](){
-				auto ptr = weak_ptr.lock();
-				if (ptr == nullptr) { return; }
-				ptr->impl(this->getSharedPtr(), this->impl_detail.m_Request);
-			}, *this);
-			QCoreApplication::instance()->postEvent(rpc, ie);
-			impl_detail.createWorker();
-		}
-		*/
 
 		template<typename Derived, typename RPCType>
 		template<typename X, std::enable_if_t<std::is_same<X, ServerStream_t>::value>*>
@@ -589,22 +536,6 @@ namespace MurmurRPC {
 			});
 			impl_detail.createWorker();
 		}
-
-		/*
-		template<typename Derived, typename RPCType>
-		template<typename X, std::enable_if_t<std::is_same<X, BidiStream_t>::value>*>
-		void RPCCall<Derived, RPCType>::handle(bool ok) {
-			RPCCall<Derived>::create(this->rpc, this->service);
-			auto weak_ptr = this->getWeakPtr();
-			auto ie = new RPCExecEvent([this, weak_ptr, ok](){
-				auto ptr = weak_ptr.lock();
-				if (ptr == nullptr) { return; }
-				ptr->impl(this->getSharedPtr());
-			}, *this);
-			QCoreApplication::instance()->postEvent(rpc, ie);
-			impl_detail.createWorker();
-		}
-		*/
 
 		template<typename Derived, typename RPCType>
 		template<typename X, std::enable_if_t<std::is_same<X, BidiStream_t>::value>*>

--- a/src/murmur/GRPCall.h
+++ b/src/murmur/GRPCall.h
@@ -7,7 +7,7 @@
 #define MUMBLE_MURMUR_GRPCALL_H
 
 #include <QDebug>
-#include <QRandomGenerator>
+//#include <QRandomGenerator>
 #include <QtCore/QCoreApplication>
 
 #include <boost/callable_traits/args.hpp>
@@ -693,6 +693,10 @@ namespace MurmurRPC {
 				};
 			};
 
+			static std::random_device r;
+			static std::seed_seq seed{r(), r(), r(), r(), r(), r(), r(), r()};
+			static std::mt19937 mt_rand(seed);
+
 			/// \brief param number for completion queue call with message to be read in
 			///
 			/// this *should* be declared in RPCCall, but g++ in c++11 mode doesn't seem
@@ -715,6 +719,7 @@ namespace MurmurRPC {
 		using Detail::ClientStream_t;
 		using Detail::ServerStream_t;
 		using Detail::BidiStream_t;
+
 
 		/// \brief RPCCall class template. Makes concrete RPCCall objects that can be used.
 		///
@@ -985,7 +990,7 @@ namespace MurmurRPC {
 				m_isCancelled(false),
 				m_alive(true),
 				m_this(static_cast<RPCCall<Derived> *>(this), Detail::rpc_deleter()),
-				m_RPCid(QRandomGenerator::global()->generate()),
+				m_RPCid(Detail::mt_rand()),
 				rpc(rpcImpl),
 				service(svc),
 				impl_detail(&context) {

--- a/src/murmur/Meta.cpp
+++ b/src/murmur/Meta.cpp
@@ -42,6 +42,12 @@ MetaParams Meta::mp;
 HANDLE Meta::hQoS = NULL;
 #endif
 
+#ifdef USE_GRPC
+// From MurmurGRPCImpl.cpp.
+void GRPCStart();
+void GRPCStop();
+#endif
+
 MetaParams::MetaParams() {
 	qsPassword = QString();
 	usPort = DEFAULT_MUMBLE_PORT;
@@ -647,6 +653,7 @@ Meta::Meta() {
 			Connection::setQoS(hQoS);
 	}
 #endif
+	connect(QCoreApplication::instance(), SIGNAL(aboutToQuit()), this, SLOT(aboutToQuit()), Qt::QueuedConnection);
 }
 
 Meta::~Meta() {
@@ -784,4 +791,13 @@ bool Meta::banCheck(const QHostAddress &addr) {
 		return true;
 	}
 	return false;
+}
+
+void Meta::aboutToQuit(void) {
+	qWarning("Killing running servers");
+	meta->killAll();
+	qWarning("Shutting down");
+#ifdef USE_GRPC
+	GRPCStop();
+#endif
 }

--- a/src/murmur/Meta.h
+++ b/src/murmur/Meta.h
@@ -202,6 +202,10 @@ class Meta : public QObject {
 		void getOSInfo();
 		void connectListener(QObject *);
 		static void getVersion(int &major, int &minor, int &patch, QString &string);
+
+	public slots:
+		void aboutToQuit(void);
+
 	signals:
 		void started(Server *);
 		void stopped(Server *);

--- a/src/murmur/MurmurGRPCImpl.cpp
+++ b/src/murmur/MurmurGRPCImpl.cpp
@@ -165,7 +165,8 @@ void InjectThreadYield() {
 		auto t = new QTimer(QCoreApplication::instance()); // NOLINT this is about to be in a unique_ptr
 		t->setInterval(0);
 		t->setSingleShot(true);
-		t->callOnTimeout(QCoreApplication::instance(), std::ref(thisfunc));
+		//t->callOnTimeout(QCoreApplication::instance(), std::ref(thisfunc));
+		QObject::connect(t, &QTimer::timeout, QCoreApplication::instance(), std::ref(thisfunc));
 		return t;}(), qtimer_deleter());
 	QCoreApplication::processEvents(QEventLoop::WaitForMoreEvents);
 	boost::this_fiber::yield();

--- a/src/murmur/MurmurGRPCImpl.cpp
+++ b/src/murmur/MurmurGRPCImpl.cpp
@@ -23,6 +23,7 @@
 #include <cerrno>
 #include <chrono>
 #include <cstring>
+#include <random>
 #include <stdexcept>
 #include <utility>
 
@@ -2612,6 +2613,16 @@ V1_RedirectWhisperGroupRemove::impl(V1_RedirectWhisperGroupRemove::rpcPtr /*unus
 	return boost::none;
 }
 
+namespace Detail {
+	uint32_t mt_random() {
+		thread_local std::mt19937 mt_rand = [](){
+			std::random_device r;
+			std::seed_seq seed{r(), r(), r(), r(), r(), r(), r(), r()};
+			return std::mt19937(seed);
+		}();
+		return mt_rand();
+	}
+} // namespace Detail
 } // namespace Wrapper
 } // namespace MurmurRPC
 

--- a/src/murmur/MurmurGRPCImpl.h
+++ b/src/murmur/MurmurGRPCImpl.h
@@ -12,6 +12,16 @@
 #include "Meta.h"
 #include "Server.h"
 
+#include <boost/config.hpp>
+#if !defined BOOST_ATTRIBUTE_NODISCARD
+# define BOOST_ATTRIBUTE_NODISCARD
+#endif
+#if BOOST_VERSION < 106900L
+namespace boost {
+template<bool B, class T = void>
+	using enable_if_t = typename ::std::enable_if<B, T>::type;
+}
+#endif
 #ifndef Q_MOC_RUN
 #include "GRPCContainer.h"
 #include "GRPCall.h"

--- a/src/murmur/MurmurGRPCImpl.h
+++ b/src/murmur/MurmurGRPCImpl.h
@@ -58,7 +58,7 @@ class MurmurRPCImpl : public QThread {
 		std::unique_ptr<grpc::Server> m_server;
 		volatile bool m_isRunning;
 	protected:
-		void customEvent(QEvent *evt);
+//		void customEvent(QEvent *evt);
 	public:
 		MurmurRPCImpl(const QString &address, std::shared_ptr<grpc::ServerCredentials> credentials);
 		~MurmurRPCImpl();

--- a/src/murmur/MurmurGRPCImpl.h
+++ b/src/murmur/MurmurGRPCImpl.h
@@ -9,33 +9,22 @@
 
 #include <QtCore/QCoreApplication>
 
-#include <boost/bind.hpp>
-
-/*
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wunused-parameter"
-#include "MurmurRPC.grpc.pb.h"
-#pragma GCC diagnostic pop
-*/
-
 #include "Server.h"
 #include "Meta.h"
 
 #ifndef Q_MOC_RUN
 #include "GRPCContainer.h"
 #include "GRPCall.h"
+#include <boost/optional.hpp>
 #endif
 
 #include <atomic>
 #include <chrono>
 #include <functional>
 #include <type_traits>
-#include <queue>
 
-#include <QEventLoopLocker>
 #include <QMultiHash>
 #include <QSet>
-#include <QBasicTimer>
 
 #include <grpc++/grpc++.h>
 #include <grpc++/security/auth_context.h>
@@ -122,7 +111,8 @@ class MurmurRPCImpl : public QThread {
 		void channelCreated(const Channel *channel);
 		void channelRemoved(const Channel *channel);
 
-		void textMessageFilter(int &res, const User *user, MumbleProto::TextMessage &message);
+		/// \brief reciever for Server::textMessageFilterSig()
+		void textMessageFilter(int& res, unsigned int uiSession, MumbleProto::TextMessage &message);
 
 		void contextAction(const User *user, const QString &action, unsigned int session, int channel);
 };

--- a/src/murmur/MurmurGRPCImpl.h
+++ b/src/murmur/MurmurGRPCImpl.h
@@ -11,33 +11,38 @@
 
 #include <boost/bind.hpp>
 
+/*
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wunused-parameter"
 #include "MurmurRPC.grpc.pb.h"
 #pragma GCC diagnostic pop
+*/
 
 #include "Server.h"
 #include "Meta.h"
 
-#include <atomic>
+#ifndef Q_MOC_RUN
+#include "GRPCContainer.h"
+#include "GRPCall.h"
+#endif
 
+#include <atomic>
+#include <chrono>
+#include <functional>
+#include <type_traits>
+#include <queue>
+
+#include <QEventLoopLocker>
 #include <QMultiHash>
 #include <QSet>
+#include <QBasicTimer>
 
 #include <grpc++/grpc++.h>
 #include <grpc++/security/auth_context.h>
 
-class RPCCall;
-
-namespace MurmurRPC {
-	namespace Wrapper {
-		class V1_ContextActionEvents;
-		class V1_Events;
-		class V1_ServerEvents;
-		class V1_AuthenticatorStream;
-		class V1_TextMessageFilter;
-	}
-}
+using MurmurRPC::Wrapper::RPCCall;
+namespace mwc = MurmurRPC::Wrapper::Container;
+namespace mw = MurmurRPC::Wrapper;
 
 class MurmurRPCAuthenticator : public ::grpc::AuthMetadataProcessor {
 	public:
@@ -55,7 +60,7 @@ class MurmurRPCImpl : public QThread {
 	protected:
 		void customEvent(QEvent *evt);
 	public:
-		MurmurRPCImpl(const QString &address, std::shared_ptr<::grpc::ServerCredentials> credentials);
+		MurmurRPCImpl(const QString &address, std::shared_ptr<grpc::ServerCredentials> credentials);
 		~MurmurRPCImpl();
 		void run();
 		std::unique_ptr<grpc::ServerCompletionQueue> m_completionQueue;
@@ -64,17 +69,20 @@ class MurmurRPCImpl : public QThread {
 		MurmurRPC::V1::AsyncService m_V1Service;
 
 		// Listeners
-		QHash<int, QMultiHash<QString, ::MurmurRPC::Wrapper::V1_ContextActionEvents *> > m_contextActionListeners;
+		typedef mwc::weakContainer<mwc::contextActionConfig<RPCCall<mw::V1_ContextActionEvents>>> contextActionMap;
+		contextActionMap m_contextActionListeners;
 
-		QSet<::MurmurRPC::Wrapper::V1_Events *> m_metaServiceListeners;
+		typedef mwc::weakContainer<mwc::setConfig<RPCCall<mw::V1_Events>>> eventSet_t;
+		eventSet_t m_metaServiceListeners;
 
-		QMultiHash<int, ::MurmurRPC::Wrapper::V1_ServerEvents *> m_serverServiceListeners;
+		typedef mwc::weakContainer<mwc::multiMapConfig<RPCCall<mw::V1_ServerEvents>>> serverServiceListenersMultiMap;
+		serverServiceListenersMultiMap m_serverServiceListeners;
 
-		QMutex qmAuthenticatorsLock;
-		QHash<int, ::MurmurRPC::Wrapper::V1_AuthenticatorStream *> m_authenticators;
+		typedef mwc::weakContainer<mwc::mapConfig<RPCCall<mw::V1_AuthenticatorStream>>> authenticatorMap;
+		authenticatorMap m_authenticators;
 
-		QMutex qmTextMessageFilterLock;
-		QHash<int, ::MurmurRPC::Wrapper::V1_TextMessageFilter *> m_textMessageFilters;
+		typedef mwc::weakContainer<mwc::mapConfig<RPCCall<mw::V1_TextMessageFilter>>> messageFilterMap;
+		messageFilterMap m_textMessageFilters;
 
 		// Maps server id -> session -> context action
 		QMap<int, QMap<unsigned int, QSet<QString> > > m_activeContextActions;
@@ -85,8 +93,9 @@ class MurmurRPCImpl : public QThread {
 		void removeUserActiveContextActions(const ::Server *s, const ::User *u);
 		void removeActiveContextActions(const ::Server *s);
 
-		void removeTextMessageFilter(const ::Server *s);
-		void removeAuthenticator(const ::Server *s);
+		void removeTextMessageFilter(int);
+		void removeAuthenticator(int);
+		void removeAuthenticator(uint32_t);
 		void sendMetaEvent(const ::MurmurRPC::Event &e);
 		void sendServerEvent(const ::Server *s, const ::MurmurRPC::Server_Event &e);
 
@@ -116,151 +125,6 @@ class MurmurRPCImpl : public QThread {
 		void textMessageFilter(int &res, const User *user, MumbleProto::TextMessage &message);
 
 		void contextAction(const User *user, const QString &action, unsigned int session, int channel);
-};
-
-class RPCExecEvent : public ExecEvent {
-	Q_DISABLE_COPY(RPCExecEvent);
-public:
-	RPCCall *call;
-	RPCExecEvent(::boost::function<void()> fn, RPCCall *rpc_call) : ExecEvent(fn), call(rpc_call) {
-	}
-};
-
-class RPCCall {
-	::std::atomic_int m_refs;
-public:
-	MurmurRPCImpl *rpc;
-	::grpc::ServerContext context;
-
-	RPCCall(MurmurRPCImpl *rpcImpl) : m_refs(0), rpc(rpcImpl) {
-		ref();
-	}
-	virtual ~RPCCall() {
-	}
-	virtual ::boost::function<void(bool)> *done() {
-		auto done_fn = ::boost::bind(&RPCCall::finish, this, _1);
-		return new ::boost::function<void(bool)>(done_fn);
-	}
-
-	virtual void error(const ::grpc::Status&) = 0;
-
-	virtual void finish(bool) {
-		deref();
-	}
-
-	virtual void deref() {
-		Q_ASSERT(m_refs > 0);
-		if (--m_refs == 0) {
-			delete this;
-		}
-	}
-	virtual void ref() {
-		m_refs++;
-	}
-
-	template<class T>
-	class Ref {
-		T *m_object;
-	public:
-		Ref(T *object) : m_object(object) {
-			if (object) {
-				object->ref();
-			}
-		}
-		~Ref() {
-			if (m_object) {
-				m_object->deref();
-			}
-		}
-		operator bool() const {
-			return m_object != nullptr && !m_object->context.IsCancelled();
-		}
-		T *operator->() {
-			return m_object;
-		}
-	};
-};
-
-template <class InType, class OutType>
-class RPCSingleSingleCall : public RPCCall {
-public:
-	InType request;
-	::grpc::ServerAsyncResponseWriter < OutType > stream;
-
-	RPCSingleSingleCall(MurmurRPCImpl *rpcImpl) : RPCCall(rpcImpl), stream(&context) {
-	}
-
-	virtual void error(const ::grpc::Status &err) {
-		stream.FinishWithError(err, done());
-	}
-
-	virtual void end(const OutType &msg = OutType()) {
-		stream.Finish(msg, ::grpc::Status::OK, done());
-	}
-};
-
-/// Base for "single-stream" RPC methods.
-///
-/// The helper method "write" automatically queues writes to the stream. Without
-/// write queuing, the grpc crashes if a stream.Write is called before a
-/// previous stream.Write completes.
-template <class InType, class OutType>
-class RPCSingleStreamCall : public RPCCall {
-	QMutex m_writeLock;
-	QQueue< QPair<OutType, void *> > m_writeQueue;
-public:
-	InType request;
-	::grpc::ServerAsyncWriter < OutType > stream;
-	RPCSingleStreamCall(MurmurRPCImpl *rpcImpl) : RPCCall(rpcImpl), stream(&context) {
-	}
-
-	virtual void error(const ::grpc::Status &err) {
-		stream.Finish(err, done());
-	}
-
-	void write(const OutType &msg, void *tag) {
-		QMutexLocker l(&m_writeLock);
-		if (m_writeQueue.size() > 0) {
-			m_writeQueue.enqueue(qMakePair(msg, tag));
-		} else {
-			m_writeQueue.enqueue(qMakePair(OutType(), tag));
-			stream.Write(msg, writeCB());
-		}
-	}
-
-private:
-	void *writeCB() {
-		auto callback = ::boost::bind(&RPCSingleStreamCall<InType, OutType>::writeCallback, this, _1);
-		return new ::boost::function<void(bool)>(callback);
-	}
-
-	void writeCallback(bool ok) {
-		QMutexLocker l(&m_writeLock);
-		auto processed = m_writeQueue.dequeue();
-		if (processed.second) {
-			auto cb = static_cast< ::boost::function<void(bool)> *>(processed.second);
-			(*cb)(ok);
-			delete cb;
-		}
-		if (m_writeQueue.size() > 0) {
-			stream.Write(m_writeQueue.head().first, writeCB());
-		}
-	}
-};
-
-template <class InType, class OutType>
-class RPCStreamStreamCall : public RPCCall {
-public:
-	InType request;
-	OutType response;
-	::grpc::ServerAsyncReaderWriter< OutType, InType > stream;
-
-	RPCStreamStreamCall(MurmurRPCImpl *rpcImpl) : RPCCall(rpcImpl), stream(&context) {
-	}
-
-	virtual void error(const ::grpc::Status &err) {
-		stream.Finish(err, done());
-	}
 };
 
 

--- a/src/murmur/Server.cpp
+++ b/src/murmur/Server.cpp
@@ -37,6 +37,10 @@
 
 #include <boost/bind.hpp>
 
+#ifdef USE_GRPC
+# include <boost/fiber/all.hpp>
+#endif
+
 #ifdef Q_OS_WIN
 # include <qos2.h>
 # include <ws2tcpip.h>
@@ -742,6 +746,9 @@ void Server::run() {
 	++nfds;
 
 	while (bRunning) {
+#ifdef USE_GRPC
+		::boost::this_fiber::yield();
+#endif
 #ifdef Q_OS_UNIX
 		int pret = poll(fds, nfds, -1);
 		if (pret <= 0) {

--- a/src/murmur/Server.cpp
+++ b/src/murmur/Server.cpp
@@ -49,6 +49,8 @@
 # include <poll.h>
 #endif
 
+#include <cstdint>
+
 #ifndef MAX
 # define MAX(a,b) ((a)>(b) ? (a):(b))
 #endif
@@ -663,7 +665,7 @@ void Server::udpActivated(int socket) {
 	iov[0].iov_base = encrypt;
 	iov[0].iov_len = UDP_PACKET_SIZE;
 
-	u_char controldata[CMSG_SPACE(MAX(sizeof(struct in6_pktinfo),sizeof(struct in_pktinfo)))];
+	uint8_t controldata[CMSG_SPACE(MAX(sizeof(struct in6_pktinfo),sizeof(struct in_pktinfo)))];
 
 	memset(&msg, 0, sizeof(msg));
 	msg.msg_name = reinterpret_cast<struct sockaddr *>(&from);
@@ -801,7 +803,7 @@ void Server::run() {
 				iov[0].iov_base = encrypt;
 				iov[0].iov_len = UDP_PACKET_SIZE;
 
-				u_char controldata[CMSG_SPACE(MAX(sizeof(struct in6_pktinfo),sizeof(struct in_pktinfo)))];
+				uint8_t controldata[CMSG_SPACE(MAX(sizeof(struct in6_pktinfo),sizeof(struct in_pktinfo)))];
 
 				memset(&msg, 0, sizeof(msg));
 				msg.msg_name = reinterpret_cast<struct sockaddr *>(&from);
@@ -974,7 +976,7 @@ void Server::sendMessage(ServerUser *u, const char *data, int len, QByteArray &c
 		iov[0].iov_base = buffer;
 		iov[0].iov_len = len+4;
 
-		u_char controldata[CMSG_SPACE(MAX(sizeof(struct in6_pktinfo),sizeof(struct in_pktinfo)))];
+		uint8_t controldata[CMSG_SPACE(MAX(sizeof(struct in6_pktinfo),sizeof(struct in_pktinfo)))];
 		memset(controldata, 0, sizeof(controldata));
 
 		memset(&msg, 0, sizeof(msg));

--- a/src/murmur/Server.h
+++ b/src/murmur/Server.h
@@ -269,13 +269,18 @@ class Server : public QThread {
 		///    by itself, it DOES NOT hold a lock on qrwlVoiceThread.
 		///    That is because ownership of data guarantees that no
 		///    other thread can write to that data.
+#ifdef USE_GRPC
+		QReadWriteLock qrwlVoiceThread{QReadWriteLock::Recursive};
+		QMutex qmCache{QMutex::Recursive};
+#else
 		QReadWriteLock qrwlVoiceThread;
+		QMutex qmCache;
+#endif
 		QHash<unsigned int, ServerUser *> qhUsers;
 		QHash<QPair<HostAddress, quint16>, ServerUser *> qhPeerUsers;
 		QHash<HostAddress, QSet<ServerUser *> > qhHostUsers;
 		QHash<unsigned int, Channel *> qhChannels;
 
-		QMutex qmCache;
 		ChanACL::ACLCache acCache;
 
 		QHash<int, QString> qhUserNameCache;

--- a/src/murmur/main.cpp
+++ b/src/murmur/main.cpp
@@ -46,7 +46,7 @@
 QFile *qfLog = NULL;
 
 static bool bVerbose = false;
-#ifdef SNIPER_NO_SNIPING
+#ifdef QT_NO_DEBUG
 static bool detach = true;
 #else
 static bool detach = false;
@@ -605,14 +605,6 @@ int main(int argc, char **argv) {
 
 	res=a.exec();
 
-	/*
-	qWarning("Killing running servers");
-
-	meta->killAll();
-
-	qWarning("Shutting down");
-	*/
-
 #ifdef USE_DBUS
 	delete MurmurDBus::qdbc;
 	MurmurDBus::qdbc = NULL;
@@ -621,12 +613,6 @@ int main(int argc, char **argv) {
 #ifdef USE_ICE
 	IceStop();
 #endif
-
-/*
-#ifdef USE_GRPC
-	GRPCStop();
-#endif
-*/
 
 	delete qfLog;
 	qfLog = NULL;

--- a/src/murmur/main.cpp
+++ b/src/murmur/main.cpp
@@ -46,7 +46,7 @@
 QFile *qfLog = NULL;
 
 static bool bVerbose = false;
-#ifdef QT_NO_DEBUG
+#ifdef SNIPER_NO_SNIPING
 static bool detach = true;
 #else
 static bool detach = false;
@@ -605,11 +605,13 @@ int main(int argc, char **argv) {
 
 	res=a.exec();
 
+	/*
 	qWarning("Killing running servers");
 
 	meta->killAll();
 
 	qWarning("Shutting down");
+	*/
 
 #ifdef USE_DBUS
 	delete MurmurDBus::qdbc;
@@ -620,9 +622,11 @@ int main(int argc, char **argv) {
 	IceStop();
 #endif
 
+/*
 #ifdef USE_GRPC
 	GRPCStop();
 #endif
+*/
 
 	delete qfLog;
 	qfLog = NULL;

--- a/src/murmur/murmur.pro
+++ b/src/murmur/murmur.pro
@@ -161,6 +161,7 @@ grpc {
 
   DEFINES *= USE_GRPC
   INCLUDEPATH *= murmur_grpc
+  INCLUDEPATH *= ../../3rdparty/mp11/include
   LIBS *= -lmurmur_grpc -lboost_fiber -lboost_context
   HEADERS *= MurmurGRPCImpl.h ./murmur_grpc/FiberScheduler.h
   SOURCES *= MurmurGRPCImpl.cpp ./murmur_grpc/FiberScheduler.cpp

--- a/src/murmur/murmur.pro
+++ b/src/murmur/murmur.pro
@@ -161,7 +161,7 @@ grpc {
 
   DEFINES *= USE_GRPC
   INCLUDEPATH *= murmur_grpc
-  LIBS *= -lmurmur_grpc
+  LIBS *= -lmurmur_grpc -lboost_fiber -lboost_context
   HEADERS *= MurmurGRPCImpl.h ./murmur_grpc/FiberScheduler.h
   SOURCES *= MurmurGRPCImpl.cpp ./murmur_grpc/FiberScheduler.cpp
 

--- a/src/murmur/murmur.pro
+++ b/src/murmur/murmur.pro
@@ -173,7 +173,7 @@ grpc {
   QMAKE_EXTRA_COMPILERS += grpc_wrapper
 
   unix {
-    QMAKE_CXXFLAGS *= -std=c++11
+  #  QMAKE_CXXFLAGS *= -std=c++11
     must_pkgconfig(grpc)
     must_pkgconfig(grpc++)
   }

--- a/src/murmur/murmur.pro
+++ b/src/murmur/murmur.pro
@@ -162,6 +162,7 @@ grpc {
   DEFINES *= USE_GRPC
   INCLUDEPATH *= murmur_grpc
   INCLUDEPATH *= ../../3rdparty/mp11/include
+  INCLUDEPATH *= ../../3rdparty/callable_traits/include
   LIBS *= -lmurmur_grpc -lboost_fiber -lboost_context
   HEADERS *= MurmurGRPCImpl.h ./murmur_grpc/FiberScheduler.h
   SOURCES *= MurmurGRPCImpl.cpp ./murmur_grpc/FiberScheduler.cpp

--- a/src/murmur/murmur.pro
+++ b/src/murmur/murmur.pro
@@ -162,9 +162,8 @@ grpc {
   DEFINES *= USE_GRPC
   INCLUDEPATH *= murmur_grpc
   LIBS *= -lmurmur_grpc
-
-  HEADERS *= MurmurGRPCImpl.h
-  SOURCES *= MurmurGRPCImpl.cpp
+  HEADERS *= MurmurGRPCImpl.h ./murmur_grpc/FiberScheduler.h
+  SOURCES *= MurmurGRPCImpl.cpp ./murmur_grpc/FiberScheduler.cpp
 
   GRPC_WRAPPER = MurmurRPC.proto
   grpc_wrapper.output = MurmurRPC.proto.Wrapper.cpp

--- a/src/murmur/murmur_grpc/FiberScheduler.cpp
+++ b/src/murmur/murmur_grpc/FiberScheduler.cpp
@@ -1,0 +1,108 @@
+// Copyright 2005-2020 The Mumble Developers. All rights reserved.
+// Use of this source code is governed by a BSD-style license
+// that can be found in the LICENSE file at the root of the
+// Mumble source tree or at <https://www.mumble.info/LICENSE>.
+
+#include "FiberScheduler.h"
+
+namespace MurmurRPC {
+namespace Scheduler {
+
+namespace bf = boost::fibers;
+
+grpc_scheduler::xferqueue_t grpc_scheduler::xferQueue{};
+std::mutex grpc_scheduler::m_xferMtx{};
+std::function<void()> grpc_scheduler::alertMain = [](){ return; };
+
+grpc_scheduler::grpc_scheduler(bool is_event_loop) : is_loop_thread(is_event_loop) {
+	if (is_event_loop) {
+		alertMain = [&](){
+			this->notify();
+			auto dispatch = QCoreApplication::eventDispatcher();
+			if (dispatch != nullptr) {
+				dispatch->interrupt();
+			}
+		};
+	}
+}
+
+void grpc_scheduler::awakened(bf::context* ctx, grpc_props& props) noexcept {
+	if (ctx->is_context(bf::type::pinned_context) || !props.run_in_main()) {
+		m_readyQueue.push_back(*ctx);
+	} else if (props.run_in_main()) {
+		if( this->is_loop_thread ) {
+			m_readyQueue.push_back(*ctx);
+		} else {
+			ctx->detach();
+			std::unique_lock<std::mutex> lk(m_xferMtx);
+			xferQueue.push_back(ctx);
+		}
+		// make sure to wait up the event loop fiber
+		// and get into a yield() call ASAP
+		alertMain();
+	}
+}
+
+bool grpc_scheduler::has_ready_fibers() const noexcept {
+	if (this->is_loop_thread) {
+		std::unique_lock<std::mutex> lk(m_xferMtx);
+		return !xferQueue.empty() || !m_readyQueue.empty();
+	}
+	return !m_readyQueue.empty();
+}
+
+bf::context* grpc_scheduler::pick_next() noexcept {
+	bf::context* ctx = nullptr;
+
+	if (this->is_loop_thread) {
+		std::unique_lock<std::mutex> lk(m_xferMtx);
+		if (! xferQueue.empty()) {
+			ctx = xferQueue.front();
+			xferQueue.pop_front();
+			lk.unlock();
+			bf::context::active()->attach(ctx);
+			return ctx;
+		}
+	}
+	if (!m_readyQueue.empty()) {
+		ctx = & m_readyQueue.front();
+		m_readyQueue.pop_front();
+	}
+	return ctx;
+}
+
+void grpc_scheduler::suspend_until(std::chrono::steady_clock::time_point const& time_point) noexcept {
+	if ((std::chrono::steady_clock::time_point::max)() == time_point) {
+		std::unique_lock< std::mutex > lk{ m_rqMtx };
+		m_cnd.wait(lk, [this](){ return flag; });
+		flag = false;
+	} else {
+		std::unique_lock< std::mutex > lk{ m_rqMtx };
+		m_cnd.wait_until(lk, time_point, [this](){ return flag; });
+		flag = false;
+	}
+}
+
+void grpc_scheduler::notify() noexcept {
+	std::unique_lock< std::mutex > lk{ m_rqMtx };
+	flag = true;
+	lk.unlock();
+	m_cnd.notify_all();
+}
+
+void grpc_scheduler::property_change(bf::context* ctx, grpc_props& props ) noexcept {
+
+	// loop thread doesn't care if it does 'other' threads work
+	if (this->is_loop_thread) {
+		return;
+	}
+	// not ours? not a problem
+	if (! ctx->ready_is_linked()) {
+		return;
+	}
+
+	ctx->ready_unlink();
+	awakened (ctx, props);
+}
+
+}}

--- a/src/murmur/murmur_grpc/FiberScheduler.h
+++ b/src/murmur/murmur_grpc/FiberScheduler.h
@@ -1,0 +1,83 @@
+// Copyright 2005-2020 The Mumble Developers. All rights reserved.
+// Use of this source code is governed by a BSD-style license
+// that can be found in the LICENSE file at the root of the
+// Mumble source tree or at <https://www.mumble.info/LICENSE>.
+
+#ifndef MUMBLE_MURMUR_GRPC_SCHEDULE_H_
+#define MUMBLE_MURMUR_GRPC_SCHEDULE_H_
+
+#include <boost/fiber/algo/algorithm.hpp>
+#include <boost/fiber/context.hpp>
+#include <boost/fiber/properties.hpp>
+#include <boost/fiber/scheduler.hpp>
+
+#include <atomic>
+#include <deque>
+#include <mutex>
+
+namespace MurmurRPC {
+namespace Scheduler {
+
+namespace bf = boost::fibers;
+
+class grpc_props: public bf::fiber_properties {
+
+	private:
+		std::atomic<bool> is_main;
+
+	public:
+		grpc_props(bf::context* ctx) noexcept : bf::fiber_properties(ctx), is_main(false) { }
+
+		bool run_in_main() noexcept { return is_main.load(); }
+
+		void run_in_main(bool b) noexcept {
+			auto p = is_main.exchange(b);
+			if (p != b) {
+				notify();
+			}
+		}
+
+		virtual ~grpc_props() = default;
+};
+
+class grpc_scheduler : public bf::algo::algorithm_with_properties<grpc_props> {
+private:
+	typedef bf::scheduler::ready_queue_type rqueue_t;
+	typedef std::deque<bf::context *> xferqueue_t;
+
+	rqueue_t m_readyQueue{};
+	std::mutex m_rqMtx{};
+	std::condition_variable m_cnd{};
+	bool flag{false};
+
+	bool is_loop_thread;
+	static xferqueue_t xferQueue;
+	static std::mutex m_xferMtx;
+	static std::function<void()> alertMain;
+
+
+public:
+	grpc_scheduler(bool is_event_loop = false);
+
+	grpc_scheduler(grpc_scheduler const&) = delete;
+	grpc_scheduler(grpc_scheduler && ) = delete;
+
+	grpc_scheduler& operator=(grpc_scheduler const&) = delete;
+	grpc_scheduler& operator=(grpc_scheduler &&) = delete;
+
+	void awakened(bf::context *, grpc_props &) noexcept override;
+
+	bf::context* pick_next() noexcept override;
+
+	bool has_ready_fibers() const noexcept override;
+
+	void suspend_until(std::chrono::steady_clock::time_point const&) noexcept override;
+
+	void notify() noexcept override;
+
+	void property_change(bf::context*, grpc_props&) noexcept override;
+};
+
+}}
+
+#endif

--- a/src/murmur/murmur_grpc/FiberScheduler.h
+++ b/src/murmur/murmur_grpc/FiberScheduler.h
@@ -20,6 +20,12 @@ namespace Scheduler {
 
 namespace bf = boost::fibers;
 
+/// \brief Properties class for a fiber.
+///
+/// This class has one purpose: to indicate if a fiber should be
+/// forced into the main event loop. Used by \ref grpc_scheduler
+/// to determine how to schedule a newly awakened fiber
+///
 class grpc_props: public bf::fiber_properties {
 
 	private:
@@ -40,6 +46,16 @@ class grpc_props: public bf::fiber_properties {
 		virtual ~grpc_props() = default;
 };
 
+/// \brief A fiber scheduler that allows forcing a fiber to run in the event loop thread.
+///
+/// Closely resembles the default round_robin scheduler that comes with boost::fibers,
+/// except you can mark one fiber as running in the main event loop thread and request
+/// that any fiber be run in that thread instead of its default thread.
+///
+/// Just read the
+/// [boost documentation](https://www.boost.org/doc/libs/1_72_0/libs/fiber/doc/html/fiber/scheduling.html)
+/// if you really want to know how this thing works.
+///
 class grpc_scheduler : public bf::algo::algorithm_with_properties<grpc_props> {
 private:
 	typedef bf::scheduler::ready_queue_type rqueue_t;

--- a/src/murmur/murmur_grpc/FiberScheduler.h
+++ b/src/murmur/murmur_grpc/FiberScheduler.h
@@ -6,6 +6,9 @@
 #ifndef MUMBLE_MURMUR_GRPC_SCHEDULE_H_
 #define MUMBLE_MURMUR_GRPC_SCHEDULE_H_
 
+#include <QCoreApplication>
+#include <QAbstractEventDispatcher>
+
 #include <boost/fiber/algo/algorithm.hpp>
 #include <boost/fiber/context.hpp>
 #include <boost/fiber/properties.hpp>

--- a/src/murmur/murmur_grpc/codegen.h
+++ b/src/murmur/murmur_grpc/codegen.h
@@ -1,0 +1,210 @@
+/// \file "codegen.h"
+/// This just exists to show the various types of Derived objects that RPCCall can use.
+///
+/// All objects are deliberately *empty* having no member variables nor non-static
+/// functions. This allows RPCCall to inherit them for *free* using via
+/// [empty base optimization](https://en.cppreference.com/w/cpp/language/ebo).
+///
+/// The impl() and, if needed, onDone() methods for each struct are written in the end of MurmurGRPCImpl.cpp
+///
+namespace MurmurRPC {
+namespace Wrapper {
+
+/// \brief Model of a Unary service.grpc created by grpc codegen.
+///
+/// By setting the RPCType to Unary_t we let RPCCall know that we are a unary service. This
+/// type of service take a single request message and sends either an error or a single
+/// responce message. This by far the most common call type and the easiest to implement,
+/// as you are only required to write one function.
+///
+struct GetUnaryFoo {
+
+	/// \brief This will always be Detail::Unary_t in this service typel
+	typedef Detail::Unary::rpctype RPCType;
+
+	/// \brief incoming protobuf message type
+	typedef FooSingleRequest InType;
+
+	/// \brief outgoing protobuf message type
+	typedef FooSingleResponce OutType;
+
+	/// \brief Service this call is for. Always MurmurRPC::V1::AsyncService currently
+	typedef MurmurRPC::V1::AsyncService Service;
+
+	/// \brief gGRPC template to communicate with the service
+	template<typename T>
+		using StreamType = ::grpc::ServerAsyncResponseWriter<T>;
+
+	/// \brief convenience typedef for the impl() function to use
+	typedef const std::shared_ptr<RPCCall<GetUnaryFoo>>& rpcPtr;
+
+	/// \brief Method that needs to be hand-written for this call
+	///
+	/// This method will always run in the main event loop thread.
+	///
+	/// With getting a std::shared_ptr to the RPCCall we live in, and
+	/// the message of InType, it is expected to either call RPCCall::end()
+	/// with an output message or throw a grpc::Status an as error.
+	///
+	/// If neither of these conditions are satisfied, it can hang the RPCCall
+	/// until gRPC shuts it down due to a timeout condition. Likely this function
+	/// signature will change i the future.
+	///
+	/// \param rpcPtr std::shared_ptr to the RPCCall we were derived from
+	/// \param InType& protobuf request message
+	static void impl(rpcPtr, InType&);
+
+	/// \brief Gets the function pointer needed to add this call to the completion queue
+	/// \return member function pointer of Service needed to hook into the completion queue
+	static Service::*RequestGetUnaryFoo getRequestFn();
+};
+
+/// \brief Model of a Server Stream service created by grpc codegen.
+///
+/// By setting RPCType to ServerStream_t we let RPCCall know we are a server streaming service. This
+/// type of service takes a single incoming request and then sends many messages to the client. These
+/// could be Meta events like servers starting or stopping, or even events such as a user
+/// joining or leaving a channel.
+///
+struct GetBazEvents {
+
+	/// \brief always ServerStream_t for kind of call
+	typedef Detail::ServerStream::rpctype RPCType;
+
+	/// \brief Incoming protobuf request type.
+	///
+	/// Usually this defines any filters on the events to be listened for
+	///
+	typedef GetBazEventsRequest InType;
+
+	/// \brief Outgoing protobuf request type.
+	///
+	/// These are typically created by slot listeners in MurmurGRPCImpl and sent to the client
+	///
+	typedef BazEvent OutType;
+
+	/// \brief Service this call is for. Always MurmurRPC::V1::AsyncService currently
+	typedef MurmurRPC::V1::AsyncService Service;
+
+	/// \brief convenience typedef for the std::shared_ptr to our holding RPCCall
+	typedef const std::shared_ptr<RPCCall<GetBazEvents>>& rpcPtr;
+
+	/// \brief gGRPC template to communicate with the service
+	template<typename T>
+		using StreamType = grpc::ServerAsyncWriter<T>;
+
+	/// \brief User-written method called when new request is recieved.
+	///
+	/// This method will always run in the main event loop thread.
+	///
+	/// A typical implementation of this method will check the validity of the
+	/// request, then add an rpcId, std::weak_ptr and any other information needed
+	/// to define what sort of event is to be listened for into a weakContainer.
+	///
+	/// This weakContainer is then used by the listeners in MurmurGRPCImpl to
+	/// look up any service that needs to have a message sent to them when
+	/// a matching event is recieved.
+	///
+	/// \param rpcPtr std::shared_ptr to the RPCCall object we were derived from
+	/// \param InType& the incoming request to start a listener stream
+	///
+	static void impl(rpcPtr, InType&);
+
+	/// \brief User-written method to be called when a listener is stopped.
+	///
+	/// This can can either be because the user canceled the call, or because an
+	/// error occured. In theory, there could be a graceful way to stop listening
+	/// but no service currently supports such an action.
+	///
+	/// A typical implementation just deletes the items from the weakContainer
+	/// that held listeners by using the index on rpcId.
+	///
+	/// \param rpcPtr std::shared_ptr to the RPCCall we live in
+	/// \param bool passed on from the completion queue callback. Ignored
+	/// by most implementations.
+	///
+	static void onDone(rpcPtr, bool);
+
+	/// \brief Gets the function pointer needed to add this call to the completion queue
+	/// \return member function pointer of Service needed to hook into the completion queue
+	static Service::*RequestGetBazEvents getRequestFn();
+};
+
+/// \brief Model of a BidiStream call generated by the grpc codegen.
+///
+/// By setting RPCType to BidiStream_t we let RPCCall know we are a streaming-streaming service. This
+/// type of service takes a stream of incoming messages, and returns a stream ouf outgoing messages.
+///
+/// This call is the least common, and the hardest to use as the code in MurmurGRPCImpl has to be
+/// far more aware of the gRPC interface. RPCCalls of this type provide nothing but methods
+/// to read and write protobuf messages without blocking any thread by exposing the boost::fibers
+/// details that the other types hide. They are also the most powerful types, with no limitations
+/// on message ordering.
+///
+struct BarFilter {
+
+	/// \brief always Detail::BidiStream_t for this type.
+	typedef Detail::BidiStream::rpctype RPCType;
+
+	/// \brief Incoming message type.
+	///
+	/// Current design is a bit off, as the initating request to start the stream
+	/// is of the same type as the responses that wanted when an outgoing message is
+	/// sent
+	///
+	/// Most current types use these as 'filters' of some sort such that the incoming
+	/// message type, except on initation, is actually a reply to a request of some sort.
+	///
+	typedef BarFilterReply InType;
+
+	/// \brief Outgoing message type.
+	///
+	/// These are usually requests generated from MurmurGRPCImpl to get a reply on some sort of
+	/// action generated. This isn't mandated however as a Bidi Stream RPCCall can use any
+	/// message order it wants---even sending multiple incoming messages before reading a reply
+	/// or reading multiple messages before sending a response.
+	///
+	typedef BarFilterRequest OutType;
+
+	/// \brief Service this call is for. Always MurmurRPC::V1::AsyncService currently
+	typedef MurmurRPC::V1::AsyncService Service;
+
+	/// \brief Convenience typedef for a std::shared_ptr reference to our RPCCall type
+	typedef const std::shared_ptr<RPCCall<BarFilter>>& rpcPtr;
+
+	/// \brief template alias to create the gRPC communication object
+	template<typename T, typename U>
+		using StreamType = ::grpc::ServerAsyncReaderWriter<T, U>;
+
+	/// \brief User-defined function to be called on initation of new call.
+	///
+	/// Very similar to GetBazEvents::impl(), except there is no pre-read message. Only
+	/// a std::shared_ptr to the RPC object is provided.
+	///
+	/// A typical implementation will then read in a message, check validity, and
+	/// then add an rpcId and std::weak_ptr to the RPCCall, along with any other
+	/// information needed to a weakContainer.
+	///
+	static void impl(rpcPtr);
+
+	/// \brief User-written method to be called when a stream is stopped.
+	///
+	/// This can can either be because the user canceled the call, or because an
+	/// error occured. In theory, there could be a graceful way to stop stream
+	/// but no service currently supports such an action.
+	///
+	/// A typical implementation just deletes the items from the weakContainer
+	/// that held listeners by using the index on rpcId.
+	///
+	/// \param rpcPtr std::shared_ptr to the RPCCall we live in
+	/// \param bool passed on from the completion queue callback. Ignored
+	/// by most implementations.
+	///
+	static void onDone(rpcPtr, bool);
+
+	/// \brief Gets the function pointer needed to add this call to the completion queue
+	/// \return member function pointer of Service needed to hook into the completion queue
+	static Service::*RequestBarFilter getRequestFn();
+};
+}
+}

--- a/src/murmur_grpcwrapper_protoc_plugin/main.cpp
+++ b/src/murmur_grpcwrapper_protoc_plugin/main.cpp
@@ -23,16 +23,16 @@ using namespace google::protobuf::io;
 const char *CSingle_SSingle = R"(
 struct $service$_$method$ {
 	typedef Detail::Unary::rpctype RPCType;
-	typedef std::remove_reference_t<decltype(std::declval<::$in$>())> InType;
-	typedef std::remove_reference_t<decltype(std::declval<::$out$>())> OutType;
-	typedef std::remove_reference_t<decltype(std::declval<::$ns$::$service$::AsyncService>())> Service;
+	typedef boost::remove_reference_t<decltype(std::declval<::$in$>())> InType;
+	typedef boost::remove_reference_t<decltype(std::declval<::$out$>())> OutType;
+	typedef boost::remove_reference_t<decltype(std::declval<::$ns$::$service$::AsyncService>())> Service;
 	template<typename T>
 		using StreamType = ::grpc::ServerAsyncResponseWriter<T>;
 	typedef const std::shared_ptr<RPCCall<$service$_$method$>>& rpcPtr;
 
 	static void impl(rpcPtr, InType&);
 
-	static auto getRequestFn() {
+	static auto getRequestFn() -> decltype((&::$ns$::$service$::AsyncService::Request$method$)) {
 		return &::$ns$::$service$::AsyncService::Request$method$;
 	}
 };
@@ -41,9 +41,9 @@ struct $service$_$method$ {
 const char *CSingle_SStream = R"(
 struct $service$_$method$ {
 	typedef Detail::ServerStream::rpctype RPCType;
-	typedef std::remove_reference_t<decltype(std::declval<::$in$>())> InType;
-	typedef std::remove_reference_t<decltype(std::declval<::$out$>())> OutType;
-	typedef std::remove_reference_t<decltype(std::declval<::$ns$::$service$::AsyncService>())> Service;
+	typedef boost::remove_reference_t<decltype(std::declval<::$in$>())> InType;
+	typedef boost::remove_reference_t<decltype(std::declval<::$out$>())> OutType;
+	typedef boost::remove_reference_t<decltype(std::declval<::$ns$::$service$::AsyncService>())> Service;
 	typedef const std::shared_ptr<RPCCall<$service$_$method$>>& rpcPtr;
 
 	template<typename T>
@@ -52,7 +52,7 @@ struct $service$_$method$ {
 	static void impl(rpcPtr, InType&);
 	static void onDone(rpcPtr, bool);
 
-	static auto getRequestFn() {
+	static auto getRequestFn() -> decltype((&::$ns$::$service$::AsyncService::Request$method$)) {
 		return &::$ns$::$service$::AsyncService::Request$method$;
 	}
 };
@@ -61,12 +61,12 @@ struct $service$_$method$ {
 const char *CStream_SSingle = R"(
 struct $service$_$method$ {
 	typedef Detail::ClientStream::rpctype RPCType;
-	typedef std::remove_reference_t<decltype(std::declval<::$in$>())> InType;
-	typedef std::remove_reference_t<decltype(std::declval<::$out$>())> OutType;
-	typedef std::remove_reference_t<decltype(std::declval<::$ns$::$service$::AsyncService>())> Service;
+	typedef boost::remove_reference_t<decltype(std::declval<::$in$>())> InType;
+	typedef boost::remove_reference_t<decltype(std::declval<::$out$>())> OutType;
+	typedef boost::remove_reference_t<decltype(std::declval<::$ns$::$service$::AsyncService>())> Service;
 	typedef const std::shared_ptr<RPCCall<$service$_$method$>>& rpcPtr;
 
-	static auto getRequestFn() {
+	static auto getRequestFn() -> decltype((&::$ns$::$service$::AsyncService::Request$method$)) {
 		return &::$ns$::$service$::AsyncService::Request$method$;
 	}
 };
@@ -75,16 +75,16 @@ struct $service$_$method$ {
 const char *CStream_SStream = R"(
 struct $service$_$method$ {
 	typedef Detail::BidiStream::rpctype RPCType;
-	typedef std::remove_reference_t<decltype(std::declval<::$in$>())> InType;
-	typedef std::remove_reference_t<decltype(std::declval<::$out$>())> OutType;
-	typedef std::remove_reference_t<decltype(std::declval<::$ns$::$service$::AsyncService>())> Service;
+	typedef boost::remove_reference_t<decltype(std::declval<::$in$>())> InType;
+	typedef boost::remove_reference_t<decltype(std::declval<::$out$>())> OutType;
+	typedef boost::remove_reference_t<decltype(std::declval<::$ns$::$service$::AsyncService>())> Service;
 	typedef const std::shared_ptr<RPCCall<$service$_$method$>>& rpcPtr;
 	template<typename T, typename U>
 		using StreamType = ::grpc::ServerAsyncReaderWriter<T, U>;
 	static void impl(rpcPtr);
 	static void onDone(rpcPtr, bool);
 
-	static auto getRequestFn() {
+	static auto getRequestFn() -> decltype((&::$ns$::$service$::AsyncService::Request$method$)) {
 		return &::$ns$::$service$::AsyncService::Request$method$;
 	}
 };

--- a/src/murmur_grpcwrapper_protoc_plugin/main.cpp
+++ b/src/murmur_grpcwrapper_protoc_plugin/main.cpp
@@ -30,7 +30,7 @@ struct $service$_$method$ {
 		using StreamType = ::grpc::ServerAsyncResponseWriter<T>;
 	typedef const std::shared_ptr<RPCCall<$service$_$method$>>& rpcPtr;
 
-	void impl(rpcPtr, InType&);
+	static void impl(rpcPtr, InType&);
 
 	static auto getRequestFn() {
 		return &::$ns$::$service$::AsyncService::Request$method$;
@@ -49,8 +49,8 @@ struct $service$_$method$ {
 	template<typename T>
 		using StreamType = ::grpc::ServerAsyncWriter<T>;
 
-	void impl(rpcPtr, InType&);
-	void onDone(rpcPtr, bool);
+	static void impl(rpcPtr, InType&);
+	static void onDone(rpcPtr, bool);
 
 	static auto getRequestFn() {
 		return &::$ns$::$service$::AsyncService::Request$method$;
@@ -81,8 +81,8 @@ struct $service$_$method$ {
 	typedef const std::shared_ptr<RPCCall<$service$_$method$>>& rpcPtr;
 	template<typename T, typename U>
 		using StreamType = ::grpc::ServerAsyncReaderWriter<T, U>;
-	void impl(rpcPtr);
-	void onDone(rpcPtr, bool);
+	static void impl(rpcPtr);
+	static void onDone(rpcPtr, bool);
 
 	static auto getRequestFn() {
 		return &::$ns$::$service$::AsyncService::Request$method$;

--- a/src/murmur_grpcwrapper_protoc_plugin/main.cpp
+++ b/src/murmur_grpcwrapper_protoc_plugin/main.cpp
@@ -30,7 +30,7 @@ struct $service$_$method$ {
 		using StreamType = ::grpc::ServerAsyncResponseWriter<T>;
 	typedef const std::shared_ptr<RPCCall<$service$_$method$>>& rpcPtr;
 
-	static void impl(rpcPtr, InType&);
+	static boost::optional< OutType > impl(rpcPtr, InType&);
 
 	static auto getRequestFn() -> decltype((&::$ns$::$service$::AsyncService::Request$method$)) {
 		return &::$ns$::$service$::AsyncService::Request$method$;

--- a/src/murmur_grpcwrapper_protoc_plugin/murmur_grpcwrapper_protoc_plugin.pro
+++ b/src/murmur_grpcwrapper_protoc_plugin/murmur_grpcwrapper_protoc_plugin.pro
@@ -12,6 +12,11 @@ SOURCES = main.cpp
 LIBS = -lprotoc
 CONFIG -= qt
 CONFIG += c++11
+unix:!macx {
+	CONFIG(static) {
+		QMAKE_LFLAGS *= -static-pie
+	}
+}
 must_pkgconfig(protobuf)
 
 include(../../qmake/symbols.pri)


### PR DESCRIPTION
The old gRPC system had a lot to be desired. Heap allocated objects flying around. The RPC class was trying to be boost::intrusive_ptr. And things as simple as cancelling a text message filter could cause the server to crash.

This is a new gRPC, based loosely on the old one. While it has many advantages, there are also many disadvantages that I would like feedback on. In the new system, the gRPC codegen generates very little; nothing more than a few typedefs and some function declarations. You then create a RPC object that uses this information to create an template that has an interface that somewhat depends on the object you gave to it.

One advantage of this, is that there is almost no dynamic dispatch, but they don't really share a base class anymore. However, basically no code cares about working with generic RPC objects. They know which ones they are after.

I have also changed most of the containers used. The primary reason for this is that I wanted to be able to look up by the RPCId (a random number b/c weak_ptr doesn't really have any good support for being in an ordered container). It also allows me to control the way the container is accessed because deletes could happen at any time.

The containers support a few basic ways of access. One is that you can send in a lambda that returns a pair of iterators. This will then be filtered to remove all expired weak_ptr (as well as converting them into shared_ptr). Due to this range being a copy, it cannot be invalidated when iterating over it, and having the shared pointers is a promise that the objects in your range stay valid. Another access method is to request an index. You can either get a const index (for quick find operations), or a unique pointer to an index that is non-const. The 'deleter' of the unique pointer holds a mutex which locks access to the container while you are using it. When you are done, assign nullptr to the index ptr and the mutex is released.

The other big change is the way callback works. RPCExecEvent is gone. When you create a new fiber, you can tell it if you want to execute in the thread it started it, or you can request it be executed in the event loop thread. It also means that the completion queue doesn't need heap allocated objects, most of the time the sender is waiting in another fiber for the response. The CQ no longer deletes the items it pulls out of the queue -- they are all on the stack. 

There is also some reorganization (letting meta delete the servers so that the CQ is still running on shutdown/using recursive mutexes as one thread could try to obtain the same mutex several times if the gRPC connection has high latency).

The biggest cons on this are: I have used c++14 pretty heavily. In fact, this change set even has some c++17 stuff in the form of structured bindings. The biggest thing i need from it is to be able to bind move-only objects into lambas. I think there is another way to make this work as well using c++11 only , but it's painful. Also with all the template meta-programming that has been done in RPC some of the convenience functions really do help make the syntax a bit more terse. 

The other big con is [Boost Fibers](https://www.boost.org/doc/libs/1_72_0/libs/fiber/doc/html/index.html). It's not header only. It doesn't support all architectures. Because it does context switching by messing with the stack memory sanitizers have a hard time with it. It also can make debugging challenging because if you wait till std::abort is called, the stack looks nothing like it did during execution and it's challenging to get a decent backtrace.

A lesser problem is size, a fully stripped binary, statically linked against musl, with ICE, DBUS, bonjour, disabled--just basically murmur and gRPC is ~15mb. That's pretty large. 

So, while this is full of extraneous debugging junk, and no real unified style as it was put together over many sleepless nights, I hope that I can get some feedback about if this *general design* is a feasible way to move forward. I think that this method makes it much easier to add new stuff to the interface, and at the same time makes it difficult to misuse. 

All feedback is appreciated!

Fixes #4197