### PR TITLE
CI(azure-pipelines): add 32 bit Windows build

### DIFF
--- a/.ci/azure-pipelines/build_linux.bash
+++ b/.ci/azure-pipelines/build_linux.bash
@@ -20,7 +20,7 @@ cd $BUILD_BINARIESDIRECTORY
 # QSslDiffieHellmanParameters was introduced in Qt 5.8, Ubuntu 16.04 has 5.5.
 cmake -G Ninja -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=appdir/usr -DBUILD_TESTING=ON -Dversion=$VER -Dsymbols=ON -Dqssldiffiehellmanparameters=OFF $BUILD_SOURCESDIRECTORY
 cmake --build .
-ctest
+ctest --verbose
 cmake --install .
 
 wget -c -nv "https://github.com/probonopd/linuxdeployqt/releases/download/continuous/linuxdeployqt-continuous-x86_64.AppImage"

--- a/.ci/azure-pipelines/build_macos.bash
+++ b/.ci/azure-pipelines/build_macos.bash
@@ -19,7 +19,7 @@ cd $BUILD_BINARIESDIRECTORY
 
 cmake -G Ninja -DCMAKE_TOOLCHAIN_FILE=$MUMBLE_ENVIRONMENT_TOOLCHAIN -DIce_HOME="$MUMBLE_ENVIRONMENT_PATH/installed/x64-osx" -DCMAKE_BUILD_TYPE=Release -DBUILD_TESTING=ON -Dversion=$VER -Dstatic=ON -Dsymbols=ON $BUILD_SOURCESDIRECTORY
 cmake --build .
-ctest
+ctest --verbose
 
 $BUILD_SOURCESDIRECTORY/macx/scripts/osxdist.py --version=$VER --source-dir=$BUILD_SOURCESDIRECTORY --binary-dir=.
 

--- a/.ci/azure-pipelines/build_windows.bat
+++ b/.ci/azure-pipelines/build_windows.bat
@@ -61,7 +61,7 @@ if errorlevel 1 (
 	exit /b %errorlevel%
 )
 
-ctest
+ctest --verbose
 
 if errorlevel 1 (
 	exit /b %errorlevel%

--- a/.ci/azure-pipelines/build_windows.bat
+++ b/.ci/azure-pipelines/build_windows.bat
@@ -25,11 +25,12 @@
 :: Defined in .azure-pipelines.yml:
 ::
 ::  MUMBLE_ENVIRONMENT_STORE     - Path to the folder the build environment is stored in.
-::  MUMBLE_ENVIRONMENT_SOURCE    - Build environment web source folder URL
+::  MUMBLE_ENVIRONMENT_SOURCE    - Build environment web source folder URL.
+::  MUMBLE_ENVIRONMENT_TRIPLET   - vcpkg triplet.
 ::  MUMBLE_ENVIRONMENT_VERSION   - Full build environment version
 ::                                 Must match archive and extracted folder name.
 ::  MUMBLE_ENVIRONMENT_TOOLCHAIN - Path to the vcpkg CMake toolchain, used for CMake.
-::
+::  VCVARS_PATH                  - Path to the Visual Studio environment initialization script.
 
 @echo on
 
@@ -37,7 +38,7 @@ for /f "tokens=* USEBACKQ" %%g in (`python "scripts/mumble-version.py"`) do (SET
 
 cd /d %BUILD_BINARIESDIRECTORY%
 
-call "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Auxiliary\Build\vcvars64.bat"
+call "%VCVARS_PATH%"
 
 :: Delete MinGW, otherwise CMake picks it over MSVC.
 :: We don't delete the (Chocolatey) packages because it takes ~10 minutes...
@@ -48,7 +49,7 @@ del C:\Strawberry\c\bin\gcc.exe
 del C:\Strawberry\c\bin\g++.exe
 del C:\Strawberry\c\bin\c++.exe
 
-cmake -G Ninja -DCMAKE_TOOLCHAIN_FILE="%MUMBLE_ENVIRONMENT_TOOLCHAIN%" -DVCPKG_TARGET_TRIPLET=x64-windows-static-md -DIce_HOME="%MUMBLE_ENVIRONMENT_PATH%\installed\x64-windows-static-md" -DCMAKE_BUILD_TYPE=Release -DBUILD_TESTING=ON -Dversion=%VER% -Dpackaging=ON -Dstatic=ON -Dsymbols=ON -Dasio=ON -Dg15=ON "%BUILD_SOURCESDIRECTORY%"
+cmake -G Ninja -DCMAKE_TOOLCHAIN_FILE="%MUMBLE_ENVIRONMENT_TOOLCHAIN%" -DVCPKG_TARGET_TRIPLET=%MUMBLE_ENVIRONMENT_TRIPLET% -DIce_HOME="%MUMBLE_ENVIRONMENT_PATH%\installed\%MUMBLE_ENVIRONMENT_TRIPLET%" -DCMAKE_BUILD_TYPE=Release -DBUILD_TESTING=ON -Dversion=%VER% -Dpackaging=ON -Dstatic=ON -Dsymbols=ON -Dasio=ON -Dg15=ON "%BUILD_SOURCESDIRECTORY%"
 
 if errorlevel 1 (
 	exit /b %errorlevel%

--- a/.ci/azure-pipelines/build_windows.bat
+++ b/.ci/azure-pipelines/build_windows.bat
@@ -34,7 +34,7 @@
 
 @echo on
 
-for /f "tokens=* USEBACKQ" %%g in (`python "scripts/mumble-version.py"`) do (SET "VER=%%g")
+for /f "tokens=* USEBACKQ" %%g in (`python "scripts/mumble-version.py"`) do (set "VER=%%g")
 
 cd /d %BUILD_BINARIESDIRECTORY%
 
@@ -61,6 +61,8 @@ if errorlevel 1 (
 	exit /b %errorlevel%
 )
 
+:: Set timeout for tests to 10min
+set QTEST_FUNCTION_TIMEOUT=600000
 ctest --verbose
 
 if errorlevel 1 (

--- a/.ci/azure-pipelines/main-pr.yml
+++ b/.ci/azure-pipelines/main-pr.yml
@@ -5,11 +5,24 @@ variables:
   MUMBLE_ENVIRONMENT_TOOLCHAIN: '$(MUMBLE_ENVIRONMENT_PATH)/scripts/buildsystems/vcpkg.cmake'
 
 jobs:
-  - job: Windows
+  - job: Windows_x86_64
+    displayName: Windows (x86_64)
     pool:
       vmImage: 'windows-latest'
     variables:
       MUMBLE_ENVIRONMENT_VERSION: 'win64-static-1.4.x-2020-05-27-ecb3c64-1151'
+      MUMBLE_ENVIRONMENT_TRIPLET: 'x64-windows-static-md'
+      VCVARS_PATH: 'C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Auxiliary\Build\vcvars64.bat'
+    steps:
+    - template: steps_windows.yml
+  - job: Windows_x86
+    displayName: Windows (x86)
+    pool:
+      vmImage: 'windows-latest'
+    variables:
+      MUMBLE_ENVIRONMENT_VERSION: 'win32-static-1.4.x-2020-07-22-dbd6271-1162'
+      MUMBLE_ENVIRONMENT_TRIPLET: 'x86-windows-static-md'
+      VCVARS_PATH: 'C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Auxiliary\Build\vcvarsamd64_x86.bat'
     steps:
     - template: steps_windows.yml
   - job: Linux

--- a/.ci/azure-pipelines/main.yml
+++ b/.ci/azure-pipelines/main.yml
@@ -5,11 +5,24 @@ variables:
   MUMBLE_ENVIRONMENT_TOOLCHAIN: '$(MUMBLE_ENVIRONMENT_PATH)/scripts/buildsystems/vcpkg.cmake'
 
 jobs:
-  - job: Windows
+  - job: Windows_x86_64
+    displayName: Windows (x86_64)
     pool:
       vmImage: 'windows-latest'
     variables:
       MUMBLE_ENVIRONMENT_VERSION: 'win64-static-1.4.x-2020-05-27-ecb3c64-1151'
+      MUMBLE_ENVIRONMENT_TRIPLET: 'x64-windows-static-md'
+      VCVARS_PATH: 'C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Auxiliary\Build\vcvars64.bat'
+    steps:
+    - template: steps_windows.yml
+  - job: Windows_x86
+    displayName: Windows (x86)
+    pool:
+      vmImage: 'windows-latest'
+    variables:
+      MUMBLE_ENVIRONMENT_VERSION: 'win32-static-1.4.x-2020-07-22-dbd6271-1162'
+      MUMBLE_ENVIRONMENT_TRIPLET: 'x86-windows-static-md'
+      VCVARS_PATH: 'C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Auxiliary\Build\vcvarsamd64_x86.bat'
     steps:
     - template: steps_windows.yml
   - job: Linux

--- a/.ci/travis-ci/script.bash
+++ b/.ci/travis-ci/script.bash
@@ -27,7 +27,7 @@ if [ "${TRAVIS_OS_NAME}" == "linux" ]; then
 		# We specify the absolute path because otherwise Travis CI's CMake is used.
 		/usr/bin/cmake -G Ninja -DCMAKE_BUILD_TYPE=Release -DBUILD_TESTING=ON -Dversion=$VER -Dsymbols=ON ..
 		/usr/bin/cmake --build .
-		/usr/bin/ctest
+		/usr/bin/ctest --verbose
 		sudo /usr/bin/cmake --install .
 	elif [ "${MUMBLE_HOST}" == "i686-w64-mingw32" ] || [ "${MUMBLE_HOST}" == "x86_64-w64-mingw32" ]; then
 		wget https://dl.mumble.info/build/extra/asio_sdk.zip -P /tmp/


### PR DESCRIPTION
As with the 64 bit build, it uses a build environment we provide on our website.