### PR TITLE
FIX(client): define and export "MumbleMain" also in debug builds

### DIFF
--- a/src/mumble/CMakeLists.txt
+++ b/src/mumble/CMakeLists.txt
@@ -246,6 +246,8 @@ set(MUMBLE_SOURCES
 if(static AND WIN32)
 	# On Windows, building a static client means building the main app into a DLL.
 	add_library(mumble SHARED ${MUMBLE_SOURCES})
+	add_compile_definitions(mumble PRIVATE "MUMBLEAPP_DLL")
+
 	set_target_properties(mumble PROPERTIES OUTPUT_NAME "mumble_app")
 	if(MINGW)
 		# Remove "lib" prefix.

--- a/src/mumble/main.cpp
+++ b/src/mumble/main.cpp
@@ -76,7 +76,7 @@ extern int os_early_init();
 extern HWND mumble_mw_hwnd;
 #endif // Q_OS_WIN
 
-#if defined(Q_OS_WIN) && !defined(QT_NO_DEBUG)
+#if defined(Q_OS_WIN) && !defined(MUMBLEAPP_DLL)
 extern "C" __declspec(dllexport) int main(int argc, char **argv) {
 #else
 int main(int argc, char **argv) {
@@ -759,7 +759,7 @@ int main(int argc, char **argv) {
 	return res;
 }
 
-#if defined(Q_OS_WIN) && defined(QT_NO_DEBUG)
+#if defined(Q_OS_WIN) && defined(MUMBLEAPP_DLL)
 extern "C" __declspec(dllexport) int MumbleMain(HINSTANCE instance, HINSTANCE prevInstance, LPSTR cmdArg, int cmdShow) {
 	Q_UNUSED(instance)
 	Q_UNUSED(prevInstance)


### PR DESCRIPTION
This fixes the loader not being able to load the DLL due to the missing symbol (mumble-voip/mumble-releng-vcpkg#8).

Previously, the function was defined and exported only when `QT_NO_DEBUG` was not defined (i.e. release builds).

This was probably the case due to:

- Our old environment not providing debug libraries.
- The DLL + loader idea only making sense when Mumble is installed. See PR #1684 for further info.