### PR TITLE
FEAT(server): Allow loading welcome text from file

### DIFF
--- a/scripts/murmur.ini
+++ b/scripts/murmur.ini
@@ -116,6 +116,11 @@ icesecretwrite=
 ; no welcome message will be sent to clients.
 welcometext="<br />Welcome to this server running <b>Murmur</b>.<br />Enjoy your stay!<br />"
 
+; The welcometext can also be read from an external file which might be useful
+; if you want to specify a rather lengthy text. If a value for welcometext is
+; set, the welcometextfile will not be read.
+;welcometextfile=
+
 ; Port to bind TCP and UDP sockets to.
 port=64738
 

--- a/src/murmur/Meta.cpp
+++ b/src/murmur/Meta.cpp
@@ -63,6 +63,7 @@ MetaParams::MetaParams() {
 	iDefaultChan = 0;
 	bRememberChan = true;
 	qsWelcomeText = QString();
+	qsWelcomeTextFile = QString();
 	qsDatabase = QString();
 	iSQLiteWAL = 0;
 	iDBPort = 0;
@@ -298,6 +299,7 @@ void MetaParams::read(QString fname) {
 	iMaxListenersPerChannel = typeCheckedFromSettings("listenersperchannel", iMaxListenersPerChannel);
 	iMaxListenerProxiesPerUser = typeCheckedFromSettings("listenersperuser", iMaxListenerProxiesPerUser);
 	qsWelcomeText = typeCheckedFromSettings("welcometext", qsWelcomeText);
+	qsWelcomeTextFile = typeCheckedFromSettings("welcometextfile", qsWelcomeTextFile);
 	bCertRequired = typeCheckedFromSettings("certrequired", bCertRequired);
 	bForceExternalAuth = typeCheckedFromSettings("forceExternalAuth", bForceExternalAuth);
 
@@ -423,6 +425,7 @@ void MetaParams::read(QString fname) {
 	qmConfig.insert(QLatin1String("defaultchannel"),QString::number(iDefaultChan));
 	qmConfig.insert(QLatin1String("rememberchannel"),bRememberChan ? QLatin1String("true") : QLatin1String("false"));
 	qmConfig.insert(QLatin1String("welcometext"),qsWelcomeText);
+	qmConfig.insert(QLatin1String("welcometextfile"),qsWelcomeTextFile);
 	qmConfig.insert(QLatin1String("registername"),qsRegName);
 	qmConfig.insert(QLatin1String("registerpassword"),qsRegPassword);
 	qmConfig.insert(QLatin1String("registerhostname"),qsRegHost);

--- a/src/murmur/Meta.h
+++ b/src/murmur/Meta.h
@@ -53,6 +53,7 @@ public:
 	bool bAllowHTML;
 	QString qsPassword;
 	QString qsWelcomeText;
+	QString qsWelcomeTextFile;
 	bool bCertRequired;
 	bool bForceExternalAuth;
 

--- a/src/murmur/Server.cpp
+++ b/src/murmur/Server.cpp
@@ -395,6 +395,7 @@ void Server::readParams() {
 	iDefaultChan = Meta::mp.iDefaultChan;
 	bRememberChan = Meta::mp.bRememberChan;
 	qsWelcomeText = Meta::mp.qsWelcomeText;
+	qsWelcomeTextFile = Meta::mp.qsWelcomeTextFile;
 	qlBind = Meta::mp.qlBind;
 	qsRegName = Meta::mp.qsRegName;
 	qsRegPassword = Meta::mp.qsRegPassword;
@@ -460,6 +461,22 @@ void Server::readParams() {
 	iDefaultChan = getConf("defaultchannel", iDefaultChan).toInt();
 	bRememberChan = getConf("rememberchannel", bRememberChan).toBool();
 	qsWelcomeText = getConf("welcometext", qsWelcomeText).toString();
+	qsWelcomeTextFile = getConf("welcometextfile", qsWelcomeTextFile).toString();
+
+	if (!qsWelcomeTextFile.isEmpty()) {
+		if (qsWelcomeText.isEmpty()) {
+			QFile f(qsWelcomeTextFile);
+			if (f.open(QFile::ReadOnly | QFile::Text)) {
+				QTextStream in(&f);
+				qsWelcomeText = in.readAll();
+				f.close();
+			} else {
+				log(QString("Failed to open welcome text file %1").arg(qsWelcomeTextFile));
+			}
+		} else {
+			log(QString("Ignoring welcometextfile %1 because welcometext is defined").arg(qsWelcomeTextFile));
+		}
+	}
 
 	qsRegName = getConf("registername", qsRegName).toString();
 	qsRegPassword = getConf("registerpassword", qsRegPassword).toString();

--- a/src/murmur/Server.h
+++ b/src/murmur/Server.h
@@ -117,6 +117,7 @@ class Server : public QThread {
 		bool bAllowHTML;
 		QString qsPassword;
 		QString qsWelcomeText;
+		QString qsWelcomeTextFile;
 		bool bCertRequired;
 		bool bForceExternalAuth;
 


### PR DESCRIPTION
This allows specifying welcometextfile in murmur.ini. If no welcometext
is set in the ini-file, the welcome text is loaded from the file.

Fixes #3723