### PR TITLE
Backport "Fix DB structure version not getting updated on table update"

### DIFF
--- a/src/murmur/ServerDB.cpp
+++ b/src/murmur/ServerDB.cpp
@@ -668,7 +668,8 @@ ServerDB::ServerDB() {
 			SQLQUERY("DROP TABLE IF EXISTS `%1bans%2`");
 			SQLQUERY("DROP TABLE IF EXISTS `%1servers%2`");
 
-			SQLDO("UPDATE `%1meta` SET `value` = '6' WHERE `keystring` = 'version'");
+			SQLDO_NO_CONVERSION(QLatin1String("UPDATE `%1meta` SET `value` = ")
+					+ QString::fromLatin1("'%1' WHERE `keystring` = 'version'").arg(DB_STRUCTURE_VERSION));
 		}
 	}
 	query.clear();


### PR DESCRIPTION
In a scenario in which a database with an older structure version
already exists this would lead to the server re-generating all tables on
every start due to the version number not being updated in the process.

Backport of #4234