### PR TITLE
 FIX(tts): OmitScope/OmitAuthor no longer reads HTML-formatted message

### DIFF
--- a/src/mumble/mumble_en.ts
+++ b/src/mumble/mumble_en.ts
@@ -5455,22 +5455,6 @@ Otherwise abort and check your certificate and username.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>(Tree) </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>(Channel) </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>(Private) </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>%2%1: %3</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Failed to load Opus, it will not be available for audio encoding/decoding.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6048,6 +6032,26 @@ Valid options are:
     </message>
     <message>
         <source>Silently disables Text-To-Speech for all text messages from the user.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Tree</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Channel</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Private</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>%1: %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>(%1) %2</source>
         <translation type="unfinished"></translation>
     </message>
 </context>


### PR DESCRIPTION
The new features "Omit Message Scope" and "Omit Message Author" where
somewhat broken.
The problems are adressed by transforming the message from HTML to
plaintext and creating a new TTS string that either contains no prefix
or just the scope or the author.

Fixes #4309