### PR TITLE
FIX(translation): Make "Ignore"-string translatable

### DIFF
--- a/src/mumble/ConnectDialogEdit.ui
+++ b/src/mumble/ConnectDialogEdit.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>430</width>
-    <height>272</height>
+    <height>356</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -94,7 +94,7 @@
             </sizepolicy>
            </property>
            <property name="text">
-            <string notr="true">&amp;Ignore</string>
+            <string>&amp;Ignore</string>
            </property>
           </widget>
          </item>

--- a/src/mumble/mumble_en.ts
+++ b/src/mumble/mumble_en.ts
@@ -3095,6 +3095,10 @@ Label of the server. This is what the server will be named like in your server l
         <source>&amp;Fill</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>&amp;Ignore</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>CoreAudioSystem</name>


### PR DESCRIPTION
For some reason the "Ignore" String in the ConnectDialogEdit was not
marked as translatable. This is fixed by this commit.

Fixes #4359