### PR TITLE
Send image pasted into the chat bar

### DIFF
--- a/src/mumble/CustomElements.cpp
+++ b/src/mumble/CustomElements.cpp
@@ -16,6 +16,7 @@
 #include <QtGui/QContextMenuEvent>
 #include <QtGui/QKeyEvent>
 #include <QtWidgets/QScrollBar>
+#include <QMimeData>
 
 // We define a global macro called 'g'. This can lead to issues when included code uses 'g' as a type or parameter name (like protobuf 3.7 does). As such, for now, we have to make this our last include.
 #include "Global.h"
@@ -149,6 +150,24 @@ void ChatbarTextEdit::setDefaultText(const QString &new_default, bool force) {
 		setFont(f);
 		setHtml(qsDefaultText);
 		bDefaultVisible = true;
+	}
+}
+
+void ChatbarTextEdit::insertFromMimeData(const QMimeData *source) {
+	if (source->hasImage()) {
+		if (g.bAllowHTML) {
+			QImage image = qvariant_cast<QImage>(source->imageData());
+
+			QString imgHtml = QLatin1String("<br />") + Log::imageToImg(image);
+
+			if (static_cast<unsigned int>(imgHtml.length()) < g.uiImageLength) {
+				emit pastedImage(imgHtml);
+			} else {
+				g.l->log(Log::Information, tr("Unable to send image: too large."));
+			}
+		}
+	} else {
+		QTextEdit::insertFromMimeData(source);
 	}
 }
 

--- a/src/mumble/CustomElements.cpp
+++ b/src/mumble/CustomElements.cpp
@@ -99,9 +99,23 @@ void ChatbarTextEdit::contextMenuEvent(QContextMenuEvent *qcme) {
 	delete menu;
 }
 
+void ChatbarTextEdit::dragEnterEvent(QDragEnterEvent *evt) {
+	inFocus(true);
+	evt->acceptProposedAction();
+}
+
+void ChatbarTextEdit::dragMoveEvent(QDragMoveEvent *evt) {
+	inFocus(true);
+	evt->acceptProposedAction();
+}
+
 void ChatbarTextEdit::dropEvent(QDropEvent *evt) {
 	inFocus(true);
-	QTextEdit::dropEvent(evt);
+	if (sendImagesFromMimeData(evt->mimeData())) {
+		evt->acceptProposedAction();
+	} else {
+		QTextEdit::dropEvent(evt);
+	}
 }
 
 ChatbarTextEdit::ChatbarTextEdit(QWidget *p) : QTextEdit(p), iHistoryIndex(-1) {
@@ -113,6 +127,7 @@ ChatbarTextEdit::ChatbarTextEdit(QWidget *p) : QTextEdit(p), iHistoryIndex(-1) {
 
 	bDefaultVisible = true;
 	setDefaultText(tr("<center>Type chat message here</center>"));
+	setAcceptDrops(true);
 }
 
 QSize ChatbarTextEdit::minimumSizeHint() const {
@@ -154,7 +169,14 @@ void ChatbarTextEdit::setDefaultText(const QString &new_default, bool force) {
 }
 
 void ChatbarTextEdit::insertFromMimeData(const QMimeData *source) {
+	if (! sendImagesFromMimeData(source)){
+		QTextEdit::insertFromMimeData(source);
+	}
+}
+
+bool ChatbarTextEdit::sendImagesFromMimeData(const QMimeData *source){
 	if (source->hasImage()) {
+		// Process the image pasted onto the chatbar.
 		if (g.bAllowHTML) {
 			QImage image = qvariant_cast<QImage>(source->imageData());
 
@@ -162,13 +184,36 @@ void ChatbarTextEdit::insertFromMimeData(const QMimeData *source) {
 
 			if (static_cast<unsigned int>(imgHtml.length()) < g.uiImageLength) {
 				emit pastedImage(imgHtml);
+				return true;
 			} else {
 				g.l->log(Log::Information, tr("Unable to send image: too large."));
 			}
 		}
-	} else {
-		QTextEdit::insertFromMimeData(source);
+	} else if (source->hasUrls()) {
+		// Process the files dropped onto the chatbar. URLs here should be understood as the URIs of files.
+		QList<QUrl> urlList = source->urls();
+
+		int count = 0;
+		for (int i = 0; i < urlList.size(); ++i)
+		{
+			QString path = urlList[i].toLocalFile();
+			QImage image(path);
+
+			if (image.isNull()) continue;
+
+			QString imgHtml = QLatin1String("<br />") + Log::imageToImg(image);
+
+			if (static_cast<unsigned int>(imgHtml.length()) < g.uiImageLength) {
+				emit pastedImage(imgHtml);
+				++count;
+			} else {
+				g.l->log(Log::Information, tr("Unable to send image %1: too large.").arg(path));
+			}
+		}
+
+		return (count > 0);
 	}
+	return false;
 }
 
 bool ChatbarTextEdit::event(QEvent *evt) {

--- a/src/mumble/CustomElements.h
+++ b/src/mumble/CustomElements.h
@@ -47,6 +47,7 @@ class ChatbarTextEdit : public QTextEdit {
 		QSize minimumSizeHint() const Q_DECL_OVERRIDE;
 		QSize sizeHint() const Q_DECL_OVERRIDE;
 		void resizeEvent(QResizeEvent *e) Q_DECL_OVERRIDE;
+		void insertFromMimeData(const QMimeData *source) Q_DECL_OVERRIDE;
 	public:
 		void setDefaultText(const QString &, bool = false);
 		unsigned int completeAtCursor();
@@ -55,6 +56,7 @@ class ChatbarTextEdit : public QTextEdit {
 		void backtabPressed(void);
 		void ctrlSpacePressed(void);
 		void entered(QString);
+		void pastedImage(QString);
 	public slots:
 		void pasteAndSend_triggered();
 		void doResize();

--- a/src/mumble/CustomElements.h
+++ b/src/mumble/CustomElements.h
@@ -42,12 +42,15 @@ class ChatbarTextEdit : public QTextEdit {
 		void focusInEvent(QFocusEvent *) Q_DECL_OVERRIDE;
 		void focusOutEvent(QFocusEvent *) Q_DECL_OVERRIDE;
 		void contextMenuEvent(QContextMenuEvent *) Q_DECL_OVERRIDE;
+		void dragEnterEvent(QDragEnterEvent *) Q_DECL_OVERRIDE;
+		void dragMoveEvent(QDragMoveEvent *) Q_DECL_OVERRIDE;
 		void dropEvent(QDropEvent *) Q_DECL_OVERRIDE;
 		bool event(QEvent *) Q_DECL_OVERRIDE;
 		QSize minimumSizeHint() const Q_DECL_OVERRIDE;
 		QSize sizeHint() const Q_DECL_OVERRIDE;
 		void resizeEvent(QResizeEvent *e) Q_DECL_OVERRIDE;
 		void insertFromMimeData(const QMimeData *source) Q_DECL_OVERRIDE;
+		bool sendImagesFromMimeData(const QMimeData *source);
 	public:
 		void setDefaultText(const QString &, bool = false);
 		unsigned int completeAtCursor();

--- a/src/mumble/MainWindow.cpp
+++ b/src/mumble/MainWindow.cpp
@@ -166,7 +166,8 @@ MainWindow::MainWindow(QWidget *p) : QMainWindow(p) {
 	connect(qmUser, SIGNAL(aboutToShow()), this, SLOT(qmUser_aboutToShow()));
 	connect(qmChannel, SIGNAL(aboutToShow()), this, SLOT(qmChannel_aboutToShow()));
 	connect(qmListener, SIGNAL(aboutToShow()), this, SLOT(qmListener_aboutToShow()));
-	connect(qteChat, SIGNAL(entered(QString)), this, SLOT(sendChatbarMessage(QString)));
+	connect(qteChat, SIGNAL(entered(QString)), this, SLOT(sendChatbarText(QString)));
+	connect(qteChat, SIGNAL(pastedImage(QString)), this, SLOT(sendChatbarMessage(QString)));
 
 	// Tray
 	connect(qstiIcon, SIGNAL(messageClicked()), this, SLOT(showRaiseWindow()));
@@ -1925,26 +1926,29 @@ void MainWindow::on_qaQuit_triggered() {
 	this->close();
 }
 
-void MainWindow::sendChatbarMessage(QString qsText) {
+void MainWindow::sendChatbarText(QString qsText) {
+	qsText = qsText.toHtmlEscaped();
+	qsText = Markdown::markdownToHTML(qsText);
+	sendChatbarMessage(qsText);
+}
+
+void MainWindow::sendChatbarMessage(QString qsMessage) {
 	if (g.uiSession == 0) return; // Check if text & connection is available
 
 	ClientUser *p = pmModel->getUser(qtvUsers->currentIndex());
 	Channel *c = pmModel->getChannel(qtvUsers->currentIndex());
-
-	qsText = qsText.toHtmlEscaped();
-	qsText = Markdown::markdownToHTML(qsText);
 
 	if (!g.s.bChatBarUseSelection || p == NULL || p->uiSession == g.uiSession) {
 		// Channel message
 		if (!g.s.bChatBarUseSelection || c == NULL) // If no channel selected fallback to current one
 			c = ClientUser::get(g.uiSession)->cChannel;
 
-		g.sh->sendChannelTextMessage(c->iId, qsText, false);
-		g.l->log(Log::TextMessage, tr("To %1: %2").arg(Log::formatChannel(c), qsText), tr("Message to channel %1").arg(c->qsName), true);
+		g.sh->sendChannelTextMessage(c->iId, qsMessage, false);
+		g.l->log(Log::TextMessage, tr("To %1: %2").arg(Log::formatChannel(c), qsMessage), tr("Message to channel %1").arg(c->qsName), true);
 	} else {
 		// User message
-		g.sh->sendUserTextMessage(p->uiSession, qsText);
-		g.l->log(Log::TextMessage, tr("To %1: %2").arg(Log::formatClientUser(p, Log::Target), qsText), tr("Message to %1").arg(p->qsName), true);
+		g.sh->sendUserTextMessage(p->uiSession, qsMessage);
+		g.l->log(Log::TextMessage, tr("To %1: %2").arg(Log::formatClientUser(p, Log::Target), qsMessage), tr("Message to %1").arg(p->qsName), true);
 	}
 
 	qteChat->clear();

--- a/src/mumble/MainWindow.cpp
+++ b/src/mumble/MainWindow.cpp
@@ -1930,6 +1930,8 @@ void MainWindow::sendChatbarText(QString qsText) {
 	qsText = qsText.toHtmlEscaped();
 	qsText = Markdown::markdownToHTML(qsText);
 	sendChatbarMessage(qsText);
+
+	qteChat->clear();
 }
 
 void MainWindow::sendChatbarMessage(QString qsMessage) {
@@ -1950,8 +1952,6 @@ void MainWindow::sendChatbarMessage(QString qsMessage) {
 		g.sh->sendUserTextMessage(p->uiSession, qsMessage);
 		g.l->log(Log::TextMessage, tr("To %1: %2").arg(Log::formatClientUser(p, Log::Target), qsMessage), tr("Message to %1").arg(p->qsName), true);
 	}
-
-	qteChat->clear();
 }
 
 /**

--- a/src/mumble/MainWindow.h
+++ b/src/mumble/MainWindow.h
@@ -289,6 +289,7 @@ class MainWindow : public QMainWindow, public MessageHandler, public Ui::MainWin
 		void destroyUserInformation();
 		void trayAboutToShow();
 		void sendChatbarMessage(QString msg);
+		void sendChatbarText(QString msg);
 		void pttReleased();
 		void whisperReleased(QVariant scdata);
 		void onResetAudio();

--- a/src/mumble/mumble_en.ts
+++ b/src/mumble/mumble_en.ts
@@ -2674,6 +2674,14 @@ Are you sure you wish to replace your certificate?
         <source>&lt;center&gt;Type chat message here&lt;/center&gt;</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Unable to send image: too large.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Unable to send image %1: too large.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ClientUser</name>


### PR DESCRIPTION
I always want to send an image by copy and paste it into the chat bar of mumble.
This is a commonly expected behavior of any chat app. Can't see why mumble should not have one. 

![image](https://user-images.githubusercontent.com/2306637/84018107-3c599c80-a9b2-11ea-9ee0-96e5eb6b5521.png)
