### PR TITLE
Backport "Use REPLACE instead of INSERT"

### DIFF
--- a/src/murmur/ServerDB.cpp
+++ b/src/murmur/ServerDB.cpp
@@ -1771,7 +1771,7 @@ void Server::updateChannel(const Channel *c) {
 				qFatal("ServerDB: internal query failure: PostgreSQL query did not return the inserted group's group_id");
 			}
 		} else {
-			SQLPREP("INSERT INTO `%1groups` (`server_id`, `channel_id`, `name`, `inherit`, `inheritable`) VALUES (?,?,?,?,?)");
+			SQLPREP("REPLACE INTO `%1groups` (`server_id`, `channel_id`, `name`, `inherit`, `inheritable`) VALUES (?,?,?,?,?)");
 			query.addBindValue(iServerNum);
 			query.addBindValue(g->c->iId);
 			query.addBindValue(g->qsName);


### PR DESCRIPTION
In #3803 it is reported that the server regularly crashes because the
MySQL/SQLite part of the database code for group changes doesn't handle
conflicts in primary keys (as the PostgreSQL part does).

This commit makes the SQL statement use REPLACE INTO instead of INSERT
INTO which according to the docs "REPLACE works exactly like INSERT,
except that if an old row in the table has the same value as a new row
for a PRIMARY KEY or a UNIQUE index, the old row is deleted before the
new row is inserted."

It's actually a MySQL extension but according to Wikipedia SQLite
supports it as well.

Backported from #4105