### PR TITLE
FEAT(server): Add rememberduration option

### DIFF
--- a/scripts/murmur.ini
+++ b/scripts/murmur.ini
@@ -206,6 +206,11 @@ allowping=true
 ;
 ;rememberchannel=true
 
+; How many seconds should the server remember the last channel of a user.
+; Set to 0 (default) to remember forever. This option has no effect if
+; rememberchannel is set to false.
+;rememberchannelduration=0
+
 ; Maximum length of text messages in characters. 0 for no limit.
 ;textmessagelength=5000
 

--- a/src/murmur/Messages.cpp
+++ b/src/murmur/Messages.cpp
@@ -246,11 +246,7 @@ void Server::msgAuthenticate(ServerUser *uSource, MumbleProto::Authenticate &msg
 	}
 
 	Channel *lc;
-	if (bRememberChan) {
-		lc = qhChannels.value(readLastChannel(uSource->iId));
-	} else {
-		lc = qhChannels.value(iDefaultChan);
-	}
+	lc = qhChannels.value(readLastChannel(uSource->iId));
 
 	if (! lc || ! hasPermission(uSource, lc, ChanACL::Enter) || isChannelFull(lc, uSource)) {
 		lc = qhChannels.value(iDefaultChan);

--- a/src/murmur/Meta.cpp
+++ b/src/murmur/Meta.cpp
@@ -62,6 +62,7 @@ MetaParams::MetaParams() {
 	bAllowHTML = true;
 	iDefaultChan = 0;
 	bRememberChan = true;
+	iRememberChanDuration = 0;
 	qsWelcomeText = QString();
 	qsDatabase = QString();
 	iSQLiteWAL = 0;
@@ -293,6 +294,7 @@ void MetaParams::read(QString fname) {
 	iMaxBandwidth = typeCheckedFromSettings("bandwidth", iMaxBandwidth);
 	iDefaultChan = typeCheckedFromSettings("defaultchannel", iDefaultChan);
 	bRememberChan = typeCheckedFromSettings("rememberchannel", bRememberChan);
+	iRememberChanDuration = typeCheckedFromSettings("rememberchannelduration", iRememberChanDuration);
 	iMaxUsers = typeCheckedFromSettings("users", iMaxUsers);
 	iMaxUsersPerChannel = typeCheckedFromSettings("usersperchannel", iMaxUsersPerChannel);
 	iMaxListenersPerChannel = typeCheckedFromSettings("listenersperchannel", iMaxListenersPerChannel);
@@ -422,6 +424,7 @@ void MetaParams::read(QString fname) {
 	qmConfig.insert(QLatin1String("users"),QString::number(iMaxUsers));
 	qmConfig.insert(QLatin1String("defaultchannel"),QString::number(iDefaultChan));
 	qmConfig.insert(QLatin1String("rememberchannel"),bRememberChan ? QLatin1String("true") : QLatin1String("false"));
+	qmConfig.insert(QLatin1String("rememberchannelduration"),QString::number(iRememberChanDuration));
 	qmConfig.insert(QLatin1String("welcometext"),qsWelcomeText);
 	qmConfig.insert(QLatin1String("registername"),qsRegName);
 	qmConfig.insert(QLatin1String("registerpassword"),qsRegPassword);

--- a/src/murmur/Meta.h
+++ b/src/murmur/Meta.h
@@ -38,6 +38,7 @@ public:
 	int iMaxListenerProxiesPerUser;
 	int iDefaultChan;
 	bool bRememberChan;
+	int iRememberChanDuration;
 	int iMaxTextMessageLength;
 	int iMaxImageMessageLength;
 	int iOpusThreshold;

--- a/src/murmur/Server.h
+++ b/src/murmur/Server.h
@@ -111,6 +111,7 @@ class Server : public QThread {
 		int iMaxUsersPerChannel;
 		int iDefaultChan;
 		bool bRememberChan;
+		int iRememberChanDuration;
 		int iMaxTextMessageLength;
 		int iMaxImageMessageLength;
 		int iOpusThreshold;
@@ -409,6 +410,9 @@ class Server : public QThread {
 		void readChannelPrivs(Channel *c);
 		void setLastChannel(const User *u);
 		int readLastChannel(int id);
+
+		/// Set last_disconnect of a registered user to the current time
+		void setLastDisconnect(const User *u);
 		void dumpChannel(const Channel *c);
 		int getUserID(const QString &name);
 		QString getUserName(int id);

--- a/src/murmur/ServerDB.h
+++ b/src/murmur/ServerDB.h
@@ -10,20 +10,22 @@
 
 #include "Timer.h"
 
+class Server;
 class Channel;
 class User;
 class Connection;
 class QSqlDatabase;
 class QSqlQuery;
 
-class ServerDB {
+class ServerDB : public QObject {
+	Q_OBJECT;
 	public:
 		/// A version number that allows us to keep track of changes we make to the DB architecture
 		/// in order to provide backwards compatibility and perform automatic updates of older DBs.
 		/// Whenever you change the DB structure (add a new table, added a new column in a table, etc.)
 		/// you have to increase this version number by one and add the respective "backwards compatibility
 		/// code" into the ServerDB code.
-		static const int DB_STRUCTURE_VERSION = 7;
+		static const int DB_STRUCTURE_VERSION = 8;
 
 		enum ChannelInfo { Channel_Description, Channel_Position, Channel_Max_Users };
 		enum UserInfo { User_Name, User_Email, User_Comment, User_Hash, User_Password, User_LastActive, User_KDFIterations };
@@ -57,6 +59,11 @@ class ServerDB {
 	private:
 		static void loadOrSetupMetaPBKDF2IterationCount(QSqlQuery &query);
 		static void writeSUPW(int srvnum, const QString &pwHash, const QString &saltHash, const QVariant &kdfIterations);
+
+	public slots:
+		/// Clear last_disconnect date of every user of the server
+		void clearLastDisconnect(Server *);
+
 };
 
 #endif

--- a/src/murmur/main.cpp
+++ b/src/murmur/main.cpp
@@ -457,6 +457,8 @@ int main(int argc, char **argv) {
 
 	meta = new Meta();
 
+	QObject::connect(meta, SIGNAL(started(Server *)), &db, SLOT(clearLastDisconnect(Server *)));
+
 #ifdef Q_OS_UNIX
 	if (readPw) {
 		char password[256];

--- a/src/murmur/murmur.pro
+++ b/src/murmur/murmur.pro
@@ -16,7 +16,7 @@ TARGET = murmur
 DBFILE = murmur.db
 LANGUAGE = C++
 FORMS =
-HEADERS *= Server.h ServerUser.h Meta.h PBKDF2.h
+HEADERS *= Server.h ServerDB.h ServerUser.h Meta.h PBKDF2.h
 SOURCES *= main.cpp Server.cpp ServerUser.cpp ServerDB.cpp Register.cpp Cert.cpp Messages.cpp Meta.cpp RPC.cpp PBKDF2.cpp
 
 PRECOMPILED_HEADER = murmur_pch.h


### PR DESCRIPTION
This option allows to set a threshold on how long a user's channel
should be remembered. This is useful for scenarios where users usually
don't want their channel to be remembered by the server unless they had
a disconnect (aka have ot re-connect after a short period of time).

Implements #4143