### PR TITLE
FIX: Revert audio corking (PulseAudio)

### DIFF
--- a/src/mumble/AudioWizard.cpp
+++ b/src/mumble/AudioWizard.cpp
@@ -37,7 +37,6 @@ AudioWizard::AudioWizard(QWidget *p) : QWizard(p) {
 	bInit            = true;
 	bLastActive      = false;
 	g.bInAudioWizard = true;
-	g.mw->onChangeMute();
 
 	ticker = new QTimer(this);
 	ticker->setObjectName(QLatin1String("Ticker"));
@@ -405,7 +404,6 @@ void AudioWizard::reject() {
 		ao->wipe();
 	aosSource        = nullptr;
 	g.bInAudioWizard = false;
-	g.mw->onChangeMute();
 
 	QWizard::reject();
 }
@@ -441,7 +439,6 @@ void AudioWizard::accept() {
 	g.bPosTest = false;
 	restartAudio();
 	g.bInAudioWizard = false;
-	g.mw->onChangeMute();
 	QWizard::accept();
 }
 

--- a/src/mumble/MainWindow.cpp
+++ b/src/mumble/MainWindow.cpp
@@ -2583,7 +2583,6 @@ void MainWindow::on_qaAudioMute_triggered() {
 		g.sh->setSelfMuteDeafState(g.s.bMute, g.s.bDeaf);
 	}
 
-	onChangeMute();
 	updateTrayIcon();
 }
 
@@ -2620,7 +2619,6 @@ void MainWindow::on_qaAudioDeaf_triggered() {
 		g.sh->setSelfMuteDeafState(g.s.bMute, g.s.bDeaf);
 	}
 
-	onChangeMute();
 	updateTrayIcon();
 }
 
@@ -3117,15 +3115,8 @@ void MainWindow::whisperReleased(QVariant scdata) {
 	updateTarget();
 }
 
-void MainWindow::onChangeMute() {
-	if (!g.ai) {
-		return;
-	}
-
-	emit corkAudioInputStream(g.s.bMute && !g.bInAudioWizard);
-}
-
-void MainWindow::onResetAudio() {
+void MainWindow::onResetAudio()
+{
 	qWarning("MainWindow: Start audio reset");
 	Audio::stop();
 	Audio::start();
@@ -3183,7 +3174,6 @@ void MainWindow::serverConnected() {
 
 	if (g.s.bMute || g.s.bDeaf) {
 		g.sh->setSelfMuteDeafState(g.s.bMute, g.s.bDeaf);
-		onChangeMute();
 	}
 
 	// Update QActions and menues

--- a/src/mumble/MainWindow.h
+++ b/src/mumble/MainWindow.h
@@ -297,9 +297,6 @@ public slots:
 	void pttReleased();
 	void whisperReleased(QVariant scdata);
 	void onResetAudio();
-	/// Called whenever the self-mute state may have changed. Dispatches
-	/// corkAudioInputStream() if the desire for audio input has changed.
-	void onChangeMute();
 	void showRaiseWindow();
 	void on_qaFilterToggle_triggered();
 	/// Opens a save dialog for the image referenced by qtcSaveImageCursor.
@@ -311,15 +308,6 @@ public slots:
 	/// filename is discarded).
 	void updateImagePath(QString filepath) const;
 signals:
-	/// Reports that audio input is now, or is no longer, required.
-	///
-	/// Signal allows an \ref AudioInput to suspend the input stream
-	/// when it is not required.
-	///
-	/// @param cork  If true, the audio backend MAY now cork/suspend
-	/// the input stream. If false, the audio backend MUST immediately
-	/// un-cork/resume the stream.
-	void corkAudioInputStream(const bool cork);
 	/// Signal emitted when the server and the client have finished
 	/// synchronizing (after a new connection).
 	void serverSynchronized();

--- a/src/mumble/PulseAudio.cpp
+++ b/src/mumble/PulseAudio.cpp
@@ -323,10 +323,6 @@ void PulseAudioSystem::eventCallback(pa_mainloop_api *api, pa_defer_event *) {
 
 			m_pulseAudio.stream_connect_record(pasInput, qPrintable(idev), &buff, PA_STREAM_ADJUST_LATENCY);
 
-			// Ensure stream is initially un-muted
-			m_pulseAudio.stream_cork(pasInput, 0, nullptr, nullptr);
-
-			connect(g.mw, &MainWindow::corkAudioInputStream, this, &PulseAudioSystem::corkAudioInputStream);
 		}
 	}
 
@@ -394,14 +390,6 @@ void PulseAudioSystem::eventCallback(pa_mainloop_api *api, pa_defer_event *) {
 
 			m_pulseAudio.stream_connect_record(pasSpeaker, qPrintable(edev), &buff, PA_STREAM_ADJUST_LATENCY);
 		}
-	}
-}
-
-void PulseAudioSystem::corkAudioInputStream(const bool cork) {
-	if (pasInput) {
-		m_pulseAudio.threaded_mainloop_lock(pam);
-		m_pulseAudio.stream_cork(pasInput, cork, nullptr, nullptr);
-		m_pulseAudio.threaded_mainloop_unlock(pam);
 	}
 }
 

--- a/src/mumble/PulseAudio.h
+++ b/src/mumble/PulseAudio.h
@@ -173,9 +173,6 @@ protected:
 	void setVolumes();
 	PulseAttenuation *getAttenuation(QString stream_restore_id);
 
-public slots:
-	void corkAudioInputStream(const bool cork);
-
 public:
 	QHash< QString, QString > qhInput;
 	QHash< QString, QString > qhOutput;

--- a/src/mumble/main.cpp
+++ b/src/mumble/main.cpp
@@ -624,7 +624,6 @@ int main(int argc, char **argv) {
 	g.p->rescanPlugins();
 
 	Audio::start();
-	g.mw->onChangeMute();
 
 	a.setQuitOnLastWindowClosed(false);
 


### PR DESCRIPTION
This reverts commit 7d0b933a7e9595e0afef854c6f0a2f68a1feea7c.

The issue with theses changes is that they cause
AudioInput::encodeAudioframe from no longer being called if the user is
muted. The functionality packed inside the mentioned function relies on
being continually being called even if there is no audio to send.

Thus no longer calling them affects the following things (maybe more):
- local user's talking state (can get stuck in a certain state)
- Audio cues for begin/end of a transmission
- Idle actions
- Framesize stuffing when using Opus
- Resetting of certain variables (iBitrate)
- Clearing/Handling of whisper targets (for last audio frame)
- Properly updating bPreviousVoice

In order to use the changes originally made by that commit, the audio
system has to be refactored first so that these things no longer rely on
this function being called continuously.

Ref: #171
Old workaround for parts of this issue: #4018