### PR TITLE
DOCS: Note about selecting OpenSSL directory

### DIFF
--- a/docs/dev/build-instructions/build_macos.md
+++ b/docs/dev/build-instructions/build_macos.md
@@ -43,3 +43,20 @@ E.g. if you only want to build the server, use `cmake -Dclient=OFF ..`.
 
 Once cmake has been run, you can issue `cmake --build .` from the build directory in order to actually start compiling the sources. If you want to
 parallelize the build, use `cmake --build . -j <jobs>` where `<jobs>` is the amount of parallel jobs to be run concurrently.
+
+
+## FAQ
+
+See the general [build-FAQ](faq.md).
+
+
+### CMake chooses Apple's SSL library
+
+It can happen that cmake will find Apple's own SSL library that comes pre-installed on your system. This is usually incompatible with Mumble though
+and you'll usually get errors about undefined OpenSSL symbols during link-time:
+```
+ld: symbol(s) not found
+```
+
+You can circumvent this problem by pointing cmake to the OpenSSL version you installed following the instructions from above. For how to do this,
+please refer to [our build-FAQ](faq.md#cmake-selects-wrong-openssl-version).

--- a/docs/dev/build-instructions/faq.md
+++ b/docs/dev/build-instructions/faq.md
@@ -8,3 +8,15 @@ In order to set the build type (Debug vs Release), you have to use the `CMAKE_BU
 Note that this only works for *single-config* generators. If you are using a *multi-config* generator (e.g. visual studio projects), the steps
 mentioned above won't have any effect. Instead, you'll have to choose the config type when invoking the build itself. This works by using e.g. `cmake
 --build . --config Release`.
+
+### CMake selects wrong OpenSSL version
+
+If the automatic search process of cmake doesn't result in the proper version of OpenSSL being selected (e.g. an older/incompatible system version
+could be chosen over the manually installed one), you always have the option of explicitly telling cmake where to look for OpenSSL via the
+`OPENSSL_ROOT_DIR` option.
+
+If for instance you have installed OpenSSL to `/usr/local/opt/openssl`, you can invoke cmake like this:
+```
+cmake -DOPENSSL_ROOT_DIR=/usr/local/opt/openssl ..
+```
+


### PR DESCRIPTION
The issue of cmake finding an incompatible OpenSSL version was
encountered on macOS in #4486, which is why the problem is also
explicitly mentioned in the macOS instructions.