### PR TITLE
Fix: Resizing buffer in audio callback causes mumble to crash

### DIFF
--- a/src/mumble/AudioOutput.cpp
+++ b/src/mumble/AudioOutput.cpp
@@ -87,27 +87,6 @@ bool AudioOutputRegistrar::canExclusive() const {
 	return false;
 }
 
-AudioOutput::AudioOutput()
-	: fSpeakers(nullptr)
-	, fSpeakerVolume(nullptr)
-	, bSpeakerPositional(nullptr)
-	, fStereoPanningFactor(nullptr)
-
-	, eSampleFormat(SampleFloat)
-
-	, bRunning(true)
-
-	, iFrameSize(SAMPLE_RATE / 100)
-	, iMixerFreq(0)
-	, iChannels(0)
-	, iSampleSize(0)
-
-	, qrwlOutputs()
-	, qmOutputs() {
-
-	// Nothing
-}
-
 AudioOutput::~AudioOutput() {
 	bRunning = false;
 	wait();
@@ -196,7 +175,7 @@ void AudioOutput::addFrameToBuffer(ClientUser *user, const QByteArray &qbaPacket
 			return;
 
 		qrwlOutputs.lockForWrite();
-		aop = new AudioOutputSpeech(user, iMixerFreq, type);
+		aop = new AudioOutputSpeech(user, iMixerFreq, type, iBufferSize);
 		qmOutputs.replace(user, aop);
 	}
 
@@ -243,7 +222,7 @@ AudioOutputSample *AudioOutput::playSample(const QString &filename, bool loop) {
 		return nullptr;
 
 	QWriteLocker locker(&qrwlOutputs);
-	AudioOutputSample *aos = new AudioOutputSample(filename, handle, loop, iMixerFreq);
+	AudioOutputSample *aos = new AudioOutputSample(filename, handle, loop, iMixerFreq, iBufferSize);
 	qmOutputs.insert(nullptr, aos);
 
 	return aos;
@@ -675,3 +654,6 @@ unsigned int AudioOutput::getMixerFreq() const {
 	return iMixerFreq;
 }
 
+void AudioOutput::setBufferSize(unsigned int bufferSize) {
+	iBufferSize = bufferSize;
+}

--- a/src/mumble/AudioOutput.h
+++ b/src/mumble/AudioOutput.h
@@ -74,18 +74,19 @@ class AudioOutput : public QThread {
 		Q_DISABLE_COPY(AudioOutput)
 	private:
 		/// Speaker positional vector
-		float *fSpeakers;
-		float *fSpeakerVolume;
-		bool *bSpeakerPositional;
+		float *fSpeakers = nullptr;
+		float *fSpeakerVolume = nullptr;
+		bool *bSpeakerPositional = nullptr;
 		/// Used when panning stereo stream w.r.t. each speaker.
-		float * fStereoPanningFactor;
+		float * fStereoPanningFactor = nullptr;
 	protected:
-		enum { SampleShort, SampleFloat } eSampleFormat;
-		volatile bool bRunning;
-		unsigned int iFrameSize;
-		volatile unsigned int iMixerFreq;
-		unsigned int iChannels;
-		unsigned int iSampleSize;
+		enum { SampleShort, SampleFloat } eSampleFormat = SampleFloat;
+		volatile bool bRunning = true;
+		unsigned int iFrameSize = SAMPLE_RATE / 100;
+		volatile unsigned int iMixerFreq = 0;
+		unsigned int iChannels = 0;
+		unsigned int iSampleSize = 0;
+		unsigned int iBufferSize = 0;
 		QReadWriteLock qrwlOutputs;
 		QMultiHash<const ClientUser *, AudioOutputUser *> qmOutputs;
 
@@ -99,7 +100,7 @@ class AudioOutput : public QThread {
 				///
 				/// This constructor is only ever called by Audio::startOutput(), and is guaranteed
 				/// to be called on the application's main thread.
-		AudioOutput();
+		AudioOutput() {};
 
 				/// Destroy an AudioOutput.
 				///
@@ -115,6 +116,7 @@ class AudioOutput : public QThread {
 		const float *getSpeakerPos(unsigned int &nspeakers);
 		static float calcGain(float dotproduct, float distance);
 		unsigned int getMixerFreq() const;
+		void setBufferSize(unsigned int bufferSize);
 };
 
 #endif

--- a/src/mumble/AudioOutputSample.cpp
+++ b/src/mumble/AudioOutputSample.cpp
@@ -210,7 +210,8 @@ QString AudioOutputSample::browseForSndfile(QString defaultpath) {
 }
 
 bool AudioOutputSample::prepareSampleBuffer(unsigned int frameCount) {
-	unsigned int sampleCount = frameCount * sfHandle->channels();
+	unsigned int channels = bStereo ? 2 : 1;
+	unsigned int sampleCount = frameCount * channels;
 	// Forward the buffer
 	for (unsigned int i=iLastConsume;i<iBufferFilled;++i)
 		pfBuffer[i-iLastConsume]=pfBuffer[i];
@@ -223,7 +224,7 @@ bool AudioOutputSample::prepareSampleBuffer(unsigned int frameCount) {
 
 	// Calculate the required buffersize to hold the results
 	unsigned int iInputFrames = static_cast<unsigned int>(ceilf(static_cast<float>(frameCount * sfHandle->samplerate()) / static_cast<float>(iOutSampleRate)));
-	unsigned int iInputSamples = iInputFrames * sfHandle->channels();
+	unsigned int iInputSamples = iInputFrames * channels;
 
 	STACKVAR(float, fOut, iInputSamples);
 
@@ -247,8 +248,8 @@ bool AudioOutputSample::prepareSampleBuffer(unsigned int frameCount) {
 			}
 		}
 
-		spx_uint32_t inlen = static_cast<unsigned int>(read) / sfHandle->channels();
-		spx_uint32_t outlen = sampleCount;
+		spx_uint32_t inlen = static_cast<unsigned int>(read) / channels;
+		spx_uint32_t outlen = frameCount;
 		if (srs) {
 			// If necessary resample
 			if (!bStereo) {
@@ -258,7 +259,7 @@ bool AudioOutputSample::prepareSampleBuffer(unsigned int frameCount) {
 			}
 		}
 
-		iBufferFilled += outlen;
+		iBufferFilled += outlen * channels;
 	} while (iBufferFilled < sampleCount);
 
 	if (eof && !bEof) {

--- a/src/mumble/AudioOutputSample.cpp
+++ b/src/mumble/AudioOutputSample.cpp
@@ -118,20 +118,24 @@ sf_count_t SoundFile::vio_tell(void *user_data) {
 	return sf->qfFile.pos();
 }
 
-AudioOutputSample::AudioOutputSample(const QString &name, SoundFile *psndfile, bool loop, unsigned int freq) : AudioOutputUser(name) {
+AudioOutputSample::AudioOutputSample(const QString &name, SoundFile *psndfile, bool loop, unsigned int freq, unsigned int systemMaxBufferSize) : AudioOutputUser(name) {
 	int err;
 
 	sfHandle = psndfile;
 	iOutSampleRate = freq;
 
 	if (sfHandle->channels() == 1) {
+		iBufferSize = systemMaxBufferSize;
 		bStereo = false;
 	} else if (sfHandle->channels() == 2) {
+		iBufferSize = systemMaxBufferSize * 2;
 		bStereo = true;
 	} else {
 		sfHandle = nullptr;  // sound file is corrupted
 		return;
 	}
+
+	pfBuffer = new float[iBufferSize];
 
 	/* qWarning() << "Channels: " << sfHandle->channels();
 	qWarning() << "Samplerate: " << sfHandle->samplerate();

--- a/src/mumble/AudioOutputSample.h
+++ b/src/mumble/AudioOutputSample.h
@@ -60,7 +60,7 @@ class AudioOutputSample : public AudioOutputUser {
 		static SoundFile* loadSndfile(const QString &filename);
 		static QString browseForSndfile(QString defaultpath=QString());
 		virtual bool prepareSampleBuffer(unsigned int frameCount) Q_DECL_OVERRIDE;
-		AudioOutputSample(const QString &name, SoundFile *psndfile, bool repeat, unsigned int freq);
+		AudioOutputSample(const QString &name, SoundFile *psndfile, bool repeat, unsigned int freq, unsigned int bufferSize);
 		~AudioOutputSample() Q_DECL_OVERRIDE;
 };
 

--- a/src/mumble/AudioOutputSpeech.h
+++ b/src/mumble/AudioOutputSpeech.h
@@ -71,7 +71,9 @@ class AudioOutputSpeech : public AudioOutputUser {
 		virtual bool prepareSampleBuffer(unsigned int frameCount) Q_DECL_OVERRIDE;
 
 		void addFrameToBuffer(const QByteArray &, unsigned int iBaseSeq);
-		AudioOutputSpeech(ClientUser *, unsigned int freq, MessageHandler::UDPMessageType type);
+
+		/// @param systemMaxBufferSize maximum number of samples the system audio play back may request each time
+		AudioOutputSpeech(ClientUser *, unsigned int freq, MessageHandler::UDPMessageType type, unsigned int systemMaxBufferSize);
 		~AudioOutputSpeech() Q_DECL_OVERRIDE;
 };
 

--- a/src/mumble/AudioOutputUser.cpp
+++ b/src/mumble/AudioOutputUser.cpp
@@ -6,10 +6,6 @@
 #include "AudioOutputUser.h"
 
 AudioOutputUser::AudioOutputUser(const QString& name) : qsName(name) {
-	iBufferSize = 0;
-	pfBuffer = nullptr;
-	pfVolume = nullptr;
-	fPos[0]=fPos[1]=fPos[2]=0.0;
 }
 
 AudioOutputUser::~AudioOutputUser() {

--- a/src/mumble/AudioOutputUser.h
+++ b/src/mumble/AudioOutputUser.h
@@ -14,14 +14,20 @@ class AudioOutputUser : public QObject {
 		Q_DISABLE_COPY(AudioOutputUser)
 	protected:
 		unsigned int iBufferSize;
+
+		/// Used to resize the buffer.
+		/// WARNING:
+		///          Audio callback is a dedicated place that can be executed
+		///          in a special thread or interrupt handler. Allocating
+		///          memory will probably crash the program!
 		void resizeBuffer(unsigned int newsize);
 	public:
 		AudioOutputUser(const QString& name);
 		~AudioOutputUser() Q_DECL_OVERRIDE;
 		const QString qsName;
-		float *pfBuffer;
-		float *pfVolume;
-		float fPos[3];
+		float *pfBuffer = nullptr;
+		float *pfVolume = nullptr;
+		float fPos[3] = {0.0, 0.0, 0.0};
 		bool bStereo;
 		virtual bool prepareSampleBuffer(unsigned int snum) = 0;
 };

--- a/src/mumble/CoreAudio.cpp
+++ b/src/mumble/CoreAudio.cpp
@@ -575,6 +575,7 @@ CoreAudioOutput::CoreAudioOutput() {
 	if (err != noErr) {
 		qWarning("CoreAudioOutput: Unable to query for allowed buffer size ranges.");
 	} else {
+		setBufferSize(range.mMaximum);
 		qWarning("CoreAudioOutput: BufferFrameSizeRange = (%.2f, %.2f)", range.mMinimum, range.mMaximum);
 	}
 

--- a/src/mumble/PulseAudio.cpp
+++ b/src/mumble/PulseAudio.cpp
@@ -197,7 +197,7 @@ void PulseAudioSystem::eventCallback(pa_mainloop_api *api, pa_defer_event *) {
 							pss.channels = 1;
 
 						pasOutput = pa_stream_new(pacContext, mumble_sink_input, &pss, (pss.channels == 1) ? NULL : &pcm);
-						pa_stream_set_state_callback(pasOutput, stream_callback, this);
+						pa_stream_set_state_callback(pasOutput, write_stream_callback, this);
 						pa_stream_set_write_callback(pasOutput, write_callback, this);
 					}
 					// Fallthrough
@@ -262,7 +262,7 @@ void PulseAudioSystem::eventCallback(pa_mainloop_api *api, pa_defer_event *) {
 						pss.channels = 1;
 
 						pasInput = pa_stream_new(pacContext, "Microphone", &pss, NULL);
-						pa_stream_set_state_callback(pasInput, stream_callback, this);
+						pa_stream_set_state_callback(pasInput, read_stream_callback, this);
 						pa_stream_set_read_callback(pasInput, read_callback, this);
 					}
 					// Fallthrough
@@ -330,7 +330,7 @@ void PulseAudioSystem::eventCallback(pa_mainloop_api *api, pa_defer_event *) {
 							pss.channels = 1;
 
 						pasSpeaker = pa_stream_new(pacContext, mumble_echo, &pss, (pss.channels == 1) ? NULL : &pcm);
-						pa_stream_set_state_callback(pasSpeaker, stream_callback, this);
+						pa_stream_set_state_callback(pasSpeaker, read_stream_callback, this);
 						pa_stream_set_read_callback(pasSpeaker, read_callback, this);
 					}
 					// Fallthrough
@@ -457,8 +457,23 @@ void PulseAudioSystem::sink_info_callback(pa_context *, const pa_sink_info *i, i
 	pas->iSinkId = i->index;
 }
 
+void PulseAudioSystem::write_stream_callback(pa_stream *s, void *userdata) {
+	PulseAudioSystem *pas = reinterpret_cast<PulseAudioSystem *>(userdata);
+	switch (pa_stream_get_state(s)) {
+		case PA_STREAM_FAILED:
+			qWarning("PulseAudio: Stream error: %s", pa_strerror(pa_context_errno(pa_stream_get_context(s))));
+			break;
+		default:
+			break;
+	}
+	const pa_buffer_attr *bufferAttr;
+	if ( (bufferAttr = pa_stream_get_buffer_attr(s)) ) {
+		g.ao->setBufferSize(bufferAttr->maxlength);
+	}
+	pas->wakeup();
+}
 
-void PulseAudioSystem::stream_callback(pa_stream *s, void *userdata) {
+void PulseAudioSystem::read_stream_callback(pa_stream *s, void *userdata) {
 	PulseAudioSystem *pas = reinterpret_cast<PulseAudioSystem *>(userdata);
 	switch (pa_stream_get_state(s)) {
 		case PA_STREAM_FAILED:

--- a/src/mumble/PulseAudio.h
+++ b/src/mumble/PulseAudio.h
@@ -61,7 +61,8 @@ class PulseAudioSystem : public QObject {
 		static void source_callback(pa_context *c, const pa_source_info *i, int eol, void *userdata);
 		static void server_callback(pa_context *c, const pa_server_info *i, void *userdata);
 		static void sink_info_callback(pa_context *c, const pa_sink_info *i, int eol, void *userdata);
-		static void stream_callback(pa_stream *s, void *userdata);
+		static void write_stream_callback(pa_stream *s, void *userdata);
+		static void read_stream_callback(pa_stream *s, void *userdata);
 		static void read_callback(pa_stream *s, size_t bytes, void *userdata);
 		static void write_callback(pa_stream *s, size_t bytes, void *userdata);
 		static void volume_sink_input_list_callback(pa_context *c, const pa_sink_input_info *i, int eol, void *userdata);


### PR DESCRIPTION
Thank @Reikion for bringing this up :).

After the stereo support is added, mumble would crash when trying to play stereo samples (customized message alert sound, etc) on some Linux distribution using PulseAudio.

According to the backtrace, I learn that this crash is caused by resizing a buffer inside prepareSampleBuffer, which is invoked by our output audio callback function mix().

```
#0  0x00007f1a10782355 in raise () from /usr/lib/libc.so.6
#1  0x00007f1a1076b853 in abort () from /usr/lib/libc.so.6
#2  0x00007f1a107c5878 in __libc_message () from /usr/lib/libc.so.6
#3  0x00007f1a107ccd3a in malloc_printerr () from /usr/lib/libc.so.6
#4  0x00007f1a107d0417 in _int_malloc () from /usr/lib/libc.so.6
#5  0x00007f1a107d15a9 in malloc () from /usr/lib/libc.so.6
#6  0x00007f1a10b1152a in operator new (sz=0x3e38) at /build/gcc/src/gcc/libstdc++-v3/libsupc++/new_op.cc:50
#7  0x000055df7d4480ab in AudioOutputUser::resizeBuffer (this=0x55df7f7c4060, newsize=0xf8e) at ../../../../mumble/src/mumble/AudioOutputUser.cpp:22
#8  0x000055df7d44541c in AudioOutputSample::prepareSampleBuffer (this=0x55df7f7c4060, frameCount=0x52f) at ../../../../mumble/src/mumble/AudioOutputSample.cpp:229
#9  0x000055df7d44005d in AudioOutput::mix (this=0x55df7f75fa60, outbuff=0x7f1a06418f70, frameCount=0x52f) at ../../../../mumble/src/mumble/AudioOutput.cpp:405
#10 0x000055df7d5ed0b7 in PulseAudioSystem::write_callback (s=0x7f19f4012970, bytes=0x2978, userdata=0x55df7eb24bd0) at ../../../../mumble/src/mumble/PulseAudio.cpp:613
```

Actually, allocating memory in the callback function may cause problems. In PortAudio's documentation, it writes

> Before we begin, it's important to realize that the callback is a delicate place. This is because **some systems perform the callback in a special thread, or interrupt handler, and it is rarely treated the same as the rest of your code**. For most modern systems, you won't be able to cause crashes by making disallowed calls in the callback, but if you want your code to produce glitch-free audio, you will have to make sure **you avoid function calls that may take an unbounded amount of time to execute. Exactly what these are depend on your platform but almost certainly include the following: memory allocation/deallocation**, I/O (including file I/O as well as console I/O, such as printf()), context switching (such as exec() or yield()), mutex operations, or anything else that might rely on the OS.

Interestingly, mumble has been doing this kind of memory allocating for decades, but not until today did it crash once. I have no idea about how PulseAudio is implemented, therefore am not able to provide more insights.

In this PR, I try to assign a big enough buffer when initializing AudioOutputUser, which is done in the ServerHandler thread, to avoid resizing this buffer on the fly. But the approach to determine the "big enough" size varies among different audio backends. Currently, I have done this to PulseAudio and CoreAudio.

I think as long as mumbe doesn't crash on other platforms, we don't have to take further measures. But I don't have a Linux environment at hand, and I guess this problem doesn't happen on all Linux platforms. So I'd like to invite @Reikion to have a test. :P 

Close #4259.