### PR TITLE
FEAT(client): Log a message if some change could not be saved due to missing certificate

### DIFF
--- a/src/mumble/MainWindow.cpp
+++ b/src/mumble/MainWindow.cpp
@@ -1674,38 +1674,50 @@ void MainWindow::on_qaUserMute_triggered() {
 
 void MainWindow::on_qaUserLocalMute_triggered() {
 	ClientUser *p = getContextMenuUser();
-	if (!p)
+	if (!p) {
 		return;
+	}
 
 	bool muted = qaUserLocalMute->isChecked();
 
 	p->setLocalMute(muted);
-	if (! p->qsHash.isEmpty())
+	if (! p->qsHash.isEmpty()) {
 		g.db->setLocalMuted(p->qsHash, muted);
+	} else {
+		logChangeNotPermanent(QObject::tr("Local Mute"), p);
+	}
 }
 
 void MainWindow::on_qaUserLocalIgnore_triggered() {
 	ClientUser *p = getContextMenuUser();
-	if (!p)
+	if (!p) {
 		return;
+	}
 
 	bool ignored = qaUserLocalIgnore->isChecked();
 
 	p->setLocalIgnore(ignored);
-	if (! p->qsHash.isEmpty())
+	if (! p->qsHash.isEmpty()) {
 		g.db->setLocalIgnored(p->qsHash, ignored);
+	} else {
+		logChangeNotPermanent(QObject::tr("Ignore Messages"), p);
+	}
 }
 
 void MainWindow::on_qaUserLocalIgnoreTTS_triggered() {
 	ClientUser *p = getContextMenuUser();
-	if (!p)
+	if (!p) {
 		return;
+	}
 
 	bool ignoredTTS = qaUserLocalIgnoreTTS->isChecked();
 
 	p->setLocalIgnoreTTS(ignoredTTS);
-	if (! p->qsHash.isEmpty())
+	if (! p->qsHash.isEmpty()) {
 		g.db->setLocalIgnoredTTS(p->qsHash, ignoredTTS);
+	} else {
+		logChangeNotPermanent(QObject::tr("Disable Text-To-Speech"), p);
+	}
 }
 
 void MainWindow::on_qaUserLocalVolume_triggered() {
@@ -3522,6 +3534,10 @@ QPair<QByteArray, QImage> MainWindow::openImageFile() {
 	retval.second = img;
 
 	return retval;
+}
+
+void MainWindow::logChangeNotPermanent(const QString &actionName, ClientUser * const p) const {
+	g.l->log(Log::Warning, QObject::tr("\"%1\" could not be saved permanently and is lost on restart because %2 does not have a certificate.").arg(actionName).arg(Log::formatClientUser(p, Log::Target)));
 }
 
 void MainWindow::destroyUserInformation() {

--- a/src/mumble/MainWindow.h
+++ b/src/mumble/MainWindow.h
@@ -329,6 +329,12 @@ class MainWindow : public QMainWindow, public MessageHandler, public Ui::MainWin
 		MUMBLE_MH_ALL
 #undef MUMBLE_MH_MSG
 		void removeContextAction(const MumbleProto::ContextActionModify &msg);
+		/// Logs a message that an action could not be saved permanently because
+		/// the user has no certificate and can't be reliably identified.
+		///
+		/// @param actionName  The name of the action that has been executed.
+		/// @param p  The user on which the action was performed.
+		void logChangeNotPermanent(const QString &actionName, ClientUser * const p) const;
 };
 
 #endif

--- a/src/mumble/UserLocalVolumeDialog.cpp
+++ b/src/mumble/UserLocalVolumeDialog.cpp
@@ -37,6 +37,7 @@
 #include "UserLocalVolumeDialog.h"
 #include "ClientUser.h"
 #include "Database.h"
+#include "MainWindow.h"
 
 #include <QtGui/QCloseEvent>
 #include <QtWidgets/QPushButton>
@@ -99,8 +100,12 @@ void UserLocalVolumeDialog::on_qbbUserLocalVolume_clicked(QAbstractButton *butto
 	}
 	if (button == qbbUserLocalVolume->button(QDialogButtonBox::Ok)) {
 		ClientUser *user = ClientUser::get(m_clientSession);
-		if (user && !user->qsHash.isEmpty()) {
-			g.db->setUserLocalVolume(user->qsHash, user->fLocalVolume);
+		if (user) {
+			if (!user->qsHash.isEmpty()) {
+			    g.db->setUserLocalVolume(user->qsHash, user->fLocalVolume);
+			} else {
+			    g.mw->logChangeNotPermanent(QObject::tr("Local Volume Adjustment..."), user);
+			}
 		}
 		UserLocalVolumeDialog::close();
 	}

--- a/src/mumble/mumble_en.ts
+++ b/src/mumble/mumble_en.ts
@@ -6961,6 +6961,26 @@ Multichannel echo cancellation requires more CPU, so you should try mixed first<
 See &lt;a href=&quot;https://wiki.mumble.info/wiki/Installing_Mumble&quot;&gt;the Mumble wiki&lt;/a&gt; for what alternatives there are.&lt;/p&gt;</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Local Mute</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Ignore Messages</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Disable Text-To-Speech</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&quot;%1&quot; could not be saved permanently and is lost on restart because %2 does not have a certificate.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Local Volume Adjustment...</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>RichTextEditor</name>


### PR DESCRIPTION
Log a message if a change like local muting of a user could not be saved because this user does not have a certificate.

The displayed message is:

> This change could not be saved permanently and is lost on restart because Username does not have a certificate.