### PR TITLE
FIX(client): don't print Zeroconf warning if the operation was cancelled

### DIFF
--- a/src/mumble/Zeroconf.cpp
+++ b/src/mumble/Zeroconf.cpp
@@ -285,7 +285,10 @@ void WINAPI Zeroconf::callbackResolveComplete(const DWORD status, void *context,
 			DnsServiceFreeInstance(instance);
 		}
 
-		qWarning("Zeroconf: DnsServiceResolve() reports status code %u, ignoring result", status);
+		if (status != ERROR_CANCELLED) {
+			qWarning("Zeroconf: DnsServiceResolve() reports status code %u, ignoring result", status);
+		}
+
 		return;
 	}
 


### PR DESCRIPTION
Closing `ConnectDialog` causes the `ZeroConf` object to be destroyed. The destructor cancels any running operations, as expected.

However, a warning is printed in `Zeroconf::callbackResolveComplete()` because `ERROR_CANCELLED` is not handled:

> Zeroconf: DnsServiceBrowse() reports status code 1223, ignoring results

This commit fixes the issue.