### PR TITLE
FIX(client): don't print Zeroconf warning if the operation was cancelled

### DIFF
--- a/src/mumble/Zeroconf.cpp
+++ b/src/mumble/Zeroconf.cpp
@@ -238,7 +238,10 @@ void WINAPI Zeroconf::callbackBrowseComplete(const DWORD status, void *context, 
 			DnsRecordListFree(records, DnsFreeRecordList);
 		}
 
-		qWarning("Zeroconf: DnsServiceBrowse() reports status code %u, ignoring results", status);
+		if (status != ERROR_CANCELLED) {
+			qWarning("Zeroconf: DnsServiceBrowse() reports status code %u, ignoring results", status);
+		}
+
 		return;
 	}
 


### PR DESCRIPTION
Closing `ConnectDialog` causes the `ZeroConf` object to be destroyed. The destructor cancels any running operations, as expected.

However, a warning is printed in `Zeroconf::callbackBrowseComplete()` because `ERROR_CANCELLED` is not handled:

> Zeroconf: DnsServiceBrowse() reports status code 1223, ignoring results

This pull request fixes the issue.

#4524 applied the exact same change to `callbackResolveComplete()`.

The error message in the commit's description is wrong, but everything else is correct.