### PR TITLE
FIX(talking-ui): Make TalkingUI float wit tiling WMs

### DIFF
--- a/src/mumble/TalkingUI.cpp
+++ b/src/mumble/TalkingUI.cpp
@@ -51,7 +51,12 @@ void TalkingUI::setupUI() {
 	setWindowTitle(QObject::tr("Talking UI"));
 
 	setAttribute(Qt::WA_ShowWithoutActivating);
-	setWindowFlags(Qt::Window | Qt::WindowStaysOnTopHint);
+	setWindowFlags(Qt::Dialog | Qt::WindowStaysOnTopHint);
+
+	// Hide the "?" (context help) button in the title bar of the widget as we don't want
+	// that due to it taking valuable screen space so that the title can't be displayed
+	// properly and as the TalkingUI doesn't provide context help anyways, this is not a big loss.
+	setWindowFlags(windowFlags() & ~Qt::WindowContextHelpButtonHint);
 
 	connect(g.mw->qtvUsers->selectionModel(), &QItemSelectionModel::currentChanged, this, &TalkingUI::on_mainWindowSelectionChanged);
 }


### PR DESCRIPTION
With tiling window managers (e.g. i3) the TalkingUI was seen as any
other regular window and thus it was assigned its own screen space.
This is however unfitting for the TalkingUI as it is meant to take the
least amount of possible screen space.

The solution is thus to mark the TalkingUI as floatable in order to
bypass the WM's tiling logic. In order to do so, the TalkingUI is now
marked as a dialog. Dialogs however also show the "?" button in the
title bar by default, which had to explicitly be disabled as it is
absolutely useless for the TalkingUI anyways.

Fixes #4324