### PR TITLE
Backport "Safeguard from potential attacks against OCB2"

### DIFF
--- a/src/CryptState.h
+++ b/src/CryptState.h
@@ -44,11 +44,11 @@ class CryptState {
 		void setKey(const unsigned char *rkey, const unsigned char *eiv, const unsigned char *div);
 		void setDecryptIV(const unsigned char *iv);
 
-		void ocb_encrypt(const unsigned char *plain, unsigned char *encrypted, unsigned int len, const unsigned char *nonce, unsigned char *tag);
-		void ocb_decrypt(const unsigned char *encrypted, unsigned char *plain, unsigned int len, const unsigned char *nonce, unsigned char *tag);
+		bool ocb_encrypt(const unsigned char *plain, unsigned char *encrypted, unsigned int len, const unsigned char *nonce, unsigned char *tag);
+		bool ocb_decrypt(const unsigned char *encrypted, unsigned char *plain, unsigned int len, const unsigned char *nonce, unsigned char *tag);
 
 		bool decrypt(const unsigned char *source, unsigned char *dst, unsigned int crypted_length);
-		void encrypt(const unsigned char *source, unsigned char *dst, unsigned int plain_length);
+		bool encrypt(const unsigned char *source, unsigned char *dst, unsigned int plain_length);
 };
 
 #endif

--- a/src/mumble/ServerHandler.cpp
+++ b/src/mumble/ServerHandler.cpp
@@ -242,7 +242,9 @@ void ServerHandler::sendMessage(const char *data, int len, bool force) {
 
 		QApplication::postEvent(this, new ServerHandlerMessageEvent(qba, MessageHandler::UDPTunnel, true));
 	} else {
-		connection->csCrypt.encrypt(reinterpret_cast<const unsigned char *>(data), crypto, len);
+		if (!connection->csCrypt.encrypt(reinterpret_cast<const unsigned char *>(data), crypto, len)) {
+			return;
+		}
 		qusUdp->writeDatagram(reinterpret_cast<const char *>(crypto), len + 4, qhaRemote, usResolvedPort);
 	}
 }
@@ -978,4 +980,3 @@ QUrl ServerHandler::getServerURL(bool withPassword) const {
 	
 	return url;
 }
-

--- a/src/murmur/Server.cpp
+++ b/src/murmur/Server.cpp
@@ -934,8 +934,9 @@ void Server::sendMessage(ServerUser *u, const char *data, int len, QByteArray &c
 				return;
 			}
 
-			u->csCrypt.encrypt(reinterpret_cast<const unsigned char *>(data), reinterpret_cast<unsigned char *>(buffer),
-							   len);
+			if (!u->csCrypt.encrypt(reinterpret_cast<const unsigned char *>(data), reinterpret_cast<unsigned char *>(buffer), len)) {
+				return;
+			}
 		}
 #ifdef Q_OS_WIN
 		DWORD dwFlow = 0;


### PR DESCRIPTION
OCB2 is known to be broken under certain conditions:
https://eprint.iacr.org/2019/311

To execute the universal attacks described in the paper, an attacker needs
access to an encryption oracle that allows it to perform encryption queries with
attacker-chosen nonce. Luckily in Mumble the encryption nonce is a fixed counter
which is far too restrictive for the universal attacks to be feasible against
Mumble.

The basic attacks do not require an attacker-chosen nonce and as such are more
applicable to Mumble. They are however of limited use and do require an en- and
a decryption oracle which Mumble seemingly does not provide at the same time.

To be on the safe side, this commit implements the counter-cryptanalysis
measure described in the paper in section 9 for the sender and receiver side.
This way if either server of client are patched, their communication is almost
certainly (merely lacking formal proof) not susceptible to the attacks described
in the paper.

Backported from #4227