### PR TITLE
FIX(cmake): Set QT_RESTRICTED_CAST_FROM_ASCII

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -124,6 +124,11 @@ target_compile_definitions(shared
 		"MUMBLE_VERSION_STRING=${version_short}"
 )
 
+target_compile_definitions(shared
+	PRIVATE
+		"QT_RESTRICTED_CAST_FROM_ASCII"
+)
+
 target_include_directories(shared
 	PUBLIC
 		${CMAKE_CURRENT_SOURCE_DIR}

--- a/src/mumble/CMakeLists.txt
+++ b/src/mumble/CMakeLists.txt
@@ -306,6 +306,7 @@ target_compile_definitions(mumble
 	PRIVATE
 		"MUMBLE"
 		"USE_OPUS"
+		"QT_RESTRICTED_CAST_FROM_ASCII"
 )
 
 target_include_directories(mumble

--- a/src/murmur/CMakeLists.txt
+++ b/src/murmur/CMakeLists.txt
@@ -57,7 +57,11 @@ set_target_properties(murmur
 		RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}
 )
 
-target_compile_definitions(murmur PRIVATE "MURMUR")
+target_compile_definitions(murmur
+	PRIVATE
+		"MURMUR"
+		"QT_RESTRICTED_CAST_FROM_ASCII"
+)
 
 target_include_directories(murmur PRIVATE
 	${CMAKE_CURRENT_SOURCE_DIR} # This is required for includes in current folder to be found by files from the shared directory.

--- a/src/murmur/Messages.cpp
+++ b/src/murmur/Messages.cpp
@@ -1460,8 +1460,8 @@ void logGroups(Server *server, const Channel *c, QString prefix = QString()) {
 		server->log(QString::fromLatin1("Channel %1 (%2) has no groups set").arg(c->qsName).arg(c->iId));
 		return;
 	} else {
-		server->log(QString::fromLatin1("%1Listing groups specified for channel \"%2\" (%3)...").arg(prefix.isEmpty() ? "" : "\t").arg(
-					c->qsName).arg(c->iId));
+		server->log(QString::fromLatin1("%1Listing groups specified for channel \"%2\" (%3)...").arg(prefix.isEmpty()
+					? QLatin1String("") : QLatin1String("\t")).arg(c->qsName).arg(c->iId));
 	}
 
 	foreach(Group *currentGroup, c->qhGroups) {
@@ -1473,11 +1473,11 @@ void logGroups(Server *server, const Channel *c, QString prefix = QString()) {
 
 		if (currentGroup->members().size() > 0) {
 			memberList.remove(memberList.length() -2, 2);
-			server->log(QString::fromLatin1("%1Group: \"%2\" contains following users: %3").arg(prefix.isEmpty() ? "\t" : "\t\t").arg(
-						currentGroup->qsName).arg(memberList));
+			server->log(QString::fromLatin1("%1Group: \"%2\" contains following users: %3").arg(prefix.isEmpty()
+						? QLatin1String("\t") : QLatin1String("\t\t")).arg(currentGroup->qsName).arg(memberList));
 		} else {
-			server->log(QString::fromLatin1("%1Group \"%2\" doesn't contain any users").arg(prefix.isEmpty() ? "\t" : "\t\t").arg(
-						currentGroup->qsName));
+			server->log(QString::fromLatin1("%1Group \"%2\" doesn't contain any users").arg(prefix.isEmpty()
+						? QLatin1String("\t") : QLatin1String("\t\t")).arg(currentGroup->qsName));
 		}
 	}
 }
@@ -1493,7 +1493,7 @@ void logACLs(Server *server, const Channel *c, QString prefix = QString()) {
 	}
 
 	foreach(const ChanACL *a, c->qlACL) {
-		server->log(QString::fromLatin1("%1%2").arg(prefix.isEmpty() ? "" : "\t").arg(static_cast<QString>(*a)));
+		server->log(QString::fromLatin1("%1%2").arg(prefix.isEmpty() ? QLatin1String("") : QLatin1String("\t")).arg(static_cast<QString>(*a)));
 	}
 }
 

--- a/src/murmur/Meta.cpp
+++ b/src/murmur/Meta.cpp
@@ -379,7 +379,7 @@ void MetaParams::read(QString fname) {
 		if (pw) {
 			uiUid = pw->pw_uid;
 			uiGid = pw->pw_gid;
-			qsHome = pw->pw_dir;
+			qsHome = QString::fromUtf8(pw->pw_dir);
 		} else if (requested) {
 			qFatal("Cannot find username %s", qPrintable(qsName));
 		}
@@ -435,8 +435,8 @@ void MetaParams::read(QString fname) {
 	qmConfig.insert(QLatin1String("registerlocation"), qsRegLocation);
 	qmConfig.insert(QLatin1String("registerurl"),qurlRegWeb.toString());
 	qmConfig.insert(QLatin1String("bonjour"), bBonjour ? QLatin1String("true") : QLatin1String("false"));
-	qmConfig.insert(QLatin1String("certificate"),qscCert.toPem());
-	qmConfig.insert(QLatin1String("key"),qskKey.toPem());
+	qmConfig.insert(QLatin1String("certificate"), QString::fromUtf8(qscCert.toPem()));
+	qmConfig.insert(QLatin1String("key"), QString::fromUtf8(qskKey.toPem()));
 	qmConfig.insert(QLatin1String("obfuscate"),bObfuscate ? QLatin1String("true") : QLatin1String("false"));
 	qmConfig.insert(QLatin1String("username"),qrUserName.pattern());
 	qmConfig.insert(QLatin1String("channelname"),qrChannelName.pattern());
@@ -640,8 +640,8 @@ bool MetaParams::loadSSLSettings() {
 	qsCiphers = tmpCiphersStr;
 	qlCiphers = tmpCiphers;
 
-	qmConfig.insert(QLatin1String("certificate"), qscCert.toPem());
-	qmConfig.insert(QLatin1String("key"), qskKey.toPem());
+	qmConfig.insert(QLatin1String("certificate"), QString::fromUtf8(qscCert.toPem()));
+	qmConfig.insert(QLatin1String("key"), QString::fromUtf8(qskKey.toPem()));
 	qmConfig.insert(QLatin1String("sslCiphers"), qsCiphers);
 	qmConfig.insert(QLatin1String("sslDHParams"), QString::fromLatin1(qbaDHParams.constData()));
 

--- a/src/murmur/PBKDF2.cpp
+++ b/src/murmur/PBKDF2.cpp
@@ -102,7 +102,7 @@ QString PBKDF2::getHash(const QString &hexSalt, const QString &password, int ite
 		return QString();
 	}
 	
-	return hash.toHex();
+	return QString::fromLatin1(hash.toHex());
 }
 
 
@@ -114,5 +114,5 @@ QString PBKDF2::getSalt() {
 		return QString();
 	}
 
-	return salt.toHex();
+	return QString::fromLatin1(salt.toHex());
 }

--- a/src/murmur/Server.cpp
+++ b/src/murmur/Server.cpp
@@ -1480,7 +1480,7 @@ void Server::encrypted() {
 	if (!certs.isEmpty()) {
 		const QSslCertificate &cert = certs.last();
 		uSource->qslEmail = cert.subjectAlternativeNames().values(QSsl::EmailEntry);
-		uSource->qsHash = cert.digest(QCryptographicHash::Sha1).toHex();
+		uSource->qsHash = QString::fromLatin1(cert.digest(QCryptographicHash::Sha1).toHex());
 		if (! uSource->qslEmail.isEmpty() && uSource->bVerified) {
 			QString subject;
 			QString issuer;
@@ -2059,7 +2059,7 @@ QString Server::addressToString(const QHostAddress &adr, unsigned short port) {
 			Q_IPV6ADDR num = adr.toIPv6Address();
 			h.addData(reinterpret_cast<const char *>(num.c), sizeof(num.c));
 		}
-		return QString("<<%1:%2>>").arg(QString(h.result().toHex()), QString::number(port));
+		return QString("<<%1:%2>>").arg(QString::fromLatin1(h.result().toHex()), QString::number(port));
 	}
 	return QString("%1:%2").arg(ha.toString(), QString::number(port));
 }

--- a/src/murmur/UnixMurmur.cpp
+++ b/src/murmur/UnixMurmur.cpp
@@ -292,7 +292,7 @@ void UnixMurmur::setuid() {
 			// QDir::homePath is broken. It only looks at $HOME
 			// instead of getpwuid() so we have to set our home
 			// ourselves
-			EnvUtils::setenv(QLatin1String("HOME"), qPrintable(Meta::mp.qsHome));
+			EnvUtils::setenv(QLatin1String("HOME"), Meta::mp.qsHome);
 		}
 #endif
 	} else if (bRoot) {


### PR DESCRIPTION
With the old qmake buildsystem we used to set QT_NO_CAST_FROM_ASCII (for
the Mumble client) in order to avoid problems with character encodings
in our Strings. This was not done in the new cmake system yet.

Instead of the aforementioned macro, this commit sets
QT_RESTRICTED_CAST_FROM_ASCII instead in order to be able to
automatically convert direct String literals to QString as these usually
don't contain any problematic characters (non-ASCII) in the first place.
And this allows to e.g. compare a QString against a String literal or do
something like
QString myString = "This is a test";
which we know to be unproblematic.

Note however that (quote from Qt's docs)
"Using this macro together with source strings outside the 7-bit range,
non-literals, or literals with embedded NUL characters is undefined."