### PR TITLE
Don't hide the setting if no-update config was used

### DIFF
--- a/src/mumble/MainWindow.cpp
+++ b/src/mumble/MainWindow.cpp
@@ -182,10 +182,6 @@ MainWindow::MainWindow(QWidget *p) : QMainWindow(p) {
 	setOnTop(g.s.aotbAlwaysOnTop == Settings::OnTopAlways ||
 	         (g.s.bMinimalView && g.s.aotbAlwaysOnTop == Settings::OnTopInMinimal) ||
 	         (!g.s.bMinimalView && g.s.aotbAlwaysOnTop == Settings::OnTopInNormal));
-
-#ifdef NO_UPDATE_CHECK
-	delete qaHelpVersionCheck;
-#endif
 }
 
 void MainWindow::createActions() {

--- a/src/mumble/NetworkConfig.cpp
+++ b/src/mumble/NetworkConfig.cpp
@@ -25,10 +25,6 @@ static ConfigRegistrar registrar(1300, NetworkConfigNew);
 
 NetworkConfig::NetworkConfig(Settings &st) : ConfigWidget(st) {
 	setupUi(this);
-#ifdef NO_UPDATE_CHECK
-	qcbAutoUpdate->hide();
-	qcbPluginUpdate->hide();
-#endif
 }
 
 QString NetworkConfig::title() const {

--- a/src/mumble/Settings.cpp
+++ b/src/mumble/Settings.cpp
@@ -788,10 +788,10 @@ void Settings::load(QSettings* settings_ptr) {
 	SAVELOAD(qsUsername, "ui/username");
 	SAVELOAD(qsLastServer, "ui/server");
 	LOADENUM(ssFilter, "ui/serverfilter");
-#ifndef NO_UPDATE_CHECK
+
 	SAVELOAD(bUpdateCheck, "ui/updatecheck");
 	SAVELOAD(bPluginCheck, "ui/plugincheck");
-#endif
+
 	SAVELOAD(bHideInTray, "ui/hidetray");
 	SAVELOAD(bStateInTray, "ui/stateintray");
 	SAVELOAD(bUsage, "ui/usage");


### PR DESCRIPTION
With commit 847ed7ad0eef3c4e1a4a7dd230e05b70f17ec412 it was introduced
that when using the no-update config flag, not only the default values
for checking or not checking for updates were affected but actually the
whole setting would be hidden from the UI.

This commit reverts that as a user should always be able to decide for
him- or herself whether or not they want to see update notifications or
not.

It does make sense for package maintainers to disable these checks by
default (as updates are received via package manager anyways) but if the
user wants to have that check enabled nonetheless, they should be able to
do so.

Context: Discussion in #4128

/cc @toby63