### PR TITLE
FEAT(talking-ui): Show selected status icons in TalkingUI

### DIFF
--- a/src/mumble/Messages.cpp
+++ b/src/mumble/Messages.cpp
@@ -365,6 +365,7 @@ void MainWindow::msgUserState(const MumbleProto::UserState &msg) {
 		pDst = pmModel->addUser(msg.session(), u8(msg.name()));
 
 		connect(pDst, &ClientUser::talkingStateChanged, g.talkingUI, &TalkingUI::on_talkingStateChanged);
+		connect(pDst, &ClientUser::muteDeafStateChanged, g.talkingUI, &TalkingUI::on_muteDeafStateChanged);
 
 		if (channel) {
 			pmModel->moveUser(pDst, channel);

--- a/src/mumble/TalkingUI.h
+++ b/src/mumble/TalkingUI.h
@@ -22,11 +22,14 @@ class Channel;
 class ClientUser;
 
 /// Smaller auxilary class for holding together two labels representing
-/// the entry for a specific user in the TalkingUI<
+/// the entry for a specific user in the TalkingUI
 struct Entry {
-	QLabel *icon;
+	QLabel *talkingIcon;
 	QLabel *name;
 	QWidget *background;
+	/// A label that'll show a user's status icons. If no icons are displayed,
+	/// this may be null!
+	QLabel *statusIcons;
 	unsigned int userSession;
 	Settings::TalkState talkingState;
 };
@@ -56,6 +59,17 @@ class TalkingUI : public QWidget {
 		QIcon m_shoutingIcon;
 		/// The icon for a whispering user
 		QIcon m_whisperingIcon;
+
+		/// The icon for a muted user
+		QIcon m_muteIcon;
+		/// The icon for a deafened user
+		QIcon m_deafIcon;
+		/// The icon for a locally muted user
+		QIcon m_localMuteIcon;
+		/// The icon for the local user if muted
+		QIcon m_selfMuteIcon;
+		/// The icon for the local user if deafened
+		QIcon m_selfDeafIcon;
 
 		/// The current line height of an entry in the TalkingUI
 		int m_currentLineHeight;
@@ -93,7 +107,12 @@ class TalkingUI : public QWidget {
 		/// Sets the icon for the given entry based on its TalkingState
 		///
 		/// @param entry A reference to the Entry to process
-		void setIcon(Entry &entry) const;
+		void setTalkingIcon(Entry &entry) const;
+
+		/// Updates the user's status icons (reflecting e.g. its mut-state)
+		///
+		/// @param user A pointer to the user that shall be processed
+		void updateStatusIcons(const ClientUser *user);
 
 		/// Set the current selection
 		///
@@ -117,6 +136,7 @@ class TalkingUI : public QWidget {
 		void on_channelChanged(QObject *user);
 		void on_settingsChanged();
 		void on_clientDisconnected(unsigned int userSession);
+		void on_muteDeafStateChanged();
 };
 
 #endif // MUMBLE_MUMBLE_TALKINGUI_H_


### PR DESCRIPTION
The icons for (local/self) muting and (self) deafening of a user are now
also displayed in the TalkingUI. The used icons are the same as in the
MainWindow.

---

Screenshot:
![Mumble_TalkingUI_Icons](https://user-images.githubusercontent.com/12751591/86355389-e4d5e600-bc6a-11ea-9851-230aa977c903.png)