### PR TITLE
BUILD(cmake): Also install man files

### DIFF
--- a/overlay_gl/CMakeLists.txt
+++ b/overlay_gl/CMakeLists.txt
@@ -5,6 +5,8 @@
 
 # Overlay payload for UNIX-like systems.
 
+include(GNUInstallDirs)
+
 if(${CMAKE_SYSTEM_PROCESSOR} STREQUAL "x86_64" OR ${CMAKE_SYSTEM_PROCESSOR} STREQUAL "amd64")
 	option(overlay-xcompile "Build 32 bit overlay library, necessary for the overlay to work with 32 bit processes." ON)
 endif()
@@ -116,3 +118,6 @@ else()
 			${LIB_COREFOUNDATION}
 	)
 endif()
+
+# install overlay man-files
+install(FILES "${CMAKE_SOURCE_DIR}/man/mumble-overlay.1" DESTINATION "${CMAKE_INSTALL_MANDIR}/man1" COMPONENT doc)

--- a/src/mumble/CMakeLists.txt
+++ b/src/mumble/CMakeLists.txt
@@ -3,6 +3,8 @@
 # that can be found in the LICENSE file at the root of the
 # Mumble source tree or at <https://www.mumble.info/LICENSE>.
 
+include(GNUInstallDirs)
+
 set(MUMBLE_RC "${CMAKE_CURRENT_BINARY_DIR}/mumble.rc")
 set(MUMBLE_DLL_RC "${CMAKE_CURRENT_BINARY_DIR}/mumble_dll.rc")
 set(MUMBLE_PLIST "${CMAKE_CURRENT_BINARY_DIR}/mumble.plist")
@@ -305,6 +307,9 @@ else()
 	else()
 		install(TARGETS mumble BUNDLE DESTINATION . COMPONENT mumble_client)
 	endif()
+
+	# Install Mumble man files
+	install(FILES "${CMAKE_SOURCE_DIR}/man/mumble.1" DESTINATION "${CMAKE_INSTALL_MANDIR}/man1" COMPONENT doc)
 endif()
 
 target_compile_definitions(mumble

--- a/src/murmur/CMakeLists.txt
+++ b/src/murmur/CMakeLists.txt
@@ -3,6 +3,8 @@
 # that can be found in the LICENSE file at the root of the
 # Mumble source tree or at <https://www.mumble.info/LICENSE>.
 
+include(GNUInstallDirs)
+
 set(MURMUR_RC "${CMAKE_CURRENT_BINARY_DIR}/murmur.rc")
 set(MURMUR_ICON "${CMAKE_SOURCE_DIR}/icons/murmur.ico")
 set(MURMUR_PLIST "${CMAKE_CURRENT_BINARY_DIR}/murmur.plist")
@@ -312,4 +314,8 @@ if(WIN32)
 	install(TARGETS murmur RUNTIME DESTINATION . COMPONENT mumble_server)
 else()
 	install(TARGETS murmur RUNTIME DESTINATION bin COMPONENT mumble_server)
+
+	# Install Murmur man files
+	install(FILES "${CMAKE_SOURCE_DIR}/man/murmurd.1" DESTINATION "${CMAKE_INSTALL_MANDIR}/man1" COMPONENT doc)
+	install(FILES "${CMAKE_SOURCE_DIR}/man/murmur-user-wrapper.1" DESTINATION "${CMAKE_INSTALL_MANDIR}/man1" COMPONENT doc)
 endif()


### PR DESCRIPTION
On Unix-systems (Linux & Mac) we now also install our man-files when
the user invokes the generated install target.

Fixes #4472