### PR TITLE
src/mumble/WebFetch.cpp: Fix endless loop if there is no prefix

### DIFF
--- a/src/mumble/WebFetch.cpp
+++ b/src/mumble/WebFetch.cpp
@@ -81,7 +81,12 @@ void WebFetch::finished() {
 
 		emit fetched(a, url, headers);
 		deleteLater();
-	} else if (url.host() == prefixedServiceHost()) {
+	} else if (url.host() == prefixedServiceHost() && url.host() != serviceHost()) {
+		// We have tried to fetch from a local service domain (e.g. de-update.mumble.info)
+		// which has failed, so naturally we want to try the non-local one (update.mumble.info)
+		// as well as maybe that one will work.
+		// This of course only makes sense, if prefixedServiceHost() and serviceHost() are in fact
+		// different hosts.
 		url.setHost(serviceHost());
 
 		qnr = Network::get(url);


### PR DESCRIPTION
If we don't have a "servicePrefix" set, prefixedServiceHost() and
serviceHost() return the same host. The code however expected them to
implicitly be different.
This only ever made a difference if the main service host wasn't
reachable but in that case the endless-loop kicks in and the CPU usage
goes up.

Fixes #3760