### PR TITLE
DOCS: Added instructions to install Visual Studio

### DIFF
--- a/docs/dev/build-instructions/README.md
+++ b/docs/dev/build-instructions/README.md
@@ -17,3 +17,4 @@ Furthermore you might find these helpful as well:
 - [List of available cmake options](cmake_options.md)
 - [IDE integration](ide_integration.md)
 - [Create an installer](build_installer.md)
+- [Setup Visual Studio](setup_visual_studio.md)

--- a/docs/dev/build-instructions/build_static.md
+++ b/docs/dev/build-instructions/build_static.md
@@ -15,6 +15,9 @@ lower bound whereas a manual installation usually tends towards the higher bound
 In addition to the dependencies installed via vcpkg, you'll also need [cmake](https://cmake.org/) (v3.15 or later). On Linux you might have to install
 cmake using a [PPA](https://apt.kitware.com/) and on macOS you can install it using [homebrew](https://formulae.brew.sh/formula/cmake).
 
+Furthermore you need a C++ compiler. On Linux and MacOS that'd usually be `gcc` (`g++`) or `clang`. On Windows you probably want to use MSVC
+(checkout [these instructions](setup_visual_studio.md) on how to install it).
+
 
 ### Installing via script
 

--- a/docs/dev/build-instructions/build_windows.md
+++ b/docs/dev/build-instructions/build_windows.md
@@ -1,3 +1,5 @@
 # Building on Windows 
 
 On Windows we only support [static builds](build_static.md).
+
+Make sure to [install Visual Studio](setup_visual_studio.md) in order to be able to compile the necessary code.

--- a/docs/dev/build-instructions/setup_visual_studio.md
+++ b/docs/dev/build-instructions/setup_visual_studio.md
@@ -1,0 +1,8 @@
+# Setup Visual Studio
+
+MSVC (Microsoft Visual C++) is Microsoft’s C++ compiler toolchain. It can be installed from Visual Studio Build Tools, or Visual Studio Community.
+Either can be downloaded [here](https://visualstudio.microsoft.com/downloads) (Any somewhat recent version should work).
+
+Make sure to select the **C++ build tools** (or Development, respectively) and "**C++ MFC for latest v14[X] build tools**" (just pick the latest
+version - e.g.v142). vcpkg also requires the **English Language pack** which is found in the Language packs section of the Visual Studio Installer.
+


### PR DESCRIPTION
It seems like this part was overlooked at the time the docs were
written.