### PR TITLE
FIX(client): Crash due to race-condition in TalkingUI

### DIFF
--- a/src/mumble/TalkingUI.h
+++ b/src/mumble/TalkingUI.h
@@ -73,7 +73,9 @@ private:
 	/// Adds an UI entry for the given User, if none exists yet.
 	///
 	/// @param channel A pointer to the user that shall be added
-	void addUser(const ClientUser *user);
+	/// @returns The pointer to the respective user entry in the TalkingUI
+	/// (may be nullptr in case of an error)
+	TalkingUIUser *findOrAddUser(const ClientUser *user);
 	/// Moves the given user into the given channel
 	///
 	/// @paam userSession The session ID of the user


### PR DESCRIPTION
The race condition was that the channel of a user could be modified
and before it gets updated in the TalkingUI as well, the talking state
of that user changes. Then inside the talkingStateChanged function the
code would assume that the TalkingUIUser is in the container representing
the current channel of that user but in fact in the TalkingUI this user
is still in its own channel, causing the user-search to return nullptr
which then yields a SegFault as soon as the returned pointer gets
dereferenced.

<!-- Please make sure that you follow our commit guidelines specified at https://github.com/mumble-voip/mumble/blob/master/COMMIT_GUIDELINES.md -->
