### PR TITLE
FEAT(client, ui): Add button to reset all settings

### DIFF
--- a/src/mumble/ConfigDialog.ui
+++ b/src/mumble/ConfigDialog.ui
@@ -49,9 +49,6 @@
        <property name="orientation">
         <enum>Qt::Horizontal</enum>
        </property>
-       <property name="standardButtons">
-        <set>QDialogButtonBox::Reset|QDialogButtonBox::RestoreDefaults</set>
-       </property>
       </widget>
      </item>
      <item>

--- a/src/mumble/mumble_en.ts
+++ b/src/mumble/mumble_en.ts
@@ -2781,16 +2781,23 @@ Are you sure you wish to replace your certificate?
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>This button will restore the defaults for the settings on the current page. Other pages will not be changed.&lt;br /&gt;To restore all settings to their defaults, you will have to use this button on every page.</source>
-        <oldsource>This button will restore the settings for the current page only to their defaults. Other pages will not be changed.&lt;br /&gt;To restore all settings to their defaults, you will have to use this button on every page.</oldsource>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Mumble Configuration</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Configuration categories</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>This button will restore the defaults for the settings on the current page. Other pages will not be changed.&lt;br /&gt;To restore all settings to their defaults, you can press the &quot;Defaults (All)&quot; button.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Restore all defaults</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>This button will restore the defaults for all settings.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -7111,6 +7118,14 @@ See &lt;a href=&quot;https://wiki.mumble.info/wiki/Installing_Mumble&quot;&gt;th
     </message>
     <message>
         <source>RNNoise is not available due to a sample rate mismatch.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Reset all settings?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Do you really want to reset all settings (not only the ones currently visible) to their default value?</source>
         <translation type="unfinished"></translation>
     </message>
 </context>


### PR DESCRIPTION
Previously the user only had the choice of setting the settings on the
current settings page to their default value. Therefore, if you wanted
to reset all settings, you had to visit every page and reset it
individually.

With this commit, there is now a reset-all button that can be used
instead.

----

Screenshot (the new button is at the bottom left):
![image](https://user-images.githubusercontent.com/12751591/97081935-1b62b280-1606-11eb-8070-c291c4acd87b.png)
