### PR TITLE
Remove bandwidth note from README

### DIFF
--- a/README
+++ b/README
@@ -63,10 +63,3 @@ Doubleclick the Murmur icon to start murmur. There will be a small icon on your
 taskbar from which you can view the log.
 
 To set the superuser password, run murmur with the parameters '-supw <password>'.
-
-Bandwidth usage
-===============
-
-Mumble will use 10-40 kbit/s outgoing, and the same incoming for each user.
-So if there are 10 other users on the server with you, your incoming
-bandwidth requirement will be 100-400 kbit/s if they all talk at the same time.

--- a/README.md
+++ b/README.md
@@ -66,9 +66,3 @@ Doubleclick the Murmur icon to start murmur. There will be a small icon on your
 taskbar from which you can view the log.
 
 To set the superuser password, run murmur with the parameters `-supw <password>`.
-
-## Bandwidth usage
-
-Mumble will use 10-40 kbit/s outgoing, and the same incoming for each user.
-So if there are 10 other users on the server with you, your incoming
-bandwidth requirement will be 100-400 kbit/s if they all talk at the same time.


### PR DESCRIPTION
This PR does 2 removes the bandwidth note from the README(.md) as according to #2184 the note is outdated anyways. As this information is apparently also covered in our wiki, I opted for removing the note instead of updating it (as I agree with the author of the linked issue that bandwidth is not that big of an issue anymore).

Fixes #2184