### PR TITLE
Show warning message for enabling update checks with no-update config

### DIFF
--- a/src/mumble/NetworkConfig.cpp
+++ b/src/mumble/NetworkConfig.cpp
@@ -11,6 +11,7 @@
 #include <QtNetwork/QHostAddress>
 #include <QtNetwork/QNetworkProxy>
 #include <QtNetwork/QNetworkAccessManager>
+#include <QSignalBlocker>
 
 // We define a global macro called 'g'. This can lead to issues when included code uses 'g' as a type or parameter name (like protobuf 3.7 does). As such, for now, we have to make this our last include.
 #include "Global.h"
@@ -62,6 +63,7 @@ void NetworkConfig::load(const Settings &r) {
 
 	loadCheckBox(qcbHideOS, s.bHideOS);
 
+	const QSignalBlocker blocker(qcbAutoUpdate);
 	loadCheckBox(qcbAutoUpdate, r.bUpdateCheck);
 	loadCheckBox(qcbPluginUpdate, r.bPluginCheck);
 	loadCheckBox(qcbUsage, r.bUsage);
@@ -143,6 +145,23 @@ void NetworkConfig::on_qcbType_currentIndexChanged(int v) {
 
 	s.ptProxyType = pt;
 }
+
+#ifdef NO_UPDATE_CHECK
+void NetworkConfig::on_qcbAutoUpdate_stateChanged(int state) {
+	if (state == Qt::Checked) {
+		QMessageBox msgBox;
+		msgBox.setText(QObject::tr("<p>You're using a Mumble version that <b>explicitly disabled</b> update-checks.<p>" 
+					"<p>This means that the update notification you might receive by using this option will "
+					"<b>most likely be meaningless</b> for you.<p>"));
+		msgBox.setInformativeText(QObject::tr("<p>If you're using Linux this is most likely because you are using a "
+					"version from your distribution's package repository that have their own update cycles.</p>"
+					"<p>If you want to always have the most recent Mumble version, you should consider using a different method of installation.\n"
+					"See <a href=\"https://wiki.mumble.info/wiki/Installing_Mumble\">the Mumble wiki</a> for what alternatives there are.</p>"));
+		msgBox.setIcon(QMessageBox::Warning);
+		msgBox.exec();
+	}
+}
+#endif
 
 QNetworkReply *Network::get(const QUrl &url) {
 	QNetworkRequest req(url);

--- a/src/mumble/NetworkConfig.h
+++ b/src/mumble/NetworkConfig.h
@@ -32,6 +32,9 @@ class NetworkConfig : public ConfigWidget, Ui::NetworkConfig {
 		void load(const Settings &r) Q_DECL_OVERRIDE;
 
 		void on_qcbType_currentIndexChanged(int v);
+#ifdef NO_UPDATE_CHECK
+		void on_qcbAutoUpdate_stateChanged(int state);
+#endif
 };
 
 namespace Network {

--- a/src/mumble/mumble_en.ts
+++ b/src/mumble/mumble_en.ts
@@ -6561,6 +6561,15 @@ Mixed echo cancellation mixes all speaker outputs in one mono stream and passes 
 Multichannel echo cancellation requires more CPU, so you should try mixed first</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>&lt;p&gt;You&apos;re using a Mumble version that &lt;b&gt;explicitly disabled&lt;/b&gt; update-checks.&lt;p&gt;&lt;p&gt;This means that the update notification you might receive by using this option will &lt;b&gt;most likely be meaningless&lt;/b&gt; for you.&lt;p&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&lt;p&gt;If you&apos;re using Linux this is most likely because you are using a version from your distribution&apos;s package repository that have their own update cycles.&lt;/p&gt;&lt;p&gt;If you want to always have the most recent Mumble version, you should consider using a different method of installation.
+See &lt;a href=&quot;https://wiki.mumble.info/wiki/Installing_Mumble&quot;&gt;the Mumble wiki&lt;/a&gt; for what alternatives there are.&lt;/p&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>RichTextEditor</name>


### PR DESCRIPTION
If Mumble has been compiled with the no-update config flag, then the
auto-updates are deactivated by default. If a user wants to enable it in
the settings, a pop-up will be shown to the user explaining that the
update notifications are probably not meaningful (as the user is most
likely getting their Mumble updates from a package repository). This is
to prevent confusion of the user.

The popup looks like this:
![Mumble_NoUpdate_WarningMessage](https://user-images.githubusercontent.com/12751591/82154346-81842600-986d-11ea-85fd-9cbcf1e0c6a1.png)

This is a followup addressing concerns voiced in #4138
@toby63 is this what you had in mind?