### PR TITLE
Add mumble icon file

### DIFF
--- a/installer/Files.wxs
+++ b/installer/Files.wxs
@@ -91,7 +91,9 @@
                   Directory="DesktopFolder"
                   Name="Mumble"
                   WorkingDirectory="INSTALLDIR"
-                  Target="[INSTALLDIR]mumble.exe">
+                  Target="[INSTALLDIR]mumble.exe"
+                  Icon="mumble.ico"
+                  IconIndex="0">
           <ShortcutProperty Key="System.AppUserModel.ID" Value="net.sourceforge.mumble.Mumble" />
         </Shortcut>
       </Component>
@@ -101,7 +103,9 @@
                   Directory="ApplicationProgramsFolder"
                   Name="Mumble"
                   WorkingDirectory="INSTALLDIR"
-                  Target="[INSTALLDIR]mumble.exe">
+                  Target="[INSTALLDIR]mumble.exe"
+                  Icon="mumble.ico"
+                  IconIndex="0">
           <ShortcutProperty Key="System.AppUserModel.ID" Value="net.sourceforge.mumble.Mumble" />
         </Shortcut>
       </Component>


### PR DESCRIPTION
Adds mumble icon file to fix icon representation in Windows 10 Menu tile and desktop icon.