### PR TITLE
CI(macOS): Use axel instead of wget

### DIFF
--- a/.ci/azure-pipelines/install-environment_macos.bash
+++ b/.ci/azure-pipelines/install-environment_macos.bash
@@ -13,15 +13,20 @@ if [ -d $MUMBLE_ENVIRONMENT_PATH ]; then
 	exit 0
 fi
 
+# We use axel to download the environment
+brew install axel
+
 echo "Environment not cached. Downloading..."
 
-wget "$MUMBLE_ENVIRONMENT_SOURCE/$MUMBLE_ENVIRONMENT_VERSION.tar.xz"
+environmentArchive="$MUMBLE_ENVIRONMENT_VERSION.tar.xz"
+
+axel -n 10 --output="$environmentArchive" "$MUMBLE_ENVIRONMENT_SOURCE/$MUMBLE_ENVIRONMENT_VERSION.tar.xz"
 
 echo "Extracting build environment to $MUMBLE_ENVIRONMENT_STORE..."
 
 mkdir -p $MUMBLE_ENVIRONMENT_STORE
 
-tar xf "$MUMBLE_ENVIRONMENT_VERSION.tar.xz" -C $MUMBLE_ENVIRONMENT_STORE
+tar xf "$environmentArchive" -C $MUMBLE_ENVIRONMENT_STORE
 
 chmod +x "$MUMBLE_ENVIRONMENT_PATH/installed/x64-osx/tools/Ice/slice2cpp"
 


### PR DESCRIPTION
Axel is a CLI download utility that'll open multiple concurrent streams
and thereby increasing the overall download speed.
Ref.: https://www.linuxjournal.com/content/speed-your-downloads-axel

Using axel to download the environment seems to be up to 5x faster than
using wget.