### PR TITLE
Added DBus methods for setting/querying the current transmit mode

### DIFF
--- a/src/mumble/DBus.cpp
+++ b/src/mumble/DBus.cpp
@@ -84,6 +84,28 @@ void MumbleDBus::focus() {
 	g.mw->activateWindow();
 }
 
+void MumbleDBus::setTransmitMode(unsigned int mode, const QDBusMessage &msg) {
+	switch (mode) {
+		case 0:
+			g.s.atTransmit = Settings::Continuous;
+			break;
+		case 1:
+			g.s.atTransmit = Settings::VAD;
+			break;
+		case 2:
+			g.s.atTransmit = Settings::PushToTalk;
+			break;
+		default:
+			QDBusConnection::sessionBus().send(msg.createErrorReply(QLatin1String("net.sourceforge.mumble.Error.transmitMode"), QLatin1String("Invalid transmit mode")));
+			return;
+	}
+	QMetaObject::invokeMethod(g.mw, "updateTransmitModeComboBox", Qt::QueuedConnection);
+}
+
+unsigned int MumbleDBus::getTransmitMode() {
+	return g.s.atTransmit;
+}
+
 void MumbleDBus::setSelfMuted(bool mute) {
 	g.mw->qaAudioMute->setChecked(!mute);
 	g.mw->qaAudioMute->trigger();

--- a/src/mumble/DBus.h
+++ b/src/mumble/DBus.h
@@ -24,6 +24,17 @@ class MumbleDBus : public QDBusAbstractAdaptor {
 		void getCurrentUrl(const QDBusMessage &);
 		void getTalkingUsers(const QDBusMessage &);
 		void focus();
+
+		/// Change when Mumble transmits voice.
+		///
+		/// @param mode The new transmit mode (0 = continous, 1 = voice activity, 2 = push-to-talk)
+		void setTransmitMode(unsigned int mode, const QDBusMessage &);
+
+		/// Get the current transmit mode.
+		///
+		/// @return The current transmit mode (0 = continous, 1 = voice activity, 2 = push-to-talk)
+		unsigned int getTransmitMode();
+
 		void setSelfMuted(bool mute);
 		void setSelfDeaf(bool deafen);
 		bool isSelfMuted();

--- a/src/mumble/MainWindow.h
+++ b/src/mumble/MainWindow.h
@@ -110,7 +110,6 @@ class MainWindow : public QMainWindow, public MessageHandler, public Ui::MainWin
 		void updateTrayIcon();
 		void updateUserModel();
 		void focusNextMainWidget();
-		void updateTransmitModeComboBox();
 		QPair<QByteArray, QImage> openImageFile();
 		
 		void updateChatBar();
@@ -191,6 +190,7 @@ class MainWindow : public QMainWindow, public MessageHandler, public Ui::MainWin
 		void on_qaSelfComment_triggered();
 		void on_qaSelfRegister_triggered();
 		void qcbTransmitMode_activated(int index);
+		void updateTransmitModeComboBox();
 		void qmUser_aboutToShow();
 		void qmListener_aboutToShow();
 		void on_qaUserCommentReset_triggered();


### PR DESCRIPTION
This lets users control their transmit mode through DBus.

Changelog
```
| Added: DBus interface for setting/querying current transmission mode
```