### PR TITLE
FIX(overlay): only use minhook for 64 bit overlay library, add missing <unknwn.h>

### DIFF
--- a/overlay/CMakeLists.txt
+++ b/overlay/CMakeLists.txt
@@ -131,7 +131,7 @@ else()
 	install(TARGETS overlay RUNTIME DESTINATION . COMPONENT mumble_client)
 endif()
 
-if(64_BIT)
+if(64_BIT AND NOT BUILD_OVERLAY_XCOMPILE)
 	add_subdirectory("${3RDPARTY_DIR}/minhook-src" "${CMAKE_CURRENT_BINARY_DIR}/minhook" EXCLUDE_FROM_ALL)
 	target_compile_definitions(overlay PRIVATE "USE_MINHOOK")
 	target_link_libraries(overlay PRIVATE minhook)

--- a/overlay/HardHook_x86.h
+++ b/overlay/HardHook_x86.h
@@ -14,6 +14,7 @@
 #include <stdarg.h>
 #include <ctype.h>
 #include <windows.h>
+#include <unknwn.h>
 #include <cmath>
 #include <map>
 #include <vector>


### PR DESCRIPTION
Related: #4377