### PR TITLE
Improve implementation of the leaky bucket algorithm

### DIFF
--- a/src/murmur/ServerUser.cpp
+++ b/src/murmur/ServerUser.cpp
@@ -113,47 +113,80 @@ int BandwidthRecord::bandwidth() const {
 	return static_cast<int>((sum * 1000000ULL) / elapsed);
 }
 
-inline static QDateTime now() {
-	return QDateTime::currentDateTimeUtc();
-}
+LeakyBucket::LeakyBucket(unsigned int tokensPerSec, unsigned int maxTokens)
+	: m_tokensPerSec(tokensPerSec),
+	  m_maxTokens(maxTokens),
+	  m_currentTokens(0),
+	  m_timer() {
+		  m_timer.start();
 
-inline static int millisecondsBetween(const QDateTime &start, const QDateTime &end) {
-	return start.msecsTo(end);
-}
-
-// Rate limiting: burst up to 5, 1 message per sec limit over longer time
-LeakyBucket::LeakyBucket(unsigned int tokensPerSec, unsigned int maxTokens) : tokensPerSec(tokensPerSec), maxTokens(maxTokens), currentTokens(0) {
-	lastUpdate = now();
+		  if (!QElapsedTimer::isMonotonic()) {
+			  qFatal("Non-monotonic clocks are not reliable enough and lead to issues as "
+					  "https://github.com/mumble-voip/mumble/issues/3985. "
+					  "This is a serious issue and should be reported!");
+		  }
 }
 
 bool LeakyBucket::ratelimit(int tokens) {
 	// First remove tokens we leaked over time
-	const QDateTime tnow = now();
-	const long ms = millisecondsBetween(lastUpdate, tnow);
+	const qint64 elapsedMillis = m_timer.elapsed();
 
-	const long drainTokens = (ms * tokensPerSec) / 1000;
+	if (elapsedMillis < 0) {
+		if (m_timer.isValid()) {
+			// By definition of a monotinic clock, this shouldn't be possible to happen.
+			// Thus if it does happen there's somthing going very wrong which is why we
+			// emit the qFatal which at the state this line here was added, will crash
+			// the server. But at least that guarantees to give us a report on the crash
+			// instead of obscure reports about the rate limiter causing all sorts of
+			// weird issues.
+			qFatal("ServerUser.cpp: Monotonic timer returned negative elapsed time!");
 
-	// Prevent constant starvation due to too many updates
-	if (drainTokens > 0) {
-		this->lastUpdate = tnow;
-
-		this->currentTokens -= drainTokens;
-		if (this->currentTokens < 0) {
-			this->currentTokens = 0;
+			// In case the implementation changes and qFatal no longer crashes the server,
+			// we'll restart the timer but limit the message.
+			m_timer.restart();
+			return true;
+		} else {
+			// For some reason the timer is in an invalid state. This shouldn't happen
+			// as we start it in the constructor, but in case it does, we log the error
+			// and reset the timer and the tokens as a fail-safe. We also won't limit
+			// in this case as a potential limit is based on an invalid timer. That's
+			// not what we want.
+			qCritical("ServerUser.cpp: Monotonic timer is invalid!");
+			m_timer.restart();
+			m_currentTokens = 0;
+			return false;
 		}
-	} else if (ms < 0) {
-
-		// Time went back for some reason. Reset lastUpdate to make sure
-		// it's tracking the current time base.
-		this->lastUpdate = tnow;
 	}
 
-	// Then try to add tokens
-	bool limit = this->currentTokens > ((static_cast<long>(maxTokens)) - tokens);
+	const qint64 drainTokens = (elapsedMillis * m_tokensPerSec) / 1000;
+
+	// Only restart the timer if enough time has elapsed so whe drain at least
+	// a single token. If we were to restart the timer every time, even if the
+	// interval between the calls to this function is so small that we don't
+	// drain a token, we can end up in a situation in which we will never drain
+	// a token even if let's say by the time this function is called the second
+	// time we would have to drain a single token (over the course of both function
+	// calls, but each function call individually wouldn't drain a token).
+	if (drainTokens > 0) {
+		m_timer.restart();
+	}
+
+	// Make sure that m_currentTokens never gets less than 0 by draining
+	if (static_cast<qint64>(m_currentTokens) < drainTokens) {
+		m_currentTokens = 0;
+	} else {
+		m_currentTokens -= drainTokens;
+	}
+
+	// Now that the tokens have been updated to reflect the constant drain caused by
+	// the imaginary leaking bucket, we can check whether the given amount of tokens
+	// still fit in this imaginary bucket (and thus the corresponding message may pass)
+	// or if it doesn't (and thus the message will be limited (rejected))
+	bool limit = m_currentTokens > ((static_cast<long>(m_maxTokens)) - tokens);
 
 	// If the bucket is not overflowed, allow message and add tokens
 	if (!limit) {
-		this->currentTokens += tokens;
+		m_currentTokens += tokens;
 	}
 
 	return limit;


### PR DESCRIPTION
The most important change is to use a timer that is based on a monotonic
clock in order to avoid time jumps and this inconsistent measurements
of time intervals (see
https://github.com/mumble-voip/mumble/issues/3985#issuecomment-601754212).

Furthermore the code-style has been adapted (m_ prefix instead of usage
of this->) and documentation has been added / extended.

This should fix #3985 and fix #3831