### PR TITLE
FIX(client): typo in gswForward() causing "WM_" messages not to be injected

### DIFF
--- a/src/mumble/MumbleApplication.cpp
+++ b/src/mumble/MumbleApplication.cpp
@@ -66,7 +66,7 @@ bool MumbleApplication::event(QEvent *e) {
 ///          by GlobalShortcutWin. Otherwise, returns false.
 static bool gswForward(MSG *msg) {
 	GlobalShortcutWin *gsw = static_cast< GlobalShortcutWin * >(GlobalShortcutEngine::engine);
-	if (gsw) {
+	if (!gsw) {
 		return false;
 	}
 	switch (msg->message) {


### PR DESCRIPTION
This could also cause a crash, in case `gswForward()` was called before `GlobalShortcutsWin`'s initialization.

For reference, the bug was introduced in #4317.