### PR TITLE
More accessibility enhancements for accessibility clients

### DIFF
--- a/src/mumble/ACLEditor.cpp
+++ b/src/mumble/ACLEditor.cpp
@@ -33,6 +33,22 @@ ACLEditor::ACLEditor(int channelparentid, QWidget *p) : QDialog(p) {
 
 	setupUi(this);
 
+	qwChannel->setAccessibleName(tr("Properties"));
+	rteChannelDescription->setAccessibleName(tr("Description"));
+	qleChannelPassword->setAccessibleName(tr("Channel password"));
+	qsbChannelPosition->setAccessibleName(tr("Position"));
+	qsbChannelMaxUsers->setAccessibleName(tr("Maximum users"));
+	qleChannelName->setAccessibleName(tr("Channel name"));
+	qcbGroupList->setAccessibleName(tr("List of groups"));
+	qlwGroupAdd->setAccessibleName(tr("Inherited group members"));
+	qlwGroupRemove->setAccessibleName(tr("Foreign group members"));
+	qlwGroupInherit->setAccessibleName(tr("Inherited channel members"));
+	qcbGroupAdd->setAccessibleName(tr("Add members to group"));
+	qcbGroupRemove->setAccessibleName(tr("Remove member from group"));
+	qlwACLs->setAccessibleName(tr("List of ACL entries"));
+	qcbACLGroup->setAccessibleName(tr("Group this entry applies to"));
+	qcbACLUser->setAccessibleName(tr("User this entry applies to"));
+
 	qsbChannelPosition->setRange(INT_MIN, INT_MAX);
 
 	setWindowTitle(tr("Mumble - Add channel"));
@@ -76,6 +92,22 @@ ACLEditor::ACLEditor(int channelid, const MumbleProto::ACL &mea, QWidget *p) : Q
 	msg = mea;
 
 	setupUi(this);
+
+	qwChannel->setAccessibleName(tr("Properties"));
+	rteChannelDescription->setAccessibleName(tr("Description"));
+	qleChannelPassword->setAccessibleName(tr("Channel password"));
+	qsbChannelPosition->setAccessibleName(tr("Position"));
+	qsbChannelMaxUsers->setAccessibleName(tr("Maximum users"));
+	qleChannelName->setAccessibleName(tr("Channel name"));
+	qcbGroupList->setAccessibleName(tr("List of groups"));
+	qlwGroupAdd->setAccessibleName(tr("Inherited group members"));
+	qlwGroupRemove->setAccessibleName(tr("Foreign group members"));
+	qlwGroupInherit->setAccessibleName(tr("Inherited channel members"));
+	qcbGroupAdd->setAccessibleName(tr("Add members to group"));
+	qcbGroupRemove->setAccessibleName(tr("Remove member from group"));
+	qlwACLs->setAccessibleName(tr("List of ACL entries"));
+	qcbACLGroup->setAccessibleName(tr("Group this entry applies to"));
+	qcbACLUser->setAccessibleName(tr("User this entry applies to"));
 
 	qcbChannelTemporary->hide();
 

--- a/src/mumble/ASIOInput.cpp
+++ b/src/mumble/ASIOInput.cpp
@@ -129,6 +129,10 @@ ASIOInput *ASIOInput::aiSelf;
 ASIOConfig::ASIOConfig(Settings &st) : ConfigWidget(st) {
 	setupUi(this);
 
+	qcbDevice->setAccessibleName(tr("Device to use for microphone"));
+	qlwMic->setAccessibleName(tr("List of microphones"));
+	qlwSpeaker->setAccessibleName(tr("List of speakers"));
+
 	// List of devices known to misbehave or be totally useless
 	QStringList blacklist;
 	blacklist << QLatin1String("{a91eaba1-cf4c-11d3-b96a-00a0c9c7b61a}"); // ASIO DirectX

--- a/src/mumble/About.cpp
+++ b/src/mumble/About.cpp
@@ -24,14 +24,17 @@ AboutDialog::AboutDialog(QWidget *p) : QDialog(p) {
 	QTextEdit *qteLicense = new QTextEdit(qtwTab);
 	qteLicense->setReadOnly(true);
 	qteLicense->setPlainText(License::license());
+	qteLicense->setAccessibleName(tr("License agreement"));
 
 	QTextEdit *qteAuthors = new QTextEdit(qtwTab);
 	qteAuthors->setReadOnly(true);
 	qteAuthors->setPlainText(License::authors());
+	qteAuthors->setAccessibleName(tr("Authors"));
 
 	QTextBrowser *qtb3rdPartyLicense = new QTextBrowser(qtwTab);
 	qtb3rdPartyLicense->setReadOnly(true);
 	qtb3rdPartyLicense->setOpenExternalLinks(true);
+	qtb3rdPartyLicense->setAccessibleName(tr("Third-party license agreements"));
 
 	QList<LicenseInfo> thirdPartyLicenses = License::thirdPartyLicenses();
 	foreach(LicenseInfo li, thirdPartyLicenses) {

--- a/src/mumble/AudioConfigDialog.cpp
+++ b/src/mumble/AudioConfigDialog.cpp
@@ -76,6 +76,25 @@ AudioInputDialog::AudioInputDialog(Settings &st) : ConfigWidget(st) {
 
 	setupUi(this);
 
+	qcbSystem->setAccessibleName(tr("Audio system"));
+	qcbDevice->setAccessibleName(tr("Input device"));
+	qcbEcho->setAccessibleName(tr("Echo cancellation mode"));
+	qcbTransmit->setAccessibleName(tr("Transmission mode"));
+	qsDoublePush->setAccessibleName(tr("PTT lock threshold"));
+	qsPTTHold->setAccessibleName(tr("PTT hold threshold"));
+	qsTransmitHold->setAccessibleName(tr("Silence below"));
+	abSpeech->setAccessibleName(tr("Current speech detection chance"));
+	qsTransmitMin->setAccessibleName(tr("Speech above"));
+	qsTransmitMax->setAccessibleName(tr("Speech below"));
+	qsFrames->setAccessibleName(tr("Audio per packet"));
+	qsQuality->setAccessibleName(tr("Quality of compression (peak bandwidth)"));
+	qsNoise->setAccessibleName(tr("Noise suppression"));
+	qsAmp->setAccessibleName(tr("Maximum amplification"));
+	qlePushClickPathOn->setAccessibleName(tr("Transmission started sound"));
+	qlePushClickPathOff->setAccessibleName(tr("Transmission stopped sound"));
+	qsbIdle->setAccessibleName(tr("Initiate idle action after (in minutes)"));
+	qcbIdleAction->setAccessibleName(tr("Idle action"));
+
 	if (AudioInputRegistrar::qmNew) {
 		QList<QString> keys = AudioInputRegistrar::qmNew->keys();
 		foreach(QString key, keys) {
@@ -451,6 +470,20 @@ void AudioInputDialog::on_qcbIdleAction_currentIndexChanged(int v) {
 
 AudioOutputDialog::AudioOutputDialog(Settings &st) : ConfigWidget(st) {
 	setupUi(this);
+
+	qcbSystem->setAccessibleName(tr("Output system"));
+	qcbDevice->setAccessibleName(tr("Output device"));
+	qsJitter->setAccessibleName(tr("Default jitter buffer"));
+	qsVolume->setAccessibleName(tr("Volume of incoming speech"));
+	qsDelay->setAccessibleName(tr("Output delay"));
+	qsOtherVolume->setAccessibleName(tr("Attenuation of other applications during speech"));
+	qsMinDistance->setAccessibleName(tr("Minimum distance"));
+	qsMaxDistance->setAccessibleName(tr("Maximum distance"));
+	qsMaxDistVolume->setAccessibleName(tr("Minimum volume"));
+	qsBloom->setAccessibleName(tr("Bloom"));
+	qsPacketDelay->setAccessibleName(tr("Delay variance"));
+	qsPacketLoss->setAccessibleName(tr("Packet loss"));
+	qcbLoopback->setAccessibleName(tr("Loopback"));
 
 	if (AudioOutputRegistrar::qmNew) {
 		QList<QString> keys = AudioOutputRegistrar::qmNew->keys();

--- a/src/mumble/AudioStats.cpp
+++ b/src/mumble/AudioStats.cpp
@@ -279,6 +279,11 @@ AudioStats::AudioStats(QWidget *p) : QDialog(p) {
 	qtTick->start(50);
 
 	setupUi(this);
+
+	abSpeech->setAccessibleName(tr("Current speech detection chance"));
+	anwNoise->setAccessibleName(tr("Power spectrum of input signal and noise estimate"));
+	aewEcho->setAccessibleName(tr("Weights of the echo canceller"));
+	
 	AudioInputPtr ai = g.ai;
 
 	if (ai && ai->sesEcho) {

--- a/src/mumble/AudioWizard.cpp
+++ b/src/mumble/AudioWizard.cpp
@@ -43,6 +43,15 @@ AudioWizard::AudioWizard(QWidget *p) : QWizard(p) {
 
 	setupUi(this);
 
+	qcbInput->setAccessibleName(tr("Input system"));
+	qcbInputDevice->setAccessibleName(tr("Input device"));
+	qcbOutput->setAccessibleName(tr("Output system"));
+	qcbOutputDevice->setAccessibleName(tr("Output device"));
+	qsOutputDelay->setAccessibleName(tr("Output delay"));
+	qsMaxAmp->setAccessibleName(tr("Maximum amplification"));
+	skwPTT->setAccessibleName(tr("PTT key"));
+	qsVAD->setAccessibleName(tr("VAD level"));
+
 	// Done
 	qcbUsage->setChecked(g.s.bUsage);
 

--- a/src/mumble/BanEditor.cpp
+++ b/src/mumble/BanEditor.cpp
@@ -15,6 +15,17 @@
 BanEditor::BanEditor(const MumbleProto::BanList &msg, QWidget *p) : QDialog(p)
 	, maskDefaultValue(32) {
 	setupUi(this);
+
+	qleSearch->setAccessibleName(tr("Search"));
+	qleUser->setAccessibleName(tr("User"));
+	qleIP->setAccessibleName(tr("IP Address"));
+	qsbMask->setAccessibleName(tr("Mask"));
+	qleReason->setAccessibleName(tr("Reason"));
+	qdteStart->setAccessibleName(tr("Start date/time"));
+	qdteEnd->setAccessibleName(tr("End date/time"));
+	qleHash->setAccessibleName(tr("Certificate hash"));
+	qlwBans->setAccessibleName(tr("Banned users"));
+
 	qlwBans->setFocus();
 
 	qlBans.clear();

--- a/src/mumble/Cert.cpp
+++ b/src/mumble/Cert.cpp
@@ -119,6 +119,17 @@ void CertView::setCert(const QList<QSslCertificate> &cert) {
 CertWizard::CertWizard(QWidget *p) : QWizard(p) {
 	setupUi(this);
 
+	cvWelcome->setAccessibleName(tr("Current certificate"));
+	qleImportFile->setAccessibleName(tr("Certificate file to import"));
+	qlePassword->setAccessibleName(tr("Certificate password"));
+	cvImport->setAccessibleName(tr("Certificate to import"));
+	cvCurrent->setAccessibleName(tr("Current certificate"));
+	cvNew->setAccessibleName(tr("New certificate"));
+	qleExportFile->setAccessibleName(tr("File to export certificate to"));
+	cvExport->setAccessibleName(tr("Current certificate"));
+	qleEmail->setAccessibleName(tr("Email address"));
+	qleName->setAccessibleName(tr("Your name"));
+
 	setOption(QWizard::NoCancelButton, false);
 
 	qwpExport->setCommitPage(true);

--- a/src/mumble/ConfigDialog.cpp
+++ b/src/mumble/ConfigDialog.cpp
@@ -23,6 +23,8 @@ QHash<QString, ConfigWidget *> ConfigDialog::s_existingWidgets;
 ConfigDialog::ConfigDialog(QWidget *p) : QDialog(p) {
 	setupUi(this);
 
+	qlwIcons->setAccessibleName(tr("Configuration categories"));
+
 	{
 		QMutexLocker lock(&s_existingWidgetsMutex);
 		s_existingWidgets.clear();

--- a/src/mumble/ConnectDialog.cpp
+++ b/src/mumble/ConnectDialog.cpp
@@ -958,6 +958,7 @@ void ConnectDialogEdit::on_qcbShowPassword_toggled(bool checked) {
 
 ConnectDialog::ConnectDialog(QWidget *p, bool autoconnect) : QDialog(p), bAutoConnect(autoconnect) {
 	setupUi(this);
+	qtwServers->setAccessibleName(tr("Server list"));
 #ifdef Q_OS_MAC
 	setWindowModality(Qt::WindowModal);
 #endif

--- a/src/mumble/GlobalShortcut.cpp
+++ b/src/mumble/GlobalShortcut.cpp
@@ -194,6 +194,7 @@ ShortcutTargetDialog::ShortcutTargetDialog(const ShortcutTarget &st, QWidget *pw
 	stTarget = st;
 	setupUi(this);
 
+
 	// Load current shortcut configuration
 	qcbForceCenter->setChecked(st.bForceCenter);
 	qgbModifiers->setVisible(true);
@@ -548,6 +549,7 @@ QString ShortcutDelegate::displayText(const QVariant &item, const QLocale &loc) 
 
 GlobalShortcutConfig::GlobalShortcutConfig(Settings &st) : ConfigWidget(st) {
 	setupUi(this);
+	qtwShortcuts->setAccessibleName(tr("Configured shortcuts"));
 	installEventFilter(this);
 
 	bool canSuppress = GlobalShortcutEngine::engine->canSuppress();

--- a/src/mumble/LCD.cpp
+++ b/src/mumble/LCD.cpp
@@ -82,7 +82,10 @@ static LCDDeviceManager devmgr;
 
 LCDConfig::LCDConfig(Settings &st) : ConfigWidget(st) {
 	setupUi(this);
-
+	qtwDevices->setAccessibleName(tr("Devices"));
+	qsMinColWidth->setAccessibleName(tr("Minimum column width"));
+	qsSplitterWidth->setAccessibleName(tr("Splitter width"));
+	
 	QTreeWidgetItem *qtwi;
 	foreach(LCDDevice *d, devmgr.qlDevices) {
 		qtwi = new QTreeWidgetItem(qtwDevices);

--- a/src/mumble/Log.cpp
+++ b/src/mumble/Log.cpp
@@ -39,7 +39,12 @@ static ConfigRegistrar registrar(4000, LogConfigDialogNew);
 
 LogConfig::LogConfig(Settings &st) : ConfigWidget(st) {
 	setupUi(this);
-
+	qtwMessages->setAccessibleName(tr("Log messages"));
+	qsVolume->setAccessibleName(tr("TTS engine volume"));
+	qsbThreshold->setAccessibleName(tr("Length threshold"));
+	qsbMaxBlocks->setAccessibleName(tr("Maximum chat length"));
+	qsbChatMessageMargins->setAccessibleName(tr("Chat message marjins"));
+	
 #ifdef USE_NO_TTS
 	qgbTTS->setDisabled(true);
 #endif

--- a/src/mumble/LookConfig.cpp
+++ b/src/mumble/LookConfig.cpp
@@ -27,7 +27,21 @@ static ConfigRegistrar registrar(1100, LookConfigNew);
 
 LookConfig::LookConfig(Settings &st) : ConfigWidget(st) {
 	setupUi(this);
-
+	qsbSilentUserLifetime->setAccessibleName(tr("Silent userlifetime"));
+	qsbPrefixCharCount->setAccessibleName(tr("Prefix character count"));
+	qsbChannelHierarchyDepth->setAccessibleName(tr("Channel hierarchy depth"));
+	qleChannelSeparator->setAccessibleName(tr("Channel separator"));
+	qsbPostfixCharCount->setAccessibleName(tr("Postfix character count"));
+	qleAbbreviationReplacement->setAccessibleName(tr("Abbreviation replacement"));
+	qsbMaxNameLength->setAccessibleName(tr("Maximum name length"));
+	qsbRelFontSize->setAccessibleName(tr("Relative font size"));
+	qcbLanguage->setAccessibleName(tr("Language"));
+	qcbTheme->setAccessibleName(tr("Theme"));
+	qcbAlwaysOnTop->setAccessibleName(tr("Always on top"));
+	qcbChannelDrag->setAccessibleName(tr("Channel dragging"));
+	qcbExpand->setAccessibleName(tr("Automatically expand channels when"));
+	qcbUserDrag->setAccessibleName(tr("User dragging behavior"));
+	
 #ifndef Q_OS_MAC
 	if (! QSystemTrayIcon::isSystemTrayAvailable())
 #endif

--- a/src/mumble/MainWindow.cpp
+++ b/src/mumble/MainWindow.cpp
@@ -160,7 +160,9 @@ MainWindow::MainWindow(QWidget *p) : QMainWindow(p) {
 	createActions();
 	setupUi(this);
 	setupGui();
-
+	qtvUsers->setAccessibleName(tr("Channels and users"));
+	qteLog->setAccessibleName(tr("Activity log"));
+	qteChat->setAccessibleName(tr("Chat message"));
 	connect(qmUser, SIGNAL(aboutToShow()), this, SLOT(qmUser_aboutToShow()));
 	connect(qmChannel, SIGNAL(aboutToShow()), this, SLOT(qmChannel_aboutToShow()));
 	connect(qmListener, SIGNAL(aboutToShow()), this, SLOT(qmListener_aboutToShow()));

--- a/src/mumble/NetworkConfig.cpp
+++ b/src/mumble/NetworkConfig.cpp
@@ -26,6 +26,12 @@ static ConfigRegistrar registrar(1300, NetworkConfigNew);
 
 NetworkConfig::NetworkConfig(Settings &st) : ConfigWidget(st) {
 	setupUi(this);
+	qcbType->setAccessibleName(tr("Type"));
+	qleHostname->setAccessibleName(tr("Hostname"));
+	qlePort->setAccessibleName(tr("Port"));
+	qleUsername->setAccessibleName(tr("Username"));
+	qlePassword->setAccessibleName(tr("Password"));
+
 }
 
 QString NetworkConfig::title() const {

--- a/src/mumble/OverlayEditor.cpp
+++ b/src/mumble/OverlayEditor.cpp
@@ -27,7 +27,7 @@ OverlayEditor::OverlayEditor(QWidget *p, QGraphicsItem *qgi, OverlaySettings *os
 		qgiPromote(qgi),
 		oes(g.s.os) {
 	setupUi(this);
-
+	qsZoom->setAccessibleName(tr("Zoom level"));
 	os = osptr ? osptr : &g.s.os;
 
 	connect(qdbbBox->button(QDialogButtonBox::Apply), SIGNAL(clicked()), this, SLOT(apply()));

--- a/src/mumble/Plugins.cpp
+++ b/src/mumble/Plugins.cpp
@@ -74,7 +74,7 @@ struct PluginFetchMeta {
 
 PluginConfig::PluginConfig(Settings &st) : ConfigWidget(st) {
 	setupUi(this);
-
+	qtwPlugins->setAccessibleName(tr("Plugins"));
 	qtwPlugins->header()->setSectionResizeMode(0, QHeaderView::Stretch);
 	qtwPlugins->header()->setSectionResizeMode(1, QHeaderView::ResizeToContents);
 

--- a/src/mumble/TextMessage.cpp
+++ b/src/mumble/TextMessage.cpp
@@ -7,6 +7,7 @@
 
 TextMessage::TextMessage(QWidget *p, QString title, bool bChannel) : QDialog(p) {
 	setupUi(this);
+	rteMessage->setAccessibleName(tr("Message"));
 	if (!bChannel)
 		qcbTreeMessage->setHidden(true);
 	setWindowTitle(title);

--- a/src/mumble/Tokens.cpp
+++ b/src/mumble/Tokens.cpp
@@ -13,6 +13,7 @@
 
 Tokens::Tokens(QWidget *p) : QDialog(p) {
 	setupUi(this);
+	qlwTokens->setAccessibleName(tr("Tokens"));
 
 	qbaDigest = g.sh->qbaDigest;
 	QStringList tokens = g.db->getTokens(qbaDigest);

--- a/src/mumble/UserEdit.cpp
+++ b/src/mumble/UserEdit.cpp
@@ -22,6 +22,10 @@ UserEdit::UserEdit(const MumbleProto::UserList &userList, QWidget *p)
 	, m_filter(new UserListFilterProxyModel(this)) {
 
 	setupUi(this);
+	qlSearch->setAccessibleName(tr("Search"));
+	qcbInactive->setAccessibleName(tr("Inactive for"));
+	qsbInactive->setAccessibleName(tr("Inactive for"));
+	qtvUserList->setAccessibleName(tr("User list"));
 
 	const int userCount = userList.users_size();
 	setWindowTitle(tr("Registered users: %n account(s)", "", userCount));

--- a/src/mumble/UserLocalVolumeDialog.cpp
+++ b/src/mumble/UserLocalVolumeDialog.cpp
@@ -52,6 +52,8 @@ UserLocalVolumeDialog::UserLocalVolumeDialog(unsigned int sessionId,
 	, m_clientSession(sessionId)
 	, m_qmUserVolTracker(qmUserVolTracker) {
 	setupUi(this);
+	qsUserLocalVolume->setAccessibleName(tr("User volume"));
+	qsbUserLocalVolume->setAccessibleName(tr("User volume"));
 
 	ClientUser *user = ClientUser::get(sessionId);
 	if (user) {

--- a/src/mumble/VoiceRecorderDialog.cpp
+++ b/src/mumble/VoiceRecorderDialog.cpp
@@ -20,6 +20,9 @@ VoiceRecorderDialog::VoiceRecorderDialog(QWidget *p) : QDialog(p), qtTimer(new Q
 	qtTimer->setObjectName(QLatin1String("qtTimer"));
 	qtTimer->setInterval(200);
 	setupUi(this);
+	qcbFormat->setAccessibleName(tr("Output format"));
+	qleTargetDirectory->setAccessibleName(tr("Target directory"));
+	qleFilename->setAccessibleName(tr("Filename"));
 
 	qleTargetDirectory->setText(g.s.qsRecordingPath);
 	qleFilename->setText(g.s.qsRecordingFile);

--- a/src/mumble/mumble_en.ts
+++ b/src/mumble/mumble_en.ts
@@ -402,6 +402,42 @@ This value allows you to set the maximum number of users allowed in the channel.
         <source>This is the sort order for the channel.</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Properties</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Channel password</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Maximum users</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Channel name</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Inherited group members</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Foreign group members</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Inherited channel members</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Add members to group</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>List of ACL entries</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ALSAAudioInput</name>
@@ -532,6 +568,14 @@ This value allows you to set the maximum number of users allowed in the channel.
         <source>Speakers</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>List of microphones</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>List of speakers</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ASIOInput</name>
@@ -572,6 +616,18 @@ This value allows you to set the maximum number of users allowed in the channel.
     </message>
     <message>
         <source>OK</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>License agreement</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Authors</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Third-party license agreements</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -988,6 +1044,78 @@ This value allows you to set the maximum number of users allowed in the channel.
         <source>%1 kbit/s (Audio %2, Position %4, Overhead %3)</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Audio system</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Input device</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Echo cancellation mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Transmission mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>PTT lock threshold</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>PTT hold threshold</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Silence below</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Current speech detection chance</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Speech above</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Speech below</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Audio per packet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Quality of compression (peak bandwidth)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Noise suppression</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Maximum amplification</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Transmission started sound</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Transmission stopped sound</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Initiate idle action after (in minutes)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Idle action</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AudioOutput</name>
@@ -1290,6 +1418,58 @@ This value allows you to set the maximum number of users allowed in the channel.
     </message>
     <message>
         <source>%1 m</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Output system</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Output device</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Default jitter buffer</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Volume of incoming speech</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Output delay</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Attenuation of other applications during speech</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Minimum distance</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Maximum distance</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Minimum volume</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Bloom</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Delay variance</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Packet loss</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Loopback</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -1795,6 +1975,38 @@ Speak loudly, as when you are annoyed or excited. Decrease the volume in the sou
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Mumble supports positional audio for some games, and will position the voice of other users relative to their position in game. Depending on their position, the volume of the voice will be changed between the speakers to simulate the direction and distance the other user is at. Such positioning depends on your speaker configuration being correct in your operating system, so a test is done here. &lt;/p&gt;&lt;p&gt;The graph below shows the position of &lt;span style=&quot; color:#56b4e9;&quot;&gt;you&lt;/span&gt;, the &lt;span style=&quot; color:#d55e00;&quot;&gt;speakers&lt;/span&gt; and a &lt;span style=&quot; color:#009e73;&quot;&gt;moving sound source&lt;/span&gt; as if seen from above. You should hear the audio move between the channels. &lt;/p&gt;&lt;p&gt;You can also use your mouse to position the &lt;span style=&quot; color:#009e73;&quot;&gt;sound source&lt;/span&gt; manually.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Input system</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Input device</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Output system</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Output device</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Output delay</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Maximum amplification</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>PTT key</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>VAD level</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>BanEditor</name>
@@ -1932,6 +2144,26 @@ Speak loudly, as when you are annoyed or excited. Decrease the volume in the sou
             <numerusform></numerusform><numerusform></numerusform>
         </translation>
     </message>
+    <message>
+        <source>Search</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>IP Address</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Mask</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Start date/time</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>End date/time</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>CertView</name>
@@ -2012,6 +2244,38 @@ Speak loudly, as when you are annoyed or excited. Decrease the volume in the sou
     </message>
     <message>
         <source>&lt;b&gt;Certificate Expiry:&lt;/b&gt; Your certificate is about to expire. You need to renew it, or you will no longer be able to connect to servers you are registered on.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Current certificate</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Certificate file to import</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Certificate password</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Certificate to import</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>New certificate</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>File to export certificate to</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Email address</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Your name</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -2493,6 +2757,10 @@ Are you sure you wish to replace your certificate?
         <source>Mumble Configuration</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Configuration categories</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ConnectDialog</name>
@@ -2650,6 +2918,10 @@ Are you sure you wish to replace your certificate?
     </message>
     <message>
         <source>Show &amp;All</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Server list</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -2998,6 +3270,10 @@ Without this option enabled, using Mumble&apos;s global shortcuts in privileged 
         <source>&lt;b&gt;This hides the button presses from other applications.&lt;/b&gt;&lt;br /&gt;Enabling this will hide the button (or the last button of a multi-button combo) from other applications. Note that not all buttons can be suppressed.</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Configured shortcuts</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>GlobalShortcutTarget</name>
@@ -3162,6 +3438,14 @@ This field describes the size of an LCD device. The size is given either in pixe
     </message>
     <message>
         <source>Splitter Width</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Minimum column width</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Splitter width</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -3523,6 +3807,18 @@ The setting only applies for new messages, the already shown ones will retain th
         <source>Message margins</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Log messages</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>TTS engine volume</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Chat message marjins</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>LookConfig</name>
@@ -3874,6 +4170,42 @@ The setting only applies for new messages, the already shown ones will retain th
     </message>
     <message>
         <source>String that gets used instead of the cut-out part of an abbreviated name.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Silent userlifetime</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Prefix character count</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Postfix character count</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Maximum name length</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Relative font size</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Always on top</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Channel dragging</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Automatically expand channels when</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>User dragging behavior</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -5674,6 +6006,18 @@ Valid options are:
 </source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Channels and users</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Activity log</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Chat message</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>Manual</name>
@@ -6329,6 +6673,10 @@ To upgrade these files to their latest versions, click the button below.</source
         <source>Overlay Editor</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Zoom level</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>OverlayEditorScene</name>
@@ -6859,6 +7207,10 @@ See &lt;a href=&quot;https://wiki.mumble.info/wiki/Installing_Mumble&quot;&gt;th
         <source>Send recursively to subchannels</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Message</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>Tokens</name>
@@ -6895,6 +7247,10 @@ An access token is a text string, which can be used as a password for very simpl
     </message>
     <message>
         <source>&amp;Remove</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Tokens</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -6941,6 +7297,14 @@ An access token is a text string, which can be used as a password for very simpl
         <translation type="unfinished">
             <numerusform></numerusform><numerusform></numerusform>
         </translation>
+    </message>
+    <message>
+        <source>Search</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>User list</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -7144,6 +7508,10 @@ An access token is a text string, which can be used as a password for very simpl
     </message>
     <message>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Use the slider or the text box to change the volume of the user.&lt;/p&gt;&lt;p&gt;&lt;span style=&quot;font-weight:600;&quot;&gt;Attention!&lt;/span&gt;&lt;/p&gt;&lt;p&gt;Increasing the volume of a user too much can permanently damage your hearing. It may also increase the background noise of the user.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>User volume</source>
         <translation type="unfinished"></translation>
     </message>
 </context>


### PR DESCRIPTION
The QT5 framework has attributes for accessibility clients (screen readers or other programs used to analyze the accessibility of an application). These attributes are:

* Accessible name: the name for the control, e.g.: the label.
* Accessible description: a description presented to accessibility clients used to elaborate on the controls function/purpose.
* Accessible role: the role (type) of a control, e.g.: button, pain, combo box, etc.

These three attributes are not uncommon and are available in most GUI frameworks. This PR sets the accessible name attribute for controls that do not automatically get this attribute set. (This only applies to Windows.) This PR sets these in code, not in QT UI files. These changes could be merged into the UI files themselves with a bit of time and effort, however the QT designer is not accessible to screen reader software. The accessible description remains unset because the other attributes (e.g.: the "What's this?" property) seem to take its place.

The controls that automatically become accessible on win32 are buttons, check boxes, ad tab controls, I believe. On Linux, only tab controls and buttons are accessible, so checkboxes will also need the accessible name attribute set. I may do this in a future PR.

It may be good practice to adopt this across all controls -- set the accessible name property to the text of the label for that control. This will make Mumble accessible across all operating systems that respect this attribute, and if I'm not mistaken that's pretty much all of them.