### PR TITLE
FIX(certificate): Retrieve QSslConfiguration after setting CA

### DIFF
--- a/src/murmur/Server.cpp
+++ b/src/murmur/Server.cpp
@@ -1373,8 +1373,9 @@ void Server::newClient() {
 		sock->setPrivateKey(qskKey);
 		sock->setLocalCertificate(qscCert);
 
-		QSslConfiguration config = sock->sslConfiguration();
+		QSslConfiguration config;
 #if QT_VERSION >= QT_VERSION_CHECK(5,15,0)
+		config = sock->sslConfiguration();
 		// Qt 5.15 introduced QSslConfiguration::addCaCertificate(s) that should be preferred over the functions in QSslSocket
 
 		// Treat the leaf certificate as a root.
@@ -1406,6 +1407,9 @@ void Server::newClient() {
 		// Add intermediate CAs found in the PEM
 		// bundle used for this server's certificate.
 		sock->addCaCertificates(qlIntermediates);
+
+		// Must not get config from socket before setting CA certificates
+		config = sock->sslConfiguration();
 #endif
 
 		config.setCiphers(Meta::mp.qlCiphers);


### PR DESCRIPTION
Commit bdb12c6 added a regression for servers built with QT older than version
5.15. After this commit these servers do not server intermediate certificates
anymore.  This happens because the QSslConfiguration is retrieved before adding
the CA certificates to the socket and is reinserted into the socket again after
adding the CA certificates, thereby overwriting the CA certificates added in
between.

This commit fixes that by retrieving the QSslConfiguration just after setting
the CA certificates in case an older QT version than 5.15 is used.