### PR TITLE
Fix racecondition for g.iTarget

### DIFF
--- a/src/mumble/AudioInput.cpp
+++ b/src/mumble/AudioInput.cpp
@@ -803,6 +803,13 @@ void AudioInput::encodeAudioFrame() {
 
 	iFrameCounter++;
 
+	// As g.iTarget is not protected by any locks, we avoid race-conditions by
+	// copying it once at this point and stick to whatever value it is here. Thus
+	// if the value of g.iTarget changes during the execution of this function,
+	// it won't cause any inconsistencies and the change is reflected once this
+	// function is called again.
+	int voiceTargetID = g.iTarget;
+
 	if (! bRunning)
 		return;
 
@@ -894,7 +901,7 @@ void AudioInput::encodeAudioFrame() {
 	bIsSpeech = bIsSpeech || (g.iPushToTalk > 0);
 
 	ClientUser *p = ClientUser::get(g.uiSession);
-	if (g.s.bMute || ((g.s.lmLoopMode != Settings::Local) && p && (p->bMute || p->bSuppress)) || g.bPushToMute || (g.iTarget < 0)) {
+	if (g.s.bMute || ((g.s.lmLoopMode != Settings::Local) && p && (p->bMute || p->bSuppress)) || g.bPushToMute || (voiceTargetID < 0)) {
 		bIsSpeech = false;
 	}
 
@@ -909,7 +916,7 @@ void AudioInput::encodeAudioFrame() {
 	if (p) {
 		if (! bIsSpeech)
 			p->setTalking(Settings::Passive);
-		else if (g.iTarget == 0)
+		else if (voiceTargetID == 0)
 			p->setTalking(Settings::Talking);
 		else
 			p->setTalking(Settings::Shouting);
@@ -1010,7 +1017,7 @@ void AudioInput::encodeAudioFrame() {
 	}
 
 	if (encoded) {
-		flushCheck(QByteArray(reinterpret_cast<char *>(&buffer[0]), len), !bIsSpeech);
+		flushCheck(QByteArray(reinterpret_cast<char *>(&buffer[0]), len), !bIsSpeech, voiceTargetID);
 	}
 
 	if (! bIsSpeech)
@@ -1033,15 +1040,15 @@ static void sendAudioFrame(const char *data, PacketDataStream &pds) {
 		sh->sendMessage(data, pds.size() + 1);
 }
 
-void AudioInput::flushCheck(const QByteArray &frame, bool terminator) {
+void AudioInput::flushCheck(const QByteArray &frame, bool terminator, int voiceTargetID) {
 	qlFrames << frame;
 
 	if (! terminator && iBufferedFrames < iAudioFrames)
 		return;
 
 	int flags = 0;
-	if (g.iTarget > 0) {
-		flags = g.iTarget;
+	if (voiceTargetID > 0) {
+		flags = voiceTargetID;
 	}
 	if (terminator && g.iPrevTarget > 0) {
 		flags = g.iPrevTarget;

--- a/src/mumble/AudioInput.h
+++ b/src/mumble/AudioInput.h
@@ -139,7 +139,7 @@ class AudioInput : public QThread {
 		int iBufferedFrames;
 
 		QList<QByteArray> qlFrames;
-		void flushCheck(const QByteArray &, bool terminator);
+		void flushCheck(const QByteArray &, bool terminator, int voiceTargetID);
 
 		void initializeMixer();
 


### PR DESCRIPTION
g.iTarget is not protected by a lock or a Mutex. This means that it can
change its value while AudioInput::encodeAudioFrame is running. However
the value is accessed at multiple stages (including
AudioInput::flushCheck that is called from encodeAudioFrame) meaning
that there could be inconsistencies of what g.iTarget was meaning for
this audio frame.

This commit makes sure that g.iTarget is only accessed once at the
beginnign of AudioInput::encodeAudioFrame and then copied to a local
variable which is then used for all the places in which g.iTarget
previously was access directly.

One scenario this race condition could be observed was pressing and
immediately releasing a whisper shortcut. This could sometimes cause one
of the whisper frames (the second last to be more precise) to be sent as
normal audio instead of whispering (the last message would have been
affected by this as well however for that there's a special workaround
in place already [9d16137393bd8a33307cac41c0b55ea1392173a3] which
covered the effects of the racecondition for that one).

Probably fixes #1616