### PR TITLE
Enable echo cancellation by default

### DIFF
--- a/src/mumble/Settings.cpp
+++ b/src/mumble/Settings.cpp
@@ -374,8 +374,14 @@ Settings::Settings() {
 	bJackStartServer = false;
 	bJackAutoConnect = true;
 
+#ifndef Q_OS_MAC
+	// Enable echo cancellation by default everywhere except for Macs as we currently
+	// on't support echo cancelling on Macs
+	bEcho = true;
+#else
 	bEcho = false;
-	bEchoMulti = true;
+#endif
+	bEchoMulti = false;
 
 	bExclusiveInput = false;
 	bExclusiveOutput = false;


### PR DESCRIPTION
Now that the echo canceller has been fixed, it is time to default-enable
echo cancelling. As multi-channel cancelling is more CPU intensive, we
default to mixed channel cancellation.

Don't enable it on MacOS though as right now we don't support echo
cancellation for that platform.

Closes: #4178

Changelog:
```
| Improved: Echo cancellation now enabled by default
```