### PR TITLE
Fix overlay

### DIFF
--- a/src/mumble/Overlay.cpp
+++ b/src/mumble/Overlay.cpp
@@ -215,6 +215,8 @@ void Overlay::setActive(bool act) {
 	if (!m_initialized.load()) {
 		platformInit();
 		forceSettings();
+
+		createPipe();
 	
 		m_initialized.store(true);
 	}

--- a/src/mumble/Overlay.cpp
+++ b/src/mumble/Overlay.cpp
@@ -211,12 +211,7 @@ Overlay::~Overlay() {
 	}
 }
 
-void Overlay::setActive(bool act) {
-	if (!act && !m_initialized.load()) {
-		// Disabling when the Overlay hasn't been initialized yet, doesn't make much sense
-		return;
-	}
-
+void Overlay::initialize() {
 	if (!m_initialized.load()) {
 		platformInit();
 		forceSettings();
@@ -225,6 +220,16 @@ void Overlay::setActive(bool act) {
 	
 		m_initialized.store(true);
 	}
+}
+
+void Overlay::setActive(bool act) {
+	if (!act && !m_initialized.load()) {
+		// Disabling when the Overlay hasn't been initialized yet, doesn't make much sense
+		return;
+	}
+
+	// Make sure the Overlay is initialized
+	initialize();
 
 	setActiveInternal(act);
 }

--- a/src/mumble/Overlay.cpp
+++ b/src/mumble/Overlay.cpp
@@ -212,6 +212,11 @@ Overlay::~Overlay() {
 }
 
 void Overlay::setActive(bool act) {
+	if (!act && !m_initialized.load()) {
+		// Disabling when the Overlay hasn't been initialized yet, doesn't make much sense
+		return;
+	}
+
 	if (!m_initialized.load()) {
 		platformInit();
 		forceSettings();

--- a/src/mumble/Overlay.h
+++ b/src/mumble/Overlay.h
@@ -89,6 +89,9 @@ class Overlay : public QObject {
 		/// A flag indicating if the platformInit has been called already
 		std::atomic<bool> m_initialized;
 
+		/// Initializes the overlay, if it hasn't been initialized yet
+		void initialize();
+
 		// These 2 functions (among others) are implemented by the system-specific backend
 		void platformInit();
 		void setActiveInternal(bool act);


### PR DESCRIPTION
This PR makes the overlay work again (got broken in https://github.com/mumble-voip/mumble/commit/aac3214d4be2ba31c852619bc8d3666391dcd02a) and furthermore makes sure that it really only is initialized if needed.

----

I have not tested the changes to actually work yet. Would be great if someone could do so :)