### PR TITLE
Fix iInFlightTCPPings check

### DIFF
--- a/src/mumble/ServerHandler.cpp
+++ b/src/mumble/ServerHandler.cpp
@@ -504,7 +504,7 @@ void ServerHandler::sendPingInternal() {
 		return;
 	}
 
-	if (g.s.iMaxInFlightTCPPings >= 0 && iInFlightTCPPings >= g.s.iMaxInFlightTCPPings) {
+	if (g.s.iMaxInFlightTCPPings > 0 && iInFlightTCPPings >= g.s.iMaxInFlightTCPPings) {
 		serverConnectionClosed(QAbstractSocket::UnknownSocketError, tr("Server is not responding to TCP pings"));
 		return;
 	}

--- a/src/mumble/Settings.cpp
+++ b/src/mumble/Settings.cpp
@@ -408,7 +408,7 @@ Settings::Settings() {
 	bAutoConnect = false;
 	ptProxyType = NoProxy;
 	usProxyPort = 0;
-	iMaxInFlightTCPPings = 2;
+	iMaxInFlightTCPPings = 4;
 	bUdpForceTcpAddr = true;
 	iPingIntervalMsec = 5000;
 	iConnectionTimeoutDurationMsec = 30000;


### PR DESCRIPTION
The `iInFlightTCPPings >= g.s.iMaxInFlightTCPPings` check would mean
that if 1 is in flight and another is started, it immediately
disconnects, so as OP said in
https://github.com/mumble-voip/mumble/issues/3448 we want to have >
here.

Maybe that already fixes most of the spurious disconnects in practice,
or maybe we want to increase the default to 3 (right now it’s
effectively 2−1, so 1).

Fixes: https://github.com/mumble-voip/mumble/issues/3448