### PR TITLE
FIX(client, ui): Make setting take effect immediately

### DIFF
--- a/src/mumble/TalkingUI.cpp
+++ b/src/mumble/TalkingUI.cpp
@@ -753,12 +753,18 @@ void TalkingUI::on_settingsChanged() {
 		}
 	}
 
+	const ClientUser *self = ClientUser::get(g.uiSession);
 
 	// Whether or not the current user should always be displayed might also have changed,
 	// so we'll have to update that as well.
 	TalkingUIUser *localUserEntry = findUser(g.uiSession);
 	if (localUserEntry) {
 		localUserEntry->restrictLifetime(!g.s.bTalkingUI_LocalUserStaysVisible);
+	} else {
+		if (self && g.s.bTalkingUI_LocalUserStaysVisible) {
+			// Add the local user as it is requested to be displayed
+			addUser(self);
+		}
 	}
 
 
@@ -766,7 +772,6 @@ void TalkingUI::on_settingsChanged() {
 	// listeners from the TalkingUI and add them again if appropriate
 	removeAllListeners();
 	if (g.s.bTalkingUI_ShowLocalListeners) {
-		const ClientUser *self = ClientUser::get(g.uiSession);
 		if (self) {
 			const QSet< int > channels = ChannelListener::getListenedChannelsForUser(self->uiSession);
 


### PR DESCRIPTION
The setting for keeping the local user always visible in the TalkingUI
was not put into effect immediately if the local user didn't happen to
be displayed in the TalkingUI at the time of applying the settings.
Instead the effect was only visible after a re-connect or after having
changed the local user's TalkingState so that it was added to the UI via
that route.

The fix was simply to add the user if it is currently not present but is
asked to be shown permanently.