### PR TITLE
Fix qtconcurrent include path

### DIFF
--- a/src/mumble/VersionCheck.cpp
+++ b/src/mumble/VersionCheck.cpp
@@ -17,7 +17,7 @@
 #include <QtXml/QDomDocument>
 #include <QtWidgets/QMessageBox>
 
-#include <QtConcurrent>
+#include <QtConcurrent/QtConcurrent>
 
 #ifdef Q_OS_WIN
 # include <shellapi.h>


### PR DESCRIPTION
The include for QtConcurrent produces an error in 1.4.0 build using the cmake project with MSVC 142 (Visual Studio 2019). This fixes the path not found error