### PR TITLE
CI(azure-pipelines): use our own macOS builder for releases

### DIFF
--- a/.ci/azure-pipelines/main-pr.yml
+++ b/.ci/azure-pipelines/main-pr.yml
@@ -24,6 +24,8 @@ jobs:
       MUMBLE_ENVIRONMENT_VERSION: 'macos-static-1.4.x-2020-05-27-ecb3c64-1151'
     steps:
     - template: steps_macos.yml
+      parameters:
+        installEnvironment: true
   - job: Translations
     pool:
       vmImage: 'ubuntu-latest'

--- a/.ci/azure-pipelines/main.yml
+++ b/.ci/azure-pipelines/main.yml
@@ -19,8 +19,11 @@ jobs:
     - template: steps_linux.yml
   - job: macOS
     pool:
-      vmImage: 'macOS-latest'
+      name: "Default"
+      demands:
+      - agent.os -equals Darwin
     variables:
-      MUMBLE_ENVIRONMENT_VERSION: 'macos-static-1.4.x-2020-05-27-ecb3c64-1151'
+      MUMBLE_ENVIRONMENT_STORE: '~/MumbleBuild'
+      MUMBLE_ENVIRONMENT_VERSION: 'latest-1.4.x'
     steps:
     - template: steps_macos.yml

--- a/.ci/azure-pipelines/steps_macos.yml
+++ b/.ci/azure-pipelines/steps_macos.yml
@@ -1,9 +1,16 @@
+parameters:
+- name: installEnvironment
+  type: boolean
+  default: false
+
 steps:
   - script: git submodule --quiet update --init --recursive
     displayName: 'Fetch submodules'
-  - template: task-environment-cache.yml
-  - script: .ci/azure-pipelines/install-environment_macos.bash
-    displayName: 'Install build environment'
+  - ${{if eq(parameters.installEnvironment, true)}}:
+    - template: task-environment-cache.yml
+  - ${{if eq(parameters.installEnvironment, true)}}:
+    - script: .ci/azure-pipelines/install-environment_macos.bash
+      displayName: 'Install build environment'
   - script: .ci/azure-pipelines/build_macos.bash
     displayName: 'Build'
   - template: task-publish-artifacts.yml


### PR DESCRIPTION
[MacStadium](https://www.macstadium.com) kindly provided us an hosted 2012 Mac mini for free last year.

Until now we only used it for testing and to build the vcpkg environment, waiting for the CMake project to be merged.

Now that everything is in place, we can use it for CI and to release builds.