### PR TITLE
FIX(plugin): initialize array to prevent warning

### DIFF
--- a/plugins/ut99/ut99.cpp
+++ b/plugins/ut99/ut99.cpp
@@ -62,7 +62,7 @@ static void norm(float *a) {
 }
 
 static bool correctFront(float *front, float *top) {
-	float n[3];
+	float n[3] = {0};
 
 	if (top[1] < 0) {
 		front[0] *= -1;


### PR DESCRIPTION
When building on CentOS 8 with default flags which includes Wall flag, 
build stops because array n[3] is not initialized. Initialize it to have all 
values to be zero.