### PR TITLE
qmake/compiler.pri: remove "/Z7" flag from compiler options

### DIFF
--- a/qmake/compiler.pri
+++ b/qmake/compiler.pri
@@ -185,6 +185,12 @@ win32-msvc* {
 	      QMAKE_CFLAGS += -arch:SSE2
 	}
 
+	# The mkspec update for MSVC2015 sets "/Z7",
+	# which bakes debug info into binaries.
+	# We, instead, want that only for the build environment.
+	QMAKE_CFLAGS -= -Z7
+	QMAKE_CXXFLAGS -= -Z7
+
 	CONFIG(symbols) {
 		# Configure build to be able to properly debug release builds
 		# (https://msdn.microsoft.com/en-us/library/fsk896zz.aspx).


### PR DESCRIPTION
The flag is added by our latest update to Qt's mkspec in our build environment: mumble-voip/mumble-releng@ad9fd58f47541feb4ec7a93d756d898789f24d40.