### PR TITLE
FIX(shortcuts-ui): Clear selection after remove

### DIFF
--- a/src/mumble/GlobalShortcut.cpp
+++ b/src/mumble/GlobalShortcut.cpp
@@ -681,6 +681,12 @@ void GlobalShortcutConfig::on_qpbRemove_clicked(bool) {
 	int idx = qtwShortcuts->indexOfTopLevelItem(qtwi);
 	delete qtwi;
 	qlShortcuts.removeAt(idx);
+
+	// Clear the selected item. If we don't do this, the next shortcut in the list will be
+	// automatically selected. This allows for the user to accidentally hit remove a second
+	// time (as the mouse is over the remove button at this point already) leading to
+	// another shortcut being deleted accidentally.
+	qtwShortcuts->setCurrentItem(nullptr);
 }
 
 void GlobalShortcutConfig::on_qtwShortcuts_currentItemChanged(QTreeWidgetItem *item, QTreeWidgetItem *) {


### PR DESCRIPTION
Right now after having removed a shortcut from the UI, the next shortcut
in the list is selected automatically. This could cause the user to
accidentally delete this next shortcut by accident as the mouse is
hovering over the remove button anyways.

This change makes mass-removing of shortcuts a bit tedious but I don't
think that this is a common thing to do. Given that you can't undo the
deletion of a shortcut, we should better be safe than sorry with this.