### PR TITLE
Make VersionCheck prepare asynchronously

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -3,7 +3,7 @@ freebsd_instance:
 
 freebsd_task:
   update_script: pkg update && pkg upgrade -y
-  install_script: pkg install -y git pkgconf gmake qt5-qmake qt5-l10n qt5-buildtools qt5-linguisttools qt5-testlib qt5-core qt5-gui qt5-network qt5-sql qt5-svg qt5-widgets qt5-xml boost-libs opus libsndfile protobuf ice avahi-libdns speech-dispatcher python
+  install_script: pkg install -y git pkgconf gmake qt5-qmake qt5-l10n qt5-buildtools qt5-linguisttools qt5-testlib qt5-core qt5-gui qt5-network qt5-sql qt5-svg qt5-widgets qt5-xml qt5-concurrent boost-libs opus libsndfile protobuf ice avahi-libdns speech-dispatcher python
   fetch_submodules_script: git submodule --quiet update --init --recursive
   build_script:
   - qmake -recursive CONFIG+="release tests warnings-as-errors no-alsa no-jackaudio no-pulseaudio"

--- a/src/mumble/VersionCheck.cpp
+++ b/src/mumble/VersionCheck.cpp
@@ -17,6 +17,8 @@
 #include <QtXml/QDomDocument>
 #include <QtWidgets/QMessageBox>
 
+#include <QtConcurrent>
+
 #ifdef Q_OS_WIN
 # include <shellapi.h>
 # include <softpub.h>
@@ -25,53 +27,60 @@
 // We define a global macro called 'g'. This can lead to issues when included code uses 'g' as a type or parameter name (like protobuf 3.7 does). As such, for now, we have to make this our last include.
 #include "Global.h"
 
-VersionCheck::VersionCheck(bool autocheck, QObject *p, bool focus) : QObject(p) {
-	QUrl url;
-	url.setPath(focus ? QLatin1String("/v1/banner") : QLatin1String("/v1/version-check"));
+VersionCheck::VersionCheck(bool autocheck, QObject *p, bool focus) : QObject(p), m_preparationWatcher() {
+	connect(&m_preparationWatcher, &QFutureWatcher<void>::finished, this, &VersionCheck::performRequest);
 
-	QList<QPair<QString, QString> > queryItems;
-	queryItems << qMakePair(QString::fromLatin1("ver"), QString::fromLatin1(QUrl::toPercentEncoding(QLatin1String(MUMBLE_RELEASE))));
+	QFuture<void> future = QtConcurrent::run([this, autocheck, focus]() {
+		m_requestURL.setPath(focus ? QLatin1String("/v1/banner") : QLatin1String("/v1/version-check"));
+
+		QList<QPair<QString, QString> > queryItems;
+		queryItems << qMakePair(QString::fromLatin1("ver"), QString::fromLatin1(QUrl::toPercentEncoding(QLatin1String(MUMBLE_RELEASE))));
 #if defined(Q_OS_WIN)
 # if defined(Q_OS_WIN64)
-	queryItems << qMakePair(QString::fromLatin1("os"), QString::fromLatin1("WinX64"));
+		queryItems << qMakePair(QString::fromLatin1("os"), QString::fromLatin1("WinX64"));
 # else
-	queryItems << qMakePair(QString::fromLatin1("os"), QString::fromLatin1("Win32"));
+		queryItems << qMakePair(QString::fromLatin1("os"), QString::fromLatin1("Win32"));
 # endif
 #elif defined(Q_OS_MAC)
 # if defined(USE_MAC_UNIVERSAL)
-	queryItems << qMakePair(QString::fromLatin1("os"), QString::fromLatin1("MacOSX-Universal"));
+		queryItems << qMakePair(QString::fromLatin1("os"), QString::fromLatin1("MacOSX-Universal"));
 # else
-	queryItems << qMakePair(QString::fromLatin1("os"), QString::fromLatin1("MacOSX"));
+		queryItems << qMakePair(QString::fromLatin1("os"), QString::fromLatin1("MacOSX"));
 # endif
 #else
-	queryItems << qMakePair(QString::fromLatin1("os"), QString::fromLatin1("Unix"));
+		queryItems << qMakePair(QString::fromLatin1("os"), QString::fromLatin1("Unix"));
 #endif
-	if (! g.s.bUsage)
-		queryItems << qMakePair(QString::fromLatin1("nousage"), QString::fromLatin1("1"));
-	if (autocheck)
-		queryItems << qMakePair(QString::fromLatin1("auto"), QString::fromLatin1("1"));
+		if (! g.s.bUsage)
+			queryItems << qMakePair(QString::fromLatin1("nousage"), QString::fromLatin1("1"));
+		if (autocheck)
+			queryItems << qMakePair(QString::fromLatin1("auto"), QString::fromLatin1("1"));
 
-	queryItems << qMakePair(QString::fromLatin1("locale"), g.s.qsLanguage.isEmpty() ? QLocale::system().name() : g.s.qsLanguage);
+		queryItems << qMakePair(QString::fromLatin1("locale"), g.s.qsLanguage.isEmpty() ? QLocale::system().name() : g.s.qsLanguage);
 
-	QFile f(qApp->applicationFilePath());
-	if (! f.open(QIODevice::ReadOnly)) {
-		qWarning("VersionCheck: Failed to open binary");
-	} else {
-		QByteArray a = f.readAll();
-		if (a.size() < 1) {
-			qWarning("VersionCheck: suspiciously small binary");
+		QFile f(qApp->applicationFilePath());
+		if (! f.open(QIODevice::ReadOnly)) {
+			qWarning("VersionCheck: Failed to open binary");
 		} else {
-			QCryptographicHash qch(QCryptographicHash::Sha1);
-			qch.addData(a);
-			queryItems << qMakePair(QString::fromLatin1("sha1"), QString::fromLatin1(qch.result().toHex()));
+			QByteArray a = f.readAll();
+			if (a.size() < 1) {
+				qWarning("VersionCheck: suspiciously small binary");
+			} else {
+				QCryptographicHash qch(QCryptographicHash::Sha1);
+				qch.addData(a);
+				queryItems << qMakePair(QString::fromLatin1("sha1"), QString::fromLatin1(qch.result().toHex()));
+			}
 		}
-	}
 
-	QUrlQuery query;
-	query.setQueryItems(queryItems);
-	url.setQuery(query);
+		QUrlQuery query;
+		query.setQueryItems(queryItems);
+		m_requestURL.setQuery(query);
+	});
 
-	WebFetch::fetch(QLatin1String("update"), url, this, SLOT(fetched(QByteArray,QUrl)));
+	m_preparationWatcher.setFuture(future);
+}
+
+void VersionCheck::performRequest() {
+	WebFetch::fetch(QLatin1String("update"), m_requestURL, this, SLOT(fetched(QByteArray,QUrl)));
 }
 
 void VersionCheck::fetched(QByteArray a, QUrl url) {

--- a/src/mumble/VersionCheck.h
+++ b/src/mumble/VersionCheck.h
@@ -9,11 +9,17 @@
 #include <QtCore/QObject>
 #include <QtCore/QByteArray>
 #include <QtCore/QUrl>
+#include <QFutureWatcher>
 
 class VersionCheck : public QObject {
 	private:
 		Q_OBJECT
 		Q_DISABLE_COPY(VersionCheck)
+
+		QFutureWatcher<void> m_preparationWatcher;
+		QUrl m_requestURL;
+	protected slots:
+		void performRequest();
 	public slots:
 		void fetched(QByteArray data, QUrl url);
 	public:

--- a/src/mumble/mumble.pro
+++ b/src/mumble/mumble.pro
@@ -11,6 +11,8 @@ DEFINES *= MUMBLE
 TEMPLATE = app
 TARGET = mumble
 
+QT += concurrent
+
 !CONFIG(qt4-legacy-compat) {
   CONFIG += no-qt4-legacy-compat
 }


### PR DESCRIPTION
As it stands, the VersionCheck always causes small mini-freezes. The
part that is responsible for them is reading the application binary
and computing its hash-value which has to be attached to the
request-URL.
Thus this whole process is outsourced to another thread so to not
delay Mumble's startup time.

Thanks to Qt's singal/slot mechanism, the processing of the incoming
answer to the request is handled in the main-thread (just as before).