### PR TITLE
FEAT(client): Show keys in tooltip in shortcuts settings, each one in a new line

### DIFF
--- a/src/mumble/GlobalShortcut.h
+++ b/src/mumble/GlobalShortcut.h
@@ -172,6 +172,8 @@ public:
 	ShortcutDelegate(QObject *);
 	~ShortcutDelegate() Q_DECL_OVERRIDE;
 	QString displayText(const QVariant &, const QLocale &) const Q_DECL_OVERRIDE;
+	bool helpEvent(QHelpEvent *, QAbstractItemView *, const QStyleOptionViewItem &,
+				   const QModelIndex &) Q_DECL_OVERRIDE;
 };
 
 /**
@@ -256,8 +258,8 @@ public:
 	bool handleButton(const QVariant &, bool);
 	static void add(GlobalShortcut *);
 	static void remove(GlobalShortcut *);
-	static QString buttonText(const QList< QVariant > &);
 	virtual QString buttonName(const QVariant &) = 0;
+	static QString buttonText(const QList< QVariant > &);
 	virtual bool canSuppress();
 
 	virtual void setEnabled(bool b);

--- a/src/mumble/mumble_en.ts
+++ b/src/mumble/mumble_en.ts
@@ -3332,10 +3332,6 @@ Without this option enabled, using Mumble&apos;s global shortcuts in privileged 
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Shortcut button combination.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>&lt;b&gt;This is the global shortcut key combination.&lt;/b&gt;&lt;br /&gt;Click this field and then press the desired key/button combo to rebind. Double-click to clear.</source>
         <oldsource>&lt;b&gt;This is the global shortcut key combination.&lt;/b&gt;&lt;br /&gt;Double-click this field and then the desired key/button combo to rebind.</oldsource>
         <translation type="unfinished"></translation>
@@ -7285,6 +7281,10 @@ See &lt;a href=&quot;https://wiki.mumble.info/wiki/Installing_Mumble&quot;&gt;th
     </message>
     <message>
         <source>Unassigned</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Shortcut button combination:</source>
         <translation type="unfinished"></translation>
     </message>
 </context>


### PR DESCRIPTION
This improves readability, especially when the keys combination and/or the keys' name is long.

Previously, the tooltip always showed "List of configured shortcuts".

![Before](https://user-images.githubusercontent.com/5897523/97067835-1d0a8700-15c2-11eb-9284-4544a85670a6.png)
![After](https://user-images.githubusercontent.com/5897523/98036673-bd5e7800-1e1a-11eb-85ad-48f0de045b16.png)