### PR TITLE
FIX(text-chat): Fix crash on TextMessage from server

### DIFF
--- a/src/mumble/Messages.cpp
+++ b/src/mumble/Messages.cpp
@@ -912,7 +912,7 @@ void MainWindow::msgTextMessage(const MumbleProto::TextMessage &msg) {
 	         tr("Message from %1").arg(plainName),
 	         false,
 	         overrideTTS.isNull() ? QString() : overrideTTS,
-	         pSrc->bLocalIgnoreTTS);
+	         pSrc ? pSrc->bLocalIgnoreTTS : false);
 }
 
 /// This message is being received when the server informs the client about the access control list (ACL) for


### PR DESCRIPTION
1a4d134a35b656113684b8070a74bfd2474304a1 (part of #4287) introduced the ability to
disable TTS for specific users. The change however didn't account for
messages that are sent from the server. In these cases pSrc is nullptr
but that commit introduced code that access it without checking for
null. This lead to a SegFault as soon as a text message from the server
is received.

This commit fixes this by simply adding a null-check before accessing
the variable.