### PR TITLE
FIX(certificate): Properly process signed certificates

### DIFF
--- a/src/SSL.cpp
+++ b/src/SSL.cpp
@@ -108,6 +108,17 @@ out:
 }
 
 void MumbleSSL::addSystemCA() {
+#if QT_VERSION >= QT_VERSION_CHECK(5,15,0)
+	// Qt 5.15 introduced adding certificates to the QSslConfiguration and deprecated doing so on QSslSocket
+	auto config = QSslConfiguration::defaultConfiguration();
+
+	config.addCaCertificates(QSslConfiguration::systemCaCertificates());
+
+	QSslConfiguration::setDefaultConfiguration(config);
+#else
+	QSslSocket::addDefaultCaCertificates(QSslConfiguration::systemCaCertificates());
+#endif
+
 #ifdef Q_OS_WIN
 	// Work around issue #1271.
 	// Skype's click-to-call feature creates an enormous


### PR DESCRIPTION
This fixes a regression introduced in
b691108d3820695d51e2f4d76d1ee080e9bfaa91. In there it was thought that
there is no need to explicitly add the system CaCertificates to the SSL
configuration. This turned out to be wrong.

It was brought up that by removing this line, properly signed
certificates would also be shown as self-signed.

Fixes #4289