### PR TITLE
FIX(packaging): Enable mac-script to run multiple times

### DIFF
--- a/macx/scripts/osxdist.py
+++ b/macx/scripts/osxdist.py
@@ -136,7 +136,8 @@ class AppBundle(object):
 		'''
 		print ' * Attempting to copy audio codec libraries into App Bundle'
 		dst = os.path.join(self.bundle, 'Contents', 'Codecs')
-		os.makedirs(dst)
+ 		if not os.path.exists(dst):
+			os.makedirs(dst)
 		codecs = (os.path.join(options.binary_dir, 'libcelt0.0.7.0.dylib'), os.path.join(options.binary_dir, 'libopus.dylib'))
 		for codec in codecs:
 			if os.path.exists(codec):
@@ -247,7 +248,7 @@ class DiskImage(FolderObject):
 		'''
 		print ' * Creating diskimage. Please wait...'
 		if os.path.exists(self.filename):
-			shutil.rmtree(self.filename)
+			os.remove(self.filename)
 		p = Popen(['hdiutil', 'create',
 		           '-srcfolder', self.tmp,
 		           '-format', 'UDBZ',


### PR DESCRIPTION
Before this PR the MacOS packaging script failed on copying Codecs
if the respective directory already existed (e.g. because the packaging
script has been run before).

Furthermore the script called a function to delete a directory (tree)
on a file. This error never surfaced before because usually when this
script is run, the respective file doesn't exist yet.

Both issues are fixed by this PR. It is now possible to run the
packaging script multiple times consecutively without it erroring on
already existing files.