### PR TITLE
BUILD(cmake): Don't re-use BUILD_TESTING

### DIFF
--- a/.ci/azure-pipelines/build_linux.bash
+++ b/.ci/azure-pipelines/build_linux.bash
@@ -18,7 +18,7 @@ VER=$(python scripts/mumble-version.py)
 cd $BUILD_BINARIESDIRECTORY
 
 # QSslDiffieHellmanParameters was introduced in Qt 5.8, Ubuntu 16.04 has 5.5.
-cmake -G Ninja -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=appdir/usr -DBUILD_TESTING=ON -Dversion=$VER -Dsymbols=ON \
+cmake -G Ninja -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=appdir/usr -Dtests=ON -Dversion=$VER -Dsymbols=ON \
 	-Dqssldiffiehellmanparameters=OFF -Donline-tests=ON $BUILD_SOURCESDIRECTORY
 cmake --build .
 ctest --verbose

--- a/.ci/azure-pipelines/build_macos.bash
+++ b/.ci/azure-pipelines/build_macos.bash
@@ -18,7 +18,7 @@ VER=$(python scripts/mumble-version.py)
 cd $BUILD_BINARIESDIRECTORY
 
 cmake -G Ninja -DCMAKE_TOOLCHAIN_FILE=$MUMBLE_ENVIRONMENT_TOOLCHAIN -DIce_HOME="$MUMBLE_ENVIRONMENT_PATH/installed/x64-osx" \
-	-DCMAKE_BUILD_TYPE=Release -DBUILD_TESTING=ON -Dversion=$VER -Dstatic=ON -Dsymbols=ON -Donline-tests=ON $BUILD_SOURCESDIRECTORY
+	-DCMAKE_BUILD_TYPE=Release -Dtests=ON -Dversion=$VER -Dstatic=ON -Dsymbols=ON -Donline-tests=ON $BUILD_SOURCESDIRECTORY
 cmake --build .
 ctest --verbose
 

--- a/.ci/azure-pipelines/build_windows.bat
+++ b/.ci/azure-pipelines/build_windows.bat
@@ -50,7 +50,7 @@ del C:\Strawberry\c\bin\g++.exe
 del C:\Strawberry\c\bin\c++.exe
 
 cmake -G Ninja -DCMAKE_TOOLCHAIN_FILE="%MUMBLE_ENVIRONMENT_TOOLCHAIN%" -DVCPKG_TARGET_TRIPLET=%MUMBLE_ENVIRONMENT_TRIPLET% ^
-	-DIce_HOME="%MUMBLE_ENVIRONMENT_PATH%\installed\%MUMBLE_ENVIRONMENT_TRIPLET%" -DCMAKE_BUILD_TYPE=Release -DBUILD_TESTING=ON ^
+	-DIce_HOME="%MUMBLE_ENVIRONMENT_PATH%\installed\%MUMBLE_ENVIRONMENT_TRIPLET%" -DCMAKE_BUILD_TYPE=Release -Dtests=ON ^
 	-Dversion=%VER% -Dpackaging=ON -Dstatic=ON -Dsymbols=ON -Dasio=ON -Dg15=ON -Donline-tests=ON "%BUILD_SOURCESDIRECTORY%"
 
 if errorlevel 1 (

--- a/.ci/travis-ci/script.bash
+++ b/.ci/travis-ci/script.bash
@@ -16,7 +16,7 @@ VER=$(python scripts/mumble-version.py)
 if [ "${TRAVIS_OS_NAME}" == "linux" ]; then
 	if [ "${MUMBLE_HOST}" == "aarch64-linux-gnu" ]; then
 		mkdir build && cd build
-		cmake -G Ninja -DCMAKE_BUILD_TYPE=Release -DBUILD_TESTING=ON -Dversion=$VER -Dsymbols=ON -Donline-tests=ON ..
+		cmake -G Ninja -DCMAKE_BUILD_TYPE=Release -Dtests=ON -Dversion=$VER -Dsymbols=ON -Donline-tests=ON ..
 		cmake --build .
 		# We don't execute tests on ARM64 because TestPacketDataStream fails.
 		# See https://github.com/mumble-voip/mumble/issues/3845.
@@ -25,7 +25,7 @@ if [ "${TRAVIS_OS_NAME}" == "linux" ]; then
 	elif [ "${MUMBLE_HOST}" == "x86_64-linux-gnu" ]; then
 		mkdir build && cd build
 		# We specify the absolute path because otherwise Travis CI's CMake is used.
-		/usr/bin/cmake -G Ninja -DCMAKE_BUILD_TYPE=Release -DBUILD_TESTING=ON -Dversion=$VER -Dsymbols=ON -Donline-tests=ON ..
+		/usr/bin/cmake -G Ninja -DCMAKE_BUILD_TYPE=Release -Dtests=ON -Dversion=$VER -Dsymbols=ON -Donline-tests=ON ..
 		/usr/bin/cmake --build .
 		/usr/bin/ctest --verbose
 		sudo /usr/bin/cmake --install .
@@ -38,7 +38,7 @@ if [ "${TRAVIS_OS_NAME}" == "linux" ]; then
 
 		PATH=$PATH:/usr/lib/mxe/usr/bin
 
-		${MUMBLE_HOST}.static-cmake -G Ninja -DCMAKE_BUILD_TYPE=Release -DBUILD_TESTING=ON -Dversion=$VER -Dstatic=ON -Dsymbols=ON -Dasio=ON \
+		${MUMBLE_HOST}.static-cmake -G Ninja -DCMAKE_BUILD_TYPE=Release -Dtests=ON -Dversion=$VER -Dstatic=ON -Dsymbols=ON -Dasio=ON \
 			-Dbonjour=OFF -Dice=OFF -Doverlay=OFF -Donline-tests=ON ..
 		cmake --build .
 		# TODO: investigate why tests fail.

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -9,7 +9,7 @@ freebsd_task:
   build_script:
   - mkdir build && cd build
   # We disable translations because of a critical issue in "lupdate": it's very slow and keeps CPU usage at 100%.
-  - cmake -G Ninja -DCMAKE_BUILD_TYPE=Release -DBUILD_TESTING=ON -Dsymbols=ON -Dtranslations=OFF ..
+  - cmake -G Ninja -DCMAKE_BUILD_TYPE=Release -Dtests=ON -Dsymbols=ON -Dtranslations=OFF ..
   - cmake --build .
   test_script:
   - cd build

--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,4 @@ doxygen/
 .qmake.stash
 .DS_Store
 .directory
+build/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,12 +32,12 @@ list(APPEND CMAKE_MODULE_PATH
 	"${CMAKE_SOURCE_DIR}/cmake/FindModules"
 )
 
+
 include(pkg-utils)
-include(CTest)
 include(project-utils)
 
 
-option(BUILD_TESTING "Build tests." OFF)
+option(tests "Build tests" OFF)
 
 option(optimize "Build a heavily optimized version, specific to the machine it's being compiled on." OFF)
 option(static "Build static binaries." OFF)
@@ -95,6 +95,21 @@ message(STATUS "Mumble version:  ${version}")
 message(STATUS "Architecture:    ${ARCH}")
 message(STATUS "Build type:      ${BUILD_STR}")
 message(STATUS "##################################################")
+
+# We have to check for BUILD_TESTING before including CTest as CTest defines this variable
+if(DEFINED BUILD_TESTING)
+	message(WARNING "Use of option \"BUILD_TESTING\" is deprecated. Use \"tests\" instead.")
+
+	if(NOT tests)
+		# Allow deprecated option to enable tests if they had been disabled otherwise
+		set(tests "${BUILD_TESTING}")
+	endif()
+endif()
+
+if(tests)
+	include(CTest)
+endif()
+
 
 add_subdirectory(src)
 

--- a/cmake/os.cmake
+++ b/cmake/os.cmake
@@ -3,7 +3,7 @@
 # that can be found in the LICENSE file at the root of the
 # Mumble source tree or at <https://www.mumble.info/LICENSE>. 
 
-if(BUILD_TESTING)
+if(tests)
 	if(WIN32 AND NOT ${CMAKE_HOST_SYSTEM_NAME} STREQUAL "Windows")
 		# We're building for Windows on a different operating system.
 		find_program(WINE

--- a/cmake/os.cmake
+++ b/cmake/os.cmake
@@ -26,9 +26,6 @@ endif()
 add_definitions(
 	"-DQT_USE_FAST_CONCATENATION"
 	"-DQT_USE_FAST_OPERATOR_PLUS"
-	# TODO: Uncomment the following definitions when the resulting errors are fixed.
-	#"-DQT_NO_CAST_FROM_ASCII"
-	#"-DQT_NO_CAST_TO_ASCII"
 )
 
 if(WIN32)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -172,6 +172,6 @@ if(server)
 	add_subdirectory(murmur)
 endif()
 
-if(BUILD_TESTING)
+if(tests)
 	add_subdirectory(tests)
 endif()

--- a/src/mumble/CMakeLists.txt
+++ b/src/mumble/CMakeLists.txt
@@ -500,7 +500,7 @@ if(bundled-opus)
 
 	target_include_directories(mumble PRIVATE "${3RDPARTY_DIR}/opus/include")
 
-	if(BUILD_TESTING)
+	if(tests)
 		set_target_properties(test_opus_decode test_opus_padding PROPERTIES RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/tests")
 	endif()
 


### PR DESCRIPTION
We used the BUILD_TESTING variable in order to indicate whether or not
tests shall be built. However this variable is used by e.g. CTest
already and there it had a different default value. Therefore we now
deprecate BUILD_TESTING and use the tests option instead.
