### PR TITLE
Fix ChannelListener not hearing shout if no real user is in shouted channel

### DIFF
--- a/src/murmur/Server.h
+++ b/src/murmur/Server.h
@@ -297,6 +297,7 @@ class Server : public QThread {
 		void sendClientPermission(ServerUser *u, Channel *c, bool updatelast = false);
 		void flushClientPermissionCache(ServerUser *u, MumbleProto::PermissionQuery &mpqq);
 		void clearACLCache(User *p = NULL);
+		void clearWhisperTargetCache();
 
 		void sendProtoAll(const ::google::protobuf::Message &msg, unsigned int msgType, unsigned int minversion);
 		void sendProtoExcept(ServerUser *, const ::google::protobuf::Message &msg, unsigned int msgType, unsigned int minversion);

--- a/src/murmur/ServerUser.h
+++ b/src/murmur/ServerUser.h
@@ -60,6 +60,14 @@ struct WhisperTarget {
 	QList<WhisperTarget::Channel> qlChannels;
 };
 
+class ServerUser;
+
+struct WhisperTargetCache {
+	QSet<ServerUser *> channelTargets;
+	QSet<ServerUser *> directTargets;
+	QSet<ServerUser *> listeningTargets;
+};
+
 class Server;
 
 /// A simple implementation for rate-limiting.
@@ -134,8 +142,7 @@ class ServerUser : public Connection, public User {
 		QStringList qslAccessTokens;
 
 		QMap<int, WhisperTarget> qmTargets;
-		typedef QPair<QSet<ServerUser *>, QSet<ServerUser *> > TargetCache;
-		QMap<int, TargetCache> qmTargetCache;
+		QMap<int, WhisperTargetCache> qmTargetCache;
 		QMap<QString, QString> qmWhisperRedirect;
 
 		LeakyBucket leakyBucket;


### PR DESCRIPTION
If you placed a listener proxy into an empty channel and someone was
shouting to that channel, you'd still not hear any of that. This is
because the old processing logic was injected into the code for the
normal shouting feature. However if there is no user in the channel, the
shouting feature won't do anything.

This commit added the listener targets as a separate entry in the
WhisperTargetCache in order for it to be processed independently of
normal shouts. It also had to tweak the logic for how and when to clean
the WhisperTargetCache in order for this to work nicely with
ChannelListeners as well.