### PR TITLE
FEAT(manual-plugin): Show speaker's position

### DIFF
--- a/src/mumble/AudioOutput.h
+++ b/src/mumble/AudioOutput.h
@@ -10,6 +10,8 @@
 #include <QtCore/QObject>
 #include <QtCore/QThread>
 
+#include "ManualPlugin.h"
+
 // AudioOutput depends on User being valid. This means it's important
 // to removeBuffer from here BEFORE MainWindow gets any UserLeft
 // messages. Any decendant user should feel free to remove unused
@@ -89,6 +91,8 @@ class AudioOutput : public QThread {
 		unsigned int iBufferSize = 0;
 		QReadWriteLock qrwlOutputs;
 		QMultiHash<const ClientUser *, AudioOutputUser *> qmOutputs;
+
+		QHash<unsigned int, Position2D> positions;
 
 		virtual void removeBuffer(AudioOutputUser *);
 		void initializeMixer(const unsigned int *chanmasks, bool forceheadphone = false);

--- a/src/mumble/ManualPlugin.ui
+++ b/src/mumble/ManualPlugin.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>631</width>
-    <height>436</height>
+    <width>731</width>
+    <height>528</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -72,16 +72,6 @@
         </item>
         <item>
          <layout class="QGridLayout" name="gridLayout_2">
-          <item row="1" column="0">
-           <widget class="QLabel" name="qlX">
-            <property name="text">
-             <string>X</string>
-            </property>
-            <property name="alignment">
-             <set>Qt::AlignCenter</set>
-            </property>
-           </widget>
-          </item>
           <item row="1" column="1">
            <widget class="QLabel" name="qlY">
             <property name="text">
@@ -92,13 +82,10 @@
             </property>
            </widget>
           </item>
-          <item row="1" column="2">
-           <widget class="QLabel" name="qlZ">
-            <property name="text">
-             <string>Z</string>
-            </property>
-            <property name="alignment">
-             <set>Qt::AlignCenter</set>
+          <item row="2" column="2">
+           <widget class="QDoubleSpinBox" name="qdsbZ">
+            <property name="suffix">
+             <string>m</string>
             </property>
            </widget>
           </item>
@@ -112,15 +99,28 @@
             </property>
            </widget>
           </item>
-          <item row="2" column="1">
-           <widget class="QDoubleSpinBox" name="qdsbY">
-            <property name="suffix">
-             <string>m</string>
+          <item row="1" column="2">
+           <widget class="QLabel" name="qlZ">
+            <property name="text">
+             <string>Z</string>
+            </property>
+            <property name="alignment">
+             <set>Qt::AlignCenter</set>
             </property>
            </widget>
           </item>
-          <item row="2" column="2">
-           <widget class="QDoubleSpinBox" name="qdsbZ">
+          <item row="1" column="0">
+           <widget class="QLabel" name="qlX">
+            <property name="text">
+             <string>X</string>
+            </property>
+            <property name="alignment">
+             <set>Qt::AlignCenter</set>
+            </property>
+           </widget>
+          </item>
+          <item row="2" column="1">
+           <widget class="QDoubleSpinBox" name="qdsbY">
             <property name="suffix">
              <string>m</string>
             </property>
@@ -133,6 +133,38 @@
      </item>
      <item>
       <layout class="QVBoxLayout" name="qhlVertical">
+       <item>
+        <widget class="QGroupBox" name="groupBox">
+         <property name="title">
+          <string>Display</string>
+         </property>
+         <layout class="QFormLayout" name="formLayout">
+          <item row="0" column="0">
+           <widget class="QLabel" name="qlSilentUserDisplaytime">
+            <property name="toolTip">
+             <string>How long silent user's positions should stay marked after they have stopped talking (in seconds).</string>
+            </property>
+            <property name="text">
+             <string>Silent user displaytime:</string>
+            </property>
+           </widget>
+          </item>
+          <item row="0" column="1">
+           <widget class="QSpinBox" name="qsbSilentUserDisplaytime">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+            <property name="toolTip">
+             <string>How long silent user's positions should stay marked after they have stopped talking (in seconds).</string>
+            </property>
+           </widget>
+          </item>
+         </layout>
+        </widget>
+       </item>
        <item>
         <widget class="QGroupBox" name="qgbHeading">
          <property name="sizePolicy">

--- a/src/mumble/Settings.cpp
+++ b/src/mumble/Settings.cpp
@@ -474,6 +474,8 @@ Settings::Settings() {
 	qsTalkingUI_ChannelSeparator = QLatin1String("/");
 	qsTalkingUI_AbbreviationReplacement = QLatin1String("...");
 
+	manualPlugin_silentUserDisplaytime = 1;
+
 	bShortcutEnable = true;
 	bSuppressMacEventTapWarning = false;
 	bEnableEvdev = false;
@@ -843,6 +845,8 @@ void Settings::load(QSettings* settings_ptr) {
 	SAVELOAD(qsTalkingUI_ChannelSeparator, "ui/talkingUI_ChannelSeparator");
 	SAVELOAD(qsTalkingUI_AbbreviationReplacement, "ui/talkingUI_AbbreviationReplacement");
 
+	SAVELOAD(manualPlugin_silentUserDisplaytime, "ui/manualPlugin_silentUserDisplaytime");
+
 	// PTT Button window
 	SAVELOAD(bShowPTTButtonWindow, "ui/showpttbuttonwindow");
 	SAVELOAD(qbaPTTButtonWindowGeometry, "ui/pttbuttonwindowgeometry");
@@ -1194,6 +1198,8 @@ void Settings::save() {
 	SAVELOAD(iTalkingUI_PostfixCharCount, "ui/talkingUI_PostfixCharCount");
 	SAVELOAD(qsTalkingUI_ChannelSeparator, "ui/talkingUI_ChannelSeparator");
 	SAVELOAD(qsTalkingUI_AbbreviationReplacement, "ui/talkingUI_AbbreviationReplacement");
+
+	SAVELOAD(manualPlugin_silentUserDisplaytime, "ui/manualPlugin_silentUserDisplaytime");
 
 	// PTT Button window
 	SAVELOAD(bShowPTTButtonWindow, "ui/showpttbuttonwindow");

--- a/src/mumble/Settings.h
+++ b/src/mumble/Settings.h
@@ -292,6 +292,8 @@ struct Settings {
 	QString qsTalkingUI_ChannelSeparator;
 	QString qsTalkingUI_AbbreviationReplacement;
 
+	int manualPlugin_silentUserDisplaytime;
+
 	QMap<int, QString> qmMessageSounds;
 	QMap<int, quint32> qmMessages;
 

--- a/src/mumble/mumble_en.ts
+++ b/src/mumble/mumble_en.ts
@@ -6161,6 +6161,18 @@ Valid options are:
         <source>Activate</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Display</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>How long silent user&apos;s positions should stay marked after they have stopped talking (in seconds).</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Silent user displaytime:</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>NetworkConfig</name>


### PR DESCRIPTION
With this change the positions of other speakers are also displayed in
the UI of the ManualPlugin (next to your own position) as red dots. This
allows for better understanding of the positional audio feature.

It is also possible to specify a time for these dots to persist even if
the corresponding speaker has stopped talking. In this time the
respective dot will start to fade out until it gets removed completely.

This does not show the names of the associated speakers in order to not
clutter the UI too much. If this information is needed, the TalkingUI
can be opened alongside the ManualPlugin to get an overview of who's
currently talking.

----

Screenshot:
![Mumble_ManualPlugin_SpeakerPositions](https://user-images.githubusercontent.com/12751591/87049922-d43ee600-c1fd-11ea-87a2-fbcde9e4bf18.png)
