### PR TITLE
Backport "Add mumble icon file"

### DIFF
--- a/installer/Files.wxs
+++ b/installer/Files.wxs
@@ -100,7 +100,9 @@
                   Directory="DesktopFolder"
                   Name="Mumble"
                   WorkingDirectory="INSTALLDIR"
-                  Target="[INSTALLDIR]mumble.exe">
+                  Target="[INSTALLDIR]mumble.exe"
+                  Icon="mumble.ico"
+                  IconIndex="0">
           <ShortcutProperty Key="System.AppUserModel.ID" Value="net.sourceforge.mumble.Mumble" />
         </Shortcut>
       </Component>


### PR DESCRIPTION
Adds mumble icon file to fix icon representation in Windows 10 Menu tile and desktop icon.

(Backported from #4204)