### PR TITLE
Stereo stream decoding and playing support

### DIFF
--- a/src/mumble/AudioOutput.cpp
+++ b/src/mumble/AudioOutput.cpp
@@ -91,19 +91,19 @@ AudioOutput::AudioOutput()
     : fSpeakers(NULL)
     , fSpeakerVolume(NULL)
     , bSpeakerPositional(NULL)
-    
+
     , eSampleFormat(SampleFloat)
-    
+
     , bRunning(true)
-    
+
     , iFrameSize(SAMPLE_RATE / 100)
     , iMixerFreq(0)
     , iChannels(0)
     , iSampleSize(0)
-    
+
     , qrwlOutputs()
     , qmOutputs() {
-	
+
 	// Nothing
 }
 
@@ -170,6 +170,9 @@ void AudioOutput::addFrameToBuffer(ClientUser *user, const QByteArray &qbaPacket
 	if (iChannels == 0)
 		return;
 	qrwlOutputs.lockForRead();
+	// qmOutputs is a map of users and their AudioOutputUser objects, which will be create when audio from that user
+	// is received. This map will be iterated in mix(). After one's audio is finished, his AudioOutputUser will be removed
+	// from this map.
 	AudioOutputSpeech *aop = qobject_cast<AudioOutputSpeech *>(qmOutputs.value(user));
 
 	if (!UDPMessageTypeIsValidVoicePacket(type)) {
@@ -362,7 +365,7 @@ void AudioOutput::initializeMixer(const unsigned int *chanmasks, bool forceheadp
 	qWarning("AudioOutput: Initialized %d channel %d hz mixer", iChannels, iMixerFreq);
 }
 
-bool AudioOutput::mix(void *outbuff, unsigned int nsamp) {
+bool AudioOutput::mix(void *outbuff, unsigned int frameNumber) {
 	// A list of users that have audio to contribute
 	QList<AudioOutputUser *> qlMix;
 	// A list of users that no longer have any audio to play and can thus be deleted
@@ -389,7 +392,7 @@ bool AudioOutput::mix(void *outbuff, unsigned int nsamp) {
 	QMultiHash<const ClientUser *, AudioOutputUser *>::const_iterator it = qmOutputs.constBegin();
 	while (it != qmOutputs.constEnd()) {
 		AudioOutputUser *aop = it.value();
-		if (! aop->prepareSampleBuffer(nsamp)) {
+		if (! aop->prepareSampleBuffer(frameNumber)) {
 			qlDel.append(aop);
 		} else {
 			qlMix.append(aop);
@@ -411,27 +414,28 @@ bool AudioOutput::mix(void *outbuff, unsigned int nsamp) {
 		STACKVAR(float, speaker, iChannels*3);
 		STACKVAR(float, svol, iChannels);
 
-		STACKVAR(float, fOutput, iChannels * nsamp);
+		STACKVAR(float, fOutput, iChannels * frameNumber);
 
 		// If the audio backend uses a float-array we can sample and mix the audio sources directly into the output. Otherwise we'll have to
 		// use an intermediate buffer which we will convert to an array of shorts later
 		float *output = (eSampleFormat == SampleFloat) ? reinterpret_cast<float *>(outbuff) : fOutput;
 		bool validListener = false;
 
-		memset(output, 0, sizeof(float) * nsamp * iChannels);
+		memset(output, 0, sizeof(float) * frameNumber * iChannels);
 
 		// Initialize recorder if recording is enabled
 		boost::shared_array<float> recbuff;
 		if (recorder) {
-			recbuff = boost::shared_array<float>(new float[nsamp]);
-			memset(recbuff.get(), 0, sizeof(float) * nsamp);
+			recbuff = boost::shared_array<float>(new float[frameNumber]);
+			memset(recbuff.get(), 0, sizeof(float) * frameNumber);
 			recorder->prepareBufferAdds();
 		}
 
 		for (unsigned int i=0;i<iChannels;++i)
 			svol[i] = mul * fSpeakerVolume[i];
 
-		if (g.s.bPositionalAudio && (iChannels > 1) && g.p->fetch() && (g.bPosTest || g.p->fCameraPosition[0] != 0 || g.p->fCameraPosition[1] != 0 || g.p->fCameraPosition[2] != 0)) {
+		if (g.s.bPositionalAudio && (iChannels > 1) && g.p->fetch()
+			&& (g.bPosTest || g.p->fCameraPosition[0] != 0 || g.p->fCameraPosition[1] != 0 || g.p->fCameraPosition[2] != 0)) {
 			// Calculate the positional audio effects if it is enabled
 
 			float front[3] = { g.p->fCameraFront[0], g.p->fCameraFront[1], g.p->fCameraFront[2] };
@@ -531,10 +535,10 @@ bool AudioOutput::mix(void *outbuff, unsigned int nsamp) {
 				}
 
 				if (prioritySpeakerActive) {
-					
+
 					if (user->tsState != Settings::Whispering
 					    && !user->bPrioritySpeaker) {
-						
+
 						volumeAdjustment *= adjustFactor;
 					}
 				}
@@ -542,21 +546,25 @@ bool AudioOutput::mix(void *outbuff, unsigned int nsamp) {
 
 			// If recording is enabled add the current audio source to the recording buffer
 			if (recorder) {
-				AudioOutputSpeech *aos = qobject_cast<AudioOutputSpeech *>(aop);
-
-				if (aos) {
-					for (unsigned int i = 0; i < nsamp; ++i) {
-						recbuff[i] += pfBuffer[i] * volumeAdjustment;
+				if (speech) {
+					if (speech->bStereo) {
+						for (unsigned int i = 0; i < frameNumber; ++i) { // Mix down stereo to mono. TODO: stereo record support
+							recbuff[i] += (pfBuffer[2*i] / 2.0 + pfBuffer[2*i+1] / 2.0) * volumeAdjustment;
+						}
+					} else {
+						for (unsigned int i = 0; i < frameNumber; ++i) {
+							recbuff[i] += pfBuffer[i] * volumeAdjustment;
+						}
 					}
 
 					if (!recorder->isInMixDownMode()) {
-						recorder->addBuffer(aos->p, recbuff, nsamp);
-						recbuff = boost::shared_array<float>(new float[nsamp]);
-						memset(recbuff.get(), 0, sizeof(float) * nsamp);
+						recorder->addBuffer(speech->p, recbuff, frameNumber);
+						recbuff = boost::shared_array<float>(new float[frameNumber]);
+						memset(recbuff.get(), 0, sizeof(float) * frameNumber);
 					}
 
 					// Don't add the local audio to the real output
-					if (qobject_cast<RecordUser *>(aos->p)) {
+					if (qobject_cast<RecordUser *>(speech->p)) {
 						continue;
 					}
 				}
@@ -585,14 +593,20 @@ bool AudioOutput::mix(void *outbuff, unsigned int nsamp) {
 					const float str = svol[s] * calcGain(dot, len) * volumeAdjustment;
 					float * RESTRICT o = output + s;
 					const float old = (aop->pfVolume[s] >= 0.0f) ? aop->pfVolume[s] : str;
-					const float inc = (str - old) / static_cast<float>(nsamp);
+					const float inc = (str - old) / static_cast<float>(frameNumber);
 					aop->pfVolume[s] = str;
 					/*
 										qWarning("%d: Pos %f %f %f : Dot %f Len %f Str %f", s, speaker[s*3+0], speaker[s*3+1], speaker[s*3+2], dot, len, str);
 					*/
 					if ((old >= 0.00000001f) || (str >= 0.00000001f))
-						for (unsigned int i=0;i<nsamp;++i)
-							o[i*nchan] += pfBuffer[i] * (old + inc*static_cast<float>(i));
+                        for (unsigned int i=0;i<frameNumber;++i) {
+                            if (speech && speech->bStereo) {
+                                // Mix stereo user's stream into mono
+                                o[i * nchan] += (pfBuffer[2*i] / 2.0 + pfBuffer[2*i+1] / 2.0) * (old + inc * static_cast<float>(i));
+                            } else {
+                                o[i * nchan] += pfBuffer[i] * (old + inc * static_cast<float>(i));
+                            }
+                        }
 				}
 			} else {
 				// Mix the current audio source into the output by adding it to the elements of the output buffer after having applied
@@ -600,23 +614,32 @@ bool AudioOutput::mix(void *outbuff, unsigned int nsamp) {
 				for (unsigned int s=0;s<nchan;++s) {
 					const float str = svol[s] * volumeAdjustment;
 					float * RESTRICT o = output + s;
-					for (unsigned int i=0;i<nsamp;++i)
-						o[i*nchan] += pfBuffer[i] * str;
+					if (speech && speech->bStereo){
+						// Linear-panning stereo stream according to the projection of fSpeaker vector on left-right
+						// direction.
+						float left_factor = (1.0 - fSpeakers[s*3+0]) / 2.0;
+						float right_factor = (1.0 + fSpeakers[s*3+0]) / 2.0;
+						for (unsigned int i=0;i<frameNumber;++i)
+							o[i*nchan] += (pfBuffer[2*i] * left_factor + pfBuffer[2*i+1] * right_factor) * str;
+					} else {
+						for (unsigned int i=0;i<frameNumber;++i)
+							o[i*nchan] += pfBuffer[i] * str;
+					}
 				}
 			}
 		}
 
 		if (recorder && recorder->isInMixDownMode()) {
-			recorder->addBuffer(NULL, recbuff, nsamp);
+			recorder->addBuffer(NULL, recbuff, frameNumber);
 		}
 
 		// Clip the output audio
 		if (eSampleFormat == SampleFloat)
-			for (unsigned int i=0;i<nsamp*iChannels;i++)
+			for (unsigned int i=0;i<frameNumber*iChannels;i++)
 				output[i] = qBound(-1.0f, output[i], 1.0f);
 		else
 			// Also convert the intermediate float array into an array of shorts before writing it to the outbuff
-			for (unsigned int i=0;i<nsamp*iChannels;i++)
+			for (unsigned int i=0;i<frameNumber*iChannels;i++)
 				reinterpret_cast<short *>(outbuff)[i] = static_cast<short>(qBound(-32768.f, (output[i] * 32768.f), 32767.f));
 	}
 

--- a/src/mumble/AudioOutput.cpp
+++ b/src/mumble/AudioOutput.cpp
@@ -624,7 +624,7 @@ bool AudioOutput::mix(void *outbuff, unsigned int frameNumber) {
 				for (unsigned int s=0;s<nchan;++s) {
 					const float str = svol[s] * volumeAdjustment;
 					float * RESTRICT o = output + s;
-					if (speech && speech->bStereo){
+					if (aop->bStereo){
 						// Linear-panning stereo stream according to the projection of fSpeaker vector on left-right
 						// direction.
 						for (unsigned int i=0;i<frameNumber;++i)

--- a/src/mumble/AudioOutput.h
+++ b/src/mumble/AudioOutput.h
@@ -88,7 +88,7 @@ class AudioOutput : public QThread {
 
 		virtual void removeBuffer(AudioOutputUser *);
 		void initializeMixer(const unsigned int *chanmasks, bool forceheadphone = false);
-		bool mix(void *output, unsigned int nsamp);
+		bool mix(void *output, unsigned int frameNumber);
 	public:
 		void wipe();
 

--- a/src/mumble/AudioOutput.h
+++ b/src/mumble/AudioOutput.h
@@ -73,9 +73,10 @@ class AudioOutput : public QThread {
 		Q_OBJECT
 		Q_DISABLE_COPY(AudioOutput)
 	private:
-		float *fSpeakers;
+		float *fSpeakers; // Speaker positional vector
 		float *fSpeakerVolume;
 		bool *bSpeakerPositional;
+		float * fStereoPanningFactor; // Used when panning stereo stream w.r.t. each speaker.
 	protected:
 		enum { SampleShort, SampleFloat } eSampleFormat;
 		volatile bool bRunning;

--- a/src/mumble/AudioOutput.h
+++ b/src/mumble/AudioOutput.h
@@ -73,10 +73,12 @@ class AudioOutput : public QThread {
 		Q_OBJECT
 		Q_DISABLE_COPY(AudioOutput)
 	private:
-		float *fSpeakers; // Speaker positional vector
+		/// Speaker positional vector
+		float *fSpeakers;
 		float *fSpeakerVolume;
 		bool *bSpeakerPositional;
-		float * fStereoPanningFactor; // Used when panning stereo stream w.r.t. each speaker.
+		/// Used when panning stereo stream w.r.t. each speaker.
+		float * fStereoPanningFactor;
 	protected:
 		enum { SampleShort, SampleFloat } eSampleFormat;
 		volatile bool bRunning;
@@ -89,20 +91,20 @@ class AudioOutput : public QThread {
 
 		virtual void removeBuffer(AudioOutputUser *);
 		void initializeMixer(const unsigned int *chanmasks, bool forceheadphone = false);
-		bool mix(void *output, unsigned int frameNumber);
+		bool mix(void *output, unsigned int frameCount);
 	public:
 		void wipe();
 
-                /// Construct an AudioOutput.
-                ///
-                /// This constructor is only ever called by Audio::startOutput(), and is guaranteed
-                /// to be called on the application's main thread.
+				/// Construct an AudioOutput.
+				///
+				/// This constructor is only ever called by Audio::startOutput(), and is guaranteed
+				/// to be called on the application's main thread.
 		AudioOutput();
 
-                /// Destroy an AudioOutput.
-                ///
-                /// This destructor is only ever called by Audio::stopOutput() and Audio::stop(),
-                /// and is guaranteed to be called on the application's main thread.
+				/// Destroy an AudioOutput.
+				///
+				/// This destructor is only ever called by Audio::stopOutput() and Audio::stop(),
+				/// and is guaranteed to be called on the application's main thread.
 		~AudioOutput() Q_DECL_OVERRIDE;
 
 		void addFrameToBuffer(ClientUser *, const QByteArray &, unsigned int iSeq, MessageHandler::UDPMessageType type);

--- a/src/mumble/AudioOutputSample.cpp
+++ b/src/mumble/AudioOutputSample.cpp
@@ -22,7 +22,7 @@ SoundFile::SoundFile(const QString &fname) {
 	siInfo.seekable = 0;
 	siInfo.format = 0;
 
-	sfFile = NULL;
+	sfFile = nullptr;
 
 	qfFile.setFileName(fname);
 
@@ -39,7 +39,7 @@ SoundFile::~SoundFile() {
 }
 
 bool SoundFile::isOpen() const {
-	return (sfFile != NULL) && qfFile.isOpen();
+	return (sfFile != nullptr) && qfFile.isOpen();
 }
 
 int SoundFile::channels() const {
@@ -129,7 +129,7 @@ AudioOutputSample::AudioOutputSample(const QString &name, SoundFile *psndfile, b
 	} else if (sfHandle->channels() == 2) {
 		bStereo = true;
 	} else {
-		sfHandle = NULL;  // sound file is corrupted
+		sfHandle = nullptr;  // sound file is corrupted
 		return;
 	}
 
@@ -143,12 +143,12 @@ AudioOutputSample::AudioOutputSample(const QString &name, SoundFile *psndfile, b
 		srs = speex_resampler_init(bStereo ? 2 : 1, sfHandle->samplerate(), iOutSampleRate, 3, &err);
 		if (err != RESAMPLER_ERR_SUCCESS) {
 			qWarning() << "Initialize " << sfHandle->samplerate() << " to " << iOutSampleRate << " resampler failed!";
-			srs = NULL;
-			sfHandle = NULL;
+			srs = nullptr;
+			sfHandle = nullptr;
 			return;
 		}
 	} else {
-		srs = NULL;
+		srs = nullptr;
 	}
 
 	iLastConsume = iBufferFilled = 0;
@@ -161,7 +161,7 @@ AudioOutputSample::~AudioOutputSample() {
 		speex_resampler_destroy(srs);
 
 	delete sfHandle;
-	sfHandle = NULL;
+	sfHandle = nullptr;
 }
 
 SoundFile* AudioOutputSample::loadSndfile(const QString &filename) {
@@ -173,31 +173,31 @@ SoundFile* AudioOutputSample::loadSndfile(const QString &filename) {
 	if (! sf->isOpen()) {
 		qWarning() << "File " << filename << " failed to open";
 		delete sf;
-		return NULL;
+		return nullptr;
 	}
 
 	if (sf->error() != SF_ERR_NO_ERROR) {
 		qWarning() << "File " << filename << " couldn't be loaded: " << sf->strError();
 		delete sf;
-		return NULL;
+		return nullptr;
 	}
 
 	if (sf->channels() <= 0 || sf->channels() > 2) {
 		qWarning() << "File " << filename << " contains " << sf->channels() << " Channels, only 1 or 2 are supported.";
 		delete sf;
-		return NULL;
+		return nullptr;
 	}
 	return sf;
 }
 
 QString AudioOutputSample::browseForSndfile(QString defaultpath) {
-	QString file = QFileDialog::getOpenFileName(NULL, tr("Choose sound file"), defaultpath, QLatin1String("*.wav *.ogg *.ogv *.oga *.flac *.aiff"));
+	QString file = QFileDialog::getOpenFileName(nullptr, tr("Choose sound file"), defaultpath, QLatin1String("*.wav *.ogg *.ogv *.oga *.flac *.aiff"));
 	if (! file.isEmpty()) {
 		SoundFile *sf = AudioOutputSample::loadSndfile(file);
-		if (sf == NULL) {
-			QMessageBox::critical(NULL,
-			                      tr("Invalid sound file"),
-			                      tr("The file '%1' cannot be used by Mumble. Please select a file with a compatible format and encoding.").arg(file.toHtmlEscaped()));
+		if (sf == nullptr) {
+			QMessageBox::critical(nullptr,
+					tr("Invalid sound file"),
+					tr("The file '%1' cannot be used by Mumble. Please select a file with a compatible format and encoding.").arg(file.toHtmlEscaped()));
 			return QString();
 		}
 		delete sf;
@@ -205,20 +205,20 @@ QString AudioOutputSample::browseForSndfile(QString defaultpath) {
 	return file;
 }
 
-bool AudioOutputSample::prepareSampleBuffer(unsigned int frameNumber) {
-	unsigned int snum = frameNumber * sfHandle->channels();
+bool AudioOutputSample::prepareSampleBuffer(unsigned int frameCount) {
+	unsigned int sampleCount = frameCount * sfHandle->channels();
 	// Forward the buffer
 	for (unsigned int i=iLastConsume;i<iBufferFilled;++i)
 		pfBuffer[i-iLastConsume]=pfBuffer[i];
 	iBufferFilled -= iLastConsume;
-	iLastConsume = snum;
+	iLastConsume = sampleCount;
 
 	// Check if we can satisfy request with current buffer
-	if (iBufferFilled >= snum)
+	if (iBufferFilled >= sampleCount)
 		return true;
 
 	// Calculate the required buffersize to hold the results
-	unsigned int iInputFrames = static_cast<unsigned int>(ceilf(static_cast<float>(frameNumber * sfHandle->samplerate()) / static_cast<float>(iOutSampleRate)));
+	unsigned int iInputFrames = static_cast<unsigned int>(ceilf(static_cast<float>(frameCount * sfHandle->samplerate()) / static_cast<float>(iOutSampleRate)));
 	unsigned int iInputSamples = iInputFrames * sfHandle->channels();
 
 	STACKVAR(float, fOut, iInputSamples);
@@ -226,7 +226,7 @@ bool AudioOutputSample::prepareSampleBuffer(unsigned int frameNumber) {
 	bool eof = false;
 	sf_count_t read;
 	do {
-		resizeBuffer(iBufferFilled + snum);
+		resizeBuffer(iBufferFilled + sampleCount);
 
 		// If we need to resample, write to the buffer on stack
 		float *pOut = (srs) ? fOut : pfBuffer + iBufferFilled;
@@ -244,8 +244,9 @@ bool AudioOutputSample::prepareSampleBuffer(unsigned int frameNumber) {
 		}
 
 		spx_uint32_t inlen = static_cast<unsigned int>(read) / sfHandle->channels();
-		spx_uint32_t outlen = snum;
-		if (srs) { // If necessary resample
+		spx_uint32_t outlen = sampleCount;
+		if (srs) {
+			// If necessary resample
 			if (!bStereo) {
 				speex_resampler_process_float(srs, 0, pOut, &inlen, pfBuffer + iBufferFilled, &outlen);
 			} else {
@@ -254,7 +255,7 @@ bool AudioOutputSample::prepareSampleBuffer(unsigned int frameNumber) {
 		}
 
 		iBufferFilled += outlen;
-	} while (iBufferFilled < snum);
+	} while (iBufferFilled < sampleCount);
 
 	if (eof && !bEof) {
 		emit playbackFinished();

--- a/src/mumble/AudioOutputSample.h
+++ b/src/mumble/AudioOutputSample.h
@@ -59,7 +59,7 @@ class AudioOutputSample : public AudioOutputUser {
 	public:
 		static SoundFile* loadSndfile(const QString &filename);
 		static QString browseForSndfile(QString defaultpath=QString());
-		virtual bool prepareSampleBuffer(unsigned int snum) Q_DECL_OVERRIDE;
+		virtual bool prepareSampleBuffer(unsigned int frameCount) Q_DECL_OVERRIDE;
 		AudioOutputSample(const QString &name, SoundFile *psndfile, bool repeat, unsigned int freq);
 		~AudioOutputSample() Q_DECL_OVERRIDE;
 };

--- a/src/mumble/AudioOutputSpeech.cpp
+++ b/src/mumble/AudioOutputSpeech.cpp
@@ -61,6 +61,7 @@ AudioOutputSpeech::AudioOutputSpeech(ClientUser *user, unsigned int freq, Messag
 		oCodec = g.oCodec;
 		if (oCodec) {
 			opusState = oCodec->opus_decoder_create(iSampleRate, bStereo ? 2 : 1, NULL);
+			oCodec->opus_decoder_ctl(opusState, OPUS_SET_PHASE_INVERSION_DISABLED(1)); // Disable phase inversion for better mono downmix.
 		}
 #endif
 	} else if (umtType == MessageHandler::UDPVoiceSpeex) {

--- a/src/mumble/AudioOutputSpeech.h
+++ b/src/mumble/AudioOutputSpeech.h
@@ -33,11 +33,11 @@ class AudioOutputSpeech : public AudioOutputUser {
 		unsigned int iOutputSize;
 		unsigned int iLastConsume;
 		unsigned int iFrameSize;
+		unsigned int iFrameSizePerChannel;
 		unsigned int iSampleRate;
 		unsigned int iMixerFreq;
 		bool bLastAlive;
 		bool bHasTerminator;
-		bool bStereo;
 
 		float *fFadeIn;
 		float *fFadeOut;
@@ -62,10 +62,14 @@ class AudioOutputSpeech : public AudioOutputUser {
 	public:
 		unsigned char ucFlags;
 		MessageHandler::UDPMessageType umtType;
+		bool bStereo;
 		int iMissedFrames;
 		ClientUser *p;
 
-		virtual bool prepareSampleBuffer(unsigned int snum) Q_DECL_OVERRIDE;
+        /// Fetch and decode frames from the jitter buffer. Called in mix().
+        ///
+        /// @param frameNumber Number of frames to decode. frame means a bundle of one sample from each channel.
+		virtual bool prepareSampleBuffer(unsigned int frameNumber) Q_DECL_OVERRIDE;
 
 		void addFrameToBuffer(const QByteArray &, unsigned int iBaseSeq);
 		AudioOutputSpeech(ClientUser *, unsigned int freq, MessageHandler::UDPMessageType type);

--- a/src/mumble/AudioOutputSpeech.h
+++ b/src/mumble/AudioOutputSpeech.h
@@ -65,10 +65,10 @@ class AudioOutputSpeech : public AudioOutputUser {
 		int iMissedFrames;
 		ClientUser *p;
 
-        /// Fetch and decode frames from the jitter buffer. Called in mix().
-        ///
-        /// @param frameNumber Number of frames to decode. frame means a bundle of one sample from each channel.
-		virtual bool prepareSampleBuffer(unsigned int frameNumber) Q_DECL_OVERRIDE;
+		/// Fetch and decode frames from the jitter buffer. Called in mix().
+		///
+		/// @param frameCount Number of frames to decode. frame means a bundle of one sample from each channel.
+		virtual bool prepareSampleBuffer(unsigned int frameCount) Q_DECL_OVERRIDE;
 
 		void addFrameToBuffer(const QByteArray &, unsigned int iBaseSeq);
 		AudioOutputSpeech(ClientUser *, unsigned int freq, MessageHandler::UDPMessageType type);

--- a/src/mumble/AudioOutputSpeech.h
+++ b/src/mumble/AudioOutputSpeech.h
@@ -62,7 +62,6 @@ class AudioOutputSpeech : public AudioOutputUser {
 	public:
 		unsigned char ucFlags;
 		MessageHandler::UDPMessageType umtType;
-		bool bStereo;
 		int iMissedFrames;
 		ClientUser *p;
 

--- a/src/mumble/AudioOutputUser.cpp
+++ b/src/mumble/AudioOutputUser.cpp
@@ -7,8 +7,8 @@
 
 AudioOutputUser::AudioOutputUser(const QString& name) : qsName(name) {
 	iBufferSize = 0;
-	pfBuffer = NULL;
-	pfVolume = NULL;
+	pfBuffer = nullptr;
+	pfVolume = nullptr;
 	fPos[0]=fPos[1]=fPos[2]=0.0;
 }
 

--- a/src/mumble/AudioOutputUser.h
+++ b/src/mumble/AudioOutputUser.h
@@ -22,6 +22,7 @@ class AudioOutputUser : public QObject {
 		float *pfBuffer;
 		float *pfVolume;
 		float fPos[3];
+		bool bStereo;
 		virtual bool prepareSampleBuffer(unsigned int snum) = 0;
 };
 

--- a/src/mumble/OpusCodec.cpp
+++ b/src/mumble/OpusCodec.cpp
@@ -73,6 +73,7 @@ OpusCodec::OpusCodec() {
 	RESOLVE(opus_encoder_ctl);
 	RESOLVE(opus_encoder_destroy);
 	RESOLVE(opus_decoder_create);
+	RESOLVE(opus_decoder_ctl);
 	RESOLVE(opus_decoder_destroy);
 
 	RESOLVE(opus_decoder_get_nb_samples);

--- a/src/mumble/OpusCodec.cpp
+++ b/src/mumble/OpusCodec.cpp
@@ -75,8 +75,7 @@ OpusCodec::OpusCodec() {
 	RESOLVE(opus_decoder_create);
 	RESOLVE(opus_decoder_destroy);
 
-	RESOLVE(opus_packet_get_nb_frames);
-	RESOLVE(opus_packet_get_samples_per_frame);
+	RESOLVE(opus_decoder_get_nb_samples);
 }
 
 OpusCodec::~OpusCodec() {

--- a/src/mumble/OpusCodec.h
+++ b/src/mumble/OpusCodec.h
@@ -34,12 +34,13 @@ class OpusCodec {
 		int (__cdecl *opus_encoder_ctl)(OpusEncoder *st, int request, ...);
 		void (__cdecl *opus_encoder_destroy)(OpusEncoder *st);
 		OpusDecoder *(__cdecl *opus_decoder_create)(opus_int32 Fs, int channels, int *error);
+		int (__cdecl *opus_decoder_ctl)(OpusDecoder *st, int request, ...);
 		void (__cdecl *opus_decoder_destroy)(OpusDecoder *st);
 
 		int (__cdecl *opus_encode)(OpusEncoder *st, const opus_int16 *pcm, int frame_size, unsigned char *compressed, int nbCompressedBytes);
 		int (__cdecl *opus_decode_float)(OpusDecoder *st, const unsigned char *data, opus_int32 len, float *pcm, int frame_size, int decode_fec);
 
-        int (__cdecl *opus_decoder_get_nb_samples)(OpusDecoder *st, const unsigned char packet[], opus_int32 len);
+		int (__cdecl *opus_decoder_get_nb_samples)(OpusDecoder *st, const unsigned char packet[], opus_int32 len);
 };
 
 #endif  // OPUSCODEC_H_

--- a/src/mumble/OpusCodec.h
+++ b/src/mumble/OpusCodec.h
@@ -39,8 +39,7 @@ class OpusCodec {
 		int (__cdecl *opus_encode)(OpusEncoder *st, const opus_int16 *pcm, int frame_size, unsigned char *compressed, int nbCompressedBytes);
 		int (__cdecl *opus_decode_float)(OpusDecoder *st, const unsigned char *data, opus_int32 len, float *pcm, int frame_size, int decode_fec);
 
-		int (__cdecl *opus_packet_get_nb_frames)(const unsigned char packet[], opus_int32 len);
-		int (__cdecl *opus_packet_get_samples_per_frame)(const unsigned char *data, opus_int32 Fs);
+        int (__cdecl *opus_decoder_get_nb_samples)(OpusDecoder *st, const unsigned char packet[], opus_int32 len);
 };
 
 #endif  // OPUSCODEC_H_


### PR DESCRIPTION
Just executed the idea in #4193. Merging this PR will close #2829, ending a three-year-long pursuit for the stereo audio, realizing the dream of dozens of forks :D.
Thank @Krzmbrzl, @streaps for their help, and @felix91gr for supporting me!

In this commit, I initialize opus decoder in stereo mode. For incoming mono stream, the opus decoder will automatically convert it into a stereo stream so we don't have to make any changes to the protocol, thus this improvement is backward compatible. I carefully tweaked the jitter buffer and the resampler and the fade in/out, and I guess that's all I should take care of.

Actually, opus decoder can also automatically convert a stereo stream into a mono stream, so even if we transmit a stereo stream to an older version of mumble, it would still work.

When mapping the stereo stream to the audio output buffer, I used the `fSpeaker ` direction vector designed for positional audio. It looks like, for CoreAudio, the only two speakers enabled are the front left speaker and front right speaker, and their direction vector does not completely point to left or right, so the mixed audio is not so "stereo". I have to switch on the "Headphone" mode in the settings panel to make that vector completely pointing to left or right.

I didn't change the AudioInput part, partly because it is useless for the normal user who has only one microphone. In fact, the motivation for me is to have mumble decode the stereo stream from my music bot :), so I don't really care about input.

## How to test this PR

To test this PR, you need to have a music bot that supports stereo audio. I have already added the stereo feature to the python library pymumble, and created [a fork of botamusique](https://github.com/TerryGeng/botamusique/tree/stereo) based on this improved version of pymumble. 

Just clone it, checkout the stereo branch `git checkout stereo` and follows the quick start guide to have it installed. Remember to run `git submodule init && git submodule update` to download the improved version of pymumble. Then find some stereo songs and enjoy! And you may also need to turn on "headphone" mode in the settings panel to get the best result.

BTW I just discovered compiled binaries of this PR can be found at [Azure Pipelines](https://dev.azure.com/Mumble-VoIP/Mumble/_build/results?buildId=1820&view=artifacts&type=publishedArtifacts). I think people interested having stereo support before next release can check this out.
-----
Closes #2829
Closes #4210 