### PR TITLE
src: Fix for b263b91

### DIFF
--- a/src/HostAddress.cpp
+++ b/src/HostAddress.cpp
@@ -140,9 +140,9 @@ QString HostAddress::toString() const {
 		if (isValid()) {
 			QString qs;
 #if QT_VERSION >= 0x050500
-			qs.asprintf("[%x:%x:%x:%x:%x:%x:%x:%x]", ntohs(shorts[0]), ntohs(shorts[1]), ntohs(shorts[2]), ntohs(shorts[3]), ntohs(shorts[4]), ntohs(shorts[5]), ntohs(shorts[6]), ntohs(shorts[7]));
+			qs = QString::asprintf("[%x:%x:%x:%x:%x:%x:%x:%x]", ntohs(shorts[0]), ntohs(shorts[1]), ntohs(shorts[2]), ntohs(shorts[3]), ntohs(shorts[4]), ntohs(shorts[5]), ntohs(shorts[6]), ntohs(shorts[7]));
 #else
-			// sprintf() has been deprecated in Qt 5.5 in favor for asprintf()
+			// sprintf() has been deprecated in Qt 5.5 in favor for the static QString::asprintf()
 			qs.sprintf("[%x:%x:%x:%x:%x:%x:%x:%x]", ntohs(shorts[0]), ntohs(shorts[1]), ntohs(shorts[2]), ntohs(shorts[3]), ntohs(shorts[4]), ntohs(shorts[5]), ntohs(shorts[6]), ntohs(shorts[7]));
 #endif
 			return qs.replace(QRegExp(QLatin1String("(:0)+")),QLatin1String(":"));

--- a/src/OSInfo.cpp
+++ b/src/OSInfo.cpp
@@ -211,13 +211,13 @@ QString OSInfo::getOSVersion() {
 	}
 
 #if QT_VERSION >= 0x050500
-	os.asprintf("%lu.%lu.%lu.%lu",
+	os = QString::asprintf("%lu.%lu.%lu.%lu",
 		static_cast<unsigned long>(ovi.dwMajorVersion),
 		static_cast<unsigned long>(ovi.dwMinorVersion),
 		static_cast<unsigned long>(ovi.dwBuildNumber),
 		(ovi.wProductType == VER_NT_WORKSTATION) ? 1UL : 0UL);
 #else
-	// sprintf() has been deprecated in Qt 5.5 in favor for asprintf()
+	// sprintf() has been deprecated in Qt 5.5 in favor for the static QString::asprintf()
 	os.sprintf("%lu.%lu.%lu.%lu",
 		static_cast<unsigned long>(ovi.dwMajorVersion),
 		static_cast<unsigned long>(ovi.dwMinorVersion),
@@ -244,13 +244,13 @@ QString OSInfo::getOSVersion() {
 	}
 
 #if QT_VERSION >= 0x050500
-	os.asprintf("%lu.%lu.%lu %s",
+	os = QString::asprintf("%lu.%lu.%lu %s",
 	           static_cast<unsigned long>(major),
 	           static_cast<unsigned long>(minor),
 	           static_cast<unsigned long>(bugfix),
 	           buildno ? buildno : "unknown");
 #else
-	// sprintf() has been deprecated in Qt 5.5 in favor for asprintf()
+	// sprintf() has been deprecated in Qt 5.5 in favor for the static QString::asprintf()
 	os.sprintf("%lu.%lu.%lu %s",
 	           static_cast<unsigned long>(major),
 	           static_cast<unsigned long>(minor),
@@ -286,9 +286,9 @@ QString OSInfo::getOSVersion() {
 		if (uname(&un) == 0) {
 #endif
 #if QT_VERSION >= 0x050500
-			os.asprintf("%s %s", un.sysname, un.release);
+			os = QString::asprintf("%s %s", un.sysname, un.release);
 #else
-			// sprintf() has been deprecated in Qt 5.5 in favor for asprintf()
+			// sprintf() has been deprecated in Qt 5.5 in favor for the static QString::asprintf()
 			os.sprintf("%s %s", un.sysname, un.release);
 #endif // QT_VERSION >= 0x050500
 		}
@@ -512,12 +512,12 @@ QString OSInfo::getOSDisplayableVersion() {
 
 	QString osv;
 #if QT_VERSION >= 0x050500
-	osv.asprintf(" - %lu.%lu.%lu",
+	osv = QString::asprintf(" - %lu.%lu.%lu",
 		static_cast<unsigned long>(ovi.dwMajorVersion),
 		static_cast<unsigned long>(ovi.dwMinorVersion),
 		static_cast<unsigned long>(ovi.dwBuildNumber));
 #else
-	// sprintf() has been deprecated in Qt 5.5 in favor for asprintf()
+	// sprintf() has been deprecated in Qt 5.5 in favor for the static QString::asprintf()
 	osv.sprintf(" - %lu.%lu.%lu",
 		static_cast<unsigned long>(ovi.dwMajorVersion),
 		static_cast<unsigned long>(ovi.dwMinorVersion),

--- a/src/mumble/AudioStats.cpp
+++ b/src/mumble/AudioStats.cpp
@@ -302,9 +302,9 @@ AudioStats::~AudioStats() {
 }
 
 #if QT_VERSION >= 0x050500
-	#define FORMAT_TO_TXT(format, arg) txt.asprintf(format, arg)
+	#define FORMAT_TO_TXT(format, arg) txt = QString::asprintf(format, arg)
 #else
-	// sprintf() has been deprecated in Qt 5.5 in favor for asprintf()
+	// sprintf() has been deprecated in Qt 5.5 in favor for the static QString::asprintf()
 	#define FORMAT_TO_TXT(format, arg) txt.sprintf(format, arg)
 #endif
 void AudioStats::on_Tick_timeout() {


### PR DESCRIPTION
In b263b91340fb8b359e34626de880f606cfd9c116 I exchanged QString::sprintf
with QString::asprintf as the former was declared deprecated from Qt 5.5
onwards. I forgot to check the docs though. If I had, I would have
noticed that in contrast to sprintf, asprintf is a static function which
returns the assembled String (sprintf wrote it to the object it was
being called on). Thus I also have to assign the return value of
asprintf to a variable in order to have it have an effect.

Fixes #4021