### PR TITLE
BUILD(cmake): Install overlay libs and scripts if enabled

### DIFF
--- a/overlay_gl/CMakeLists.txt
+++ b/overlay_gl/CMakeLists.txt
@@ -91,6 +91,8 @@ if(NOT APPLE)
 					"-ldl"
 					"-lrt"
 			)
+			# install 32bit overlay library
+			install(TARGETS overlay_gl_x86 LIBRARY DESTINATION "${MUMBLE_INSTALL_LIBDIR}")
 		endif()
 	endif()
 else()
@@ -118,6 +120,12 @@ else()
 			${LIB_COREFOUNDATION}
 	)
 endif()
+
+# install native overlay library
+install(TARGETS overlay_gl LIBRARY DESTINATION "${MUMBLE_INSTALL_LIBDIR}")
+
+# install overlay script
+install(PROGRAMS "${CMAKE_SOURCE_DIR}/scripts/mumble-overlay" DESTINATION bin)
 
 # install overlay man-files
 install(FILES "${CMAKE_SOURCE_DIR}/man/mumble-overlay.1" DESTINATION "${CMAKE_INSTALL_MANDIR}/man1" COMPONENT doc)

--- a/scripts/mumble-overlay
+++ b/scripts/mumble-overlay
@@ -12,12 +12,13 @@ fi
 
 for libpath in /usr/lib /usr/lib/mumble /usr/lib32 /usr/lib32/mumble /usr/lib64 /usr/lib64/mumble; do
   if [ -d "$libpath" ]; then
-    if [ -f "$libpath/libmumble.so.1" ]; then
-      case $(file -L "$libpath/libmumble.so.1") in
-        *64-bit*) MUMBLE_OVERLAY_PATH_64="$libpath" ; echo set ;;
-        *32-bit*) MUMBLE_OVERLAY_PATH_32="$libpath" ;;
+    for lib in $libpath/libmumbleoverlay*.so
+    do
+      case $(file -L "$lib") in
+        *64-bit*) MUMBLE_OVERLAY_PATH_64="$lib" ; echo set ;;
+        *32-bit*) MUMBLE_OVERLAY_PATH_32="$lib" ;;
       esac
-    fi
+    done
   fi
 done
 
@@ -40,27 +41,27 @@ is32=no
 case $(file -L "$binary") in
 	*64-bit*)
 		if [ -z "${MUMBLE_OVERLAY_PATH_64}" ]; then
-			echo "64-bit libmumble.so.1 not found" >&2
+			echo "64-bit libmumbleoverlay.so not found" >&2
 			exit 1
 		fi
-		MUMBLE_PRELOAD="${MUMBLE_OVERLAY_PATH_64}/libmumble.so.1"
+		MUMBLE_PRELOAD="${MUMBLE_OVERLAY_PATH_64}"
 		;;
 	*32-bit*)
 		if [ -z "${MUMBLE_OVERLAY_PATH_32}" ]; then
-			echo "32-bit libmumble.so.1 not found" >&2
+			echo "32-bit libmumbleoverlay.so not found" >&2
 			exit 1
 		fi
-		MUMBLE_PRELOAD="${MUMBLE_OVERLAY_PATH_32}/libmumble.so.1"
+		MUMBLE_PRELOAD="${MUMBLE_OVERLAY_PATH_32}"
 		;;
 	*)
 		if [ -n "${MUMBLE_OVERLAY_PATH_64}" ]; then
-			MUMBLE_PRELOAD="${MUMBLE_OVERLAY_PATH_64}/libmumble.so.1"
+			MUMBLE_PRELOAD="${MUMBLE_OVERLAY_PATH_64}"
 		fi
 		if [ -n "${MUMBLE_OVERLAY_PATH_32}" ]; then
-			MUMBLE_PRELOAD="${MUMBLE_PRELOAD} ${MUMBLE_OVERLAY_PATH_32}/libmumble.so.1"
+			MUMBLE_PRELOAD="${MUMBLE_PRELOAD} ${MUMBLE_OVERLAY_PATH_32}"
 		fi
 		if [ -z "${MUMBLE_PRELOAD}" ]; then
-			echo "Neither 32-bit or 64-bit libmumble.so.1 found"
+			echo "Neither 32-bit or 64-bit libmumbleoverlay.so found"
 			exit 1
 		fi
 esac


### PR DESCRIPTION
Before the overlay libraries and the related script would not be
installed. Instead the user would have to manually install them on the
system.

Now the overlay libraries are added to the install. The script was fixed
to take into account the correct overlay library names.

Closes: #4471