### PR TITLE
FEAT(client): Easier pasting of images

### DIFF
--- a/src/mumble/CustomElements.h
+++ b/src/mumble/CustomElements.h
@@ -53,6 +53,7 @@ protected:
 	void resizeEvent(QResizeEvent *e) Q_DECL_OVERRIDE;
 	void insertFromMimeData(const QMimeData *source) Q_DECL_OVERRIDE;
 	bool sendImagesFromMimeData(const QMimeData *source);
+	bool emitPastedImage(QImage image);
 
 public:
 	void setDefaultText(const QString &, bool = false);

--- a/src/mumble/Log.cpp
+++ b/src/mumble/Log.cpp
@@ -522,37 +522,29 @@ QString Log::imageToImg(const QByteArray &format, const QByteArray &image) {
 	return QString::fromLatin1("<img src=\"data:image/%1;base64,%2\" />").arg(fmt).arg(QLatin1String(encoded));
 }
 
-QString Log::imageToImg(QImage img) {
+QString Log::imageToImg(QImage img, int maxSize) {
 	if ((img.width() > 480) || (img.height() > 270)) {
 		img = img.scaled(480, 270, Qt::KeepAspectRatio, Qt::SmoothTransformation);
 	}
 
 	int quality       = 100;
-	QByteArray format = "PNG";
+	QByteArray format = "JPEG";
 
 	QByteArray qba;
-	{
-		QBuffer qb(&qba);
-		qb.open(QIODevice::WriteOnly);
-
-		QImageWriter imgwrite(&qb, format);
-		imgwrite.write(img);
-	}
-
-	while ((qba.length() >= 65536) && (quality > 0)) {
+	QString result;
+	while (quality > 0) {
 		qba.clear();
 		QBuffer qb(&qba);
 		qb.open(QIODevice::WriteOnly);
 
-		format = "JPEG";
-
 		QImageWriter imgwrite(&qb, format);
 		imgwrite.setQuality(quality);
 		imgwrite.write(img);
+		result = imageToImg(format, qba);
+		if (result.length() < maxSize || maxSize == 0) {
+			return result;
+		}
 		quality -= 10;
-	}
-	if (qba.length() < 65536) {
-		return imageToImg(format, qba);
 	}
 	return QString();
 }

--- a/src/mumble/Log.h
+++ b/src/mumble/Log.h
@@ -125,7 +125,7 @@ public:
 	void clearIgnore();
 	static QString validHtml(const QString &html, QTextCursor *tc = nullptr);
 	static QString imageToImg(const QByteArray &format, const QByteArray &image);
-	static QString imageToImg(QImage img);
+	static QString imageToImg(QImage img, int maxSize = 0);
 	static QString msgColor(const QString &text, LogColorType t);
 	static QString formatClientUser(ClientUser *cu, LogColorType t, const QString &displayName = QString());
 	static QString formatChannel(::Channel *c);

--- a/src/mumble/mumble_en.ts
+++ b/src/mumble/mumble_en.ts
@@ -2694,6 +2694,10 @@ Are you sure you wish to replace your certificate?
         <source>Unable to send image %1: too large.</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>This server does not allow sending images.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ClientUser</name>


### PR DESCRIPTION
Currently pasting or dragging and dropping images in the Mumble chat is
difficult because:

1) They are rejected because they exceed the allowed size. As a user I
would not expect it to transmitted losslessly but I would hope that the
client compresses it to a size the server allows.
2) Images are rejected because the server does not allow html. When
inserting an image via drag and drop you aren't notified what went
wrong.