### PR TITLE
Add cmake option to disable X11

### DIFF
--- a/docs/dev/build-instructions/cmake_options.md
+++ b/docs/dev/build-instructions/cmake_options.md
@@ -229,6 +229,11 @@ All warnings are treated as errors.
 Build support for WASAPI.
 (Default: ON)
 
+### x11
+
+Build support for X11
+(Default: ON)
+
 ### xboxinput
 
 Build support for global shortcuts from Xbox controllers via the XInput DLL.

--- a/src/mumble/CMakeLists.txt
+++ b/src/mumble/CMakeLists.txt
@@ -49,6 +49,7 @@ elseif(UNIX)
 		option(alsa "Build support for ALSA." ON)
 		option(pulseaudio "Build support for PulseAudio." ON)
 		option(speechd "Build support for Speech Dispatcher." ON)
+		option(x11 "Build support for X11" ON)
 		option(xinput2 "Build support for XI2" ON)
 	endif()
 endif()
@@ -438,13 +439,24 @@ else()
 	target_sources(mumble PRIVATE "SharedMemory_unix.cpp")
 
 	if(NOT APPLE)
-		find_pkg(X11 COMPONENTS Xext REQUIRED)
+		if(x11)
+			find_pkg(X11 COMPONENTS Xext REQUIRED)
+			target_link_libraries(mumble PRIVATE X11::Xext)
 
-		if(xinput2)
-			find_pkg(X11 COMPONENTS Xi REQUIRED)
-			target_link_libraries(mumble PRIVATE X11::Xi)
+			if(xinput2)
+				find_pkg(X11 COMPONENTS Xi REQUIRED)
+				target_link_libraries(mumble PRIVATE X11::Xi)
+			else()
+				target_compile_definitions(mumble PRIVATE "NO_XINPUT2")
+			endif()
+
+			target_sources(mumble
+				PRIVATE
+					"GlobalShortcut_x11.cpp"
+					"GlobalShortcut_x11.h"
+			)
 		else()
-			target_compile_definitions(mumble PRIVATE "NO_XINPUT2")
+			target_compile_definitions(mumble PRIVATE "NO_X11" "NO_XINPUT2")
 		endif()
 
 		if(static AND TARGET Qt5::QXcbIntegrationPlugin)
@@ -454,8 +466,6 @@ else()
 
 		target_sources(mumble
 			PRIVATE
-				"GlobalShortcut_unix.cpp"
-				"GlobalShortcut_unix.h"
 				"Log_unix.cpp"
 				"os_unix.cpp"
 		)
@@ -463,9 +473,14 @@ else()
 		if(${CMAKE_SYSTEM_NAME} STREQUAL "Linux")
 			find_library(LIB_RT rt)
 			target_link_libraries(mumble PRIVATE ${LIB_RT})
-		endif()
 
-		target_link_libraries(mumble PRIVATE X11::Xext)
+			# TODO: check on evdev/udev or linux/input.h presence instead of Linux as it's also present in FreeBSD
+			target_sources(mumble
+				PRIVATE
+					"GlobalShortcut_linux.cpp"
+					"GlobalShortcut_linux.h"
+			)
+		endif()
 	else()
 		find_library(LIB_APPKIT "AppKit")
 		find_library(LIB_APPLICATIONSERVICES "ApplicationServices")

--- a/src/mumble/GlobalShortcut.h
+++ b/src/mumble/GlobalShortcut.h
@@ -226,6 +226,7 @@ struct ShortcutKey {
  * classes (GlobalShortcutPlatform).
  *
  * @see GlobalShortcutX
+ * @see GlobalShortcutLinux
  * @see GlobalShortcutMac
  * @see GlobalShortcutWin
  */

--- a/src/mumble/GlobalShortcut_linux.cpp
+++ b/src/mumble/GlobalShortcut_linux.cpp
@@ -172,7 +172,16 @@ void GlobalShortcutLinux::directoryChanged(const QString &dir) {
 }
 
 QString GlobalShortcutLinux::buttonName(const QVariant &v) {
-	// FIXME
-	(void)v;
-	return QString();
+	bool ok;
+	unsigned int key = v.toUInt(&ok);
+	//char buffer[128];
+
+	if (!ok)
+		return QString();
+
+	if ((key < 0x118) || (key >= 0x128)) {
+		return QLatin1String("0x") + QString::number(key, 16);
+	} else {
+		return tr("Mouse %1").arg(key - 0x118);
+	}
 }

--- a/src/mumble/GlobalShortcut_linux.cpp
+++ b/src/mumble/GlobalShortcut_linux.cpp
@@ -1,0 +1,178 @@
+// Copyright 2005-2020 The Mumble Developers. All rights reserved.
+// Use of this source code is governed by a BSD-style license
+// that can be found in the LICENSE file at the root of the
+// Mumble source tree or at <https://www.mumble.info/LICENSE>.
+
+#include "GlobalShortcut_linux.h"
+
+#include "Settings.h"
+
+#include <QtCore/QFileSystemWatcher>
+#include <QtCore/QSocketNotifier>
+
+#ifdef Q_OS_LINUX
+#	include <fcntl.h>
+#	include <linux/input.h>
+#endif
+
+// We define a global macro called 'g'. This can lead to issues when included code uses 'g' as a type or parameter name
+// (like protobuf 3.7 does). As such, for now, we have to make this our last incl
+#include "Global.h"
+
+// We have to use a global 'diagnostic ignored' pragmas because
+// we still support old versions of GCC. (FreeBSD 9.3 ships with GCC 4.2)
+#if defined(__GNUC__)
+// ScreenCount(...) and so on are macros that access the private structure and
+// cast their return value using old-style-casts. Hence we suppress these warnings
+// for this section of code.
+#	pragma GCC diagnostic ignored "-Wold-style-cast"
+// XKeycodeToKeysym is deprecated.
+// For backwards compatibility reasons we want to keep using the
+// old function as long as possible. The replacement function
+// XkbKeycodeToKeysym requires the XKB extension which isn't
+// guaranteed to be present.
+#	pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+#endif
+
+/**
+ * Returns a platform specific GlobalShortcutEngine object.
+ *
+ * @see GlobalShortcutX
+ * @see GlobalShortcutLinux
+ * @see GlobalShortcutMac
+ * @see GlobalShortcutWin
+ */
+GlobalShortcutEngine *GlobalShortcutEngine::platformInit() {
+	return new GlobalShortcutLinux();
+}
+
+GlobalShortcutLinux::GlobalShortcutLinux() {
+	if (g.s.bEnableEvdev) {
+		QString dir             = QLatin1String("/dev/input");
+		QFileSystemWatcher *fsw = new QFileSystemWatcher(QStringList(dir), this);
+		connect(fsw, SIGNAL(directoryChanged(const QString &)), this, SLOT(directoryChanged(const QString &)));
+		directoryChanged(dir);
+
+		if (qsKeyboards.isEmpty()) {
+			foreach (QFile *f, qmInputDevices)
+				delete f;
+			qmInputDevices.clear();
+
+			delete fsw;
+			qWarning("GlobalShortcutLinux: Unable to open any keyboard input devices under /dev/input");
+		} else {
+			return;
+		}
+	} else {
+		qWarning("GlobalShortcutLinux: No evdev support, global shortcuts disabled");
+	}
+}
+
+GlobalShortcutLinux::~GlobalShortcutLinux() {
+	wait();
+}
+
+// One of the raw /dev/input devices has ready input
+void GlobalShortcutLinux::inputReadyRead(int) {
+	if (!g.s.bEnableEvdev) {
+		return;
+	}
+
+	struct input_event ev;
+
+	if (bNeedRemap)
+		remap();
+
+	QFile *f = qobject_cast< QFile * >(sender()->parent());
+	if (!f)
+		return;
+
+	bool found = false;
+
+	while (f->read(reinterpret_cast< char * >(&ev), sizeof(ev)) == sizeof(ev)) {
+		found = true;
+		if (ev.type != EV_KEY)
+			continue;
+		bool down;
+		switch (ev.value) {
+			case 0:
+				down = false;
+				break;
+			case 1:
+				down = true;
+				break;
+			default:
+				continue;
+		}
+		int evtcode = ev.code + 8;
+		handleButton(evtcode, down);
+	}
+
+	if (!found) {
+		int fd      = f->handle();
+		int version = 0;
+		if ((ioctl(fd, EVIOCGVERSION, &version) < 0) || (((version >> 16) & 0xFF) < 1)) {
+			qWarning("GlobalShortcutLinux: Removing dead input device %s", qPrintable(f->fileName()));
+			qmInputDevices.remove(f->fileName());
+			qsKeyboards.remove(f->fileName());
+			delete f;
+		}
+	}
+}
+
+#define test_bit(bit, array) (array[bit / 8] & (1 << (bit % 8)))
+
+// The /dev/input directory changed
+void GlobalShortcutLinux::directoryChanged(const QString &dir) {
+	if (!g.s.bEnableEvdev) {
+		return;
+	}
+
+	QDir d(dir, QLatin1String("event*"), 0, QDir::System);
+	foreach (QFileInfo fi, d.entryInfoList()) {
+		QString path = fi.absoluteFilePath();
+		if (!qmInputDevices.contains(path)) {
+			QFile *f = new QFile(path, this);
+			if (f->open(QIODevice::ReadOnly)) {
+				int fd = f->handle();
+				int version;
+				char name[256];
+				uint8_t events[EV_MAX / 8 + 1];
+				memset(events, 0, sizeof(events));
+				if ((ioctl(fd, EVIOCGVERSION, &version) >= 0) && (ioctl(fd, EVIOCGNAME(sizeof(name)), name) >= 0)
+					&& (ioctl(fd, EVIOCGBIT(0, sizeof(events)), &events) >= 0) && test_bit(EV_KEY, events)
+					&& (((version >> 16) & 0xFF) > 0)) {
+					name[255] = 0;
+					qWarning("GlobalShortcutLinux: %s: %s", qPrintable(f->fileName()), name);
+					// Is it grabbed by someone else?
+					if ((ioctl(fd, EVIOCGRAB, 1) < 0)) {
+						qWarning("GlobalShortcutLinux: Device exclusively grabbed by someone else (X11 using "
+								 "exclusive-mode evdev?)");
+						delete f;
+					} else {
+						ioctl(fd, EVIOCGRAB, 0);
+						uint8_t keys[KEY_MAX / 8 + 1];
+						if ((ioctl(fd, EVIOCGBIT(EV_KEY, sizeof(keys)), &keys) >= 0) && test_bit(KEY_SPACE, keys))
+							qsKeyboards.insert(f->fileName());
+
+						fcntl(f->handle(), F_SETFL, O_NONBLOCK);
+						connect(new QSocketNotifier(f->handle(), QSocketNotifier::Read, f), SIGNAL(activated(int)),
+								this, SLOT(inputReadyRead(int)));
+
+						qmInputDevices.insert(f->fileName(), f);
+					}
+				} else {
+					delete f;
+				}
+			} else {
+				delete f;
+			}
+		}
+	}
+}
+
+QString GlobalShortcutLinux::buttonName(const QVariant &v) {
+	// FIXME
+	(void)v;
+	return QString();
+}

--- a/src/mumble/GlobalShortcut_linux.h
+++ b/src/mumble/GlobalShortcut_linux.h
@@ -1,0 +1,25 @@
+// Copyright 2005-2020 The Mumble Developers. All rights reserved.
+// Use of this source code is governed by a BSD-style license
+// that can be found in the LICENSE file at the root of the
+// Mumble source tree or at <https://www.mumble.info/LICENSE>.
+
+#ifndef MUMBLE_MUMBLE_GLOBALSHORTCUT_LINUX_H_
+
+#include "ConfigDialog.h"
+#include "Global.h"
+#include "GlobalShortcut.h"
+
+class GlobalShortcutLinux : public GlobalShortcutEngine {
+public:
+	GlobalShortcutLinux();
+	~GlobalShortcutLinux() Q_DECL_OVERRIDE;
+	QString buttonName(const QVariant &) Q_DECL_OVERRIDE;
+
+	QMap< QString, QFile * > qmInputDevices;
+	QSet< QString > qsKeyboards;
+public slots:
+	void inputReadyRead(int);
+	void directoryChanged(const QString &);
+};
+
+#endif

--- a/src/mumble/GlobalShortcut_win.cpp
+++ b/src/mumble/GlobalShortcut_win.cpp
@@ -101,6 +101,7 @@ uint qHash(const GUID &a) {
  * Returns a platform specific GlobalShortcutEngine object.
  *
  * @see GlobalShortcutX
+ * @see GlobalShortcutLinux
  * @see GlobalShortcutMac
  * @see GlobalShortcutWin
  */

--- a/src/mumble/GlobalShortcut_x11.cpp
+++ b/src/mumble/GlobalShortcut_x11.cpp
@@ -3,7 +3,7 @@
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.
 
-#include "GlobalShortcut_unix.h"
+#include "GlobalShortcut_x11.h"
 
 #include "Settings.h"
 
@@ -16,11 +16,6 @@
 #ifndef NO_XINPUT2
 #	include <X11/extensions/XI2.h>
 #	include <X11/extensions/XInput2.h>
-#endif
-
-#ifdef Q_OS_LINUX
-#	include <fcntl.h>
-#	include <linux/input.h>
 #endif
 
 // We define a global macro called 'g'. This can lead to issues when included code uses 'g' as a type or parameter name
@@ -46,6 +41,7 @@
  * Returns a platform specific GlobalShortcutEngine object.
  *
  * @see GlobalShortcutX
+ * @see GlobalShortcutLinux
  * @see GlobalShortcutMac
  * @see GlobalShortcutWin
  */
@@ -63,27 +59,6 @@ GlobalShortcutX::GlobalShortcutX() {
 		qWarning("GlobalShortcutX: Unable to open dedicated display connection.");
 		return;
 	}
-
-#ifdef Q_OS_LINUX
-	if (g.s.bEnableEvdev) {
-		QString dir             = QLatin1String("/dev/input");
-		QFileSystemWatcher *fsw = new QFileSystemWatcher(QStringList(dir), this);
-		connect(fsw, SIGNAL(directoryChanged(const QString &)), this, SLOT(directoryChanged(const QString &)));
-		directoryChanged(dir);
-
-		if (qsKeyboards.isEmpty()) {
-			foreach (QFile *f, qmInputDevices)
-				delete f;
-			qmInputDevices.clear();
-
-			delete fsw;
-			qWarning(
-				"GlobalShortcutX: Unable to open any keyboard input devices under /dev/input, falling back to XInput");
-		} else {
-			return;
-		}
-	}
-#endif
 
 	for (int i = 0; i < ScreenCount(display); ++i)
 		qsRootWindows.insert(RootWindow(display, i));
@@ -245,111 +220,6 @@ void GlobalShortcutX::displayReadyRead(int) {
 
 		XFreeEventData(display, cookie);
 	}
-#endif
-}
-
-// One of the raw /dev/input devices has ready input
-void GlobalShortcutX::inputReadyRead(int) {
-#ifdef Q_OS_LINUX
-	if (!g.s.bEnableEvdev) {
-		return;
-	}
-
-	struct input_event ev;
-
-	if (bNeedRemap)
-		remap();
-
-	QFile *f = qobject_cast< QFile * >(sender()->parent());
-	if (!f)
-		return;
-
-	bool found = false;
-
-	while (f->read(reinterpret_cast< char * >(&ev), sizeof(ev)) == sizeof(ev)) {
-		found = true;
-		if (ev.type != EV_KEY)
-			continue;
-		bool down;
-		switch (ev.value) {
-			case 0:
-				down = false;
-				break;
-			case 1:
-				down = true;
-				break;
-			default:
-				continue;
-		}
-		int evtcode = ev.code + 8;
-		handleButton(evtcode, down);
-	}
-
-	if (!found) {
-		int fd      = f->handle();
-		int version = 0;
-		if ((ioctl(fd, EVIOCGVERSION, &version) < 0) || (((version >> 16) & 0xFF) < 1)) {
-			qWarning("GlobalShortcutX: Removing dead input device %s", qPrintable(f->fileName()));
-			qmInputDevices.remove(f->fileName());
-			qsKeyboards.remove(f->fileName());
-			delete f;
-		}
-	}
-#endif
-}
-
-#define test_bit(bit, array) (array[bit / 8] & (1 << (bit % 8)))
-
-// The /dev/input directory changed
-void GlobalShortcutX::directoryChanged(const QString &dir) {
-#ifdef Q_OS_LINUX
-	if (!g.s.bEnableEvdev) {
-		return;
-	}
-
-	QDir d(dir, QLatin1String("event*"), 0, QDir::System);
-	foreach (QFileInfo fi, d.entryInfoList()) {
-		QString path = fi.absoluteFilePath();
-		if (!qmInputDevices.contains(path)) {
-			QFile *f = new QFile(path, this);
-			if (f->open(QIODevice::ReadOnly)) {
-				int fd = f->handle();
-				int version;
-				char name[256];
-				uint8_t events[EV_MAX / 8 + 1];
-				memset(events, 0, sizeof(events));
-				if ((ioctl(fd, EVIOCGVERSION, &version) >= 0) && (ioctl(fd, EVIOCGNAME(sizeof(name)), name) >= 0)
-					&& (ioctl(fd, EVIOCGBIT(0, sizeof(events)), &events) >= 0) && test_bit(EV_KEY, events)
-					&& (((version >> 16) & 0xFF) > 0)) {
-					name[255] = 0;
-					qWarning("GlobalShortcutX: %s: %s", qPrintable(f->fileName()), name);
-					// Is it grabbed by someone else?
-					if ((ioctl(fd, EVIOCGRAB, 1) < 0)) {
-						qWarning("GlobalShortcutX: Device exclusively grabbed by someone else (X11 using "
-								 "exclusive-mode evdev?)");
-						delete f;
-					} else {
-						ioctl(fd, EVIOCGRAB, 0);
-						uint8_t keys[KEY_MAX / 8 + 1];
-						if ((ioctl(fd, EVIOCGBIT(EV_KEY, sizeof(keys)), &keys) >= 0) && test_bit(KEY_SPACE, keys))
-							qsKeyboards.insert(f->fileName());
-
-						fcntl(f->handle(), F_SETFL, O_NONBLOCK);
-						connect(new QSocketNotifier(f->handle(), QSocketNotifier::Read, f), SIGNAL(activated(int)),
-								this, SLOT(inputReadyRead(int)));
-
-						qmInputDevices.insert(f->fileName(), f);
-					}
-				} else {
-					delete f;
-				}
-			} else {
-				delete f;
-			}
-		}
-	}
-#else
-	Q_UNUSED(dir);
 #endif
 }
 

--- a/src/mumble/GlobalShortcut_x11.h
+++ b/src/mumble/GlobalShortcut_x11.h
@@ -3,8 +3,8 @@
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.
 
-#ifndef MUMBLE_MUMBLE_GLOBALSHORTCUT_UNIX_H_
-#define MUMBLE_MUMBLE_GLOBALSHORTCUT_UNIX_H_
+#ifndef MUMBLE_MUMBLE_GLOBALSHORTCUT_X11_H_
+#define MUMBLE_MUMBLE_GLOBALSHORTCUT_X11_H_
 
 #include "ConfigDialog.h"
 #include "Global.h"
@@ -28,8 +28,6 @@ public:
 	QSet< int > qsMasterDevices;
 
 	volatile bool bRunning;
-	QSet< QString > qsKeyboards;
-	QMap< QString, QFile * > qmInputDevices;
 
 	GlobalShortcutX();
 	~GlobalShortcutX() Q_DECL_OVERRIDE;


### PR DESCRIPTION
This is useful in a system where X11 isn't available (such as some embedded devices).

Draft: Compiles and launches but untested beyond that