### PR TITLE
Use TCP_NODELAY by default and remove attempts to flush.

### DIFF
--- a/src/Connection.cpp
+++ b/src/Connection.cpp
@@ -36,6 +36,9 @@ Connection::Connection(QObject *p, QSslSocket *qtsSock) : QObject(p) {
 		qRegisterMetaType<QAbstractSocket::SocketError>("QAbstractSocket::SocketError");
 	}
 
+	int nodelay = 1;
+	setsockopt(static_cast<int>(qtsSocket->socketDescriptor()), IPPROTO_TCP, TCP_NODELAY, reinterpret_cast<char *>(&nodelay), static_cast<socklen_t>(sizeof(nodelay)));
+
 	connect(qtsSocket, SIGNAL(error(QAbstractSocket::SocketError)), this, SLOT(socketError(QAbstractSocket::SocketError)));
 	connect(qtsSocket, SIGNAL(encrypted()), this, SIGNAL(encrypted()));
 	connect(qtsSocket, SIGNAL(readyRead()), this, SLOT(socketRead()));
@@ -190,14 +193,7 @@ void Connection::forceFlush() {
 	if (! qtsSocket->isEncrypted())
 		return;
 
-	int nodelay;
-
 	qtsSocket->flush();
-
-	nodelay = 1;
-	setsockopt(static_cast<int>(qtsSocket->socketDescriptor()), IPPROTO_TCP, TCP_NODELAY, reinterpret_cast<char *>(&nodelay), static_cast<socklen_t>(sizeof(nodelay)));
-	nodelay = 0;
-	setsockopt(static_cast<int>(qtsSocket->socketDescriptor()), IPPROTO_TCP, TCP_NODELAY, reinterpret_cast<char *>(&nodelay), static_cast<socklen_t>(sizeof(nodelay)));
 }
 
 void Connection::disconnectSocket(bool force) {


### PR DESCRIPTION
Having the server perform 2 syscalls per TCP audio packet is extreme - turning this
off led to 30% lower CPU utilization in a test with 200 music-playing bots.

Switching to TCP_NODELAY for all packets is probably a win as well - TCP is only
typically used for control packets like users joining and leaving channels, of
which there are few. (As alluded to above, TCP is also sometimes used for audio,
in which case it should be in TCP_NODELAY mode anyway).