### PR TITLE
FEAT(talking-ui): Make channels selectable

### DIFF
--- a/src/mumble/CMakeLists.txt
+++ b/src/mumble/CMakeLists.txt
@@ -177,6 +177,8 @@ set(MUMBLE_SOURCES
 	"SvgIcon.h"
 	"TalkingUI.cpp"
 	"TalkingUI.h"
+	"TalkingUISelection.cpp"
+	"TalkingUISelection.h"
 	"TextMessage.cpp"
 	"TextMessage.h"
 	"TextMessage.ui"

--- a/src/mumble/TalkingUI.h
+++ b/src/mumble/TalkingUI.h
@@ -11,7 +11,10 @@
 #include <QtCore/QSet>
 #include <QtGui/QIcon>
 
+#include <memory>
+
 #include "Settings.h"
+#include "TalkingUISelection.h"
 
 class QLabel;
 class QGroupBox;
@@ -49,7 +52,7 @@ class TalkingUI : public QWidget {
 		/// that have stopped speaking for a certain amount of time.
 		QHash<unsigned int, QTimer *> m_timers;
 		/// The Entry corresponding to the currently selected user
-		Entry *m_currentSelection;
+		std::unique_ptr<TalkingUISelection> m_currentSelection;
 
 		/// The icon for a talking user
 		QIcon m_talkingIcon;
@@ -118,8 +121,8 @@ class TalkingUI : public QWidget {
 
 		/// Set the current selection
 		///
-		/// @param entry A pointer to the Entry that shall be selected or nullptr to clear the selection
-		void setSelection(Entry *entry);
+		/// @param selection The new selection
+		void setSelection(const TalkingUISelection &selection);
 
 		void mousePressEvent(QMouseEvent *event) Q_DECL_OVERRIDE;
 

--- a/src/mumble/TalkingUISelection.cpp
+++ b/src/mumble/TalkingUISelection.cpp
@@ -1,0 +1,86 @@
+// Copyright 2020 The Mumble Developers. All rights reserved.
+// Use of this source code is governed by a BSD-style license
+// that can be found in the LICENSE file at the root of the
+// Mumble source tree or at <https://www.mumble.info/LICENSE>.
+
+#include "TalkingUISelection.h"
+#include "MainWindow.h"
+#include "UserModel.h"
+
+#include <QWidget>
+#include <QVariant>
+
+// We define a global macro called 'g'. This can lead to issues when included code uses 'g' as a type or parameter name (like protobuf 3.7 does). As such, for now, we have to make this our last include.
+#include "Global.h"
+
+TalkingUISelection::TalkingUISelection(QWidget *widget) : m_widget(widget) {
+}
+
+
+void TalkingUISelection::setActive(bool active) {
+	if (m_widget) {
+		m_widget->setProperty("selected", active);
+		// Unpolish the widget's style so that the new property can take effect
+		m_widget->style()->unpolish(m_widget);
+	}
+}
+
+void TalkingUISelection::apply() {
+	setActive(true);
+}
+
+void TalkingUISelection::discard() {
+	setActive(false);
+}
+
+bool TalkingUISelection::operator==(const TalkingUISelection &other) const {
+	return m_widget == other.m_widget;
+}
+
+bool TalkingUISelection::operator!=(const TalkingUISelection &other) const {
+	return m_widget != other.m_widget;
+}
+
+
+
+UserSelection::UserSelection(QWidget *widget, unsigned int userSession)
+	: TalkingUISelection(widget),
+	  m_userSession(userSession) {
+}
+
+void UserSelection::syncToMainWindow() const {
+	if (g.mw && g.mw->pmModel) {
+		g.mw->pmModel->setSelectedUser(m_userSession);
+	}
+}
+
+std::unique_ptr<TalkingUISelection> UserSelection::cloneToHeap() const {
+	return std::make_unique<UserSelection>(*this);
+}
+
+
+
+ChannelSelection::ChannelSelection(QWidget *widget, int channelID)
+	: TalkingUISelection(widget),
+	  m_channelID(channelID) {
+}
+
+void ChannelSelection::syncToMainWindow() const {
+	if (g.mw && g.mw->pmModel) {
+		g.mw->pmModel->setSelectedChannel(m_channelID);
+	}
+}
+
+std::unique_ptr<TalkingUISelection> ChannelSelection::cloneToHeap() const {
+	return std::make_unique<ChannelSelection>(*this);
+}
+
+
+
+void EmptySelection::syncToMainWindow() const {
+	// Do nothing
+}
+
+std::unique_ptr<TalkingUISelection> EmptySelection::cloneToHeap() const {
+	return std::make_unique<EmptySelection>(*this);
+}

--- a/src/mumble/TalkingUISelection.h
+++ b/src/mumble/TalkingUISelection.h
@@ -1,0 +1,86 @@
+// Copyright 2020 The Mumble Developers. All rights reserved.
+// Use of this source code is governed by a BSD-style license
+// that can be found in the LICENSE file at the root of the
+// Mumble source tree or at <https://www.mumble.info/LICENSE>.
+
+#ifndef MUMBLE_MUMBLE_TALKINGUISELECTION_H_
+#define MUMBLE_MUMBLE_TALKINGUISELECTION_H_
+
+#include <memory>
+
+class QWidget;
+
+/// Base class of all selections within the TalkingUI
+class TalkingUISelection {
+	protected:
+		/// The widget that is used to represent this selection (it'll be marked
+		/// as selected).
+		QWidget *m_widget;
+
+		explicit TalkingUISelection() = default;
+	
+	public:
+		explicit TalkingUISelection(QWidget *widget);
+		virtual ~TalkingUISelection() = default;
+
+		/// Turns this selection on or off. Turning it on usually involves marking the
+		/// associated Widget in a certain way while deactivating the selection reverts this effect.
+		///
+		/// @param active Whether to activate this selection
+		virtual void setActive(bool active);
+
+		/// Applies this selection. This is a shortcut for setActive(true).
+		virtual void apply() final;
+
+		/// Discards this selection. This is a shortcut for setActive(false).
+		virtual void discard() final;
+
+		/// Synchronizes this selection to the MainWindow
+		virtual void syncToMainWindow() const = 0;
+
+		bool operator==(const TalkingUISelection &other) const;
+		bool operator!=(const TalkingUISelection &other) const;
+
+		virtual std::unique_ptr<TalkingUISelection> cloneToHeap() const = 0;	
+};
+
+/// A class representing the selection of a user in the TalkingUI
+class UserSelection : public TalkingUISelection {
+	protected:
+		const unsigned int m_userSession;
+
+	public:
+		explicit UserSelection(QWidget *widget, unsigned int userSession);
+		explicit UserSelection(const UserSelection &) = default;
+
+		virtual void syncToMainWindow() const override;
+
+		virtual std::unique_ptr<TalkingUISelection> cloneToHeap() const override;	
+};
+
+/// A class representing the selection of a channel in the TalkingUI
+class ChannelSelection : public TalkingUISelection {
+	protected:
+		const int m_channelID;
+
+	public:
+		explicit ChannelSelection(QWidget *widget, int channelID);
+		explicit ChannelSelection(const ChannelSelection &) = default;
+
+		virtual void syncToMainWindow() const override;
+
+		virtual std::unique_ptr<TalkingUISelection> cloneToHeap() const override;	
+};
+
+/// A class representing an empty selection in the TalkingUI
+class EmptySelection : public TalkingUISelection {
+	public:
+		explicit EmptySelection() = default;
+		explicit EmptySelection(const EmptySelection &) = default;
+
+		virtual void syncToMainWindow() const override;
+
+		virtual std::unique_ptr<TalkingUISelection> cloneToHeap() const override;	
+};
+
+#endif // MUMBLE_MUMBLE_TALKINGUISELECTION_H_

--- a/src/mumble/mumble.pro
+++ b/src/mumble/mumble.pro
@@ -135,7 +135,8 @@ HEADERS *= BanEditor.h \
     Screen.h \
     SvgIcon.h \
     Markdown.h \
-    TalkingUI.h
+    TalkingUI.h \
+	TalkingUISelection.h
 
 SOURCES *= BanEditor.cpp \
     ACLEditor.cpp \
@@ -198,7 +199,8 @@ SOURCES *= BanEditor.cpp \
     Screen.cpp \
     SvgIcon.cpp \
     Markdown.cpp \
-    TalkingUI.cpp
+    TalkingUI.cpp \
+	TalkingUISelection.cpp
 
 !CONFIG(no-overlay) {
 	DEFINES *= USE_OVERLAY


### PR DESCRIPTION
Before this commit it was only possible to select users in the TalkingUI
(and thereby it was also only possible to trigger the context menu for
users via the TalkingUI).

This commit extends the functionality that currently exists for users to
channels as well. This includes selection as well as the context menu.

![Mumble_TalkingUI_ChannelSelection](https://user-images.githubusercontent.com/12751591/88796865-b3d1ce00-d1a2-11ea-8f33-4d94e5e9651a.png)
