### PR TITLE
BUILD(cmake): Fix overlay link option being overwritten

### DIFF
--- a/overlay_gl/CMakeLists.txt
+++ b/overlay_gl/CMakeLists.txt
@@ -19,7 +19,7 @@ set_target_properties(overlay_gl
 )
 
 if(NOT APPLE)
-	target_link_options(overlay_gl
+	target_link_options(overlay_gl BEFORE
 		PRIVATE
 			"-Wl,-z,lazy"
 	)


### PR DESCRIPTION
If a system for instance uses -z,now in their default build flags (as
Arch Linux does), it will overwrite the -z,lazy flag which however is
needed in order for the overlay to work with games that are not directly
linked with OpenGL.

By using the BEFORE keyword in cmake, we can prevent this from
happening.

This commit can be viewed as a follow-up for #3307.

Fixes #3296
