### PR TITLE
Allow disabling the public-server-list

### DIFF
--- a/src/mumble/ConnectDialog.cpp
+++ b/src/mumble/ConnectDialog.cpp
@@ -110,7 +110,7 @@ ServerView::ServerView(QWidget *p) : QTreeWidget(p) {
 	siLAN = nullptr;
 #endif
 
-	if (!g.s.disablePublicList) {
+	if (!g.s.bDisablePublicList) {
 		siPublic = new ServerItem(tr("Public Internet"), ServerItem::PublicType);
 		siPublic->setChildIndicatorPolicy(QTreeWidgetItem::ShowIndicator);
 		addTopLevelItem(siPublic);
@@ -936,7 +936,7 @@ ConnectDialog::ConnectDialog(QWidget *p, bool autoconnect) : QDialog(p), bAutoCo
 
 	qtwServers->setItemDelegate(new ServerViewDelegate());
 
-	if (!g.s.disablePublicList) {
+	if (!g.s.bDisablePublicList) {
 		const QIcon qiFlag = ServerItem::loadIcon(QLatin1String("skin:categories/applications-internet.svg"));
 		// Add continents and 'Unknown' to the location combobox
 		qcbSearchLocation->addItem(qiFlag, tr("All"),           QLatin1String("all"));
@@ -1279,7 +1279,7 @@ void ConnectDialog::on_qtwServers_itemExpanded(QTreeWidgetItem *item) {
 			                                   QMessageBox::Yes|QMessageBox::No);
 			g.s.bPingServersDialogViewed = true;
 			if (result == QMessageBox::No) {
-				g.s.disablePublicList = true;
+				g.s.bDisablePublicList = true;
 				item->setExpanded(false);
 				item->setHidden(true);
 				return;
@@ -1519,8 +1519,10 @@ void ConnectDialog::timeTick() {
 }
 
 void ConnectDialog::filterPublicServerList() const {
-    foreach(ServerItem * const si, qtwServers->siPublic->qlChildren) {
-		filterServer(si);
+	if (!g.s.bDisablePublicList) {
+		foreach(ServerItem * const si, qtwServers->siPublic->qlChildren) {
+			filterServer(si);
+		}
 	}
 }
 

--- a/src/mumble/NetworkConfig.cpp
+++ b/src/mumble/NetworkConfig.cpp
@@ -56,6 +56,7 @@ void NetworkConfig::load(const Settings &r) {
 	loadCheckBox(qcbQoS, s.bQoS);
 	loadCheckBox(qcbAutoReconnect, s.bReconnect);
 	loadCheckBox(qcbAutoConnect, s.bAutoConnect);
+	loadCheckBox(qcbDisablePublicList, s.bDisablePublicList);
 	loadCheckBox(qcbSuppressIdentity, s.bSuppressIdentity);
 	loadComboBox(qcbType, s.ptProxyType);
 
@@ -84,6 +85,7 @@ void NetworkConfig::save() const {
 	s.bQoS = qcbQoS->isChecked();
 	s.bReconnect = qcbAutoReconnect->isChecked();
 	s.bAutoConnect = qcbAutoConnect->isChecked();
+	s.bDisablePublicList = qcbDisablePublicList->isChecked();
 	s.bSuppressIdentity = qcbSuppressIdentity->isChecked();
 	s.bHideOS = qcbHideOS->isChecked();
 

--- a/src/mumble/NetworkConfig.ui
+++ b/src/mumble/NetworkConfig.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>576</width>
-    <height>567</height>
+    <height>572</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -337,6 +337,19 @@ Prevents the client from sending potentially identifying information about the o
         </property>
         <property name="text">
          <string>Submit anonymous statistics</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QCheckBox" name="qcbDisablePublicList">
+        <property name="enabled">
+         <bool>true</bool>
+        </property>
+        <property name="toolTip">
+         <string>When toggled this hides the public server list from the connect dialog</string>
+        </property>
+        <property name="text">
+         <string>Hide public server list</string>
         </property>
        </widget>
       </item>

--- a/src/mumble/Settings.cpp
+++ b/src/mumble/Settings.cpp
@@ -415,6 +415,7 @@ Settings::Settings() {
 	bQoS = true;
 	bReconnect = true;
 	bAutoConnect = false;
+	bDisablePublicList = false;
 	ptProxyType = NoProxy;
 	usProxyPort = 0;
 	iMaxInFlightTCPPings = 4;
@@ -440,7 +441,6 @@ Settings::Settings() {
 
 	// Special configuration options not exposed to UI
 	bDisableCELT = false;
-	disablePublicList = false;
 	disableConnectDialogEditing = false;
 	bPingServersDialogViewed = false;
 
@@ -828,6 +828,7 @@ void Settings::load(QSettings* settings_ptr) {
 	SAVELOAD(iMaxLogBlocks, "ui/MaxLogBlocks");
 	SAVELOAD(bLog24HourClock, "ui/24HourClock");
 	SAVELOAD(iChatMessageMargins, "ui/ChatMessageMargins");
+	SAVELOAD(bDisablePublicList, "ui/disablepubliclist");
 
 	// TalkingUI
 	SAVELOAD(bShowTalkingUI, "ui/showTalkingUI");
@@ -855,7 +856,6 @@ void Settings::load(QSettings* settings_ptr) {
 
 	// Special configuration options not exposed to UI
 	SAVELOAD(bDisableCELT, "audio/disablecelt");
-	SAVELOAD(disablePublicList, "ui/disablepubliclist");
 	SAVELOAD(disableConnectDialogEditing, "ui/disableconnectdialogediting");
 	SAVELOAD(bPingServersDialogViewed, "consent/pingserversdialogviewed");
 
@@ -1180,6 +1180,7 @@ void Settings::save() {
 	SAVELOAD(iMaxLogBlocks, "ui/MaxLogBlocks");
 	SAVELOAD(bLog24HourClock, "ui/24HourClock");
 	SAVELOAD(iChatMessageMargins, "ui/ChatMessageMargins");
+	SAVELOAD(bDisablePublicList, "ui/disablepubliclist");
 
 	// TalkingUI
 	SAVELOAD(bShowTalkingUI, "ui/showTalkingUI");
@@ -1207,7 +1208,6 @@ void Settings::save() {
 
 	// Special configuration options not exposed to UI
 	SAVELOAD(bDisableCELT, "audio/disablecelt");
-	SAVELOAD(disablePublicList, "ui/disablepubliclist");
 	SAVELOAD(disableConnectDialogEditing, "ui/disableconnectdialogediting");
 	SAVELOAD(bPingServersDialogViewed, "consent/pingserversdialogviewed");
 

--- a/src/mumble/Settings.h
+++ b/src/mumble/Settings.h
@@ -345,6 +345,8 @@ struct Settings {
 	bool bReconnect;
 	bool bAutoConnect;
 	bool bQoS;
+	/// Disables the "Public Internet" section in the connect dialog if set.
+	bool bDisablePublicList;
 	ProxyType ptProxyType;
 	QString qsProxyHost, qsProxyUsername, qsProxyPassword;
 	unsigned short usProxyPort;
@@ -416,9 +418,6 @@ struct Settings {
 	
 	/// Codec kill-switch
 	bool bDisableCELT;
-	
-	/// Disables the "Public Internet" section in the connect dialog if set.
-	bool disablePublicList;
 	
 	/// Removes the add and edit options in the connect dialog if set.
 	bool disableConnectDialogEditing;

--- a/src/mumble/mumble_en.ts
+++ b/src/mumble/mumble_en.ts
@@ -6362,6 +6362,14 @@ Prevents the client from sending potentially identifying information about the o
         <source>Do not send OS information to Mumble servers and web servers</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>When toggled this hides the public server list from the connect dialog</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hide public server list</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>Overlay</name>


### PR DESCRIPTION
This implements #4070 and makes it possible to hide the public-server-list from the connect dialog.
The save location was left under ui for backwards compatibility.

This is a follow-up on #4305