### PR TITLE
Improve Azure-Pipelines Windows build

### DIFF
--- a/scripts/azure-pipelines/install-environment.ps1
+++ b/scripts/azure-pipelines/install-environment.ps1
@@ -38,7 +38,14 @@ if (-Not (Test-Path $env_7z)) {
     Write-Host "Environment not cached. Downloading..."
     $env_url = "$MUMBLE_ENVIRONMENT_SOURCE/$MUMBLE_ENVIRONMENT_VERSION.7z"
 	try {
+		# According to https://github.com/PowerShell/PowerShell/issues/2138 disabling the
+		# progressbar can significantly increase the speed of Invoke-Web-Request. 
+		$ProgressPreference = 'SilentlyContinue'
+
 		Invoke-WebRequest -Uri $env_url -OutFile $env_7z
+
+		# Reset progressbar
+		$ProgressPreference = 'Continue'
 	} catch {
 		Write-Host "Failed at downloading build-environment: $PSItem"
 		exit 1

--- a/scripts/azure-pipelines/install-environment.ps1
+++ b/scripts/azure-pipelines/install-environment.ps1
@@ -37,7 +37,12 @@ $env_7z = Join-Path $MUMBLE_ENVIRONMENT_STORE "$MUMBLE_ENVIRONMENT_VERSION.7z";
 if (-Not (Test-Path $env_7z)) {
     Write-Host "Environment not cached. Downloading..."
     $env_url = "$MUMBLE_ENVIRONMENT_SOURCE/$MUMBLE_ENVIRONMENT_VERSION.7z"
-    Invoke-WebRequest -Uri $env_url -OutFile $env_7z
+	try {
+		Invoke-WebRequest -Uri $env_url -OutFile $env_7z
+	} catch {
+		Write-Host "Failed at downloading build-environment: $PSItem"
+		exit 1
+	}
 }
 
 if (-Not (Test-Path (Join-Path $MUMBLE_ENVIRONMENT_PATH $MUMBLE_ENVIRONMENT_VERSION))) {


### PR DESCRIPTION
This PR will improve the script downloading the windows build-env by
- Wrapping `Invoke-WebRequest` in a `try/catch`-block to print the enountered error on failure
- Disabling the 'progressbar` for the `Invoke-WebRequest` command which speeds it up a lot (see https://github.com/PowerShell/PowerShell/issues/2138 for reference)
