### PR TITLE
Backport "src/mumble/OverlayText.h: add missing <QtGui/QPainterPath> include for Qt 5.15"

### DIFF
--- a/src/mumble/OverlayText.h
+++ b/src/mumble/OverlayText.h
@@ -6,6 +6,7 @@
 #ifndef MUMBLE_MUMBLE_OVERLAYTEXT_H_
 #define MUMBLE_MUMBLE_OVERLAYTEXT_H_
 
+#include <QtGui/QPainterPath>
 #include <QtGui/QPixmap>
 #include <QtGui/QFont>
 


### PR DESCRIPTION
#4231