### PR TITLE
Added config options autostart and bootserverid

### DIFF
--- a/scripts/murmur.ini
+++ b/scripts/murmur.ini
@@ -395,6 +395,18 @@ allowping=true
 ;
 ;logaclchanges=false
 
+; Can be used to disable the automatic start of all configured virtual servers.
+; Default is true.
+;
+; autostart=false
+
+; Can be used to only boot the server with the given ID at startup. If set
+; to a value less than 0, the option is disabled.
+; Note that this option takes precedence over the autostart option. If it
+; is set only the given single server is attempted to be booted.
+;
+; bootserverid=1
+
 ; You can configure any of the configuration options for Ice here. We recommend
 ; leave the defaults as they are.
 ; Please note that this section has to be last in the configuration file.

--- a/src/murmur/Meta.cpp
+++ b/src/murmur/Meta.cpp
@@ -100,6 +100,9 @@ MetaParams::MetaParams() {
 	bLogGroupChanges = false;
 	bLogACLChanges = false;
 
+	bAutostart = true;
+	iBootServerID = -1;
+
 	qsSettings = NULL;
 }
 
@@ -346,6 +349,9 @@ void MetaParams::read(QString fname) {
 
 	bLogGroupChanges = typeCheckedFromSettings("loggroupchanges", bLogGroupChanges);
 	bLogACLChanges = typeCheckedFromSettings("logaclchanges", bLogACLChanges);
+
+	bAutostart = typeCheckedFromSettings("autostart", bAutostart);
+	iBootServerID = typeCheckedFromSettings("bootserverid", iBootServerID);
 
 	iOpusThreshold = typeCheckedFromSettings("opusthreshold", iOpusThreshold);
 

--- a/src/murmur/Meta.h
+++ b/src/murmur/Meta.h
@@ -145,6 +145,13 @@ public:
 	/// A flag indicating whether changes in ACLs should be logged
 	bool bLogACLChanges;
 
+	/// A flag indicating whether all configured servers should be automatically
+	/// started (booted) on Mumur's startup.
+	bool bAutostart;
+	/// The ID of the server to boot. If this is < 0, all servers are booted, if
+	/// autostart is set to true.
+	int iBootServerID;
+
 	/// qsAbsSettingsFilePath is the absolute path to
 	/// the murmur.ini used by this Meta instance.
 	QString qsAbsSettingsFilePath;

--- a/src/murmur/main.cpp
+++ b/src/murmur/main.cpp
@@ -599,9 +599,19 @@ int main(int argc, char **argv) {
 	QString strver;
 	meta->getVersion(major, minor, patch, strver);
 
-	qWarning("Murmur %d.%d.%d (%s) running on %s: %s: Booting servers", major, minor, patch, qPrintable(strver), qPrintable(meta->qsOS), qPrintable(meta->qsOSVersion));
+	qWarning("Murmur %d.%d.%d (%s) running on %s: %s", major, minor, patch, qPrintable(strver), qPrintable(meta->qsOS), qPrintable(meta->qsOSVersion));
 
-	meta->bootAll();
+	if (meta->mp.iBootServerID >= 0) {
+		qWarning("Booting server %d...", meta->mp.iBootServerID);
+		if (!meta->boot(meta->mp.iBootServerID)) {
+			qFatal("Failed to boot server!");
+		}
+	} else if (meta->mp.bAutostart) {
+		qWarning("Booting all servers...");
+		meta->bootAll();
+	} else {
+		qWarning("No server booted as autostart is set to false.");
+	}
 
 	res=a.exec();
 


### PR DESCRIPTION
With these options it can be controlled whether all available virtual
servers shall be booted automatically (autostart) or if only a specific
server should be booted (bootserverid).

If bootserverid is not set and autostart is set to false, no server is
booted. The user then has to explicitly boot a server using e.g. ICE or
gRPC.

Fixes #4183 

Changelog
```
| Added: autostart config option
| Added bootserverid config option
```