### PR TITLE
CI(azure): Disable environment caching

### DIFF
--- a/.ci/azure-pipelines/steps_macos.yml
+++ b/.ci/azure-pipelines/steps_macos.yml
@@ -7,8 +7,6 @@ steps:
   - script: git submodule --quiet update --init --recursive
     displayName: 'Fetch submodules'
   - ${{if eq(parameters.installEnvironment, true)}}:
-    - template: task-environment-cache.yml
-  - ${{if eq(parameters.installEnvironment, true)}}:
     - script: .ci/azure-pipelines/install-environment_macos.bash
       displayName: 'Install build environment'
   - script: .ci/azure-pipelines/build_macos.bash

--- a/.ci/azure-pipelines/steps_windows.yml
+++ b/.ci/azure-pipelines/steps_windows.yml
@@ -1,7 +1,6 @@
 steps:
   - script: git submodule --quiet update --init --recursive
     displayName: 'Fetch submodules'
-  - template: task-environment-cache.yml
   - powershell: .ci/azure-pipelines/install-environment_windows.ps1
     displayName: 'Install build environment'
   - script: .ci/azure-pipelines/build_windows.bat


### PR DESCRIPTION
This feature of AzurePipelines has only been introduced recently.
However it turned out that on average the caching of the environment
takes significantly more time than simply downloading it on every run.
Thus this commit disables environment caching again.