### PR TITLE
CI(azure-pipelines): Use static vcpkg environment for Linux build

### DIFF
--- a/.ci/azure-pipelines/install-environment_linux.bash
+++ b/.ci/azure-pipelines/install-environment_linux.bash
@@ -1,9 +1,12 @@
 #!/bin/bash -ex
 #
-# Copyright 2019-2020 The Mumble Developers. All rights reserved.
+# Copyright 2019-2021 The Mumble Developers. All rights reserved.
 # Use of this source code is governed by a BSD-style license
 # that can be found in the LICENSE file at the root of the
 # Mumble source tree or at <https://www.mumble.info/LICENSE>.
+
+currentDir=$(pwd)
+cd $AGENT_TEMPDIRECTORY
 
 sudo apt-get update
 
@@ -15,3 +18,24 @@ sudo apt-get -y install build-essential g++-multilib ninja-build pkg-config \
                         libogg-dev libsndfile1-dev libspeechd-dev \
                         libavahi-compat-libdnssd-dev libzeroc-ice-dev \
                         zsync appstream libgrpc++-dev protobuf-compiler-grpc
+
+if [ -d $MUMBLE_ENVIRONMENT_PATH ]; then
+	exit 0
+fi
+
+# We use axel to download the environment
+sudo apt-get -y install axel
+
+echo "Environment not cached. Downloading..."
+
+environmentArchive="$MUMBLE_ENVIRONMENT_VERSION.tar.xz"
+
+axel -n 10 --output="$environmentArchive" "$MUMBLE_ENVIRONMENT_SOURCE/$MUMBLE_ENVIRONMENT_VERSION.tar.xz"
+
+echo "Extracting build environment to $MUMBLE_ENVIRONMENT_STORE..."
+
+mkdir -p $MUMBLE_ENVIRONMENT_STORE
+
+"$currentDir"/.ci/azure-pipelines/extractWithProgress.bash "$environmentArchive" $MUMBLE_ENVIRONMENT_STORE
+
+ls -l $MUMBLE_ENVIRONMENT_STORE

--- a/.ci/azure-pipelines/main-pr.yml
+++ b/.ci/azure-pipelines/main-pr.yml
@@ -34,6 +34,8 @@ jobs:
   - job: Linux
     pool:
       vmImage: 'ubuntu-18.04'
+    variables:
+      MUMBLE_ENVIRONMENT_VERSION: 'linux-static-1.4.x~2021-02-16~gcd7e9f9d-no-debug.x64'
     steps:
     - template: steps_linux.yml
   - job: macOS

--- a/.ci/azure-pipelines/main.yml
+++ b/.ci/azure-pipelines/main.yml
@@ -32,6 +32,8 @@ jobs:
   - job: Linux
     pool:
       vmImage: 'ubuntu-18.04'
+    variables:
+      MUMBLE_ENVIRONMENT_VERSION: 'linux-static-1.4.x~2021-02-16~gcd7e9f9d-no-debug.x64'
     steps:
     - template: steps_linux.yml
   - job: macOS


### PR DESCRIPTION
This will allow us to build static server releases with up-to-date dependencies.

Previously, they were built on an old CentOS machine using Ermine.

The reason why we were not able to do this earlier is microsoft/vcpkg#11727.

@kafeg provided a working workaround.