### PR TITLE
qmake/compiler.pri: ignore LNK4099 warning

### DIFF
--- a/qmake/compiler.pri
+++ b/qmake/compiler.pri
@@ -201,6 +201,9 @@ win32-msvc* {
 		QMAKE_LFLAGS *= /DEBUG /OPT:REF /OPT:ICF /INCREMENTAL:NO
 	}
 
+	# Ignore LNK4099.
+	QMAKE_LFLAGS *= /ignore:4099
+
 	CONFIG(vld) {
 		CONFIG(debug, debug|release) {
 			DEFINES *= USE_VLD


### PR DESCRIPTION
```
libeay32.lib(aes_misc.obj) : warning LNK4099: PDB 'lib.pdb' was not found with 'libeay32.lib(aes_misc.obj)' or at 'D:\a\1\s\release\lib.pdb'; linking object as if no debug info
LINK : error LNK1218: warning treated as error; no output file generated
```

openssl/openssl#8939