### PR TITLE
CirrusCI: Update to FreeBSD 12.1

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,5 +1,5 @@
 freebsd_instance:
-  image: freebsd-12-0-release-amd64
+  image: freebsd-12-1-release-amd64
 
 freebsd_task:
   update_script: pkg update && pkg upgrade -y


### PR DESCRIPTION
We are currently using FreeBSD 12.0 for our CI which [has reached EOL](https://www.mail-archive.com/freebsd-security@freebsd.org/msg07438.html) on February 29, 2020.

This appears to result in errors during CI and thus this PR here will update CirrusCI to use FreeBSD 12.1 instead.