### PR TITLE
BUILD(cmake): Don't build retracted plugins by default

### DIFF
--- a/plugins/CMakeLists.txt
+++ b/plugins/CMakeLists.txt
@@ -3,6 +3,12 @@
 # that can be found in the LICENSE file at the root of the
 # Mumble source tree or at <https://www.mumble.info/LICENSE>.
 
+option(retracted-plugins "Build redacted (outdated) plugins as well" OFF)
+
+if(retracted-plugins)
+	message(STATUS "Including retracted plugins")
+endif()
+
 set(CMAKE_INCLUDE_CURRENT_DIR ON)
 
 if(NOT WIN32 AND NOT (${CMAKE_SYSTEM_NAME} STREQUAL "Linux"))
@@ -18,7 +24,17 @@ file(GLOB ITEMS RELATIVE ${CMAKE_CURRENT_SOURCE_DIR} "${CMAKE_CURRENT_SOURCE_DIR
 
 foreach(ITEM ${ITEMS})
 	if(IS_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/${ITEM}")
+		set(PLUGIN_RETRACTED OFF)
+
+		# If the plugin is retracted the corresponding CMakeLists.txt is supposed to set the
+		# PLUGIN_RETRACTED variable in the parent scope so that we can access it here
 		add_subdirectory(${ITEM})
+
+		if(PLUGIN_RETRACTED AND NOT retracted-plugins)
+			# The included subdir didn't actually add a target since the associated plugin is retracted
+			# and therefore it should not be built.
+			continue()
+		endif()
 
 		if(WIN32)
 			target_link_libraries(${ITEM} user32.lib)

--- a/plugins/css/CMakeLists.txt
+++ b/plugins/css/CMakeLists.txt
@@ -3,6 +3,9 @@
 # that can be found in the LICENSE file at the root of the
 # Mumble source tree or at <https://www.mumble.info/LICENSE>.
 
-add_library(css SHARED "../null_plugin.cpp")
+set(PLUGIN_RETRACTED ON PARENT_SCOPE)
+if(retracted-plugins)
+	add_library(css SHARED "../null_plugin.cpp")
 
-target_compile_definitions(css PRIVATE "NULL_DESC=L\"Counter Strike: Source (retracted, now using Link)\"")
+	target_compile_definitions(css PRIVATE "NULL_DESC=L\"Counter Strike: Source (retracted, now using Link)\"")
+endif()

--- a/plugins/dods/CMakeLists.txt
+++ b/plugins/dods/CMakeLists.txt
@@ -3,6 +3,9 @@
 # that can be found in the LICENSE file at the root of the
 # Mumble source tree or at <https://www.mumble.info/LICENSE>.
 
-add_library(dods SHARED "../null_plugin.cpp")
+set(PLUGIN_RETRACTED ON PARENT_SCOPE)
+if(retracted-plugins)
+	add_library(dods SHARED "../null_plugin.cpp")
 
-target_compile_definitions(dods PRIVATE "NULL_DESC=L\"Day of Defeat: Source (retracted, now using Link)\"")
+	target_compile_definitions(dods PRIVATE "NULL_DESC=L\"Day of Defeat: Source (retracted, now using Link)\"")
+endif()

--- a/plugins/hl2dm/CMakeLists.txt
+++ b/plugins/hl2dm/CMakeLists.txt
@@ -3,6 +3,9 @@
 # that can be found in the LICENSE file at the root of the
 # Mumble source tree or at <https://www.mumble.info/LICENSE>.
 
-add_library(hl2dm SHARED "../null_plugin.cpp")
+set(PLUGIN_RETRACTED ON PARENT_SCOPE)
+if(retracted-plugins)
+	add_library(hl2dm SHARED "../null_plugin.cpp")
 
-target_compile_definitions(hl2dm PRIVATE "NULL_DESC=L\"Half-Life 2: Deathmatch (retracted, now using Link)\"")
+	target_compile_definitions(hl2dm PRIVATE "NULL_DESC=L\"Half-Life 2: Deathmatch (retracted, now using Link)\"")
+endif()

--- a/plugins/sto/CMakeLists.txt
+++ b/plugins/sto/CMakeLists.txt
@@ -3,6 +3,9 @@
 # that can be found in the LICENSE file at the root of the
 # Mumble source tree or at <https://www.mumble.info/LICENSE>.
 
-add_library(sto SHARED "../null_plugin.cpp")
+set(PLUGIN_RETRACTED ON PARENT_SCOPE)
+if(retracted-plugins)
+	add_library(sto SHARED "../null_plugin.cpp")
 
-target_compile_definitions(sto PRIVATE "NULL_DESC=L\"Star Trek Online (retracted due to lack of maintenance)\"")
+	target_compile_definitions(sto PRIVATE "NULL_DESC=L\"Star Trek Online (retracted due to lack of maintenance)\"")
+endif()

--- a/plugins/tf2/CMakeLists.txt
+++ b/plugins/tf2/CMakeLists.txt
@@ -3,6 +3,9 @@
 # that can be found in the LICENSE file at the root of the
 # Mumble source tree or at <https://www.mumble.info/LICENSE>.
 
-add_library(tf2 SHARED "../null_plugin.cpp")
+set(PLUGIN_RETRACTED ON PARENT_SCOPE)
+if(retracted-plugins)
+	add_library(tf2 SHARED "../null_plugin.cpp")
 
-target_compile_definitions(tf2 PRIVATE "NULL_DESC=L\"Team Fortress 2 (retracted, now using Link)\"")
+	target_compile_definitions(tf2 PRIVATE "NULL_DESC=L\"Team Fortress 2 (retracted, now using Link)\"")
+endif()


### PR DESCRIPTION
As these plugins typically don't do anything anymore it doesn't make all
that much sense to include them by default.

If you still want to include retracted plugins, use
-Dretracted-plugins=ON when invoking cmake.