### PR TITLE
Added check for unprocessed translations

### DIFF
--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -53,3 +53,11 @@ jobs:
       inputs:
         pathtoPublish: '$(Build.ArtifactStagingDirectory)'
         artifactName: macOS installer
+  - job: Translations
+    pool:
+      vmImage: 'ubuntu-latest'
+    steps:
+    - script: scripts/azure-pipelines/install-environment_linux_translations.bash
+      displayName: 'Install Qt tools'
+    - script: scripts/azure-pipelines/assertNoTranslationChanges.sh
+      displayName: 'Checking for translation changes'

--- a/scripts/azure-pipelines/assertNoTranslationChanges.sh
+++ b/scripts/azure-pipelines/assertNoTranslationChanges.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+#
+# Copyright 2020 The Mumble Developers. All rights reserved.
+# Use of this source code is governed by a BSD-style license
+# that can be found in the LICENSE file at the root of the
+# Mumble source tree or at <https://www.mumble.info/LICENSE>.
+
+set -e
+
+# Get path to the updatetranslations script
+updateScript="`dirname $0`/../updatetranslations.sh"
+
+# Get current commit hash
+oldHash=`git rev-parse HEAD`
+
+# In order for any commits to be possible, we'll have to set up a dummy user
+git config user.name "CI"
+git config user.email "ci@mumble.info"
+
+# Execute updatetranslations that'll commit any translation changes
+"./$updateScript" > /dev/null
+echo
+
+# Ger new commit hash
+newHash=`git rev-parse HEAD`
+
+# Check if the commit hash has changed (aka whether a commit has been made).
+# If so that means that there are unprocessed translation changes.
+if [[ "$oldHash" = "$newHash" ]]; then
+	echo "No translations have changed"
+	exit 0
+else
+	echo "[ERROR]: There are unprocessed translation changes!"
+	exit 1
+fi

--- a/scripts/azure-pipelines/install-environment_linux_translations.bash
+++ b/scripts/azure-pipelines/install-environment_linux_translations.bash
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+#
+# Copyright 2020 The Mumble Developers. All rights reserved.
+# Use of this source code is governed by a BSD-style license
+# that can be found in the LICENSE file at the root of the
+# Mumble source tree or at <https://www.mumble.info/LICENSE>.
+
+set -e
+set -x
+
+sudo apt-get update
+
+sudo apt-get -y install qttools5-dev-tools qt5-qmake

--- a/src/mumble/mumble_en.ts
+++ b/src/mumble/mumble_en.ts
@@ -758,10 +758,6 @@ This value allows you to set the maximum number of users allowed in the channel.
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Cancel echo from speakers</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Enabling this will cancel the echo from your speakers. Mixed has low CPU impact, but only works well if your speakers are equally loud and equidistant from the microphone. Multichannel echo cancellation provides much better echo cancellation, but at a higher CPU cost.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6473,6 +6469,14 @@ To upgrade these files to their latest versions, click the button below.</source
     </message>
     <message>
         <source>Talking UI</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Cancel echo from speakers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Echo cancellation is not supported for the interface combination &quot;%1&quot; (in) and &quot;%2&quot; (out).</source>
         <translation type="unfinished"></translation>
     </message>
 </context>


### PR DESCRIPTION
As it happens rather frequently for someone (e.g. me) to forget to
update the translations after having messed with translated strings,
this commit introduces a check to the CI that verifies that the
translations are always up-to-date.