### PR TITLE
FEAT(client, mainwindow): Show volume adjustments

### DIFF
--- a/src/mumble/AudioOutput.cpp
+++ b/src/mumble/AudioOutput.cpp
@@ -518,7 +518,7 @@ bool AudioOutput::mix(void *outbuff, unsigned int frameCount) {
 			AudioOutputSpeech *speech = qobject_cast<AudioOutputSpeech *>(aop);
 			if (speech) {
 				const ClientUser *user = speech->p;
-				volumeAdjustment *= user->fLocalVolume;
+				volumeAdjustment *= user->getLocalVolumeAdjustments();
 
 				if (user->cChannel && ChannelListener::isListening(g.uiSession, user->cChannel->iId) && (speech->ucFlags & SpeechFlags::Listen)) {
 					// We are receiving this audio packet only because we are listening to the channel

--- a/src/mumble/ClientUser.cpp
+++ b/src/mumble/ClientUser.cpp
@@ -24,9 +24,12 @@ ClientUser::ClientUser(QObject *p) : QObject(p),
 		fPowerMin(0.0f),
 		fPowerMax(0.0f),
 		fAverageAvailable(0.0f),
-		fLocalVolume(1.0f),
 		iFrames(0),
 		iSequence(0) {
+}
+
+float ClientUser::getLocalVolumeAdjustments() const {
+	return m_localVolume;
 }
 
 ClientUser *ClientUser::get(unsigned int uiSession) {
@@ -237,6 +240,13 @@ void ClientUser::setRecording(bool recording) {
 		return;
 	bRecording = recording;
 	emit recordingStateChanged();
+}
+
+void ClientUser::setLocalVolumeAdjustment(float adjustment) {
+	float oldAdjustment = m_localVolume;
+	m_localVolume = adjustment;
+
+	emit localVolumeAdjustmentsChanged(m_localVolume, oldAdjustment);
 }
 
 bool ClientUser::lessThanOverlay(const ClientUser *first, const ClientUser *second) {

--- a/src/mumble/ClientUser.h
+++ b/src/mumble/ClientUser.h
@@ -17,6 +17,10 @@ class ClientUser : public QObject, public User {
 	private:
 		Q_OBJECT
 		Q_DISABLE_COPY(ClientUser)
+
+	protected:
+		float m_localVolume = 1.0f;
+
 	public:
 		Settings::TalkState tsState;
 		Timer tLastTalkStateChange;
@@ -26,7 +30,6 @@ class ClientUser : public QObject, public User {
 
 		float fPowerMin, fPowerMax;
 		float fAverageAvailable;
-		float fLocalVolume;
 
 		int iFrames;
 		int iSequence;
@@ -36,6 +39,8 @@ class ClientUser : public QObject, public User {
 
 		QString getFlagsString() const;
 		ClientUser(QObject *p = nullptr);
+
+		float getLocalVolumeAdjustments() const;
 
 		/**
 		 * Determines whether a user is active or not
@@ -74,11 +79,13 @@ class ClientUser : public QObject, public User {
 		void setSelfDeaf(bool deaf);
 		void setPrioritySpeaker(bool priority);
 		void setRecording(bool recording);
+		void setLocalVolumeAdjustment(float adjustment);
 	signals:
 		void talkingStateChanged();
 		void muteDeafStateChanged();
 		void prioritySpeakerStateChanged();
 		void recordingStateChanged();
+		void localVolumeAdjustmentsChanged(float newAdjustment, float oldAdjustment);
 };
 
 #endif

--- a/src/mumble/LookConfig.cpp
+++ b/src/mumble/LookConfig.cpp
@@ -189,6 +189,7 @@ void LookConfig::load(const Settings &r) {
 	loadCheckBox(qcbHideTray, r.bHideInTray);
 	loadCheckBox(qcbStateInTray, r.bStateInTray);
 	loadCheckBox(qcbShowUserCount, r.bShowUserCount);
+	loadCheckBox(qcbShowVolumeAdjustments, r.bShowVolumeAdjustments);
 	loadCheckBox(qcbShowContextMenuInMenuBar, r.bShowContextMenuInMenuBar);
 	loadCheckBox(qcbShowTransmitModeComboBox, r.bShowTransmitModeComboBox);
 	loadCheckBox(qcbHighContrast, r.bHighContrast);
@@ -249,6 +250,7 @@ void LookConfig::save() const {
 	s.bHideInTray = qcbHideTray->isChecked();
 	s.bStateInTray = qcbStateInTray->isChecked();
 	s.bShowUserCount = qcbShowUserCount->isChecked();
+	s.bShowVolumeAdjustments = qcbShowVolumeAdjustments->isChecked();
 	s.bShowContextMenuInMenuBar = qcbShowContextMenuInMenuBar->isChecked();
 	s.bShowTransmitModeComboBox = qcbShowTransmitModeComboBox->isChecked();
 	s.bHighContrast = qcbHighContrast->isChecked();

--- a/src/mumble/LookConfig.ui
+++ b/src/mumble/LookConfig.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>728</width>
-    <height>1120</height>
+    <height>1148</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -671,6 +671,33 @@
       <string>Channel Tree</string>
      </property>
      <layout class="QGridLayout" name="gridLayout_2" columnstretch="0,0">
+      <item row="7" column="0" colspan="2">
+       <widget class="QCheckBox" name="qcbFilterHidesEmptyChannels">
+        <property name="text">
+         <string>Filter automatically hides empty channels</string>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="1">
+       <widget class="MUComboBox" name="qcbExpand">
+        <property name="toolTip">
+         <string>When to automatically expand channels</string>
+        </property>
+        <property name="whatsThis">
+         <string>This sets which channels to automatically expand. &lt;i&gt;None&lt;/i&gt; and &lt;i&gt;All&lt;/i&gt; will expand no or all channels, while &lt;i&gt;Only with users&lt;/i&gt; will expand and collapse channels as users join and leave them.</string>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="1">
+       <widget class="MUComboBox" name="qcbUserDrag">
+        <property name="toolTip">
+         <string>This changes the behavior when moving users.</string>
+        </property>
+        <property name="whatsThis">
+         <string>This sets the behavior of user drags; it can be used to prevent accidental dragging. &lt;i&gt;Move&lt;/i&gt; moves the user without prompting. &lt;i&gt;Do Nothing&lt;/i&gt; does nothing and prints an error message. &lt;i&gt;Ask&lt;/i&gt; uses a message box to confirm if you really wanted to move the user.</string>
+        </property>
+       </widget>
+      </item>
       <item row="1" column="0">
        <widget class="QLabel" name="qliUserDrag">
         <property name="text">
@@ -678,17 +705,24 @@
         </property>
        </widget>
       </item>
-      <item row="2" column="0">
-       <widget class="QLabel" name="qliExpand">
-        <property name="text">
-         <string>Expand</string>
-        </property>
-       </widget>
-      </item>
       <item row="0" column="0">
        <widget class="QLabel" name="qliChannelDrag">
         <property name="text">
          <string>Channel Dragging</string>
+        </property>
+       </widget>
+      </item>
+      <item row="6" column="0" colspan="2">
+       <widget class="QCheckBox" name="qcbChatBarUseSelection">
+        <property name="text">
+         <string>Use selected item as the chat bar target</string>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="0">
+       <widget class="QLabel" name="qliExpand">
+        <property name="text">
+         <string>Expand</string>
         </property>
        </widget>
       </item>
@@ -726,36 +760,12 @@
        </widget>
       </item>
       <item row="5" column="0" colspan="2">
-       <widget class="QCheckBox" name="qcbChatBarUseSelection">
-        <property name="text">
-         <string>Use selected item as the chat bar target</string>
-        </property>
-       </widget>
-      </item>
-      <item row="2" column="1">
-       <widget class="MUComboBox" name="qcbExpand">
+       <widget class="QCheckBox" name="qcbShowVolumeAdjustments">
         <property name="toolTip">
-         <string>When to automatically expand channels</string>
+         <string>Show the local volume adjustment for each user (if any).</string>
         </property>
-        <property name="whatsThis">
-         <string>This sets which channels to automatically expand. &lt;i&gt;None&lt;/i&gt; and &lt;i&gt;All&lt;/i&gt; will expand no or all channels, while &lt;i&gt;Only with users&lt;/i&gt; will expand and collapse channels as users join and leave them.</string>
-        </property>
-       </widget>
-      </item>
-      <item row="6" column="0" colspan="2">
-       <widget class="QCheckBox" name="qcbFilterHidesEmptyChannels">
         <property name="text">
-         <string>Filter automatically hides empty channels</string>
-        </property>
-       </widget>
-      </item>
-      <item row="1" column="1">
-       <widget class="MUComboBox" name="qcbUserDrag">
-        <property name="toolTip">
-         <string>This changes the behavior when moving users.</string>
-        </property>
-        <property name="whatsThis">
-         <string>This sets the behavior of user drags; it can be used to prevent accidental dragging. &lt;i&gt;Move&lt;/i&gt; moves the user without prompting. &lt;i&gt;Do Nothing&lt;/i&gt; does nothing and prints an error message. &lt;i&gt;Ask&lt;/i&gt; uses a message box to confirm if you really wanted to move the user.</string>
+         <string>Show volume adjustments</string>
         </property>
        </widget>
       </item>

--- a/src/mumble/Messages.cpp
+++ b/src/mumble/Messages.cpp
@@ -522,7 +522,7 @@ void MainWindow::msgUserState(const MumbleProto::UserState &msg) {
 			pDst->setLocalIgnore(true);
 		if (g.db->isLocalIgnoredTTS(pDst->qsHash))
 			pDst->setLocalIgnoreTTS(true);
-		pDst->fLocalVolume = g.db->getUserLocalVolume(pDst->qsHash);
+		pDst->setLocalVolumeAdjustment(g.db->getUserLocalVolume(pDst->qsHash));
 	}
 
 	if (msg.has_self_deaf() || msg.has_self_mute()) {

--- a/src/mumble/Settings.cpp
+++ b/src/mumble/Settings.cpp
@@ -356,6 +356,7 @@ Settings::Settings() {
 	bStateInTray = true;
 	bUsage = true;
 	bShowUserCount = false;
+	bShowVolumeAdjustments = true;
 	bChatBarUseSelection = false;
 	bFilterHidesEmptyChannels = true;
 	bFilterActive = false;
@@ -1176,6 +1177,8 @@ void Settings::save() {
 	SAVELOAD(bStateInTray, "ui/stateintray");
 	SAVELOAD(bUsage, "ui/usage");
 	SAVELOAD(bShowUserCount, "ui/showusercount");
+	SAVELOAD(bShowVolumeAdjustments, "ui/showVolumeAdjustments");
+	SAVELOAD(bShowVolumeAdjustments, "ui/showVolumeAdjustments");
 	SAVELOAD(bChatBarUseSelection, "ui/chatbaruseselection");
 	SAVELOAD(bFilterHidesEmptyChannels, "ui/filterhidesemptychannels");
 	SAVELOAD(bFilterActive, "ui/filteractive");

--- a/src/mumble/Settings.h
+++ b/src/mumble/Settings.h
@@ -322,6 +322,7 @@ struct Settings {
 	bool bStateInTray;
 	bool bUsage;
 	bool bShowUserCount;
+	bool bShowVolumeAdjustments;
 	bool bChatBarUseSelection;
 	bool bFilterHidesEmptyChannels;
 	bool bFilterActive;

--- a/src/mumble/TalkingUI.h
+++ b/src/mumble/TalkingUI.h
@@ -35,6 +35,7 @@ struct Entry {
 	QLabel *statusIcons;
 	unsigned int userSession;
 	Settings::TalkState talkingState;
+	QString qsName;
 };
 
 /// The talking UI is a widget that will display the users you are currently
@@ -142,6 +143,7 @@ class TalkingUI : public QWidget {
 		void on_settingsChanged();
 		void on_clientDisconnected(unsigned int userSession);
 		void on_muteDeafStateChanged();
+		void on_userLocalVolumeAdjustmentsChanged(float newAdjustment, float oldAdjustment);
 };
 
 #endif // MUMBLE_MUMBLE_TALKINGUI_H_

--- a/src/mumble/UserLocalVolumeDialog.cpp
+++ b/src/mumble/UserLocalVolumeDialog.cpp
@@ -60,7 +60,7 @@ UserLocalVolumeDialog::UserLocalVolumeDialog(unsigned int sessionId,
 	if (user) {
 		QString title = tr("Adjusting local volume for %1").arg(user->qsName);
 		setWindowTitle(title);
-		qsUserLocalVolume->setValue(qRound(log2(user->fLocalVolume) * 6.0));
+		qsUserLocalVolume->setValue(qRound(log2(user->getLocalVolumeAdjustments()) * 6.0));
 		m_originalVolumeAdjustmentDecibel = qsUserLocalVolume->value();
 	}
 
@@ -92,7 +92,7 @@ void UserLocalVolumeDialog::on_qsUserLocalVolume_valueChanged(int value) {
 	ClientUser *user = ClientUser::get(m_clientSession);
 	if (user) {
 		// Decibel formula: +6db = *2
-		user->fLocalVolume = static_cast<float>(pow(2.0, qsUserLocalVolume->value() / 6.0));
+		user->setLocalVolumeAdjustment(static_cast<float>(pow(2.0, qsUserLocalVolume->value() / 6.0)));
 	}
 }
 
@@ -108,7 +108,7 @@ void UserLocalVolumeDialog::on_qbbUserLocalVolume_clicked(QAbstractButton *butto
 		ClientUser *user = ClientUser::get(m_clientSession);
 		if (user) {
 			if (!user->qsHash.isEmpty()) {
-			    g.db->setUserLocalVolume(user->qsHash, user->fLocalVolume);
+			    g.db->setUserLocalVolume(user->qsHash, user->getLocalVolumeAdjustments());
 			} else {
 			    g.mw->logChangeNotPermanent(QObject::tr("Local Volume Adjustment..."), user);
 			}

--- a/src/mumble/UserModel.h
+++ b/src/mumble/UserModel.h
@@ -186,6 +186,9 @@ class UserModel : public QAbstractItemModel {
 
 		unsigned int uiSessionComment;
 		int iChannelDescription;
+
+
+		static QString createDisplayString(const ClientUser &user, bool isChannelListener, const Channel *parentChannel);
 	public slots:
 		/// Invalidates the model data of the ClientUser triggering this slot.
 		void userStateChanged();

--- a/src/mumble/mumble_en.ts
+++ b/src/mumble/mumble_en.ts
@@ -4267,6 +4267,14 @@ The setting only applies for new messages, the already shown ones will retain th
         <source>Silent user lifetime</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Show the local volume adjustment for each user (if any).</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show volume adjustments</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>MainWindow</name>


### PR DESCRIPTION
This feature optionally allows users to display the set volume
adjustments next to the user's/listener's name.
It will only be shown if it is not equal to 0 dB (aka: it is actually
having an effect).

By default this option is enabled since it is only visible if volume
adjustments are set up anyways.

Screenshot:
![Mumble_ShowVolumeAdjustments](https://user-images.githubusercontent.com/12751591/91524676-159b6a00-e900-11ea-88b4-c0bd25daeb72.png)
