### PR TITLE
CI(azure): Don't overwrite build artifacts

### DIFF
--- a/.ci/azure-pipelines/main-pr.yml
+++ b/.ci/azure-pipelines/main-pr.yml
@@ -15,6 +15,8 @@ jobs:
       VCVARS_PATH: 'C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Auxiliary\Build\vcvars64.bat'
     steps:
     - template: steps_windows.yml
+      parameters:
+        arch: 'x64'
   - job: Windows_x86
     displayName: Windows (x86)
     pool:
@@ -25,6 +27,8 @@ jobs:
       VCVARS_PATH: 'C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Auxiliary\Build\vcvarsamd64_x86.bat'
     steps:
     - template: steps_windows.yml
+      parameters:
+        arch: 'x86'
   - job: Linux
     pool:
       vmImage: 'ubuntu-16.04'

--- a/.ci/azure-pipelines/main.yml
+++ b/.ci/azure-pipelines/main.yml
@@ -15,6 +15,8 @@ jobs:
       VCVARS_PATH: 'C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Auxiliary\Build\vcvars64.bat'
     steps:
     - template: steps_windows.yml
+      parameters:
+        arch: 'x64'
   - job: Windows_x86
     displayName: Windows (x86)
     pool:
@@ -25,6 +27,8 @@ jobs:
       VCVARS_PATH: 'C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Auxiliary\Build\vcvarsamd64_x86.bat'
     steps:
     - template: steps_windows.yml
+      parameters:
+        arch: 'x86'
   - job: Linux
     pool:
       vmImage: 'ubuntu-16.04'

--- a/.ci/azure-pipelines/steps_windows.yml
+++ b/.ci/azure-pipelines/steps_windows.yml
@@ -8,11 +8,11 @@ steps:
     displayName: 'Build'
   - powershell: |
       cd $(Build.BinariesDirectory)
-      .\Create-Win32InstallerMUI.ps1 -PackageName 'Mumble' -Version '1.4.0'
+      .\Create-Win32InstallerMUI.ps1 -PackageName 'Mumble_${{parameters.arch}}' -Version '1.4.0'
       cp *.sha* $(Build.ArtifactStagingDirectory)
       cp *.msi $(Build.ArtifactStagingDirectory)
       cp *.pdb $(Build.ArtifactStagingDirectory)
     displayName: Build installer
   - template: task-publish-artifacts.yml
     parameters:
-      name: "Windows installer"
+      name: 'Windows (${{parameters.arch}}) installer'


### PR DESCRIPTION
As of now the built x86 files overwrite the x64 ones since the x64
build is usually done first but they both produce files of the same
name.

With this commit the build artifacts for x86 and x64 are separated.