### PR TITLE
src/mumble/Settings: Removed implementation of deprecated expert-setting

### DIFF
--- a/src/mumble/Settings.cpp
+++ b/src/mumble/Settings.cpp
@@ -272,7 +272,6 @@ Settings::Settings() {
 
 	uiDoublePush = 0;
 	pttHold = 0;
-	bExpert = true;
 
 #ifdef NO_UPDATE_CHECK
 	bUpdateCheck = false;
@@ -711,7 +710,6 @@ void Settings::load(QSettings* settings_ptr) {
 	// Privacy settings
 	SAVELOAD(bHideOS, "privacy/hideos");
 
-	SAVELOAD(bExpert, "ui/expert");
 	SAVELOAD(qsLanguage, "ui/language");
 	SAVELOAD(themeName, "ui/theme");
 	SAVELOAD(themeStyleName, "ui/themestyle");
@@ -1050,7 +1048,6 @@ void Settings::save() {
 	// Privacy settings
 	SAVELOAD(bHideOS, "privacy/hideos");
 
-	SAVELOAD(bExpert, "ui/expert");
 	SAVELOAD(qsLanguage, "ui/language");
 	SAVELOAD(themeName, "ui/theme");
 	SAVELOAD(themeStyleName, "ui/themestyle");

--- a/src/mumble/Settings.h
+++ b/src/mumble/Settings.h
@@ -155,10 +155,6 @@ struct Settings {
 	quint64 uiDoublePush;
 	quint64 pttHold;
 
-	/// Removed. This was previously used to configure whether the Mumble
-	/// ConfigDialog should show advanced options or not.
-	bool bExpert;
-
 	bool bTxAudioCue;
 	static const QString cqsDefaultPushClickOn;
 	static const QString cqsDefaultPushClickOff;


### PR DESCRIPTION
Fixes #3951 