### PR TITLE
Join user's channel context action

### DIFF
--- a/src/mumble/MainWindow.h
+++ b/src/mumble/MainWindow.h
@@ -213,6 +213,7 @@ class MainWindow : public QMainWindow, public MessageHandler, public Ui::MainWin
 		void on_qaUserFriendUpdate_triggered();
 		void qmChannel_aboutToShow();
 		void on_qaChannelJoin_triggered();
+		void on_qaUserJoin_triggered();
 		void on_qaChannelListen_triggered();
 		void on_qaChannelAdd_triggered();
 		void on_qaChannelRemove_triggered();

--- a/src/mumble/MainWindow.ui
+++ b/src/mumble/MainWindow.ui
@@ -947,6 +947,14 @@ the channel's context menu.</string>
     <string>Toggles the visibility of the TalkingUI.</string>
    </property>
   </action>
+  <action name="qaUserJoin">
+   <property name="text">
+    <string>Join user's channel</string>
+   </property>
+   <property name="toolTip">
+    <string>Joins the channel of this user.</string>
+   </property>
+  </action>
  </widget>
  <customwidgets>
   <customwidget>

--- a/src/mumble/mumble_en.ts
+++ b/src/mumble/mumble_en.ts
@@ -758,10 +758,6 @@ This value allows you to set the maximum number of users allowed in the channel.
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Cancel echo from speakers</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Enabling this will cancel the echo from your speakers. Mixed has low CPU impact, but only works well if your speakers are equally loud and equidistant from the microphone. Multichannel echo cancellation provides much better echo cancellation, but at a higher CPU cost.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5587,6 +5583,14 @@ the channel&apos;s context menu.</source>
         <source>Toggles the visibility of the TalkingUI.</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Join user&apos;s channel</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Joins the channel of this user.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>Manual</name>
@@ -6473,6 +6477,14 @@ To upgrade these files to their latest versions, click the button below.</source
     </message>
     <message>
         <source>Talking UI</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Cancel echo from speakers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Echo cancellation is not supported for the interface combination &quot;%1&quot; (in) and &quot;%2&quot; (out).</source>
         <translation type="unfinished"></translation>
     </message>
 </context>


### PR DESCRIPTION
This might be useful for situations in which a channel is pretty full
and thus one doesn't see the channel entry in the UI but instead sees
some users that are in that channel. Now if you want to join these
users, you don't really care about which channel they are in anyway, so
with this you can just right click on any user in a different channel
and join their channel via the context menu.

Changelog
```
| Added: Context action to join a user's channel
```