### PR TITLE
Implemented options to display channel hierarchy in TalkingUI

### DIFF
--- a/src/mumble/ConfigDialog.cpp
+++ b/src/mumble/ConfigDialog.cpp
@@ -227,6 +227,8 @@ void ConfigDialog::apply() {
 	g.iPushToTalk = 0;
 
 	Audio::start();
+
+	emit settingsAccepted();
 }
 
 void ConfigDialog::accept() {

--- a/src/mumble/ConfigDialog.h
+++ b/src/mumble/ConfigDialog.h
@@ -34,6 +34,11 @@ class ConfigDialog : public QDialog, public Ui::ConfigDialog {
 		/// @returns The pointer to the existing ConfigWidget with the given name or nullptr,
 		/// 	if no such widget exists.
 		static ConfigWidget *getConfigWidget(const QString &name);
+
+	signals:
+		/// Emitted whenever the settings dialog has been accepted. For potential slots this
+		/// means that the settings potentially have changed.
+		void settingsAccepted();
 	public slots:
 		void on_pageButtonBox_clicked(QAbstractButton *);
 		void on_dialogButtonBox_clicked(QAbstractButton *);

--- a/src/mumble/LookConfig.cpp
+++ b/src/mumble/LookConfig.cpp
@@ -184,8 +184,16 @@ void LookConfig::load(const Settings &r) {
 	const boost::optional<ThemeInfo::StyleInfo> configuredStyle = Themes::getConfiguredStyle(r);
 	reloadThemes(configuredStyle);
 
-	qsbSilentUserLifetime->setValue(r.iTalkingUI_SilentUserLifeTime);
 	loadCheckBox(qcbLocalUserVisible, r.bTalkingUI_LocalUserStaysVisible);
+	loadCheckBox(qcbAbbreviateChannelNames, r.bTalkingUI_AbbreviateChannelNames);
+	loadCheckBox(qcbAbbreviateCurrentChannel, r.bTalkingUI_AbbreviateCurrentChannel);
+	qsbSilentUserLifetime->setValue(r.iTalkingUI_SilentUserLifeTime);
+	qsbChannelHierarchyDepth->setValue(r.iTalkingUI_ChannelHierarchyDepth);
+	qsbMaxNameLength->setValue(r.iTalkingUI_MaxChannelNameLength);
+	qsbPrefixCharCount->setValue(r.iTalkingUI_PrefixCharCount);
+	qsbPostfixCharCount->setValue(r.iTalkingUI_PostfixCharCount);
+	qleChannelSeparator->setText(r.qsTalkingUI_ChannelSeparator);
+	qleAbbreviationReplacement->setText(r.qsTalkingUI_AbbreviationReplacement);
 }
 
 void LookConfig::save() const {
@@ -239,8 +247,16 @@ void LookConfig::save() const {
 		Themes::setConfiguredStyle(s, themeData.value<ThemeInfo::StyleInfo>(), s.requireRestartToApply);
 	}
 
-	s.iTalkingUI_SilentUserLifeTime = qsbSilentUserLifetime->value();
 	s.bTalkingUI_LocalUserStaysVisible = qcbLocalUserVisible->isChecked();
+	s.bTalkingUI_AbbreviateChannelNames = qcbAbbreviateChannelNames->isChecked();
+	s.bTalkingUI_AbbreviateCurrentChannel = qcbAbbreviateCurrentChannel->isChecked();
+	s.iTalkingUI_SilentUserLifeTime = qsbSilentUserLifetime->value();
+	s.iTalkingUI_ChannelHierarchyDepth = qsbChannelHierarchyDepth->value();
+	s.iTalkingUI_MaxChannelNameLength = qsbMaxNameLength->value();
+	s.iTalkingUI_PrefixCharCount = qsbPrefixCharCount->value();
+	s.iTalkingUI_PostfixCharCount = qsbPostfixCharCount->value();
+	s.qsTalkingUI_ChannelSeparator = qleChannelSeparator->text();
+	s.qsTalkingUI_AbbreviationReplacement = qleAbbreviationReplacement->text();
 }
 
 void LookConfig::accept() const {
@@ -255,4 +271,17 @@ void LookConfig::themeDirectoryChanged() {
 	} else {
 		reloadThemes(themeData.value<ThemeInfo::StyleInfo>());
 	}
+}
+
+void LookConfig::on_qcbAbbreviateChannelNames_stateChanged(int state) {
+	bool abbreviateNames = state == Qt::Checked;
+
+	// Only enable the abbreviation related settings if abbreviation is actually enabled
+	qcbAbbreviateCurrentChannel->setEnabled(abbreviateNames);
+	qsbChannelHierarchyDepth->setEnabled(abbreviateNames);
+	qsbMaxNameLength->setEnabled(abbreviateNames);
+	qsbPrefixCharCount->setEnabled(abbreviateNames);
+	qsbPostfixCharCount->setEnabled(abbreviateNames);
+	qleChannelSeparator->setEnabled(abbreviateNames);
+	qleAbbreviationReplacement->setEnabled(abbreviateNames);
 }

--- a/src/mumble/LookConfig.h
+++ b/src/mumble/LookConfig.h
@@ -31,6 +31,7 @@ class LookConfig : public ConfigWidget, Ui::LookConfig {
 		void save() const Q_DECL_OVERRIDE;
 		void load(const Settings &r) Q_DECL_OVERRIDE;
 		void themeDirectoryChanged();
+		void on_qcbAbbreviateChannelNames_stateChanged(int state);
 	private:
 		/// Reload themes combobox and select given configuredStyle in it
 		void reloadThemes(const boost::optional<ThemeInfo::StyleInfo> configuredStyle);

--- a/src/mumble/LookConfig.ui
+++ b/src/mumble/LookConfig.ui
@@ -6,115 +6,210 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>740</width>
-    <height>744</height>
+    <width>728</width>
+    <height>1082</height>
    </rect>
   </property>
   <property name="windowTitle">
    <string notr="true">Form</string>
   </property>
   <layout class="QGridLayout" name="gridLayout_4">
-   <item row="1" column="1">
-    <widget class="QGroupBox" name="qgbApplication">
-     <property name="title">
-      <string>Application</string>
+   <item row="4" column="1">
+    <widget class="QGroupBox" name="groupBox">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
      </property>
-     <layout class="QGridLayout" name="gridLayout_3" columnstretch="0,0">
+     <property name="title">
+      <string>Talking UI</string>
+     </property>
+     <property name="flat">
+      <bool>false</bool>
+     </property>
+     <property name="checkable">
+      <bool>false</bool>
+     </property>
+     <layout class="QGridLayout" name="gridLayout_5">
+      <property name="horizontalSpacing">
+       <number>6</number>
+      </property>
+      <item row="5" column="0">
+       <widget class="QLabel" name="qlChannelHierarchyDepth">
+        <property name="toolTip">
+         <string>The names of how many parent channels should be included in the channel's name when displaying it in the TalkingUI?</string>
+        </property>
+        <property name="text">
+         <string>Channel hierarchy depth</string>
+        </property>
+       </widget>
+      </item>
+      <item row="12" column="1">
+       <widget class="QLineEdit" name="qleAbbreviationReplacement">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="toolTip">
+         <string>String that gets used isntead of the cut-out part of an abbreviated name.</string>
+        </property>
+       </widget>
+      </item>
+      <item row="3" column="1">
+       <widget class="QSpinBox" name="qsbSilentUserLifetime">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="toolTip">
+         <string>A user that is silent for the given amount of seconds will be removed from the Talkin UI.</string>
+        </property>
+       </widget>
+      </item>
+      <item row="8" column="0">
+       <widget class="QLabel" name="qlPrefixCharCount">
+        <property name="toolTip">
+         <string>How many characters from the original name to display at the beginning of an abbreviated name.</string>
+        </property>
+        <property name="text">
+         <string>Abbreviated prefix characters</string>
+        </property>
+       </widget>
+      </item>
+      <item row="9" column="0">
+       <widget class="QLabel" name="qlPostfixCharCount">
+        <property name="toolTip">
+         <string>How many characters from the original name to display at the end of an abbreviated name.</string>
+        </property>
+        <property name="text">
+         <string>Abbreviated postfix characters</string>
+        </property>
+       </widget>
+      </item>
       <item row="0" column="0">
-       <widget class="QLabel" name="qliAlwaysOnTop">
+       <widget class="QCheckBox" name="qcbLocalUserVisible">
+        <property name="toolTip">
+         <string>If this is checked, the local user (yourself) will always be visible in the TalkingUI (regardless of talking state).</string>
+        </property>
         <property name="text">
-         <string>Always On Top</string>
+         <string>Always keep local user visible</string>
         </property>
        </widget>
       </item>
-      <item row="0" column="1">
-       <widget class="MUComboBox" name="qcbAlwaysOnTop">
+      <item row="12" column="0">
+       <widget class="QLabel" name="qlAbbreviationReplacement">
         <property name="toolTip">
-         <string>This setting controls when the application will be always on top.</string>
-        </property>
-        <property name="whatsThis">
-         <string>This setting controls in which situations the application will stay always on top. If you select &lt;i&gt;Never&lt;/i&gt; the application will not stay on top. &lt;i&gt;Always&lt;/i&gt; will always keep the application on top. &lt;i&gt;In minimal view&lt;/i&gt; / &lt;i&gt;In normal view&lt;/i&gt; will only keep the application always on top when minimal view is activated / deactivated.</string>
-        </property>
-        <item>
-         <property name="text">
-          <string>Never</string>
-         </property>
-        </item>
-        <item>
-         <property name="text">
-          <string>Always</string>
-         </property>
-        </item>
-        <item>
-         <property name="text">
-          <string>In minimal view</string>
-         </property>
-        </item>
-        <item>
-         <property name="text">
-          <string>In normal view</string>
-         </property>
-        </item>
-       </widget>
-      </item>
-      <item row="1" column="0" colspan="2">
-       <widget class="QCheckBox" name="qcbShowContextMenuInMenuBar">
-        <property name="toolTip">
-         <string>Adds user and channel context menus into the menu bar</string>
+         <string>String that gets used isntead of the cut-out part of an abbreviated name.</string>
         </property>
         <property name="text">
-         <string>Show context menu in menu bar</string>
+         <string>Abbreviation replacement</string>
+        </property>
+       </widget>
+      </item>
+      <item row="8" column="1">
+       <widget class="QSpinBox" name="qsbPrefixCharCount">
+        <property name="toolTip">
+         <string>How many characters from the original name to display at the beginning of an abbreviated name.</string>
+        </property>
+       </widget>
+      </item>
+      <item row="3" column="0">
+       <widget class="QLabel" name="qlSilentUserLifetime">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="toolTip">
+         <string>A user that is silent for the given amount of seconds will be removed from the Talkin UI.</string>
+        </property>
+        <property name="text">
+         <string>Remove silent user after</string>
         </property>
        </widget>
       </item>
       <item row="2" column="0" colspan="2">
-       <widget class="QCheckBox" name="qcbAskOnQuit">
+       <widget class="QCheckBox" name="qcbAbbreviateCurrentChannel">
         <property name="toolTip">
-         <string>Ask whether to close or minimize when quitting Mumble.</string>
-        </property>
-        <property name="whatsThis">
-         <string>&lt;b&gt;If set, will verify you want to quit if connected.&lt;/b&gt;</string>
+         <string>Whether to also allow abbreviating the current channel of a user (instead of only its parent channels).</string>
         </property>
         <property name="text">
-         <string>Ask on quit while connected</string>
+         <string>Abbreviate current channel name</string>
         </property>
        </widget>
       </item>
-      <item row="3" column="0" colspan="2">
-       <widget class="QCheckBox" name="qcbEnableDeveloperMenu">
-        <property name="whatsThis">
-         <string>&lt;b&gt;Enable Developer menu&lt;/b&gt;&lt;br /&gt;This enables the &quot;Developer&quot;-menu in Mumble. This menu is used for developer-specific features, such as the Developer Console.</string>
+      <item row="1" column="0" colspan="2">
+       <widget class="QCheckBox" name="qcbAbbreviateChannelNames">
+        <property name="toolTip">
+         <string>Whether the channel (hierarchy) name should be abbreviated, if it exceeds the specified maximum length.</string>
         </property>
         <property name="text">
-         <string>Enable Developer menu</string>
+         <string>Abbreviate channel names</string>
         </property>
        </widget>
       </item>
-      <item row="4" column="0" colspan="2">
-       <widget class="QCheckBox" name="qcbLockLayout">
-        <property name="whatsThis">
-         <string>When in custom layout mode, checking this disables rearranging.</string>
+      <item row="11" column="0">
+       <widget class="QLabel" name="qlChannelSeparator">
+        <property name="toolTip">
+         <string>String to separate a channel name from its parent's.</string>
         </property>
         <property name="text">
-         <string>Lock layout</string>
+         <string>Channel separator</string>
+        </property>
+       </widget>
+      </item>
+      <item row="9" column="1">
+       <widget class="QSpinBox" name="qsbPostfixCharCount">
+        <property name="toolTip">
+         <string>How many characters from the original name to display at the end of an abbreviated name.</string>
+        </property>
+       </widget>
+      </item>
+      <item row="11" column="1">
+       <widget class="QLineEdit" name="qleChannelSeparator">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="toolTip">
+         <string>String to separate a channel name from its parent's.</string>
+        </property>
+       </widget>
+      </item>
+      <item row="5" column="1">
+       <widget class="QSpinBox" name="qsbChannelHierarchyDepth">
+        <property name="toolTip">
+         <string>The names of how many parent channels should be included in the channel's name when displaying it in the TalkingUI?</string>
+        </property>
+       </widget>
+      </item>
+      <item row="7" column="0">
+       <widget class="QLabel" name="qlMaxNameLength">
+        <property name="toolTip">
+         <string>The preferred maximum length of a channel (hierarchy) name in the Talking UI. Note that this is not a hard limit though.</string>
+        </property>
+        <property name="text">
+         <string>Max. channel name length</string>
+        </property>
+       </widget>
+      </item>
+      <item row="7" column="1">
+       <widget class="QSpinBox" name="qsbMaxNameLength">
+        <property name="toolTip">
+         <string>The preferred maximum length of a channel (hierarchy) name in the Talking UI. Note that this is not a hard limit though.</string>
         </property>
        </widget>
       </item>
      </layout>
     </widget>
-   </item>
-   <item row="5" column="1">
-    <spacer name="horizontalSpacer">
-     <property name="orientation">
-      <enum>Qt::Horizontal</enum>
-     </property>
-     <property name="sizeHint" stdset="0">
-      <size>
-       <width>40</width>
-       <height>20</height>
-      </size>
-     </property>
-    </spacer>
    </item>
    <item row="0" column="0" colspan="2">
     <widget class="QGroupBox" name="qgbLayout">
@@ -318,15 +413,231 @@
      </layout>
     </widget>
    </item>
-   <item row="6" column="1">
-    <spacer name="verticalSpacer_2">
+   <item row="1" column="0" rowspan="4">
+    <widget class="QGroupBox" name="qgbLookFeel">
+     <property name="title">
+      <string>Look and Feel</string>
+     </property>
+     <layout class="QGridLayout" name="gridLayout">
+      <item row="3" column="0" colspan="2">
+       <widget class="MUComboBox" name="qcbLanguage">
+        <property name="toolTip">
+         <string>Language to use (requires restart)</string>
+        </property>
+        <property name="whatsThis">
+         <string>&lt;b&gt;This sets which language Mumble should use.&lt;/b&gt;&lt;br /&gt;You have to restart Mumble to use the new language.</string>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="0">
+       <widget class="QLabel" name="qliTheme">
+        <property name="text">
+         <string>Theme</string>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="0" colspan="2">
+       <widget class="MUComboBox" name="qcbTheme">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="toolTip">
+         <string>Theme to use to style the user interface</string>
+        </property>
+        <property name="whatsThis">
+         <string>&lt;b&gt;Configures which theme the Mumble user interface should be styled with&lt;/b&gt;&lt;br /&gt;Mumble will pick up themes from certain directories and display them in this list. The one you select will be used to customize the visual appearance of Mumble. This includes colors, icons and more.</string>
+        </property>
+       </widget>
+      </item>
+      <item row="5" column="0" colspan="2">
+       <widget class="QCheckBox" name="qcbShowTransmitModeComboBox">
+        <property name="text">
+         <string>Show transmit mode dropdown in toolbar</string>
+        </property>
+       </widget>
+      </item>
+      <item row="4" column="0" colspan="2">
+       <widget class="QCheckBox" name="qcbHighContrast">
+        <property name="toolTip">
+         <string>Apply some high contrast optimizations for visually impaired users</string>
+        </property>
+        <property name="text">
+         <string>Optimize for high contrast</string>
+        </property>
+       </widget>
+      </item>
+      <item row="6" column="0">
+       <spacer name="verticalSpacer">
+        <property name="orientation">
+         <enum>Qt::Vertical</enum>
+        </property>
+        <property name="sizeHint" stdset="0">
+         <size>
+          <width>20</width>
+          <height>40</height>
+         </size>
+        </property>
+       </spacer>
+      </item>
+      <item row="2" column="0">
+       <widget class="QLabel" name="qliLanguage">
+        <property name="text">
+         <string>Language</string>
+        </property>
+        <property name="buddy">
+         <cstring>qcbLanguage</cstring>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="1">
+       <widget class="QLabel" name="qlThemesDirectory">
+        <property name="text">
+         <string/>
+        </property>
+        <property name="alignment">
+         <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item row="2" column="1">
+    <widget class="QGroupBox" name="qgbTray">
+     <property name="title">
+      <string>Tray Icon</string>
+     </property>
+     <layout class="QVBoxLayout" name="verticalLayout">
+      <item>
+       <widget class="QCheckBox" name="qcbHideTray">
+        <property name="toolTip">
+         <string>Hide the main Mumble window in the tray when it is minimized.</string>
+        </property>
+        <property name="whatsThis">
+         <string>&lt;b&gt;If set, minimizing the Mumble main window will cause it to be hidden and accessible only from the tray. Otherwise, it will be minimized as a window normally would.&lt;/b&gt;</string>
+        </property>
+        <property name="text">
+         <string>Hide in tray when minimized</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QCheckBox" name="qcbStateInTray">
+        <property name="toolTip">
+         <string>Displays talking status in system tray</string>
+        </property>
+        <property name="whatsThis">
+         <string/>
+        </property>
+        <property name="text">
+         <string>Show talking status in tray icon</string>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item row="1" column="1">
+    <widget class="QGroupBox" name="qgbApplication">
+     <property name="title">
+      <string>Application</string>
+     </property>
+     <layout class="QGridLayout" name="gridLayout_3" columnstretch="0,0">
+      <item row="0" column="0">
+       <widget class="QLabel" name="qliAlwaysOnTop">
+        <property name="text">
+         <string>Always On Top</string>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="1">
+       <widget class="MUComboBox" name="qcbAlwaysOnTop">
+        <property name="toolTip">
+         <string>This setting controls when the application will be always on top.</string>
+        </property>
+        <property name="whatsThis">
+         <string>This setting controls in which situations the application will stay always on top. If you select &lt;i&gt;Never&lt;/i&gt; the application will not stay on top. &lt;i&gt;Always&lt;/i&gt; will always keep the application on top. &lt;i&gt;In minimal view&lt;/i&gt; / &lt;i&gt;In normal view&lt;/i&gt; will only keep the application always on top when minimal view is activated / deactivated.</string>
+        </property>
+        <item>
+         <property name="text">
+          <string>Never</string>
+         </property>
+        </item>
+        <item>
+         <property name="text">
+          <string>Always</string>
+         </property>
+        </item>
+        <item>
+         <property name="text">
+          <string>In minimal view</string>
+         </property>
+        </item>
+        <item>
+         <property name="text">
+          <string>In normal view</string>
+         </property>
+        </item>
+       </widget>
+      </item>
+      <item row="1" column="0" colspan="2">
+       <widget class="QCheckBox" name="qcbShowContextMenuInMenuBar">
+        <property name="toolTip">
+         <string>Adds user and channel context menus into the menu bar</string>
+        </property>
+        <property name="text">
+         <string>Show context menu in menu bar</string>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="0" colspan="2">
+       <widget class="QCheckBox" name="qcbAskOnQuit">
+        <property name="toolTip">
+         <string>Ask whether to close or minimize when quitting Mumble.</string>
+        </property>
+        <property name="whatsThis">
+         <string>&lt;b&gt;If set, will verify you want to quit if connected.&lt;/b&gt;</string>
+        </property>
+        <property name="text">
+         <string>Ask on quit while connected</string>
+        </property>
+       </widget>
+      </item>
+      <item row="3" column="0" colspan="2">
+       <widget class="QCheckBox" name="qcbEnableDeveloperMenu">
+        <property name="whatsThis">
+         <string>&lt;b&gt;Enable Developer menu&lt;/b&gt;&lt;br /&gt;This enables the &quot;Developer&quot;-menu in Mumble. This menu is used for developer-specific features, such as the Developer Console.</string>
+        </property>
+        <property name="text">
+         <string>Enable Developer menu</string>
+        </property>
+       </widget>
+      </item>
+      <item row="4" column="0" colspan="2">
+       <widget class="QCheckBox" name="qcbLockLayout">
+        <property name="whatsThis">
+         <string>When in custom layout mode, checking this disables rearranging.</string>
+        </property>
+        <property name="text">
+         <string>Lock layout</string>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item row="5" column="1">
+    <spacer name="horizontalSpacer">
      <property name="orientation">
-      <enum>Qt::Vertical</enum>
+      <enum>Qt::Horizontal</enum>
      </property>
      <property name="sizeHint" stdset="0">
       <size>
-       <width>20</width>
-       <height>40</height>
+       <width>40</width>
+       <height>20</height>
       </size>
      </property>
     </spacer>
@@ -428,195 +739,18 @@
      </layout>
     </widget>
    </item>
-   <item row="2" column="1">
-    <widget class="QGroupBox" name="qgbTray">
-     <property name="title">
-      <string>Tray Icon</string>
+   <item row="6" column="1">
+    <spacer name="verticalSpacer_2">
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
      </property>
-     <layout class="QVBoxLayout" name="verticalLayout">
-      <item>
-       <widget class="QCheckBox" name="qcbHideTray">
-        <property name="toolTip">
-         <string>Hide the main Mumble window in the tray when it is minimized.</string>
-        </property>
-        <property name="whatsThis">
-         <string>&lt;b&gt;If set, minimizing the Mumble main window will cause it to be hidden and accessible only from the tray. Otherwise, it will be minimized as a window normally would.&lt;/b&gt;</string>
-        </property>
-        <property name="text">
-         <string>Hide in tray when minimized</string>
-        </property>
-       </widget>
-      </item>
-      <item>
-       <widget class="QCheckBox" name="qcbStateInTray">
-        <property name="toolTip">
-         <string>Displays talking status in system tray</string>
-        </property>
-        <property name="whatsThis">
-         <string/>
-        </property>
-        <property name="text">
-         <string>Show talking status in tray icon</string>
-        </property>
-       </widget>
-      </item>
-     </layout>
-    </widget>
-   </item>
-   <item row="4" column="1">
-    <widget class="QGroupBox" name="groupBox">
-     <property name="sizePolicy">
-      <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
-       <horstretch>0</horstretch>
-       <verstretch>0</verstretch>
-      </sizepolicy>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>20</width>
+       <height>40</height>
+      </size>
      </property>
-     <property name="title">
-      <string>Talking UI</string>
-     </property>
-     <property name="flat">
-      <bool>false</bool>
-     </property>
-     <property name="checkable">
-      <bool>false</bool>
-     </property>
-     <layout class="QGridLayout" name="gridLayout_5">
-      <property name="horizontalSpacing">
-       <number>6</number>
-      </property>
-      <item row="0" column="1">
-       <widget class="QSpinBox" name="qsbSilentUserLifetime">
-        <property name="sizePolicy">
-         <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-          <horstretch>0</horstretch>
-          <verstretch>0</verstretch>
-         </sizepolicy>
-        </property>
-        <property name="toolTip">
-         <string>A user that is silent for the given amount of seconds will be removed from the Talkin UI.</string>
-        </property>
-       </widget>
-      </item>
-      <item row="0" column="0">
-       <widget class="QLabel" name="qlSilentUserLifetime">
-        <property name="sizePolicy">
-         <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-          <horstretch>0</horstretch>
-          <verstretch>0</verstretch>
-         </sizepolicy>
-        </property>
-        <property name="toolTip">
-         <string>A user that is silent for the given amount of seconds will be removed from the Talkin UI.</string>
-        </property>
-        <property name="text">
-         <string>Remove silent user after</string>
-        </property>
-       </widget>
-      </item>
-      <item row="1" column="0" colspan="2">
-       <widget class="QCheckBox" name="qcbLocalUserVisible">
-        <property name="toolTip">
-         <string>If this is checked, the local user (yourself) will always be visible in the TalkingUI (regardless of talking state).</string>
-        </property>
-        <property name="text">
-         <string>Always keep local user visible</string>
-        </property>
-       </widget>
-      </item>
-     </layout>
-    </widget>
-   </item>
-   <item row="1" column="0" rowspan="4">
-    <widget class="QGroupBox" name="qgbLookFeel">
-     <property name="title">
-      <string>Look and Feel</string>
-     </property>
-     <layout class="QGridLayout" name="gridLayout">
-      <item row="3" column="0" colspan="2">
-       <widget class="MUComboBox" name="qcbLanguage">
-        <property name="toolTip">
-         <string>Language to use (requires restart)</string>
-        </property>
-        <property name="whatsThis">
-         <string>&lt;b&gt;This sets which language Mumble should use.&lt;/b&gt;&lt;br /&gt;You have to restart Mumble to use the new language.</string>
-        </property>
-       </widget>
-      </item>
-      <item row="0" column="0">
-       <widget class="QLabel" name="qliTheme">
-        <property name="text">
-         <string>Theme</string>
-        </property>
-       </widget>
-      </item>
-      <item row="1" column="0" colspan="2">
-       <widget class="MUComboBox" name="qcbTheme">
-        <property name="sizePolicy">
-         <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-          <horstretch>0</horstretch>
-          <verstretch>0</verstretch>
-         </sizepolicy>
-        </property>
-        <property name="toolTip">
-         <string>Theme to use to style the user interface</string>
-        </property>
-        <property name="whatsThis">
-         <string>&lt;b&gt;Configures which theme the Mumble user interface should be styled with&lt;/b&gt;&lt;br /&gt;Mumble will pick up themes from certain directories and display them in this list. The one you select will be used to customize the visual appearance of Mumble. This includes colors, icons and more.</string>
-        </property>
-       </widget>
-      </item>
-      <item row="5" column="0" colspan="2">
-       <widget class="QCheckBox" name="qcbShowTransmitModeComboBox">
-        <property name="text">
-         <string>Show transmit mode dropdown in toolbar</string>
-        </property>
-       </widget>
-      </item>
-      <item row="4" column="0" colspan="2">
-       <widget class="QCheckBox" name="qcbHighContrast">
-        <property name="toolTip">
-         <string>Apply some high contrast optimizations for visually impaired users</string>
-        </property>
-        <property name="text">
-         <string>Optimize for high contrast</string>
-        </property>
-       </widget>
-      </item>
-      <item row="6" column="0">
-       <spacer name="verticalSpacer">
-        <property name="orientation">
-         <enum>Qt::Vertical</enum>
-        </property>
-        <property name="sizeHint" stdset="0">
-         <size>
-          <width>20</width>
-          <height>40</height>
-         </size>
-        </property>
-       </spacer>
-      </item>
-      <item row="2" column="0">
-       <widget class="QLabel" name="qliLanguage">
-        <property name="text">
-         <string>Language</string>
-        </property>
-        <property name="buddy">
-         <cstring>qcbLanguage</cstring>
-        </property>
-       </widget>
-      </item>
-      <item row="0" column="1">
-       <widget class="QLabel" name="qlThemesDirectory">
-        <property name="text">
-         <string/>
-        </property>
-        <property name="alignment">
-         <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-        </property>
-       </widget>
-      </item>
-     </layout>
-    </widget>
+    </spacer>
    </item>
   </layout>
  </widget>

--- a/src/mumble/MainWindow.cpp
+++ b/src/mumble/MainWindow.cpp
@@ -2474,7 +2474,9 @@ void MainWindow::on_qaAudioUnlink_triggered() {
 }
 
 void MainWindow::on_qaConfigDialog_triggered() {
-	QDialog *dlg = new ConfigDialog(this);
+	ConfigDialog *dlg = new ConfigDialog(this);
+
+	QObject::connect(dlg, &ConfigDialog::settingsAccepted, g.talkingUI, &TalkingUI::on_settingsChanged);
 
 	if (dlg->exec() == QDialog::Accepted) {
 		setupView(false);

--- a/src/mumble/Settings.cpp
+++ b/src/mumble/Settings.cpp
@@ -452,8 +452,16 @@ Settings::Settings() {
 	iChatMessageMargins = 3;
 
 	bShowTalkingUI = false;
-	iTalkingUI_SilentUserLifeTime = 5;
 	bTalkingUI_LocalUserStaysVisible = false;
+	bTalkingUI_AbbreviateChannelNames = true;
+	bTalkingUI_AbbreviateCurrentChannel = false;
+	iTalkingUI_SilentUserLifeTime = 5;
+	iTalkingUI_ChannelHierarchyDepth = 1;
+	iTalkingUI_MaxChannelNameLength = 20;
+	iTalkingUI_PrefixCharCount = 3;
+	iTalkingUI_PostfixCharCount = 2;
+	qsTalkingUI_ChannelSeparator = QLatin1String("/");
+	qsTalkingUI_AbbreviationReplacement = QLatin1String("...");
 
 	bShortcutEnable = true;
 	bSuppressMacEventTapWarning = false;
@@ -812,8 +820,16 @@ void Settings::load(QSettings* settings_ptr) {
 
 	// TalkingUI
 	SAVELOAD(bShowTalkingUI, "ui/showTalkingUI");
-	SAVELOAD(iTalkingUI_SilentUserLifeTime, "ui/talkingUI_SilentUserLifeTime");
 	SAVELOAD(bTalkingUI_LocalUserStaysVisible, "ui/talkingUI_LocalUserStaysVisible");
+	SAVELOAD(bTalkingUI_AbbreviateChannelNames, "ui/talkingUI_AbbreviateChannelNames");
+	SAVELOAD(bTalkingUI_AbbreviateCurrentChannel, "ui/talkingUI_AbbreviateCurrentChannel");
+	SAVELOAD(iTalkingUI_SilentUserLifeTime, "ui/talkingUI_SilentUserLifeTime");
+	SAVELOAD(iTalkingUI_ChannelHierarchyDepth, "ui/talkingUI_ChannelHierarchieDepth");
+	SAVELOAD(iTalkingUI_MaxChannelNameLength, "ui/talkingUI_MaxChannelNameLength");
+	SAVELOAD(iTalkingUI_PrefixCharCount, "ui/talkingUI_PrefixCharCount");
+	SAVELOAD(iTalkingUI_PostfixCharCount, "ui/talkingUI_PostfixCharCount");
+	SAVELOAD(qsTalkingUI_ChannelSeparator, "ui/talkingUI_ChannelSeparator");
+	SAVELOAD(qsTalkingUI_AbbreviationReplacement, "ui/talkingUI_AbbreviationReplacement");
 
 	// PTT Button window
 	SAVELOAD(bShowPTTButtonWindow, "ui/showpttbuttonwindow");
@@ -1154,8 +1170,16 @@ void Settings::save() {
 
 	// TalkingUI
 	SAVELOAD(bShowTalkingUI, "ui/showTalkingUI");
-	SAVELOAD(iTalkingUI_SilentUserLifeTime, "ui/talkingUI_SilentUserLifeTime");
 	SAVELOAD(bTalkingUI_LocalUserStaysVisible, "ui/talkingUI_LocalUserStaysVisible");
+	SAVELOAD(bTalkingUI_AbbreviateChannelNames, "ui/talkingUI_AbbreviateChannelNames");
+	SAVELOAD(bTalkingUI_AbbreviateCurrentChannel, "ui/talkingUI_AbbreviateCurrentChannel");
+	SAVELOAD(iTalkingUI_SilentUserLifeTime, "ui/talkingUI_SilentUserLifeTime");
+	SAVELOAD(iTalkingUI_ChannelHierarchyDepth, "ui/talkingUI_ChannelHierarchieDepth");
+	SAVELOAD(iTalkingUI_MaxChannelNameLength, "ui/talkingUI_MaxChannelNameLength");
+	SAVELOAD(iTalkingUI_PrefixCharCount, "ui/talkingUI_PrefixCharCount");
+	SAVELOAD(iTalkingUI_PostfixCharCount, "ui/talkingUI_PostfixCharCount");
+	SAVELOAD(qsTalkingUI_ChannelSeparator, "ui/talkingUI_ChannelSeparator");
+	SAVELOAD(qsTalkingUI_AbbreviationReplacement, "ui/talkingUI_AbbreviationReplacement");
 
 	// PTT Button window
 	SAVELOAD(bShowPTTButtonWindow, "ui/showpttbuttonwindow");

--- a/src/mumble/Settings.h
+++ b/src/mumble/Settings.h
@@ -279,8 +279,16 @@ struct Settings {
 	int iChatMessageMargins;
 
 	bool bShowTalkingUI;
-	int iTalkingUI_SilentUserLifeTime;
 	bool bTalkingUI_LocalUserStaysVisible;
+	bool bTalkingUI_AbbreviateChannelNames;
+	bool bTalkingUI_AbbreviateCurrentChannel;
+	int iTalkingUI_SilentUserLifeTime;
+	int iTalkingUI_ChannelHierarchyDepth;
+	int iTalkingUI_MaxChannelNameLength;
+	int iTalkingUI_PrefixCharCount;
+	int iTalkingUI_PostfixCharCount;
+	QString qsTalkingUI_ChannelSeparator;
+	QString qsTalkingUI_AbbreviationReplacement;
 
 	QMap<int, QString> qmMessageSounds;
 	QMap<int, quint32> qmMessages;

--- a/src/mumble/TalkingUI.h
+++ b/src/mumble/TalkingUI.h
@@ -99,6 +99,7 @@ class TalkingUI : public QWidget {
 		void on_serverSynchronized();
 		void on_serverDisconnected();
 		void on_channelChanged(QObject *user);
+		void on_settingsChanged();
 };
 
 #endif // MUMBLE_MUMBLE_TALKINGUI_H_


### PR DESCRIPTION
…

Instead of only showing the name of the channel the respective user is
currently in, this commit adds the possibility to also include (parts
of) the channel hierarchy to remove ambiguities.

Alongside comes a system to potentially abbreviate the (hierarchy) names
in order to not use too much screen space.

Thiis is how it can look:

![Mumble_TalkingUI_ChannelParents](https://user-images.githubusercontent.com/12751591/81336515-c4920c80-90a9-11ea-82e5-1cc66c2cc426.png)
