### PR TITLE
Don't start JACK by default on mumble start

### DIFF
--- a/src/mumble/Settings.cpp
+++ b/src/mumble/Settings.cpp
@@ -322,7 +322,7 @@ Settings::Settings() {
 
 	qsJackClientName = QLatin1String("mumble");
 	qsJackAudioOutput = QLatin1String("1");
-	bJackStartServer = true;
+	bJackStartServer = false;
 	bJackAutoConnect = true;
 
 	bEcho = false;


### PR DESCRIPTION
Setting bJackStartServer to false, so mumble will not unconditionally start a JACK server on start (#3989).