### PR TITLE
FEAT(server): Send text messages also to users only listening to channels

### DIFF
--- a/src/murmur/Messages.cpp
+++ b/src/murmur/Messages.cpp
@@ -1413,6 +1413,14 @@ void Server::msgTextMessage(ServerUser *uSource, MumbleProto::TextMessage &msg) 
 		foreach (User *p, c->qlUsers)
 			users.insert(static_cast< ServerUser * >(p));
 
+		// Users only listening in that channel
+		foreach (unsigned int session, ChannelListener::getListenersForChannel(c)) {
+			ServerUser *currentUser = qhUsers.value(session);
+			if (currentUser) {
+				users.insert(currentUser);
+			}
+		}
+
 		tm.qlChannels.append(id);
 	}
 
@@ -1446,6 +1454,13 @@ void Server::msgTextMessage(ServerUser *uSource, MumbleProto::TextMessage &msg) 
 			// Users directly in that channel
 			foreach (User *p, c->qlUsers)
 				users.insert(static_cast< ServerUser * >(p));
+			// Users only listening in that channel
+			foreach (unsigned int session, ChannelListener::getListenersForChannel(c)) {
+				ServerUser *currentUser = qhUsers.value(session);
+				if (currentUser) {
+					users.insert(currentUser);
+				}
+			}
 		}
 	}
 

--- a/src/murmur/Messages.cpp
+++ b/src/murmur/Messages.cpp
@@ -1377,10 +1377,12 @@ void Server::msgTextMessage(ServerUser *uSource, MumbleProto::TextMessage &msg) 
 		PERM_DENIED_TYPE(TextTooLong);
 		return;
 	}
-	if (text.isEmpty())
+	if (text.isEmpty()) {
 		return;
-	if (changed)
+	}
+	if (changed) {
 		msg.set_message(u8(text));
+	}
 
 	tm.qsText = text;
 
@@ -1401,8 +1403,9 @@ void Server::msgTextMessage(ServerUser *uSource, MumbleProto::TextMessage &msg) 
 		unsigned int id = msg.channel_id(i);
 
 		Channel *c = qhChannels.value(id);
-		if (!c)
+		if (!c) {
 			return;
+		}
 
 		if (!ChanACL::hasPermission(uSource, c, ChanACL::TextMessage, &acCache)) {
 			PERM_DENIED(uSource, c, ChanACL::TextMessage);
@@ -1410,8 +1413,9 @@ void Server::msgTextMessage(ServerUser *uSource, MumbleProto::TextMessage &msg) 
 		}
 
 		// Users directly in that channel
-		foreach (User *p, c->qlUsers)
+		foreach (User *p, c->qlUsers) {
 			users.insert(static_cast< ServerUser * >(p));
+		}
 
 		// Users only listening in that channel
 		foreach (unsigned int session, ChannelListener::getListenersForChannel(c)) {
@@ -1430,8 +1434,9 @@ void Server::msgTextMessage(ServerUser *uSource, MumbleProto::TextMessage &msg) 
 		unsigned int id = msg.tree_id(i);
 
 		Channel *c = qhChannels.value(id);
-		if (!c)
+		if (!c) {
 			return;
+		}
 
 		if (!ChanACL::hasPermission(uSource, c, ChanACL::TextMessage, &acCache)) {
 			PERM_DENIED(uSource, c, ChanACL::TextMessage);
@@ -1449,11 +1454,13 @@ void Server::msgTextMessage(ServerUser *uSource, MumbleProto::TextMessage &msg) 
 	while (!q.isEmpty()) {
 		Channel *c = q.dequeue();
 		if (ChanACL::hasPermission(uSource, c, ChanACL::TextMessage, &acCache)) {
-			foreach (Channel *sub, c->qlChannels)
+			foreach (Channel *sub, c->qlChannels) {
 				q.enqueue(sub);
+			}
 			// Users directly in that channel
-			foreach (User *p, c->qlUsers)
+			foreach (User *p, c->qlUsers) {
 				users.insert(static_cast< ServerUser * >(p));
+			}
 			// Users only listening in that channel
 			foreach (unsigned int session, ChannelListener::getListenersForChannel(c)) {
 				ServerUser *currentUser = qhUsers.value(session);
@@ -1483,8 +1490,9 @@ void Server::msgTextMessage(ServerUser *uSource, MumbleProto::TextMessage &msg) 
 	users.remove(uSource);
 
 	// Actually send the original message to the affected users
-	foreach (ServerUser *u, users)
+	foreach (ServerUser *u, users) {
 		sendMessage(u, msg);
+	}
 
 	// Emit the signal for RPC consumers
 	emit userTextMessage(uSource, tm);


### PR DESCRIPTION
The "Channel Listeners" (#4011) feature allows users to hear the audio
from a channel without joining it. This commit also delivers text
messages to all users who are just "listening to" a channel this way.

Implements #4539

The actual code change is just 4 lines but I've added some comments along as I was worked my way through understanding the code. If you want of course, I can submit only the required code changes.