### PR TITLE
Backport "Document settings missing in example murmur.ini"

### DIFF
--- a/scripts/murmur.ini
+++ b/scripts/murmur.ini
@@ -89,15 +89,6 @@ icesecretwrite=
 ;grpccert=""
 ;grpckey=""
 
-; How many login attempts do we tolerate from one IP
-; inside a given timeframe before we ban the connection?
-; Note that this is global (shared between all virtual servers), and that
-; it counts both successfull and unsuccessfull connection attempts.
-; Set either Attempts or Timeframe to 0 to disable.
-;autobanAttempts = 10
-;autobanTimeframe = 120
-;autobanTime = 300
-
 ; Specifies the file Murmur should log to. By default, Murmur
 ; logs to the file 'murmur.log'. If you leave this field blank
 ; on Unix-like systems, Murmur will force itself into foreground
@@ -133,8 +124,23 @@ serverpassword=
 ; to send speech at.
 bandwidth=72000
 
+; Murmur and Mumble are usually pretty good about cleaning up hung clients, but
+; occasionally one will get stuck on the server. The timeout setting will cause
+; a periodic check of all clients who haven't communicated with the server in
+; this many seconds - causing zombie clients to be disconnected.
+;
+; Note that this has no effect on idle clients or people who are AFK. It will
+; only affect people who are already disconnected, and just haven't told the
+; server.
+;timeout=30
+
 ; Maximum number of concurrent clients allowed.
 users=100
+
+; Where users sets a blanket limit on the number of clients per virtual server,
+; usersperchannel sets a limit on the number per channel. The default is 0, for
+; no limit.
+;usersperchannel=0
 
 ; Per-user rate limiting
 ;
@@ -175,6 +181,25 @@ allowping=true
 ; (Note that you have to escape backslashes with \ )
 ;username=[-=\\w\\[\\]\\{\\}\\(\\)\\@\\|\\.]+
 
+; If a user has no stored channel (they've never been connected to the server
+; before, or rememberchannel is set to false) and the client hasn't been given
+; a URL that includes a channel path, the default behavior is that they will
+; end up in the root channel.
+;
+; You can set this setting to a channel ID, and the user will automatically be
+; moved into that channel instead. Note that this is the numeric ID of the
+; channel, which can be a little tricky to get (you'll either need to use an
+; RPC mechanism, watch the console of a debug client, or root around through
+; the Murmur Database to get it).
+;
+;defaultchannel=0
+
+; When a user connects to a server they've already been on, by default the
+; server will remember the last channel they were in and move them to it
+; automatically. Toggling this setting to false will disable that feature.
+;
+;rememberchannel=true
+
 ; Maximum length of text messages in characters. 0 for no limit.
 ;textmessagelength=5000
 
@@ -196,12 +221,17 @@ allowping=true
 ; updates will need the same password. Don't lose your password.
 ; The URL is your own website, and only set the registerHostname for static IP
 ; addresses.
-; Only uncomment the 'registerName' parameter if you wish to give your "Root" channel a custom name.
+; Location is typically the country of typical users of the server, in
+; two-letter TLD style (ISO 3166-1 alpha-2 country code)
+;
+; If you only wish to give your "Root" channel a custom name, then only
+; uncomment the 'registerName' parameter.
 ;
 ;registerName=Mumble Server
 ;registerPassword=secret
 ;registerUrl=http://www.mumble.info/
 ;registerHostname=
+;registerLocation=
 
 ; If this option is enabled, the server will announce its presence via the
 ; bonjour service discovery protocol. To change the name announced by bonjour
@@ -214,6 +244,18 @@ allowping=true
 ; Otherwise, Murmur will create its own certificate automatically.
 ;sslCert=
 ;sslKey=
+
+; If the keyfile specified above is encrypted with a passphrase, you can enter
+; it in this setting. It must be plaintext, so you may wish to adjust the
+; permissions on your murmur.ini file accordingly.
+;sslPassPhrase=
+
+; If your certificate is signed by an authority that uses a sub-signed or
+; "intermediate" certificate, you probably need to bundle it with your
+; certificate in order to get Murmur to accept it. You can either concatenate
+; the two certificates into one file, or you can put it in a file by itself and
+; put the path to that PEM-file in sslCA.
+;sslCA=
 
 ; The sslDHParams option allows you to specify a PEM-encoded file with
 ; Diffie-Hellman parameters, which will be used as the default Diffie-
@@ -251,6 +293,15 @@ allowping=true
 ; This option is ignored if Murmur isn't started with root privileges.
 ;uname=
 
+; By default, in log files and in the user status window for privileged users,
+; Mumble will show IP addresses - in some situations you may find this unwanted
+; behavior. If obfuscate is set to true, Murmur will randomize the IP addresses
+; of connecting users.
+;
+; The obfuscate function only affects the log file and DOES NOT effect the user
+; information section in the client window.
+;obfuscate=false
+
 ; If this options is enabled, only clients which have a certificate are allowed
 ; to connect.
 ;certrequired=False
@@ -258,6 +309,39 @@ allowping=true
 ; If enabled, clients are sent information about the servers version and operating
 ; system.
 ;sendversion=True
+
+; You can set a recommended minimum version for your server, and clients will
+; be notified in their log when they connect if their client does not meet the
+; minimum requirements. suggestVersion expects the version in the format X.X.X.
+;
+; Note that the suggest* options appeared after 1.2.3 and will have no effect
+; on client versions 1.2.3 and earlier.
+;
+;suggestVersion=
+
+; Setting this to "true" will alert any user who does not have positional audio
+; enabled that the server administrators recommend enabling it. Setting it to
+; "false" will have the opposite effect - if you do not care whether the user
+; enables positional audio or not, set it to blank. The message will appear in
+; the log window upon connection, but only if the user's settings do not match
+; what the server requests.
+;
+; Note that the suggest* options appeared after 1.2.3 and will have no effect
+; on client versions 1.2.3 and earlier.
+;
+;suggestPositional=
+
+; Setting this to "true" will alert any user who does not have Push-To-Talk
+; enabled that the server administrators recommend enabling it. Setting it to
+; "false" will have the opposite effect - if you do not care whether the user
+; enables PTT or not, set it to blank. The message will appear in the log
+; window upon connection, but only if the user's settings do not match what the
+; server requests.
+;
+; Note that the suggest* options appeared after 1.2.3 and will have no effect
+; on client versions 1.2.3 and earlier.
+;
+;suggestPushToTalk=
 
 ; This sets password hash storage to legacy mode (1.2.4 and before)
 ; (Note that setting this to true is insecure and should not be used unless absolutely necessary)
@@ -267,6 +351,25 @@ allowping=true
 ; overrides the automatic benchmark and forces a specific number of iterations.
 ; (Note that you should only change this value if you know what you are doing)
 ;kdfIterations=-1
+
+; In order to prevent misconfigured, impolite or malicious clients from
+; affecting the low-latency of other users, Murmur has a rudimentary global-ban
+; system. It's configured using the autobanAttempts, autobanTimeframe and
+; autobanTime settings.
+;
+; If a client attempts autobanAttempts connections in autobanTimeframe seconds,
+; they will be banned for autobanTime seconds. This is a global ban, from all
+; virtual servers on the Murmur process. It will not show up in any of the
+; ban-lists on the server, and they can't be removed without restarting the
+; Murmur process - just let them expire. A single, properly functioning client
+; should not trip these bans.
+;
+; To disable, set autobanAttempts or autobanTimeframe to 0. Commenting these
+; settings out will cause Murmur to use the defaults:
+;
+;autobanAttempts=10
+;autobanTimeframe=120
+;autobanTime=300
 
 ; You can configure any of the configuration options for Ice here. We recommend
 ; leave the defaults as they are.


### PR DESCRIPTION
(Backport of 7fde61f681653a9636a8afe1feb785d575776ad7 and changed to fit
the 1.3.x branch)

This should lead to an updated ini file being shipped in e.g. the static server binary for the 1.3.x series

reference: #4184