### PR TITLE
Streamline noise cancel chain

### DIFF
--- a/src/mumble/AudioConfigDialog.h
+++ b/src/mumble/AudioConfigDialog.h
@@ -21,6 +21,8 @@ class AudioInputDialog : public ConfigWidget, public Ui::AudioInput {
 		void showEvent(QShowEvent *event) Q_DECL_OVERRIDE;
 		void updateEchoEnableState();
 
+		void showSpeexNoiseSuppressionSlider(bool show);
+
 	public:
 		/// The unique name of this ConfigWidget
 		static const QString name;
@@ -47,11 +49,13 @@ class AudioInputDialog : public ConfigWidget, public Ui::AudioInput {
 		void on_qsAmp_valueChanged(int v);
 		void on_qsDoublePush_valueChanged(int v);
 		void on_qsPTTHold_valueChanged(int v);
-		void on_qsNoise_valueChanged(int v);
+		void on_qsSpeexNoiseSupStrength_valueChanged(int v);
 		void on_qcbTransmit_currentIndexChanged(int v);
 		void on_qcbSystem_currentIndexChanged(int);
 		void on_Tick_timeout();
 		void on_qcbIdleAction_currentIndexChanged(int v);
+		void on_qrbNoiseSupSpeex_toggled(bool checked);
+		void on_qrbNoiseSupBoth_toggled(bool checked);
 };
 
 class AudioOutputDialog : public ConfigWidget, public Ui::AudioOutput {

--- a/src/mumble/AudioInput.cpp
+++ b/src/mumble/AudioInput.cpp
@@ -720,7 +720,7 @@ void AudioInput::resetAudioProcessor() {
 	speex_preprocess_ctl(sppPreprocess, SPEEX_PREPROCESS_SET_AGC_DECREMENT, &iArg);
 
 	if (noiseCancel == Settings::NoiseCancelSpeex) {
-		iArg = g.s.iNoiseSuppress;
+		iArg = g.s.iSpeexNoiseCancelStrength;
 		speex_preprocess_ctl(sppPreprocess, SPEEX_PREPROCESS_SET_NOISE_SUPPRESS, &iArg);
 	}
 
@@ -818,8 +818,7 @@ bool AudioInput::selectCodec() {
 
 void AudioInput::selectNoiseCancel() {
 
-	//noiseCancel = g.s.noiseCancel;
-	noiseCancel = g.s.bDenoise ? Settings::NoiseCancelRNN : Settings::NoiseCancelSpeex;
+	noiseCancel = g.s.noiseCancelMode;
 
 	if (noiseCancel == Settings::NoiseCancelRNN || noiseCancel == Settings::NoiseCancelBoth) {
 #ifdef USE_RNNOISE
@@ -940,7 +939,7 @@ void AudioInput::encodeAudioFrame(AudioChunk chunk) {
 	speex_preprocess_ctl(sppPreprocess, SPEEX_PREPROCESS_GET_AGC_GAIN, &iArg);
 	float gainValue = static_cast<float>(iArg);
 	if (noiseCancel == Settings::NoiseCancelSpeex || noiseCancel == Settings::NoiseCancelBoth) {
-		iArg = g.s.iNoiseSuppress - iArg;
+		iArg = g.s.iSpeexNoiseCancelStrength - iArg;
 		speex_preprocess_ctl(sppPreprocess, SPEEX_PREPROCESS_SET_NOISE_SUPPRESS, &iArg);
 	}
 

--- a/src/mumble/AudioInput.cpp
+++ b/src/mumble/AudioInput.cpp
@@ -821,7 +821,7 @@ void AudioInput::selectNoiseCancel() {
 	//noiseCancel = g.s.noiseCancel;
 	noiseCancel = g.s.bDenoise ? Settings::NoiseCancelRNN : Settings::NoiseCancelSpeex;
 
-	if (noiseCancel == Settings::NoiseCancelRNN) {
+	if (noiseCancel == Settings::NoiseCancelRNN || noiseCancel == Settings::NoiseCancelBoth) {
 #ifdef USE_RNNOISE
 		if (!denoiseState || iFrameSize != 480) {
 			qWarning("AudioInput: Ignoring request to enable RNNoise: internal error");
@@ -844,6 +844,10 @@ void AudioInput::selectNoiseCancel() {
 			break;
 		case Settings::NoiseCancelRNN:
 			qWarning("AudioInput: Using RNNoise as noise canceller");
+			break;
+		case Settings::NoiseCancelBoth:
+			iArg = 1;
+			qWarning("AudioInput: Using RNNoise and Speex as noise canceller");
 			break;
 	}
 	speex_preprocess_ctl(sppPreprocess, SPEEX_PREPROCESS_SET_DENOISE, &iArg);
@@ -935,7 +939,7 @@ void AudioInput::encodeAudioFrame(AudioChunk chunk) {
 
 	speex_preprocess_ctl(sppPreprocess, SPEEX_PREPROCESS_GET_AGC_GAIN, &iArg);
 	float gainValue = static_cast<float>(iArg);
-	if (noiseCancel == Settings::NoiseCancelSpeex) {
+	if (noiseCancel == Settings::NoiseCancelSpeex || noiseCancel == Settings::NoiseCancelBoth) {
 		iArg = g.s.iNoiseSuppress - iArg;
 		speex_preprocess_ctl(sppPreprocess, SPEEX_PREPROCESS_SET_NOISE_SUPPRESS, &iArg);
 	}
@@ -950,7 +954,7 @@ void AudioInput::encodeAudioFrame(AudioChunk chunk) {
 
 #ifdef USE_RNNOISE
 	// At the time of writing this code, RNNoise only supports a sample rate of 48000 Hz.
-	if (noiseCancel == Settings::NoiseCancelRNN) {
+	if (noiseCancel == Settings::NoiseCancelRNN || noiseCancel == Settings::NoiseCancelBoth) {
 		float denoiseFrames[480];
 		for (int i = 0; i < 480; i++) {
 			denoiseFrames[i] = psSource[i];

--- a/src/mumble/AudioInput.h
+++ b/src/mumble/AudioInput.h
@@ -169,6 +169,7 @@ class AudioInput : public QThread {
 		OpusEncoder *opusState;
 		DenoiseState *denoiseState;
 		bool selectCodec();
+		void selectNoiseCancel();
 		
 		typedef boost::array<unsigned char, 960> EncodingOutputBuffer;
 		
@@ -186,6 +187,7 @@ class AudioInput : public QThread {
 		quint64 uiMicChannelMask, uiEchoChannelMask;
 
 		bool bEchoMulti;
+		Settings::NoiseCancel noiseCancel;
 		static const unsigned int iSampleRate = SAMPLE_RATE;
 		static const int iFrameSize = SAMPLE_RATE / 100;
 

--- a/src/mumble/AudioInput.ui
+++ b/src/mumble/AudioInput.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>588</width>
-    <height>811</height>
+    <height>844</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -94,7 +94,7 @@
         </property>
        </widget>
       </item>
-      <item row="1" column="1">
+      <item row="1" column="4">
        <widget class="QCheckBox" name="qcbExclusive">
         <property name="minimumSize">
          <size>
@@ -111,41 +111,6 @@
         <property name="text">
          <string>Exclusive</string>
         </property>
-       </widget>
-      </item>
-      <item row="1" column="3">
-       <widget class="QLabel" name="qliEcho">
-        <property name="toolTip">
-         <string/>
-        </property>
-        <property name="text">
-         <string>Echo Cancellation</string>
-        </property>
-       </widget>
-      </item>
-      <item row="1" column="4">
-       <widget class="MUComboBox" name="qcbEcho">
-        <property name="toolTip">
-         <string/>
-        </property>
-        <property name="whatsThis">
-         <string>Enabling this will cancel the echo from your speakers. Mixed has low CPU impact, but only works well if your speakers are equally loud and equidistant from the microphone. Multichannel echo cancellation provides much better echo cancellation, but at a higher CPU cost.</string>
-        </property>
-        <item>
-         <property name="text">
-          <string>Disabled</string>
-         </property>
-        </item>
-        <item>
-         <property name="text">
-          <string>Mixed echo cancellation</string>
-         </property>
-        </item>
-        <item>
-         <property name="text">
-          <string>Multichannel echo cancellation</string>
-         </property>
-        </item>
        </widget>
       </item>
      </layout>
@@ -603,13 +568,38 @@
       <string>Audio Processing</string>
      </property>
      <layout class="QGridLayout">
-      <item row="0" column="0">
-       <widget class="QLabel" name="qliNoise">
-        <property name="text">
-         <string>Noise Suppression</string>
+      <item row="1" column="1">
+       <widget class="QSlider" name="qsAmp">
+        <property name="toolTip">
+         <string>Maximum amplification of input sound</string>
         </property>
-        <property name="buddy">
-         <cstring>qsNoise</cstring>
+        <property name="whatsThis">
+         <string>&lt;b&gt;Maximum amplification of input.&lt;/b&gt;&lt;br /&gt;Mumble normalizes the input volume before compressing, and this sets how much it's allowed to amplify.&lt;br /&gt;The actual level is continually updated based on your current speech pattern, but it will never go above the level specified here.&lt;br /&gt;If the &lt;i&gt;Microphone loudness&lt;/i&gt; level of the audio statistics hover around 100%, you probably want to set this to 2.0 or so, but if, like most people, you are unable to reach 100%, set this to something much higher.&lt;br /&gt;Ideally, set it so &lt;i&gt;Microphone Loudness * Amplification Factor &gt;= 100&lt;/i&gt;, even when you're speaking really soft.&lt;br /&gt;&lt;br /&gt;Note that there is no harm in setting this to maximum, but Mumble will start picking up other conversations if you leave it to auto-tune to that level.</string>
+        </property>
+        <property name="maximum">
+         <number>19500</number>
+        </property>
+        <property name="singleStep">
+         <number>500</number>
+        </property>
+        <property name="pageStep">
+         <number>2000</number>
+        </property>
+        <property name="orientation">
+         <enum>Qt::Horizontal</enum>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="2">
+       <widget class="QLabel" name="qlNoise">
+        <property name="minimumSize">
+         <size>
+          <width>30</width>
+          <height>0</height>
+         </size>
+        </property>
+        <property name="text">
+         <string/>
         </property>
        </widget>
       </item>
@@ -635,19 +625,6 @@
         </property>
        </widget>
       </item>
-      <item row="0" column="2">
-       <widget class="QLabel" name="qlNoise">
-        <property name="minimumSize">
-         <size>
-          <width>30</width>
-          <height>0</height>
-         </size>
-        </property>
-        <property name="text">
-         <string/>
-        </property>
-       </widget>
-      </item>
       <item row="1" column="0">
        <widget class="QLabel" name="qliAmp">
         <property name="text">
@@ -655,28 +632,6 @@
         </property>
         <property name="buddy">
          <cstring>qsAmp</cstring>
-        </property>
-       </widget>
-      </item>
-      <item row="1" column="1">
-       <widget class="QSlider" name="qsAmp">
-        <property name="toolTip">
-         <string>Maximum amplification of input sound</string>
-        </property>
-        <property name="whatsThis">
-         <string>&lt;b&gt;Maximum amplification of input.&lt;/b&gt;&lt;br /&gt;Mumble normalizes the input volume before compressing, and this sets how much it's allowed to amplify.&lt;br /&gt;The actual level is continually updated based on your current speech pattern, but it will never go above the level specified here.&lt;br /&gt;If the &lt;i&gt;Microphone loudness&lt;/i&gt; level of the audio statistics hover around 100%, you probably want to set this to 2.0 or so, but if, like most people, you are unable to reach 100%, set this to something much higher.&lt;br /&gt;Ideally, set it so &lt;i&gt;Microphone Loudness * Amplification Factor &gt;= 100&lt;/i&gt;, even when you're speaking really soft.&lt;br /&gt;&lt;br /&gt;Note that there is no harm in setting this to maximum, but Mumble will start picking up other conversations if you leave it to auto-tune to that level.</string>
-        </property>
-        <property name="maximum">
-         <number>19500</number>
-        </property>
-        <property name="singleStep">
-         <number>500</number>
-        </property>
-        <property name="pageStep">
-         <number>2000</number>
-        </property>
-        <property name="orientation">
-         <enum>Qt::Horizontal</enum>
         </property>
        </widget>
       </item>
@@ -693,7 +648,7 @@
         </property>
        </widget>
       </item>
-      <item row="2" column="0">
+      <item row="3" column="0">
        <widget class="QCheckBox" name="qcbDenoise">
         <property name="minimumSize">
          <size>
@@ -710,6 +665,51 @@
         <property name="text">
          <string>RNNoise</string>
         </property>
+       </widget>
+      </item>
+      <item row="0" column="0">
+       <widget class="QLabel" name="qliNoise">
+        <property name="text">
+         <string>Noise Suppression</string>
+        </property>
+        <property name="buddy">
+         <cstring>qsNoise</cstring>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="0">
+       <widget class="QLabel" name="qliEcho">
+        <property name="toolTip">
+         <string/>
+        </property>
+        <property name="text">
+         <string>Echo Cancellation</string>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="1">
+       <widget class="MUComboBox" name="qcbEcho">
+        <property name="toolTip">
+         <string/>
+        </property>
+        <property name="whatsThis">
+         <string>Enabling this will cancel the echo from your speakers. Mixed has low CPU impact, but only works well if your speakers are equally loud and equidistant from the microphone. Multichannel echo cancellation provides much better echo cancellation, but at a higher CPU cost.</string>
+        </property>
+        <item>
+         <property name="text">
+          <string>Disabled</string>
+         </property>
+        </item>
+        <item>
+         <property name="text">
+          <string>Mixed echo cancellation</string>
+         </property>
+        </item>
+        <item>
+         <property name="text">
+          <string>Multichannel echo cancellation</string>
+         </property>
+        </item>
        </widget>
       </item>
      </layout>
@@ -934,7 +934,6 @@
  <tabstops>
   <tabstop>qcbSystem</tabstop>
   <tabstop>qcbDevice</tabstop>
-  <tabstop>qcbEcho</tabstop>
   <tabstop>qcbTransmit</tabstop>
   <tabstop>qsDoublePush</tabstop>
   <tabstop>qrbSNR</tabstop>

--- a/src/mumble/AudioInput.ui
+++ b/src/mumble/AudioInput.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>588</width>
-    <height>844</height>
+    <height>940</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -568,7 +568,7 @@
       <string>Audio Processing</string>
      </property>
      <layout class="QGridLayout">
-      <item row="1" column="1">
+      <item row="2" column="1">
        <widget class="QSlider" name="qsAmp">
         <property name="toolTip">
          <string>Maximum amplification of input sound</string>
@@ -590,42 +590,7 @@
         </property>
        </widget>
       </item>
-      <item row="0" column="2">
-       <widget class="QLabel" name="qlNoise">
-        <property name="minimumSize">
-         <size>
-          <width>30</width>
-          <height>0</height>
-         </size>
-        </property>
-        <property name="text">
-         <string/>
-        </property>
-       </widget>
-      </item>
-      <item row="0" column="1">
-       <widget class="QSlider" name="qsNoise">
-        <property name="toolTip">
-         <string>Noise suppression</string>
-        </property>
-        <property name="whatsThis">
-         <string>&lt;b&gt;This sets the amount of noise suppression to apply.&lt;/b&gt;&lt;br /&gt;The higher this value, the more aggressively stationary noise will be suppressed.</string>
-        </property>
-        <property name="minimum">
-         <number>14</number>
-        </property>
-        <property name="maximum">
-         <number>60</number>
-        </property>
-        <property name="pageStep">
-         <number>5</number>
-        </property>
-        <property name="orientation">
-         <enum>Qt::Horizontal</enum>
-        </property>
-       </widget>
-      </item>
-      <item row="1" column="0">
+      <item row="2" column="0">
        <widget class="QLabel" name="qliAmp">
         <property name="text">
          <string>Max. Amplification</string>
@@ -635,7 +600,7 @@
         </property>
        </widget>
       </item>
-      <item row="1" column="2">
+      <item row="2" column="2">
        <widget class="QLabel" name="qlAmp">
         <property name="minimumSize">
          <size>
@@ -649,35 +614,6 @@
        </widget>
       </item>
       <item row="3" column="0">
-       <widget class="QCheckBox" name="qcbDenoise">
-        <property name="minimumSize">
-         <size>
-          <width>0</width>
-          <height>27</height>
-         </size>
-        </property>
-        <property name="toolTip">
-         <string>Apply RNNoise's noise suppression filter.</string>
-        </property>
-        <property name="whatsThis">
-         <string>&lt;b&gt;This applies RNNoise's noise suppression filter.&lt;/b&gt;&lt;br /&gt;RNNoise is based on machine learning and used in WebRTC.</string>
-        </property>
-        <property name="text">
-         <string>RNNoise</string>
-        </property>
-       </widget>
-      </item>
-      <item row="0" column="0">
-       <widget class="QLabel" name="qliNoise">
-        <property name="text">
-         <string>Noise Suppression</string>
-        </property>
-        <property name="buddy">
-         <cstring>qsNoise</cstring>
-        </property>
-       </widget>
-      </item>
-      <item row="2" column="0">
        <widget class="QLabel" name="qliEcho">
         <property name="toolTip">
          <string/>
@@ -687,7 +623,118 @@
         </property>
        </widget>
       </item>
-      <item row="2" column="1">
+      <item row="4" column="0" colspan="3">
+       <widget class="QGroupBox" name="groupBox">
+        <property name="title">
+         <string>Noise suppression</string>
+        </property>
+        <layout class="QVBoxLayout" name="verticalLayout">
+         <item>
+          <layout class="QHBoxLayout" name="horizontalLayout_2">
+           <item>
+            <widget class="QRadioButton" name="qrbNoiseSupDeactivated">
+             <property name="toolTip">
+              <string>Don't use noise suppression.</string>
+             </property>
+             <property name="text">
+              <string>Disabled</string>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <widget class="QRadioButton" name="qrbNoiseSupSpeex">
+             <property name="toolTip">
+              <string>Use the noise suppression algorithm provided by Speex.</string>
+             </property>
+             <property name="text">
+              <string notr="true">Speex</string>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <widget class="QRadioButton" name="qrbNoiseSupRNNoise">
+             <property name="toolTip">
+              <string>Use the noise suppression algorithm provided by RNNoise.</string>
+             </property>
+             <property name="text">
+              <string notr="true">RNNoise</string>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <widget class="QRadioButton" name="qrbNoiseSupBoth">
+             <property name="toolTip">
+              <string>Use a combination of Speex and RNNoise to do noise suppression.</string>
+             </property>
+             <property name="text">
+              <string>Both</string>
+             </property>
+            </widget>
+           </item>
+          </layout>
+         </item>
+         <item>
+          <layout class="QHBoxLayout" name="horizontalLayout_3">
+           <item>
+            <widget class="QLabel" name="qlSpeexNoiseSup">
+             <property name="toolTip">
+              <string>This controls the amount by which Speex will suppress noise.</string>
+             </property>
+             <property name="text">
+              <string>Speex suppression strength</string>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <widget class="QSlider" name="qsSpeexNoiseSupStrength">
+             <property name="toolTip">
+              <string>This controls the amount by which Speex will suppress noise.</string>
+             </property>
+             <property name="whatsThis">
+              <string>&lt;b&gt;This sets the amount of noise suppression to apply.&lt;/b&gt;&lt;br /&gt;The higher this value, the more aggressively stationary noise will be suppressed.</string>
+             </property>
+             <property name="minimum">
+              <number>15</number>
+             </property>
+             <property name="maximum">
+              <number>60</number>
+             </property>
+             <property name="pageStep">
+              <number>5</number>
+             </property>
+             <property name="orientation">
+              <enum>Qt::Horizontal</enum>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <widget class="QLabel" name="qlSpeexNoiseSupStrength">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+               <horstretch>0</horstretch>
+               <verstretch>0</verstretch>
+              </sizepolicy>
+             </property>
+             <property name="minimumSize">
+              <size>
+               <width>30</width>
+               <height>0</height>
+              </size>
+             </property>
+             <property name="toolTip">
+              <string>This controls the amount by which Speex will suppress noise.</string>
+             </property>
+             <property name="text">
+              <string/>
+             </property>
+            </widget>
+           </item>
+          </layout>
+         </item>
+        </layout>
+       </widget>
+      </item>
+      <item row="3" column="1" colspan="2">
        <widget class="MUComboBox" name="qcbEcho">
         <property name="toolTip">
          <string/>
@@ -942,8 +989,6 @@
   <tabstop>qsTransmitMax</tabstop>
   <tabstop>qsQuality</tabstop>
   <tabstop>qsFrames</tabstop>
-  <tabstop>qsNoise</tabstop>
-  <tabstop>qcbDenoise</tabstop>
   <tabstop>qsAmp</tabstop>
  </tabstops>
  <resources/>

--- a/src/mumble/Settings.h
+++ b/src/mumble/Settings.h
@@ -150,7 +150,7 @@ struct Settings {
 	enum ServerShow { ShowPopulated, ShowReachable, ShowAll };
 	enum TalkState { Passive, Talking, Whispering, Shouting, MutedTalking };
 	enum IdleAction { Nothing, Deafen, Mute };
-	enum NoiseCancel { NoiseCancelOff, NoiseCancelSpeex, NoiseCancelRNN };
+	enum NoiseCancel { NoiseCancelOff, NoiseCancelSpeex, NoiseCancelRNN, NoiseCancelBoth };
 	typedef QPair<QList<QSslCertificate>, QSslKey> KeyPair;
 
 	AudioTransmit atTransmit;

--- a/src/mumble/Settings.h
+++ b/src/mumble/Settings.h
@@ -182,9 +182,9 @@ struct Settings {
 	///backend.
 	QString qsTTSLanguage;
 	int iQuality, iMinLoudness, iVoiceHold, iJitterBufferSize;
-	int iNoiseSuppress;
 	bool bAllowLowDelay;
-	bool bDenoise; //TODO: replace with NoiseCancel noiseCancel;
+	NoiseCancel noiseCancelMode;
+	int iSpeexNoiseCancelStrength;
 	quint64 uiAudioInputChannelMask;
 
 	// Idle auto actions

--- a/src/mumble/Settings.h
+++ b/src/mumble/Settings.h
@@ -150,6 +150,7 @@ struct Settings {
 	enum ServerShow { ShowPopulated, ShowReachable, ShowAll };
 	enum TalkState { Passive, Talking, Whispering, Shouting, MutedTalking };
 	enum IdleAction { Nothing, Deafen, Mute };
+	enum NoiseCancel { NoiseCancelOff, NoiseCancelSpeex, NoiseCancelRNN };
 	typedef QPair<QList<QSslCertificate>, QSslKey> KeyPair;
 
 	AudioTransmit atTransmit;
@@ -183,7 +184,7 @@ struct Settings {
 	int iQuality, iMinLoudness, iVoiceHold, iJitterBufferSize;
 	int iNoiseSuppress;
 	bool bAllowLowDelay;
-	bool bDenoise;
+	bool bDenoise; //TODO: replace with NoiseCancel noiseCancel;
 	quint64 uiAudioInputChannelMask;
 
 	// Idle auto actions

--- a/src/mumble/mumble_en.ts
+++ b/src/mumble/mumble_en.ts
@@ -790,10 +790,6 @@ This value allows you to set the maximum number of users allowed in the channel.
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Noise Suppression</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Noise suppression</source>
         <translation type="unfinished"></translation>
     </message>
@@ -970,18 +966,6 @@ This value allows you to set the maximum number of users allowed in the channel.
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Apply RNNoise&apos;s noise suppression filter.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>&lt;b&gt;This applies RNNoise&apos;s noise suppression filter.&lt;/b&gt;&lt;br /&gt;RNNoise is based on machine learning and used in WebRTC.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>RNNoise</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Audio input</source>
         <translation type="unfinished"></translation>
     </message>
@@ -999,6 +983,34 @@ This value allows you to set the maximum number of users allowed in the channel.
     </message>
     <message>
         <source>Allow low delay mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Don&apos;t use noise suppression.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Use the noise suppression algorithm provided by Speex.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Use the noise suppression algorithm provided by RNNoise.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Use a combination of Speex and RNNoise to do noise suppression.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Both</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>This controls the amount by which Speex will suppress noise.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Speex suppression strength</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -7095,6 +7107,10 @@ See &lt;a href=&quot;https://wiki.mumble.info/wiki/Installing_Mumble&quot;&gt;th
     </message>
     <message>
         <source>Toggle Text-to-Speech for all events</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>RNNoise is not available due to a sample rate mismatch.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>


### PR DESCRIPTION
This PR does the following:

* It disables the Speex noise canceller when RNNoise is enabled as per https://github.com/mumble-voip/mumble/issues/4181
* It moves RNNoise after the echo canceller so that the input DSP chain is always Input -> Resampler -> Echo cancel -> Noise cancel -> Additional filters -> VAD -> Encoder as per https://github.com/mumble-voip/mumble/issues/4181
* It adds provision for disabling the noise canceller altogether, going in the direction of https://github.com/mumble-voip/mumble/issues/3323

Since I did not use RNNoise before, can someone who really likes RNNoise test this branch and see if it works just as well for his/her use case?

-----

The Windows installer containing the changes of this PR: 
[WindowsInstaller.zip](https://github.com/mumble-voip/mumble/files/4808046/WindowsInstaller.zip) (20.06.2020)
