### PR TITLE
FIX(client, ui): Container prio never sinks in TalkingUI

### DIFF
--- a/src/mumble/TalkingUIContainer.cpp
+++ b/src/mumble/TalkingUIContainer.cpp
@@ -150,6 +150,10 @@ TalkingUIChannel::~TalkingUIChannel() {
 }
 
 void TalkingUIChannel::updatePriority() {
+	// First reset the priority to the lowest possible value as the loop below
+	// will only update it to be higher than the current priority
+	m_highestUserPriority = EntryPriority::LOWEST;
+
 	for (auto &currentEntry : m_entries) {
 		if (currentEntry->getPriority() > m_highestUserPriority) {
 			m_highestUserPriority = currentEntry->getPriority();

--- a/src/mumble/TalkingUIContainer.h
+++ b/src/mumble/TalkingUIContainer.h
@@ -75,7 +75,7 @@ class TalkingUIChannel : public TalkingUIContainer {
 protected:
 	QGroupBox *m_channelBox;
 
-	EntryPriority m_highestUserPriority = EntryPriority::LOW;
+	EntryPriority m_highestUserPriority = EntryPriority::LOWEST;
 
 	void updatePriority();
 

--- a/src/mumble/TalkingUIEntry.h
+++ b/src/mumble/TalkingUIEntry.h
@@ -24,7 +24,7 @@ class Channel;
 
 enum class EntryType { USER, LISTENER };
 
-enum class EntryPriority { LOW, DEFAULT, HIGH };
+enum class EntryPriority { LOWEST, LOW, DEFAULT, HIGH };
 
 
 class TalkingUIEntry : public TalkingUIComponent {


### PR DESCRIPTION
The way TalkingUIContainer::updatePriority() worked prevented a
container's priority to decrease (even thought the entry because of which
the priority initially increased is no longer contained).

To fix this, the referenced function will now simply reset the cached
priority to the lowest possible value before performing the actual
checking.