### PR TITLE
BUILD(cmake): Fix use of generator expression

### DIFF
--- a/cmake/compiler.cmake
+++ b/cmake/compiler.cmake
@@ -11,6 +11,8 @@ else()
 	message(FATAL_ERROR "Unknown architecture - only 32bit and 64bit are supported")
 endif()
 
+set(CMAKE_POSITION_INDEPENDENT_CODE ON)
+
 if(MSVC)
 	if($<CONFIG:Release>)
 		add_compile_options(
@@ -96,18 +98,17 @@ elseif(UNIX OR MINGW)
 		# In Mumble builds with warnings-as-errors, this will cause build failures.
 		add_compile_options("-U_FORTIFY_SOURCE")
 
-		if($<CONFIG:Debug>)
-			if(NOT MINGW)
-				add_compile_options("-fstack-protector")
-			endif()
-			add_compile_options("-fPIE")
-			add_link_options(
-				"-pie"
-				"-Wl,--no-add-needed"
-			)
-		else()
-			add_compile_options("-D_FORTIFY_SOURCE=2")
+		if(NOT MINGW)
+			add_compile_options($<$<CONFIG:Debug>:-fstack-protector>)
 		endif()
+
+		add_compile_options(
+			$<$<NOT:$<CONFIG:Debug>>:-D_FORTIFY_SOURCE=2>
+		)
+
+		add_link_options(
+			$<$<CONFIG:Debug>:-Wl,--no-add-needed>
+		)
 
 		if(symbols)
 			add_compile_options("-g")

--- a/g15helper/CMakeLists.txt
+++ b/g15helper/CMakeLists.txt
@@ -25,9 +25,7 @@ set_target_properties(g15-helper
 		RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}
 )
 
-if($<CONFIG:Debug>)
-	target_compile_definitions(g15-helper PRIVATE "USE_LOGFILE")
-endif()
+target_compile_definitions(g15-helper PRIVATE $<$<CONFIG:Debug>:USE_LOGFILE>)
 
 if(g15-emulator)
 	find_pkg(Qt5 COMPONENTS Core Gui Widgets REQUIRED)


### PR DESCRIPTION
The changed files used a generator expression in an if-statement, which
is invalid as these generator expressions are not evaluated during the
initial configuration stage (at which point the if-statement is
evaluated).

This commit changes the use of the generator-expression in such a way
that it will actually do what it was meant to.

Note that this commit also enables position independent code for all
platforms and all build-types instead of only for debug builds on unix
systems. This was the preferred choice instead of porting the -fPIE
compiler option to use proper generator expressions as the presence of
these options caused linking errors with Celt/Opus.