### PR TITLE
Add option to log ACL & group changes

### DIFF
--- a/src/ACL.h
+++ b/src/ACL.h
@@ -63,6 +63,10 @@ class ChanACL : public QObject {
 		/// @returns Whether the given ChanACL represents a password. 
 		bool isPassword() const;
 
+		/// @ereturns A string representation of this ChanACL summarizing what permissions are granted or denied.
+		/// 	If this ACL neither grants nor denies any permissions, an empty String is returned.
+		explicit operator QString() const;
+
 #ifdef MURMUR
 		static bool hasPermission(ServerUser *p, Channel *c, QFlags<Perm> perm, ACLCache *cache);
 		static QFlags<Perm> effectivePermissions(ServerUser *p, Channel *c, ACLCache *cache);

--- a/src/murmur/Meta.cpp
+++ b/src/murmur/Meta.cpp
@@ -94,6 +94,9 @@ MetaParams::MetaParams() {
 
 	qsCiphers = MumbleSSL::defaultOpenSSLCipherString();
 
+	bLogGroupChanges = false;
+	bLogACLChanges = false;
+
 	qsSettings = NULL;
 }
 
@@ -334,6 +337,9 @@ void MetaParams::read(QString fname) {
 	qvSuggestPushToTalk = qsSettings->value("suggestPushToTalk");
 	if (qvSuggestPushToTalk.toString().trimmed().isEmpty())
 		qvSuggestPushToTalk = QVariant();
+
+	bLogGroupChanges = typeCheckedFromSettings("loggroupchanges", bLogGroupChanges);
+	bLogACLChanges = typeCheckedFromSettings("logaclchanges", bLogACLChanges);
 
 	iOpusThreshold = typeCheckedFromSettings("opusthreshold", iOpusThreshold);
 

--- a/src/murmur/Meta.h
+++ b/src/murmur/Meta.h
@@ -137,6 +137,11 @@ public:
 	QVariant qvSuggestPositional;
 	QVariant qvSuggestPushToTalk;
 
+	/// A flag indicating whether changes in groups should be logged
+	bool bLogGroupChanges;
+	/// A flag indicating whether changes in ACLs should be logged
+	bool bLogACLChanges;
+
 	/// qsAbsSettingsFilePath is the absolute path to
 	/// the murmur.ini used by this Meta instance.
 	QString qsAbsSettingsFilePath;

--- a/src/murmur/main.cpp
+++ b/src/murmur/main.cpp
@@ -241,6 +241,8 @@ int main(int argc, char **argv) {
 #ifdef Q_OS_UNIX
 	bool readPw = false;
 #endif
+	bool logGroups = false;
+	bool logACL = false;
 
 	qsrand(QDateTime::currentDateTime().toTime_t());
 
@@ -353,6 +355,8 @@ int main(int argc, char **argv) {
 #endif
 			       "  -wipessl               Remove SSL certificates from database.\n"
 			       "  -wipelogs              Remove all log entries from database.\n"
+				   "  -loggroups             Turns on logging for group changes for all servers."
+				   "  -logacls               Turns on logging for ACL changes for all servers."
 			       "  -version               Show version information.\n"
 			       "\n"
 			       "  -license               Show Murmur's license.\n"
@@ -370,6 +374,10 @@ int main(int argc, char **argv) {
 			unixhandler.finalcap();
 			LimitTest::testLimits(a);
 #endif
+		} else if (arg == "-loggroups") {
+			logGroups = true;
+		} else if (arg == "-logacls") {
+			logACL = true;
 		} else {
 			detach = false;
 			qFatal("Unknown argument %s", qPrintable(args.at(i)));
@@ -391,6 +399,14 @@ int main(int argc, char **argv) {
 #endif
 
 	Meta::mp.read(inifile);
+
+	// Activating the logging of ACLs and groups via commandLine overwrites whatever is set in the ini file
+	if (logGroups) {
+		Meta::mp.bLogGroupChanges = logGroups;
+	}
+	if (logACL) {
+		Meta::mp.bLogACLChanges = logACL;
+	}
 
 	// need to open log file early so log dir can be root owned:
 	// http://article.gmane.org/gmane.comp.security.oss.general/4404

--- a/src/murmur/main.cpp
+++ b/src/murmur/main.cpp
@@ -347,7 +347,7 @@ int main(int argc, char **argv) {
 			       "                         The purpose of this option is to test how many clients Murmur can handle.\n"
 			       "                         Murmur will exit after this test.\n"
 #endif
-			       "  -v                     Add verbose output.\n"
+			       "  -v                     Use verbose logging (include debug-logs).\n"
 #ifdef Q_OS_UNIX
 			       "  -fg                    Don't detach from console.\n"
 #else


### PR DESCRIPTION
Fixes #2481 

See commit messages for detailed description of what this PR doe in detail.

This PR adds 2 new murmur config options:

| *Name* | *Description* |
| --- | --- |
| `loggroupchanges` | Enables logging of group changes |
| `logaclchanges` | Enables logging of ACL changes |

This PR also adds 2 new command-line options that allow enabling these features regardless of what is set in the config file. The options are named `loggroups` and `logacls` respectively. 

The PR itself is inspired by @sss123next's code patches given in #2481