### PR TITLE
TalkingUI: Fix ghost users

### DIFF
--- a/src/mumble/Messages.cpp
+++ b/src/mumble/Messages.cpp
@@ -738,6 +738,8 @@ void MainWindow::msgUserRemove(const MumbleProto::UserRemove &msg) {
 	}
 	if (pDst != pSelf)
 		pmModel->removeUser(pDst);
+
+	QMetaObject::invokeMethod(g.talkingUI, "on_clientDisconnected", Qt::QueuedConnection, Q_ARG(unsigned int, pDst->uiSession));
 }
 
 /// This message is being received when the server informs the local client about channel properties (either during connection/login

--- a/src/mumble/TalkingUI.cpp
+++ b/src/mumble/TalkingUI.cpp
@@ -489,7 +489,11 @@ void TalkingUI::on_talkingStateChanged() {
 	ClientUser *user = qobject_cast<ClientUser *>(sender());
 
 	if (!user) {
-		qWarning("TalkingUI::on_talkingStateChanged User not found");
+		// If the user that caused this event doesn't exist anymore, it means that it
+		// got deleted in the meantime. This in turn means that the user disconnected
+		// from the server. In that case it has been removed via on_clientDisconnected
+		// already (or shortly will be), so it is safe to silently ignore this case
+		// here.
 		return;
 	}
 
@@ -692,3 +696,12 @@ void TalkingUI::on_settingsChanged() {
 		}
 	}
 }
+
+void TalkingUI::on_clientDisconnected(unsigned int userSession) {
+	if (m_entries.contains(userSession)) {
+		// If the user that just disconnected is contained in the TalkingUI, make sure
+		// it is hidden.
+		hideUser(userSession);
+	}
+}
+

--- a/src/mumble/TalkingUI.h
+++ b/src/mumble/TalkingUI.h
@@ -116,6 +116,7 @@ class TalkingUI : public QWidget {
 		void on_serverDisconnected();
 		void on_channelChanged(QObject *user);
 		void on_settingsChanged();
+		void on_clientDisconnected(unsigned int userSession);
 };
 
 #endif // MUMBLE_MUMBLE_TALKINGUI_H_


### PR DESCRIPTION
When a client disconnected from the server that was still talking and
therefore showing up in the TalkingUI, it could happen that this user
was not removed from it even though it was no longer on the server. This
is due to a race-condition in the event chain: It could happen that the
respective user object got deleted before the on_talkingStateChanged
function in the TalkingUI got called. This then led to this function not
getting a reference to the user object which causes it to return.

This commit explicitly wires up the UserRemove event with the TalkingUI
to make sure a user gets removed from it once it is removed from the
server.