### PR TITLE
Revamp ServerBrowser UI

### DIFF
--- a/src/mumble/ConnectDialog.ui
+++ b/src/mumble/ConnectDialog.ui
@@ -13,8 +13,15 @@
   <property name="windowTitle">
    <string>Mumble Server Connect</string>
   </property>
-  <layout class="QVBoxLayout" name="verticalLayout">
-   <item>
+  <layout class="QGridLayout" name="gridLayout">
+   <item row="2" column="0" colspan="3">
+    <widget class="QDialogButtonBox" name="qdbbButtonBox">
+     <property name="standardButtons">
+      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
+     </property>
+    </widget>
+   </item>
+   <item row="0" column="0" colspan="3">
     <widget class="ServerView" name="qtwServers">
      <property name="contextMenuPolicy">
       <enum>Qt::CustomContextMenu</enum>
@@ -60,11 +67,69 @@
      </column>
     </widget>
    </item>
-   <item>
-    <widget class="QDialogButtonBox" name="qdbbButtonBox">
-     <property name="standardButtons">
-      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
+   <item row="1" column="0" colspan="3">
+    <widget class="QGroupBox" name="qgbSearch">
+     <property name="enabled">
+      <bool>true</bool>
      </property>
+     <property name="title">
+      <string>Search</string>
+     </property>
+     <layout class="QGridLayout">
+      <item row="1" column="0">
+       <widget class="QLabel" name="qlSearchServername">
+        <property name="text">
+         <string>Servername</string>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="2">
+       <widget class="QLineEdit" name="qleSearchServername">
+        <property name="placeholderText">
+         <string>Servername</string>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="0">
+       <widget class="QLabel" name="qlSearchLocation">
+        <property name="text">
+         <string>Location</string>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="2">
+       <widget class="QComboBox" name="qcbSearchLocation"/>
+      </item>
+      <item row="3" column="0">
+       <widget class="QLabel" name="qlFilter">
+        <property name="text">
+         <string>Filter</string>
+        </property>
+       </widget>
+      </item>
+      <item row="3" column="2">
+       <widget class="QComboBox" name="qcbFilter">
+        <property name="enabled">
+         <bool>true</bool>
+        </property>
+        <item>
+         <property name="text">
+          <string>Show All</string>
+         </property>
+        </item>
+        <item>
+         <property name="text">
+          <string>Show Populated</string>
+         </property>
+        </item>
+        <item>
+         <property name="text">
+          <string>Show Reachable</string>
+         </property>
+        </item>
+       </widget>
+      </item>
+     </layout>
     </widget>
    </item>
   </layout>
@@ -94,45 +159,6 @@
   <action name="qaUrl">
    <property name="text">
     <string>Open &amp;Webpage</string>
-   </property>
-  </action>
-  <action name="qaShowReachable">
-   <property name="checkable">
-    <bool>true</bool>
-   </property>
-   <property name="checked">
-    <bool>true</bool>
-   </property>
-   <property name="text">
-    <string>Show &amp;Reachable</string>
-   </property>
-   <property name="toolTip">
-    <string>Show all servers that respond to ping</string>
-   </property>
-  </action>
-  <action name="qaShowPopulated">
-   <property name="checkable">
-    <bool>true</bool>
-   </property>
-   <property name="checked">
-    <bool>true</bool>
-   </property>
-   <property name="text">
-    <string>Show &amp;Populated</string>
-   </property>
-   <property name="toolTip">
-    <string>Show all servers with users</string>
-   </property>
-  </action>
-  <action name="qaShowAll">
-   <property name="checkable">
-    <bool>true</bool>
-   </property>
-   <property name="text">
-    <string>Show &amp;All</string>
-   </property>
-   <property name="toolTip">
-    <string>Show all servers</string>
    </property>
   </action>
   <action name="qaFavoriteCopy">

--- a/src/mumble/Settings.cpp
+++ b/src/mumble/Settings.cpp
@@ -439,7 +439,8 @@ Settings::Settings() {
 	bDisableCELT = false;
 	disablePublicList = false;
 	disableConnectDialogEditing = false;
-	
+	bPingServersDialogViewed = false;
+
 	// Config updates
 	uiUpdateCounter = 0;
 
@@ -853,6 +854,7 @@ void Settings::load(QSettings* settings_ptr) {
 	SAVELOAD(bDisableCELT, "audio/disablecelt");
 	SAVELOAD(disablePublicList, "ui/disablepubliclist");
 	SAVELOAD(disableConnectDialogEditing, "ui/disableconnectdialogediting");
+	SAVELOAD(bPingServersDialogViewed, "consent/pingserversdialogviewed");
 
 	// OverlayPrivateWin
 	SAVELOAD(iOverlayWinHelperRestartCooldownMsec, "overlay_win/helper/restart_cooldown_msec");
@@ -1204,6 +1206,7 @@ void Settings::save() {
 	SAVELOAD(bDisableCELT, "audio/disablecelt");
 	SAVELOAD(disablePublicList, "ui/disablepubliclist");
 	SAVELOAD(disableConnectDialogEditing, "ui/disableconnectdialogediting");
+	SAVELOAD(bPingServersDialogViewed, "consent/pingserversdialogviewed");
 
 	// OverlayPrivateWin
 	SAVELOAD(iOverlayWinHelperRestartCooldownMsec, "overlay_win/helper/restart_cooldown_msec");

--- a/src/mumble/Settings.h
+++ b/src/mumble/Settings.h
@@ -422,6 +422,9 @@ struct Settings {
 	
 	/// Removes the add and edit options in the connect dialog if set.
 	bool disableConnectDialogEditing;
+
+	/// Asks the user for consent to ping servers in the public server list if not set.
+	bool bPingServersDialogViewed;
 	
 	// Config updates
 	unsigned int uiUpdateCounter;

--- a/src/mumble/mumble_en.ts
+++ b/src/mumble/mumble_en.ts
@@ -2849,10 +2849,6 @@ Are you sure you wish to replace your certificate?
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>&amp;Filters</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Unknown</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2882,18 +2878,6 @@ Are you sure you wish to replace your certificate?
     </message>
     <message>
         <source>Add custom server</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Show all servers that respond to ping</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Show all servers with users</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Show all servers</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -2929,19 +2913,67 @@ Are you sure you wish to replace your certificate?
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Show &amp;Reachable</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Show &amp;Populated</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Show &amp;All</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Server list</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Search</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Location</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Filter</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show All</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show Populated</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show Reachable</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>All</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Africa</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Asia</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Europe</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>North America</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Oceania</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>South America</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Consent to the transmission of private data</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&lt;p&gt;To measure the latency (ping) of public servers and determine the number of active users, your IP address must be transmitted to each public server.&lt;/p&gt;&lt;p&gt;Do you consent to the transmission of your IP address? If you answer no, the public server list will be deactivated. However, you can reactivate it at any time in the network settings.&lt;/p&gt;</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -7107,34 +7139,6 @@ See &lt;a href=&quot;https://wiki.mumble.info/wiki/Installing_Mumble&quot;&gt;th
     </message>
     <message>
         <source>Public Internet</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Unknown</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Africa</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Asia</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>North America</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>South America</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Europe</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Oceania</source>
         <translation type="unfinished"></translation>
     </message>
 </context>


### PR DESCRIPTION
This PR revamps the ServerBrowserUI to facilitate its usage. Additionally it also adds a search-functionality to it.

Fixes #3532

----
Screenshot:
![Mumble_ServerBrowser](https://user-images.githubusercontent.com/12751591/85829626-4ab5ff80-b78b-11ea-983a-166887b73e22.png)
