### PR TITLE
FIX(client): Compile error without manual plugin

### DIFF
--- a/src/mumble/AudioOutput.cpp
+++ b/src/mumble/AudioOutput.cpp
@@ -355,7 +355,9 @@ void AudioOutput::initializeMixer(const unsigned int *chanmasks, bool forceheadp
 }
 
 bool AudioOutput::mix(void *outbuff, unsigned int frameCount) {
+#ifdef USE_MANUAL_PLUGIN
 	positions.clear();
+#endif
 
 	// A list of users that have audio to contribute
 	QList<AudioOutputUser *> qlMix;
@@ -566,11 +568,13 @@ bool AudioOutput::mix(void *outbuff, unsigned int frameCount) {
 			if (validListener && ((aop->fPos[0] != 0.0f) || (aop->fPos[1] != 0.0f) || (aop->fPos[2] != 0.0f))) {
 				// Add position to position map
 				AudioOutputSpeech *speech = qobject_cast<AudioOutputSpeech *>(aop);
+#ifdef USE_MANUAL_PLUGIN
 				if (speech) {
 					const ClientUser *user = speech->p;
 					// The coordinates in the plane are actually given by x and z instead of x and y (y is up)
 				 	positions.insert(user->uiSession, {aop->fPos[0], aop->fPos[2]});
 				}
+#endif
 
 				// If positional audio is enabled, calculate the respective audio effect here
 				float dir[3] = { aop->fPos[0] - g.p->fCameraPosition[0], aop->fPos[1] - g.p->fCameraPosition[1], aop->fPos[2] - g.p->fCameraPosition[2] };
@@ -652,7 +656,9 @@ bool AudioOutput::mix(void *outbuff, unsigned int frameCount) {
 	foreach(AudioOutputUser *aop, qlDel)
 		removeBuffer(aop);
 
+#ifdef USE_MANUAL_PLUGIN
 	Manual::setSpeakerPositions(positions);
+#endif
 	
 	// Return whether data has been written to the outbuff
 	return (! qlMix.isEmpty());

--- a/src/mumble/AudioOutput.h
+++ b/src/mumble/AudioOutput.h
@@ -10,7 +10,9 @@
 #include <QtCore/QObject>
 #include <QtCore/QThread>
 
-#include "ManualPlugin.h"
+#ifdef USE_MANUAL_PLUGIN
+	#include "ManualPlugin.h"
+#endif
 
 // AudioOutput depends on User being valid. This means it's important
 // to removeBuffer from here BEFORE MainWindow gets any UserLeft
@@ -92,7 +94,9 @@ class AudioOutput : public QThread {
 		QReadWriteLock qrwlOutputs;
 		QMultiHash<const ClientUser *, AudioOutputUser *> qmOutputs;
 
+#ifdef USE_MANUAL_PLUGIN
 		QHash<unsigned int, Position2D> positions;
+#endif
 
 		virtual void removeBuffer(AudioOutputUser *);
 		void initializeMixer(const unsigned int *chanmasks, bool forceheadphone = false);

--- a/src/mumble/Plugins.cpp
+++ b/src/mumble/Plugins.cpp
@@ -12,8 +12,10 @@
 #include "../../plugins/mumble_plugin.h"
 #include "WebFetch.h"
 #include "MumbleApplication.h"
-#include "ManualPlugin.h"
 #include "Utils.h"
+#ifdef USE_MANUAL_PLUGIN
+	#include "ManualPlugin.h"
+#endif
 
 #include <QtCore/QLibrary>
 #include <QtCore/QUrlQuery>


### PR DESCRIPTION
Whe using CONFIG+=no-manual-plugin with the old qmake buildsystem or
-Dmanual-plugin=OFF with the new cmake one, there were compile errors
due to the ManualPlugin being referenced in other files without include
guards.

This commit makes sure that in case the manual plugin is not included,
other code won't reference it either.

Fixes #4422