### PR TITLE
BUILD(cmake): Fix gRPC not being found

### DIFF
--- a/.ci/azure-pipelines/build_linux.bash
+++ b/.ci/azure-pipelines/build_linux.bash
@@ -19,7 +19,7 @@ cd $BUILD_BINARIESDIRECTORY
 
 # QSslDiffieHellmanParameters was introduced in Qt 5.8, Ubuntu 16.04 has 5.5.
 cmake -G Ninja -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=appdir/usr -Dtests=ON Donline-tests=ON -Dversion=$VER -Dsymbols=ON \
-	-Dqssldiffiehellmanparameters=OFF -Donline-tests=ON $BUILD_SOURCESDIRECTORY
+	-Dqssldiffiehellmanparameters=OFF -Donline-tests=ON -Dgrpc=ON $BUILD_SOURCESDIRECTORY
 
 cmake --build .
 ctest --verbose

--- a/.ci/azure-pipelines/build_linux.bash
+++ b/.ci/azure-pipelines/build_linux.bash
@@ -17,9 +17,8 @@ VER=$(python scripts/mumble-version.py)
 
 cd $BUILD_BINARIESDIRECTORY
 
-# QSslDiffieHellmanParameters was introduced in Qt 5.8, Ubuntu 16.04 has 5.5.
 cmake -G Ninja -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=appdir/usr -Dtests=ON Donline-tests=ON -Dversion=$VER -Dsymbols=ON \
-	-Dqssldiffiehellmanparameters=OFF -Donline-tests=ON -Dgrpc=ON $BUILD_SOURCESDIRECTORY
+	-Donline-tests=ON -Dgrpc=ON $BUILD_SOURCESDIRECTORY
 
 cmake --build .
 ctest --verbose

--- a/.ci/azure-pipelines/build_macos.bash
+++ b/.ci/azure-pipelines/build_macos.bash
@@ -18,7 +18,7 @@ VER=$(python scripts/mumble-version.py)
 cd $BUILD_BINARIESDIRECTORY
 
 cmake -G Ninja -DCMAKE_TOOLCHAIN_FILE=$MUMBLE_ENVIRONMENT_TOOLCHAIN -DIce_HOME="$MUMBLE_ENVIRONMENT_PATH/installed/x64-osx" \
-	-DCMAKE_BUILD_TYPE=Release -Dtests=ON -Dversion=$VER -Dstatic=ON -Dsymbols=ON -Donline-tests=ON $BUILD_SOURCESDIRECTORY
+	-DCMAKE_BUILD_TYPE=Release -Dtests=ON -Dversion=$VER -Dstatic=ON -Dsymbols=ON -Donline-tests=ON -Dgrpc=ON $BUILD_SOURCESDIRECTORY
 cmake --build .
 ctest --verbose
 

--- a/.ci/azure-pipelines/build_windows.bat
+++ b/.ci/azure-pipelines/build_windows.bat
@@ -51,7 +51,7 @@ del C:\Strawberry\c\bin\c++.exe
 
 cmake -G Ninja -DCMAKE_TOOLCHAIN_FILE="%MUMBLE_ENVIRONMENT_TOOLCHAIN%" -DVCPKG_TARGET_TRIPLET=%MUMBLE_ENVIRONMENT_TRIPLET% ^
 	-DIce_HOME="%MUMBLE_ENVIRONMENT_PATH%\installed\%MUMBLE_ENVIRONMENT_TRIPLET%" -DCMAKE_BUILD_TYPE=Release -Dtests=ON ^
-	-Dversion=%VER% -Dpackaging=ON -Dstatic=ON -Dsymbols=ON -Dasio=ON -Dg15=ON -Donline-tests=ON "%BUILD_SOURCESDIRECTORY%"
+	-Dversion=%VER% -Dpackaging=ON -Dstatic=ON -Dsymbols=ON -Dasio=ON -Dg15=ON -Donline-tests=ON -Dgrpc=ON "%BUILD_SOURCESDIRECTORY%"
 
 if errorlevel 1 (
 	exit /b %errorlevel%

--- a/.ci/azure-pipelines/install-environment_linux.bash
+++ b/.ci/azure-pipelines/install-environment_linux.bash
@@ -14,4 +14,4 @@ sudo apt-get -y install build-essential g++-multilib ninja-build pkg-config \
                         libasound2-dev libasound2-plugins libasound2-plugins-extra\
                         libogg-dev libsndfile1-dev libspeechd-dev \
                         libavahi-compat-libdnssd-dev libzeroc-ice-dev \
-                        zsync appstream
+                        zsync appstream libgrpc++-dev

--- a/.ci/azure-pipelines/install-environment_linux.bash
+++ b/.ci/azure-pipelines/install-environment_linux.bash
@@ -9,9 +9,9 @@ sudo apt-get update
 
 sudo apt-get -y install build-essential g++-multilib ninja-build pkg-config \
                         qt5-default qttools5-dev qttools5-dev-tools libqt5svg5-dev \
-                        libboost-dev libssl-dev libprotobuf-dev protobuf-compiler \
+                        libboost-dev libssl-dev libprotobuf-dev protobuf-compiler libprotoc-dev \
                         libcap-dev libxi-dev \
                         libasound2-dev libasound2-plugins libasound2-plugins-extra\
                         libogg-dev libsndfile1-dev libspeechd-dev \
                         libavahi-compat-libdnssd-dev libzeroc-ice-dev \
-                        zsync appstream libgrpc++-dev
+                        zsync appstream libgrpc++-dev protobuf-compiler-grpc

--- a/.ci/travis-ci/before_install.bash
+++ b/.ci/travis-ci/before_install.bash
@@ -12,11 +12,11 @@ if [ "${TRAVIS_OS_NAME}" == "linux" ]; then
 		sudo apt-get -qq update
 		sudo apt-get -y install build-essential ninja-build pkg-config \
                                 qt5-default qttools5-dev qttools5-dev-tools libqt5svg5-dev \
-                                libboost-dev libssl-dev libprotobuf-dev protobuf-compiler \
+                                libboost-dev libssl-dev libprotobuf-dev protobuf-compiler libprotoc-dev \
                                 libcap-dev libxi-dev \
                                 libasound2-dev \
                                 libogg-dev libsndfile1-dev libspeechd-dev \
-                                libavahi-compat-libdnssd-dev libzeroc-ice-dev
+                                libavahi-compat-libdnssd-dev libzeroc-ice-dev libgrpc++-dev protobuf-compiler-grpc
 		if [ "${MUMBLE_HOST}" == "aarch64-linux-gnu" ]; then
 			# Kitware's APT repository doesn't provide packages for ARM64.
 			cd ${HOME}

--- a/.ci/travis-ci/script.bash
+++ b/.ci/travis-ci/script.bash
@@ -16,7 +16,7 @@ VER=$(python scripts/mumble-version.py)
 if [ "${TRAVIS_OS_NAME}" == "linux" ]; then
 	if [ "${MUMBLE_HOST}" == "aarch64-linux-gnu" ]; then
 		mkdir build && cd build
-		cmake -G Ninja -DCMAKE_BUILD_TYPE=Release -Dtests=ON -Dversion=$VER -Dsymbols=ON -Donline-tests=ON ..
+		cmake -G Ninja -DCMAKE_BUILD_TYPE=Release -Dtests=ON -Dversion=$VER -Dsymbols=ON -Donline-tests=ON -Dgrpc=ON ..
 		cmake --build .
 		# We don't execute tests on ARM64 because TestPacketDataStream fails.
 		# See https://github.com/mumble-voip/mumble/issues/3845.
@@ -25,7 +25,7 @@ if [ "${TRAVIS_OS_NAME}" == "linux" ]; then
 	elif [ "${MUMBLE_HOST}" == "x86_64-linux-gnu" ]; then
 		mkdir build && cd build
 		# We specify the absolute path because otherwise Travis CI's CMake is used.
-		/usr/bin/cmake -G Ninja -DCMAKE_BUILD_TYPE=Release -Dtests=ON -Dversion=$VER -Dsymbols=ON -Donline-tests=ON ..
+		/usr/bin/cmake -G Ninja -DCMAKE_BUILD_TYPE=Release -Dtests=ON -Dversion=$VER -Dsymbols=ON -Donline-tests=ON -Dgrpc=ON ..
 		/usr/bin/cmake --build .
 		/usr/bin/ctest --verbose
 		sudo /usr/bin/cmake --install .

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -4,12 +4,12 @@ freebsd_instance:
 freebsd_task:
   pkg_script:
   - pkg update && pkg upgrade -y
-  - pkg install -y git ninja pkgconf cmake qt5-buildtools qt5-qmake qt5-linguisttools qt5-concurrent qt5-network qt5-xml qt5-sql qt5-svg qt5-testlib boost-libs libsndfile protobuf ice avahi-libdns
+  - pkg install -y git ninja pkgconf cmake qt5-buildtools qt5-qmake qt5-linguisttools qt5-concurrent qt5-network qt5-xml qt5-sql qt5-svg qt5-testlib boost-libs libsndfile protobuf ice avahi-libdns grpc
   fetch_submodules_script: git submodule --quiet update --init --recursive
   build_script:
   - mkdir build && cd build
   # We disable translations because of a critical issue in "lupdate": it's very slow and keeps CPU usage at 100%.
-  - cmake -G Ninja -DCMAKE_BUILD_TYPE=Release -Dtests=ON -Dsymbols=ON -Dtranslations=OFF ..
+  - cmake -G Ninja -DCMAKE_BUILD_TYPE=Release -Dtests=ON -Dsymbols=ON -Dtranslations=OFF -Dgrpc=ON ..
   - cmake --build .
   test_script:
   - cd build

--- a/cmake/compiler.cmake
+++ b/cmake/compiler.cmake
@@ -13,6 +13,11 @@ endif()
 
 set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 
+if(WIN32)
+	message(STATUS "Using Win7 as the oldest supported Windows version")
+	add_compile_definitions(_WIN32_WINNT=0x0601)
+endif()
+
 if(MSVC)
 	add_compile_options(
 		"$<$<CONFIG:Release>:/Ox>"

--- a/src/murmur/CMakeLists.txt
+++ b/src/murmur/CMakeLists.txt
@@ -63,6 +63,10 @@ set_target_properties(murmur
 		RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}
 )
 
+set(AUTOGEN_BUILD_DIR "${CMAKE_CURRENT_BINARY_DIR}/murmur_autogen")
+message(STATUS "File: ${AUTOGEN_BUILD_DIR}")
+set_source_files_properties("${AUTOGEN_BUILD_DIR}/mocs_compilation.cpp" PROPERTIES COMPILE_FLAGS "-w")
+
 target_compile_definitions(murmur
 	PRIVATE
 		"MURMUR"
@@ -190,14 +194,11 @@ if(dbus AND NOT WIN32 AND NOT APPLE)
 endif()
 
 if(grpc)
-	find_pkg(GRPC REQUIRED)
+	# "gRPC" is the name of the official gRPC target whereas "GRPC" is the one used by our custom FindGRPC.cmake in 
+	# the cmake sub-dir at the project's root.
+	find_pkg("gRPC;GRPC" REQUIRED)
 
 	protobuf_generate(LANGUAGE cpp TARGET murmur PROTOS ${GRPC_FILE} OUT_VAR BUILT_GRPC_FILES)
-
-	# Disable warnings for the generated source files
-	foreach(CURRENT_FILE IN LISTS BUILT_GRPC_FILES)
-		set_source_files_properties("${CURRENT_FILE}" PROPERTIES COMPILE_FLAGS "-w")
-	endforeach()
 
 	add_subdirectory("${SHARED_SOURCE_DIR}/murmur_grpcwrapper_protoc_plugin" "${CMAKE_CURRENT_BINARY_DIR}/murmur_grpcwrapper_protoc_plugin")
 
@@ -228,6 +229,11 @@ if(grpc)
 		VERBATIM
 	)
 
+	# Disable warnings for the generated source files
+	foreach(CURRENT_FILE IN LISTS GRPC_GENERATED_FILES BUILT_GRPC_FILES)
+		set_source_files_properties("${CURRENT_FILE}" PROPERTIES COMPILE_FLAGS "-w")
+	endforeach()
+
 	add_custom_target(generate-grpc-files
 		DEPENDS
 			"MurmurRPC.proto.Wrapper.cpp"
@@ -243,11 +249,18 @@ if(grpc)
 			${GRPC_GENERATED_FILES}
 	)
 
+	if(NOT MSVC)
+		# Disable the unused parameter warning for this file as it implicitly includes one of the generated
+		# files that contains a lot of unused parameters that would otherwise create a warning.
+		set_source_files_properties("MurmurGRPCImpl.cpp" PROPERTIES COMPILE_FLAGS "-Wno-unused-parameter")
+	endif()
+
 	target_compile_definitions(murmur PRIVATE "USE_GRPC")
 	target_include_directories(murmur PRIVATE ${CMAKE_CURRENT_BINARY_DIR})
-	target_link_libraries(murmur PRIVATE gRPC::grpc++_reflection)
 
-	if(${CMAKE_SYSTEM_NAME} STREQUAL "FreeBSD")
+	target_link_libraries(murmur PRIVATE gRPC::grpc++)
+
+	if (TARGET gRPC::gpr)
 		target_link_libraries(murmur PRIVATE gRPC::gpr)
 	endif()
 endif()


### PR DESCRIPTION
We are using a custom FindGRPC.cmake script in order to locate the gRPC
targets as not all distribution variants of gRPC include the respective
cmake support. Those that do however will use "gRPC" (note the lowercase
"g") as the target's name and therefore our current way of searching for
it via find_pkg won't find them.

The solution is to first look for "gRPC" and only if that fails, check
for "GRPC". This way the official target "gRPC" should be found and
preferred if present.

Fixes #4508