### PR TITLE
MAINT: Fix Dockerfile 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,8 +24,7 @@ RUN apt-get update && apt-get install --no-install-recommends -y \
 	libsndfile1-dev \
 	libgrpc++-dev \
 	libxi-dev \
-	libbz2-dev \
-	qtcreator
+	libbz2-dev
 
 RUN rm -rf /var/lib/apt/lists/* 
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM ubuntu:latest
 # needed to install tzdata in disco
 ENV DEBIAN_FRONTEND=noninteractive
 
-RUN apt-get update && apt-get install --no-install-recommends -y && rm -rf /var/lib/apt/lists/* \
+RUN apt-get update && apt-get install --no-install-recommends -y \
 	build-essential \
 	cmake \
 	pkg-config \
@@ -27,6 +27,8 @@ RUN apt-get update && apt-get install --no-install-recommends -y && rm -rf /var/
 	libbz2-dev \
 	qtcreator
 
+RUN rm -rf /var/lib/apt/lists/* 
+
 COPY . /root/mumble
 WORKDIR /root/mumble/build
 
@@ -37,7 +39,7 @@ RUN make -j $(nproc)
 FROM ubuntu:latest
 
 RUN adduser murmur
-RUN apt-get update && apt-get install --no-install-recommends -y && rm -rf /var/lib/apt/lists/* \
+RUN apt-get update && apt-get install --no-install-recommends -y \
 	libcap2 \
 	libzeroc-ice3.7 \
 	'^libprotobuf[0-9]+$' \
@@ -49,8 +51,9 @@ RUN apt-get update && apt-get install --no-install-recommends -y && rm -rf /var/
 	libqt5sql5 \
 	libqt5xml5 \
 	libqt5dbus5 \
-	ca-certificates \
-	&& rm -rf /var/lib/apt/lists/*
+	ca-certificates
+
+RUN rm -rf /var/lib/apt/lists/* 
 
 COPY --from=0 /root/mumble/build/murmurd /usr/bin/murmurd
 COPY --from=0 /root/mumble/scripts/murmur.ini /etc/murmur/murmur.ini


### PR DESCRIPTION
### Part 1

The Dockerfile contained instructions at the wrong position causing it
to not work properly (it didn't install the necessary dependencies).

Fixes #4600

### Part 2

Don't install qtcreator via Dockerfile

The Qt Creator IDE should not be needed in the Docker image at all.

