### PR TITLE
MAINT: Disable warnings for 3rdparty projects

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,6 +33,8 @@ list(APPEND CMAKE_MODULE_PATH
 
 include(pkg-utils)
 include(CTest)
+include(project-utils)
+
 
 option(BUILD_TESTING "Build tests." OFF)
 

--- a/cmake/project-utils.cmake
+++ b/cmake/project-utils.cmake
@@ -1,0 +1,65 @@
+# Copyright 2020 The Mumble Developers. All rights reserved.
+# Use of this source code is governed by a BSD-style license
+# that can be found in the LICENSE file at the root of the
+# Mumble source tree or at <https://www.mumble.info/LICENSE>.
+
+# This function gets all included subdirectories in the given DIR recursively.
+# It'll write the found subdirs into SUBDIRS.
+# Note that the DIR itself will not be added to SUBDIRS
+# Note also that a subdirectory in this context is a dir that has been included with the
+# add_subdirectory command.
+function(get_subdirectories SUBDIRS DIR)
+	# Get the defined subdirs via the directory property
+	get_directory_property(NEW_SUBDIRS DIRECTORY "${DIR}" SUBDIRECTORIES)
+
+	# iterate all subdirs and call this function recursively to also get the
+	# subdirs of the subdirs (if any)
+	foreach(CURRENT_SUBDIR IN LISTS NEW_SUBDIRS)
+		get_subdirectories(REC_SUBDIRS "${CURRENT_SUBDIR}")
+		list(APPEND SUBDIRS ${REC_SUBDIRS})
+	endforeach()
+
+	list(APPEND SUBDIRS ${NEW_SUBDIRS})
+
+	# "Return" SUBDIRS
+	set(${SUBDIRS} PARENT_SCOPE)
+endfunction()
+
+# This function gets all defined targets in the given DIR or any of its
+# subdirectories as returned by get_subdirectories. The found targets are
+# written into DEFINED_TARGETS.
+function(get_targets DEFINED_TARGETS DIR)
+	# First get all defined subdirectories
+	get_subdirectories(SUBDIRS "${DIR}")
+
+	if(EXISTS "${DIR}/CMakeLists.txt")
+		# If the DIR itself contains a CMakeLists.txt file, add it to the
+		# list of directories to process as it may already define some targets
+		# itself.
+		list(APPEND SUBDIRS "${DIR}")
+	endif()
+
+	# Iterate over all directories and check each for the defined targets via the
+	# respective directory property.
+	foreach(CURRENT_SUBDIR IN LISTS SUBDIRS)
+		get_directory_property(NEW_TARGETS DIRECTORY "${CURRENT_SUBDIR}" BUILDSYSTEM_TARGETS)
+		list(APPEND DEFINED_TARGETS ${NEW_TARGETS})
+	endforeach()
+
+	# "Return" DEFINED_TARGETS
+	set(${DEFINED_TARGETS} PARENT_SCOPE)
+endfunction()
+
+# This function will disable all warnings for the targets defined in the given DIR
+# or any of its subdirectories as returned by get_subdirectories.
+function(disable_warnings_for_all_targets_in DIR)
+	# First get all targets
+	get_targets(DEFINED_TARGETS "${DIR}")
+
+	message(STATUS "Disabling warnings for targets: ${DEFINED_TARGETS}")
+
+	# Iterate over all targets and disable warnings for them
+	foreach(CURRENT_TARGET IN LISTS DEFINED_TARGETS)
+		target_disable_warnings("${CURRENT_TARGET}")
+	endforeach()
+endfunction()

--- a/src/mumble/CMakeLists.txt
+++ b/src/mumble/CMakeLists.txt
@@ -382,6 +382,10 @@ if(WIN32)
 	endif()
 
 	add_subdirectory("${3RDPARTY_DIR}/xinputcheck-build" "${CMAKE_CURRENT_BINARY_DIR}/xinputcheck")
+
+	# Disable all warnings that the xinputcheck code may emit
+	disable_warnings_for_all_targets_in("${3RDPARTY_DIR}/xinputcheck-build")
+
 	target_link_libraries(mumble PRIVATE xinputcheck)
 
 	if(MSVC)
@@ -481,6 +485,9 @@ if(bundled-opus)
 
 	add_subdirectory("${3RDPARTY_DIR}/opus-src" "${CMAKE_CURRENT_BINARY_DIR}/opus")
 
+	# Disable all warnings that the Opus code may emit
+	disable_warnings_for_all_targets_in("${3RDPARTY_DIR}/opus-src")
+
 	add_dependencies(mumble opus)
 
 	target_include_directories(mumble PRIVATE "${3RDPARTY_DIR}/opus-src/include")
@@ -507,6 +514,9 @@ endif()
 if(bundled-celt)
 	add_subdirectory("${3RDPARTY_DIR}/celt-0.7.0-build" "${CMAKE_CURRENT_BINARY_DIR}/celt")
 
+	# Disable all warnings that the Celt code may emit
+	disable_warnings_for_all_targets_in("${3RDPARTY_DIR}/celt-0.7.0-build")
+
 	add_dependencies(mumble celt)
 
 	target_include_directories(mumble PRIVATE "${3RDPARTY_DIR}/celt-0.7.0-src/libcelt")
@@ -528,6 +538,10 @@ endif()
 
 if(bundled-speex)
 	add_subdirectory("${3RDPARTY_DIR}/speex-build" "${CMAKE_CURRENT_BINARY_DIR}/speex")
+
+	# Disable all warnings that the speex code may emit
+	disable_warnings_for_all_targets_in("${3RDPARTY_DIR}/speex-build")
+
 	target_link_libraries(mumble PRIVATE speex)
 
 	if(WIN32)
@@ -548,6 +562,10 @@ endif()
 
 if(rnnoise)
 	add_subdirectory("${3RDPARTY_DIR}/rnnoise-build" "${CMAKE_CURRENT_BINARY_DIR}/rnnoise")
+
+	# Disable all warnings that the RNNoise code may emit
+	disable_warnings_for_all_targets_in("${3RDPARTY_DIR}/rnnoise-build")
+
 	target_compile_definitions(mumble PRIVATE "USE_RNNOISE")
 	target_link_libraries(mumble PRIVATE rnnoise)
 


### PR DESCRIPTION
In order to not be spammed with warnings from 3rdparty projects that we
make use of in Mumble, this commit modifies the respective cmake files
in a way that disables warnings for the respective projects.