### PR TITLE
src/murmur/murmur_grpc/murmur_grpc.pro: Fix GRPC build

### DIFF
--- a/src/murmur/murmur_grpc/murmur_grpc.pro
+++ b/src/murmur/murmur_grpc/murmur_grpc.pro
@@ -14,7 +14,7 @@ isEmpty(GRPC_CPP_PLUGIN) {
   equals(QMAKE_HOST.os, "Windows") {
     GRPC_CPP_PLUGIN = grpc_cpp_plugin
   } else {
-    $$system(which grpc_cpp_plugin)
+    GRPC_CPP_PLUGIN = $$system(which grpc_cpp_plugin)
   }
 }
 


### PR DESCRIPTION
b380274e3d85b8de1370a2dad43ec501bb43ca08 (#3476) changed the way we look
for the GRPC_CPP_PLUGIN but forgot to include an assignment for that
variable on non-Windows systems, which caused the build to fail for
them.