### PR TITLE
MAINT/FIX(server): Fix systemd murmur.service

### DIFF
--- a/scripts/murmur.service
+++ b/scripts/murmur.service
@@ -3,9 +3,8 @@ Description=Mumble Daemon
 After=network.target
 
 [Service]
-Type=forking
-PIDFile=/run/murmur/murmur.pid
-ExecStart=/usr/bin/murmurd -ini /etc/murmur.ini
+Type=exec
+ExecStart=/usr/bin/murmurd -fg -ini /etc/murmur.ini
 Restart=always
 PrivateDevices=true
 PrivateTmp=true


### PR DESCRIPTION
As things are now, `systemctl start murmur` hangs and eventually times out.

The problem is that in the unit file, both `Type=forking` and `PIDFile=/run/murmur/murmur.pid` are specified. In this scenario systemd will wait for the PID file to appear. However, it will never appear there, as murmur does setuid on its own before writing the pid file, and thus lacks the rights to write to /run, and even if it had the rights, it doesn't try to create a missing directory anyway.

Although the unit file has been broken for a long time, Debian-based distros still use the `/etc/init.d/mumble-server` wrapped with `systemd-sysv-generator,` and haven't noticed the problem.
