### PR TITLE
CI(azure): Fix brew-error for installed packages

### DIFF
--- a/scripts/azure-pipelines/install-environment_macos.bash
+++ b/scripts/azure-pipelines/install-environment_macos.bash
@@ -6,4 +6,15 @@
 # Mumble source tree or at <https://www.mumble.info/LICENSE>.
 
 brew update
-brew install pkg-config qt5 boost libogg libvorbis flac libsndfile protobuf openssl ice
+
+# As brew will set a non-zero exit status if one of the packages it is asked to install
+# is installed already. Thus we have to iterate through every single one and check if it
+# is installed first.
+for pkg in pkg-config qt5 boost libogg libvorbis flac libsndfile protobuf openssl ice; do
+	if brew ls --versions "$pkg" > /dev/null; then
+		echo "Skipping installation of $pkg as it is already installed"
+	else
+		brew install "$pkg"
+	fi
+done
+


### PR DESCRIPTION
If brew is asked to install a package that is already installed, it will
set a non-zero exit status that causes the CI to abort and fail.

The fix for that is to explicitly check every package for whether it is
already installed and only if they are not, ask brew to install them.

This fix is the same that has been applied in
3e0c5065d21dfbd1e56b91f81c28fccdbadad794