### PR TITLE
Improve echo cancellation settings ui

### DIFF
--- a/src/mumble/ASIOInput.cpp
+++ b/src/mumble/ASIOInput.cpp
@@ -18,6 +18,8 @@
 // From os_win.cpp.
 extern HWND mumble_mw_hwnd;
 
+const QString ASIOConfig::name = QLatin1String("ASIOConfig");
+
 class ASIOAudioInputRegistrar : public AudioInputRegistrar {
 	public:
 		ASIOAudioInputRegistrar();
@@ -323,6 +325,10 @@ void ASIOConfig::on_qpbRemSpeaker_clicked() {
 
 QString ASIOConfig::title() const {
 	return tr("ASIO");
+}
+
+const QString &ASIOConfig::getName() const {
+	return ASIOConfig::name;
 }
 
 QIcon ASIOConfig::icon() const {

--- a/src/mumble/ASIOInput.h
+++ b/src/mumble/ASIOInput.h
@@ -32,8 +32,11 @@ class ASIOConfig : public ConfigWidget, public Ui::ASIOConfig {
 		QList<ASIODev> qlDevs;
 		bool bOk;
 	public:
+		/// The unique name of this ConfigWidget
+		static const QString name;
 		ASIOConfig(Settings &st);
 		virtual QString title() const Q_DECL_OVERRIDE;
+		virtual const QString &getName() const Q_DECL_OVERRIDE;
 		virtual QIcon icon() const Q_DECL_OVERRIDE;
 	public slots:
 		void save() const Q_DECL_OVERRIDE;

--- a/src/mumble/AudioConfigDialog.cpp
+++ b/src/mumble/AudioConfigDialog.cpp
@@ -407,7 +407,14 @@ void AudioInputDialog::updateEchoEnableState() {
 		outputInterface = s.qsAudioOutput;
 	}
 
-	qcbEcho->setEnabled(air->canEcho(outputInterface));
+	if (air->canEcho(outputInterface)) {
+		qcbEcho->setEnabled(true);
+		qcbEcho->setToolTip(QObject::tr("Cancel echo from speakers"));
+	} else {
+		qcbEcho->setEnabled(false);
+		qcbEcho->setToolTip(QObject::tr("Echo cancellation is not supported for the interface "
+					"combination \"%1\" (in) and \"%2\" (out).").arg(air->name).arg(outputInterface));
+	}
 }
 
 void AudioInputDialog::on_Tick_timeout() {

--- a/src/mumble/AudioConfigDialog.cpp
+++ b/src/mumble/AudioConfigDialog.cpp
@@ -43,6 +43,10 @@
 #include "NetworkConfig.h"
 #include "Utils.h"
 
+const QString AudioOutputDialog::name = QLatin1String("AudioOutputWidget");
+const QString AudioInputDialog::name = QLatin1String("AudioInputWidget");
+
+
 static ConfigWidget *AudioInputDialogNew(Settings &st) {
 	return new AudioInputDialog(st);
 }
@@ -93,6 +97,10 @@ AudioInputDialog::AudioInputDialog(Settings &st) : ConfigWidget(st) {
 
 QString AudioInputDialog::title() const {
 	return tr("Audio Input");
+}
+
+const QString &AudioInputDialog::getName() const {
+	return AudioInputDialog::name;
 }
 
 QIcon AudioInputDialog::icon() const {
@@ -431,6 +439,10 @@ AudioOutputDialog::AudioOutputDialog(Settings &st) : ConfigWidget(st) {
 
 QString AudioOutputDialog::title() const {
 	return tr("Audio Output");
+}
+
+const QString &AudioOutputDialog::getName() const {
+	return AudioOutputDialog::name;
 }
 
 QIcon AudioOutputDialog::icon() const {

--- a/src/mumble/AudioConfigDialog.h
+++ b/src/mumble/AudioConfigDialog.h
@@ -21,8 +21,11 @@ class AudioInputDialog : public ConfigWidget, public Ui::AudioInput {
 		void showEvent(QShowEvent *event) Q_DECL_OVERRIDE;
 
 	public:
+		/// The unique name of this ConfigWidget
+		static const QString name;
 		AudioInputDialog(Settings &st);
 		QString title() const Q_DECL_OVERRIDE;
+		const QString &getName() const Q_DECL_OVERRIDE;
 		QIcon icon() const Q_DECL_OVERRIDE;
 
 	public slots:
@@ -55,8 +58,11 @@ class AudioOutputDialog : public ConfigWidget, public Ui::AudioOutput {
 		Q_OBJECT
 		Q_DISABLE_COPY(AudioOutputDialog)
 	public:
+		/// The unique name of this ConfigWidget
+		static const QString name;
 		AudioOutputDialog(Settings &st);
 		QString title() const Q_DECL_OVERRIDE;
+		const QString &getName() const Q_DECL_OVERRIDE;
 		QIcon icon() const Q_DECL_OVERRIDE;
 	public slots:
 		void save() const Q_DECL_OVERRIDE;

--- a/src/mumble/AudioConfigDialog.h
+++ b/src/mumble/AudioConfigDialog.h
@@ -19,6 +19,7 @@ class AudioInputDialog : public ConfigWidget, public Ui::AudioInput {
 		QTimer *qtTick;
 		void hideEvent(QHideEvent *event) Q_DECL_OVERRIDE;
 		void showEvent(QShowEvent *event) Q_DECL_OVERRIDE;
+		void updateEchoEnableState();
 
 	public:
 		/// The unique name of this ConfigWidget
@@ -64,6 +65,8 @@ class AudioOutputDialog : public ConfigWidget, public Ui::AudioOutput {
 		QString title() const Q_DECL_OVERRIDE;
 		const QString &getName() const Q_DECL_OVERRIDE;
 		QIcon icon() const Q_DECL_OVERRIDE;
+		/// @returns The name of the currently selected audio output interface
+		QString getCurrentlySelectedOutputInterfaceName() const;
 	public slots:
 		void save() const Q_DECL_OVERRIDE;
 		void load(const Settings &r) Q_DECL_OVERRIDE;

--- a/src/mumble/AudioInput.ui
+++ b/src/mumble/AudioInput.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>588</width>
-    <height>794</height>
+    <height>811</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -123,7 +123,7 @@
       <item row="1" column="4">
        <widget class="MUComboBox" name="qcbEcho">
         <property name="toolTip">
-         <string>Cancel echo from speakers</string>
+         <string/>
         </property>
         <property name="whatsThis">
          <string>Enabling this will cancel the echo from your speakers. Mixed has low CPU impact, but only works well if your speakers are equally loud and equidistant from the microphone. Multichannel echo cancellation provides much better echo cancellation, but at a higher CPU cost.</string>

--- a/src/mumble/ConfigDialog.h
+++ b/src/mumble/ConfigDialog.h
@@ -11,11 +11,15 @@
 
 #include "ui_ConfigDialog.h"
 
+#include <QtCore/QMutex>
+
 class ConfigDialog : public QDialog, public Ui::ConfigDialog {
 	private:
 		Q_OBJECT
 		Q_DISABLE_COPY(ConfigDialog)
 	protected:
+		static QMutex s_existingWidgetsMutex;
+		static QHash<QString, ConfigWidget *> s_existingWidgets;
 		QHash<ConfigWidget *, QWidget *> qhPages;
 		QMap<unsigned int, ConfigWidget *> qmWidgets;
 		QMap<QListWidgetItem *, ConfigWidget *> qmIconWidgets;
@@ -26,6 +30,10 @@ class ConfigDialog : public QDialog, public Ui::ConfigDialog {
 	public:
 		ConfigDialog(QWidget *p = NULL);
 		~ConfigDialog() Q_DECL_OVERRIDE;
+
+		/// @returns The pointer to the existing ConfigWidget with the given name or nullptr,
+		/// 	if no such widget exists.
+		static ConfigWidget *getConfigWidget(const QString &name);
 	public slots:
 		void on_pageButtonBox_clicked(QAbstractButton *);
 		void on_dialogButtonBox_clicked(QAbstractButton *);

--- a/src/mumble/ConfigWidget.h
+++ b/src/mumble/ConfigWidget.h
@@ -30,6 +30,7 @@ class ConfigWidget : public QWidget {
 		Settings &s;
 		ConfigWidget(Settings &st);
 		virtual QString title() const = 0;
+		virtual const QString &getName() const = 0;
 		virtual QIcon icon() const;
 	public slots:
 		virtual void accept() const;

--- a/src/mumble/GlobalShortcut.cpp
+++ b/src/mumble/GlobalShortcut.cpp
@@ -24,6 +24,8 @@
 // We define a global macro called 'g'. This can lead to issues when included code uses 'g' as a type or parameter name (like protobuf 3.7 does). As such, for now, we have to make this our last include.
 #include "Global.h"
 
+const QString GlobalShortcutConfig::name = QLatin1String("GlobalShortcutConfig");
+
 /**
  * Used to save the global, unique, platform specific GlobalShortcutEngine.
  */
@@ -700,6 +702,10 @@ void GlobalShortcutConfig::on_qtwShortcuts_itemChanged(QTreeWidgetItem *item, in
 
 QString GlobalShortcutConfig::title() const {
 	return tr("Shortcuts");
+}
+
+const QString &GlobalShortcutConfig::getName() const {
+	return GlobalShortcutConfig::name;
 }
 
 QIcon GlobalShortcutConfig::icon() const {

--- a/src/mumble/GlobalShortcut.h
+++ b/src/mumble/GlobalShortcut.h
@@ -185,8 +185,11 @@ class GlobalShortcutConfig : public ConfigWidget, public Ui::GlobalShortcut {
 		bool showWarning() const;
 		bool eventFilter(QObject *, QEvent *) Q_DECL_OVERRIDE;
 	public:
+		/// The unique name of this ConfigWidget
+		static const QString name;
 		GlobalShortcutConfig(Settings &st);
 		virtual QString title() const Q_DECL_OVERRIDE;
+		virtual const QString &getName() const Q_DECL_OVERRIDE;
 		virtual QIcon icon() const Q_DECL_OVERRIDE;
 	public slots:
 		void accept() const Q_DECL_OVERRIDE;

--- a/src/mumble/LCD.cpp
+++ b/src/mumble/LCD.cpp
@@ -16,6 +16,8 @@
 // We define a global macro called 'g'. This can lead to issues when included code uses 'g' as a type or parameter name (like protobuf 3.7 does). As such, for now, we have to make this our last include.
 #include "Global.h"
 
+const QString LCDConfig::name = QLatin1String("LCDConfig");
+
 QList<LCDEngineNew> *LCDEngineRegistrar::qlInitializers;
 
 LCDEngineRegistrar::LCDEngineRegistrar(LCDEngineNew cons) {
@@ -102,6 +104,10 @@ LCDConfig::LCDConfig(Settings &st) : ConfigWidget(st) {
 
 QString LCDConfig::title() const {
 	return tr("LCD");
+}
+
+const QString &LCDConfig::getName() const {
+	return LCDConfig::name;
 }
 
 QIcon LCDConfig::icon() const {

--- a/src/mumble/LCD.h
+++ b/src/mumble/LCD.h
@@ -19,8 +19,11 @@ class LCDConfig : public ConfigWidget, public Ui::LCDConfig {
 		Q_OBJECT
 		Q_DISABLE_COPY(LCDConfig)
 	public:
+		/// The unique name of this ConfigWidget
+		static const QString name;
 		LCDConfig(Settings &st);
 		QString title() const Q_DECL_OVERRIDE;
+		const QString &getName() const Q_DECL_OVERRIDE;
 		QIcon icon() const Q_DECL_OVERRIDE;
 	public slots:
 		void on_qsMinColWidth_valueChanged(int v);

--- a/src/mumble/Log.cpp
+++ b/src/mumble/Log.cpp
@@ -29,6 +29,8 @@
 // We define a global macro called 'g'. This can lead to issues when included code uses 'g' as a type or parameter name (like protobuf 3.7 does). As such, for now, we have to make this our last include.
 #include "Global.h"
 
+const QString LogConfig::name = QLatin1String("LogConfig");
+
 static ConfigWidget *LogConfigDialogNew(Settings &st) {
 	return new LogConfig(st);
 }
@@ -83,6 +85,10 @@ LogConfig::LogConfig(Settings &st) : ConfigWidget(st) {
 
 QString LogConfig::title() const {
 	return windowTitle();
+}
+
+const QString &LogConfig::getName() const {
+	return LogConfig::name;
 }
 
 QIcon LogConfig::icon() const {

--- a/src/mumble/Log.h
+++ b/src/mumble/Log.h
@@ -24,9 +24,12 @@ class LogConfig : public ConfigWidget, public Ui::LogConfig {
 		Q_OBJECT
 		Q_DISABLE_COPY(LogConfig)
 	public:
+		/// The unique name of this ConfigWidget
+		static const QString name;
 		enum Column { ColMessage, ColConsole, ColNotification, ColHighlight, ColTTS, ColStaticSound, ColStaticSoundPath };
 		LogConfig(Settings &st);
 		QString title() const Q_DECL_OVERRIDE;
+		const QString &getName() const Q_DECL_OVERRIDE;
 		QIcon icon() const Q_DECL_OVERRIDE;
 	public slots:
 		void accept() const Q_DECL_OVERRIDE;

--- a/src/mumble/LookConfig.cpp
+++ b/src/mumble/LookConfig.cpp
@@ -17,6 +17,8 @@
 // We define a global macro called 'g'. This can lead to issues when included code uses 'g' as a type or parameter name (like protobuf 3.7 does). As such, for now, we have to make this our last include.
 #include "Global.h"
 
+const QString LookConfig::name = QLatin1String("LookConfig");
+
 static ConfigWidget *LookConfigNew(Settings &st) {
 	return new LookConfig(st);
 }
@@ -91,6 +93,10 @@ LookConfig::LookConfig(Settings &st) : ConfigWidget(st) {
 
 QString LookConfig::title() const {
 	return tr("User Interface");
+}
+
+const QString &LookConfig::getName() const {
+	return LookConfig::name;
 }
 
 QIcon LookConfig::icon() const {

--- a/src/mumble/LookConfig.h
+++ b/src/mumble/LookConfig.h
@@ -19,8 +19,11 @@ class LookConfig : public ConfigWidget, Ui::LookConfig {
 		Q_OBJECT
 		Q_DISABLE_COPY(LookConfig)
 	public:
+		/// The unique name of this ConfigWidget
+		static const QString name;
 		LookConfig(Settings &st);
 		virtual QString title() const Q_DECL_OVERRIDE;
+		virtual const QString &getName() const Q_DECL_OVERRIDE;
 		virtual QIcon icon() const Q_DECL_OVERRIDE;
 
 	public slots:

--- a/src/mumble/NetworkConfig.cpp
+++ b/src/mumble/NetworkConfig.cpp
@@ -15,6 +15,8 @@
 // We define a global macro called 'g'. This can lead to issues when included code uses 'g' as a type or parameter name (like protobuf 3.7 does). As such, for now, we have to make this our last include.
 #include "Global.h"
 
+const QString NetworkConfig::name = QLatin1String("NetworkConfig");
+
 static ConfigWidget *NetworkConfigNew(Settings &st) {
 	return new NetworkConfig(st);
 }
@@ -31,6 +33,10 @@ NetworkConfig::NetworkConfig(Settings &st) : ConfigWidget(st) {
 
 QString NetworkConfig::title() const {
 	return tr("Network");
+}
+
+const QString &NetworkConfig::getName() const {
+	return NetworkConfig::name;
 }
 
 QIcon NetworkConfig::icon() const {

--- a/src/mumble/NetworkConfig.h
+++ b/src/mumble/NetworkConfig.h
@@ -18,8 +18,11 @@ class NetworkConfig : public ConfigWidget, Ui::NetworkConfig {
 		Q_OBJECT
 		Q_DISABLE_COPY(NetworkConfig)
 	public:
+		/// The unique name of this ConfigWidget
+		static const QString name;
 		NetworkConfig(Settings &st);
 		virtual QString title() const Q_DECL_OVERRIDE;
+		virtual const QString &getName() const Q_DECL_OVERRIDE;
 		virtual QIcon icon() const Q_DECL_OVERRIDE;
 		static void SetupProxy();
 		static bool TcpModeEnabled();

--- a/src/mumble/OverlayConfig.cpp
+++ b/src/mumble/OverlayConfig.cpp
@@ -36,6 +36,8 @@
 // We define a global macro called 'g'. This can lead to issues when included code uses 'g' as a type or parameter name (like protobuf 3.7 does). As such, for now, we have to make this our last include.
 #include "Global.h"
 
+const QString OverlayConfig::name = QLatin1String("OverlayConfig");
+
 static const int OVERLAYCONFIG_PATH_ROLE = Qt::UserRole;
 static const int OVERLAYCONFIG_BUILTIN_ROLE = Qt::UserRole + 1;
 
@@ -414,6 +416,10 @@ void OverlayConfig::load(const Settings &r) {
 
 QString OverlayConfig::title() const {
 	return tr("Overlay");
+}
+
+const QString &OverlayConfig::getName() const {
+	return OverlayConfig::name;
 }
 
 QIcon OverlayConfig::icon() const {

--- a/src/mumble/OverlayConfig.h
+++ b/src/mumble/OverlayConfig.h
@@ -86,8 +86,11 @@ class OverlayConfig : public ConfigWidget, public Ui::OverlayConfig {
 		void resizeScene(bool force=false);
 
 	public:
+		/// The uniqe name of this ConfigWidget
+		static const QString name;
 		OverlayConfig(Settings &st);
 		virtual QString title() const Q_DECL_OVERRIDE;
+		virtual const QString &getName() const Q_DECL_OVERRIDE;
 		virtual QIcon icon() const Q_DECL_OVERRIDE;
 	public slots:
 		void accept() const Q_DECL_OVERRIDE;

--- a/src/mumble/Plugins.cpp
+++ b/src/mumble/Plugins.cpp
@@ -33,6 +33,8 @@
 // We define a global macro called 'g'. This can lead to issues when included code uses 'g' as a type or parameter name (like protobuf 3.7 does). As such, for now, we have to make this our last include.
 #include "Global.h"
 
+const QString PluginConfig::name = QLatin1String("PluginConfig");
+
 static ConfigWidget *PluginConfigDialogNew(Settings &st) {
 	return new PluginConfig(st);
 }
@@ -81,6 +83,10 @@ PluginConfig::PluginConfig(Settings &st) : ConfigWidget(st) {
 
 QString PluginConfig::title() const {
 	return tr("Plugins");
+}
+
+const QString &PluginConfig::getName() const {
+	return PluginConfig::name;
 }
 
 QIcon PluginConfig::icon() const {

--- a/src/mumble/Plugins.h
+++ b/src/mumble/Plugins.h
@@ -29,8 +29,11 @@ class PluginConfig : public ConfigWidget, public Ui::PluginConfig {
 		void refillPluginList();
 		PluginInfo *pluginForItem(QTreeWidgetItem *) const;
 	public:
+		/// The unique name of this ConfigWidget
+		static const QString name;
 		PluginConfig(Settings &st);
 		virtual QString title() const Q_DECL_OVERRIDE;
+		const QString &getName() const Q_DECL_OVERRIDE;
 		virtual QIcon icon() const Q_DECL_OVERRIDE;
 	public slots:
 		void save() const Q_DECL_OVERRIDE;


### PR DESCRIPTION
This PR makes sure that the enablement of the echo cancellation ComboBox in the setting is done correctly (and on-the-fly: No need to press `Apply` for this to work) and if it is disabled, a tooltip will explain why.

Fixes #4110 

Changelog
```
| Improved: Echo cancellation setting in the UI is now much more intuitive in regards to when and why it is disabled
```