### PR TITLE
FIX(ui): Make chatwidget max height >= than its minimum height

### DIFF
--- a/src/mumble/CustomElements.cpp
+++ b/src/mumble/CustomElements.cpp
@@ -136,7 +136,9 @@ QSize ChatbarTextEdit::minimumSizeHint() const {
 
 QSize ChatbarTextEdit::sizeHint() const {
 	QSize sh = QTextEdit::sizeHint();
-	sh.setHeight(static_cast<qint32>(document()->documentLayout()->documentSize().height()));
+	const int minHeight = minimumSizeHint().height();
+	const int documentHeight = document()->documentLayout()->documentSize().height();
+	sh.setHeight(std::max(minHeight, documentHeight));
 	const_cast<ChatbarTextEdit *>(this)->setMaximumHeight(sh.height());
 	return sh;
 }


### PR DESCRIPTION
I can consistently reproduce the linked issue on my machine.
Let me know if you want me to test some other approach.

Fixes https://github.com/mumble-voip/mumble/issues/3701.