### PR TITLE
Talking UI

### DIFF
--- a/src/mumble/AudioOutputSpeech.cpp
+++ b/src/mumble/AudioOutputSpeech.cpp
@@ -114,6 +114,10 @@ AudioOutputSpeech::~AudioOutputSpeech() {
 
 	jitter_buffer_destroy(jbJitter);
 
+	if (p) {
+		p->setTalking(Settings::Passive);
+	}
+
 	delete [] fFadeIn;
 	delete [] fFadeOut;
 	delete [] fResamplerBuffer;

--- a/src/mumble/Global.cpp
+++ b/src/mumble/Global.cpp
@@ -71,6 +71,7 @@ Global::Global() {
 	p = 0;
 	nam = 0;
 	c = 0;
+	talkingUI = 0;
 	uiSession = 0;
 	uiDoublePush = 1000000;
 	iPushToTalk = 0;

--- a/src/mumble/Global.h
+++ b/src/mumble/Global.h
@@ -32,6 +32,7 @@ class CELTCodec;
 class OpusCodec;
 class LogEmitter;
 class DeveloperConsole;
+class TalkingUI;
 
 class QNetworkAccessManager;
 
@@ -58,6 +59,7 @@ public:
 	QNetworkAccessManager *nam;
 	QSharedPointer<LogEmitter> le;
 	DeveloperConsole *c;
+	TalkingUI *talkingUI;
 	int iPushToTalk;
 	Timer tDoublePush;
 	quint64 uiDoublePush;

--- a/src/mumble/LookConfig.cpp
+++ b/src/mumble/LookConfig.cpp
@@ -177,6 +177,8 @@ void LookConfig::load(const Settings &r) {
 	
 	const boost::optional<ThemeInfo::StyleInfo> configuredStyle = Themes::getConfiguredStyle(r);
 	reloadThemes(configuredStyle);
+
+	qsbSilentUserLifetime->setValue(r.iTalkingUI_SilentUserLifeTime);
 }
 
 void LookConfig::save() const {
@@ -229,6 +231,8 @@ void LookConfig::save() const {
 	} else {
 		Themes::setConfiguredStyle(s, themeData.value<ThemeInfo::StyleInfo>(), s.requireRestartToApply);
 	}
+
+	s.iTalkingUI_SilentUserLifeTime = qsbSilentUserLifetime->value();
 }
 
 void LookConfig::accept() const {

--- a/src/mumble/LookConfig.ui
+++ b/src/mumble/LookConfig.ui
@@ -6,14 +6,138 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>702</width>
-    <height>611</height>
+    <width>740</width>
+    <height>744</height>
    </rect>
   </property>
   <property name="windowTitle">
    <string notr="true">Form</string>
   </property>
   <layout class="QGridLayout" name="gridLayout_4">
+   <item row="1" column="1">
+    <widget class="QGroupBox" name="qgbApplication">
+     <property name="title">
+      <string>Application</string>
+     </property>
+     <layout class="QGridLayout" name="gridLayout_3" columnstretch="0,0">
+      <item row="0" column="0">
+       <widget class="QLabel" name="qliAlwaysOnTop">
+        <property name="text">
+         <string>Always On Top</string>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="1">
+       <widget class="MUComboBox" name="qcbAlwaysOnTop">
+        <property name="toolTip">
+         <string>This setting controls when the application will be always on top.</string>
+        </property>
+        <property name="whatsThis">
+         <string>This setting controls in which situations the application will stay always on top. If you select &lt;i&gt;Never&lt;/i&gt; the application will not stay on top. &lt;i&gt;Always&lt;/i&gt; will always keep the application on top. &lt;i&gt;In minimal view&lt;/i&gt; / &lt;i&gt;In normal view&lt;/i&gt; will only keep the application always on top when minimal view is activated / deactivated.</string>
+        </property>
+        <item>
+         <property name="text">
+          <string>Never</string>
+         </property>
+        </item>
+        <item>
+         <property name="text">
+          <string>Always</string>
+         </property>
+        </item>
+        <item>
+         <property name="text">
+          <string>In minimal view</string>
+         </property>
+        </item>
+        <item>
+         <property name="text">
+          <string>In normal view</string>
+         </property>
+        </item>
+       </widget>
+      </item>
+      <item row="1" column="0" colspan="2">
+       <widget class="QCheckBox" name="qcbShowContextMenuInMenuBar">
+        <property name="toolTip">
+         <string>Adds user and channel context menus into the menu bar</string>
+        </property>
+        <property name="text">
+         <string>Show context menu in menu bar</string>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="0" colspan="2">
+       <widget class="QCheckBox" name="qcbAskOnQuit">
+        <property name="toolTip">
+         <string>Ask whether to close or minimize when quitting Mumble.</string>
+        </property>
+        <property name="whatsThis">
+         <string>&lt;b&gt;If set, will verify you want to quit if connected.&lt;/b&gt;</string>
+        </property>
+        <property name="text">
+         <string>Ask on quit while connected</string>
+        </property>
+       </widget>
+      </item>
+      <item row="3" column="0" colspan="2">
+       <widget class="QCheckBox" name="qcbEnableDeveloperMenu">
+        <property name="whatsThis">
+         <string>&lt;b&gt;Enable Developer menu&lt;/b&gt;&lt;br /&gt;This enables the &quot;Developer&quot;-menu in Mumble. This menu is used for developer-specific features, such as the Developer Console.</string>
+        </property>
+        <property name="text">
+         <string>Enable Developer menu</string>
+        </property>
+       </widget>
+      </item>
+      <item row="4" column="0" colspan="2">
+       <widget class="QCheckBox" name="qcbLockLayout">
+        <property name="whatsThis">
+         <string>When in custom layout mode, checking this disables rearranging.</string>
+        </property>
+        <property name="text">
+         <string>Lock layout</string>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item row="2" column="1">
+    <widget class="QGroupBox" name="qgbTray">
+     <property name="title">
+      <string>Tray Icon</string>
+     </property>
+     <layout class="QVBoxLayout" name="verticalLayout">
+      <item>
+       <widget class="QCheckBox" name="qcbHideTray">
+        <property name="toolTip">
+         <string>Hide the main Mumble window in the tray when it is minimized.</string>
+        </property>
+        <property name="whatsThis">
+         <string>&lt;b&gt;If set, minimizing the Mumble main window will cause it to be hidden and accessible only from the tray. Otherwise, it will be minimized as a window normally would.&lt;/b&gt;</string>
+        </property>
+        <property name="text">
+         <string>Hide in tray when minimized</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QCheckBox" name="qcbStateInTray">
+        <property name="toolTip">
+         <string>Displays talking status in system tray</string>
+        </property>
+        <property name="whatsThis">
+         <string/>
+        </property>
+        <property name="text">
+         <string>Show talking status in tray icon</string>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
    <item row="1" column="0" rowspan="3">
     <widget class="QGroupBox" name="qgbLookFeel">
      <property name="title">
@@ -106,41 +230,6 @@
      </layout>
     </widget>
    </item>
-   <item row="2" column="1">
-    <widget class="QGroupBox" name="qgbTray">
-     <property name="title">
-      <string>Tray Icon</string>
-     </property>
-     <layout class="QVBoxLayout" name="verticalLayout">
-      <item>
-       <widget class="QCheckBox" name="qcbHideTray">
-        <property name="toolTip">
-         <string>Hide the main Mumble window in the tray when it is minimized.</string>
-        </property>
-        <property name="whatsThis">
-         <string>&lt;b&gt;If set, minimizing the Mumble main window will cause it to be hidden and accessible only from the tray. Otherwise, it will be minimized as a window normally would.&lt;/b&gt;</string>
-        </property>
-        <property name="text">
-         <string>Hide in tray when minimized</string>
-        </property>
-       </widget>
-      </item>
-      <item>
-       <widget class="QCheckBox" name="qcbStateInTray">
-        <property name="toolTip">
-         <string>Displays talking status in system tray</string>
-        </property>
-        <property name="whatsThis">
-         <string/>
-        </property>
-        <property name="text">
-         <string>Show talking status in tray icon</string>
-        </property>
-       </widget>
-      </item>
-     </layout>
-    </widget>
-   </item>
    <item row="5" column="1">
     <spacer name="verticalSpacer_2">
      <property name="orientation">
@@ -153,205 +242,6 @@
       </size>
      </property>
     </spacer>
-   </item>
-   <item row="4" column="1">
-    <spacer name="horizontalSpacer">
-     <property name="orientation">
-      <enum>Qt::Horizontal</enum>
-     </property>
-     <property name="sizeHint" stdset="0">
-      <size>
-       <width>40</width>
-       <height>20</height>
-      </size>
-     </property>
-    </spacer>
-   </item>
-   <item row="1" column="1">
-    <widget class="QGroupBox" name="qgbApplication">
-     <property name="title">
-      <string>Application</string>
-     </property>
-     <layout class="QGridLayout" name="gridLayout_3" columnstretch="0,0">
-      <item row="0" column="0">
-       <widget class="QLabel" name="qliAlwaysOnTop">
-        <property name="text">
-         <string>Always On Top</string>
-        </property>
-       </widget>
-      </item>
-      <item row="0" column="1">
-       <widget class="MUComboBox" name="qcbAlwaysOnTop">
-        <property name="toolTip">
-         <string>This setting controls when the application will be always on top.</string>
-        </property>
-        <property name="whatsThis">
-         <string>This setting controls in which situations the application will stay always on top. If you select &lt;i&gt;Never&lt;/i&gt; the application will not stay on top. &lt;i&gt;Always&lt;/i&gt; will always keep the application on top. &lt;i&gt;In minimal view&lt;/i&gt; / &lt;i&gt;In normal view&lt;/i&gt; will only keep the application always on top when minimal view is activated / deactivated.</string>
-        </property>
-        <item>
-         <property name="text">
-          <string>Never</string>
-         </property>
-        </item>
-        <item>
-         <property name="text">
-          <string>Always</string>
-         </property>
-        </item>
-        <item>
-         <property name="text">
-          <string>In minimal view</string>
-         </property>
-        </item>
-        <item>
-         <property name="text">
-          <string>In normal view</string>
-         </property>
-        </item>
-       </widget>
-      </item>
-      <item row="1" column="0" colspan="2">
-       <widget class="QCheckBox" name="qcbShowContextMenuInMenuBar">
-        <property name="toolTip">
-         <string>Adds user and channel context menus into the menu bar</string>
-        </property>
-        <property name="text">
-         <string>Show context menu in menu bar</string>
-        </property>
-       </widget>
-      </item>
-      <item row="2" column="0" colspan="2">
-       <widget class="QCheckBox" name="qcbAskOnQuit">
-        <property name="toolTip">
-         <string>Ask whether to close or minimize when quitting Mumble.</string>
-        </property>
-        <property name="whatsThis">
-         <string>&lt;b&gt;If set, will verify you want to quit if connected.&lt;/b&gt;</string>
-        </property>
-        <property name="text">
-         <string>Ask on quit while connected</string>
-        </property>
-       </widget>
-      </item>
-      <item row="3" column="0" colspan="2">
-       <widget class="QCheckBox" name="qcbEnableDeveloperMenu">
-        <property name="whatsThis">
-         <string>&lt;b&gt;Enable Developer menu&lt;/b&gt;&lt;br /&gt;This enables the &quot;Developer&quot;-menu in Mumble. This menu is used for developer-specific features, such as the Developer Console.</string>
-        </property>
-        <property name="text">
-         <string>Enable Developer menu</string>
-        </property>
-       </widget>
-      </item>
-      <item row="4" column="0" colspan="2">
-       <widget class="QCheckBox" name="qcbLockLayout">
-        <property name="whatsThis">
-         <string>When in custom layout mode, checking this disables rearranging.</string>
-        </property>
-        <property name="text">
-         <string>Lock layout</string>
-        </property>
-       </widget>
-      </item>
-     </layout>
-    </widget>
-   </item>
-   <item row="3" column="1">
-    <widget class="QGroupBox" name="qgbChannel">
-     <property name="title">
-      <string>Channel Tree</string>
-     </property>
-     <layout class="QGridLayout" name="gridLayout_2" columnstretch="0,0">
-      <item row="0" column="0">
-       <widget class="QLabel" name="qliChannelDrag">
-        <property name="text">
-         <string>Channel Dragging</string>
-        </property>
-       </widget>
-      </item>
-      <item row="0" column="1">
-       <widget class="MUComboBox" name="qcbChannelDrag">
-        <property name="toolTip">
-         <string>This changes the behavior when moving channels.</string>
-        </property>
-        <property name="whatsThis">
-         <string>This sets the behavior of channel drags; it can be used to prevent accidental dragging. &lt;i&gt;Move&lt;/i&gt; moves the channel without prompting. &lt;i&gt;Do Nothing&lt;/i&gt; does nothing and prints an error message. &lt;i&gt;Ask&lt;/i&gt; uses a message box to confirm if you really wanted to move the channel.</string>
-        </property>
-       </widget>
-      </item>
-      <item row="1" column="0">
-       <widget class="QLabel" name="qliUserDrag">
-        <property name="text">
-         <string>User Dragging</string>
-        </property>
-       </widget>
-      </item>
-      <item row="1" column="1">
-       <widget class="MUComboBox" name="qcbUserDrag">
-        <property name="toolTip">
-         <string>This changes the behavior when moving users.</string>
-        </property>
-        <property name="whatsThis">
-         <string>This sets the behavior of user drags; it can be used to prevent accidental dragging. &lt;i&gt;Move&lt;/i&gt; moves the user without prompting. &lt;i&gt;Do Nothing&lt;/i&gt; does nothing and prints an error message. &lt;i&gt;Ask&lt;/i&gt; uses a message box to confirm if you really wanted to move the user.</string>
-        </property>
-       </widget>
-      </item>
-      <item row="2" column="0">
-       <widget class="QLabel" name="qliExpand">
-        <property name="text">
-         <string>Expand</string>
-        </property>
-       </widget>
-      </item>
-      <item row="2" column="1">
-       <widget class="MUComboBox" name="qcbExpand">
-        <property name="toolTip">
-         <string>When to automatically expand channels</string>
-        </property>
-        <property name="whatsThis">
-         <string>This sets which channels to automatically expand. &lt;i&gt;None&lt;/i&gt; and &lt;i&gt;All&lt;/i&gt; will expand no or all channels, while &lt;i&gt;Only with users&lt;/i&gt; will expand and collapse channels as users join and leave them.</string>
-        </property>
-       </widget>
-      </item>
-      <item row="3" column="0" colspan="2">
-       <widget class="QCheckBox" name="qcbUsersTop">
-        <property name="toolTip">
-         <string>List users above subchannels (requires restart).</string>
-        </property>
-        <property name="whatsThis">
-         <string>&lt;b&gt;If set, users will be shown above subchannels in the channel view.&lt;/b&gt;&lt;br /&gt;A restart of Mumble is required to see the change.</string>
-        </property>
-        <property name="text">
-         <string>Users above Channels</string>
-        </property>
-       </widget>
-      </item>
-      <item row="4" column="0" colspan="2">
-       <widget class="QCheckBox" name="qcbShowUserCount">
-        <property name="toolTip">
-         <string>Show number of users in each channel</string>
-        </property>
-        <property name="text">
-         <string>Show channel user count</string>
-        </property>
-       </widget>
-      </item>
-      <item row="5" column="0" colspan="2">
-       <widget class="QCheckBox" name="qcbChatBarUseSelection">
-        <property name="text">
-         <string>Use selected item as the chat bar target</string>
-        </property>
-       </widget>
-      </item>
-      <item row="6" column="0" colspan="2">
-       <widget class="QCheckBox" name="qcbFilterHidesEmptyChannels">
-        <property name="text">
-         <string>Filter automatically hides empty channels</string>
-        </property>
-       </widget>
-      </item>
-     </layout>
-    </widget>
    </item>
    <item row="0" column="0" colspan="2">
     <widget class="QGroupBox" name="qgbLayout">
@@ -554,6 +444,169 @@
       </item>
      </layout>
     </widget>
+   </item>
+   <item row="3" column="1">
+    <widget class="QGroupBox" name="qgbChannel">
+     <property name="title">
+      <string>Channel Tree</string>
+     </property>
+     <layout class="QGridLayout" name="gridLayout_2" columnstretch="0,0">
+      <item row="0" column="0">
+       <widget class="QLabel" name="qliChannelDrag">
+        <property name="text">
+         <string>Channel Dragging</string>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="1">
+       <widget class="MUComboBox" name="qcbChannelDrag">
+        <property name="toolTip">
+         <string>This changes the behavior when moving channels.</string>
+        </property>
+        <property name="whatsThis">
+         <string>This sets the behavior of channel drags; it can be used to prevent accidental dragging. &lt;i&gt;Move&lt;/i&gt; moves the channel without prompting. &lt;i&gt;Do Nothing&lt;/i&gt; does nothing and prints an error message. &lt;i&gt;Ask&lt;/i&gt; uses a message box to confirm if you really wanted to move the channel.</string>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="0">
+       <widget class="QLabel" name="qliUserDrag">
+        <property name="text">
+         <string>User Dragging</string>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="1">
+       <widget class="MUComboBox" name="qcbUserDrag">
+        <property name="toolTip">
+         <string>This changes the behavior when moving users.</string>
+        </property>
+        <property name="whatsThis">
+         <string>This sets the behavior of user drags; it can be used to prevent accidental dragging. &lt;i&gt;Move&lt;/i&gt; moves the user without prompting. &lt;i&gt;Do Nothing&lt;/i&gt; does nothing and prints an error message. &lt;i&gt;Ask&lt;/i&gt; uses a message box to confirm if you really wanted to move the user.</string>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="0">
+       <widget class="QLabel" name="qliExpand">
+        <property name="text">
+         <string>Expand</string>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="1">
+       <widget class="MUComboBox" name="qcbExpand">
+        <property name="toolTip">
+         <string>When to automatically expand channels</string>
+        </property>
+        <property name="whatsThis">
+         <string>This sets which channels to automatically expand. &lt;i&gt;None&lt;/i&gt; and &lt;i&gt;All&lt;/i&gt; will expand no or all channels, while &lt;i&gt;Only with users&lt;/i&gt; will expand and collapse channels as users join and leave them.</string>
+        </property>
+       </widget>
+      </item>
+      <item row="3" column="0" colspan="2">
+       <widget class="QCheckBox" name="qcbUsersTop">
+        <property name="toolTip">
+         <string>List users above subchannels (requires restart).</string>
+        </property>
+        <property name="whatsThis">
+         <string>&lt;b&gt;If set, users will be shown above subchannels in the channel view.&lt;/b&gt;&lt;br /&gt;A restart of Mumble is required to see the change.</string>
+        </property>
+        <property name="text">
+         <string>Users above Channels</string>
+        </property>
+       </widget>
+      </item>
+      <item row="4" column="0" colspan="2">
+       <widget class="QCheckBox" name="qcbShowUserCount">
+        <property name="toolTip">
+         <string>Show number of users in each channel</string>
+        </property>
+        <property name="text">
+         <string>Show channel user count</string>
+        </property>
+       </widget>
+      </item>
+      <item row="5" column="0" colspan="2">
+       <widget class="QCheckBox" name="qcbChatBarUseSelection">
+        <property name="text">
+         <string>Use selected item as the chat bar target</string>
+        </property>
+       </widget>
+      </item>
+      <item row="6" column="0" colspan="2">
+       <widget class="QCheckBox" name="qcbFilterHidesEmptyChannels">
+        <property name="text">
+         <string>Filter automatically hides empty channels</string>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item row="4" column="0">
+    <widget class="QGroupBox" name="groupBox">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="title">
+      <string>Talking UI</string>
+     </property>
+     <property name="flat">
+      <bool>false</bool>
+     </property>
+     <property name="checkable">
+      <bool>false</bool>
+     </property>
+     <layout class="QGridLayout" name="gridLayout_5">
+      <property name="horizontalSpacing">
+       <number>6</number>
+      </property>
+      <item row="0" column="0">
+       <widget class="QLabel" name="qlSilentUserLifetime">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="toolTip">
+         <string>A user that is silent for the given amount of seconds will be removed from the Talkin UI.</string>
+        </property>
+        <property name="text">
+         <string>Remove silent user after</string>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="1">
+       <widget class="QSpinBox" name="qsbSilentUserLifetime">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="toolTip">
+         <string>A user that is silent for the given amount of seconds will be removed from the Talkin UI.</string>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item row="4" column="1">
+    <spacer name="horizontalSpacer">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>40</width>
+       <height>20</height>
+      </size>
+     </property>
+    </spacer>
    </item>
   </layout>
  </widget>

--- a/src/mumble/MainWindow.cpp
+++ b/src/mumble/MainWindow.cpp
@@ -51,6 +51,7 @@
 #include "ListenerLocalVolumeDialog.h"
 #include "ChannelListener.h"
 #include "Markdown.h"
+#include "TalkingUI.h"
 
 #ifdef Q_OS_WIN
 # include "TaskList.h"
@@ -1960,6 +1961,10 @@ void MainWindow::on_qmConfig_aboutToShow() {
 	qmConfig->addAction(qaAudioTTS);
 	qmConfig->addSeparator();
 	qmConfig->addAction(qaConfigMinimal);
+
+	qaTalkingUIToggle->setChecked(g.talkingUI && g.talkingUI->isVisible());
+
+	qmConfig->addAction(qaTalkingUIToggle);
 	if (g.s.bMinimalView)
 		qmConfig->addAction(qaConfigHideFrame);
 }
@@ -3273,6 +3278,17 @@ void MainWindow::on_Icon_activated(QSystemTrayIcon::ActivationReason reason) {
 		}
 		default: break;
 	}
+}
+
+void MainWindow::on_qaTalkingUIToggle_triggered() {
+	if (!g.talkingUI) {
+		qCritical("MainWindow: Attempting to show Talking UI before it has been created!");
+		return;
+	}
+
+	g.talkingUI->setVisible(!g.talkingUI->isVisible());
+
+	g.s.bShowTalkingUI = g.talkingUI->isVisible();
 }
 
 /**

--- a/src/mumble/MainWindow.h
+++ b/src/mumble/MainWindow.h
@@ -268,6 +268,7 @@ class MainWindow : public QMainWindow, public MessageHandler, public Ui::MainWin
 		void on_gsSendClipboardTextMessage_triggered(bool, QVariant);
 		void on_Reconnect_timeout();
 		void on_Icon_activated(QSystemTrayIcon::ActivationReason);
+		void on_qaTalkingUIToggle_triggered();
 		void voiceRecorderDialog_finished(int);
 		void qtvUserCurrentChanged(const QModelIndex &, const QModelIndex &);
 		void serverConnected();

--- a/src/mumble/MainWindow.ui
+++ b/src/mumble/MainWindow.ui
@@ -936,6 +936,17 @@ the channel's context menu.</string>
     <string>Locally adjust the volume for this virtual ear.</string>
    </property>
   </action>
+  <action name="qaTalkingUIToggle">
+   <property name="checkable">
+    <bool>true</bool>
+   </property>
+   <property name="text">
+    <string>Talking UI</string>
+   </property>
+   <property name="toolTip">
+    <string>Toggles the visibility of the TalkingUI.</string>
+   </property>
+  </action>
  </widget>
  <customwidgets>
   <customwidget>

--- a/src/mumble/Messages.cpp
+++ b/src/mumble/Messages.cpp
@@ -32,6 +32,7 @@
 #include "CryptState.h"
 #include "Utils.h"
 #include "ChannelListener.h"
+#include "TalkingUI.h"
 
 // We define a global macro called 'g'. This can lead to issues when included code uses 'g' as a type or parameter name (like protobuf 3.7 does). As such, for now, we have to make this our last include.
 #include "Global.h"
@@ -357,6 +358,8 @@ void MainWindow::msgUserState(const MumbleProto::UserState &msg) {
 		}
 
 		pDst = pmModel->addUser(msg.session(), u8(msg.name()));
+
+		connect(pDst, &ClientUser::talkingStateChanged, g.talkingUI, &TalkingUI::on_talkingStateChanged);
 
 		if (channel) {
 			pmModel->moveUser(pDst, channel);

--- a/src/mumble/Settings.cpp
+++ b/src/mumble/Settings.cpp
@@ -451,6 +451,9 @@ Settings::Settings() {
 	bLog24HourClock = true;
 	iChatMessageMargins = 3;
 
+	bShowTalkingUI = false;
+	iTalkingUI_SilentUserLifeTime = 5;
+
 	bShortcutEnable = true;
 	bSuppressMacEventTapWarning = false;
 	bEnableEvdev = false;
@@ -805,6 +808,8 @@ void Settings::load(QSettings* settings_ptr) {
 	SAVELOAD(iMaxLogBlocks, "ui/MaxLogBlocks");
 	SAVELOAD(bLog24HourClock, "ui/24HourClock");
 	SAVELOAD(iChatMessageMargins, "ui/ChatMessageMargins");
+	SAVELOAD(bShowTalkingUI, "ui/showTalkingUI");
+	SAVELOAD(iTalkingUI_SilentUserLifeTime, "ui/talkingUI_SilentUserLifeTime");
 
 	// PTT Button window
 	SAVELOAD(bShowPTTButtonWindow, "ui/showpttbuttonwindow");
@@ -1142,6 +1147,8 @@ void Settings::save() {
 	SAVELOAD(iMaxLogBlocks, "ui/MaxLogBlocks");
 	SAVELOAD(bLog24HourClock, "ui/24HourClock");
 	SAVELOAD(iChatMessageMargins, "ui/ChatMessageMargins");
+	SAVELOAD(bShowTalkingUI, "ui/showTalkingUI");
+	SAVELOAD(iTalkingUI_SilentUserLifeTime, "ui/talkingUI_SilentUserLifeTime");
 
 	// PTT Button window
 	SAVELOAD(bShowPTTButtonWindow, "ui/showpttbuttonwindow");

--- a/src/mumble/Settings.h
+++ b/src/mumble/Settings.h
@@ -277,6 +277,9 @@ struct Settings {
 	int iMaxLogBlocks;
 	bool bLog24HourClock;
 	int iChatMessageMargins;
+	bool bShowTalkingUI;
+	int iTalkingUI_SilentUserLifeTime;
+
 	QMap<int, QString> qmMessageSounds;
 	QMap<int, quint32> qmMessages;
 

--- a/src/mumble/TalkingUI.cpp
+++ b/src/mumble/TalkingUI.cpp
@@ -1,0 +1,364 @@
+// Copyright 2020 The Mumble Developers. All rights reserved.
+// Use of this source code is governed by a BSD-style license
+// that can be found in the LICENSE file at the root of the
+// Mumble source tree or at <https://www.mumble.info/LICENSE>.
+
+#include "TalkingUI.h"
+#include "ClientUser.h"
+#include "Channel.h"
+#include "MainWindow.h"
+#include "UserModel.h"
+
+#include <QGroupBox>
+#include <QLabel>
+#include <QVBoxLayout>
+#include <QHBoxLayout>
+#include <QGuiApplication>
+#include <QtCore/QDateTime>
+#include <QtCore/QTimer>
+#include <QScreen>
+#include <QMouseEvent>
+#include <QPalette>
+#include <QItemSelectionModel>
+#include <QModelIndex>
+
+// We define a global macro called 'g'. This can lead to issues when included code uses 'g' as a type or parameter name (like protobuf 3.7 does). As such, for now, we have to make this our last include.
+#include "Global.h"
+
+TalkingUI::TalkingUI(QWidget *parent)
+	: QWidget(parent),
+	  m_entries(),
+	  m_channels(),
+	  m_timers(),
+	  m_currentSelection(nullptr),
+	  m_talkingIcon(QIcon(QLatin1String("skin:talking_on.svg"))),
+	  m_passiveIcon(QIcon(QLatin1String("skin:talking_off.svg"))),
+	  m_shoutingIcon(QIcon(QLatin1String("skin:talking_alt.svg"))),
+	  m_whisperingIcon(QIcon(QLatin1String("skin:talking_whisper.svg"))) {
+
+	setupUI();
+}
+
+void TalkingUI::setupUI() {
+	QVBoxLayout *layout = new QVBoxLayout;
+
+	setLayout(layout);
+
+	setWindowTitle(QObject::tr("Talking UI"));
+
+	setAttribute(Qt::WA_ShowWithoutActivating);
+	setWindowFlags(Qt::Window | Qt::WindowStaysOnTopHint);
+
+	connect(g.mw->qtvUsers->selectionModel(), &QItemSelectionModel::currentChanged, this, &TalkingUI::on_mainWindowSelectionChanged);
+}
+
+void TalkingUI::removeUser(unsigned int session) {
+	QHash<unsigned int, Entry>::iterator iter = m_entries.find(session);
+	if (iter == m_entries.end()) {
+		return;
+	}
+	
+	Entry &entry = iter.value();
+
+	entry.background->hide();
+
+	// In principle the user could have changed channel since it has been added to
+	// the UI, so we'll iterate over all GroupBoxes and remove the labels from every
+	// single one of them.
+	QHashIterator<int, QGroupBox *> it(m_channels);
+
+	while (it.hasNext()) {
+		it.next();
+
+		QGroupBox *channelBox = it.value();
+
+		channelBox->layout()->removeWidget(entry.background);
+
+		if (channelBox->layout()->count() == 0) {
+			// There are no active speakers in this channel anymore
+			channelBox->hide();
+			layout()->removeWidget(channelBox);
+		}
+	}
+
+	updateUI();
+}
+
+void TalkingUI::updateUI() {
+	// Use timer to execute this after all other events have been processed
+	QTimer::singleShot(0, [this]() { adjustSize(); });
+}
+
+void TalkingUI::setSelection(Entry *entry) {
+	if (entry != m_currentSelection) {
+		if (m_currentSelection) {
+			m_currentSelection->background->setStyleSheet(QLatin1String(""));
+		}
+		if (entry) {
+			QString colorHex = palette().color(QPalette::Normal, QPalette::Highlight).name(QColor::HexRgb);
+			entry->background->setStyleSheet(QString::fromLatin1("background-color: %1;").arg(colorHex));
+
+			if (g.mw && g.mw->pmModel) {
+				g.mw->pmModel->setSelectedUser(entry->userSession);
+			}
+		}
+
+		m_currentSelection = entry;
+	}
+}
+
+void TalkingUI::mousePressEvent(QMouseEvent *event) {
+	Q_UNUSED(event);
+
+	QWidget *widget = qApp->widgetAt(event->globalPos());
+
+	if (!widget) {
+		setSelection(nullptr);
+		return;
+	}
+
+	// iterate all available entries
+	QMutableHashIterator<unsigned int, Entry> it(m_entries);
+
+	Entry *entry = nullptr;
+
+	while (it.hasNext()) {
+		it.next();
+
+		Entry *currentEntry = &it.value();
+		if (currentEntry->icon == widget || currentEntry->name == widget || currentEntry->background == widget) {
+			entry = currentEntry;
+			break;
+		}
+	}
+
+	setSelection(entry);
+
+	updateUI();
+}
+
+void TalkingUI::setVisible(bool visible) {
+	if (visible) {
+		adjustSize();
+	}
+
+	QWidget::setVisible(visible);
+}
+
+QSize TalkingUI::sizeHint() const {
+	// Prefer to occupy at least 10% of the screen's size
+	// This aims to be a good compromise between not being in the way and not
+	// being too small to being handled properly.
+	int width =  QGuiApplication::screens()[0]->availableSize().width() * 0.1;
+
+	return {width, 0};
+}
+
+QSize TalkingUI::minimumSizeHint() const {
+	return {0, 0};
+}
+
+void TalkingUI::on_talkingStateChanged() {
+	ClientUser *user = qobject_cast<ClientUser *>(sender());
+
+	if (!user) {
+		return;
+	}
+
+	if (!user->cChannel) {
+		// If the user doesn't have an associated channel, something's either wrong
+		// or that user has just disconnected. In either way, we want to make sure
+		// that this user won't stick around in the UI.
+		removeUser(user->uiSession);
+		return;
+	}
+
+	bool isSelf = g.uiSession == user->uiSession;
+
+	if (!m_channels.contains(user->cChannel->iId)) {
+		// Create a QGroupBox for this user
+		QGroupBox *box = new QGroupBox(user->cChannel->qsName, this);
+		QVBoxLayout *layout = new QVBoxLayout();
+		layout->setContentsMargins(0, 0, 0, 0);
+		box->setLayout(layout);
+
+		m_channels.insert(user->cChannel->iId, box);
+	}
+
+	if (!m_entries.contains(user->uiSession)) {
+		// Create an Entry for this user (alongside the respective labels)
+		// We initially set the labels to not be visible, so that we'll
+		// enter the code-block further down.
+
+		QWidget *background = new QWidget(this);
+		QLayout *backgroundLayout = new QHBoxLayout();
+		backgroundLayout->setContentsMargins(2, 3, 2, 3);
+		background->setLayout(backgroundLayout);
+		background->setAutoFillBackground(true);
+		background->hide();
+
+		background->setProperty("userName", user->qsName);
+
+		QLabel *name = new QLabel(background);
+		if (isSelf) {
+			// Indicate self by bold name
+			name->setText(QString::fromLatin1("<b>%1</b>").arg(user->qsName));
+		} else {
+			name->setText(user->qsName);
+		}
+
+		QLabel *icon = new QLabel(background);
+		icon->setAlignment(Qt::AlignCenter);
+		icon->setSizePolicy(QSizePolicy::Maximum, QSizePolicy::Maximum);
+
+		m_entries.insert(user->uiSession, {icon, name, background, user->uiSession});
+
+		backgroundLayout->addWidget(icon);
+		backgroundLayout->addWidget(name);
+
+		// Also create a timer for this specific user
+		QTimer *timer = new QTimer(this);
+		timer->setSingleShot(true);
+		const unsigned int session = user->uiSession;
+		QObject::connect(timer, &QTimer::timeout, [this, session](){
+			removeUser(session);
+		});
+
+		m_timers.insert(user->uiSession, timer);
+
+		// If this user is currently selected, mark him/her as such
+		if (g.mw && g.mw->pmModel && g.mw->pmModel->getSelectedUser() == user) {
+			setSelection(&m_entries[user->uiSession]);
+		}
+	}
+
+
+	// * 1000 as the setting is in seconds whereas the timer expects milliseconds
+	// We set the interval every time the talking state of a user has changed, in case the settings for
+	// it have changed during runtime.
+	m_timers[user->uiSession]->setInterval(g.s.iTalkingUI_SilentUserLifeTime * 1000);
+
+	// Get the Entry for this user
+	Entry entry = m_entries[user->uiSession];
+
+
+	// Set the icon for this user according to the TalkingState
+	QIcon *icon = nullptr;
+	switch (user->tsState) {
+		case Settings::Talking:
+			icon = &m_talkingIcon;
+			break;
+		case Settings::Whispering:
+			icon = &m_whisperingIcon;
+			break;
+		case Settings::Shouting:
+			icon = &m_shoutingIcon;
+			break;
+		default:
+			icon = &m_passiveIcon;
+			break;
+
+	}
+	const int height = fontMetrics().height(); // Make icon as high as the text
+	entry.icon->setPixmap(icon->pixmap(QSize(height, height), QIcon::Normal, QIcon::On));
+
+
+	if (user->tsState == Settings::Passive) {
+		// User stopped talking
+		// Start the timer that will remove this user
+		m_timers[user->uiSession]->start();
+	} else {
+		// User started talking
+		// Stop the timer for this user in case it has been started before but the user
+		// started speaking again before having been removed
+		m_timers[user->uiSession]->stop();
+
+		// Get the box we'll want to have the user in (representing the current
+		// channel of the user)
+		QGroupBox *channelBox = m_channels[user->cChannel->iId];
+
+		if (!channelBox) {
+			qCritical("TalkingUI: Can't find channel for speaker");
+			return;
+		}
+
+		// Check if the user has changed channel and handle this separately in case
+		// the user is currently still displayed as being in that channel
+		bool changedChannel = false;
+		if (channelBox->layout()->indexOf(entry.name) < 0) {
+			changedChannel = true;
+
+			removeUser(user->uiSession);
+		}
+
+		bool adjust = false;
+		if (!channelBox->isVisible()) {
+			// Make sure the channel-box is visible
+			channelBox->show();
+
+			// Sort the channels alphabetically
+			bool inserted = false;
+			for (int i = 0; i < layout()->count(); i++) {
+				QGroupBox *currentBox = static_cast<QGroupBox *>(layout()->itemAt(i)->widget());
+
+				if (currentBox->title() > channelBox->title()) {
+					static_cast<QVBoxLayout *>(layout())->insertWidget(i, channelBox);
+					inserted = true;
+					break;
+				}
+			}
+
+			if (!inserted) {
+				layout()->addWidget(channelBox);
+			}
+
+			adjust = true;
+		}
+
+		if (!entry.background->isVisible() || changedChannel) {
+			// Make sure the Entry for this user is visible
+			entry.background->show();
+
+			// Sort the users alphabetically
+			QString currentName = entry.background->property("userName").toString();
+			bool inserted = false;
+			for (int i = 0; i < channelBox->layout()->count(); i++) {
+				QWidget *currentBackground = static_cast<QWidget *>(channelBox->layout()->itemAt(i)->widget());
+
+				QString userName = currentBackground->property("userName").toString();
+
+				if (userName > currentName) {
+					static_cast<QHBoxLayout *>(channelBox->layout())->insertWidget(i, entry.background);
+					inserted = true;
+					break;
+				}
+			}
+
+			if (!inserted) {
+				channelBox->layout()->addWidget(entry.background);
+			}
+
+
+			adjust = true;
+		}
+
+		if (adjust) {
+			updateUI();
+		}
+	}
+}
+
+void TalkingUI::on_mainWindowSelectionChanged(const QModelIndex &current, const QModelIndex &previous) {
+	Q_UNUSED(previous);
+
+	// Sync the selection in the MainWindow to the TalkingUI
+	if (g.mw && g.mw->pmModel) {
+		ClientUser *user = g.mw->pmModel->getUser(current);
+
+		if (user && m_entries.contains(user->uiSession)) {
+			setSelection(&m_entries[user->uiSession]);
+		} else {
+			setSelection(nullptr);
+		}
+	}
+}

--- a/src/mumble/TalkingUI.h
+++ b/src/mumble/TalkingUI.h
@@ -1,0 +1,81 @@
+// Copyright 2020 The Mumble Developers. All rights reserved.
+// Use of this source code is governed by a BSD-style license
+// that can be found in the LICENSE file at the root of the
+// Mumble source tree or at <https://www.mumble.info/LICENSE>.
+
+#ifndef MUMBLE_MUMBLE_TALKINGUI_H_
+#define MUMBLE_MUMBLE_TALKINGUI_H_
+
+#include <QWidget>
+#include <QtCore/QHash>
+#include <QtCore/QSet>
+#include <QtGui/QIcon>
+
+class QLabel;
+class QGroupBox;
+class QTimer;
+class QMouseEvent;
+
+/// Smaller auxilary class for holding together two labels representing
+/// the entry for a specific user in the TalkingUI<
+struct Entry {
+	QLabel *icon;
+	QLabel *name;
+	QWidget *background;
+	unsigned int userSession;
+};
+
+/// The talking UI is a widget that will display the users you are currently
+/// hearing to you.
+class TalkingUI : public QWidget {
+	private:
+		Q_OBJECT
+		Q_DISABLE_COPY(TalkingUI);
+
+		/// A map between user session ID and the corresponding Entry
+		QHash<unsigned int, Entry> m_entries;
+		/// A map between channel ID and the QGroupBox used to represent it
+		QHash<int, QGroupBox *> m_channels;
+		/// A map betweem user session IDs and the timer used to remove users
+		/// that have stopped speaking for a certain amount of time.
+		QHash<unsigned int, QTimer *> m_timers;
+
+		Entry *m_currentSelection;
+
+		/// The icon for a talking user
+		QIcon m_talkingIcon;
+		/// The icon for a silent user
+		QIcon m_passiveIcon;
+		/// The icon for a shouting user
+		QIcon m_shoutingIcon;
+		/// The icon for a whispering user
+		QIcon m_whisperingIcon;
+
+		/// Sets up the UI components
+		void setupUI();
+		/// Removes a user from being displayed
+		void removeUser(unsigned int session);
+
+		/// Update (resize) the UI to its content
+		void updateUI();
+
+		/// Set the current selection
+		///
+		/// @param entry A pointer to the Entry that shall be selected or nullptr to clear the selection
+		void setSelection(Entry *entry);
+
+		void mousePressEvent(QMouseEvent *event) Q_DECL_OVERRIDE;
+
+	public:
+		TalkingUI(QWidget *parent = nullptr);
+
+		void setVisible(bool visible) Q_DECL_OVERRIDE;
+		QSize sizeHint() const Q_DECL_OVERRIDE;
+		QSize minimumSizeHint() const Q_DECL_OVERRIDE;
+
+	public slots:
+		void on_talkingStateChanged();
+		void on_mainWindowSelectionChanged(const QModelIndex &current, const QModelIndex &previous);
+};
+
+#endif // MUMBLE_MUMBLE_TALKINGUI_H_

--- a/src/mumble/UserModel.cpp
+++ b/src/mumble/UserModel.cpp
@@ -1482,6 +1482,19 @@ ClientUser *UserModel::getSelectedUser() const {
 	return nullptr;
 }
 
+void UserModel::setSelectedUser(unsigned int session) {
+	QModelIndex idx = index(ClientUser::get(session));
+
+	if (!idx.isValid()) {
+		return;
+	}
+
+	QTreeView *v = g.mw->qtvUsers;
+	if (v) {
+		v->setCurrentIndex(idx);
+	}
+}
+
 Channel *UserModel::getChannel(const QModelIndex &idx) const {
 	if (! idx.isValid())
 		return NULL;
@@ -1505,6 +1518,19 @@ Channel *UserModel::getSelectedChannel() const {
 	}
 
 	return nullptr;
+}
+
+void UserModel::setSelectedChannel(int id) {
+	QModelIndex idx = index(Channel::get(id));
+
+	if (!idx.isValid()) {
+		return;
+	}
+
+	QTreeView *v = g.mw->qtvUsers;
+	if (v) {
+		v->setCurrentIndex(idx);
+	}
 }
 
 Channel *UserModel::getSubChannel(Channel *p, int idx) const {

--- a/src/mumble/UserModel.h
+++ b/src/mumble/UserModel.h
@@ -124,11 +124,19 @@ class UserModel : public QAbstractItemModel {
 		ClientUser *getUser(const QString &hash) const;
 		/// @returns A pointer to the currently selected User or nullptr if there is none
 		ClientUser *getSelectedUser() const;
+		/// Sets the selection to the User with the given session
+		///
+		/// @param session The session ID of the respective User
+		void setSelectedUser(unsigned int session);
 
 		Channel *addChannel(int id, Channel *p, const QString &name);
 		Channel *getChannel(const QModelIndex &idx) const;
 		/// @returns A pointer to the currently selected Channel or nullptr if there is none
 		Channel *getSelectedChannel() const;
+		/// Sets the selection to the Channel with the given ID
+		///
+		/// @param session The ID of the respective Channel
+		void setSelectedChannel(int id);
 
 		/// Adds the guven user as a listener to the given channel
 		///

--- a/src/mumble/main.cpp
+++ b/src/mumble/main.cpp
@@ -36,6 +36,7 @@
 #include "UserLockFile.h"
 #include "License.h"
 #include "EnvUtils.h"
+#include "TalkingUI.h"
 
 #include <QtCore/QLibraryInfo>
 #include <QtCore/QProcess>
@@ -448,6 +449,9 @@ int main(int argc, char **argv) {
 	g.mw=new MainWindow(NULL);
 	g.mw->show();
 
+	g.talkingUI = new TalkingUI();
+	g.talkingUI->setVisible(g.s.bShowTalkingUI);
+
 	// Initialize logger
 	// Log::log() needs the MainWindow to already exist. Thus creating the Log instance
 	// before the MainWindow one, does not make sense. if you need logging before this
@@ -589,6 +593,7 @@ int main(int argc, char **argv) {
 		QThread::yieldCurrentThread();
 	sh.reset();
 
+	delete g.talkingUI;
 	delete g.mw;
 
 	delete g.nam;

--- a/src/mumble/mumble.pro
+++ b/src/mumble/mumble.pro
@@ -144,7 +144,8 @@ HEADERS *= BanEditor.h \
     XMLTools.h \
     Screen.h \
     SvgIcon.h \
-    Markdown.h
+    Markdown.h \
+    TalkingUI.h
 
 SOURCES *= BanEditor.cpp \
     ACLEditor.cpp \
@@ -216,7 +217,8 @@ SOURCES *= BanEditor.cpp \
     XMLTools.cpp \
     Screen.cpp \
     SvgIcon.cpp \
-    Markdown.cpp
+    Markdown.cpp \
+    TalkingUI.cpp
 
 CONFIG(qtspeech) {
   SOURCES *= TextToSpeech.cpp

--- a/src/mumble/mumble_en.ts
+++ b/src/mumble/mumble_en.ts
@@ -3799,6 +3799,18 @@ The setting only applies for new messages, the already shown ones will retain th
         <source>Lock layout</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Talking UI</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>A user that is silent for the given amount of seconds will be removed from the Talkin UI.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Remove silent user after</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>MainWindow</name>
@@ -5570,6 +5582,14 @@ the channel&apos;s context menu.</source>
         <source>%1 stopped listening to your channel</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Talking UI</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Toggles the visibility of the TalkingUI.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>Manual</name>
@@ -6452,6 +6472,10 @@ To upgrade these files to their latest versions, click the button below.</source
     <name>QObject</name>
     <message>
         <source>CodecInit: Failed to load Opus, it will not be available for encoding/decoding audio.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Talking UI</source>
         <translation type="unfinished"></translation>
     </message>
 </context>


### PR DESCRIPTION
The TalkingUI is meant as some sort of a light version of the Overlay
primarily intended for use when using the computer normally (e.g. with
many different programs instead of one that is FullScreen).

It consists of a small window that can be toggled and it will show the
names of the person currently talking as well as the channel that person
is in.

If a person has stopped talking for some time (5s in the current
implementation), it will be removed from the UI again.

By default the UI will stay on top of all other windows so that you'll
always be able to see it.

Note that the selection in the TalkingUI and the MainWindow is synchronised in terms of selected users (if a channel is selected, the TalkingUI will not show a selection).
This means that this feature plays nicely with the "Whisper to selected" feature (#4048): Select a user in the TalkingUI and you can will use that user as a whisper target if you have your shortcut set to whisper to the currently selected item.

![Mumble_TalkingUI](https://user-images.githubusercontent.com/12751591/79144649-9c233500-7dbf-11ea-869c-dc2a357b3eee.png)


Changelog
```
| Added: Talking UI
```