### PR TITLE
Allow disabling autoUpdates for snapshot-builds

### DIFF
--- a/src/mumble/NetworkConfig.cpp
+++ b/src/mumble/NetworkConfig.cpp
@@ -63,11 +63,6 @@ void NetworkConfig::load(const Settings &r) {
 	loadCheckBox(qcbAutoUpdate, r.bUpdateCheck);
 	loadCheckBox(qcbPluginUpdate, r.bPluginCheck);
 	loadCheckBox(qcbUsage, r.bUsage);
-
-#if defined(SNAPSHOT_BUILD) && defined(QT_NO_DEBUG)
-	qcbAutoUpdate->setEnabled(false);
-	qcbAutoUpdate->setToolTip(tr("Updates are mandatory when using snapshot releases."));
-#endif
 }
 
 void NetworkConfig::save() const {

--- a/src/mumble/main.cpp
+++ b/src/mumble/main.cpp
@@ -536,13 +536,18 @@ int main(int argc, char **argv) {
 		g.l->log(Log::Warning, CertWizard::tr("<b>Certificate Expiry:</b> Your certificate is about to expire. You need to renew it, or you will no longer be able to connect to servers you are registered on."));
 
 #ifdef QT_NO_DEBUG
+	// Only perform the version-check for non-debug builds
+	if (g.s.bUpdateCheck) {
+		// Use different settings for the version checks depending on whether this is a snapshot build
+		// or a normal release build
 #ifndef SNAPSHOT_BUILD
-	if (g.s.bUpdateCheck)
-#endif
+		// release build
 		new VersionCheck(true, g.mw);
-#ifdef SNAPSHOT_BUILD
-	new VersionCheck(false, g.mw, true);
+#else
+		// snapshot build
+		new VersionCheck(false, g.mw, true);
 #endif
+	}
 #else
 	g.mw->msgBox(MainWindow::tr("Skipping version check in debug mode."));
 #endif


### PR DESCRIPTION
bdbd4808fe9a45f945856db76d5266b7e662f09c intentionally forced the auto-update feature on all snapshot-users.
While I see the benefits of having snapshot-users to always be on the newest version, I highly disagree with forcing it upon them. Thus in this PR I revert the changes made in that commit (10 years ago).