### PR TITLE
FIX(server): Prevent listeners from hearing all shouts

### DIFF
--- a/src/murmur/Server.cpp
+++ b/src/murmur/Server.cpp
@@ -1199,9 +1199,7 @@ void Server::processMsg(ServerUser *u, const char *data, int len) {
 						}
 					}
 
-					// Send audio to users in the linked channel but only if they
-					// haven't received the audio already (because they are listening
-					// to the original channel).
+					// Send audio to users in the linked channel
 					foreach (User *p, l->qlUsers) {
 						if (!ChannelListener::isListening(p->uiSession, c->iId)) {
 							ServerUser *pDst = static_cast< ServerUser * >(p);
@@ -1264,6 +1262,7 @@ void Server::processMsg(ServerUser *u, const char *data, int len) {
 								if (ChanACL::hasPermission(u, tc, ChanACL::Whisper, &acCache)) {
 									foreach (User *p, tc->qlUsers) {
 										ServerUser *su = static_cast< ServerUser * >(p);
+
 										if (!group || Group::isMember(tc, tc, qsg, su)) {
 											channel.insert(su);
 										}
@@ -1272,7 +1271,9 @@ void Server::processMsg(ServerUser *u, const char *data, int len) {
 									foreach (unsigned int currentSession, ChannelListener::getListenersForChannel(tc)) {
 										ServerUser *pDst = static_cast< ServerUser * >(qhUsers.value(currentSession));
 
-										if (pDst) {
+										if (pDst && (!group || Group::isMember(tc, tc, qsg, pDst))) {
+											// Only send audio to listener if the user exists and it is in the group the speech is directed
+											// at (if any)
 											listener << pDst;
 										}
 									}


### PR DESCRIPTION
Before this commit, the code on the server made sure that a
ChannelListener would always receive audio that was being shouted to a
channel. It didn't respect though if the shout was actually restricted
to be received by only a specific group.

This patch now makes sure that listeners are also checked for their
group so that a listener that doesn't belong to the target group (if one
is set) won't receive the audio either.

<!-- Please make sure that you follow our commit guidelines specified at https://github.com/mumble-voip/mumble/blob/master/COMMIT_GUIDELINES.md -->
