### PR TITLE
CI(windows): Zip all PDB files

### DIFF
--- a/.ci/azure-pipelines/steps_windows.yml
+++ b/.ci/azure-pipelines/steps_windows.yml
@@ -11,7 +11,8 @@ steps:
       .\Create-Win32InstallerMUI.ps1 -PackageName 'Mumble' -Version '1.4.0'
       cp *.sha* $(Build.ArtifactStagingDirectory)
       cp *.msi $(Build.ArtifactStagingDirectory)
-      cp *.pdb $(Build.ArtifactStagingDirectory)
+      7z a PDBs.7z *.pdb 
+      cp PDBs.7z $(Build.ArtifactStagingDirectory)
     displayName: Build installer
   - template: task-publish-artifacts.yml
     parameters:


### PR DESCRIPTION
Instead of publishing each and every PDB file separately, we now zip
them together into an archive and publish that. That'll reduce the
amount of published files which should make it easier to find what
you're looking for.