### PR TITLE
FIX(client): Always run Disconnected-EH on exit

### DIFF
--- a/src/mumble/MainWindow.cpp
+++ b/src/mumble/MainWindow.cpp
@@ -475,11 +475,6 @@ void MainWindow::closeEvent(QCloseEvent *e) {
 	}
 	sh.reset();
 #endif
-	// Save ChannelListeners (has to be done before resetting g.uiSession
-	ChannelListener::saveToDB();
-
-	g.uiSession = 0;
-	g.pPermissions = ChanACL::None;
 
 	if (g.s.bMinimalView) {
 		g.s.qbaMinimalViewGeometry = saveGeometry();


### PR DESCRIPTION
MainWindow::serverDisconnected did not always get called when
terminating Mumble normally (not by pressing Ctrl+C). The reason for
that was that 2-fold:
a) There was a race between the main thread and the ServerHandler
thread. If the ServerHandler did not exit fast enough, the disconnect
event it emitted wouldn't reach the main thread in time to be processed
before the application exits
b) The main thread didn't make sure that all events have been processed
before actually shutting down and starting deleting objects.

This is solved now by first waiting for the ServerHandler thread to exit
before proceeding the shutdown process. In order to never run in the
situation in which the main thread won't exit because the ServerHandler
got stuck somehow, a hard limit of 2 seconds was set.

After the ServerHandler has exited, the main thread will ask Qt to
process all pending events before starting to do the cleanup (deleting
objects).

Due to the disconnect EH now reliably being called, it is no longer
necessary to duplicate actions in the EH and in the shutdown process
(e.g. save ChannelListeners or saving server-specific shortcuts). Thus
these are now only performed in the disconnect EH.