### PR TITLE
Fix sqlite version requirement

### DIFF
--- a/src/murmur/ServerDB.cpp
+++ b/src/murmur/ServerDB.cpp
@@ -186,7 +186,7 @@ ServerDB::ServerDB() {
 				minor = splitVersion.at(1).toInt();
 				hasversion = true;
 			}
-			if (major >= 3 || (major == 3 && minor >= 7)) {
+			if (major > 3 || (major == 3 && minor >= 7)) {
 				okversion = true;
 			}
 


### PR DESCRIPTION
Fixes the version-check for when to use Write-Ahead-Logging (https://www.sqlite.org/wal.html) with SQLite.

Fixes #4162 