### PR TITLE
Fix grpc build

### DIFF
--- a/scripts/travis-ci/before_install.bash
+++ b/scripts/travis-ci/before_install.bash
@@ -22,7 +22,8 @@ if [ "${TRAVIS_OS_NAME}" == "linux" ]; then
                                 libcap-dev libxi-dev \
                                 libasound2-dev libpulse-dev \
                                 libogg-dev libsndfile1-dev libspeechd-dev \
-                                libavahi-compat-libdnssd-dev libzeroc-ice-dev libg15daemon-client-dev
+                                libavahi-compat-libdnssd-dev libzeroc-ice-dev libg15daemon-client-dev \
+                                libgrpc++-dev libprotoc-dev protobuf-compiler-grpc
 	elif [ "${MUMBLE_HOST}" == "i686-w64-mingw32" ]; then
 		sudo dpkg --add-architecture i386
 		sudo apt-get -qq update

--- a/scripts/travis-ci/script.bash
+++ b/scripts/travis-ci/script.bash
@@ -17,11 +17,11 @@ if [ "${TRAVIS_OS_NAME}" == "linux" ]; then
 		if [ "${MUMBLE_NO_PCH}" == "1" ]; then
 			EXTRA_CONFIG="no-pch ${EXTRA_CONFIG}"
 		fi
-		qmake CONFIG+="release tests g15-emulator ${EXTRA_CONFIG}" DEFINES+="MUMBLE_VERSION=${TRAVIS_COMMIT:0:7}" -recursive
+		qmake CONFIG+="release tests g15-emulator grpc ${EXTRA_CONFIG}" DEFINES+="MUMBLE_VERSION=${TRAVIS_COMMIT:0:7}" -recursive
 		make -j2
 		make check
 	elif [ "${MUMBLE_HOST}" == "aarch64-linux-gnu" ]; then
-		qmake CONFIG+="release tests warnings-as-errors ${EXTRA_CONFIG}" -recursive
+		qmake CONFIG+="release tests warnings-as-errors grpc ${EXTRA_CONFIG}" -recursive
 		make -j $(nproc)
 	elif [ "${MUMBLE_HOST}" == "i686-w64-mingw32" ]; then
 		wget http://www.steinberg.net/sdk_downloads/asiosdk2.3.zip -P ../

--- a/src/murmur/MurmurGRPCImpl.cpp
+++ b/src/murmur/MurmurGRPCImpl.cpp
@@ -283,7 +283,12 @@ void ToRPC(const ::Server *srv, const ::User *u, ::MurmurRPC::User *ru) {
 	ru->set_udp_ping_msecs(su->dUDPPingAvg);
 	ru->set_tcp_ping_msecs(su->dTCPPingAvg);
 
+#if QT_VERSION >= QT_VERSION_CHECK(5, 14, 0)
+	ru->set_tcp_only(su->aiUdpFlag.loadRelaxed() == 0);
+#else
+	// Qt 5.14 introduced QAtomicInteger::loadRelaxed() which deprecates QAtomicInteger::load()
 	ru->set_tcp_only(su->aiUdpFlag.load() == 0);
+#endif
 
 	ru->set_address(su->haAddress.toStdString());
 }

--- a/src/murmur/MurmurGRPCImpl.h
+++ b/src/murmur/MurmurGRPCImpl.h
@@ -39,7 +39,7 @@ namespace MurmurRPC {
 	}
 }
 
-class MurmurRPCAuthenticator : public ::grpc_impl::AuthMetadataProcessor {
+class MurmurRPCAuthenticator : public ::grpc::AuthMetadataProcessor {
 	public:
 		MurmurRPCAuthenticator();
 		grpc::Status Process(const InputMetadata&, ::grpc::AuthContext*, OutputMetadata*, OutputMetadata*);


### PR DESCRIPTION
This PR fixes a compilation error that occurs when building murmur with GRPC enabled with an older version of the GRPC lib (probably a version less than 1.28 but I'm not sure of the exact version).

Furthermore it fixes a Qt warning about a deprecated function (Qt >= 5.14) in the GRPC code.

Finally it adds GRPC to be built on our CI in order to catch errors in the GRPC code in the CI as well.