### PR TITLE
WIP: Use AppImageUpdaterBridge for checking and installing updates for Mumble AppImage

### DIFF
--- a/qmake/appimageupdaterbridge.pri
+++ b/qmake/appimageupdaterbridge.pri
@@ -13,5 +13,10 @@ unix {
 		DEFINES += USE_APPIMAGE_UPDATER_BRIDGE
 		CONFIG *= link_pkgconfig
 		must_pkgconfig(AppImageUpdaterBridge)
+		message(Will be using AppImageUpdaterBridge)
+	}
+} else {
+	APPIMAGE_UPDATER_BRIDGE_ENABLED {
+		error(You cannot use AppImageUpdaterBridge for this type of build)
 	}
 }

--- a/qmake/appimageupdaterbridge.pri
+++ b/qmake/appimageupdaterbridge.pri
@@ -1,0 +1,17 @@
+# Copyright 2005-2020 The Mumble Developers. All rights reserved.
+# Use of this source code is governed by a BSD-style license
+# that can be found in the LICENSE file at the root of the
+# Mumble source tree or at <https://www.mumble.info/LICENSE>.
+
+include(pkgconfig.pri)
+
+# Please note that you have to make sure that AppImageUpdaterBridge's
+# pkgconfig files are available in the $PKG_CONFIG_PATH.
+# Because most of the time it's not.
+unix {
+	APPIMAGE_UPDATER_BRIDGE_ENABLED {
+		DEFINES += USE_APPIMAGE_UPDATER_BRIDGE
+		CONFIG *= link_pkgconfig
+		must_pkgconfig(AppImageUpdaterBridge)
+	}
+}

--- a/scripts/azure-pipelines/build_linux.bash
+++ b/scripts/azure-pipelines/build_linux.bash
@@ -17,7 +17,7 @@ cd AppImageUpdaterBridge
 git checkout "v1.1.6" 
 cmake -DLOGGING_DISABLED=ON .
 make -j $(nproc)
-make install
+sudo make install
 cd ..
 rm -rf AppImageUpdaterBridge # cleanup
 

--- a/scripts/azure-pipelines/build_linux.bash
+++ b/scripts/azure-pipelines/build_linux.bash
@@ -7,6 +7,9 @@
 
 ver=$(python scripts/mumble-version.py)
 
+# Use the Qt kit installed through PPA
+source /opt/qt*/bin/qt*-env.sh || true
+
 # clone and install AppImageUpdaterBridge to the system
 git clone https://github.com/antony-jr/AppImageUpdaterBridge
 cd AppImageUpdaterBridge

--- a/scripts/azure-pipelines/build_linux.bash
+++ b/scripts/azure-pipelines/build_linux.bash
@@ -8,7 +8,7 @@
 ver=$(python scripts/mumble-version.py)
 
 # Use the Qt kit installed through PPA
-source /opt/qt*/bin/qt*-env.sh || true
+source /opt/qt*/bin/qt*-env.sh
 
 # clone and install AppImageUpdaterBridge to the system
 git clone https://github.com/antony-jr/AppImageUpdaterBridge
@@ -16,11 +16,11 @@ cd AppImageUpdaterBridge
 git checkout "v1.1.6" 
 cmake -DLOGGING_DISABLED=ON .
 make -j $(nproc)
-DESTDIR=/tmp make install
+make install
 cd ..
 rm -rf AppImageUpdaterBridge # cleanup
 
-export PKG_CONFIG_PATH=/tmp/usr/local/lib/pkgconfig
+export PKG_CONFIG_PATH=/usr/local/lib/pkgconfig
 qmake -recursive CONFIG+="release tests warnings-as-errors APPIMAGE_UPDATER_BRIDGE_ENABLED" DEFINES+="MUMBLE_VERSION=${ver}"
 
 make -j $(nproc)

--- a/scripts/azure-pipelines/build_linux.bash
+++ b/scripts/azure-pipelines/build_linux.bash
@@ -9,7 +9,13 @@ ver=$(python scripts/mumble-version.py)
 
 # Use the Qt kit installed through PPA
 # even though the source executes successfully, it does return code 1
-source /opt/qt*/bin/qt*-env.sh || true
+echo "set -x" > test.sh
+cat /opt/qt*/bin/qt*-env.sh >> test.sh
+cat test.sh
+source test.sh
+set +x
+rm -rf test.sh
+# source /opt/qt*/bin/qt*-env.sh || true
 
 # clone and install AppImageUpdaterBridge to the system
 git clone https://github.com/antony-jr/AppImageUpdaterBridge

--- a/scripts/azure-pipelines/build_linux.bash
+++ b/scripts/azure-pipelines/build_linux.bash
@@ -7,7 +7,18 @@
 
 ver=$(python scripts/mumble-version.py)
 
-qmake -recursive CONFIG+="release tests warnings-as-errors" DEFINES+="MUMBLE_VERSION=${ver}"
+# clone and install AppImageUpdaterBridge to the system
+git clone https://github.com/antony-jr/AppImageUpdaterBridge
+cd AppImageUpdaterBridge
+git checkout "v1.1.6" 
+cmake -DLOGGING_DISABLED=ON .
+make -j $(nproc)
+DESTDIR=/tmp make install
+cd ..
+rm -rf AppImageUpdaterBridge # cleanup
+
+export PKG_CONFIG_PATH=/tmp/usr/local/lib/pkgconfig:$PKG_CONFIG_PATH
+qmake -recursive CONFIG+="release tests warnings-as-errors APPIMAGE_UPDATER_BRIDGE_ENABLED" DEFINES+="MUMBLE_VERSION=${ver}"
 
 make -j $(nproc)
 make check

--- a/scripts/azure-pipelines/build_linux.bash
+++ b/scripts/azure-pipelines/build_linux.bash
@@ -8,7 +8,8 @@
 ver=$(python scripts/mumble-version.py)
 
 # Use the Qt kit installed through PPA
-source /opt/qt*/bin/qt*-env.sh
+# even though the source executes successfully, it does return code 1
+source /opt/qt*/bin/qt*-env.sh || true
 
 # clone and install AppImageUpdaterBridge to the system
 git clone https://github.com/antony-jr/AppImageUpdaterBridge
@@ -20,7 +21,7 @@ make install
 cd ..
 rm -rf AppImageUpdaterBridge # cleanup
 
-export PKG_CONFIG_PATH=/usr/local/lib/pkgconfig
+export PKG_CONFIG_PATH=$PKG_CONFIG_PATH:/usr/local/lib/pkgconfig
 qmake -recursive CONFIG+="release tests warnings-as-errors APPIMAGE_UPDATER_BRIDGE_ENABLED" DEFINES+="MUMBLE_VERSION=${ver}"
 
 make -j $(nproc)

--- a/scripts/azure-pipelines/build_linux.bash
+++ b/scripts/azure-pipelines/build_linux.bash
@@ -20,7 +20,7 @@ DESTDIR=/tmp make install
 cd ..
 rm -rf AppImageUpdaterBridge # cleanup
 
-export PKG_CONFIG_PATH=/tmp/usr/local/lib/pkgconfig:$PKG_CONFIG_PATH
+export PKG_CONFIG_PATH=/tmp/usr/local/lib/pkgconfig
 qmake -recursive CONFIG+="release tests warnings-as-errors APPIMAGE_UPDATER_BRIDGE_ENABLED" DEFINES+="MUMBLE_VERSION=${ver}"
 
 make -j $(nproc)

--- a/scripts/azure-pipelines/install-environment_linux.bash
+++ b/scripts/azure-pipelines/install-environment_linux.bash
@@ -13,4 +13,4 @@ sudo apt-get -y install build-essential pkg-config qt5-default qttools5-dev-tool
                         libasound2-dev libpulse-dev \
                         libogg-dev libsndfile1-dev libspeechd-dev \
                         libavahi-compat-libdnssd-dev libzeroc-ice-dev libg15daemon-client-dev \
-                        zsync
+                        zsync git cmake

--- a/scripts/azure-pipelines/install-environment_linux.bash
+++ b/scripts/azure-pipelines/install-environment_linux.bash
@@ -4,12 +4,13 @@
 # Use of this source code is governed by a BSD-style license
 # that can be found in the LICENSE file at the root of the
 # Mumble source tree or at <https://www.mumble.info/LICENSE>.
-
+sudo add-apt-repository ppa:beineri/opt-qt-5.12.7-xenial -y
 sudo apt-get update
 
-sudo apt-get -y install build-essential pkg-config qt5-default qttools5-dev-tools libqt5svg5-dev \
-                        libboost-dev libssl-dev libprotobuf-dev protobuf-compiler \
-                        libcap-dev libxi-dev \
+sudo apt-get -y install build-essential pkg-config qt512base qt512svg qt512tools \
+	                qt512translations libboost-dev libssl-dev libprotobuf-dev \
+			protobuf-compiler \
+                        libcap-dev libxi-dev libgl1-mesa-dev\
                         libasound2-dev libpulse-dev \
                         libogg-dev libsndfile1-dev libspeechd-dev \
                         libavahi-compat-libdnssd-dev libzeroc-ice-dev libg15daemon-client-dev \

--- a/scripts/azure-pipelines/install-environment_linux.bash
+++ b/scripts/azure-pipelines/install-environment_linux.bash
@@ -5,7 +5,7 @@
 # that can be found in the LICENSE file at the root of the
 # Mumble source tree or at <https://www.mumble.info/LICENSE>.
 sudo add-apt-repository ppa:beineri/opt-qt-5.12.7-xenial -y
-sudo apt-get update
+sudo apt-get update -qq
 
 sudo apt-get -y install build-essential pkg-config qt512base qt512svg qt512tools \
 	                qt512translations libboost-dev libssl-dev libprotobuf-dev \

--- a/src/mumble.pri
+++ b/src/mumble.pri
@@ -8,6 +8,9 @@ include(../qmake/qt.pri)
 include(../qmake/rcc.pri)
 include(../qmake/pkgconfig.pri)
 
+# Add AppImageUpdaterBridge
+include(../qmake/appimageupdaterbridge.pri)
+
 VERSION		= 1.4.0
 DIST		= mumble.pri Message.h PacketDataStream.h CryptState.h Timer.h Version.h OSInfo.h SSL.h
 CONFIG		+= qt thread debug_and_release warn_on

--- a/src/mumble.pri
+++ b/src/mumble.pri
@@ -8,9 +8,6 @@ include(../qmake/qt.pri)
 include(../qmake/rcc.pri)
 include(../qmake/pkgconfig.pri)
 
-# Add AppImageUpdaterBridge
-include(../qmake/appimageupdaterbridge.pri)
-
 VERSION		= 1.4.0
 DIST		= mumble.pri Message.h PacketDataStream.h CryptState.h Timer.h Version.h OSInfo.h SSL.h
 CONFIG		+= qt thread debug_and_release warn_on

--- a/src/mumble/VersionCheck.cpp
+++ b/src/mumble/VersionCheck.cpp
@@ -224,7 +224,9 @@ void VersionCheck::fetched(QByteArray a, QUrl url) {
 
 	deleteLater();
 }
-#else // USE_APPIMAGE_UPDATER_BRIDGE
+#endif // USE_APPIMAGE_UPDATER_BRIDGE
+
+#if defined(USE_APPIMAGE_UPDATER_BRIDGE) && defined(Q_OS_LINUX)
 void VersionCheck::handleUpdateCheck(bool updateAvailable,const QJsonObject &info){
 	(void)info;
 	disconnect(m_Revisioner, &AppImageDeltaRevisioner::updateAvailable,
@@ -233,19 +235,19 @@ void VersionCheck::handleUpdateCheck(bool updateAvailable,const QJsonObject &inf
 		   this, &VersionCheck::handleUpdateCheckError);
 
 	if(!updateAvailable){ // Notify the user they are using the latest version.
-		g.mw->msgBox(QString::fromUtf8("You are currently using the latest version of Mumble AppImage."));
+		g.mw->msgBox(QString::fromLatin1("You are currently using the latest version of Mumble AppImage."));
 		//Qt parent to child deallocation should take care of m_Revisioner
 		deleteLater();
 		return;
 	}
 	
-	g.mw->msgBox(QString::fromUtf8("A new version of Mumble AppImage is available."));
+	g.mw->msgBox(QString::fromLatin1("A new version of Mumble AppImage is available."));
 	
 	int flags = AppImageUpdaterDialog::Default;
 	flags ^= AppImageUpdaterDialog::ShowBeforeProgress; // No show before progress
 	flags ^= AppImageUpdaterDialog::NotifyWhenNoUpdateIsAvailable;
 
-	m_UpdaterDialog = new AppImageUpdaterDialog(QPixmap(QString::fromUtf8(":/mumble.svg")), nullptr, flags);
+	m_UpdaterDialog = new AppImageUpdaterDialog(QPixmap(QString::fromLatin1(":/mumble.svg")), nullptr, flags);
 
 	connect(m_UpdaterDialog, &AppImageUpdaterDialog::error,
 		this, &VersionCheck::handleUpdateError);
@@ -286,4 +288,4 @@ void VersionCheck::handleUpdateCancel(){
 	return;
 }
 
-#endif // USE_APPIMAGE_UPDATER_BRIDGE
+#endif // defined(APPIMAGE_UPDATER_BRIDGE) && defined(Q_OS_LINUX)

--- a/src/mumble/VersionCheck.cpp
+++ b/src/mumble/VersionCheck.cpp
@@ -85,7 +85,7 @@ VersionCheck::VersionCheck(bool autocheck, QObject *p, bool focus) : QObject(p) 
 #else // When USE_APPIMAGE_UPDATER_BRIDGE is defined
 // USE_APPIMAGE_UPDATER_BRIDGE implies that we are on a linux machine 
 // so we are going to assume that.
-
+	Q_UNUSED(focus)
 	m_UpdaterDialog = nullptr;
 	m_Revisioner = new AppImageDeltaRevisioner(/*singleThreaded=*/true,/*parent=*/this);
 	

--- a/src/mumble/VersionCheck.h
+++ b/src/mumble/VersionCheck.h
@@ -27,7 +27,8 @@ class VersionCheck : public QObject {
 #ifndef USE_APPIMAGE_UPDATER_BRIDGE
 	public slots:
 		void fetched(QByteArray data, QUrl url);
-#else
+#endif
+#if defined(USE_APPIMAGE_UPDATER_BRIDGE) && defined(Q_OS_LINUX)
 	public slots:
 		void handleUpdateCheck(bool,const QJsonObject&);
 		void handleUpdateCheckError(short);
@@ -40,4 +41,4 @@ class VersionCheck : public QObject {
 		VersionCheck(bool autocheck, QObject *parent = NULL, bool focus = false);
 };
 
-#endif
+#endif // MUMBLE_MUMBLE_VERSIONCHECK_H_

--- a/src/mumble/VersionCheck.h
+++ b/src/mumble/VersionCheck.h
@@ -5,17 +5,37 @@
 
 #ifndef MUMBLE_MUMBLE_VERSIONCHECK_H_
 #define MUMBLE_MUMBLE_VERSIONCHECK_H_
-
 #include <QtCore/QObject>
-#include <QtCore/QByteArray>
-#include <QtCore/QUrl>
+#ifndef USE_APPIMAGE_UPDATER_BRIDGE
+# include <QtCore/QByteArray>
+# include <QtCore/QUrl>
+#else
+# include <QJsonObject>
+# include <QString>
+# include <AppImageUpdaterBridge>
+# include <AppImageUpdaterDialog>
+#endif
 
 class VersionCheck : public QObject {
 	private:
 		Q_OBJECT
 		Q_DISABLE_COPY(VersionCheck)
+#ifdef USE_APPIMAGE_UPDATER_BRIDGE
+		AppImageUpdaterBridge::AppImageDeltaRevisioner *m_Revisioner;
+		AppImageUpdaterBridge::AppImageUpdaterDialog *m_UpdaterDialog;
+#endif
+#ifndef USE_APPIMAGE_UPDATER_BRIDGE
 	public slots:
 		void fetched(QByteArray data, QUrl url);
+#else
+	public slots:
+		void handleUpdateCheck(bool,const QJsonObject&);
+		void handleUpdateCheckError(short);
+
+		void handleUpdateFinish(const QJsonObject&);
+		void handleUpdateCancel();
+		void handleUpdateError(const QString&,short);
+#endif
 	public:
 		VersionCheck(bool autocheck, QObject *parent = NULL, bool focus = false);
 };

--- a/src/mumble/mumble.pro
+++ b/src/mumble/mumble.pro
@@ -7,6 +7,9 @@ include(../mumble.pri)
 include(../../qmake/python.pri)
 include(../../qmake/lrelease.pri)
 
+# Add AppImageUpdaterBridge
+include(../../qmake/appimageupdaterbridge.pri)
+
 DEFINES *= MUMBLE
 TEMPLATE = app
 TARGET = mumble

--- a/src/mumble/mumble.pro
+++ b/src/mumble/mumble.pro
@@ -6,9 +6,7 @@
 include(../mumble.pri)
 include(../../qmake/python.pri)
 include(../../qmake/lrelease.pri)
-
-# Add AppImageUpdaterBridge
-include(../../qmake/appimageupdaterbridge.pri)
+include(../../qmake/appimageupdaterbridge.pri) # add AppImageUpdaterBridge
 
 DEFINES *= MUMBLE
 TEMPLATE = app


### PR DESCRIPTION
This PR modifies ```VersionCheck.cpp``` and ```VersionCheck.hpp``` to use the mentioned library for checking and installing the update. This feature can be turned on when you give qmake with ```APPIMAGE_UPDATER_BRIDGE_ENABLED``` as config.

**This PR is still a Work in progress, reviews are needed**.

Refer: https://github.com/mumble-voip/mumble/pull/3705