### PR TITLE
Replace deprecated constructs

### DIFF
--- a/src/Connection.cpp
+++ b/src/Connection.cpp
@@ -154,7 +154,12 @@ void Connection::socketDisconnected() {
 }
 
 void Connection::messageToNetwork(const ::google::protobuf::Message &msg, unsigned int msgType, QByteArray &cache) {
+#if GOOGLE_PROTOBUF_VERSION >= 3004000
+	int len = msg.ByteSizeLong();
+#else
+	// ByteSize() has been deprecated as of protobuf v3.4
 	int len = msg.ByteSize();
+#endif
 	if (len > 0x7fffff)
 		return;
 	cache.resize(len + 6);

--- a/src/HostAddress.cpp
+++ b/src/HostAddress.cpp
@@ -139,7 +139,12 @@ QString HostAddress::toString() const {
 	if (isV6()) {
 		if (isValid()) {
 			QString qs;
+#if QT_VERSION >= 0x050500
+			qs.asprintf("[%x:%x:%x:%x:%x:%x:%x:%x]", ntohs(shorts[0]), ntohs(shorts[1]), ntohs(shorts[2]), ntohs(shorts[3]), ntohs(shorts[4]), ntohs(shorts[5]), ntohs(shorts[6]), ntohs(shorts[7]));
+#else
+			// sprintf() has been deprecated in Qt 5.5 in favor for asprintf()
 			qs.sprintf("[%x:%x:%x:%x:%x:%x:%x:%x]", ntohs(shorts[0]), ntohs(shorts[1]), ntohs(shorts[2]), ntohs(shorts[3]), ntohs(shorts[4]), ntohs(shorts[5]), ntohs(shorts[6]), ntohs(shorts[7]));
+#endif
 			return qs.replace(QRegExp(QLatin1String("(:0)+")),QLatin1String(":"));
 		} else {
 			return QLatin1String("[::]");

--- a/src/OSInfo.cpp
+++ b/src/OSInfo.cpp
@@ -210,7 +210,21 @@ QString OSInfo::getOSVersion() {
 		return QString();
 	}
 
-	os.sprintf("%lu.%lu.%lu.%lu", static_cast<unsigned long>(ovi.dwMajorVersion), static_cast<unsigned long>(ovi.dwMinorVersion), static_cast<unsigned long>(ovi.dwBuildNumber), (ovi.wProductType == VER_NT_WORKSTATION) ? 1UL : 0UL);
+#if QT_VERSION >= 0x050500
+	os.asprintf("%lu.%lu.%lu.%lu",
+		static_cast<unsigned long>(ovi.dwMajorVersion),
+		static_cast<unsigned long>(ovi.dwMinorVersion),
+		static_cast<unsigned long>(ovi.dwBuildNumber),
+		(ovi.wProductType == VER_NT_WORKSTATION) ? 1UL : 0UL);
+#else
+	// sprintf() has been deprecated in Qt 5.5 in favor for asprintf()
+	os.sprintf("%lu.%lu.%lu.%lu",
+		static_cast<unsigned long>(ovi.dwMajorVersion),
+		static_cast<unsigned long>(ovi.dwMinorVersion),
+		static_cast<unsigned long>(ovi.dwBuildNumber),
+		(ovi.wProductType == VER_NT_WORKSTATION) ? 1UL : 0UL);
+#endif // QT_VERSION >= 0x050500
+
 #elif defined(Q_OS_MAC)
 	SInt32 major, minor, bugfix;
 	OSErr err = Gestalt(gestaltSystemVersionMajor, &major);
@@ -229,11 +243,20 @@ QString OSInfo::getOSVersion() {
 		buildno = &buildno_buf[0];
 	}
 
+#if QT_VERSION >= 0x050500
+	os.asprintf("%lu.%lu.%lu %s",
+	           static_cast<unsigned long>(major),
+	           static_cast<unsigned long>(minor),
+	           static_cast<unsigned long>(bugfix),
+	           buildno ? buildno : "unknown");
+#else
+	// sprintf() has been deprecated in Qt 5.5 in favor for asprintf()
 	os.sprintf("%lu.%lu.%lu %s",
 	           static_cast<unsigned long>(major),
 	           static_cast<unsigned long>(minor),
 	           static_cast<unsigned long>(bugfix),
 	           buildno ? buildno : "unknown");
+#endif // QT_VERSION >= 0x050500
 #else
 #ifdef Q_OS_LINUX
 	QProcess qp;
@@ -262,7 +285,12 @@ QString OSInfo::getOSVersion() {
 		// other UNIX-like systems return a 0 on success.
 		if (uname(&un) == 0) {
 #endif
+#if QT_VERSION >= 0x050500
+			os.asprintf("%s %s", un.sysname, un.release);
+#else
+			// sprintf() has been deprecated in Qt 5.5 in favor for asprintf()
 			os.sprintf("%s %s", un.sysname, un.release);
+#endif // QT_VERSION >= 0x050500
 		}
 	}
 #endif
@@ -483,7 +511,18 @@ QString OSInfo::getOSDisplayableVersion() {
 	}
 
 	QString osv;
-	osv.sprintf(" - %lu.%lu.%lu", static_cast<unsigned long>(ovi.dwMajorVersion), static_cast<unsigned long>(ovi.dwMinorVersion), static_cast<unsigned long>(ovi.dwBuildNumber));
+#if QT_VERSION >= 0x050500
+	osv.asprintf(" - %lu.%lu.%lu",
+		static_cast<unsigned long>(ovi.dwMajorVersion),
+		static_cast<unsigned long>(ovi.dwMinorVersion),
+		static_cast<unsigned long>(ovi.dwBuildNumber));
+#else
+	// sprintf() has been deprecated in Qt 5.5 in favor for asprintf()
+	osv.sprintf(" - %lu.%lu.%lu",
+		static_cast<unsigned long>(ovi.dwMajorVersion),
+		static_cast<unsigned long>(ovi.dwMinorVersion),
+		static_cast<unsigned long>(ovi.dwBuildNumber));
+#endif // QT_VERSION >= 0x050500
 	osdispver.append(osv);
 
 	return osdispver;

--- a/src/mumble/Audio.cpp
+++ b/src/mumble/Audio.cpp
@@ -93,8 +93,8 @@ LoopUser::LoopUser() {
 	bLocalIgnore = bLocalMute = bSelfDeaf = false;
 	tsState = Settings::Passive;
 	cChannel = NULL;
-	qtTicker.start();
-	qtLastFetch.start();
+	qetTicker.start();
+	qetLastFetch.start();
 }
 
 void LoopUser::addFrame(const QByteArray &packet) {
@@ -105,9 +105,9 @@ void LoopUser::addFrame(const QByteArray &packet) {
 
 	{
 		QMutexLocker l(&qmLock);
-		bool restart = (qtLastFetch.elapsed() > 100);
+		bool restart = (qetLastFetch.elapsed() > 100);
 
-		double time = qtTicker.elapsed();
+		double time = qetTicker.elapsed();
 
 		double r;
 		if (restart)
@@ -119,7 +119,7 @@ void LoopUser::addFrame(const QByteArray &packet) {
 	}
 
 	// Restart check
-	if (qtLastFetch.elapsed() > 100) {
+	if (qetLastFetch.elapsed() > 100) {
 		AudioOutputPtr ao = g.ao;
 		if (ao) {
 			MessageHandler::UDPMessageType msgType = static_cast<MessageHandler::UDPMessageType>((packet.at(0) >> 5) & 0x7);
@@ -137,7 +137,7 @@ void LoopUser::fetchFrames() {
 		return;
 	}
 
-	double cmp = qtTicker.elapsed();
+	double cmp = qetTicker.elapsed();
 
 	QMultiMap<float, QByteArray>::iterator i = qmPackets.begin();
 
@@ -164,7 +164,7 @@ void LoopUser::fetchFrames() {
 		i = qmPackets.erase(i);
 	}
 
-	qtLastFetch.restart();
+	qetLastFetch.restart();
 }
 
 RecordUser::RecordUser() : LoopUser() {

--- a/src/mumble/Audio.h
+++ b/src/mumble/Audio.h
@@ -10,7 +10,7 @@
 #include <QtCore/QMultiMap>
 #include <QtCore/QMutex>
 #include <QtCore/QString>
-#include <QtCore/QTime>
+#include <QtCore/QElapsedTimer>
 #include <QtCore/QVariant>
 
 #include "ClientUser.h"
@@ -24,8 +24,8 @@ class LoopUser : public ClientUser {
 		Q_DISABLE_COPY(LoopUser)
 	protected:
 		QMutex qmLock;
-		QTime qtTicker;
-		QTime qtLastFetch;
+		QElapsedTimer qetTicker;
+		QElapsedTimer qetLastFetch;
 		QMultiMap<float, QByteArray> qmPackets;
 		LoopUser();
 	public:

--- a/src/mumble/AudioStats.cpp
+++ b/src/mumble/AudioStats.cpp
@@ -301,6 +301,12 @@ AudioStats::AudioStats(QWidget *p) : QDialog(p) {
 AudioStats::~AudioStats() {
 }
 
+#if QT_VERSION >= 0x050500
+	#define FORMAT_TO_TXT(format, arg) txt.asprintf(format, arg)
+#else
+	// sprintf() has been deprecated in Qt 5.5 in favor for asprintf()
+	#define FORMAT_TO_TXT(format, arg) txt.sprintf(format, arg)
+#endif
 void AudioStats::on_Tick_timeout() {
 	AudioInputPtr ai = g.ai;
 
@@ -311,13 +317,13 @@ void AudioStats::on_Tick_timeout() {
 
 	QString txt;
 
-	txt.sprintf("%06.2f dB",ai->dPeakMic);
+	FORMAT_TO_TXT("%06.2f dB", ai->dPeakMic);
 	qlMicLevel->setText(txt);
 
-	txt.sprintf("%06.2f dB",ai->dPeakSpeaker);
+	FORMAT_TO_TXT("%06.2f dB", ai->dPeakSpeaker);
 	qlSpeakerLevel->setText(txt);
 
-	txt.sprintf("%06.2f dB",ai->dPeakSignal);
+	FORMAT_TO_TXT("%06.2f dB", ai->dPeakSignal);
 	qlSignalLevel->setText(txt);
 
 	spx_int32_t ps_size = 0;
@@ -340,19 +346,19 @@ void AudioStats::on_Tick_timeout() {
 		n += sqrtf(static_cast<float>(noise[i]));
 	}
 
-	txt.sprintf("%06.3f",s / n);
+	FORMAT_TO_TXT("%06.3f",s / n);
 	qlMicSNR->setText(txt);
 
 	spx_int32_t v;
 	speex_preprocess_ctl(ai->sppPreprocess, SPEEX_PREPROCESS_GET_AGC_GAIN, &v);
 	float fv = powf(10.0f, (static_cast<float>(v) / 20.0f));
-	txt.sprintf("%03.0f%%",100.0f / fv);
+	FORMAT_TO_TXT("%03.0f%%",100.0f / fv);
 	qlMicVolume->setText(txt);
 
-	txt.sprintf("%03.0f%%",ai->fSpeechProb * 100.0f);
+	FORMAT_TO_TXT("%03.0f%%",ai->fSpeechProb * 100.0f);
 	qlSpeechProb->setText(txt);
 
-	txt.sprintf("%04.1f kbit/s",static_cast<float>(ai->iBitrate) / 1000.0f);
+	FORMAT_TO_TXT("%04.1f kbit/s",static_cast<float>(ai->iBitrate) / 1000.0f);
 	qlBitrate->setText(txt);
 
 	if (nTalking != bTalking) {
@@ -365,7 +371,7 @@ void AudioStats::on_Tick_timeout() {
 	if (g.uiDoublePush > 1000000)
 		txt = tr(">1000 ms");
 	else
-		txt.sprintf("%04llu ms",g.uiDoublePush / 1000);
+		FORMAT_TO_TXT("%04llu ms",g.uiDoublePush / 1000);
 	qlDoublePush->setText(txt);
 
 	abSpeech->iBelow = iroundf(g.s.fVADmin * 32767.0f + 0.5f);
@@ -383,3 +389,4 @@ void AudioStats::on_Tick_timeout() {
 	if (aewEcho)
 		aewEcho->update();
 }
+#undef FORMAT_TO_TXT

--- a/src/mumble/ConnectDialog.cpp
+++ b/src/mumble/ConnectDialog.cpp
@@ -1393,7 +1393,12 @@ void ConnectDialog::onResolved(BonjourRecord record, QString host, int port) {
 
 void ConnectDialog::onUpdateLanList(const QList<BonjourRecord> &list) {
 	QSet<ServerItem *> items;
+#if QT_VERSION >= QT_VERSION_CHECK(5,14,0)
+	QSet<ServerItem *> old = QSet<ServerItem*>(qtwServers->siLAN->qlChildren.begin(), qtwServers->siLAN->qlChildren.end());
+#else
+	// In Qt 5.14 QList::toSet() has been deprecated as there exists a dedicated constructor of QSet for this now
 	QSet<ServerItem *> old = qtwServers->siLAN->qlChildren.toSet();
+#endif
 
 	foreach(const BonjourRecord &record, list) {
 		bool found = false;
@@ -1673,11 +1678,11 @@ void ConnectDialog::lookedUp() {
 			qhPings[addr].insert(si);
 		}
 
-		si->qlAddresses = qs.toList();
+		si->qlAddresses = qs.values();
 	}
 
 	qlDNSLookup.removeAll(unresolved);
-	qhDNSCache.insert(unresolved, qs.toList());
+	qhDNSCache.insert(unresolved, qs.values());
 	qhDNSWait.remove(unresolved);
 
 	foreach(ServerItem *si, waiting) {

--- a/src/mumble/GlobalShortcut.cpp
+++ b/src/mumble/GlobalShortcut.cpp
@@ -781,8 +781,14 @@ GlobalShortcutEngine::GlobalShortcutEngine(QObject *p) : QThread(p) {
 
 GlobalShortcutEngine::~GlobalShortcutEngine() {
 	QSet<ShortcutKey *> qs;
-	foreach(const QList<ShortcutKey*> &ql, qlShortcutList)
+	foreach(const QList<ShortcutKey*> &ql, qlShortcutList) {
+#if QT_VERSION >= QT_VERSION_CHECK(5,14,0)
+		qs += QSet<ShortcutKey*>(ql.begin(), ql.end());
+#else
+		// In Qt 5.14 QList::toSet() has been deprecated as there exists a dedicated constructor of QSet for this now
 		qs += ql.toSet();
+#endif
+	}
 
 	foreach(ShortcutKey *sk, qs)
 		delete sk;
@@ -792,8 +798,14 @@ void GlobalShortcutEngine::remap() {
 	bNeedRemap = false;
 
 	QSet<ShortcutKey *> qs;
-	foreach(const QList<ShortcutKey*> &ql, qlShortcutList)
+	foreach(const QList<ShortcutKey*> &ql, qlShortcutList) {
+#if QT_VERSION >= QT_VERSION_CHECK(5,14,0)
+		qs += QSet<ShortcutKey*>(ql.begin(), ql.end());
+#else
+		// In Qt 5.14 QList::toSet() has been deprecated as there exists a dedicated constructor of QSet for this now
 		qs += ql.toSet();
+#endif
+	}
 
 	foreach(ShortcutKey *sk, qs)
 		delete sk;

--- a/src/mumble/MainWindow.cpp
+++ b/src/mumble/MainWindow.cpp
@@ -2910,9 +2910,16 @@ void MainWindow::serverDisconnected(QAbstractSocket::SocketError err, QString re
 	}
 
 	QSet<QAction *> qs;
+#if QT_VERSION >= QT_VERSION_CHECK(5, 14, 0)
+	qs += QSet<QAction*>(qlServerActions.begin(), qlServerActions.end());
+	qs += QSet<QAction*>(qlChannelActions.begin(), qlChannelActions.end());
+	qs += QSet<QAction*>(qlUserActions.begin(), qlUserActions.end());
+#else
+	// In Qt 5.14 QList::toSet() has been deprecated as there exists a dedicated constructor of QSet for this now
 	qs += qlServerActions.toSet();
 	qs += qlChannelActions.toSet();
 	qs += qlUserActions.toSet();
+#endif
 
 	foreach(QAction *a, qs)
 		delete a;

--- a/src/mumble/Messages.cpp
+++ b/src/mumble/Messages.cpp
@@ -891,9 +891,16 @@ void MainWindow::removeContextAction(const MumbleProto::ContextActionModify &msg
 	QString action = u8(msg.action());
 
 	QSet<QAction *> qs;
+#if QT_VERSION >= QT_VERSION_CHECK(5, 14, 0)
+	qs += QSet<QAction*>(qlServerActions.begin(), qlServerActions.end());
+	qs += QSet<QAction*>(qlChannelActions.begin(), qlChannelActions.end());
+	qs += QSet<QAction*>(qlUserActions.begin(), qlUserActions.end());
+#else
+	// In Qt 5.14 QList::toSet() has been deprecated as there exists a dedicated constructor of QSet for this now
 	qs += qlServerActions.toSet();
 	qs += qlChannelActions.toSet();
 	qs += qlUserActions.toSet();
+#endif
 
 	foreach(QAction *a, qs) {
 		if (a->data() == action) {

--- a/src/mumble/Overlay.ui
+++ b/src/mumble/Overlay.ui
@@ -299,7 +299,7 @@
               </brush>
              </property>
              <property name="renderHints">
-              <set>QPainter::Antialiasing|QPainter::HighQualityAntialiasing|QPainter::SmoothPixmapTransform|QPainter::TextAntialiasing</set>
+              <set>QPainter::Antialiasing|QPainter::SmoothPixmapTransform|QPainter::TextAntialiasing</set>
              </property>
             </widget>
            </item>

--- a/src/mumble/SvgIcon.cpp
+++ b/src/mumble/SvgIcon.cpp
@@ -32,7 +32,6 @@ void SvgIcon::addSvgPixmapsToIcon(QIcon &icon, QString fn) {
 		p.setRenderHint(QPainter::Antialiasing);
 		p.setRenderHint(QPainter::TextAntialiasing);
 		p.setRenderHint(QPainter::SmoothPixmapTransform);
-		p.setRenderHint(QPainter::HighQualityAntialiasing);
 		svg.render(&p);
 
 		icon.addPixmap(pm);

--- a/src/murmur/DBus.cpp
+++ b/src/murmur/DBus.cpp
@@ -484,15 +484,15 @@ void MurmurDBus::getACL(int id, const QDBusMessage &msg, QList<ACLInfo> &acls, Q
 		if (pg)
 			members = pg->members();
 		if (g) {
-			gi.add = g->qsAdd.toList();
-			gi.remove = g->qsRemove.toList();
+			gi.add = g->qsAdd.values();
+			gi.remove = g->qsRemove.values();
 			gi.inherited = false;
 			members+=g->qsAdd;
 			members-=g->qsRemove;
 		} else {
 			gi.inherited = true;
 		}
-		gi.members = members.toList();
+		gi.members = members.values();
 		groups << gi;
 	}
 }
@@ -522,8 +522,14 @@ void MurmurDBus::setACL(int id, const QList<ACLInfo> &acls, const QList<GroupInf
 		g = new Group(cChannel, gi.name);
 		g->bInherit=gi.inherit;
 		g->bInheritable=gi.inheritable;
+#if QT_VERSION >= QT_VERSION_CHECK(5, 14, 0)
+		g->qsAdd = QSet<int>(gi.add.begin(), gi.add.end());
+		g->qsRemove = QSet<int>(gi.remove.begin(), gi.remove.end());
+#else
+		// In Qt 5.14 QList::toSet() has been deprecated as there exists a dedicated constructor of QSet for this now
 		g->qsAdd = gi.add.toSet();
 		g->qsRemove = gi.remove.toSet();
+#endif
 		g->qsTemporary = hOldTemp.value(gi.name);
 	}
 

--- a/src/murmur/Messages.cpp
+++ b/src/murmur/Messages.cpp
@@ -440,7 +440,12 @@ void Server::msgBanList(ServerUser *uSource, MumbleProto::BanList &msg) {
 		}
 		sendMessage(uSource, msg);
 	} else {
+#if QT_VERSION >= QT_VERSION_CHECK(5, 14, 0)
+		previousBans = QSet<Ban>(qlBans.begin(), qlBans.end());
+#else
+		// In Qt 5.14 QList::toSet() has been deprecated as there exists a dedicated constructor of QSet for this now
 		previousBans = qlBans.toSet();
+#endif
 		qlBans.clear();
 		for (int i=0;i < msg.bans_size(); ++i) {
 			const MumbleProto::BanList_BanEntry &be = msg.bans(i);
@@ -462,7 +467,12 @@ void Server::msgBanList(ServerUser *uSource, MumbleProto::BanList &msg) {
 				qlBans << b;
 			}
 		}
+#if QT_VERSION >= QT_VERSION_CHECK(5, 14, 0)
+		newBans = QSet<Ban>(qlBans.begin(), qlBans.end());
+#else
+		// In Qt 5.14 QList::toSet() has been deprecated as there exists a dedicated constructor of QSet for this now
 		newBans = qlBans.toSet();
+#endif
 		QSet<Ban> removed = previousBans - newBans;
 		QSet<Ban> added = newBans - previousBans;
 		foreach(const Ban &b, removed) {

--- a/src/murmur/Messages.cpp
+++ b/src/murmur/Messages.cpp
@@ -403,7 +403,12 @@ void Server::msgAuthenticate(ServerUser *uSource, MumbleProto::Authenticate &msg
 		mpsug.set_positional(qvSuggestPositional.toBool());
 	if (! qvSuggestPushToTalk.isNull())
 		mpsug.set_push_to_talk(qvSuggestPushToTalk.toBool());
+#if GOOGLE_PROTOBUF_VERSION >= 3004000
+	if (mpsug.ByteSizeLong() > 0) {
+#else
+	// ByteSize() has been deprecated as of protobuf v3.4
 	if (mpsug.ByteSize() > 0) {
+#endif
 		sendMessage(uSource, mpsug);
 	}
 

--- a/src/murmur/MurmurIce.cpp
+++ b/src/murmur/MurmurIce.cpp
@@ -123,7 +123,12 @@ static void userToUser(const ::User *p, Murmur::User &mp) {
 	mp.udpPing = u->dUDPPingAvg;
 	mp.tcpPing = u->dTCPPingAvg;
 
+#if QT_VERSION >= QT_VERSION_CHECK(5, 14, 0)
+	mp.tcponly = u->aiUdpFlag.loadRelaxed() == 0;
+#else
+	// Qt 5.14 introduced QAtomicInteger::loadRelaxed() which deprecates QAtomicInteger::load()
 	mp.tcponly = u->aiUdpFlag.load() == 0;
+#endif
 
 	::Murmur::NetAddress addr(16, 0);
 	const Q_IPV6ADDR &a = u->haAddress.qip6;

--- a/src/murmur/Server.cpp
+++ b/src/murmur/Server.cpp
@@ -930,7 +930,12 @@ bool Server::checkDecrypt(ServerUser *u, const char *encrypt, char *plain, unsig
 }
 
 void Server::sendMessage(ServerUser *u, const char *data, int len, QByteArray &cache, bool force) {
+#if QT_VERSION >= QT_VERSION_CHECK(5, 14, 0)
+	if ((u->aiUdpFlag.loadRelaxed() == 1 || force) && (u->sUdpSocket != INVALID_SOCKET)) {
+#else
+	// Qt 5.14 introduced QAtomicInteger::loadRelaxed() which deprecates QAtomicInteger::load()
 	if ((u->aiUdpFlag.load() == 1 || force) && (u->sUdpSocket != INVALID_SOCKET)) {
+#endif
 #if defined(__LP64__)
 		STACKVAR(char, ebuffer, len+4+16);
 		char *buffer = reinterpret_cast<char *>(((reinterpret_cast<quint64>(ebuffer) + 8) & ~7) + 4);

--- a/src/tests/TestSSLLocks/TestSSLLocks.cpp
+++ b/src/tests/TestSSLLocks/TestSSLLocks.cpp
@@ -29,7 +29,12 @@ public:
 
 	void run() {
 		unsigned char buf[64];
+#if QT_VERSION >= QT_VERSION_CHECK(5, 14, 0)
+		while (m_running->loadRelaxed() == 1) {
+#else
+		// Qt 5.14 introduced QAtomicInteger::loadRelaxed() which deprecates QAtomicInteger::load()
 		while (m_running->load() == 1) {
+#endif 
 			for (int i = 0; i < 1024; i++) {
 				if (m_seed) {
 					RAND_seed(buf, sizeof(buf));


### PR DESCRIPTION
Our failing macOS CI indicates that there are a few constructs in our code-base that are considered deprecated. This PR attempts to fix that.