### PR TITLE
Allow ChannelListener in same channel

### DIFF
--- a/src/mumble/MainWindow.cpp
+++ b/src/mumble/MainWindow.cpp
@@ -1993,15 +1993,17 @@ void MainWindow::qmChannel_aboutToShow() {
 	if (c && c->iId != ClientUser::get(g.uiSession)->cChannel->iId) {
 		qmChannel->addAction(qaChannelJoin);
 
-		if (g.sh->uiVersion >= 0x010400) {
-			// If the server's version is less than 1.4, the listening feature is not supported yet
-			// and thus it doesn't make sense to show the action for it
-			qmChannel->addAction(qaChannelListen);
-			qaChannelListen->setChecked(ChannelListener::isListening(g.uiSession, c->iId));
-		}
-
 		qmChannel->addSeparator();
 	}
+
+	if (c && g.sh && g.sh->uiVersion >= 0x010400) {
+		// If the server's version is less than 1.4, the listening feature is not supported yet
+		// and thus it doesn't make sense to show the action for it
+		qmChannel->addAction(qaChannelListen);
+		qaChannelListen->setChecked(ChannelListener::isListening(g.uiSession, c->iId));
+	}
+
+	qmChannel->addSeparator();
 
 	qmChannel->addAction(qaChannelAdd);
 	qmChannel->addAction(qaChannelACL);

--- a/src/mumble/UserModel.cpp
+++ b/src/mumble/UserModel.cpp
@@ -1444,6 +1444,13 @@ void UserModel::removeAll() {
 	iChannelDescription = -1;
 	bClicked = false;
 
+	// in order to avoid complications, we remove all ChannelListeners first
+	foreach(i, item->qlChildren) {
+		if (i->pUser && i->isListener) {
+			removeChannelListener(i, item);
+		}
+	}
+
 	foreach(i, item->qlChildren) {
 		if (i->pUser)
 			removeUser(i->pUser);

--- a/src/mumble/UserModel.cpp
+++ b/src/mumble/UserModel.cpp
@@ -213,9 +213,9 @@ int ModelItem::insertIndex(ClientUser *p, bool isListener) const {
 QString ModelItem::hash() const {
 	if (pUser) {
 		if (! pUser->qsHash.isEmpty())
-			return pUser->qsHash;
+			return pUser->qsHash + (isListener ? QLatin1String("l"): QString());
 		else
-			return QLatin1String(sha1(pUser->qsName).toHex());
+			return QLatin1String(sha1(pUser->qsName + (isListener ? QLatin1String("l") : QString())).toHex());
 	} else {
 		QCryptographicHash chash(QCryptographicHash::Sha1);
 

--- a/src/murmur/Messages.cpp
+++ b/src/murmur/Messages.cpp
@@ -907,12 +907,6 @@ void Server::msgUserState(ServerUser *uSource, MumbleProto::UserState &msg) {
 		userEnterChannel(pDstServerUser, c, msg);
 		log(uSource, QString("Moved %1 to %2").arg(QString(*pDstServerUser), QString(*c)));
 		bBroadcast = true;
-
-		if (ChannelListener::isListening(pDstServerUser, c)) {
-			// If a user joins a channel (s)he has been listening to before, it means that this user will no
-			// longer listen into that channel (as joining it can be viewed as promoting the listening to a join)
-			msg.add_listening_channel_remove(c->iId);
-		}
 	}
 
 	// Handle channel listening


### PR DESCRIPTION
Before you weren't able to place a listener proxy (ChannelListener) into
the same channel that you're currently in and if you joined a channel
that you were listening to before, your listener proxy would be removed
from that channel.

It was brought to my attention though that there are cases in which a
person wants to hear what's going on in several channels and thus places
listener proxies into them. However if that same person needs to
constantly hop between these listened channels (e.g. to talk to the
folks in there), it gets very annoying as that person constantly has to
think about re-adding the listener proxy into the channel it just left.