### PR TITLE
Ensure CI reflects the actual build status

### DIFF
--- a/scripts/azure-pipelines/build_linux.bash
+++ b/scripts/azure-pipelines/build_linux.bash
@@ -9,7 +9,8 @@ ver=$(python scripts/mumble-version.py)
 
 qmake -recursive CONFIG+="release tests warnings-as-errors" DEFINES+="MUMBLE_VERSION=${ver}"
 
-make -j $(nproc) && make check
+make -j $(nproc)
+make check
 
 # TODO: The next few lines should be done by "make install": https://github.com/mumble-voip/mumble/issues/1029
 mkdir -p appdir/usr/bin appdir/usr/lib/mumble appdir/usr/share/metainfo/ appdir/usr/share/icons/hicolor/scalable/apps/ appdir/usr/share/applications/

--- a/scripts/azure-pipelines/build_macos.bash
+++ b/scripts/azure-pipelines/build_macos.bash
@@ -15,7 +15,8 @@ ver=$(python scripts/mumble-version.py)
 
 qmake -recursive CONFIG+="release tests warnings-as-errors" DEFINES+="MUMBLE_VERSION=${ver}"
 
-make -j $(sysctl -n hw.ncpu) && make check
+make -j $(sysctl -n hw.ncpu)
+make check
 
 # Build installer
 ./macx/scripts/osxdist.py --version=${ver}

--- a/scripts/azure-pipelines/install-environment_macos.bash
+++ b/scripts/azure-pipelines/install-environment_macos.bash
@@ -5,4 +5,5 @@
 # that can be found in the LICENSE file at the root of the
 # Mumble source tree or at <https://www.mumble.info/LICENSE>.
 
-brew update && brew install pkg-config qt5 boost libogg libvorbis flac libsndfile protobuf openssl ice
+brew update
+brew install pkg-config qt5 boost libogg libvorbis flac libsndfile protobuf openssl ice

--- a/scripts/travis-ci/script.bash
+++ b/scripts/travis-ci/script.bash
@@ -18,7 +18,8 @@ if [ "${TRAVIS_OS_NAME}" == "linux" ]; then
 			EXTRA_CONFIG="no-pch ${EXTRA_CONFIG}"
 		fi
 		qmake CONFIG+="release tests g15-emulator ${EXTRA_CONFIG}" DEFINES+="MUMBLE_VERSION=${TRAVIS_COMMIT:0:7}" -recursive
-		make -j2 && make check
+		make -j2
+		make check
 	elif [ "${MUMBLE_HOST}" == "aarch64-linux-gnu" ]; then
 		qmake CONFIG+="release tests warnings-as-errors ${EXTRA_CONFIG}" -recursive
 		make -j $(nproc)


### PR DESCRIPTION
As encountered by @deluxghost, the macOS CI reports success even though the actual buikld fails.

Our build-scripts use bash's `-e` flag that terminate the script on the first encountered error. However this is only true for error that are encountered outside if-like structures.

Unfortunately compilation happens via
https://github.com/mumble-voip/mumble/blob/ce40787cc576eef4771a707c3e2738c8cfdd6839/scripts/azure-pipelines/build_macos.bash#L18
And the use of `&&` turns this statement into such an if-like structure.

This can be easily verified by running the following script:
```
#!/usr/bin/env bash

set -e

echo "Now failing"

false && echo "This won't even be executed"

echo "This is printed even though above statement failed"
```

The conclusion of this is: When using `-e` don't use the `&&` operator. And this is what this PR will do.