### PR TITLE
DOCS: Improve CMake install instructions

### DIFF
--- a/docs/dev/build-instructions/build_static.md
+++ b/docs/dev/build-instructions/build_static.md
@@ -12,8 +12,10 @@ on all major platforms (Windows, Linux, macOS, probably more), so the instructio
 The entire build environment will require between 30GB and 60GB of space on your hard-drive. If installed via script, it tends to converge towards the
 lower bound whereas a manual installation usually tends towards the higher bound.
 
-In addition to the dependencies installed via vcpkg, you'll also need [cmake](https://cmake.org/) (v3.15 or later). On Linux you might have to install
-cmake using a [PPA](https://apt.kitware.com/) and on macOS you can install it using [homebrew](https://formulae.brew.sh/formula/cmake).
+In addition to the dependencies installed via vcpkg, you'll also need [cmake](https://cmake.org/) version 3.15 or higher.
+On macOS you can install it using [homebrew](https://formulae.brew.sh/formula/cmake).
+Linux distributions usually provide a cmake package you can install through your package manager (for example `apt-get install cmake`).
+On Windows you download and install the *latest release* installer from the [official CMake download website](https://cmake.org/download/).
 
 
 ### Installing via script


### PR DESCRIPTION
We require CMake in at least version 3.5 and mention this.

All supported Ubuntu versions (starting with Xenial) provide the cmake package in version 3.5.1 or higher. [1]

All supported Debian versions (starting with 'oldstable') provide the cmake package in version 3.7.2 or higher. [2]

The upstream CMake PPA[3] only provides PPAs for Ubuntu Xenial and up.

Hence we can depend on cmake package versions usually being 3.5 or up for Linux distributions. Listing the PPA does not help for older Ubuntu versions where using it would be necessary. And it does not make sense for non-Ubuntu distributions as only Ubuntu PPAs are provided.

[1] https://packages.ubuntu.com/search?keywords=cmake&searchon=names&exact=1&suite=all&section=main
[2] https://packages.debian.org/search?keywords=cmake&searchon=names&exact=1&suite=oldstable&section=all
[3] https://apt.kitware.com/