### PR TITLE
Revamp audio wizard

### DIFF
--- a/src/mumble/AudioWizard.cpp
+++ b/src/mumble/AudioWizard.cpp
@@ -485,15 +485,19 @@ void AudioWizard::on_Ticker_timeout() {
 
 	if (! qgsScene) {
 		unsigned int nspeaker = 0;
+		// Note: when updating these, make sure the colors in AudioWizard.ui match up.
+		const QColor skyBlueColor(QLatin1String("#56b4e9"));
+		const QColor bluishGreenColor(QLatin1String("#009e73"));
+		const QColor vermillionColor(QLatin1String("#d55e00"));
 		const float *spos = ao->getSpeakerPos(nspeaker);
 		if ((nspeaker > 0) && spos) {
 			qgsScene = new QGraphicsScene(QRectF(-4.0f, -4.0f, 8.0f, 8.0f), this);
-			qgsScene->addEllipse(QRectF(-0.12f, -0.12f, 0.24f, 0.24f), QPen(Qt::black), QBrush(Qt::darkRed));
+			qgsScene->addEllipse(QRectF(-0.12f, -0.12f, 0.24f, 0.24f), QPen(Qt::black), QBrush(skyBlueColor));
 			for (unsigned int i=0;i<nspeaker;++i) {
 				if ((spos[3*i] != 0.0f) || (spos[3*i+1] != 0.0f) || (spos[3*i+2] != 0.0f))
-					qgsScene->addEllipse(QRectF(spos[3*i] - 0.1f, spos[3*i+2] - 0.1f, 0.2f, 0.2f), QPen(Qt::black), QBrush(Qt::yellow));
+					qgsScene->addEllipse(QRectF(spos[3*i] - 0.1f, spos[3*i+2] - 0.1f, 0.2f, 0.2f), QPen(Qt::black), QBrush(vermillionColor));
 			}
-			qgiSource = qgsScene->addEllipse(QRectF(-.15f, -.15f, 0.3f, 0.3f), QPen(Qt::black), QBrush(Qt::green));
+			qgiSource = qgsScene->addEllipse(QRectF(-.15f, -.15f, 0.3f, 0.3f), QPen(Qt::black), QBrush(bluishGreenColor));
 			qgvView->setScene(qgsScene);
 			qgvView->fitInView(-4.0f, -4.0f, 8.0f, 8.0f, Qt::KeepAspectRatio);
 		}

--- a/src/mumble/AudioWizard.cpp
+++ b/src/mumble/AudioWizard.cpp
@@ -547,9 +547,16 @@ void AudioWizard::on_Ticker_timeout() {
 			qgvView->fitInView(-4.0f, -4.0f, 8.0f, 8.0f, Qt::KeepAspectRatio);
 		}
 	} else if (currentPage() == qwpPositional) {
+		// This block here is responsible for setting the position of
+		// the audio source. Unless the user has clicked on the scene,
+		// the source will rotate around the origin at a radius of 2.
+		// Once the user has clicked on the scene, the sound source
+		// is put where (s)he clicked last.
 		float xp, yp;
 		if ((fX == 0.0f) && (fY == 0.0f)) {
-			fAngle += 0.05f;
+			// increase the angle of the sound source by a certain amount. he higher
+			// this value is, the faster will the source rotate.
+			fAngle += 0.02f;
 
 			xp = sinf(fAngle) * 2.0f;
 			yp = cosf(fAngle) * 2.0f;

--- a/src/mumble/AudioWizard.cpp
+++ b/src/mumble/AudioWizard.cpp
@@ -161,6 +161,7 @@ AudioWizard::AudioWizard(QWidget *p) : QWizard(p) {
 	aosSource = NULL;
 	qgvView->scale(1.0f, -1.0f);
 	qgvView->viewport()->installEventFilter(this);
+	qgvView->setRenderHints(QPainter::Antialiasing);
 
 	// Volume
 	qsMaxAmp->setValue(g.s.iMinLoudness);
@@ -484,20 +485,64 @@ void AudioWizard::on_Ticker_timeout() {
 	}
 
 	if (! qgsScene) {
+		const float baseRadius = 0.5;
+
 		unsigned int nspeaker = 0;
+
 		// Note: when updating these, make sure the colors in AudioWizard.ui match up.
 		const QColor skyBlueColor(QLatin1String("#56b4e9"));
 		const QColor bluishGreenColor(QLatin1String("#009e73"));
 		const QColor vermillionColor(QLatin1String("#d55e00"));
+
+		// Get the directions of the speakers as unit vectors and also the amount of them
 		const float *spos = ao->getSpeakerPos(nspeaker);
+
 		if ((nspeaker > 0) && spos) {
 			qgsScene = new QGraphicsScene(QRectF(-4.0f, -4.0f, 8.0f, 8.0f), this);
-			qgsScene->addEllipse(QRectF(-0.12f, -0.12f, 0.24f, 0.24f), QPen(Qt::black), QBrush(skyBlueColor));
+
+			QPen pen;
+			// A width of 0 will cause it to always use a width
+			// of exactly 1 pixel
+			pen.setWidth(0);
+
+			QGraphicsEllipseItem *ownPos = qgsScene->addEllipse(QRectF(-baseRadius, -baseRadius, 2*baseRadius, 2*baseRadius), pen, QBrush(skyBlueColor));
+			ownPos->setPos(0, 0);
+
+			// Good for debugging: This draws a cross at the origin
+			// qgsScene->addLine(QLineF(0,-1,0,1), pen);
+			// qgsScene->addLine(QLineF(-1,0,1,0), pen);
+
+			const float speakerScale = 0.9;
+			const float speakerRadius = baseRadius * speakerScale;
+
+			// nspeaker is in format [x1,y1,z1, x2,y2,z2, ...]
 			for (unsigned int i=0;i<nspeaker;++i) {
-				if ((spos[3*i] != 0.0f) || (spos[3*i+1] != 0.0f) || (spos[3*i+2] != 0.0f))
-					qgsScene->addEllipse(QRectF(spos[3*i] - 0.1f, spos[3*i+2] - 0.1f, 0.2f, 0.2f), QPen(Qt::black), QBrush(vermillionColor));
+				if ((spos[3*i] != 0.0f) || (spos[3*i+1] != 0.0f) || (spos[3*i+2] != 0.0f)) {
+					float x = spos[3*i];
+					float z = spos[3*i + 2];
+
+					const float lengthInPlane = std::sqrt(x*x + z*z);
+
+					// Scale the vector in the xz plane so that its length is at least enough for
+					// the speaker icons and the icon for the own pos don't overlap
+					if ((baseRadius + speakerRadius) < lengthInPlane) {
+						const float scaleFactor = (baseRadius + speakerRadius) / lengthInPlane;
+
+						x *= scaleFactor;
+						z *= scaleFactor;
+					}
+
+					QGraphicsEllipseItem *ellipse = qgsScene->addEllipse(QRectF(-speakerRadius, -speakerRadius, 2 * speakerRadius , 2 * speakerRadius), pen, QBrush(vermillionColor));
+					ellipse->setPos(x, z);
+				}
 			}
-			qgiSource = qgsScene->addEllipse(QRectF(-.15f, -.15f, 0.3f, 0.3f), QPen(Qt::black), QBrush(bluishGreenColor));
+
+			const float sourceScale = 0.9;
+			const float sourceRadius = baseRadius * sourceScale;
+
+			qgiSource = qgsScene->addEllipse(QRectF(-sourceRadius, -sourceRadius, 2 * sourceRadius, 2 * sourceRadius), pen, QBrush(bluishGreenColor));
+			qgiSource->setPos(0, (sourceRadius + baseRadius) * 1.5);
+
 			qgvView->setScene(qgsScene);
 			qgvView->fitInView(-4.0f, -4.0f, 8.0f, 8.0f, Qt::KeepAspectRatio);
 		}

--- a/src/mumble/AudioWizard.ui
+++ b/src/mumble/AudioWizard.ui
@@ -27,12 +27,7 @@
     <item>
      <widget class="QLabel" name="label">
       <property name="text">
-       <string>&lt;p&gt;
-This is the audio tuning wizard for Mumble. This will help you correctly set the input levels of your sound card, and also set the correct parameters for sound processing in Mumble.
-&lt;/p&gt;
-&lt;p&gt;
-Please be aware that as long as this wizard is active, audio will be looped locally to allow you to listen to it, and no audio will be sent to the server.
-&lt;/p&gt;</string>
+       <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;This is the audio tuning wizard for Mumble. This will help you correctly set the input levels of your sound card, and also set the correct parameters for sound processing in Mumble. &lt;/p&gt;&lt;p&gt;Please be aware that as long as this wizard is active, audio will be looped locally to allow you to listen to it, and no audio will be sent to the server. &lt;/p&gt;&lt;p&gt;Note that you can cancel this wizard at any time without it having an effect on your current audio systems. The settings are only once this wizard has been completed.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
       </property>
       <property name="wordWrap">
        <bool>true</bool>
@@ -503,7 +498,16 @@ Speak loudly, as when you are annoyed or excited. Decrease the volume in the sou
     <item row="5" column="0" colspan="2">
      <widget class="QWidget" name="qwVAD" native="true">
       <layout class="QVBoxLayout" name="verticalLayout_6">
-       <property name="margin">
+       <property name="leftMargin">
+        <number>0</number>
+       </property>
+       <property name="topMargin">
+        <number>0</number>
+       </property>
+       <property name="rightMargin">
+        <number>0</number>
+       </property>
+       <property name="bottomMargin">
         <number>0</number>
        </property>
        <item>

--- a/src/mumble/AudioWizard.ui
+++ b/src/mumble/AudioWizard.ui
@@ -32,6 +32,9 @@
       <property name="wordWrap">
        <bool>true</bool>
       </property>
+      <property name="textInteractionFlags">
+       <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByMouse</set>
+      </property>
      </widget>
     </item>
     <item>
@@ -251,6 +254,9 @@ You should hear a voice sample. Change the slider below to the lowest value whic
       <property name="wordWrap">
        <bool>true</bool>
       </property>
+      <property name="textInteractionFlags">
+       <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByMouse</set>
+      </property>
      </widget>
     </item>
     <item row="1" column="0">
@@ -334,6 +340,9 @@ Speak loudly, as when you are annoyed or excited. Decrease the volume in the sou
       <property name="wordWrap">
        <bool>true</bool>
       </property>
+      <property name="textInteractionFlags">
+       <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByMouse</set>
+      </property>
      </widget>
     </item>
     <item>
@@ -349,6 +358,9 @@ Speak loudly, as when you are annoyed or excited. Decrease the volume in the sou
       </property>
       <property name="wordWrap">
        <bool>true</bool>
+      </property>
+      <property name="textInteractionFlags">
+       <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByMouse</set>
       </property>
      </widget>
     </item>
@@ -370,6 +382,9 @@ Speak loudly, as when you are annoyed or excited. Decrease the volume in the sou
       <property name="wordWrap">
        <bool>true</bool>
       </property>
+      <property name="textInteractionFlags">
+       <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByMouse</set>
+      </property>
      </widget>
     </item>
     <item>
@@ -382,6 +397,9 @@ Speak loudly, as when you are annoyed or excited. Decrease the volume in the sou
       </property>
       <property name="wordWrap">
        <bool>true</bool>
+      </property>
+      <property name="textInteractionFlags">
+       <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByMouse</set>
       </property>
      </widget>
     </item>
@@ -459,6 +477,9 @@ Speak loudly, as when you are annoyed or excited. Decrease the volume in the sou
       <property name="wordWrap">
        <bool>true</bool>
       </property>
+      <property name="textInteractionFlags">
+       <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByMouse</set>
+      </property>
      </widget>
     </item>
     <item row="1" column="0">
@@ -528,6 +549,9 @@ Speak loudly, as when you are annoyed or excited. Decrease the volume in the sou
          <property name="wordWrap">
           <bool>true</bool>
          </property>
+         <property name="textInteractionFlags">
+          <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByMouse</set>
+         </property>
         </widget>
        </item>
        <item>
@@ -537,6 +561,9 @@ Speak loudly, as when you are annoyed or excited. Decrease the volume in the sou
          </property>
          <property name="wordWrap">
           <bool>true</bool>
+         </property>
+         <property name="textInteractionFlags">
+          <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByMouse</set>
          </property>
         </widget>
        </item>
@@ -631,6 +658,9 @@ Speak loudly, as when you are annoyed or excited. Decrease the volume in the sou
          <property name="wordWrap">
           <bool>true</bool>
          </property>
+         <property name="textInteractionFlags">
+          <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByMouse</set>
+         </property>
         </widget>
        </item>
        <item row="1" column="0">
@@ -657,6 +687,9 @@ Speak loudly, as when you are annoyed or excited. Decrease the volume in the sou
          <property name="wordWrap">
           <bool>true</bool>
          </property>
+         <property name="textInteractionFlags">
+          <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByMouse</set>
+         </property>
         </widget>
        </item>
        <item row="2" column="0">
@@ -680,6 +713,9 @@ Speak loudly, as when you are annoyed or excited. Decrease the volume in the sou
          <property name="wordWrap">
           <bool>true</bool>
          </property>
+         <property name="textInteractionFlags">
+          <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByMouse</set>
+         </property>
         </widget>
        </item>
        <item row="3" column="0">
@@ -693,6 +729,9 @@ Speak loudly, as when you are annoyed or excited. Decrease the volume in the sou
         <widget class="QLabel" name="qlQualityCustom">
          <property name="text">
           <string>You already set a customized quality configuration in Mumble. Select this setting to keep it.</string>
+         </property>
+         <property name="textInteractionFlags">
+          <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByMouse</set>
          </property>
         </widget>
        </item>
@@ -763,6 +802,9 @@ Speak loudly, as when you are annoyed or excited. Decrease the volume in the sou
       <property name="wordWrap">
        <bool>true</bool>
       </property>
+      <property name="textInteractionFlags">
+       <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByMouse</set>
+      </property>
      </widget>
     </item>
     <item>
@@ -817,6 +859,9 @@ Mumble is under continuous development, and the development team wants to focus 
       </property>
       <property name="wordWrap">
        <bool>true</bool>
+      </property>
+      <property name="textInteractionFlags">
+       <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByMouse</set>
       </property>
      </widget>
     </item>

--- a/src/mumble/AudioWizard.ui
+++ b/src/mumble/AudioWizard.ui
@@ -758,13 +758,7 @@ Speak loudly, as when you are annoyed or excited. Decrease the volume in the sou
     <item>
      <widget class="QLabel" name="qliPositionalText">
       <property name="text">
-       <string>&lt;p&gt;
-Mumble supports positional audio for some games, and will position the voice of other users relative to their position in game. Depending on their position, the volume of the voice will be changed between the speakers to simulate the direction and distance the other user is at. Such positioning depends on your speaker configuration being correct in your operating system, so a test is done here.
-&lt;/p&gt;
-&lt;p&gt;
-The graph below shows the position of &lt;font color=&quot;#56b4e9&quot;&gt;you&lt;/font&gt;, the &lt;font color=&quot;#d55e00&quot;&gt;speakers&lt;/font&gt; and a &lt;font color=&quot;#009e73&quot;&gt;moving sound source&lt;/font&gt; as if seen from above. You should hear the audio move between the channels.
-&lt;/p&gt;
-</string>
+       <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Mumble supports positional audio for some games, and will position the voice of other users relative to their position in game. Depending on their position, the volume of the voice will be changed between the speakers to simulate the direction and distance the other user is at. Such positioning depends on your speaker configuration being correct in your operating system, so a test is done here. &lt;/p&gt;&lt;p&gt;The graph below shows the position of &lt;span style=&quot; color:#56b4e9;&quot;&gt;you&lt;/span&gt;, the &lt;span style=&quot; color:#d55e00;&quot;&gt;speakers&lt;/span&gt; and a &lt;span style=&quot; color:#009e73;&quot;&gt;moving sound source&lt;/span&gt; as if seen from above. You should hear the audio move between the channels. &lt;/p&gt;&lt;p&gt;You can also use your mouse to position the &lt;span style=&quot; color:#009e73;&quot;&gt;sound source&lt;/span&gt; manually.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
       </property>
       <property name="wordWrap">
        <bool>true</bool>

--- a/src/mumble/AudioWizard.ui
+++ b/src/mumble/AudioWizard.ui
@@ -758,7 +758,7 @@ Speak loudly, as when you are annoyed or excited. Decrease the volume in the sou
 Mumble supports positional audio for some games, and will position the voice of other users relative to their position in game. Depending on their position, the volume of the voice will be changed between the speakers to simulate the direction and distance the other user is at. Such positioning depends on your speaker configuration being correct in your operating system, so a test is done here.
 &lt;/p&gt;
 &lt;p&gt;
-The graph below shows the position of &lt;font color=&quot;red&quot;&gt;you&lt;/font&gt;, the &lt;font color=&quot;yellow&quot;&gt;speakers&lt;/font&gt; and a &lt;font color=&quot;green&quot;&gt;moving sound source&lt;/font&gt; as if seen from above. You should hear the audio move between the channels.
+The graph below shows the position of &lt;font color=&quot;#56b4e9&quot;&gt;you&lt;/font&gt;, the &lt;font color=&quot;#d55e00&quot;&gt;speakers&lt;/font&gt; and a &lt;font color=&quot;#009e73&quot;&gt;moving sound source&lt;/font&gt; as if seen from above. You should hear the audio move between the channels.
 &lt;/p&gt;
 </string>
       </property>

--- a/src/mumble/mumble_en.ts
+++ b/src/mumble/mumble_en.ts
@@ -1549,15 +1549,6 @@ This value allows you to set the maximum number of users allowed in the channel.
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>&lt;p&gt;
-This is the audio tuning wizard for Mumble. This will help you correctly set the input levels of your sound card, and also set the correct parameters for sound processing in Mumble.
-&lt;/p&gt;
-&lt;p&gt;
-Please be aware that as long as this wizard is active, audio will be looped locally to allow you to listen to it, and no audio will be sent to the server.
-&lt;/p&gt;</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Input Device</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1603,16 +1594,6 @@ Speak loudly, as when you are annoyed or excited. Decrease the volume in the sou
     </message>
     <message>
         <source>Adjusting attenuation of positional audio.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>&lt;p&gt;
-Mumble supports positional audio for some games, and will position the voice of other users relative to their position in game. Depending on their position, the volume of the voice will be changed between the speakers to simulate the direction and distance the other user is at. Such positioning depends on your speaker configuration being correct in your operating system, so a test is done here.
-&lt;/p&gt;
-&lt;p&gt;
-The graph below shows the position of &lt;font color=&quot;red&quot;&gt;you&lt;/font&gt;, the &lt;font color=&quot;yellow&quot;&gt;speakers&lt;/font&gt; and a &lt;font color=&quot;green&quot;&gt;moving sound source&lt;/font&gt; as if seen from above. You should hear the audio move between the channels.
-&lt;/p&gt;
-</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -1808,6 +1789,14 @@ Speak loudly, as when you are annoyed or excited. Decrease the volume in the sou
     </message>
     <message>
         <source>&lt;b&gt;This is the Output method to use for audio.&lt;/b&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;This is the audio tuning wizard for Mumble. This will help you correctly set the input levels of your sound card, and also set the correct parameters for sound processing in Mumble. &lt;/p&gt;&lt;p&gt;Please be aware that as long as this wizard is active, audio will be looped locally to allow you to listen to it, and no audio will be sent to the server. &lt;/p&gt;&lt;p&gt;Note that you can cancel this wizard at any time without it having an effect on your current audio systems. The settings are only once this wizard has been completed.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Mumble supports positional audio for some games, and will position the voice of other users relative to their position in game. Depending on their position, the volume of the voice will be changed between the speakers to simulate the direction and distance the other user is at. Such positioning depends on your speaker configuration being correct in your operating system, so a test is done here. &lt;/p&gt;&lt;p&gt;The graph below shows the position of &lt;span style=&quot; color:#56b4e9;&quot;&gt;you&lt;/span&gt;, the &lt;span style=&quot; color:#d55e00;&quot;&gt;speakers&lt;/span&gt; and a &lt;span style=&quot; color:#009e73;&quot;&gt;moving sound source&lt;/span&gt; as if seen from above. You should hear the audio move between the channels. &lt;/p&gt;&lt;p&gt;You can also use your mouse to position the &lt;span style=&quot; color:#009e73;&quot;&gt;sound source&lt;/span&gt; manually.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
 </context>


### PR DESCRIPTION
This PR improves the appearance of the AudioWizard by performing the following steps:
* Include a commit of @mkrautz that fixes #2735 (use colors in which the text is actually readable)
* Make the showcase for the positional audio render properly (not this pixelated mess it was before)
* Add some additional explanations and clarifications
* Make explanatory texts selectable. Fixes #4002 

-----
This is how the positional audio showcase renders after this PR:
![Mumble_AudioWizard_PosAudio](https://user-images.githubusercontent.com/12751591/80192456-7e539c80-8617-11ea-810e-397cf43ca56e.png)


Changelog
```
| Improved: Appearance & Accessibility of AudioWizard
```