### PR TITLE
src/Mumble/JackAudio.cpp: remove C++17 usage in JackAudioOutput::run()

### DIFF
--- a/src/mumble/JackAudio.cpp
+++ b/src/mumble/JackAudio.cpp
@@ -1083,12 +1083,14 @@ void JackAudioOutput::run() {
 			writtenFrames += bOk ? wanted : 0;
 		}
 
+		const auto gap = writeVector->len - (wanted * iSampleSize);
+
 		if (!bOk || wanted == iFrameSize) {
 			goto next;
 		}
 
 		// Corner case where one sample wraps around the buffer
-		if (auto gap = writeVector->len - (wanted * iSampleSize); gap != 0) {
+		if (gap != 0) {
 			writeVector->buf += wanted * iSampleSize;
 			bOk = mix(spareSample.get(), 1);
 			if (bOk) {


### PR DESCRIPTION
We build AppImage releases with Ubuntu 16.04, which has a compiler that doesn't support C++17.