### PR TITLE
FIX(client, audio): Loading sample fails silently

### DIFF
--- a/src/mumble/AudioOutputSample.cpp
+++ b/src/mumble/AudioOutputSample.cpp
@@ -31,6 +31,10 @@ SoundFile::SoundFile(const QString &fname) {
 									 &SoundFile::vio_write, &SoundFile::vio_tell };
 
 		sfFile = sf_open_virtual(&svi, SFM_READ, &siInfo, this);
+
+		if (!sfFile) {
+			qWarning("AudioOutputSample: Failed to open sound-file: %s", qUtf8Printable(strError()));
+		}
 	}
 }
 


### PR DESCRIPTION
If a sound-file failed to load, there is no hint about this in the logs
or anywhere else as it never actually gets ensured that the loading was
successful.

Now and explicit check is performed and if the loading failed, a warning
is printed to the console.

Closes #4492