### PR TITLE
FIX(client): Initialize variable before use

### DIFF
--- a/src/mumble/ALSAAudio.cpp
+++ b/src/mumble/ALSAAudio.cpp
@@ -514,7 +514,7 @@ void ALSAAudioOutput::run() {
 		if (revents & POLLERR) {
 			snd_pcm_prepare(pcm_handle);
 		} else if (revents & POLLOUT) {
-			snd_pcm_sframes_t avail;
+			snd_pcm_sframes_t avail{};
 			ALSA_ERRCHECK(avail = snd_pcm_avail_update(pcm_handle));
 			while (avail >= static_cast<int>(period_size)) {
 				stillRun = mix(outbuff, static_cast<int>(period_size));


### PR DESCRIPTION
'ALSA_ERRCHECK' is an unsafe function-like macro that should be replaced with a function. 'avail' is used uninitialized whenever 'bOk' is false which is undefined behavior.