### PR TITLE
Fixed UserIndex::rowOf() function for listener proxies

### DIFF
--- a/src/mumble/UserModel.cpp
+++ b/src/mumble/UserModel.cpp
@@ -776,87 +776,123 @@ void UserModel::recursiveClone(const ModelItem *old, ModelItem *item, QModelInde
 		recursiveClone(old->qlChildren.at(i), item->qlChildren.at(i), from, to);
 }
 
-ModelItem *UserModel::moveItem(ModelItem *oldparent, ModelItem *newparent, ModelItem *item) {
+ModelItem *UserModel::moveItem(ModelItem *oldparent, ModelItem *newparent, ModelItem *oldItem) {
 	// Here's the idea. We insert the item, update persistent indexes, THEN remove it.
-	int oldrow = oldparent->qlChildren.indexOf(item);
+
+	// Get the current position of the item under its parent (aka its "row")
+	int oldrow = oldparent->qlChildren.indexOf(oldItem);
+
+	// Get the row of the item at its new position. This depends on whether we're moving a
+	// channel or a user.
 	int newrow = -1;
-
-	if (item->cChan)
-		newrow = newparent->insertIndex(item->cChan);
-	else
-		newrow = newparent->insertIndex(item->pUser);
-
-	if ((oldparent == newparent) && (newrow == oldrow)) {
-		emit dataChanged(index(item),index(item));
-		return item;
+	if (oldItem->cChan) {
+		newrow = newparent->insertIndex(oldItem->cChan);
+	} else {
+		newrow = newparent->insertIndex(oldItem->pUser);
 	}
 
-	// Shallow clone
-	ModelItem *t = new ModelItem(item);
+	if ((oldparent == newparent) && (newrow == oldrow)) {
+		// This is a no-op. We still claim that the data has changed in order
+		// to trigger potential event handlers.
+		emit dataChanged(index(oldItem),index(oldItem));
+		return oldItem;
+	}
+
+	// Shallow clone. newItem is the new ModelItem that will be added to newparent
+	ModelItem *newItem = new ModelItem(oldItem);
 
 	// Store the index if it's "active".
 	// The selection is stored as "from"-"to" pairs, so if we move up in the same channel,
 	// we'd move only "from" and select half the channel.
 
+	// Check whether the moved item is currently selected and if so, store it as a persistent
+	// model index in active. Also clear the selection as we're going to mess with the active
+	// item.
 	QTreeView *v=g.mw->qtvUsers;
 	QItemSelectionModel *sel=v->selectionModel();
 	QPersistentModelIndex active;
-	QModelIndex oindex = createIndex(oldrow, 0, item);
+	QModelIndex oindex = createIndex(oldrow, 0, oldItem);
 	if (sel->isSelected(oindex) || (oindex == v->currentIndex())) {
-		active = index(item);
+		active = index(oldItem);
 		v->clearSelection();
 		v->setCurrentIndex(QModelIndex());
 	}
 
-	bool expanded = v->isExpanded(index(item));
+	// Check whether the oldItem is currently expanded in order to restore the same
+	// state once we have moved it.
+	bool expanded = v->isExpanded(index(oldItem));
 
 	if (newparent == oldparent) {
-		// Mangle rows. newrow needs to be pre-remove. oldrow needs to be postremove.
+		// If the moving happens within the same parent, we have to watch out that we use the correct
+		// row indices for our operation here.
+		// As we're inserting the new item before remving the old one, newrow has to be the index
+		// applicable before the removal (aka "as is" atm) whereas oldrow has to be applicable
+		// after we've inserted the new item.
 		if (oldrow >= newrow) {
+			// The new item will be inserted above the old one. Thus we have to account for that extra
+			// item in the used row index.
 			oldrow++;
 		} else {
 			newrow++;
 		}
 	}
 
+	// Insert the new item to its (new) parent
 	beginInsertRows(index(newparent), newrow, newrow);
-	t->parent = newparent;
-	newparent->qlChildren.insert(newrow, t);
+	newItem->parent = newparent;
+	newparent->qlChildren.insert(newrow, newItem);
 
-	if (item->cChan) {
-		oldparent->cChan->removeChannel(item->cChan);
-		newparent->cChan->addChannel(item->cChan);
+	if (oldItem->cChan) {
+		// When moving a channel, we'll also have to move any sub-channels
+		oldparent->cChan->removeChannel(oldItem->cChan);
+		newparent->cChan->addChannel(oldItem->cChan);
 	} else {
-		newparent->cChan->addClientUser(item->pUser);
+		newparent->cChan->addClientUser(oldItem->pUser);
 	}
 
 	endInsertRows();
 
 
 	QModelIndexList from, to;
-	from << createIndex(oldrow, 0, item);
-	from << createIndex(oldrow, 1, item);
-	to << createIndex(newrow, 0, t);
-	to << createIndex(newrow, 1, t);
+	from << createIndex(oldrow, 0, oldItem);
+	from << createIndex(oldrow, 1, oldItem);
+	to << createIndex(newrow, 0, newItem);
+	to << createIndex(newrow, 1, newItem);
 
-	recursiveClone(item, t, from, to);
+	// Clone all children of oldItem and attach them to newItem
+	recursiveClone(oldItem, newItem, from, to);
 
+	// Update all persistent model indices that are affected by our action here. This includes (but is in general
+	// not limited to) the "active" index we potentially created above.
 	changePersistentIndexList(from, to);
 
+	// Now that we have added the new index, it is time to actually remove the old one
 	beginRemoveRows(index(oldparent), oldrow, oldrow);
 	oldparent->qlChildren.removeAt(oldrow);
 	endRemoveRows();
 
-	item->wipe();
-	delete item;
+	// oldItem is now longer needed as it is not present in the model anymore and all potential
+	// references to it should be updated to point to the new (moved) item instead.
+	// Thus we can delete it and all its children (which have been cloned and reference-updated
+	// as well.
+	oldItem->wipe();
+	delete oldItem;
 
 	if (active.isValid()) {
+		// If the moved item has been previously selected, we restore that selection to now be the
+		// new item using the "active" model index which has been updated to now point to the new
+		// item.
 		sel->select(active, QItemSelectionModel::SelectCurrent);
 		v->setCurrentIndex(active);
 	}
-	if (expanded)
-		v->expand(index(t));
-	return t;
+
+	if (expanded) {
+		// If the old item (or rather the parent it has been living in) has been expanded,
+		// restore that state for the new item.
+		v->expand(index(newItem));
+	}
+
+	return newItem;
 }
 
 void UserModel::expandAll(Channel *c) {

--- a/src/mumble/UserModel.cpp
+++ b/src/mumble/UserModel.cpp
@@ -136,9 +136,9 @@ int ModelItem::rowOf(Channel *c) const {
 	return -1;
 }
 
-int ModelItem::rowOf(ClientUser *p) const {
+int ModelItem::rowOf(ClientUser *p, const bool isListener) const {
 	for (int i=0;i<qlChildren.count();i++)
-		if (qlChildren.at(i)->pUser == p)
+		if (qlChildren.at(i)->isListener == isListener && qlChildren.at(i)->pUser == p)
 			return i;
 	return -1;
 }
@@ -149,7 +149,7 @@ int ModelItem::rowOfSelf() const {
 		return 0;
 
 	if (pUser)
-		return parent->rowOf(pUser);
+		return parent->rowOf(pUser, isListener);
 	else
 		return parent->rowOf(cChan);
 }

--- a/src/mumble/UserModel.h
+++ b/src/mumble/UserModel.h
@@ -51,7 +51,7 @@ public:
 	ClientUser *userAt(int idx) const;
 	Channel *channelAt(int idx) const;
 	int rowOf(Channel *c) const;
-	int rowOf(ClientUser *p) const;
+	int rowOf(ClientUser *p, const bool isListener) const;
 	int rowOfSelf() const;
 	int rows() const;
 	int insertIndex(Channel *c) const;


### PR DESCRIPTION
The ModelIndex::rowOf functions did not take into account that checking
whether ModelIndex::pUser is not sufficient anymore as listener proxies
share the same associated user. Thus to uniquely identify the index for
the actual user, it also has to be taken into account whether the index
at hand corresponds to a listener proxy.

This mis-behavior was responsible for a segfault triggered by being in a
channel you also have a listener proxy in and then being dragged out of
that channel (the dragging part is important). During this process it
would delete the wrong item which it later wanted to select again
(causing access to deleted memory) resulting in the segfault.