### PR TITLE
REFAC(plugins): Use Toolhelp32ReadProcessMemory() instead of ReadProcessMemory(), move "m_ok" to Process

### DIFF
--- a/plugins/HostLinux.cpp
+++ b/plugins/HostLinux.cpp
@@ -12,7 +12,7 @@
 
 #include <sys/uio.h>
 
-HostLinux::HostLinux(const procid_t pid) : m_ok(true), m_pid(pid) {
+HostLinux::HostLinux(const procid_t pid) : m_pid(pid) {
 }
 
 HostLinux::~HostLinux() {

--- a/plugins/HostLinux.h
+++ b/plugins/HostLinux.h
@@ -15,12 +15,9 @@ typedef uint64_t procptr_t;
 
 class HostLinux {
 protected:
-	bool m_ok;
 	procid_t m_pid;
 
 public:
-	inline bool isOk() const { return m_ok; }
-
 	bool peek(const procptr_t address, void *dst, const size_t size) const;
 	procptr_t module(const std::string &module) const;
 

--- a/plugins/HostWindows.cpp
+++ b/plugins/HostWindows.cpp
@@ -10,22 +10,15 @@
 #include <windows.h>
 #include <tlhelp32.h>
 
-HostWindows::HostWindows(const procid_t pid) : m_ok(false), m_pid(pid) {
-	m_handle = OpenProcess(PROCESS_VM_READ, false, m_pid);
-	if (m_handle) {
-		m_ok = true;
-	}
+HostWindows::HostWindows(const procid_t pid) : m_ok(true), m_pid(pid) {
 }
 
 HostWindows::~HostWindows() {
-	if (m_handle) {
-		CloseHandle(m_handle);
-	}
 }
 
 bool HostWindows::peek(const procptr_t address, void *dst, const size_t size) const {
 	SIZE_T read;
-	const BOOL ok = ReadProcessMemory(m_handle, reinterpret_cast< void * >(address), dst, size, &read);
+	const auto ok = Toolhelp32ReadProcessMemory(m_pid, reinterpret_cast< void * >(address), dst, size, &read);
 	return (ok && read == size);
 }
 

--- a/plugins/HostWindows.cpp
+++ b/plugins/HostWindows.cpp
@@ -10,7 +10,7 @@
 #include <windows.h>
 #include <tlhelp32.h>
 
-HostWindows::HostWindows(const procid_t pid) : m_ok(true), m_pid(pid) {
+HostWindows::HostWindows(const procid_t pid) : m_pid(pid) {
 }
 
 HostWindows::~HostWindows() {

--- a/plugins/HostWindows.h
+++ b/plugins/HostWindows.h
@@ -17,7 +17,6 @@ class HostWindows {
 protected:
 	bool m_ok;
 	procid_t m_pid;
-	void *m_handle;
 
 public:
 	inline bool isOk() const { return m_ok; }

--- a/plugins/HostWindows.h
+++ b/plugins/HostWindows.h
@@ -15,12 +15,9 @@ typedef uint64_t procptr_t;
 
 class HostWindows {
 protected:
-	bool m_ok;
 	procid_t m_pid;
 
 public:
-	inline bool isOk() const { return m_ok; }
-
 	bool peek(const procptr_t address, void *dst, const size_t size) const;
 	procptr_t module(const std::string &module) const;
 

--- a/plugins/Process.cpp
+++ b/plugins/Process.cpp
@@ -9,7 +9,7 @@
 
 #include <chrono>
 
-Process::Process(const procid_t id, const std::string &name) : Host(id), m_name(name), m_pointerSize(0) {
+Process::Process(const procid_t id, const std::string &name) : Host(id), m_ok(false), m_name(name), m_pointerSize(0) {
 }
 
 Process::~Process() {

--- a/plugins/Process.h
+++ b/plugins/Process.h
@@ -21,12 +21,15 @@ using Host = HostLinux;
 /// Only defines stuff that can be used with both Linux and Windows processes.
 class Process : public Host {
 protected:
+	bool m_ok;
 	std::string m_name;
 	uint8_t m_pointerSize;
 
 public:
 	using Host::module;
 	using Host::peek;
+
+	inline bool isOk() const { return m_ok; }
 
 	template< typename T > inline bool peek(const procptr_t address, T &dst) const {
 		return peek(address, &dst, sizeof(T));

--- a/plugins/ProcessLinux.cpp
+++ b/plugins/ProcessLinux.cpp
@@ -8,12 +8,6 @@
 #include <elf.h>
 
 ProcessLinux::ProcessLinux(const procid_t id, const std::string &name) : Process(id, name) {
-	if (!m_ok) {
-		return;
-	}
-
-	m_ok = false;
-
 	const auto address = module(name);
 	if (!address) {
 		return;

--- a/plugins/ProcessWindows.cpp
+++ b/plugins/ProcessWindows.cpp
@@ -8,12 +8,6 @@
 #include "mumble_plugin_win32_internals.h"
 
 ProcessWindows::ProcessWindows(const procid_t id, const std::string &name) : Process(id, name) {
-	if (!m_ok) {
-		return;
-	}
-
-	m_ok = false;
-
 	const auto address = module(name);
 	if (!address) {
 		return;


### PR DESCRIPTION
[Toolhelp32ReadProcessMemory()](https://docs.microsoft.com/en-us/windows/win32/api/tlhelp32/nf-tlhelp32-toolhelp32readprocessmemory) takes the process ID, as opposed to [ReadProcessMemory()](https://docs.microsoft.com/en-us/windows/win32/api/memoryapi/nf-memoryapi-readprocessmemory).

This allows us to read memory without the need for an handle ([OpenProcess()](https://docs.microsoft.com/en-us/windows/win32/api/processthreadsapi/nf-processthreadsapi-openprocess)).

This PR also moves `m_ok` to `Process`.