### PR TITLE
REFAC(client): Store plugin paths in a list, always load from "./plugins"

### DIFF
--- a/src/mumble/Plugins.h
+++ b/src/mumble/Plugins.h
@@ -62,8 +62,8 @@ protected:
 	void clearPlugins();
 	int iPluginTry;
 	QMap< QString, PluginFetchMeta > qmPluginFetchMeta;
-	QString qsSystemPlugins;
-	QString qsUserPlugins;
+	QString downloadPath;
+	QStringList loadPaths;
 #ifdef Q_OS_WIN
 	HANDLE hToken;
 	TOKEN_PRIVILEGES tpPrevious;


### PR DESCRIPTION
When building Mumble, plugin shared libraries are in `./plugins` (relative to the build folder).

Until #4503, `MUMBLE_PLUGIN_PATH` (previously` PLUGIN_PATH`) was not defined, causing plugins to be loaded from `./plugins`.

Now that `MUMBLE_PLUGIN_PATH` is always set through CMake to the installation directory for plugins (e.g. `/usr/local/lib/mumble/plugins`), the alternate logic path is dead and `./plugins` is only used with the debug preset.

This commit refactors the code so that the paths are stored in a `QStringList` rather than two different `QString` and `./plugins` is restored.

Also, there's now a dedicated `QString` variable for the download path (which is not changed by this commit).

The paths priority is retained. More specifically, when a path is appended it has an higher priority over the one that was added before.

Priority only matters when a file with the same name is found in multiple paths.

That's how the plugin update system currently works, it basically overrides the plugins in the installation directory.