### PR TITLE
Improve log message style

### DIFF
--- a/src/mumble/Log.cpp
+++ b/src/mumble/Log.cpp
@@ -509,7 +509,14 @@ void Log::log(MsgType mt, const QString &console, const QString &terse, bool own
 			tc.movePosition(QTextCursor::End);
 		}
 
-		if (plain.contains(QRegExp(QLatin1String("[\\r\\n]")))) {
+		// Convert CRLF to unix-style LF and old mac-style LF (single \r) to unix-style as well
+		QString fixedNLPlain = plain.replace(QLatin1String("\r\n"), QLatin1String("\n")).replace(QLatin1String("\r"), QLatin1String("\n"));
+
+		if (fixedNLPlain.contains(QRegExp(QLatin1String("\\n[ \\t]*$")))) {
+			// If the message ends with one or more blank lines (or lines only containing whitespace)
+			// paint a border around the message to make clear that it contains invisible parts.
+			// The beginning of the message is clear anyway (the date and potentially the "To XY" part)
+			// so we don't have to care about that.
 			QTextFrameFormat qttf;
 			qttf.setBorder(1);
 			qttf.setPadding(2);

--- a/src/mumble/Log.cpp
+++ b/src/mumble/Log.cpp
@@ -515,7 +515,10 @@ void Log::log(MsgType mt, const QString &console, const QString &terse, bool own
 			qttf.setPadding(2);
 			qttf.setBorderStyle(QTextFrameFormat::BorderStyle_Solid);
 			tc.insertFrame(qttf);
-		} else if (! g.mw->qteLog->document()->isEmpty()) {
+		} else if (!tc.block().text().isEmpty()) {
+			// Only insert a block if the current block is not empty. It may be empty because
+			// it is the default block of an empty document. Another cause might be that apparently
+			// a new empty block is automatically inserted after a frame.
 			tc.insertBlock();
 		}
 

--- a/src/mumble/Log.cpp
+++ b/src/mumble/Log.cpp
@@ -108,6 +108,7 @@ void LogConfig::load(const Settings &r) {
 
 	qsbMaxBlocks->setValue(r.iMaxLogBlocks);
 	qcb24HourClock->setChecked(r.bLog24HourClock);
+	qsbChatMessageMargins->setValue(r.iChatMessageMargins);
 
 #ifdef USE_NO_TTS
 	qtwMessages->hideColumn(ColTTS);
@@ -145,6 +146,7 @@ void LogConfig::save() const {
 	}
 	s.iMaxLogBlocks = qsbMaxBlocks->value();
 	s.bLog24HourClock = qcb24HourClock->isChecked();
+	s.iChatMessageMargins = qsbChatMessageMargins->value();
 
 #ifndef USE_NO_TTS
 	s.iTTSVolume=qsVolume->value();
@@ -496,6 +498,16 @@ void Log::log(MsgType mt, const QString &console, const QString &terse, bool own
 	if ((flags & Settings::LogConsole)) {
 		QTextCursor tc = g.mw->qteLog->textCursor();
 
+		// We copy the value from the settings in order to make sure that
+		// we use the same margin everywhere while in this method (even if
+		// the setting might change in that time).
+		const int msgMargin = g.s.iChatMessageMargins;
+
+		QTextBlockFormat format = tc.blockFormat();
+		format.setTopMargin(msgMargin);
+		format.setBottomMargin(msgMargin);
+		tc.setBlockFormat(format);
+
 		LogTextBrowser *tlog = g.mw->qteLog;
 		const int oldscrollvalue = tlog->getLogScroll();
 		const bool scroll = (oldscrollvalue == tlog->getLogScrollMaximum());
@@ -520,7 +532,8 @@ void Log::log(MsgType mt, const QString &console, const QString &terse, bool own
 			QTextFrameFormat qttf;
 			qttf.setBorder(1);
 			qttf.setPadding(2);
-			qttf.setBorderStyle(QTextFrameFormat::BorderStyle_Solid);
+			qttf.setMargin(msgMargin);
+			qttf.setBorderStyle(QTextFrameFormat::BorderStyle_Dashed);
 			tc.insertFrame(qttf);
 		} else if (!tc.block().text().isEmpty()) {
 			// Only insert a block if the current block is not empty. It may be empty because

--- a/src/mumble/Log.ui
+++ b/src/mumble/Log.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>554</width>
-    <height>405</height>
+    <height>414</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -202,10 +202,15 @@
       <string>Chat Log</string>
      </property>
      <layout class="QGridLayout" name="_2">
-      <item row="0" column="0">
-       <widget class="QLabel" name="qlMaxBlocks">
+      <item row="1" column="0">
+       <widget class="QCheckBox" name="qcb24HourClock">
+        <property name="toolTip">
+         <string>If checked the time at the beginning of a message will be displayed in the 24-hour format.
+
+The setting only applies for new messages, the already shown ones will retain the previous time format.</string>
+        </property>
         <property name="text">
-         <string>Maximum chat length</string>
+         <string>Use 24-hour clock</string>
         </property>
        </widget>
       </item>
@@ -228,6 +233,13 @@
         </property>
        </widget>
       </item>
+      <item row="0" column="0">
+       <widget class="QLabel" name="qlMaxBlocks">
+        <property name="text">
+         <string>Maximum chat length</string>
+        </property>
+       </widget>
+      </item>
       <item row="0" column="2">
        <spacer name="horizontalSpacer">
         <property name="orientation">
@@ -241,15 +253,23 @@
         </property>
        </spacer>
       </item>
-      <item row="1" column="0">
-       <widget class="QCheckBox" name="qcb24HourClock">
+      <item row="2" column="0">
+       <widget class="QLabel" name="qlChatMessageMargins">
         <property name="toolTip">
-         <string>If checked the time at the beginning of a message will be displayed in the 24-hour format.
-
-The setting only applies for new messages, the already shown ones will retain the previous time format.</string>
+         <string>How far individual messages are spaced out from one another.</string>
         </property>
         <property name="text">
-         <string>Use 24-hour clock</string>
+         <string>Message margins</string>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="1">
+       <widget class="QSpinBox" name="qsbChatMessageMargins">
+        <property name="toolTip">
+         <string>How far individual messages are spaced out from one another.</string>
+        </property>
+        <property name="frame">
+         <bool>true</bool>
         </property>
        </widget>
       </item>

--- a/src/mumble/Settings.cpp
+++ b/src/mumble/Settings.cpp
@@ -400,6 +400,7 @@ Settings::Settings() {
 
 	iMaxLogBlocks = 0;
 	bLog24HourClock = true;
+	iChatMessageMargins = 3;
 
 	bShortcutEnable = true;
 	bSuppressMacEventTapWarning = false;
@@ -755,6 +756,7 @@ void Settings::load(QSettings* settings_ptr) {
 	SAVELOAD(bHighContrast, "ui/HighContrast");
 	SAVELOAD(iMaxLogBlocks, "ui/MaxLogBlocks");
 	SAVELOAD(bLog24HourClock, "ui/24HourClock");
+	SAVELOAD(iChatMessageMargins, "ui/ChatMessageMargins");
 
 	// PTT Button window
 	SAVELOAD(bShowPTTButtonWindow, "ui/showpttbuttonwindow");
@@ -1092,6 +1094,7 @@ void Settings::save() {
 	SAVELOAD(bHighContrast, "ui/HighContrast");
 	SAVELOAD(iMaxLogBlocks, "ui/MaxLogBlocks");
 	SAVELOAD(bLog24HourClock, "ui/24HourClock");
+	SAVELOAD(iChatMessageMargins, "ui/ChatMessageMargins");
 
 	// PTT Button window
 	SAVELOAD(bShowPTTButtonWindow, "ui/showpttbuttonwindow");

--- a/src/mumble/Settings.h
+++ b/src/mumble/Settings.h
@@ -279,6 +279,7 @@ struct Settings {
 	enum MessageLog { LogNone = 0x00, LogConsole = 0x01, LogTTS = 0x02, LogBalloon = 0x04, LogSoundfile = 0x08, LogHighlight = 0x10 };
 	int iMaxLogBlocks;
 	bool bLog24HourClock;
+	int iChatMessageMargins;
 	QMap<int, QString> qmMessageSounds;
 	QMap<int, quint32> qmMessages;
 

--- a/src/mumble/mumble_en.ts
+++ b/src/mumble/mumble_en.ts
@@ -3495,6 +3495,14 @@ The setting only applies for new messages, the already shown ones will retain th
         <source>Use 24-hour clock</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>How far individual messages are spaced out from one another.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Message margins</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>LookConfig</name>
@@ -5479,6 +5487,10 @@ the channel&apos;s context menu.</source>
         <source>Protocol violation. Server sent remove for occupied channel.</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Unable to %1 into %2 - Adding the respective access (password) token might grant you access.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>Manual</name>
@@ -5559,10 +5571,6 @@ the channel&apos;s context menu.</source>
     <name>NetworkConfig</name>
     <message>
         <source>Network</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Updates are mandatory when using snapshot releases.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>


### PR DESCRIPTION
See individual commit messages for what has been done. In here I only want to provide some screenshots.

Before this PR:
![Mumble_LogStyle_Old](https://user-images.githubusercontent.com/12751591/78126278-98cc9880-7412-11ea-86d8-d42f37be4eef.png)

After this PR:
![Mumble_LogStyle_New](https://user-images.githubusercontent.com/12751591/78126092-40959680-7412-11ea-9d6c-698f2b575e8e.png)


Fixes #1590 by only drawing borders around messages that end with one or more empty lines. If a message contains line-breaks in between or at the beginning, we no longer draw a border around the message as its start and end are clearly visible to the user.