### PR TITLE
Add permission for Reset Comment/Avatar

### DIFF
--- a/src/ACL.cpp
+++ b/src/ACL.cpp
@@ -155,13 +155,15 @@ QFlags<ChanACL::Perm> ChanACL::effectivePermissions(ServerUser *p, Channel *chan
 						granted |= Kick;
 					if (acl->pAllow & Ban)
 						granted |= Ban;
+					if (acl->pAllow & ResetUserContent)
+						granted |= ResetUserContent;
 					if (acl->pAllow & Register)
 						granted |= Register;
 					if (acl->pAllow & SelfRegister)
 						granted |= SelfRegister;
 				}
 				if ((ch==chan && acl->bApplyHere) || (ch!=chan && acl->bApplySubs)) {
-					granted |= (acl->pAllow & ~(Kick|Ban|Register|SelfRegister|Cached));
+					granted |= (acl->pAllow & ~(Kick|Ban|ResetUserContent|Register|SelfRegister|Cached));
 					granted &= ~acl->pDeny;
 				}
 			}
@@ -175,7 +177,7 @@ QFlags<ChanACL::Perm> ChanACL::effectivePermissions(ServerUser *p, Channel *chan
 	if (granted & Write) {
 		granted |= Traverse|Enter|MuteDeafen|Move|MakeChannel|LinkChannel|TextMessage|MakeTempChannel|Listen;
 		if (chan->iId == 0)
-			granted |= Kick|Ban|Register|SelfRegister;
+			granted |= Kick|Ban|ResetUserContent|Register|SelfRegister;
 	}
 
 	if (cache) {
@@ -236,6 +238,8 @@ QString ChanACL::whatsThis(Perm p) {
 			return tr("This represents the permission to forcibly remove users from the server.");
 		case Ban:
 			return tr("This represents the permission to permanently remove users from the server.");
+		case ResetUserContent:
+			return tr("This represents the permission to reset the comment or avatar of a user.");
 		case Register:
 			return tr("This represents the permission to register and unregister users on the server.");
 		case SelfRegister:
@@ -289,6 +293,8 @@ QString ChanACL::permName(Perm p) {
 			return tr("Kick");
 		case Ban:
 			return tr("Ban");
+		case ResetUserContent:
+			return tr("Reset User Content");
 		case Register:
 			return tr("Register User");
 		case SelfRegister:

--- a/src/ACL.h
+++ b/src/ACL.h
@@ -38,11 +38,12 @@ class ChanACL : public QObject {
 			Ban = 0x20000,
 			Register = 0x40000,
 			SelfRegister = 0x80000,
+			ResetUserContent = 0x100000,
 
 			Cached = 0x8000000,
 			All = Write + Traverse + Enter + Speak + MuteDeafen + Move
 				+ MakeChannel + LinkChannel + Whisper + TextMessage + MakeTempChannel + Listen
-				+ Kick + Ban + Register + SelfRegister
+				+ Kick + Ban + Register + SelfRegister + ResetUserContent
 		};
 
 		Q_DECLARE_FLAGS(Permissions, Perm)

--- a/src/mumble/ACLEditor.cpp
+++ b/src/mumble/ACLEditor.cpp
@@ -115,6 +115,9 @@ ACLEditor::ACLEditor(int channelid, const MumbleProto::ACL &mea, QWidget *p) : Q
 		QString name = ChanACL::permName(perm);
 
 		if (! name.isEmpty()) {
+			// If the server's version is less than 1.4.0 then it won't support the new permission to reset a comment/avatar. Skipping this iteration of the loop prevents checkboxes for it being added to the UI.
+			if ((g.sh->uiVersion < 0x010400) && (perm == ChanACL::ResetUserContent)) continue;
+
 			QCheckBox *qcb;
 			l = new QLabel(name, qgbACLpermissions);
 			grid->addWidget(l, idx, 0);

--- a/src/mumble/MainWindow.cpp
+++ b/src/mumble/MainWindow.cpp
@@ -1594,8 +1594,14 @@ void MainWindow::qmUser_aboutToShow() {
 		qaUserLocalMute->setEnabled(! isSelf);
 		qaUserLocalVolume->setEnabled(! isSelf);
 		qaUserLocalIgnore->setEnabled(! isSelf);
-		qaUserCommentReset->setEnabled(! p->qbaCommentHash.isEmpty() && (g.pPermissions & (ChanACL::Move | ChanACL::Write)));
-		qaUserTextureReset->setEnabled(! p->qbaTextureHash.isEmpty() && (g.pPermissions & (ChanACL::Move | ChanACL::Write)));
+		// If the server's version is less than 1.4.0 it won't support the new permission to reset a comment/avatar, so fall back to the old method
+		if (g.sh->uiVersion < 0x010400) {
+			qaUserCommentReset->setEnabled(! p->qbaCommentHash.isEmpty() && (g.pPermissions & (ChanACL::Move | ChanACL::Write)));
+			qaUserTextureReset->setEnabled(! p->qbaTextureHash.isEmpty() && (g.pPermissions & (ChanACL::Move | ChanACL::Write)));
+		} else {
+			qaUserCommentReset->setEnabled(! p->qbaCommentHash.isEmpty() && (g.pPermissions & (ChanACL::ResetUserContent | ChanACL::Write)));
+			qaUserTextureReset->setEnabled(! p->qbaTextureHash.isEmpty() && (g.pPermissions & (ChanACL::ResetUserContent | ChanACL::Write)));
+		}
 		qaUserCommentView->setEnabled(! p->qbaCommentHash.isEmpty());
 
 		qaUserMute->setChecked(p->bMute || p->bSuppress);
@@ -3501,4 +3507,3 @@ void MainWindow::destroyUserInformation() {
 		}
 	}
 }
-

--- a/src/mumble/mumble_en.ts
+++ b/src/mumble/mumble_en.ts
@@ -2390,6 +2390,14 @@ Are you sure you wish to replace your certificate?
         <source>Listen</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>This represents the permission to reset the comment or avatar of a user.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Reset User Content</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ChatbarTextEdit</name>

--- a/src/murmur/Messages.cpp
+++ b/src/murmur/Messages.cpp
@@ -730,8 +730,8 @@ void Server::msgUserState(ServerUser *uSource, MumbleProto::UserState &msg) {
 		bool changed = false;
 		comment = u8(msg.comment());
 		if (uSource != pDstServerUser) {
-			if (! hasPermission(uSource, root, ChanACL::Move)) {
-				PERM_DENIED(uSource, root, ChanACL::Move);
+			if (! hasPermission(uSource, root, ChanACL::ResetUserContent)) {
+				PERM_DENIED(uSource, root, ChanACL::ResetUserContent);
 				return;
 			}
 			if (comment.length() > 0) {
@@ -755,8 +755,8 @@ void Server::msgUserState(ServerUser *uSource, MumbleProto::UserState &msg) {
 			return;
 		}
 		if (uSource != pDstServerUser) {
-			if (! hasPermission(uSource, root, ChanACL::Move)) {
-				PERM_DENIED(uSource, root, ChanACL::Move);
+			if (! hasPermission(uSource, root, ChanACL::ResetUserContent)) {
+				PERM_DENIED(uSource, root, ChanACL::ResetUserContent);
 				return;
 			}
 			if (msg.texture().length() > 0) {

--- a/src/murmur/Murmur.ice
+++ b/src/murmur/Murmur.ice
@@ -170,6 +170,8 @@ module Murmur
 	const int PermissionRegister = 0x40000;
 	/** Register and unregister users. Only valid on root channel. */
 	const int PermissionRegisterSelf = 0x80000;
+	/** Reset the comment or avatar of a user. Only valid on root channel. */
+	const int ResetUserContent = 0x100000;
 
 
 	/** Access Control List for a channel. ACLs are defined per channel, and can be inherited from parent channels.


### PR DESCRIPTION
Currently if a user has a "move" permission, they can also reset the comment or avatar of another user as describe in issue #1016. I stumbled into this by accident when I gave a user the move permission to help get new users into the right channels with their friends.

After reviewing the content found in PR #1223 which introduced the reset avatar feature, I found the code that allowed a user to do these resets and changed the required permission from Move to RegisterUser as suggested by @bontibon in the issue thread. As they state, this permission makes more sense than the move permission.

After compiling I found no issues and the changes worked as expected. The one caveat is that if the server has these changes implemented and not the client, (seems daft but this is preferable for me so I don't have to ask my users to change anything) it makes the permissions required to do the reset be move AND registeruser. The client will expect the user to have Move permission and the server will expect the RegisterUser permission, hence then requiring both.

Fixes #1016