### PR TITLE
REFAC(positional-audio): Proper functions/classes for module-related operations

### DIFF
--- a/plugins/HostLinux.h
+++ b/plugins/HostLinux.h
@@ -6,12 +6,9 @@
 #ifndef HOSTLINUX_H_
 #define HOSTLINUX_H_
 
-#include <cstddef>
-#include <cstdint>
-#include <string>
+#include "Module.h"
 
 typedef uint32_t procid_t;
-typedef uint64_t procptr_t;
 
 class HostLinux {
 protected:
@@ -19,7 +16,7 @@ protected:
 
 public:
 	bool peek(const procptr_t address, void *dst, const size_t size) const;
-	procptr_t module(const std::string &module) const;
+	Modules modules() const;
 
 	static bool isWine(const procid_t id);
 

--- a/plugins/HostWindows.h
+++ b/plugins/HostWindows.h
@@ -6,12 +6,9 @@
 #ifndef HOSTWINDOWS_H_
 #define HOSTWINDOWS_H_
 
-#include <cstddef>
-#include <cstdint>
-#include <string>
+#include "Module.h"
 
 typedef uint32_t procid_t;
-typedef uint64_t procptr_t;
 
 class HostWindows {
 protected:
@@ -19,7 +16,7 @@ protected:
 
 public:
 	bool peek(const procptr_t address, void *dst, const size_t size) const;
-	procptr_t module(const std::string &module) const;
+	Modules modules() const;
 
 	HostWindows(const procid_t pid);
 	virtual ~HostWindows();

--- a/plugins/Module.cpp
+++ b/plugins/Module.cpp
@@ -1,0 +1,18 @@
+// Copyright 2020 The Mumble Developers. All rights reserved.
+// Use of this source code is governed by a BSD-style license
+// that can be found in the LICENSE file at the root of the
+// Mumble source tree or at <https://www.mumble.info/LICENSE>.
+
+#include "Module.h"
+
+Module::Module(const std::string &name) : m_name(name) {
+}
+
+procptr_t Module::baseAddress() const {
+	const auto iter = m_regions.cbegin();
+	if (iter != m_regions.cend()) {
+		return iter->address;
+	}
+
+	return 0;
+}

--- a/plugins/Module.h
+++ b/plugins/Module.h
@@ -1,0 +1,48 @@
+// Copyright 2020 The Mumble Developers. All rights reserved.
+// Use of this source code is governed by a BSD-style license
+// that can be found in the LICENSE file at the root of the
+// Mumble source tree or at <https://www.mumble.info/LICENSE>.
+
+#ifndef MODULE_H
+#define MODULE_H
+
+#include <set>
+#include <string>
+#include <unordered_map>
+
+typedef uint64_t procptr_t;
+
+struct MemoryRegion {
+	procptr_t address;
+	size_t size;
+
+	bool readable;
+	bool writable;
+	bool executable;
+
+	bool operator<(const MemoryRegion &region) const { return address < region.address; }
+
+	MemoryRegion() : address(0), size(0), readable(false), writable(false), executable(false) {}
+};
+
+typedef std::set< MemoryRegion > MemoryRegions;
+
+class Module {
+protected:
+	std::string m_name;
+	MemoryRegions m_regions;
+
+public:
+	inline std::string name() const { return m_name; }
+	inline MemoryRegions regions() const { return m_regions; }
+
+	inline bool addRegion(const MemoryRegion &region) { return m_regions.insert(region).second; }
+
+	procptr_t baseAddress() const;
+
+	Module(const std::string &name);
+};
+
+typedef std::unordered_map< std::string, Module > Modules;
+
+#endif // MODULE_H

--- a/plugins/Process.h
+++ b/plugins/Process.h
@@ -26,7 +26,6 @@ protected:
 	uint8_t m_pointerSize;
 
 public:
-	using Host::module;
 	using Host::peek;
 
 	inline bool isOk() const { return m_ok; }

--- a/plugins/ProcessLinux.cpp
+++ b/plugins/ProcessLinux.cpp
@@ -8,7 +8,13 @@
 #include <elf.h>
 
 ProcessLinux::ProcessLinux(const procid_t id, const std::string &name) : Process(id, name) {
-	const auto address = module(name);
+	const auto mods = modules();
+	const auto iter = mods.find(name);
+	if (iter == mods.cend()) {
+		return;
+	}
+
+	const auto address = iter->second.baseAddress();
 	if (!address) {
 		return;
 	}

--- a/plugins/ProcessWindows.cpp
+++ b/plugins/ProcessWindows.cpp
@@ -8,7 +8,13 @@
 #include "mumble_plugin_win32_internals.h"
 
 ProcessWindows::ProcessWindows(const procid_t id, const std::string &name) : Process(id, name) {
-	const auto address = module(name);
+	const auto mods = modules();
+	const auto iter = mods.find(name);
+	if (iter == mods.cend()) {
+		return;
+	}
+
+	const auto address = iter->second.baseAddress();
 	if (!address) {
 		return;
 	}

--- a/plugins/mumble_plugin_utils.h
+++ b/plugins/mumble_plugin_utils.h
@@ -10,6 +10,7 @@
 #include <codecvt>
 #include <fstream>
 #include <locale>
+#include <sstream>
 
 #ifdef OS_LINUX
 #	include <fenv.h>
@@ -116,6 +117,37 @@ static inline std::string readFile(const std::string &path) {
 	}
 
 	return content;
+}
+
+/// Reads characters from the stream until \p character is encountered.
+/// @return Read characters and whether the stream is still good.
+static inline std::pair< std::string, bool > readUntil(std::stringstream &stream,
+													   const std::stringstream::int_type character) {
+	std::string buf;
+
+	for (auto input = stream.get(); input != character; input = stream.get()) {
+		if (!stream) {
+			return { buf, false };
+		}
+
+		buf.push_back(input);
+	};
+
+	return { buf, true };
+}
+
+/// Discards characters in the stream until the specified one is encountered.
+/// @param[inverted] Inverts the behavior.
+/// @return Whether the stream is still good.
+static inline bool skipUntil(std::stringstream &stream, const std::stringstream::int_type character,
+							 const bool inverted) {
+	for (auto input = stream.get(); inverted ? (input == character) : (input != character); input = stream.get()) {
+		if (!stream) {
+			return false;
+		}
+	}
+
+	return true;
 }
 
 /// Calculates sine and cosine of the specified value.

--- a/plugins/se/CMakeLists.txt
+++ b/plugins/se/CMakeLists.txt
@@ -6,6 +6,7 @@
 add_library(se SHARED
 	"se.cpp"
 
+	"../Module.cpp"
 	"../Process.cpp"
 	"../ProcessWindows.cpp"
 )

--- a/plugins/se/se.cpp
+++ b/plugins/se/se.cpp
@@ -215,12 +215,24 @@ static int tryLock(const std::multimap< std::wstring, unsigned long long int > &
 		return false;
 	}
 
-	const auto engine = proc->module(isWin32 ? "engine.dll" : "engine.so");
+	const auto modules = proc->modules();
+
+	auto iter = modules.find(isWin32 ? "engine.dll" : "engine.so");
+	if (iter == modules.cend()) {
+		return false;
+	}
+
+	const auto engine = iter->second.baseAddress();
 	if (!engine) {
 		return false;
 	}
 
-	const auto client = proc->module(isWin32 ? "client.dll" : "client.so");
+	iter = modules.find(isWin32 ? "client.dll" : "client.so");
+	if (iter == modules.cend()) {
+		return false;
+	}
+
+	const auto client = iter->second.baseAddress();
 	if (!client) {
 		return false;
 	}


### PR DESCRIPTION
Previously, only `module()` was present: it retrieved the base address of the specified module.

It worked fine, but it iterated through the process' modules every time it was called.

This commit replaces it with `modules()`, which returns an `std::unordered_map` containing all modules.

The map uses the module name as key and Module as value.

Aside from the performance improvement, the new code also provides info for each module region:

- Start address.
- Size.
- Whether it's readable, writable and/or executable.