### PR TITLE
Made font size for TalkingUI entries configurable

### DIFF
--- a/src/mumble/LookConfig.cpp
+++ b/src/mumble/LookConfig.cpp
@@ -187,6 +187,7 @@ void LookConfig::load(const Settings &r) {
 	loadCheckBox(qcbLocalUserVisible, r.bTalkingUI_LocalUserStaysVisible);
 	loadCheckBox(qcbAbbreviateChannelNames, r.bTalkingUI_AbbreviateChannelNames);
 	loadCheckBox(qcbAbbreviateCurrentChannel, r.bTalkingUI_AbbreviateCurrentChannel);
+	qsbRelFontSize->setValue(r.iTalkingUI_RelativeFontSize);
 	qsbSilentUserLifetime->setValue(r.iTalkingUI_SilentUserLifeTime);
 	qsbChannelHierarchyDepth->setValue(r.iTalkingUI_ChannelHierarchyDepth);
 	qsbMaxNameLength->setValue(r.iTalkingUI_MaxChannelNameLength);
@@ -250,6 +251,7 @@ void LookConfig::save() const {
 	s.bTalkingUI_LocalUserStaysVisible = qcbLocalUserVisible->isChecked();
 	s.bTalkingUI_AbbreviateChannelNames = qcbAbbreviateChannelNames->isChecked();
 	s.bTalkingUI_AbbreviateCurrentChannel = qcbAbbreviateCurrentChannel->isChecked();
+	s.iTalkingUI_RelativeFontSize = qsbRelFontSize->value();
 	s.iTalkingUI_SilentUserLifeTime = qsbSilentUserLifetime->value();
 	s.iTalkingUI_ChannelHierarchyDepth = qsbChannelHierarchyDepth->value();
 	s.iTalkingUI_MaxChannelNameLength = qsbMaxNameLength->value();

--- a/src/mumble/LookConfig.ui
+++ b/src/mumble/LookConfig.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>728</width>
-    <height>1082</height>
+    <height>1120</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -35,30 +35,7 @@
       <property name="horizontalSpacing">
        <number>6</number>
       </property>
-      <item row="5" column="0">
-       <widget class="QLabel" name="qlChannelHierarchyDepth">
-        <property name="toolTip">
-         <string>The names of how many parent channels should be included in the channel's name when displaying it in the TalkingUI?</string>
-        </property>
-        <property name="text">
-         <string>Channel hierarchy depth</string>
-        </property>
-       </widget>
-      </item>
-      <item row="12" column="1">
-       <widget class="QLineEdit" name="qleAbbreviationReplacement">
-        <property name="sizePolicy">
-         <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-          <horstretch>0</horstretch>
-          <verstretch>0</verstretch>
-         </sizepolicy>
-        </property>
-        <property name="toolTip">
-         <string>String that gets used isntead of the cut-out part of an abbreviated name.</string>
-        </property>
-       </widget>
-      </item>
-      <item row="3" column="1">
+      <item row="4" column="1">
        <widget class="QSpinBox" name="qsbSilentUserLifetime">
         <property name="sizePolicy">
          <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
@@ -71,7 +48,24 @@
         </property>
        </widget>
       </item>
-      <item row="8" column="0">
+      <item row="9" column="1">
+       <widget class="QSpinBox" name="qsbPrefixCharCount">
+        <property name="toolTip">
+         <string>How many characters from the original name to display at the beginning of an abbreviated name.</string>
+        </property>
+       </widget>
+      </item>
+      <item row="12" column="0">
+       <widget class="QLabel" name="qlChannelSeparator">
+        <property name="toolTip">
+         <string>String to separate a channel name from its parent's.</string>
+        </property>
+        <property name="text">
+         <string>Channel separator</string>
+        </property>
+       </widget>
+      </item>
+      <item row="9" column="0">
        <widget class="QLabel" name="qlPrefixCharCount">
         <property name="toolTip">
          <string>How many characters from the original name to display at the beginning of an abbreviated name.</string>
@@ -81,44 +75,7 @@
         </property>
        </widget>
       </item>
-      <item row="9" column="0">
-       <widget class="QLabel" name="qlPostfixCharCount">
-        <property name="toolTip">
-         <string>How many characters from the original name to display at the end of an abbreviated name.</string>
-        </property>
-        <property name="text">
-         <string>Abbreviated postfix characters</string>
-        </property>
-       </widget>
-      </item>
-      <item row="0" column="0">
-       <widget class="QCheckBox" name="qcbLocalUserVisible">
-        <property name="toolTip">
-         <string>If this is checked, the local user (yourself) will always be visible in the TalkingUI (regardless of talking state).</string>
-        </property>
-        <property name="text">
-         <string>Always keep local user visible</string>
-        </property>
-       </widget>
-      </item>
-      <item row="12" column="0">
-       <widget class="QLabel" name="qlAbbreviationReplacement">
-        <property name="toolTip">
-         <string>String that gets used isntead of the cut-out part of an abbreviated name.</string>
-        </property>
-        <property name="text">
-         <string>Abbreviation replacement</string>
-        </property>
-       </widget>
-      </item>
-      <item row="8" column="1">
-       <widget class="QSpinBox" name="qsbPrefixCharCount">
-        <property name="toolTip">
-         <string>How many characters from the original name to display at the beginning of an abbreviated name.</string>
-        </property>
-       </widget>
-      </item>
-      <item row="3" column="0">
+      <item row="4" column="0">
        <widget class="QLabel" name="qlSilentUserLifetime">
         <property name="sizePolicy">
          <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
@@ -134,6 +91,23 @@
         </property>
        </widget>
       </item>
+      <item row="6" column="1">
+       <widget class="QSpinBox" name="qsbChannelHierarchyDepth">
+        <property name="toolTip">
+         <string>The names of how many parent channels should be included in the channel's name when displaying it in the TalkingUI?</string>
+        </property>
+       </widget>
+      </item>
+      <item row="10" column="0">
+       <widget class="QLabel" name="qlPostfixCharCount">
+        <property name="toolTip">
+         <string>How many characters from the original name to display at the end of an abbreviated name.</string>
+        </property>
+        <property name="text">
+         <string>Abbreviated postfix characters</string>
+        </property>
+       </widget>
+      </item>
       <item row="2" column="0" colspan="2">
        <widget class="QCheckBox" name="qcbAbbreviateCurrentChannel">
         <property name="toolTip">
@@ -141,6 +115,56 @@
         </property>
         <property name="text">
          <string>Abbreviate current channel name</string>
+        </property>
+       </widget>
+      </item>
+      <item row="6" column="0">
+       <widget class="QLabel" name="qlChannelHierarchyDepth">
+        <property name="toolTip">
+         <string>The names of how many parent channels should be included in the channel's name when displaying it in the TalkingUI?</string>
+        </property>
+        <property name="text">
+         <string>Channel hierarchy depth</string>
+        </property>
+       </widget>
+      </item>
+      <item row="12" column="1">
+       <widget class="QLineEdit" name="qleChannelSeparator">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="toolTip">
+         <string>String to separate a channel name from its parent's.</string>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="0">
+       <widget class="QCheckBox" name="qcbLocalUserVisible">
+        <property name="toolTip">
+         <string>If this is checked, the local user (yourself) will always be visible in the TalkingUI (regardless of talking state).</string>
+        </property>
+        <property name="text">
+         <string>Always keep local user visible</string>
+        </property>
+       </widget>
+      </item>
+      <item row="13" column="0">
+       <widget class="QLabel" name="qlAbbreviationReplacement">
+        <property name="toolTip">
+         <string>String that gets used isntead of the cut-out part of an abbreviated name.</string>
+        </property>
+        <property name="text">
+         <string>Abbreviation replacement</string>
+        </property>
+       </widget>
+      </item>
+      <item row="10" column="1">
+       <widget class="QSpinBox" name="qsbPostfixCharCount">
+        <property name="toolTip">
+         <string>How many characters from the original name to display at the end of an abbreviated name.</string>
         </property>
        </widget>
       </item>
@@ -154,44 +178,7 @@
         </property>
        </widget>
       </item>
-      <item row="11" column="0">
-       <widget class="QLabel" name="qlChannelSeparator">
-        <property name="toolTip">
-         <string>String to separate a channel name from its parent's.</string>
-        </property>
-        <property name="text">
-         <string>Channel separator</string>
-        </property>
-       </widget>
-      </item>
-      <item row="9" column="1">
-       <widget class="QSpinBox" name="qsbPostfixCharCount">
-        <property name="toolTip">
-         <string>How many characters from the original name to display at the end of an abbreviated name.</string>
-        </property>
-       </widget>
-      </item>
-      <item row="11" column="1">
-       <widget class="QLineEdit" name="qleChannelSeparator">
-        <property name="sizePolicy">
-         <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-          <horstretch>0</horstretch>
-          <verstretch>0</verstretch>
-         </sizepolicy>
-        </property>
-        <property name="toolTip">
-         <string>String to separate a channel name from its parent's.</string>
-        </property>
-       </widget>
-      </item>
-      <item row="5" column="1">
-       <widget class="QSpinBox" name="qsbChannelHierarchyDepth">
-        <property name="toolTip">
-         <string>The names of how many parent channels should be included in the channel's name when displaying it in the TalkingUI?</string>
-        </property>
-       </widget>
-      </item>
-      <item row="7" column="0">
+      <item row="8" column="0">
        <widget class="QLabel" name="qlMaxNameLength">
         <property name="toolTip">
          <string>The preferred maximum length of a channel (hierarchy) name in the Talking UI. Note that this is not a hard limit though.</string>
@@ -201,10 +188,46 @@
         </property>
        </widget>
       </item>
-      <item row="7" column="1">
+      <item row="13" column="1">
+       <widget class="QLineEdit" name="qleAbbreviationReplacement">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="toolTip">
+         <string>String that gets used isntead of the cut-out part of an abbreviated name.</string>
+        </property>
+       </widget>
+      </item>
+      <item row="8" column="1">
        <widget class="QSpinBox" name="qsbMaxNameLength">
         <property name="toolTip">
          <string>The preferred maximum length of a channel (hierarchy) name in the Talking UI. Note that this is not a hard limit though.</string>
+        </property>
+       </widget>
+      </item>
+      <item row="3" column="0">
+       <widget class="QLabel" name="qlRelFontSize">
+        <property name="toolTip">
+         <string>Relative font size to use in the Talking UI in percent.</string>
+        </property>
+        <property name="text">
+         <string>Rel. font size (%)</string>
+        </property>
+       </widget>
+      </item>
+      <item row="3" column="1">
+       <widget class="QSpinBox" name="qsbRelFontSize">
+        <property name="toolTip">
+         <string>Relative font size to use in the Talking UI in percent.</string>
+        </property>
+        <property name="minimum">
+         <number>1</number>
+        </property>
+        <property name="maximum">
+         <number>500</number>
         </property>
        </widget>
       </item>

--- a/src/mumble/Settings.cpp
+++ b/src/mumble/Settings.cpp
@@ -455,6 +455,7 @@ Settings::Settings() {
 	bTalkingUI_LocalUserStaysVisible = false;
 	bTalkingUI_AbbreviateChannelNames = true;
 	bTalkingUI_AbbreviateCurrentChannel = false;
+	iTalkingUI_RelativeFontSize = 100;
 	iTalkingUI_SilentUserLifeTime = 5;
 	iTalkingUI_ChannelHierarchyDepth = 1;
 	iTalkingUI_MaxChannelNameLength = 20;
@@ -823,6 +824,7 @@ void Settings::load(QSettings* settings_ptr) {
 	SAVELOAD(bTalkingUI_LocalUserStaysVisible, "ui/talkingUI_LocalUserStaysVisible");
 	SAVELOAD(bTalkingUI_AbbreviateChannelNames, "ui/talkingUI_AbbreviateChannelNames");
 	SAVELOAD(bTalkingUI_AbbreviateCurrentChannel, "ui/talkingUI_AbbreviateCurrentChannel");
+	SAVELOAD(iTalkingUI_RelativeFontSize, "ui/talkingUI_RelativeFontSize");
 	SAVELOAD(iTalkingUI_SilentUserLifeTime, "ui/talkingUI_SilentUserLifeTime");
 	SAVELOAD(iTalkingUI_ChannelHierarchyDepth, "ui/talkingUI_ChannelHierarchieDepth");
 	SAVELOAD(iTalkingUI_MaxChannelNameLength, "ui/talkingUI_MaxChannelNameLength");
@@ -1173,6 +1175,7 @@ void Settings::save() {
 	SAVELOAD(bTalkingUI_LocalUserStaysVisible, "ui/talkingUI_LocalUserStaysVisible");
 	SAVELOAD(bTalkingUI_AbbreviateChannelNames, "ui/talkingUI_AbbreviateChannelNames");
 	SAVELOAD(bTalkingUI_AbbreviateCurrentChannel, "ui/talkingUI_AbbreviateCurrentChannel");
+	SAVELOAD(iTalkingUI_RelativeFontSize, "ui/talkingUI_RelativeFontSize");
 	SAVELOAD(iTalkingUI_SilentUserLifeTime, "ui/talkingUI_SilentUserLifeTime");
 	SAVELOAD(iTalkingUI_ChannelHierarchyDepth, "ui/talkingUI_ChannelHierarchieDepth");
 	SAVELOAD(iTalkingUI_MaxChannelNameLength, "ui/talkingUI_MaxChannelNameLength");

--- a/src/mumble/Settings.h
+++ b/src/mumble/Settings.h
@@ -282,6 +282,8 @@ struct Settings {
 	bool bTalkingUI_LocalUserStaysVisible;
 	bool bTalkingUI_AbbreviateChannelNames;
 	bool bTalkingUI_AbbreviateCurrentChannel;
+	/// relative font size in %
+	int iTalkingUI_RelativeFontSize;
 	int iTalkingUI_SilentUserLifeTime;
 	int iTalkingUI_ChannelHierarchyDepth;
 	int iTalkingUI_MaxChannelNameLength;

--- a/src/mumble/TalkingUI.cpp
+++ b/src/mumble/TalkingUI.cpp
@@ -192,7 +192,7 @@ void TalkingUI::addChannel(const Channel *channel) {
 
 		QGroupBox *box = new QGroupBox(channelName, this);
 		QVBoxLayout *layout = new QVBoxLayout();
-		layout->setContentsMargins(0, 0, 0, 0);
+		layout->setContentsMargins(0, 10, 0, 0);
 		box->setLayout(layout);
 
 		setFontSize(box);

--- a/src/mumble/TalkingUI.cpp
+++ b/src/mumble/TalkingUI.cpp
@@ -23,6 +23,8 @@
 #include <QModelIndex>
 #include <QtCore/QStringList>
 
+#include <algorithm>
+
 // We define a global macro called 'g'. This can lead to issues when included code uses 'g' as a type or parameter name (like protobuf 3.7 does). As such, for now, we have to make this our last include.
 #include "Global.h"
 
@@ -51,6 +53,52 @@ void TalkingUI::setupUI() {
 	setWindowFlags(Qt::Window | Qt::WindowStaysOnTopHint);
 
 	connect(g.mw->qtvUsers->selectionModel(), &QItemSelectionModel::currentChanged, this, &TalkingUI::on_mainWindowSelectionChanged);
+}
+
+void TalkingUI::setFontSize(QWidget *widget) {
+	const double fontFactor = g.s.iTalkingUI_RelativeFontSize / 100.0;
+	
+	// We have to do this in a complicated way as Qt is very stubborn when it
+	// comes to manipulating fonts.
+	// We have to use stylesheets because this seems to be the only way Qt will
+	// actually change the font size (setFont has no effect). However the font size
+	// won't update the moment the stylesheet is applied, so we have to copy the font
+	// of the widget, set the size and use that to calculate the line height for that
+	// particular font (needed to size the icons appropriately).
+	QFont newFont = widget->font();
+	if (font().pixelSize() >= 0) {
+		// font specified in pixels
+		widget->setStyleSheet(QString::fromLatin1("font-size: %1px;").arg(
+					static_cast<int>(std::max(fontFactor * font().pixelSize(), 1.0))));
+		newFont.setPixelSize(std::max(fontFactor * font().pixelSize(), 1.0));
+	} else {
+		// font specified in points
+		widget->setStyleSheet(QString::fromLatin1("font-size: %1pt;").arg(
+					static_cast<int>(std::max(fontFactor * font().pointSize(), 1.0))));
+		newFont.setPointSize(std::max(fontFactor * font().pointSize(), 1.0));
+	}
+
+	m_currentLineHeight = QFontMetrics(newFont).height();
+}
+
+void TalkingUI::setIcon(Entry &entry) const {
+	const QIcon *icon = nullptr;
+	switch (entry.talkingState) {
+		case Settings::Talking:
+			icon = &m_talkingIcon;
+			break;
+		case Settings::Whispering:
+			icon = &m_whisperingIcon;
+			break;
+		case Settings::Shouting:
+			icon = &m_shoutingIcon;
+			break;
+		default:
+			icon = &m_passiveIcon;
+			break;
+	}
+
+	entry.icon->setPixmap(icon->pixmap(QSize(m_currentLineHeight, m_currentLineHeight), QIcon::Normal, QIcon::On));
 }
 
 void TalkingUI::hideUser(unsigned int session) {
@@ -147,6 +195,8 @@ void TalkingUI::addChannel(const Channel *channel) {
 		layout->setContentsMargins(0, 0, 0, 0);
 		box->setLayout(layout);
 
+		setFontSize(box);
+
 		m_channels.insert(channel->iId, box);
 	}
 }
@@ -162,7 +212,7 @@ void TalkingUI::addUser(const ClientUser *user) {
 		// We initially set the labels to not be visible, so that we'll
 		// enter the code-block further down.
 
-		QWidget *background = new QWidget(this);
+		QWidget *background = new QWidget(m_channels[user->cChannel->iId]);
 		QLayout *backgroundLayout = new QHBoxLayout();
 		backgroundLayout->setContentsMargins(2, 3, 2, 3);
 		background->setLayout(backgroundLayout);
@@ -183,11 +233,11 @@ void TalkingUI::addUser(const ClientUser *user) {
 		icon->setAlignment(Qt::AlignCenter);
 		icon->setSizePolicy(QSizePolicy::Maximum, QSizePolicy::Maximum);
 
-		// As a default use the passive icon
-		const int height = fontMetrics().height(); // Make icon as high as the text
-		icon->setPixmap(m_passiveIcon.pixmap(QSize(height, height), QIcon::Normal, QIcon::On));
+		// As a default use the passive state
+		Entry entry = {icon, name, background, user->uiSession, Settings::Passive};
+		setIcon(entry);
+		m_entries.insert(user->uiSession, entry);
 
-		m_entries.insert(user->uiSession, {icon, name, background, user->uiSession});
 
 		backgroundLayout->addWidget(icon);
 		backgroundLayout->addWidget(name);
@@ -411,28 +461,11 @@ void TalkingUI::on_talkingStateChanged() {
 	addUser(user);
 
 	// Get the Entry for this user
-	Entry entry = m_entries[user->uiSession];
+	Entry &entry = m_entries[user->uiSession];
+	entry.talkingState = user->tsState;
 
 	// Set the icon for this user according to the TalkingState
-	QIcon *icon = nullptr;
-	switch (user->tsState) {
-		case Settings::Talking:
-			icon = &m_talkingIcon;
-			break;
-		case Settings::Whispering:
-			icon = &m_whisperingIcon;
-			break;
-		case Settings::Shouting:
-			icon = &m_shoutingIcon;
-			break;
-		default:
-			icon = &m_passiveIcon;
-			break;
-	}
-
-	const int height = fontMetrics().height(); // Make icon as high as the text
-	entry.icon->setPixmap(icon->pixmap(QSize(height, height), QIcon::Normal, QIcon::On));
-
+	setIcon(entry);
 
 	if (user->tsState == Settings::Passive) {
 		// User stopped talking
@@ -552,9 +585,23 @@ void TalkingUI::on_settingsChanged() {
 				g.s.iTalkingUI_PostfixCharCount, g.s.iTalkingUI_MaxChannelNameLength, g.s.iTalkingUI_ChannelHierarchyDepth,
 				g.s.qsTalkingUI_ChannelSeparator, g.s.qsTalkingUI_AbbreviationReplacement, g.s.bTalkingUI_AbbreviateCurrentChannel)
 			);
+
+			// The font size might have changed as well -> update it
+			// As all other items are children to the channel boxes, the new font
+			// size should propagate through.
+			setFontSize(box);
 		} else {
 			qCritical("TalkingUI: Can't find channel for stored ID");
 		}
+	}
+
+	// If the font has changed, we have to update the icon size as well
+	QMutableHashIterator<unsigned int, Entry> entryIt(m_entries);
+	while(entryIt.hasNext()) {
+		Entry &entry = entryIt.next().value();
+		// The new line height has already been set by setFontSize, so we only have
+		// to call setIcon
+		setIcon(entry);
 	}
 
 	// The time that a silent user may stick around might have changed as well

--- a/src/mumble/TalkingUI.h
+++ b/src/mumble/TalkingUI.h
@@ -11,6 +11,8 @@
 #include <QtCore/QSet>
 #include <QtGui/QIcon>
 
+#include "Settings.h"
+
 class QLabel;
 class QGroupBox;
 class QTimer;
@@ -26,6 +28,7 @@ struct Entry {
 	QLabel *name;
 	QWidget *background;
 	unsigned int userSession;
+	Settings::TalkState talkingState;
 };
 
 /// The talking UI is a widget that will display the users you are currently
@@ -54,6 +57,9 @@ class TalkingUI : public QWidget {
 		/// The icon for a whispering user
 		QIcon m_whisperingIcon;
 
+		/// The current line height of an entry in the TalkingUI
+		int m_currentLineHeight;
+
 		/// Sets up the UI components
 		void setupUI();
 		/// Hides an user
@@ -78,6 +84,16 @@ class TalkingUI : public QWidget {
 
 		/// Update (resize) the UI to its content
 		void updateUI();
+
+		/// Sets the font size according to the settings
+		///
+		/// @param widget a pointer to the widget to set the font size for
+		void setFontSize(QWidget *widget);
+
+		/// Sets the icon for the given entry based on its TalkingState
+		///
+		/// @param entry A reference to the Entry to process
+		void setIcon(Entry &entry) const;
 
 		/// Set the current selection
 		///

--- a/src/mumble/mumble_en.ts
+++ b/src/mumble/mumble_en.ts
@@ -3804,6 +3804,78 @@ The setting only applies for new messages, the already shown ones will retain th
         <source>Always keep local user visible</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>How many characters from the original name to display at the beginning of an abbreviated name.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>String to separate a channel name from its parent&apos;s.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Channel separator</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Abbreviated prefix characters</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The names of how many parent channels should be included in the channel&apos;s name when displaying it in the TalkingUI?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>How many characters from the original name to display at the end of an abbreviated name.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Abbreviated postfix characters</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Whether to also allow abbreviating the current channel of a user (instead of only its parent channels).</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Abbreviate current channel name</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Channel hierarchy depth</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>String that gets used isntead of the cut-out part of an abbreviated name.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Abbreviation replacement</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Whether the channel (hierarchy) name should be abbreviated, if it exceeds the specified maximum length.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Abbreviate channel names</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The preferred maximum length of a channel (hierarchy) name in the Talking UI. Note that this is not a hard limit though.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Max. channel name length</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Relative font size to use in the Talking UI in percent.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Rel. font size (%)</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>MainWindow</name>


### PR DESCRIPTION
With this new settings the user can scale the font size for the
TalkingUI to make it bigger or smaller (relative to the default font
size). This way every user can set it to his/her preferred size.