### PR TITLE
Add alias for places/network-workgroup.svg

### DIFF
--- a/themes/ClassicTheme.qrc
+++ b/themes/ClassicTheme.qrc
@@ -52,6 +52,7 @@
     <file alias="actions/format-text-underline.svg">Classic/tango/actions/format-text-underline.svg</file>
     <file alias="actions/media-record.svg">Classic/tango/actions/media-record.svg</file>
     <file alias="categories/applications-internet.svg">Classic/tango/categories/applications-internet.svg</file>
+    <file alias="places/network-workgroup.svg">Classic/tango/places/network-workgroup.svg</file>
     <file alias="emblems/emblem-favorite.svg">Classic/tango/emblems/emblem-favorite.svg</file>
     <file alias="mimetypes/image-x-generic.svg">Classic/tango/mimetypes/image-x-generic.svg</file>
     <file alias="mimetypes/text-html.svg">Classic/tango/mimetypes/text-html.svg</file>

--- a/themes/MumbleTheme.qrc
+++ b/themes/MumbleTheme.qrc
@@ -58,6 +58,7 @@
     <file alias="actions/format-text-underline.svg">Mumble/actions/format-text-underline.svg</file>
     <file alias="actions/media-record.svg">Mumble/actions/media-record.svg</file>
     <file alias="categories/applications-internet.svg">Mumble/categories/applications-internet.svg</file>
+    <file alias="places/network-workgroup.svg">Classic/tango/places/network-workgroup.svg</file>
     <file alias="controls/arrow_down.svg">Mumble/controls/arrow_down.svg</file>
     <file alias="controls/arrow_down_disabled.svg">Mumble/controls/arrow_down_disabled.svg</file>
     <file alias="controls/arrow_up.svg">Mumble/controls/arrow_up.svg</file>


### PR DESCRIPTION
This icon is referenced/needed from ConnectDialog and before this
commit, an error would be printed that this icon can't be found (#4057).

Fixes #4057