### PR TITLE
src/mumble: remove positional audio check in audio backends

### DIFF
--- a/src/mumble/ALSAAudio.cpp
+++ b/src/mumble/ALSAAudio.cpp
@@ -414,15 +414,11 @@ void ALSAAudioOutput::run() {
 	ALSA_ERRBAIL(snd_pcm_open(&pcm_handle, device_name.data(), SND_PCM_STREAM_PLAYBACK, 0));
 	ALSA_ERRCHECK(snd_pcm_hw_params_any(pcm_handle, hw_params));
 
-	if (g.s.doPositionalAudio()) {
-		iChannels = 1;
-		ALSA_ERRBAIL(snd_pcm_hw_params_get_channels_max(hw_params, &iChannels));
-		if (iChannels > 9) {
-			qWarning("ALSAAudioOutput: ALSA reports %d output channels. Clamping to 2.",iChannels);
-			iChannels = 2;
-		}
-	} else {
-		iChannels = 1;
+	iChannels = 1;
+	ALSA_ERRBAIL(snd_pcm_hw_params_get_channels_max(hw_params, &iChannels));
+	if (iChannels > 9) {
+		qWarning("ALSAAudioOutput: ALSA reports %d output channels. Clamping to 2.",iChannels);
+		iChannels = 2;
 	}
 
 	ALSA_ERRBAIL(snd_pcm_hw_params_set_access(pcm_handle, hw_params, SND_PCM_ACCESS_RW_INTERLEAVED));

--- a/src/mumble/OSS.cpp
+++ b/src/mumble/OSS.cpp
@@ -281,12 +281,7 @@ void OSSOutput::run() {
 		return;
 	}
 
-	iChannels = 0;
-
-	if (g.s.doPositionalAudio())
-		iChannels = 2;
-	else
-		iChannels = 1;
+	iChannels = 2;
 
 	ival = iChannels;
 	if ((ioctl(fd, SNDCTL_DSP_CHANNELS, &ival) == -1) && (ival == static_cast<int>(iChannels))) {

--- a/src/mumble/PulseAudio.cpp
+++ b/src/mumble/PulseAudio.cpp
@@ -71,7 +71,6 @@ PulseAudioSystem::PulseAudioSystem() {
 	pasInput = pasOutput = pasSpeaker = NULL;
 	bSourceDone=bSinkDone=bServerDone = false;
 	iDelayCache = 0;
-	bPositionalCache = false;
 	bAttenuating = false;
 	iRemainingOperations = 0;
 	bPulseIsGood = false;
@@ -194,7 +193,7 @@ void PulseAudioSystem::eventCallback(pa_mainloop_api *api, pa_defer_event *) {
 							pss.format = PA_SAMPLE_FLOAT32NE;
 						if (pss.rate == 0)
 							pss.rate = SAMPLE_RATE;
-						if ((pss.channels == 0) || (! g.s.doPositionalAudio()))
+						if (pss.channels == 0)
 							pss.channels = 1;
 
 						pasOutput = pa_stream_new(pacContext, mumble_sink_input, &pss, (pss.channels == 1) ? NULL : &pcm);
@@ -207,8 +206,6 @@ void PulseAudioSystem::eventCallback(pa_mainloop_api *api, pa_defer_event *) {
 					break;
 				case PA_STREAM_READY: {
 						if (g.s.iOutputDelay != iDelayCache) {
-							do_stop = true;
-						} else if (g.s.doPositionalAudio() != bPositionalCache) {
 							do_stop = true;
 						} else if (odev != qsOutputCache) {
 							do_stop = true;
@@ -236,7 +233,6 @@ void PulseAudioSystem::eventCallback(pa_mainloop_api *api, pa_defer_event *) {
 			buff.fragsize = iBlockLen;
 
 			iDelayCache = g.s.iOutputDelay;
-			bPositionalCache = g.s.doPositionalAudio();
 			qsOutputCache = odev;
 
 			pa_stream_connect_playback(pasOutput, qPrintable(odev), &buff, PA_STREAM_ADJUST_LATENCY, NULL, NULL);

--- a/src/mumble/PulseAudio.h
+++ b/src/mumble/PulseAudio.h
@@ -41,7 +41,6 @@ class PulseAudioSystem : public QObject {
 
 		int iDelayCache;
 		QString qsOutputCache, qsInputCache, qsEchoCache;
-		bool bPositionalCache;
 		bool bEchoMultiCache;
 		QHash<QString, QString> qhEchoMap;
 		QHash<QString, pa_sample_spec> qhSpecMap;


### PR DESCRIPTION
The check was originally implemented to avoid initializing multiple channels when it was guaranteed only one would be available (i.e. positional audio disabled).

Now that we support stereo audio decoding (#4209), the check has to be removed in order to make the feature available when positional audio is disabled.