### PR TITLE
 FEAT(client): Allow specifying config file via commandline switch 

### DIFF
--- a/src/mumble/Database.h
+++ b/src/mumble/Database.h
@@ -25,6 +25,10 @@ class Database : public QObject {
 		Q_DISABLE_COPY(Database)
 
 		QSqlDatabase db;
+		/// This function is called when no database location is configured
+		/// in the config file. It tries to find an existing database file and
+		/// creates a new one if none was found.
+		bool findOrCreateDatabase();
 	public:
 		Database(const QString &dbname);
 		~Database() Q_DECL_OVERRIDE;

--- a/src/mumble/Global.h
+++ b/src/mumble/Global.h
@@ -108,7 +108,7 @@ public:
 	bool bHappyEaster;
 	static const char ccHappyEaster[];
 
-	Global();
+	Global(const QString &qsConfigPath = QString());
 	~Global();
 };
 

--- a/src/mumble/Settings.cpp
+++ b/src/mumble/Settings.cpp
@@ -674,6 +674,8 @@ void Settings::load(QSettings* settings_ptr) {
 	// Config updates
 	SAVELOAD(uiUpdateCounter, "lastupdate");
 
+	SAVELOAD(qsDatabaseLocation, "databaselocation");
+
 	SAVELOAD(bMute, "audio/mute");
 	SAVELOAD(bDeaf, "audio/deaf");
 	LOADENUM(atTransmit, "audio/transmit");
@@ -1030,6 +1032,8 @@ void Settings::save() {
 
 	// Config updates
 	SAVELOAD(uiUpdateCounter, "lastupdate");
+
+	SAVELOAD(qsDatabaseLocation, "databaselocation");
 
 	SAVELOAD(bMute, "audio/mute");
 	SAVELOAD(bDeaf, "audio/deaf");

--- a/src/mumble/Settings.h
+++ b/src/mumble/Settings.h
@@ -430,6 +430,9 @@ struct Settings {
 	// Config updates
 	unsigned int uiUpdateCounter;
 
+	/// Path to SQLite-DB
+	QString qsDatabaseLocation;
+
 	// Nonsaved
 	LoopMode lmLoopMode;
 	float dPacketLoss;

--- a/src/mumble/mumble_en.ts
+++ b/src/mumble/mumble_en.ts
@@ -3166,13 +3166,16 @@ Label of the server. This is what the server will be named like in your server l
 <context>
     <name>Database</name>
     <message>
-        <source>Mumble failed to initialize a database in any
-of the possible locations.</source>
+        <source>The database &apos;%1&apos; is read-only. Mumble cannot store server settings (i.e. SSL certificates) until you fix this problem.</source>
+        <oldsource>The database &apos;%1&apos; is read-only. Mumble can not store server settings (ie. SSL certificates) until you fix this problem.</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>The database &apos;%1&apos; is read-only. Mumble cannot store server settings (i.e. SSL certificates) until you fix this problem.</source>
-        <oldsource>The database &apos;%1&apos; is read-only. Mumble can not store server settings (ie. SSL certificates) until you fix this problem.</oldsource>
+        <source>The database file &apos;%1&apos; set in the configuration file does not exist. Do you want to create a new database file at this location?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Mumble failed to initialize a database in any of the possible locations.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -6008,45 +6011,6 @@ the channel&apos;s context menu.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Usage: mumble [options] [&lt;url&gt;]
-
-&lt;url&gt; specifies a URL to connect to after startup instead of showing
-the connection window, and has the following form:
-mumble://[&lt;username&gt;[:&lt;password&gt;]@]&lt;host&gt;[:&lt;port&gt;][/&lt;channel&gt;[/&lt;subchannel&gt;...]][?version=&lt;x.y.z&gt;]
-
-The version query parameter has to be set in order to invoke the
-correct client version. It currently defaults to 1.2.0.
-
-Valid options are:
-  -h, --help    Show this help text and exit.
-  -m, --multiple
-                Allow multiple instances of the client to be started.
-  -n, --noidentity
-                Suppress loading of identity files (i.e., certificates.)
-  -jn, --jackname &lt;arg&gt;
-                Set custom Jack client name.
-  --license
-                Show the Mumble license.
-  --authors
-                Show the Mumble authors.
-  --third-party-licenses
-                Show licenses for third-party software used by Mumble.
-  --window-title-ext &lt;arg&gt;
-                Sets a custom window title extension.
-  --dump-input-streams
-                Dump PCM streams at various parts of the input chain
-                (useful for debugging purposes)
-                - raw microphone input
-                - speaker readback for echo cancelling
-                - processed microphone input
-  --print-echocancel-queue
-                Print on stdout the echo cancellation queue state
-                (useful for debugging purposes)
-
-</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Channels and users</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6088,6 +6052,54 @@ Valid options are:
     </message>
     <message>
         <source>(%1) %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Configuration file %1 does not exist or is not writable.
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Usage: mumble [options] [&lt;url&gt;]
+
+&lt;url&gt; specifies a URL to connect to after startup instead of showing
+the connection window, and has the following form:
+mumble://[&lt;username&gt;[:&lt;password&gt;]@]&lt;host&gt;[:&lt;port&gt;][/&lt;channel&gt;[/&lt;subchannel&gt;...]][?version=&lt;x.y.z&gt;]
+
+The version query parameter has to be set in order to invoke the
+correct client version. It currently defaults to 1.2.0.
+
+Valid options are:
+  -h, --help    Show this help text and exit.
+  -m, --multiple
+                Allow multiple instances of the client to be started.
+  -c, --config
+                Specify an alternative configuration file.
+                If you use this to run multiple instances of Mumble at once,
+                make sure to set an alternative &apos;database&apos; value in the config.
+  -n, --noidentity
+                Suppress loading of identity files (i.e., certificates.)
+  -jn, --jackname &lt;arg&gt;
+                Set custom Jack client name.
+  --license
+                Show the Mumble license.
+  --authors
+                Show the Mumble authors.
+  --third-party-licenses
+                Show licenses for third-party software used by Mumble.
+  --window-title-ext &lt;arg&gt;
+                Sets a custom window title extension.
+  --dump-input-streams
+                Dump PCM streams at various parts of the input chain
+                (useful for debugging purposes)
+                - raw microphone input
+                - speaker readback for echo cancelling
+                - processed microphone input
+  --print-echocancel-queue
+                Print on stdout the echo cancellation queue state
+                (useful for debugging purposes)
+
+</source>
         <translation type="unfinished"></translation>
     </message>
 </context>


### PR DESCRIPTION
This adds the switch -c/--config to the mumble client. If -c is followed by a filename, this file will be read instead of the standard config.
A new config option `database=` has been added to the 'General' section of the ini file. This can be used to specify a different database which is necessary to run multiple completely separate Mumble instances at the same time.
 
Additionaly the (undocumented) function to merge another ini file by providing it as a parameter has been removed as it was conflicting with the added functionality.

FIXES #3953