### PR TITLE
Publish Windows installer as build artifact

### DIFF
--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -5,6 +5,7 @@ jobs:
         MSVC_2015:
           MUMBLE_QT: qt5
           MUMBLE_HOST: x86_64-pc-windows-msvc
+          MUMBLE_PUBLISH_INSTALLER: 1
         MSVC_2015_NO_PCH:
           MUMBLE_QT: qt5
           MUMBLE_HOST: x86_64-pc-windows-msvc
@@ -20,6 +21,10 @@ jobs:
       displayName: 'Install build environment'
     - powershell: scripts/azure-pipelines/build.ps1
       displayName: 'Build'
+    - task: PublishBuildArtifacts@1
+      inputs:
+        pathtoPublish: '$(Build.ArtifactStagingDirectory)'
+        artifactName: WindowsInstaller
   - job: Linux
     pool:
       vmImage: 'ubuntu-16.04'

--- a/scripts/azure-pipelines/build.ps1
+++ b/scripts/azure-pipelines/build.ps1
@@ -60,4 +60,15 @@ $env:MUMBLE_BUILDENV_DIR = $MUMBLE_BUILDENV_DIR
 Get-ChildItem -Path $MUMBLE_BUILD_DIR
 
 & $MUMBLE_BUILDSCRIPT
+
+if ($lastexitcode -ne 0) {
+	Write-Output "Skipping build-artifatcs due to a build-error"
+	exit $lastexitcode
+}
+
+if ($env:MUMBLE_PUBLISH_INSTALLER -eq 1) {
+	Write-Output "Copying build-artifacts to destination directory '$env:BUILD_ARTIFACTSTAGINGDIRECTORY'"
+	cp installer\bin\x64\Release\*.msi "$env:BUILD_ARTIFACTSTAGINGDIRECTORY"
+}
+
 exit $lastexitcode


### PR DESCRIPTION
Currently we are publishing the build artifacts on Azure-pipelines for Linux (AppImage) and for macOS (installer) but we don't do it for windows.
This PR aims at changing that.