### PR TITLE
CI: Introduce GitHub Actions

### DIFF
--- a/.github/actions/install-dependencies/action.yml
+++ b/.github/actions/install-dependencies/action.yml
@@ -1,0 +1,22 @@
+name: 'Install Dependencies'
+description: 'Install the required build dependencies based on the runner''s OS'
+author: 'Mumble Developers'
+
+inputs:
+    type:
+        description: 'The type of dependencies to install ("static" or "shared")'
+        required: True
+    os:
+        description: 'The OS to fetch the dependencies for'
+        required: True
+    arch:
+        description: 'The architecture to fetch the deps for'
+        required: True
+        default: '64bit'
+    
+
+runs:
+    using: "composite"
+    steps:
+        - run: '$GITHUB_ACTION_PATH/main.sh "${{ inputs.os }}" "${{ inputs.type }}" "${{ inputs.arch }}"'
+          shell: bash

--- a/.github/actions/install-dependencies/extractWithProgress.sh
+++ b/.github/actions/install-dependencies/extractWithProgress.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+#
+# Copyright 2020 The Mumble Developers. All rights reserved.
+# Use of this source code is governed by a BSD-style license
+# that can be found in the LICENSE file at the root of the
+# Mumble source tree or at <https://www.mumble.info/LICENSE>.
+
+set -e
+
+fromFile="$1"
+targetDir="$2"
+
+if [ -z "$fromFile" ]; then
+	echo "[ERROR]: Missing argument"
+	exit 1
+fi
+
+if [ -z "$targetDir" ]; then
+	targetDir="."
+fi
+
+echo "Extracting from \"$fromFile\" to \"$targetDir\""
+echo ""
+
+# Get sizes in bytes
+fromSize=$(xz --robot --list "$fromFile" | tail -n -1 | cut -f 4)
+toSize=$(xz --robot --list "$fromFile" | tail -n -1 | cut -f 5)
+# Convert sizes to KB
+toSizeKB=$(expr "$toSize" / 1000)
+fromSizeKB=$(expr "$fromSize" / 1000)
+
+echo "Compressed size:   $fromSizeKB KB"
+echo "Uncompressed size: $toSizeKB KB"
+
+steps=100
+checkPointStep=$(expr "$toSizeKB" / "$steps" )
+
+echo ""
+
+# Use gtar instead of tar if available (for MacOS compatibility)
+tarExec="tar"
+if [ -x "$(command -v gtar)" ]; then
+	tarExec="gtar"
+fi
+
+"$tarExec" -x --record-size=1K --checkpoint="$checkPointStep" --checkpoint-action="echo=%u / $toSize" -f "$fromFile" -C "$targetDir"

--- a/.github/actions/install-dependencies/install_ubuntu_shared_64bit.sh
+++ b/.github/actions/install-dependencies/install_ubuntu_shared_64bit.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+
+sudo apt update
+
+sudo apt -y install \
+	build-essential \
+	g++-multilib \
+	ninja-build \
+	pkg-config \
+    qt5-default \
+	qttools5-dev \
+	qttools5-dev-tools \
+	libqt5svg5-dev \
+	libboost-dev \
+	libssl-dev \
+	libprotobuf-dev \
+	protobuf-compiler \
+	libprotoc-dev \
+	libcap-dev \
+	libxi-dev \
+	libasound2-dev \
+	libasound2-plugins \
+	libasound2-plugins-extra\
+	libogg-dev \
+	libsndfile1-dev \
+	libspeechd-dev \
+	libavahi-compat-libdnssd-dev \
+	libzeroc-ice-dev \
+	zsync \
+	appstream \
+	libgrpc++-dev \
+	protobuf-compiler-grpc

--- a/.github/actions/install-dependencies/install_ubuntu_static_64bit.sh
+++ b/.github/actions/install-dependencies/install_ubuntu_static_64bit.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+
+sudo apt update
+
+sudo apt -y install \
+	build-essential \
+	g++-multilib \
+	ninja-build \
+	libcap-dev \
+	libdbus-1-dev \
+	libxi-dev \
+	libxkbcommon-dev \
+	libxkbcommon-x11-dev \
+	libxcb-icccm4-dev \
+	libxcb-image0-dev \
+	libxcb-keysyms1-dev \
+	libxcb-render-util0-dev \
+	libxcb-xinerama0-dev \
+	libxcb-xinput-dev
+	libxcb-xkb-dev \
+	libasound2-dev \
+	libpulse-dev \
+	libspeechd-dev \
+	libl1-mesa-dev \
+	libavahi-compat-libdnssd-dev \
+	libglu1-mesa-dev \
+	mesa-common-dev \
+	libxrandr-dev \
+	libxxf86vm-dev \
+	libgl-dev
+
+
+if [[ "$MUMBLE_ENVIRONMENT_SOURCE" == "" ]]; then
+	echo "MUMBLE_ENVIRONMENT_SOURCE not set!"
+	exit 1
+fi
+if [[ "$MUMBLE_ENVIRONMENT_VERSION" == "" ]]; then
+	echo "MUMBLE_ENVIRONMENT_VERSION not set!"
+	exit 1
+fi
+if [[ "$MUMBLE_ENVIRONMENT_DIR" == ""  ]]; then
+	echo "MUMBLE_ENVIRONMENT_DIR not set!"
+	exit 1
+fi
+if [[ "$MUMBLE_BUILD_ENV_PATH" == ""  ]]; then
+	echo "MUMBLE_BUILD_ENV_PATH not set!"
+	exit 1
+fi
+
+envDir="$MUMBLE_BUILD_ENV_PATH"
+
+echo "$MUMBLE_BUILD_ENV_PATH"
+echo "$envDir"
+echo "$MUMBLE_ENVIRONMENT_PA"
+
+ls -al "$envDir"
+
+if [[ -d "$envDir" && -n "$(ls -A '$envDir')" ]]; then
+	echo "Environment is cached"
+else
+	sudo apt install axel
+
+	envArchive="$MUMBLE_ENVIRONMENT_VERSION.tar.xz"
+
+	axel -n 5 --output="$envArchive" "$MUMBLE_ENVIRONMENT_SOURCE/$envArchive"
+
+	echo "Extracting archive..."
+	if [[ ! -d "$MUMBLE_ENVIRONMENT_DIR" ]]; then
+		mkdir -p "$envDir"
+	fi
+
+	"$(dirname $0)/extractWithProgress.sh" "$envArchive" "$MUMBLE_ENVIRONMENT_DIR"
+
+	if [[ ! -d "$envDir" || -n "$(ls -A '$envDir')" ]]; then
+		echo "Environment did not follow expected form"
+		ls -al "$MUMBLE_ENVIRONMENT_PATH"
+		exit 1
+	fi
+
+	ls -al "$envDir"
+fi
+
+

--- a/.github/actions/install-dependencies/main.sh
+++ b/.github/actions/install-dependencies/main.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+
+os="$1"
+dep_type="$2"
+arch="$3"
+
+if [[ "$os" == "" || "$dep_type" == "" || "$arch" == "" ]]; then
+	echo "Invalid/Missing parameters"
+	exit 1
+fi
+
+# Turn variables into lowercase
+os="${os,,}"
+# only consider name up to the hyphen
+os=$(sed 's/-.*//' <<< "$os")
+dep_type="${dep_type,,}"
+arch="${arch,,}"
+
+echo "Installing dependencies for $os ($dep_type) - $arch"
+
+script_dir=$(dirname "$0")
+script_name="install_${os}_${dep_type}_${arch}.sh"
+
+# Execute respective script
+"$script_dir/$script_name"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,71 @@
+name: Build
+
+on: [push, pull_request]
+
+env:
+  # Customize the CMake build type here (Release, Debug, RelWithDebInfo, etc.)
+  BUILD_TYPE: Release
+  CMAKE_OPTIONS: |
+      -Dtests=ON -Donline-tests=ON -Dsymbols=ON -Dgrpc=ON -Ddisplay-install-paths=ON
+  MUMBLE_ENVIRONMENT_SOURCE: 'https://dl.mumble.info/build/vcpkg/'
+
+
+jobs:
+  build:
+    strategy:
+        fail-fast: false
+        matrix:
+            os: [ubuntu-18.04, ubuntu-20.04]
+            type: [shared] # Currently the "static" build doesn't work for Linux systems
+            arch: [64bit]
+            
+    runs-on: ${{ matrix.os }}
+
+    steps:
+    - name: Print diskspace
+      run: df -BM
+      shell: bash
+
+
+    - uses: actions/checkout@v2
+      with:
+          submodules: 'recursive'
+
+
+    - name: Set environment variables
+      run: $GITHUB_WORKSPACE/.github/workflows/set_environment_variables.sh "${{ matrix.os }}" "${{ matrix.type }}" "${{ matrix.arch }}" "${{ runner.workspace }}"
+      shell: bash
+
+
+    - uses: actions/cache@v2
+      with:
+          path: '${{ env.MUMBLE_BUILD_ENV_PATH }}'
+          key: ${{ env.MUMBLE_ENVIRONMENT_VERSION }}
+
+
+    - uses: ./.github/actions/install-dependencies
+      with:
+          type: ${{ matrix.type }}
+          os: ${{ matrix.os }}
+          arch: ${{ matrix.arch }}
+
+
+    - name: Create build dir
+      run: cmake -E make_directory ${{runner.workspace}}/build
+
+    - name: Run CMake
+      run: |
+          cmake -G Ninja -S $GITHUB_WORKSPACE -B ${{runner.workspace}}/build -DCMAKE_BUILD_TYPE=$BUILD_TYPE $CMAKE_OPTIONS \
+            $ADDITIONAL_CMAKE_OPTIONS $VCPKG_CMAKE_OPTIONS
+      shell: bash
+
+    - name: Build
+      working-directory: ${{runner.workspace}}/build
+      run: cmake --build . --config $BUILD_TYPE
+      shell: bash
+
+    - name: Test
+      working-directory: ${{runner.workspace}}/build
+      shell: bash
+      run: ctest -v -C $BUILD_TYPE
+

--- a/.github/workflows/set_environment_variables.sh
+++ b/.github/workflows/set_environment_variables.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+
+os=$1
+build_type=$2
+arch=$3
+workspace=$4
+
+
+if [[ "$os" == "" || "$build_type" == "" || "$arch" == "" || "$workspace" == "" ]]; then
+	echo "Invalid parameters"
+	exit 1
+fi
+
+# Turn variables into lowercase
+os="${os,,}"
+# only consider name up to the hyphen
+os=$(echo "$os" | sed 's/-.*//')
+build_type="${build_type,,}"
+arch="${arch,,}"
+
+
+MUMBLE_ENVIRONMENT_DIR="$workspace/mumble-build-environment"
+MUMBLE_BUILD_ENV_PATH=""
+MUMBLE_ENVIRONMENT_VERSION=""
+ADDITIONAL_CMAKE_OPTIONS=""
+VCPKG_CMAKE_OPTIONS=""
+
+case "$os" in
+	"ubuntu")
+		# We have to use the version without debug symbols in order for the size of the
+		# uncompressed archive to not exceed CI size limits
+		MUMBLE_ENVIRONMENT_VERSION="linux-static-1.4.x-2020-08-24-f65cd5d-1168-no-debug"
+		;;
+	"windows")
+		if [[ "$arch" == "64bit" ]]; then
+			MUMBLE_ENVIRONMENT_VERSION="win64-static-1.4.x-2020-07-22-dbd6271-1162"
+		else
+			MUMBLE_ENVIRONMENT_VERSION="win64-static-1.4.x-2020-07-22-dbd6271-1162"
+		fi
+		;;
+	"macos")
+		MUMBLE_ENVIRONMENT_VERSION="macos-static-1.4.x-2020-07-22-dbd6271-1162"
+		;;
+	*)
+		echo "OS $os is not supported"
+		exit 1
+		;;
+esac
+
+MUMBLE_BUILD_ENV_PATH="$MUMBLE_ENVIRONMENT_DIR/$MUMBLE_ENVIRONMENT_VERSION"
+
+if [[ "$build_type" == "static" ]]; then
+	ADDITIONAL_CMAKE_OPTIONS="$ADDITIONAL_CMAKE_OPTIONS -Dstatic=ON"
+
+	VCPKG_TARGET_TRIPLET=""
+	case "$os" in
+		"ubuntu")
+			VCPKG_TARGET_TRIPLET="linux"
+			;;
+		"windows")
+			VCPKG_TARGET_TRIPLET="windows-static-md"
+			ADDITIONAL_CMAKE_OPTIONS="$ADDITIONAL_CMAKE_OPTIONS -Dpackaging=ON"
+			;;
+		"macos")
+			VCPKG_TARGET_TRIPLET="osx"
+			;;
+	esac
+
+	if [[ "$arch" == "64bit" ]]; then
+		VCPKG_TARGET_TRIPLET="x64-$VCPKG_TARGET_TRIPLET"
+	else
+		VCPKG_TARGET_TRIPLET="x32-$VCPKG_TARGET_TRIPLET"
+	fi
+
+	VCPKG_CMAKE_OPTIONS="-DCMAKE_TOOLCHAIN_FILE='$MUMBLE_BUILD_ENV_PATH/scripts/buildsystems/vcpkg.cmake' 
+		-DVCPKG_TARGET_TRIPLET='$VCPKG_TARGET_TRIPLET'
+		-DIce_HOME='$MUMBLE_BUILD_ENV_PATH/installed/$VCPKG_TARGET_TRIPLET'"
+fi
+
+# set environment variables in a way that GitHub Actions understands and preserves
+echo "MUMBLE_ENVIRONMENT_DIR=$MUMBLE_ENVIRONMENT_DIR" >> "$GITHUB_ENV"
+echo "MUMBLE_BUILD_ENV_PATH=$MUMBLE_BUILD_ENV_PATH" >> "$GITHUB_ENV"
+echo "MUMBLE_ENVIRONMENT_VERSION=$MUMBLE_ENVIRONMENT_VERSION" >> "$GITHUB_ENV"
+echo "ADDITIONAL_CMAKE_OPTIONS=$ADDITIONAL_CMAKE_OPTIONS" >> "$GITHUB_ENV"
+echo "VCPKG_CMAKE_OPTIONS=$VCPKG_CMAKE_OPTIONS" >> "$GITHUB_ENV"


### PR DESCRIPTION
Now that Travis CI decided to stop offering their services for free, we
had to look for an alternative solution. GitHub Actions seems to fit the
picture really well and has the benefit of being tightly integrated into
GitHub (obviously).

For now only shared builds for Ubuntu 18.04 and 20.04 are included. The
scripts and the framework for also including static builds is part of
this commit as well but as it stands the static build always failed and
therefore it was given up upon for now.

Adding support for other OS will require a few tweaks and a couple of
new scripts but in general the framework was built with this kind of
extension in mind.