### PR TITLE
CI(azure-pipelines): use correct path for build output

### DIFF
--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -23,7 +23,7 @@ jobs:
     - script: scripts/azure-pipelines/build_windows.bat
       displayName: 'Build'
     - powershell: |
-        cd $(Agent.BuildDirectory)
+        cd $(Build.BinariesDirectory)
         .\Create-Win32InstallerMUI.ps1 -PackageName 'Mumble' -Version '1.4.0'
         cp *.sha* $(Build.ArtifactStagingDirectory)
         cp *.msi $(Build.ArtifactStagingDirectory)

--- a/scripts/azure-pipelines/build_linux.bash
+++ b/scripts/azure-pipelines/build_linux.bash
@@ -7,15 +7,15 @@
 #
 # Below is a list of configuration variables used from environment.
 #
-#  AGENT_BUILDDIRECTORY       - The local path on the agent where all folders
-#                               for a given build pipeline are created
-#  BUILD_SOURCESDIRECTORY     - The local path on the agent where the
-#                               repository is downloaded.
+#  BUILD_BINARIESDIRECTORY - The local path on the agent that can be used
+#                            as an output folder for compiled binaries.
+#  BUILD_SOURCESDIRECTORY  - The local path on the agent where the
+#                            repository is downloaded.
 #
 
 VER=$(python scripts/mumble-version.py)
 
-cd $AGENT_BUILDDIRECTORY
+cd $BUILD_BINARIESDIRECTORY
 
 # QSslDiffieHellmanParameters was introduced in Qt 5.8, Ubuntu 16.04 has 5.5.
 cmake -G Ninja -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=appdir/usr -DBUILD_TESTING=ON -Dversion=$VER -Dsymbols=ON -Dqssldiffiehellmanparameters=OFF $BUILD_SOURCESDIRECTORY

--- a/scripts/azure-pipelines/build_macos.bash
+++ b/scripts/azure-pipelines/build_macos.bash
@@ -7,15 +7,15 @@
 #
 # Below is a list of configuration variables used from environment.
 #
-#  AGENT_BUILDDIRECTORY       - The local path on the agent where all folders
-#                               for a given build pipeline are created
-#  BUILD_SOURCESDIRECTORY     - The local path on the agent where the
-#                               repository is downloaded.
+#  BUILD_BINARIESDIRECTORY - The local path on the agent that can be used
+#                            as an output folder for compiled binaries.
+#  BUILD_SOURCESDIRECTORY  - The local path on the agent where the
+#                            repository is downloaded.
 #
 
 VER=$(python scripts/mumble-version.py)
 
-cd $AGENT_BUILDDIRECTORY
+cd $BUILD_BINARIESDIRECTORY
 
 cmake -G Ninja -DCMAKE_TOOLCHAIN_FILE=$MUMBLE_ENVIRONMENT_TOOLCHAIN -DIce_HOME="$MUMBLE_ENVIRONMENT_PATH/installed/x64-osx" -DCMAKE_BUILD_TYPE=Release -DBUILD_TESTING=ON -Dversion=$VER -Dstatic=ON -Dsymbols=ON $BUILD_SOURCESDIRECTORY
 cmake --build .

--- a/scripts/azure-pipelines/build_windows.bat
+++ b/scripts/azure-pipelines/build_windows.bat
@@ -12,8 +12,8 @@
 ::
 :: Predefined variables:
 ::
-::  AGENT_BUILDDIRECTORY         - The local path on the agent where all folders
-::                                 for a given build pipeline are created
+::  BUILD_BINARIESDIRECTORY      - The local path on the agent that can be used
+::                                 as an output folder for compiled binaries.
 ::  BUILD_SOURCESDIRECTORY       - The local path on the agent where the
 ::                                 repository is downloaded.
 ::  AGENT_TOOLSDIRECTORY         - The directory used by tasks such as
@@ -35,7 +35,7 @@
 
 for /f "tokens=* USEBACKQ" %%g in (`python "scripts/mumble-version.py"`) do (SET "VER=%%g")
 
-cd /d %AGENT_BUILDDIRECTORY%
+cd /d %BUILD_BINARIESDIRECTORY%
 
 call "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Auxiliary\Build\vcvars64.bat"
 


### PR DESCRIPTION
`Agent.BuildDirectory` refers to the path on the agent where all folders for the pipeline are created.

`Build.BinariesDirectory` is the correct variable to use: it refers to the path that can be used as an output folder for compiled binaries.

Reference: https://docs.microsoft.com/en-us/azure/devops/pipelines/build/variables