### PR TITLE
FIX(talking-ui): Context-menu z-index issues

### DIFF
--- a/src/mumble/MainWindow.cpp
+++ b/src/mumble/MainWindow.cpp
@@ -742,13 +742,16 @@ bool MainWindow::handleSpecialContextMenu(const QUrl &url, const QPoint &pos_, b
 	return true;
 }
 
-void MainWindow::on_qtvUsers_customContextMenuRequested(const QPoint &mpos) {
+void MainWindow::on_qtvUsers_customContextMenuRequested(const QPoint &mpos, bool usePositionForGettingContext) {
 	QModelIndex idx = qtvUsers->indexAt(mpos);
-	if (!idx.isValid())
+	if (!idx.isValid() || !usePositionForGettingContext) {
 		idx = qtvUsers->currentIndex();
-	else
+	} else {
 		qtvUsers->setCurrentIndex(idx);
+	}
+
 	ClientUser *p = pmModel->getUser(idx);
+	Channel *channel = pmModel->getChannel(idx);
 
 	qpContextPosition = mpos;
 	if (pmModel->isChannelListener(idx)) {
@@ -767,10 +770,19 @@ void MainWindow::on_qtvUsers_customContextMenuRequested(const QPoint &mpos) {
 	} else {
 		if (p) {
 			cuContextUser.clear();
+			if (!usePositionForGettingContext) {
+				cuContextUser = p;
+			}
+
 			qmUser->exec(qtvUsers->mapToGlobal(mpos), nullptr);
 			cuContextUser.clear();
 		} else {
 			cContextChannel.clear();
+
+			if (!usePositionForGettingContext && channel) {
+				cContextChannel = channel;
+			}
+
 			qmChannel->exec(qtvUsers->mapToGlobal(mpos), nullptr);
 			cContextChannel.clear();
 		}

--- a/src/mumble/MainWindow.h
+++ b/src/mumble/MainWindow.h
@@ -254,7 +254,7 @@ public slots:
 	void on_qteChat_tabPressed();
 	void on_qteChat_backtabPressed();
 	void on_qteChat_ctrlSpacePressed();
-	void on_qtvUsers_customContextMenuRequested(const QPoint &mpos);
+	void on_qtvUsers_customContextMenuRequested(const QPoint &mpos, bool usePositionForGettingContext = true);
 	void on_qteLog_customContextMenuRequested(const QPoint &pos);
 	void on_qteLog_anchorClicked(const QUrl &);
 	void on_qteLog_highlighted(const QUrl &link);

--- a/src/mumble/TalkingUI.cpp
+++ b/src/mumble/TalkingUI.cpp
@@ -551,7 +551,7 @@ void TalkingUI::mousePressEvent(QMouseEvent *event) {
 			// resulting in the proper context menu being shown at the position of the mouse which in this case is in
 			// the TalkingUI.
 			QMetaObject::invokeMethod(g.mw, "on_qtvUsers_customContextMenuRequested", Qt::QueuedConnection,
-									  Q_ARG(QPoint, g.mw->qtvUsers->mapFromGlobal(event->globalPos())));
+									  Q_ARG(QPoint, g.mw->qtvUsers->mapFromGlobal(event->globalPos())), Q_ARG(bool, false));
 		}
 	} else {
 		// Clear selection


### PR DESCRIPTION
In cases where the TalkingUI was overlaying the MainWindow, it could
happen that a context menu triggered from the TalkingUI would actually
be created using another element (listener, channel, user) as the
context for that menu. This would happen because in these cases there is
an entry below the cursor (behind the TalkingUI) that would
automatically be recognized as the desired target.

The fix works by explicitly disabling the position-dependent target
search and using explicitly defined targets instead.