### PR TITLE
WIP: Add Capabilities message to conduct voice protocol negotiation

### DIFF
--- a/src/Connection.cpp
+++ b/src/Connection.cpp
@@ -29,7 +29,6 @@ Connection::Connection(QObject *p, QSslSocket *qtsSock) : QObject(p) {
 	qtsSocket->setParent(this);
 	iPacketLength = -1;
 	bDisconnectedEmitted = false;
-	csCrypt = std::make_unique<CryptStateOCB2>();
 
 	static bool bDeclared = false;
 	if (! bDeclared) {
@@ -258,3 +257,15 @@ void Connection::setQoS(HANDLE hParentQoS) {
 	hQoS = hParentQoS;
 }
 #endif
+
+void Connection::initializeCipher() {
+	switch (vptVoiceProtocolType) {
+		case VoiceProtocolType::UDP_OCB2:
+			csCrypt = std::make_unique<CryptStateOCB2>();
+			break;
+		case VoiceProtocolType::UNDEFINED:
+		case VoiceProtocolType::CUSTOM:
+		default:
+			break;
+	}
+}

--- a/src/Connection.h
+++ b/src/Connection.h
@@ -21,6 +21,7 @@
 #include <QtCore/QObject>
 #include <QtNetwork/QSslSocket>
 #include <memory>
+#include <utility>
 
 #ifdef Q_OS_WIN
 # include <ws2tcpip.h>
@@ -31,6 +32,20 @@ namespace protobuf {
 class Message;
 }
 }
+
+enum VoiceProtocolType {UNDEFINED, CUSTOM, UDP_OCB2};
+struct VoiceProtocol {
+	VoiceProtocolType protocolType;
+	std::string customProtocolName;
+	explicit VoiceProtocol (VoiceProtocolType t) {
+		protocolType = t;
+		customProtocolName = "";
+	}
+	explicit VoiceProtocol (std::string s) {
+		protocolType = VoiceProtocolType::CUSTOM;
+		customProtocolName = std::move(s);
+	}
+};
 
 class Connection : public QObject {
 	private:
@@ -68,6 +83,8 @@ class Connection : public QObject {
 		qint64 activityTime() const;
 		void resetActivityTime();
 
+		void initializeCipher();
+
 #ifdef MURMUR
 		/// qmCrypt locks access to csCrypt.
 		QMutex qmCrypt;
@@ -85,6 +102,7 @@ class Connection : public QObject {
 		/// Look up the local port of this Connection.
 		quint16 localPort() const;
 		bool bDisconnectedEmitted;
+		VoiceProtocolType vptVoiceProtocolType = VoiceProtocolType::UNDEFINED;
 
 		void setToS();
 #ifdef Q_OS_WIN

--- a/src/Message.h
+++ b/src/Message.h
@@ -13,7 +13,8 @@
 /**
   Protobuf packet type enumeration for message handler generation.
 
-  Warning: Only append to the end.
+  Warning: This list will be used to generate an enum so
+           ONLY APPEND NEW MESSAGE TYPE AT THE END OF IT.
  */
 #define MUMBLE_MH_ALL \
 	MUMBLE_MH_MSG(Version) \
@@ -41,7 +42,8 @@
 	MUMBLE_MH_MSG(UserStats) \
 	MUMBLE_MH_MSG(RequestBlob) \
 	MUMBLE_MH_MSG(ServerConfig) \
-	MUMBLE_MH_MSG(SuggestConfig)
+	MUMBLE_MH_MSG(SuggestConfig) \
+	MUMBLE_MH_MSG(Capabilities)
 
 class MessageHandler {
 	public:

--- a/src/Mumble.proto
+++ b/src/Mumble.proto
@@ -20,6 +20,35 @@ message Version {
 	optional string os_version = 4;
 }
 
+// Send after the version packet, indicate the protocol preference of the client.
+// - This message is not required for text-only clients. It can be send before or after
+//   the Authenticate message. However, it has be sent prior to a client attempts to send
+//   or receive any audio data.
+// - As reply, the server will send an Capabilities message as well, with only one item in
+//   the list, indicating the protocol it determines to use.
+// - In the middle of a session, a client can re-perform this negotiation by send a valid
+//   Capabilities packet again. A server may also request the client to use another Capabilities
+//   with the protocol it'd like to use inside.
+message Capabilities {
+	enum VoiceProtocol {
+		UNDEFINED = 0;  // Placeholder used by the server to indicate it doesn't support any protocol the client has provided.
+		CUSTOM = 1;
+		UDP_OCB2 = 2;
+	}
+
+	// A list of supported protocols of the client sent to the server, sort by preference.
+	// If the client wants to include a custom protocol that is not listed in VoiceProtocol,
+	// he can use CUSTOM as placeholders. Server will look up custom_protocols and map CUSTOM
+	// with the protocol names inside custom_protocols in turn.
+	repeated VoiceProtocol supported_protocols = 1;
+	// Protocol names used to fill the CUSTOM placeholders appear in supported_protocols.
+	repeated string custom_protocols = 2;
+
+	// Example. Client's preference: UDP_ChaCha, custom_x, UDP_OCB3, custom_y
+  //          Message it sends: supported_protocols = [UDP_ChaCha, CUSTOM, UDP_OCB3, CUSTOM]
+	//                            custom_protocols = ['custom_x', 'custom_y']
+}
+
 // Not used. Not even for tunneling UDP through TCP.
 message UDPTunnel {
 	// Not used.

--- a/src/mumble/Messages.cpp
+++ b/src/mumble/Messages.cpp
@@ -59,6 +59,26 @@
 		return; \
 	}
 
+/// This message is being received after the client send a Capabilities message with its preferred protocols inside.
+/// The server replies with a Capabilities message with only one protocol in it to indicate the protocol it has chosen.
+///
+void MainWindow::msgCapabilities(const MumbleProto::Capabilities &msg) {
+	if (msg.supported_protocols_size() == 0)
+		return;
+
+	ConnectionPtr c = g.sh->cConnection;
+
+	auto protocol_type = msg.supported_protocols(0);
+	switch (protocol_type) {
+		case MumbleProto::Capabilities_VoiceProtocol_UDP_OCB2:
+			c->vptVoiceProtocolType = VoiceProtocolType::UDP_OCB2;
+			c->initializeCipher();
+		case MumbleProto::Capabilities_VoiceProtocol_CUSTOM:
+		default:
+			break;
+	}
+}
+
 /// The authenticate message is being used by the client to send the authentication credentials to the server. Therefore the
 /// server won't send this message type to the client which is why this implementation does nothing.
 void MainWindow::msgAuthenticate(const MumbleProto::Authenticate &) {

--- a/src/mumble/ServerHandler.cpp
+++ b/src/mumble/ServerHandler.cpp
@@ -708,6 +708,14 @@ void ServerHandler::serverConnectionConnected() {
 
 	sendMessage(mpv);
 
+	// Set default cipher, in case the server doesn't support Capabilities message.
+	connection->vptVoiceProtocolType = VoiceProtocolType::UDP_OCB2;
+	connection->initializeCipher();
+	MumbleProto::Capabilities mpc;
+	mpc.add_supported_protocols(MumbleProto::Capabilities_VoiceProtocol_UDP_OCB2);
+
+	sendMessage(mpc);
+
 	MumbleProto::Authenticate mpa;
 	mpa.set_username(u8(qsUserName));
 	mpa.set_password(u8(qsPassword));

--- a/src/murmur/Meta.cpp
+++ b/src/murmur/Meta.cpp
@@ -282,6 +282,27 @@ void MetaParams::read(QString fname) {
 		}
 	}
 
+	QString qsVoiceProtocol = qsSettings->value("voiceProtocolPreference", QString()).toString();
+	if (! qsVoiceProtocol.isEmpty()) {
+#if QT_VERSION >= QT_VERSION_CHECK(5, 14, 0)
+		foreach(const QString &protocol_name, qsHost.split(',', Qt::SkipEmptyParts)) {
+#else
+		// Qt 5.14 introduced the Qt::SplitBehavior flags deprecating the QString fields
+		foreach(const QString &protocol_name, qsHost.split(',', QString::SkipEmptyParts)) {
+#endif
+			QString protocol_trimmed_lower = protocol_name.trimmed().toLower();
+			if (protocol_trimmed_lower == "udp_ocb2"){
+				qlAllowedVoiceProtocolTypes.append(VoiceProtocolType::UDP_OCB2);
+				qInfo("Meta: Add UDP_OCB2 into voice protocol preference list.");
+			}
+		}
+	} else {
+		// Fall back to default protocol
+		qlAllowedVoiceProtocolTypes.append(VoiceProtocolType::UDP_OCB2);
+		qInfo("Meta: No voice protocol preference set. Use UDP_OCB2 as default voice protocol.");
+	}
+
+
 	qsPassword = typeCheckedFromSettings("serverpassword", qsPassword);
 	usPort = static_cast<unsigned short>(typeCheckedFromSettings("port", static_cast<uint>(usPort)));
 	iTimeout = typeCheckedFromSettings("timeout", iTimeout);

--- a/src/murmur/Meta.h
+++ b/src/murmur/Meta.h
@@ -7,6 +7,7 @@
 #define MUMBLE_MURMUR_META_H_
 
 #include "Timer.h"
+#include "Connection.h"
 
 #ifdef Q_OS_WIN
 # include "win.h"
@@ -55,6 +56,8 @@ public:
 	QString qsWelcomeText;
 	bool bCertRequired;
 	bool bForceExternalAuth;
+
+	QList<VoiceProtocolType> qlAllowedVoiceProtocolTypes;
 
 	int iBanTries;
 	int iBanTimeframe;

--- a/src/murmur/Server.cpp
+++ b/src/murmur/Server.cpp
@@ -925,6 +925,9 @@ void Server::run() {
 bool Server::checkDecrypt(ServerUser *u, const char *encrypt, char *plain, unsigned int len) {
 	QMutexLocker l(&u->qmCrypt);
 
+	if (u->vptVoiceProtocolType == VoiceProtocolType::UNDEFINED)
+		return false;
+
 	if (u->csCrypt->isValid() && u->csCrypt->decrypt(reinterpret_cast<const unsigned char *>(encrypt), reinterpret_cast<unsigned char *>(plain), len))
 		return true;
 

--- a/src/murmur/Server.h
+++ b/src/murmur/Server.h
@@ -19,6 +19,7 @@
 #include "Timer.h"
 #include "HostAddress.h"
 #include "Ban.h"
+#include "Connection.h"
 
 #ifndef Q_MOC_RUN
 # include <boost/function.hpp>

--- a/src/murmur/ServerUser.h
+++ b/src/murmur/ServerUser.h
@@ -20,6 +20,8 @@
 #include <QtCore/QStringList>
 #include <QtCore/QElapsedTimer>
 
+#include <string>
+
 #ifdef Q_OS_WIN
 # include <winsock2.h>
 #else
@@ -138,6 +140,8 @@ class ServerUser : public Connection, public User {
 
 		QList<int> qlCodecs;
 		bool bOpus;
+
+		QList<VoiceProtocol> qlSupportedVoiceProtocols;
 
 		QStringList qslAccessTokens;
 


### PR DESCRIPTION
This PR is a continuation of #4238, implements the idea of #3918 and #4248.

See Mumble.proto for more details. Mumble doesn't support other voice protocol so far, so this message is intended to be used to negotiate the cipher type used in transportation. 

It is sent between Version and Authenticate message before the CryptState is sent from the server when handling the Authenticate message.

A config option "voiceProtocolPreference" is also added to allow the server administrator to specify the protocol allowed by the server. But currently the only protocol support is UDP_OCB2 so it is not really useful.

The comment and docstring are pretty much self-explanatory. But I will elaborate more on some lines by adding reviews.

