### PR TITLE
FEAT(ui): Add ability to paste and send messages using a keyboard shortcut

### DIFF
--- a/src/mumble/CustomElements.cpp
+++ b/src/mumble/CustomElements.cpp
@@ -90,6 +90,7 @@ void ChatbarTextEdit::contextMenuEvent(QContextMenuEvent *qcme) {
 	QMenu *menu = createStandardContextMenu();
 
 	QAction *action = new QAction(tr("Paste and &Send") + QLatin1Char('\t'), menu);
+	action->setShortcut(Qt::CTRL + Qt::Key_Shift + Qt::Key_V);
 	action->setEnabled(!QApplication::clipboard()->text().isEmpty());
 	connect(action, SIGNAL(triggered()), this, SLOT(pasteAndSend_triggered()));
 	if (menu->actions().count() > 6)
@@ -249,6 +250,9 @@ bool ChatbarTextEdit::event(QEvent *evt) {
 			return true;
 		} else if (kev->key() == Qt::Key_Down && kev->modifiers() == Qt::ControlModifier) {
 			historyDown();
+			return true;
+		} else if (kev->key() == Qt::Key_V && (kev->modifiers() & Qt::ControlModifier) && (kev->modifiers() & Qt::ShiftModifier)) {
+			pasteAndSend_triggered();
 			return true;
 		}
 	}


### PR DESCRIPTION
As requested in Issue #4257 this commit implements the ability to paste and send messages whit a single keyboard shortcut.
The keyboard shortcut is Ctrl + Shift + V, as requested.
I tried to add the shortcut into the "paste and send" drop down menu item but the shortcut is not visible to me, maybe it's because my screen resolution.

Implements #4257