### PR TITLE
UserLocalVolumeDialog: "Inherit" AlwaysOnTop behavior

### DIFF
--- a/src/mumble/UserLocalVolumeDialog.cpp
+++ b/src/mumble/UserLocalVolumeDialog.cpp
@@ -37,6 +37,7 @@
 #include "UserLocalVolumeDialog.h"
 #include "ClientUser.h"
 #include "Database.h"
+#include "MainWindow.h"
 
 #include <QtGui/QCloseEvent>
 #include <QtWidgets/QPushButton>
@@ -61,6 +62,12 @@ UserLocalVolumeDialog::UserLocalVolumeDialog(unsigned int sessionId,
 		setWindowTitle(title);
 		qsUserLocalVolume->setValue(qRound(log2(user->fLocalVolume) * 6.0));
 		m_originalVolumeAdjustmentDecibel = qsUserLocalVolume->value();
+	}
+
+	if (g.mw && g.mw->windowFlags() & Qt::WindowStaysOnTopHint) {
+		// If the main window is set to always be on top of other windows, we should make the
+		// volume dialog behave the same in order for it to not get hidden behind the main window.
+		setWindowFlags(Qt::WindowStaysOnTopHint);
 	}
 }
 


### PR DESCRIPTION
Before this commit, if the MainWindow was set to be always on top of
other windows, it could happen that the UserLocalVolumeDialog got hidden
behind the MainWindow (it wanted to open on top of it but since the
MainWindow is set to be on top of all other windows, it couldn't). This
could be especially annoying on Windows where you can't move the
MainWindow away as long as the UserLocalVolumeDialog is open (luckily
you can close it via Esc though).

In order to avoid this kind of situation, this commit make the
UserLocalVolumeDialog "inherit" the AlwaysOnTop flag from the
MainWindow. This way it can open on top of it again and won't be hidden.