### PR TITLE
src/mumble/UserModel.cpp: Fix talking indicator

### DIFF
--- a/src/mumble/UserModel.cpp
+++ b/src/mumble/UserModel.cpp
@@ -359,6 +359,14 @@ QVariant UserModel::data(const QModelIndex &idx, int role) const {
 		switch (role) {
 			case Qt::DecorationRole:
 				if (idx.column() == 0) {
+					if (p == pSelf && p->bSelfMute) {
+						// This is a workaround for a bug that can lead to the user having muted him/herself but
+						// the talking icon is stuck at qiTalkingOn for some reason.
+						// Until someone figures out how to fix the root of the problem, we'll have this workaround
+						// to cure the symptoms of the bug.
+						return qiTalkingOff;
+					}
+
 					switch (p->tsState) {
 						case Settings::Talking:
 							return qiTalkingOn;


### PR DESCRIPTION
Right now Mumble can come in a state where the local client is muted but
its talking state is still frozen to Talking.
This is also reflected in the UI (#4006) so this commit provides a
workaround that at least fixes the UI symptoms of the bug as I haven't
been able to track down the actual origin of it.