### PR TITLE
Added option to add custom window title extension 

### DIFF
--- a/src/mumble/Global.h
+++ b/src/mumble/Global.h
@@ -97,6 +97,7 @@ public:
 	unsigned int uiImageLength;
 	unsigned int uiMaxUsers;
 	bool bQuit;
+	QString windowTitlePostfix;
 
 	bool bHappyEaster;
 	static const char ccHappyEaster[];

--- a/src/mumble/MainWindow.cpp
+++ b/src/mumble/MainWindow.cpp
@@ -397,6 +397,11 @@ void MainWindow::updateWindowTitle() {
 	} else {
 		title = tr("Mumble -- %1");
 	}
+
+	if (!g.windowTitlePostfix.isEmpty()) {
+		title += QString::fromLatin1(" | %1").arg(g.windowTitlePostfix);
+	}
+
 	setWindowTitle(title.arg(QLatin1String(MUMBLE_RELEASE)));
 }
 

--- a/src/mumble/main.cpp
+++ b/src/mumble/main.cpp
@@ -170,6 +170,8 @@ int main(int argc, char **argv) {
 					"                Show the Mumble authors.\n"
 					"  --third-party-licenses\n"
 					"                Show licenses for third-party software used by Mumble.\n"
+					"  --window-title-ext <arg>\n"
+					"                Sets a custom window title extension.\n"
 					"\n"
 				);
 				QString rpcHelpBanner = MainWindow::tr(
@@ -221,6 +223,14 @@ int main(int argc, char **argv) {
 					++i;
 				} else {
 					qCritical("Missing argument for --jackname!");
+					return 1;
+				}
+			} else if (args.at(i) == QLatin1String("--window-title-ext")) {
+				if (i + 1 < args.count()) {
+					g.windowTitlePostfix = QString(args.at(i+1));
+					++i;
+				} else {
+					qCritical("Missing argument for --window-title-ext!");
 					return 1;
 				}
 			} else if (args.at(i) == QLatin1String("-license") || args.at(i) == QLatin1String("--license")) {

--- a/src/mumble/main.cpp
+++ b/src/mumble/main.cpp
@@ -162,7 +162,7 @@ int main(int argc, char **argv) {
 					"                Allow multiple instances of the client to be started.\n"
 					"  -n, --noidentity\n"
 					"                Suppress loading of identity files (i.e., certificates.)\n"
-					"  -jn, --jackname\n"
+					"  -jn, --jackname <arg>\n"
 					"                Set custom Jack client name.\n"
 					"  --license\n"
 					"                Show the Mumble license.\n"
@@ -215,8 +215,14 @@ int main(int argc, char **argv) {
 				suppressIdentity = true;
 				g.s.bSuppressIdentity = true;
 			} else if (args.at(i) == QLatin1String("-jn") || args.at(i) == QLatin1String("--jackname")) {
-				g.s.qsJackClientName = QString(args.at(i+1));
-				customJackClientName = true;
+				if (i + 1 < args.count()) {
+					g.s.qsJackClientName = QString(args.at(i+1));
+					customJackClientName = true;
+					++i;
+				} else {
+					qCritical("Missing argument for --jackname!");
+					return 1;
+				}
 			} else if (args.at(i) == QLatin1String("-license") || args.at(i) == QLatin1String("--license")) {
 				printf("%s\n", qPrintable(License::license()));
 				return 0;

--- a/src/mumble/mumble_en.ts
+++ b/src/mumble/mumble_en.ts
@@ -5242,34 +5242,6 @@ Otherwise abort and check your certificate and username.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Usage: mumble [options] [&lt;url&gt;]
-
-&lt;url&gt; specifies a URL to connect to after startup instead of showing
-the connection window, and has the following form:
-mumble://[&lt;username&gt;[:&lt;password&gt;]@]&lt;host&gt;[:&lt;port&gt;][/&lt;channel&gt;[/&lt;subchannel&gt;...]][?version=&lt;x.y.z&gt;]
-
-The version query parameter has to be set in order to invoke the
-correct client version. It currently defaults to 1.2.0.
-
-Valid options are:
-  -h, --help    Show this help text and exit.
-  -m, --multiple
-                Allow multiple instances of the client to be started.
-  -n, --noidentity
-                Suppress loading of identity files (i.e., certificates.)
-  -jn, --jackname
-                Set custom Jack client name.
-  --license
-                Show the Mumble license.
-  --authors
-                Show the Mumble authors.
-  --third-party-licenses
-                Show licenses for third-party software used by Mumble.
-
-</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Usage: mumble rpc &lt;action&gt; [options]
 
 It is possible to remote control a running instance of Mumble by using
@@ -5661,6 +5633,36 @@ the channel&apos;s context menu.</source>
     </message>
     <message>
         <source>Joins the channel of this user.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Usage: mumble [options] [&lt;url&gt;]
+
+&lt;url&gt; specifies a URL to connect to after startup instead of showing
+the connection window, and has the following form:
+mumble://[&lt;username&gt;[:&lt;password&gt;]@]&lt;host&gt;[:&lt;port&gt;][/&lt;channel&gt;[/&lt;subchannel&gt;...]][?version=&lt;x.y.z&gt;]
+
+The version query parameter has to be set in order to invoke the
+correct client version. It currently defaults to 1.2.0.
+
+Valid options are:
+  -h, --help    Show this help text and exit.
+  -m, --multiple
+                Allow multiple instances of the client to be started.
+  -n, --noidentity
+                Suppress loading of identity files (i.e., certificates.)
+  -jn, --jackname &lt;arg&gt;
+                Set custom Jack client name.
+  --license
+                Show the Mumble license.
+  --authors
+                Show the Mumble authors.
+  --third-party-licenses
+                Show licenses for third-party software used by Mumble.
+  --window-title-ext &lt;arg&gt;
+                Sets a custom window title extension.
+
+</source>
         <translation type="unfinished"></translation>
     </message>
 </context>


### PR DESCRIPTION
In #4153 it was requested to have an option that allows to customize the
window title in order to better differentiate between the windows of
multiple Mumble instances.

This commit allows just that by letting the user specify a postfix
that'll be appended to the window title.

Fixes #4153

Changelog
```
| Added --window-title-ext to set a custom window title extension
```

