### PR TITLE
Dockerfile: update ubuntu version to latest

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -39,8 +39,8 @@ RUN adduser murmur
 RUN apt-get update && apt-get install -y \
 	libcap2 \
 	libzeroc-ice3.7 \
-	libprotobuf17 \
-	libgrpc6 \
+	'^libprotobuf[0-9]+$' \
+	'^libgrpc[0-9]+$' \
 	libgrpc++1 \
 	libavahi-compat-libdnssd1 \
 	libqt5core5a \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:disco
+FROM ubuntu:latest
 
 # needed to install tzdata in disco
 ENV DEBIAN_FRONTEND=noninteractive
@@ -33,7 +33,7 @@ RUN qmake -recursive main.pro CONFIG+="no-client grpc"
 RUN make release
 
 # Clean distribution stage
-FROM ubuntu:disco
+FROM ubuntu:latest
 
 RUN adduser murmur
 RUN apt-get update && apt-get install -y \


### PR DESCRIPTION
Building a docker image with the current Dockerfile seems to run into
issues caused by not finding files on the Ubuntu disco repositories
anymore. So, this patch updates the Ubuntu version in the Dockerfile
from disco to eoan.

Signed-off-by: hwipl <33433250+hwipl@users.noreply.github.com>