### PR TITLE
FIX(client): Respect unlimited imagemessagelength

### DIFF
--- a/src/mumble/CustomElements.cpp
+++ b/src/mumble/CustomElements.cpp
@@ -187,7 +187,7 @@ bool ChatbarTextEdit::sendImagesFromMimeData(const QMimeData *source) {
 
 			QString imgHtml = QLatin1String("<br />") + Log::imageToImg(image);
 
-			if (static_cast< unsigned int >(imgHtml.length()) < g.uiImageLength) {
+			if ((g.uiImageLength == 0) || static_cast< unsigned int >(imgHtml.length()) < g.uiImageLength) {
 				emit pastedImage(imgHtml);
 				return true;
 			} else {


### PR DESCRIPTION
When you set the imagemessagelength to 0 on the server and paste an
image into the client chat no error should pop up that the image is too
large.