### PR TITLE
CI: Show progress for decompressing

### DIFF
--- a/.ci/azure-pipelines/extractWithProgress.bash
+++ b/.ci/azure-pipelines/extractWithProgress.bash
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+#
+# Copyright 2020 The Mumble Developers. All rights reserved.
+# Use of this source code is governed by a BSD-style license
+# that can be found in the LICENSE file at the root of the
+# Mumble source tree or at <https://www.mumble.info/LICENSE>.
+
+set -e
+
+fromFile="$1"
+targetDir="$2"
+
+if [ -z "$fromFile" ]; then
+	echo "[ERROR]: Missing argument"
+	exit 1
+fi
+
+if [ -z "$targetDir" ]; then
+	targetDir="."
+fi
+
+echo "Extracting from \"$fromFile\" to \"$targetDir\""
+echo ""
+
+# Get sizes in bytes
+fromSize=$(xz --robot --list "$fromFile" | tail -n -1 | cut -f 4)
+toSize=$(xz --robot --list "$fromFile" | tail -n -1 | cut -f 5)
+# Convert sizes to KB
+toSizeKB=$(expr "$toSize" / 1000)
+fromSizeKB=$(expr "$fromSize" / 1000)
+
+echo "Compressed size:   $fromSizeKB KB"
+echo "Uncompressed size: $toSizeKB KB"
+
+steps=100
+checkPointStep=$(expr "$toSizeKB" / "$steps" )
+
+echo ""
+
+# Use gtar instead of tar if available (for MacOS compatibility)
+tarExec="tar"
+if [ -x "$(command -v gtar)" ]; then
+	tarExec="gtar"
+fi
+
+"$tarExec" -x --record-size=1K --checkpoint="$checkPointStep" --checkpoint-action="echo=%u / $toSize" -f "$fromFile" -C "$targetDir"

--- a/.ci/azure-pipelines/install-environment_macos.bash
+++ b/.ci/azure-pipelines/install-environment_macos.bash
@@ -5,6 +5,7 @@
 # that can be found in the LICENSE file at the root of the
 # Mumble source tree or at <https://www.mumble.info/LICENSE>.
 
+currentDir=$(pwd)
 cd $AGENT_TEMPDIRECTORY
 
 brew install ninja
@@ -15,6 +16,8 @@ fi
 
 # We use axel to download the environment
 brew install axel
+# We use gtar instead of tar as the default tar on macOS doesn't support the --record-size option
+brew install gnu-tar
 
 echo "Environment not cached. Downloading..."
 
@@ -26,7 +29,7 @@ echo "Extracting build environment to $MUMBLE_ENVIRONMENT_STORE..."
 
 mkdir -p $MUMBLE_ENVIRONMENT_STORE
 
-tar xf "$environmentArchive" -C $MUMBLE_ENVIRONMENT_STORE
+"$currentDir"/.ci/azure-pipelines/extractWithProgress.bash "$environmentArchive" $MUMBLE_ENVIRONMENT_STORE
 
 chmod +x "$MUMBLE_ENVIRONMENT_PATH/installed/x64-osx/tools/Ice/slice2cpp"
 


### PR DESCRIPTION
As tar doesn't support a proper progress bar this commit adds a helper
script that'll print a rough progress.