### PR TITLE
Added setting for TalkingUI to keep local user visible

### DIFF
--- a/src/mumble/LookConfig.cpp
+++ b/src/mumble/LookConfig.cpp
@@ -179,6 +179,7 @@ void LookConfig::load(const Settings &r) {
 	reloadThemes(configuredStyle);
 
 	qsbSilentUserLifetime->setValue(r.iTalkingUI_SilentUserLifeTime);
+	loadCheckBox(qcbLocalUserVisible, r.bTalkingUI_LocalUserStaysVisible);
 }
 
 void LookConfig::save() const {
@@ -233,6 +234,7 @@ void LookConfig::save() const {
 	}
 
 	s.iTalkingUI_SilentUserLifeTime = qsbSilentUserLifetime->value();
+	s.bTalkingUI_LocalUserStaysVisible = qcbLocalUserVisible->isChecked();
 }
 
 void LookConfig::accept() const {

--- a/src/mumble/LookConfig.ui
+++ b/src/mumble/LookConfig.ui
@@ -103,142 +103,15 @@
      </layout>
     </widget>
    </item>
-   <item row="2" column="1">
-    <widget class="QGroupBox" name="qgbTray">
-     <property name="title">
-      <string>Tray Icon</string>
-     </property>
-     <layout class="QVBoxLayout" name="verticalLayout">
-      <item>
-       <widget class="QCheckBox" name="qcbHideTray">
-        <property name="toolTip">
-         <string>Hide the main Mumble window in the tray when it is minimized.</string>
-        </property>
-        <property name="whatsThis">
-         <string>&lt;b&gt;If set, minimizing the Mumble main window will cause it to be hidden and accessible only from the tray. Otherwise, it will be minimized as a window normally would.&lt;/b&gt;</string>
-        </property>
-        <property name="text">
-         <string>Hide in tray when minimized</string>
-        </property>
-       </widget>
-      </item>
-      <item>
-       <widget class="QCheckBox" name="qcbStateInTray">
-        <property name="toolTip">
-         <string>Displays talking status in system tray</string>
-        </property>
-        <property name="whatsThis">
-         <string/>
-        </property>
-        <property name="text">
-         <string>Show talking status in tray icon</string>
-        </property>
-       </widget>
-      </item>
-     </layout>
-    </widget>
-   </item>
-   <item row="1" column="0" rowspan="3">
-    <widget class="QGroupBox" name="qgbLookFeel">
-     <property name="title">
-      <string>Look and Feel</string>
-     </property>
-     <layout class="QGridLayout" name="gridLayout">
-      <item row="3" column="0" colspan="2">
-       <widget class="MUComboBox" name="qcbLanguage">
-        <property name="toolTip">
-         <string>Language to use (requires restart)</string>
-        </property>
-        <property name="whatsThis">
-         <string>&lt;b&gt;This sets which language Mumble should use.&lt;/b&gt;&lt;br /&gt;You have to restart Mumble to use the new language.</string>
-        </property>
-       </widget>
-      </item>
-      <item row="0" column="0">
-       <widget class="QLabel" name="qliTheme">
-        <property name="text">
-         <string>Theme</string>
-        </property>
-       </widget>
-      </item>
-      <item row="1" column="0" colspan="2">
-       <widget class="MUComboBox" name="qcbTheme">
-        <property name="sizePolicy">
-         <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-          <horstretch>0</horstretch>
-          <verstretch>0</verstretch>
-         </sizepolicy>
-        </property>
-        <property name="toolTip">
-         <string>Theme to use to style the user interface</string>
-        </property>
-        <property name="whatsThis">
-         <string>&lt;b&gt;Configures which theme the Mumble user interface should be styled with&lt;/b&gt;&lt;br /&gt;Mumble will pick up themes from certain directories and display them in this list. The one you select will be used to customize the visual appearance of Mumble. This includes colors, icons and more.</string>
-        </property>
-       </widget>
-      </item>
-      <item row="5" column="0" colspan="2">
-       <widget class="QCheckBox" name="qcbShowTransmitModeComboBox">
-        <property name="text">
-         <string>Show transmit mode dropdown in toolbar</string>
-        </property>
-       </widget>
-      </item>
-      <item row="4" column="0" colspan="2">
-       <widget class="QCheckBox" name="qcbHighContrast">
-        <property name="toolTip">
-         <string>Apply some high contrast optimizations for visually impaired users</string>
-        </property>
-        <property name="text">
-         <string>Optimize for high contrast</string>
-        </property>
-       </widget>
-      </item>
-      <item row="6" column="0">
-       <spacer name="verticalSpacer">
-        <property name="orientation">
-         <enum>Qt::Vertical</enum>
-        </property>
-        <property name="sizeHint" stdset="0">
-         <size>
-          <width>20</width>
-          <height>40</height>
-         </size>
-        </property>
-       </spacer>
-      </item>
-      <item row="2" column="0">
-       <widget class="QLabel" name="qliLanguage">
-        <property name="text">
-         <string>Language</string>
-        </property>
-        <property name="buddy">
-         <cstring>qcbLanguage</cstring>
-        </property>
-       </widget>
-      </item>
-      <item row="0" column="1">
-       <widget class="QLabel" name="qlThemesDirectory">
-        <property name="text">
-         <string/>
-        </property>
-        <property name="alignment">
-         <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-        </property>
-       </widget>
-      </item>
-     </layout>
-    </widget>
-   </item>
    <item row="5" column="1">
-    <spacer name="verticalSpacer_2">
+    <spacer name="horizontalSpacer">
      <property name="orientation">
-      <enum>Qt::Vertical</enum>
+      <enum>Qt::Horizontal</enum>
      </property>
      <property name="sizeHint" stdset="0">
       <size>
-       <width>20</width>
-       <height>40</height>
+       <width>40</width>
+       <height>20</height>
       </size>
      </property>
     </spacer>
@@ -445,43 +318,29 @@
      </layout>
     </widget>
    </item>
+   <item row="6" column="1">
+    <spacer name="verticalSpacer_2">
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>20</width>
+       <height>40</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
    <item row="3" column="1">
     <widget class="QGroupBox" name="qgbChannel">
      <property name="title">
       <string>Channel Tree</string>
      </property>
      <layout class="QGridLayout" name="gridLayout_2" columnstretch="0,0">
-      <item row="0" column="0">
-       <widget class="QLabel" name="qliChannelDrag">
-        <property name="text">
-         <string>Channel Dragging</string>
-        </property>
-       </widget>
-      </item>
-      <item row="0" column="1">
-       <widget class="MUComboBox" name="qcbChannelDrag">
-        <property name="toolTip">
-         <string>This changes the behavior when moving channels.</string>
-        </property>
-        <property name="whatsThis">
-         <string>This sets the behavior of channel drags; it can be used to prevent accidental dragging. &lt;i&gt;Move&lt;/i&gt; moves the channel without prompting. &lt;i&gt;Do Nothing&lt;/i&gt; does nothing and prints an error message. &lt;i&gt;Ask&lt;/i&gt; uses a message box to confirm if you really wanted to move the channel.</string>
-        </property>
-       </widget>
-      </item>
       <item row="1" column="0">
        <widget class="QLabel" name="qliUserDrag">
         <property name="text">
          <string>User Dragging</string>
-        </property>
-       </widget>
-      </item>
-      <item row="1" column="1">
-       <widget class="MUComboBox" name="qcbUserDrag">
-        <property name="toolTip">
-         <string>This changes the behavior when moving users.</string>
-        </property>
-        <property name="whatsThis">
-         <string>This sets the behavior of user drags; it can be used to prevent accidental dragging. &lt;i&gt;Move&lt;/i&gt; moves the user without prompting. &lt;i&gt;Do Nothing&lt;/i&gt; does nothing and prints an error message. &lt;i&gt;Ask&lt;/i&gt; uses a message box to confirm if you really wanted to move the user.</string>
         </property>
        </widget>
       </item>
@@ -492,13 +351,30 @@
         </property>
        </widget>
       </item>
-      <item row="2" column="1">
-       <widget class="MUComboBox" name="qcbExpand">
+      <item row="0" column="0">
+       <widget class="QLabel" name="qliChannelDrag">
+        <property name="text">
+         <string>Channel Dragging</string>
+        </property>
+       </widget>
+      </item>
+      <item row="4" column="0" colspan="2">
+       <widget class="QCheckBox" name="qcbShowUserCount">
         <property name="toolTip">
-         <string>When to automatically expand channels</string>
+         <string>Show number of users in each channel</string>
+        </property>
+        <property name="text">
+         <string>Show channel user count</string>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="1">
+       <widget class="MUComboBox" name="qcbChannelDrag">
+        <property name="toolTip">
+         <string>This changes the behavior when moving channels.</string>
         </property>
         <property name="whatsThis">
-         <string>This sets which channels to automatically expand. &lt;i&gt;None&lt;/i&gt; and &lt;i&gt;All&lt;/i&gt; will expand no or all channels, while &lt;i&gt;Only with users&lt;/i&gt; will expand and collapse channels as users join and leave them.</string>
+         <string>This sets the behavior of channel drags; it can be used to prevent accidental dragging. &lt;i&gt;Move&lt;/i&gt; moves the channel without prompting. &lt;i&gt;Do Nothing&lt;/i&gt; does nothing and prints an error message. &lt;i&gt;Ask&lt;/i&gt; uses a message box to confirm if you really wanted to move the channel.</string>
         </property>
        </widget>
       </item>
@@ -515,20 +391,20 @@
         </property>
        </widget>
       </item>
-      <item row="4" column="0" colspan="2">
-       <widget class="QCheckBox" name="qcbShowUserCount">
-        <property name="toolTip">
-         <string>Show number of users in each channel</string>
-        </property>
-        <property name="text">
-         <string>Show channel user count</string>
-        </property>
-       </widget>
-      </item>
       <item row="5" column="0" colspan="2">
        <widget class="QCheckBox" name="qcbChatBarUseSelection">
         <property name="text">
          <string>Use selected item as the chat bar target</string>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="1">
+       <widget class="MUComboBox" name="qcbExpand">
+        <property name="toolTip">
+         <string>When to automatically expand channels</string>
+        </property>
+        <property name="whatsThis">
+         <string>This sets which channels to automatically expand. &lt;i&gt;None&lt;/i&gt; and &lt;i&gt;All&lt;/i&gt; will expand no or all channels, while &lt;i&gt;Only with users&lt;/i&gt; will expand and collapse channels as users join and leave them.</string>
         </property>
        </widget>
       </item>
@@ -539,10 +415,55 @@
         </property>
        </widget>
       </item>
+      <item row="1" column="1">
+       <widget class="MUComboBox" name="qcbUserDrag">
+        <property name="toolTip">
+         <string>This changes the behavior when moving users.</string>
+        </property>
+        <property name="whatsThis">
+         <string>This sets the behavior of user drags; it can be used to prevent accidental dragging. &lt;i&gt;Move&lt;/i&gt; moves the user without prompting. &lt;i&gt;Do Nothing&lt;/i&gt; does nothing and prints an error message. &lt;i&gt;Ask&lt;/i&gt; uses a message box to confirm if you really wanted to move the user.</string>
+        </property>
+       </widget>
+      </item>
      </layout>
     </widget>
    </item>
-   <item row="4" column="0">
+   <item row="2" column="1">
+    <widget class="QGroupBox" name="qgbTray">
+     <property name="title">
+      <string>Tray Icon</string>
+     </property>
+     <layout class="QVBoxLayout" name="verticalLayout">
+      <item>
+       <widget class="QCheckBox" name="qcbHideTray">
+        <property name="toolTip">
+         <string>Hide the main Mumble window in the tray when it is minimized.</string>
+        </property>
+        <property name="whatsThis">
+         <string>&lt;b&gt;If set, minimizing the Mumble main window will cause it to be hidden and accessible only from the tray. Otherwise, it will be minimized as a window normally would.&lt;/b&gt;</string>
+        </property>
+        <property name="text">
+         <string>Hide in tray when minimized</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QCheckBox" name="qcbStateInTray">
+        <property name="toolTip">
+         <string>Displays talking status in system tray</string>
+        </property>
+        <property name="whatsThis">
+         <string/>
+        </property>
+        <property name="text">
+         <string>Show talking status in tray icon</string>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item row="4" column="1">
     <widget class="QGroupBox" name="groupBox">
      <property name="sizePolicy">
       <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
@@ -563,6 +484,19 @@
       <property name="horizontalSpacing">
        <number>6</number>
       </property>
+      <item row="0" column="1">
+       <widget class="QSpinBox" name="qsbSilentUserLifetime">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="toolTip">
+         <string>A user that is silent for the given amount of seconds will be removed from the Talkin UI.</string>
+        </property>
+       </widget>
+      </item>
       <item row="0" column="0">
        <widget class="QLabel" name="qlSilentUserLifetime">
         <property name="sizePolicy">
@@ -579,8 +513,44 @@
         </property>
        </widget>
       </item>
-      <item row="0" column="1">
-       <widget class="QSpinBox" name="qsbSilentUserLifetime">
+      <item row="1" column="0" colspan="2">
+       <widget class="QCheckBox" name="qcbLocalUserVisible">
+        <property name="toolTip">
+         <string>If this is checked, the local user (yourself) will always be visible in the TalkingUI (regardless of talking state).</string>
+        </property>
+        <property name="text">
+         <string>Always keep local user visible</string>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item row="1" column="0" rowspan="4">
+    <widget class="QGroupBox" name="qgbLookFeel">
+     <property name="title">
+      <string>Look and Feel</string>
+     </property>
+     <layout class="QGridLayout" name="gridLayout">
+      <item row="3" column="0" colspan="2">
+       <widget class="MUComboBox" name="qcbLanguage">
+        <property name="toolTip">
+         <string>Language to use (requires restart)</string>
+        </property>
+        <property name="whatsThis">
+         <string>&lt;b&gt;This sets which language Mumble should use.&lt;/b&gt;&lt;br /&gt;You have to restart Mumble to use the new language.</string>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="0">
+       <widget class="QLabel" name="qliTheme">
+        <property name="text">
+         <string>Theme</string>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="0" colspan="2">
+       <widget class="MUComboBox" name="qcbTheme">
         <property name="sizePolicy">
          <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
           <horstretch>0</horstretch>
@@ -588,25 +558,65 @@
          </sizepolicy>
         </property>
         <property name="toolTip">
-         <string>A user that is silent for the given amount of seconds will be removed from the Talkin UI.</string>
+         <string>Theme to use to style the user interface</string>
+        </property>
+        <property name="whatsThis">
+         <string>&lt;b&gt;Configures which theme the Mumble user interface should be styled with&lt;/b&gt;&lt;br /&gt;Mumble will pick up themes from certain directories and display them in this list. The one you select will be used to customize the visual appearance of Mumble. This includes colors, icons and more.</string>
+        </property>
+       </widget>
+      </item>
+      <item row="5" column="0" colspan="2">
+       <widget class="QCheckBox" name="qcbShowTransmitModeComboBox">
+        <property name="text">
+         <string>Show transmit mode dropdown in toolbar</string>
+        </property>
+       </widget>
+      </item>
+      <item row="4" column="0" colspan="2">
+       <widget class="QCheckBox" name="qcbHighContrast">
+        <property name="toolTip">
+         <string>Apply some high contrast optimizations for visually impaired users</string>
+        </property>
+        <property name="text">
+         <string>Optimize for high contrast</string>
+        </property>
+       </widget>
+      </item>
+      <item row="6" column="0">
+       <spacer name="verticalSpacer">
+        <property name="orientation">
+         <enum>Qt::Vertical</enum>
+        </property>
+        <property name="sizeHint" stdset="0">
+         <size>
+          <width>20</width>
+          <height>40</height>
+         </size>
+        </property>
+       </spacer>
+      </item>
+      <item row="2" column="0">
+       <widget class="QLabel" name="qliLanguage">
+        <property name="text">
+         <string>Language</string>
+        </property>
+        <property name="buddy">
+         <cstring>qcbLanguage</cstring>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="1">
+       <widget class="QLabel" name="qlThemesDirectory">
+        <property name="text">
+         <string/>
+        </property>
+        <property name="alignment">
+         <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
         </property>
        </widget>
       </item>
      </layout>
     </widget>
-   </item>
-   <item row="4" column="1">
-    <spacer name="horizontalSpacer">
-     <property name="orientation">
-      <enum>Qt::Horizontal</enum>
-     </property>
-     <property name="sizeHint" stdset="0">
-      <size>
-       <width>40</width>
-       <height>20</height>
-      </size>
-     </property>
-    </spacer>
    </item>
   </layout>
  </widget>

--- a/src/mumble/MainWindow.cpp
+++ b/src/mumble/MainWindow.cpp
@@ -846,6 +846,8 @@ static void recreateServerHandler() {
 	g.mw->connect(sh.get(), SIGNAL(connected()), g.mw, SLOT(serverConnected()));
 	g.mw->connect(sh.get(), SIGNAL(disconnected(QAbstractSocket::SocketError, QString)), g.mw, SLOT(serverDisconnected(QAbstractSocket::SocketError, QString)));
 	g.mw->connect(sh.get(), SIGNAL(error(QAbstractSocket::SocketError, QString)), g.mw, SLOT(resolverError(QAbstractSocket::SocketError, QString)));
+
+	QObject::connect(sh.get(), &ServerHandler::disconnected, g.talkingUI, &TalkingUI::on_serverDisconnected);
 }
 
 void MainWindow::openUrl(const QUrl &url) {

--- a/src/mumble/MainWindow.h
+++ b/src/mumble/MainWindow.h
@@ -311,6 +311,9 @@ class MainWindow : public QMainWindow, public MessageHandler, public Ui::MainWin
 		/// the input stream. If false, the audio backend MUST immediately
 		/// un-cork/resume the stream.
 		void corkAudioInputStream(const bool cork);
+		/// Signal emitted when the server and the client have finished
+		/// synchronizing (after a new connection).
+		void serverSynchronized();
 	public:
 		MainWindow(QWidget *parent);
 		~MainWindow() Q_DECL_OVERRIDE;

--- a/src/mumble/Messages.cpp
+++ b/src/mumble/Messages.cpp
@@ -196,6 +196,8 @@ void MainWindow::msgServerSync(const MumbleProto::ServerSync &msg) {
 			ChannelListener::setListenerLocalVolumeAdjustment(it.key(), it.value());
 		}
 	});
+
+	emit serverSynchronized();
 }
 
 /// This message is being received when the server informs this client about server configuration details. This contains
@@ -386,6 +388,11 @@ void MainWindow::msgUserState(const MumbleProto::UserState &msg) {
 		Channel *oldChannel = pDst->cChannel;
 		if (channel != oldChannel) {
 			pmModel->moveUser(pDst, channel);
+
+			if (g.talkingUI) {
+				// Pass the pointer as QObject in order to avoid having to register ClientUser as a QMetaType
+				QMetaObject::invokeMethod(g.talkingUI, "on_channelChanged", Qt::QueuedConnection, Q_ARG(QObject *, pDst));
+			}
 
 			if (pSelf) {
 				if (pDst == pSelf) {

--- a/src/mumble/Settings.cpp
+++ b/src/mumble/Settings.cpp
@@ -453,6 +453,7 @@ Settings::Settings() {
 
 	bShowTalkingUI = false;
 	iTalkingUI_SilentUserLifeTime = 5;
+	bTalkingUI_LocalUserStaysVisible = false;
 
 	bShortcutEnable = true;
 	bSuppressMacEventTapWarning = false;
@@ -808,8 +809,11 @@ void Settings::load(QSettings* settings_ptr) {
 	SAVELOAD(iMaxLogBlocks, "ui/MaxLogBlocks");
 	SAVELOAD(bLog24HourClock, "ui/24HourClock");
 	SAVELOAD(iChatMessageMargins, "ui/ChatMessageMargins");
+
+	// TalkingUI
 	SAVELOAD(bShowTalkingUI, "ui/showTalkingUI");
 	SAVELOAD(iTalkingUI_SilentUserLifeTime, "ui/talkingUI_SilentUserLifeTime");
+	SAVELOAD(bTalkingUI_LocalUserStaysVisible, "ui/talkingUI_LocalUserStaysVisible");
 
 	// PTT Button window
 	SAVELOAD(bShowPTTButtonWindow, "ui/showpttbuttonwindow");
@@ -1147,8 +1151,11 @@ void Settings::save() {
 	SAVELOAD(iMaxLogBlocks, "ui/MaxLogBlocks");
 	SAVELOAD(bLog24HourClock, "ui/24HourClock");
 	SAVELOAD(iChatMessageMargins, "ui/ChatMessageMargins");
+
+	// TalkingUI
 	SAVELOAD(bShowTalkingUI, "ui/showTalkingUI");
 	SAVELOAD(iTalkingUI_SilentUserLifeTime, "ui/talkingUI_SilentUserLifeTime");
+	SAVELOAD(bTalkingUI_LocalUserStaysVisible, "ui/talkingUI_LocalUserStaysVisible");
 
 	// PTT Button window
 	SAVELOAD(bShowPTTButtonWindow, "ui/showpttbuttonwindow");

--- a/src/mumble/Settings.h
+++ b/src/mumble/Settings.h
@@ -277,8 +277,10 @@ struct Settings {
 	int iMaxLogBlocks;
 	bool bLog24HourClock;
 	int iChatMessageMargins;
+
 	bool bShowTalkingUI;
 	int iTalkingUI_SilentUserLifeTime;
+	bool bTalkingUI_LocalUserStaysVisible;
 
 	QMap<int, QString> qmMessageSounds;
 	QMap<int, quint32> qmMessages;

--- a/src/mumble/TalkingUI.h
+++ b/src/mumble/TalkingUI.h
@@ -16,6 +16,9 @@ class QGroupBox;
 class QTimer;
 class QMouseEvent;
 
+class Channel;
+class ClientUser;
+
 /// Smaller auxilary class for holding together two labels representing
 /// the entry for a specific user in the TalkingUI<
 struct Entry {
@@ -39,7 +42,7 @@ class TalkingUI : public QWidget {
 		/// A map betweem user session IDs and the timer used to remove users
 		/// that have stopped speaking for a certain amount of time.
 		QHash<unsigned int, QTimer *> m_timers;
-
+		/// The Entry corresponding to the currently selected user
 		Entry *m_currentSelection;
 
 		/// The icon for a talking user
@@ -53,8 +56,25 @@ class TalkingUI : public QWidget {
 
 		/// Sets up the UI components
 		void setupUI();
-		/// Removes a user from being displayed
-		void removeUser(unsigned int session);
+		/// Hides an user
+		///
+		/// @param session The session ID of the user that shall be hidden
+		void hideUser(unsigned int session);
+		/// Adds an UI entry for the given Channel, if none exists yet.
+		///
+		/// @param channel A pointer to the channel that shall be added
+		void addChannel(const Channel *channel);;
+		/// Adds an UI entry for the given User, if none exists yet.
+		///
+		/// @param channel A pointer to the user that shall be added
+		void addUser(const ClientUser *user);
+		/// Makes sure the user with the given session is visible and
+		/// placed in the channel with the given ID. Note that both the
+		/// user and the channel are expected to have an UI entry already.
+		///
+		/// @paam userSession The session ID of the user
+		/// @param channelID The channel ID of the channel
+		void ensureVisible(unsigned int userSession, int channelID);
 
 		/// Update (resize) the UI to its content
 		void updateUI();
@@ -76,6 +96,9 @@ class TalkingUI : public QWidget {
 	public slots:
 		void on_talkingStateChanged();
 		void on_mainWindowSelectionChanged(const QModelIndex &current, const QModelIndex &previous);
+		void on_serverSynchronized();
+		void on_serverDisconnected();
+		void on_channelChanged(QObject *user);
 };
 
 #endif // MUMBLE_MUMBLE_TALKINGUI_H_

--- a/src/mumble/main.cpp
+++ b/src/mumble/main.cpp
@@ -452,6 +452,8 @@ int main(int argc, char **argv) {
 	g.talkingUI = new TalkingUI();
 	g.talkingUI->setVisible(g.s.bShowTalkingUI);
 
+	QObject::connect(g.mw, &MainWindow::serverSynchronized, g.talkingUI, &TalkingUI::on_serverSynchronized);
+
 	// Initialize logger
 	// Log::log() needs the MainWindow to already exist. Thus creating the Log instance
 	// before the MainWindow one, does not make sense. if you need logging before this

--- a/src/mumble/mumble_en.ts
+++ b/src/mumble/mumble_en.ts
@@ -3811,6 +3811,14 @@ The setting only applies for new messages, the already shown ones will retain th
         <source>Remove silent user after</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>If this is checked, the local user (yourself) will always be visible in the TalkingUI (regardless of talking state).</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Always keep local user visible</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>MainWindow</name>


### PR DESCRIPTION
With this setting enabled, the local user is always visible in the
TalkingUI as long as the user is connected to a server.

Furthermore the local user will always be listed first in its channel
and the channel of the local user will also be at the top of the
TalkingUI. This is independent from the new setting.

In order to make sure that the state displayed in the TalkingUI is
actually correct, some EventHandlers are added to the TalkingUI as well.