### PR TITLE
Fix "empty entry bug"

### DIFF
--- a/src/mumble/TalkingUI.cpp
+++ b/src/mumble/TalkingUI.cpp
@@ -369,7 +369,7 @@ void TalkingUI::ensureVisible(unsigned int userSession, int channelID) {
 			QString userName = currentBackground->property("userName").toString();
 
 			if (userName > currentName) {
-				static_cast<QHBoxLayout *>(channelBox->layout())->insertWidget(i, entry.background);
+				static_cast<QVBoxLayout *>(channelBox->layout())->insertWidget(i, entry.background);
 				inserted = true;
 				break;
 			}
@@ -383,7 +383,7 @@ void TalkingUI::ensureVisible(unsigned int userSession, int channelID) {
 		if (channelBox == localUserBox) {
 			// Make sure that the local user is always listed first 
 			localUserBox->layout()->removeWidget(localUserEntry.background);
-			static_cast<QHBoxLayout *>(localUserBox->layout())->insertWidget(0, localUserEntry.background);
+			static_cast<QVBoxLayout *>(localUserBox->layout())->insertWidget(0, localUserEntry.background);
 		}
 
 		adjust = true;

--- a/src/mumble/TalkingUI.cpp
+++ b/src/mumble/TalkingUI.cpp
@@ -104,6 +104,7 @@ void TalkingUI::setIcon(Entry &entry) const {
 void TalkingUI::hideUser(unsigned int session) {
 	QHash<unsigned int, Entry>::iterator iter = m_entries.find(session);
 	if (iter == m_entries.end()) {
+		qWarning("TalkingUI::hideUser: Session ID not found");
 		return;
 	}
 	
@@ -488,6 +489,7 @@ void TalkingUI::on_talkingStateChanged() {
 	ClientUser *user = qobject_cast<ClientUser *>(sender());
 
 	if (!user) {
+		qWarning("TalkingUI::on_talkingStateChanged User not found");
 		return;
 	}
 
@@ -605,7 +607,7 @@ void TalkingUI::on_channelChanged(QObject *obj) {
 	// According to this function's doc, the passed object must be of type ClientUser
 	ClientUser *user = static_cast<ClientUser *>(obj);
 
-	if (m_entries.contains(user->uiSession)) {
+	if (user && m_entries.contains(user->uiSession)) {
 		if (m_entries[user->uiSession].background->isVisible()) {
 			// The user is visible, so we call ensureVisible in order to update
 			// the channel this particular user is being displayed in.

--- a/src/mumble/TalkingUI.cpp
+++ b/src/mumble/TalkingUI.cpp
@@ -380,7 +380,7 @@ void TalkingUI::ensureVisible(unsigned int userSession, int channelID) {
 			channelBox->layout()->addWidget(entry.background);
 		}
 
-		if (channelBox == localUserBox) {
+		if (channelBox == localUserBox && localUserBox->layout()->indexOf(localUserEntry.background) > 0) {
 			// Make sure that the local user is always listed first 
 			localUserBox->layout()->removeWidget(localUserEntry.background);
 			static_cast<QVBoxLayout *>(localUserBox->layout())->insertWidget(0, localUserEntry.background);

--- a/src/mumble/TalkingUI.cpp
+++ b/src/mumble/TalkingUI.cpp
@@ -219,7 +219,7 @@ void TalkingUI::addUser(const ClientUser *user) {
 			return;
 		}
 
-		QWidget *background = new QWidget(m_channels[user->cChannel->iId]);
+		QWidget *background = new QWidget(channelBox);
 		background->setProperty("selected", false);
 		QLayout *backgroundLayout = new QHBoxLayout();
 		backgroundLayout->setContentsMargins(2, 3, 2, 3);

--- a/src/mumble/TalkingUI.cpp
+++ b/src/mumble/TalkingUI.cpp
@@ -291,7 +291,7 @@ void TalkingUI::ensureVisible(unsigned int userSession, int channelID) {
 	// Check if the user has changed channel and handle this separately in case
 	// the user is currently still displayed as being in that channel
 	bool changedChannel = false;
-	if (channelBox->layout()->indexOf(entry.name) < 0) {
+	if (channelBox->layout()->indexOf(entry.background) < 0) {
 		changedChannel = true;
 
 		hideUser(userSession);


### PR DESCRIPTION
The bug appeared occasionally when changing channel into another one in
which there was someone talking. In that case it could happen that in
the TalkingUI the old channel the local user has just moved out from,
would still show up and remain in the TalkingUI (until another action -
change of talking state or change of channel) even though that channel
was empty now.

This was due to a race condition between the channelChanged and the
talkingStateChanged event. If the talkingStateChanged event arrived
first, the code that is responsible for inserting the local user at the
top of the channel it is in, would then blindly "remove" the local user
from that channel in order to add it again at the top. In this situation
however, the local user wasn't even in that channel yet (in the
TalkingUI that is) so the "remove" actually didn't do anything whereas
the adding now added the user to a channel it wasn't in before. As this
bypassed all mechanisms for normal channel change (that include
potential clean-up of old, empty channels), the old channel would not be
hidden by this.

This commit now simply checks whether the local user is actually in the
channel in question already (in the TalkingUI) and only if it isn't
this part of the code is simply skipped assuming that the channelChanged
event for the local user will be processed later causing it to land at
the top of that channel eventually.

Before this commit, the bug could be most easily reproduced if one
commented out the body of TalkingUI::on_channelChanged. Then you need 2
clients (transmit mode = continuous) on the same server. Make sure you
start out in different channels. Then change channel of one client to
the channel of the other client. The bug most often occurred on the
first try. If not, try again (use mute/unmute to update the channel of
the local user in the TalkingUI in between).

----

The other commits contain additional (more or less) minor improvements and fixes. See their commit message for what they do.