### PR TITLE
TalkingUI: Fix race leading to crash

### DIFF
--- a/src/mumble/TalkingUI.cpp
+++ b/src/mumble/TalkingUI.cpp
@@ -288,6 +288,12 @@ void TalkingUI::ensureVisible(unsigned int userSession, int channelID) {
 	}
 
 	ClientUser *self = ClientUser::get(g.uiSession);
+	// In case the locals user (self) has changed channel but this method here was called before on_channelChanged
+	// has been called (e.g. triggered via on_talkingStateChanged of another user), we have to make sure that the
+	// channel of the local user actually exists in the TalkingUI. This is necessary because the channel update of
+	// a user and the call to on_channelChanged happen asynchronously (the latter runs through the event loop and
+	// thus typically (significantly) after the channel has been updated already.
+	addChannel(self->cChannel);
 	QGroupBox *localUserBox = m_channels[self->cChannel->iId];
 
 	bool adjust = false;


### PR DESCRIPTION
The problem that can arise is the following: A user changes channel.
Inside Messages.cpp UserModel::moveUser gets called that directly
updates the channel of the user. In order to propagate this change to
the TalkingUI, QMetaObject::invokeMethod is used leading to an
asynchronous processing of this event. If however in the same iteration
of the event loop the audio system sent a change in TalkingState, that
will be processed first in the next iteration of the event loop (before
the channel change is processed). This violates the assumption of
TalkingUI::ensureVisible that the channel of the local user is always
present in the TalkingUI. Due to how HashMaps work for non-existent keys
when using the [] operator, a nullptr gets inserted in the HashMap. If
that gets dereferenced at a different point in the code, we get a
SegFault.

This commit prevents this by first explicitly adding the local user's
channel first. This covers the edge case described above.