### PR TITLE
Allow bundled translations to overwrite Qt's

### DIFF
--- a/scripts/generate-mumble_qt-qrc.py
+++ b/scripts/generate-mumble_qt-qrc.py
@@ -12,12 +12,52 @@ import platform
 import sys
 
 allowed_prefixes = ('qt', 'qtbase')
+override_qt = []
 
-def dirToQrc(of, dirName, alreadyProcessedLangs):
+def parseTranslationsConfig(configFile):
+	configHandle = open(configFile, "r")
+
+	for currentLine in configHandle.readlines():
+		currentLine = currentLine.strip()
+		# Skip comments and empty lines
+		if currentLine.startswith("#") or not currentLine:
+			continue
+
+		# A config entry is supposed to be in the format <operator> <fileName>
+		splitParts = currentLine.split(" ", 1)
+		if len(splitParts) != 2:
+			raise RuntimeError("Invalid line in translation config file: %s" % currentLine)
+
+		operator = splitParts[0].lower().strip()
+		translationFileName = splitParts[1].strip()
+
+		if not translationFileName:
+			raise RuntimeError("Empty filename in translation config: %s" % currentLine)
+
+		if not translationFileName.endswith(".ts"):
+			raise RuntimeError("Expected translation file to have a '*.ts' name but got %s" % translationFileName)
+
+		# Replace the trailing .ts with .qm as this is what lrelease will turn it into
+		translationFileName = translationFileName[:-3] + ".qm"
+
+		if operator == "fallback":
+			# fallback files are the default, so no special action has to be taken
+			pass
+		# be programmer friendly and allow "override" as well
+		elif operator == "overwrite" or operator == "override":
+			override_qt.append(translationFileName)
+
+
+def dirToQrc(of, dirName, alreadyProcessedLangs, localTranslationDir = False):
 	processedLangs = []
 	absDirName = os.path.abspath(dirName)
 	fns = os.listdir(dirName)
 	for fn in fns:
+		isOverride = False
+		if fn in override_qt and localTranslationDir:
+			# This translation should be used to overwrite an existing Qt-translation.
+			isOverride = True
+
 		fnRoot, fnExt = os.path.splitext(fn)
 		if fnExt.lower() != '.qm':
 			continue
@@ -31,21 +71,36 @@ def dirToQrc(of, dirName, alreadyProcessedLangs):
 			nextToLastUnderscoreIdx = prefix.rfind('_')
 			prefix = fnRoot[:nextToLastUnderscoreIdx]
 			lang = fnRoot[nextToLastUnderscoreIdx+1:]
-		if lang in alreadyProcessedLangs:
+		if lang in alreadyProcessedLangs and not isOverride:
 			continue
 		if not prefix in allowed_prefixes:
 			continue
 		absFn = os.path.join(absDirName, fn)
 		if platform.system() == 'Windows':
 			absFn = absFn.replace('\\', '/')
-		of.write(' <file alias="{0}">{1}</file>\n'.format(fn, absFn))
-		processedLangs.append(lang)
+		
+		if not isOverride:
+			of.write(' <file alias="{0}">{1}</file>\n'.format(fn, absFn))
+			processedLangs.append(lang)
+		else:
+			# In order to recognize translation-overrides, we have to prefix them
+			of.write(' <file alias="{0}">{1}</file>\n'.format("mumble_overwrite_" + fn, absFn))
+
 	return processedLangs
 
 def main():
-	# python generate-mumble_qt-qrc.py <output-fn> [inputs...]
+	# python generate-mumble_qt-qrc.py <output-fn> [inputs...] localDir
 	output = sys.argv[1]
-	inputs = sys.argv[2:]
+	inputs = sys.argv[2:-1]
+	localDir = sys.argv[-1]
+
+	# parse config file
+	if localDir.endswith("/") or localDir.endswith("\\"):
+		localDir = localDir[:-1]
+
+	configFile = os.path.join(localDir, "translations.conf")
+	if os.path.isfile(configFile):
+		parseTranslationsConfig(configFile)
 
 	of = open(output, 'w')
 	of.write('<!DOCTYPE RCC><RCC version="1.0">\n')
@@ -54,6 +109,8 @@ def main():
 	for dirName in inputs:
 		newlyProcssedLangs = dirToQrc(of, dirName, processedLangs)
 		processedLangs.extend(newlyProcssedLangs)
+	# Process translations provided by Mumble itself (aka local translations)
+	dirToQrc(of, localDir, processedLangs, True)
 	of.write('</qresource>\n')
 	of.write('</RCC>\n')
 	of.close()

--- a/src/mumble/main.cpp
+++ b/src/mumble/main.cpp
@@ -397,13 +397,21 @@ int main(int argc, char **argv) {
 	//
 	// See http://doc.qt.io/qt-5/linguist-programmers.html#deploying-translations for more information
 	QTranslator qttranslator;
-	if (qttranslator.load(QLatin1String("qt_") + locale, QLibraryInfo::location(QLibraryInfo::TranslationsPath))) { // Try system qt translations
+	// First we try and see if there is a translation packaged with Mumble that shall overwrite any potentially existing Qt translations.
+	// If not, we try to load the qt-translations installed on the host-machine and if that fails as well,
+	// we try to load translations bundled in Mumble.
+	// Note: Resource starting with :/ are bundled resources specified in a .qrc file
+	if (qttranslator.load(QLatin1String(":/mumble_overwrite_qt_") + locale)) {
+		a.installTranslator(&qttranslator);
+	} else if (qttranslator.load(QLatin1String(":/mumble_overwrite_qtbase_") + locale)) { 
+		a.installTranslator(&qttranslator);
+	} else if (qttranslator.load(QLatin1String("qt_") + locale, QLibraryInfo::location(QLibraryInfo::TranslationsPath))) {
 		a.installTranslator(&qttranslator);
 	} else if (qttranslator.load(QLatin1String("qtbase_") + locale, QLibraryInfo::location(QLibraryInfo::TranslationsPath))) {
 		a.installTranslator(&qttranslator);
-	} else if (qttranslator.load(QLatin1String(":qt_") + locale)) { // Try bundled translations
+	} else if (qttranslator.load(QLatin1String(":/qt_") + locale)) {
 		a.installTranslator(&qttranslator);
-	} else if (qttranslator.load(QLatin1String(":qtbase_") + locale)) {
+	} else if (qttranslator.load(QLatin1String(":/qtbase_") + locale)) {
 		a.installTranslator(&qttranslator);
 	}
 	

--- a/src/mumble/mumble.pro
+++ b/src/mumble/mumble.pro
@@ -707,15 +707,15 @@ CONFIG(no-update) {
 }
 
 !CONFIG(no-embed-qt-translations) {
-  QT_TRANSLATIONS_FALLBACK_DIR = qttranslations
-  QT_TRANSLATIONS_FALLBACK_FILES = $$files($$QT_TRANSLATIONS_FALLBACK_DIR/*.ts)
-  for(fn, QT_TRANSLATIONS_FALLBACK_FILES) {
+  QT_TRANSLATIONS_LOCAL_DIR = qttranslations
+  QT_TRANSLATIONS_LOCAL_FILES = $$files($$QT_TRANSLATIONS_LOCAL_DIR/*.ts)
+  for(fn, QT_TRANSLATIONS_LOCAL_FILES) {
     !system($$QMAKE_LRELEASE -silent $$fn) {
       error(Failed to run lrelease for $$fn)
     }
   }
   GENQRC = $$PYTHON ../../scripts/generate-mumble_qt-qrc.py
-  !system($$GENQRC mumble_qt_auto.qrc $$[QT_INSTALL_TRANSLATIONS] $$QT_TRANSLATIONS_FALLBACK_DIR) {
+  !system($$GENQRC mumble_qt_auto.qrc $$[QT_INSTALL_TRANSLATIONS] $$QT_TRANSLATIONS_LOCAL_DIR) {
     error(Failed to run generate-mumble_qt-qrc.py script)
   }
   RESOURCES *= mumble_qt_auto.qrc

--- a/src/mumble/qttranslations/translations.conf
+++ b/src/mumble/qttranslations/translations.conf
@@ -1,0 +1,21 @@
+# This file controls whether the translations foudn in this
+# directory are simply a fallback for the cases in which Qt
+# doesn't ship with its own translation for that locale or
+# whether our translations are actually enforced (aka they
+# overwrite Qt's)
+#
+# A line starting with a # is interpreted as a comment and is
+# discarded
+# All non-empty lines that are no comment have to be in the format
+# <operator> <fileName>
+# where <operator> is either fallback or overwrite (or override)
+#
+# To provide translation file x.ts as a fallback use
+# fallback x.ts
+# to force its usage use
+# overwrite x.ts
+
+fallback qt_it.ts
+fallback qt_nl.ts
+fallback qt_tr.ts
+


### PR DESCRIPTION
- I adapted the python script generating the qrc-file for bundled qt-translations so that it'll respect a config-file stating whether some translations shall overwrite the official qt-translations
- I adapted the actual cpp code loading the translations so that it'll always prefer packaged translations for the ones that have been marked to overwrite Qt's translations 