### PR TITLE
Fixed typos in accessibility names

### DIFF
--- a/src/mumble/Log.cpp
+++ b/src/mumble/Log.cpp
@@ -43,7 +43,7 @@ LogConfig::LogConfig(Settings &st) : ConfigWidget(st) {
 	qsVolume->setAccessibleName(tr("TTS engine volume"));
 	qsbThreshold->setAccessibleName(tr("Length threshold"));
 	qsbMaxBlocks->setAccessibleName(tr("Maximum chat length"));
-	qsbChatMessageMargins->setAccessibleName(tr("Chat message marjins"));
+	qsbChatMessageMargins->setAccessibleName(tr("Chat message margins"));
 	
 #ifdef USE_NO_TTS
 	qgbTTS->setDisabled(true);

--- a/src/mumble/LookConfig.cpp
+++ b/src/mumble/LookConfig.cpp
@@ -27,7 +27,7 @@ static ConfigRegistrar registrar(1100, LookConfigNew);
 
 LookConfig::LookConfig(Settings &st) : ConfigWidget(st) {
 	setupUi(this);
-	qsbSilentUserLifetime->setAccessibleName(tr("Silent userlifetime"));
+	qsbSilentUserLifetime->setAccessibleName(tr("Silent user lifetime"));
 	qsbPrefixCharCount->setAccessibleName(tr("Prefix character count"));
 	qsbChannelHierarchyDepth->setAccessibleName(tr("Channel hierarchy depth"));
 	qleChannelSeparator->setAccessibleName(tr("Channel separator"));

--- a/src/mumble/mumble_en.ts
+++ b/src/mumble/mumble_en.ts
@@ -3816,7 +3816,7 @@ The setting only applies for new messages, the already shown ones will retain th
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Chat message marjins</source>
+        <source>Chat message margins</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -4173,10 +4173,6 @@ The setting only applies for new messages, the already shown ones will retain th
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Silent userlifetime</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Prefix character count</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4206,6 +4202,10 @@ The setting only applies for new messages, the already shown ones will retain th
     </message>
     <message>
         <source>User dragging behavior</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Silent user lifetime</source>
         <translation type="unfinished"></translation>
     </message>
 </context>


### PR DESCRIPTION
These typos have been introduced in #4211 