### PR TITLE
Explicitly set permissions for overlay-pipe

### DIFF
--- a/src/mumble/Overlay.cpp
+++ b/src/mumble/Overlay.cpp
@@ -191,6 +191,9 @@ Overlay::Overlay() : QObject() {
 	forceSettings();
 
 	qlsServer = new QLocalServer(this);
+	// Allow anyone to access the pipe in order to communicate with the overlay
+	qlsServer->setSocketOptions(QLocalServer::WorldAccessOption);
+
 	QString pipepath;
 #ifdef Q_OS_WIN
 	pipepath = QLatin1String("MumbleOverlayPipe");


### PR DESCRIPTION
As noted in #3970 we are currently relying on system defaults for the access permissions of the pipe created for communication to the overlay.
In this PR I changed the code to explicitly set these permissions in order to not be dependent on whatever the system considers the default.

(Hopefully) fixes #3970 - we'll see about that once it has been tested :point_up: 

(The first commit is from #3980 which is required to get an installer out of the CI in order to test that this actually fixes the issue)