### PR TITLE
FEAT(client,ui): Add "select all" for messages

### DIFF
--- a/src/mumble/Log.h
+++ b/src/mumble/Log.h
@@ -23,6 +23,10 @@ class LogConfig : public ConfigWidget, public Ui::LogConfig {
 	private:
 		Q_OBJECT
 		Q_DISABLE_COPY(LogConfig)
+
+		QTreeWidgetItem *allMessagesItem;
+	protected:
+		void updateSelectAllButtons();
 	public:
 		/// The unique name of this ConfigWidget
 		static const QString name;

--- a/src/mumble/mumble_en.ts
+++ b/src/mumble/mumble_en.ts
@@ -7073,6 +7073,30 @@ See &lt;a href=&quot;https://wiki.mumble.info/wiki/Installing_Mumble&quot;&gt;th
         <source>Talking (muted)</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>All messages</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Toggle console for all events</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Toggle pop-up notifications for all events</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Toggle window highlight (if not active) for all events</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Click here to toggle sound notifications for all events</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Toggle Text-to-Speech for all events</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>RichTextEditor</name>


### PR DESCRIPTION
If someone wants to select or deselect all messages in a given column,
they had to do that manually. With this commit a new header row is
introduced that allows for easily selecting or deselecting all entries in
a column.

Fixes #4464

Screenshot:
![image](https://user-images.githubusercontent.com/12751591/92461443-93495a80-f1c9-11ea-81a9-279257707964.png)