### PR TITLE
Add autobanSuccessfulConnections flag.

### DIFF
--- a/scripts/murmur.ini
+++ b/scripts/murmur.ini
@@ -373,9 +373,13 @@ allowping=true
 ; To disable, set autobanAttempts or autobanTimeframe to 0. Commenting these
 ; settings out will cause Murmur to use the defaults:
 ;
+; To avoid autobanning successful connection attempts from the same IP address,
+; set autobanSuccessfulConnections=False.
+;
 ;autobanAttempts=10
 ;autobanTimeframe=120
 ;autobanTime=300
+;autobanSuccessfulConnections=True
 
 ; Enables logging of group changes. This means that every time a group in a
 ; channel changes, the server will log all groups and their members from before

--- a/src/murmur/Meta.cpp
+++ b/src/murmur/Meta.cpp
@@ -763,7 +763,7 @@ void Meta::successfulConnectionFrom(const QHostAddress &addr) {
 }
 
 bool Meta::banCheck(const QHostAddress &addr) {
-	if ((mp.iBanTries == 0) || (mp.iBanTimeframe == 0))
+	if ((mp.iBanTries <= 0) || (mp.iBanTimeframe <= 0))
 		return false;
 
 	if (qhBans.contains(addr)) {

--- a/src/murmur/Meta.cpp
+++ b/src/murmur/Meta.cpp
@@ -78,6 +78,7 @@ MetaParams::MetaParams() {
 	iBanTries = 10;
 	iBanTimeframe = 120;
 	iBanTime = 300;
+	bBanSuccessful = true;
 
 #ifdef Q_OS_UNIX
 	uiUid = uiGid = 0;
@@ -329,6 +330,7 @@ void MetaParams::read(QString fname) {
 	iBanTries = typeCheckedFromSettings("autobanAttempts", iBanTries);
 	iBanTimeframe = typeCheckedFromSettings("autobanTimeframe", iBanTimeframe);
 	iBanTime = typeCheckedFromSettings("autobanTime", iBanTime);
+	bBanSuccessful = typeCheckedFromSettings("autobanSuccessfulConnections", bBanSuccessful);
 
 	qvSuggestVersion = MumbleVersion::getRaw(qsSettings->value("suggestVersion").toString());
 	if (qvSuggestVersion.toUInt() == 0)
@@ -745,6 +747,19 @@ void Meta::killAll() {
 		delete s;
 	}
 	qhServers.clear();
+}
+
+void Meta::successfulConnectionFrom(const QHostAddress &addr) {
+	if (!mp.bBanSuccessful) {
+		QList<Timer> &ql = qhAttempts[addr];
+		// Seems like this is the most efficient way to clear the list, given:
+		// 1. ql.clear() allocates a new array
+		// 2. ql has less than iBanAttempts members
+		// 3. seems like ql.removeFirst() might actually copy elements to shift to the front
+		while (!ql.empty()) {
+			ql.removeLast();
+		}
+	}
 }
 
 bool Meta::banCheck(const QHostAddress &addr) {

--- a/src/murmur/Meta.h
+++ b/src/murmur/Meta.h
@@ -59,6 +59,7 @@ public:
 	int iBanTries;
 	int iBanTimeframe;
 	int iBanTime;
+	bool bBanSuccessful;
 
 	QString qsDatabase;
 	int iSQLiteWAL;
@@ -192,6 +193,10 @@ class Meta : public QObject {
 		void bootAll();
 		bool boot(int);
 		bool banCheck(const QHostAddress &);
+
+		/// Called whenever we get a successful connection from a client.
+		/// Used to reset autoban tracking for the address.
+		void successfulConnectionFrom(const QHostAddress &);
 		void kill(int);
 		void killAll();
 		void getOSInfo();

--- a/src/murmur/Server.cpp
+++ b/src/murmur/Server.cpp
@@ -1362,6 +1362,8 @@ void Server::newClient() {
 		sock->setProtocol(QSsl::TlsV1_0);
 #endif
 		sock->startServerEncryption();
+
+		meta->successfulConnectionFrom(adr);
 	}
 }
 


### PR DESCRIPTION
The idea here is that sometimes you really do have a lot of folks connecting from a single IP,
and if those connections are successful you don't want to ban any of them.
However, in cases where the server needs to guard against malicious users attempting a DDOS
by reconnecting their valid user account over and over, we need to be able to configure the
server to still ban those successful attempts.

How does this idea sound, and how does this code look for solving it? Thanks! 