### PR TITLE
FIX: volume adjustment display

### DIFF
--- a/src/mumble/MainWindow.cpp
+++ b/src/mumble/MainWindow.cpp
@@ -313,6 +313,8 @@ void MainWindow::setupGui() {
 	QObject::connect(
 		this, &MainWindow::userRemovedChannelListener, pmModel,
 		static_cast< void (UserModel::*)(const ClientUser *, const Channel *) >(&UserModel::removeChannelListener));
+	QObject::connect(&ChannelListener::get(), &ChannelListener::localVolumeAdjustmentsChanged, pmModel,
+			&UserModel::on_channelListenerLocalVolumeAdjustmentChanged);
 
 	qaAudioMute->setChecked(g.s.bMute);
 	qaAudioDeaf->setChecked(g.s.bDeaf);

--- a/src/mumble/UserModel.cpp
+++ b/src/mumble/UserModel.cpp
@@ -1018,6 +1018,7 @@ ClientUser *UserModel::addUser(unsigned int id, const QString &name) {
 	connect(p, SIGNAL(muteDeafStateChanged()), this, SLOT(userStateChanged()));
 	connect(p, SIGNAL(prioritySpeakerStateChanged()), this, SLOT(userStateChanged()));
 	connect(p, SIGNAL(recordingStateChanged()), this, SLOT(userStateChanged()));
+	connect(p, &ClientUser::localVolumeAdjustmentsChanged, this, &UserModel::userStateChanged);
 
 	Channel *c       = Channel::get(0);
 	ModelItem *citem = ModelItem::c_qhChannels.value(c);
@@ -1659,6 +1660,7 @@ Channel *UserModel::getSubChannel(Channel *p, int idx) const {
 
 void UserModel::userStateChanged() {
 	ClientUser *user = qobject_cast< ClientUser * >(sender());
+
 	if (!user)
 		return;
 
@@ -1666,6 +1668,14 @@ void UserModel::userStateChanged() {
 	emit dataChanged(idx, idx);
 
 	updateOverlay();
+}
+
+void UserModel::on_channelListenerLocalVolumeAdjustmentChanged(int channelID, float oldValue, float newValue) {
+	Q_UNUSED(oldValue);
+	Q_UNUSED(newValue);
+
+	const QModelIndex idx = channelListenerIndex(ClientUser::get(g.uiSession), Channel::get(channelID));
+	emit dataChanged(idx, idx);
 }
 
 void UserModel::toggleChannelFiltered(Channel *c) {

--- a/src/mumble/UserModel.cpp
+++ b/src/mumble/UserModel.cpp
@@ -1929,9 +1929,15 @@ QString UserModel::createDisplayString(const ClientUser &user, bool isChannelLis
 	// Get the configured volume adjustment. Depending on whether
 	// this display string is for a ChannelListener or a regular user, we have to fetch
 	// the volume adjustment differently.
-	float volumeAdjustment = isChannelListener && parentChannel
-								 ? ChannelListener::getListenerLocalVolumeAdjustment(parentChannel->iId)
-								 : user.getLocalVolumeAdjustments();
+	float volumeAdjustment = 1.0f;
+	if (isChannelListener) {
+		if (parentChannel && user.uiSession == g.uiSession) {
+			// Only the listener of the local user can have a volume adjustment
+			volumeAdjustment = ChannelListener::getListenerLocalVolumeAdjustment(parentChannel->iId);
+		}
+	} else {
+		volumeAdjustment = user.getLocalVolumeAdjustments();
+	}
 
 	// Transform the adjustment into dB
 	// *2 == 6 dB

--- a/src/mumble/UserModel.h
+++ b/src/mumble/UserModel.h
@@ -208,6 +208,7 @@ public:
 public slots:
 	/// Invalidates the model data of the ClientUser triggering this slot.
 	void userStateChanged();
+	void on_channelListenerLocalVolumeAdjustmentChanged(int channelID, float oldValue, float newValue);
 	void ensureSelfVisible();
 	void recheckLinks();
 	void updateOverlay() const;


### PR DESCRIPTION
This is a followup on #4439 (and #4436) that fixes 2 issues of that implementation:
- Wrong volume adjustments being displayed for ChannelListeners in certain situations
- MainWindow not updating automatically when the adjustments change