### PR TITLE
FIX(cmake): define "MUMBLE_VERSION_STRING" to short version (e.g. "1.4.0")

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -121,7 +121,7 @@ target_sources(shared
 target_compile_definitions(shared
 	PUBLIC
 		"MUMBLE_VERSION=${version}"
-		"MUMBLE_VERSION_STRING=${version}"
+		"MUMBLE_VERSION_STRING=${version_short}"
 )
 
 target_include_directories(shared


### PR DESCRIPTION
This fixes the version appearing as `0.0.0` in builds produced by CI.

We should probably choose a better name for the two defines. Perhaps `MUMBLE_VERSION_SHORT` and `MUMBLE_VERSION_EXTENDED`.