### PR TITLE
FEAT(client): Adds shortcut to listen to a channel

### DIFF
--- a/src/mumble/CMakeLists.txt
+++ b/src/mumble/CMakeLists.txt
@@ -157,6 +157,7 @@ set(MUMBLE_SOURCES
 	"GlobalShortcutButtons.h"
 	"GlobalShortcutButtons.ui"
 	"GlobalShortcutTarget.ui"
+	"GlobalShortcutTypes.h"
 	"JSONSerialization.cpp"
 	"JSONSerialization.h"
 	"LCD.cpp"

--- a/src/mumble/GlobalShortcut.cpp
+++ b/src/mumble/GlobalShortcut.cpp
@@ -26,6 +26,8 @@
 #	include <QtCore/QOperatingSystemVersion>
 #endif
 
+#include <cassert>
+
 const QString GlobalShortcutConfig::name = QLatin1String("GlobalShortcutConfig");
 
 /**
@@ -101,6 +103,31 @@ void ShortcutToggleWidget::setIndex(int idx) {
 }
 
 int ShortcutToggleWidget::index() const {
+	return itemData(currentIndex()).toInt();
+}
+
+ChannelSelectWidget::ChannelSelectWidget(QWidget *parent) : MUComboBox(parent) {
+	QReadLocker lock(&Channel::c_qrwlChannels);
+
+	int index = 0;
+
+	for (const Channel *currentChannel : Channel::c_qhChannels) {
+		assert(currentChannel);
+
+		insertItem(index, currentChannel->qsName);
+		setItemData(index, currentChannel->iId);
+
+		index++;
+	}
+
+	model()->sort(0);
+}
+
+void ChannelSelectWidget::setCurrentChannel(const ChannelTarget &target) {
+	setCurrentIndex(findData(target.channelID));
+}
+
+ChannelTarget ChannelSelectWidget::currentChannel() const {
 	return itemData(currentIndex()).toInt();
 }
 
@@ -432,6 +459,8 @@ ShortcutDelegate::ShortcutDelegate(QObject *p) : QStyledItemDelegate(p) {
 	factory->registerEditor(QVariant::Int, new QStandardItemEditorCreator< ShortcutToggleWidget >());
 	factory->registerEditor(static_cast< QVariant::Type >(QVariant::fromValue(ShortcutTarget()).userType()),
 							new QStandardItemEditorCreator< ShortcutTargetWidget >());
+	factory->registerEditor(static_cast< QVariant::Type >(QVariant::fromValue(ChannelTarget()).userType()),
+							new QStandardItemEditorCreator< ChannelSelectWidget >());
 	factory->registerEditor(QVariant::String, new QStandardItemEditorCreator< QLineEdit >());
 	factory->registerEditor(QVariant::Invalid, new QStandardItemEditorCreator< QWidget >());
 	setItemEditorFactory(factory);
@@ -448,6 +477,15 @@ ShortcutDelegate::~ShortcutDelegate() {
 QString ShortcutDelegate::displayText(const QVariant &item, const QLocale &loc) const {
 	if (item.userType() == QVariant::fromValue(ShortcutTarget()).userType()) {
 		return ShortcutTargetWidget::targetString(item.value< ShortcutTarget >());
+	} else if (item.userType() == QVariant::fromValue(ChannelTarget()).userType()) {
+		ChannelTarget target = item.value< ChannelTarget >();
+
+		const Channel *c = Channel::get(target.channelID);
+		if (c) {
+			return c->qsName;
+		} else {
+			return tr("< Unknown Channel >");
+		}
 	}
 
 	switch (item.type()) {

--- a/src/mumble/GlobalShortcut.cpp
+++ b/src/mumble/GlobalShortcut.cpp
@@ -665,7 +665,7 @@ void GlobalShortcutConfig::on_qtwShortcuts_itemChanged(QTreeWidgetItem *item, in
 	sc.bSuppress = item->checkState(3) == Qt::Checked;
 
 	const ::GlobalShortcut *gs = GlobalShortcutEngine::engine->qmShortcuts.value(sc.iIndex);
-	if (gs && sc.qvData.type() != gs->qvDefault.type()) {
+	if (gs && sc.qvData.userType() != gs->qvDefault.userType()) {
 		item->setData(1, Qt::DisplayRole, gs->qvDefault);
 	}
 }

--- a/src/mumble/GlobalShortcut.h
+++ b/src/mumble/GlobalShortcut.h
@@ -11,6 +11,7 @@
 #include <QtWidgets/QStyledItemDelegate>
 #include <QtWidgets/QToolButton>
 
+#include "Channel.h"
 #include "ConfigDialog.h"
 #include "MUComboBox.h"
 #include "Timer.h"
@@ -70,6 +71,17 @@ public:
 	ShortcutToggleWidget(QWidget *p = nullptr);
 	int index() const;
 	void setIndex(int);
+};
+
+class ChannelSelectWidget : public MUComboBox {
+	Q_OBJECT
+	Q_DISABLE_COPY(ChannelSelectWidget)
+	Q_PROPERTY(ChannelTarget currentChannel READ currentChannel WRITE setCurrentChannel USER true)
+public:
+	ChannelSelectWidget(QWidget *parent = nullptr);
+
+	ChannelTarget currentChannel() const;
+	void setCurrentChannel(const ChannelTarget &);
 };
 
 /**
@@ -136,6 +148,7 @@ public slots:
  * @see ShortcutKeyWidget
  * @see ShortcutActionWidget
  * @see ShortcutTargetWidget
+ * @see ChannelSelectWidget
  */
 class ShortcutDelegate : public QStyledItemDelegate {
 	Q_OBJECT

--- a/src/mumble/GlobalShortcutTypes.h
+++ b/src/mumble/GlobalShortcutTypes.h
@@ -1,0 +1,48 @@
+// Copyright 2022 The Mumble Developers. All rights reserved.
+// Use of this source code is governed by a BSD-style license
+// that can be found in the LICENSE file at the root of the
+// Mumble source tree or at <https://www.mumble.info/LICENSE>.
+
+#ifndef MUMBLE_MUMBLE_GLOBALSHORTCUTTYPES_H_
+#define MUMBLE_MUMBLE_GLOBALSHORTCUTTYPES_H_
+
+/**
+ * The entries in this namespace/enum represent the shortcut types (often referred to as a shortcut's "index")
+ * of the existing global shortcuts.
+ *
+ * IMPORTANT: ONLY EVER APPEND TO THE END OF THE ENUM!
+ */
+namespace GlobalShortcutType {
+enum Type {
+	PushToTalk = 1,
+	ResetAudio,
+	MuteSelf,
+	DeafenSelf,
+	UnlinkPlugin,
+	PushToMute,
+	JoinChannel,
+	ToggleOverlay,
+	ToggleMinimalView,
+	VolumeUp,
+	VolumeDown,
+	Whisper_Shout,
+	LinkChannel,
+	CycleTransmitMode,
+	ToggleMainWindowVisibility,
+	UsePushToTalk,
+	UseContinous,
+	UseVAD,
+	SendTextMessage,
+	SendTextMessageClipboard,
+	ToggleTalkingUI,
+	ToggleSearch,
+};
+
+// A few assertions meant to catch, if anyone inserts a new value in-between instead of appending
+// to the end of the enum
+static_assert(PushToTalk == 1, "You may only append to the end of the enum!");
+static_assert(ToggleMinimalView == 9, "You may only append to the end of the enum!");
+static_assert(ToggleSearch == 22, "You may only append to the end of the enum!");
+} // namespace GlobalShortcutType
+
+#endif // MUMBLE_MUMBLE_GLOBALSHORTCUTTYPES_H_

--- a/src/mumble/GlobalShortcutTypes.h
+++ b/src/mumble/GlobalShortcutTypes.h
@@ -36,6 +36,7 @@ enum Type {
 	SendTextMessageClipboard,
 	ToggleTalkingUI,
 	ToggleSearch,
+	ListenToChannel,
 };
 
 // A few assertions meant to catch, if anyone inserts a new value in-between instead of appending

--- a/src/mumble/MainWindow.cpp
+++ b/src/mumble/MainWindow.cpp
@@ -239,6 +239,12 @@ void MainWindow::createActions() {
 	gsJoinChannel->setObjectName(QLatin1String("MetaChannel"));
 	gsJoinChannel->qsToolTip = tr("Use in conjunction with Whisper to.", "Global Shortcut");
 
+	gsListenChannel =
+		new GlobalShortcut(this, GlobalShortcutType::ListenToChannel, tr("Listen to Channel", "Global Shortcut"),
+						   QVariant::fromValue(ChannelTarget()));
+	gsListenChannel->setObjectName(QLatin1String("gsListenChannel"));
+	gsListenChannel->qsToolTip = tr("Toggles listening to the given channel.", "Global Shortcut");
+
 #ifdef USE_OVERLAY
 	gsToggleOverlay =
 		new GlobalShortcut(this, GlobalShortcutType::ToggleOverlay, tr("Toggle Overlay", "Global Shortcut"));
@@ -3097,6 +3103,19 @@ void MainWindow::on_gsToggleMainWindowVisibility_triggered(bool down, QVariant) 
 			Global::get().mw->hide();
 		} else {
 			Global::get().mw->show();
+		}
+	}
+}
+
+void MainWindow::on_gsListenChannel_triggered(bool down, QVariant scdata) {
+	ChannelTarget target = scdata.value< ChannelTarget >();
+	const Channel *c     = Channel::get(target.channelID);
+
+	if (down && c) {
+		if (!Global::get().channelListenerManager->isListening(Global::get().uiSession, c->iId)) {
+			Global::get().sh->startListeningToChannel(c->iId);
+		} else {
+			Global::get().sh->stopListeningToChannel(c->iId);
 		}
 	}
 }

--- a/src/mumble/MainWindow.cpp
+++ b/src/mumble/MainWindow.cpp
@@ -24,6 +24,7 @@
 #include "NetworkConfig.h"
 #include "OpusCodec.h"
 #include "GlobalShortcut.h"
+#include "GlobalShortcutTypes.h"
 #ifdef USE_OVERLAY
 #	include "OverlayClient.h"
 #endif
@@ -202,8 +203,7 @@ MainWindow::MainWindow(QWidget *p)
 }
 
 void MainWindow::createActions() {
-	int idx    = 1;
-	gsPushTalk = new GlobalShortcut(this, idx++, tr("Push-to-Talk", "Global Shortcut"));
+	gsPushTalk = new GlobalShortcut(this, GlobalShortcutType::PushToTalk, tr("Push-to-Talk", "Global Shortcut"));
 	gsPushTalk->setObjectName(QLatin1String("PushToTalk"));
 	gsPushTalk->qsToolTip   = tr("Push and hold this button to send voice.", "Global Shortcut");
 	gsPushTalk->qsWhatsThis = tr(
@@ -211,35 +211,37 @@ void MainWindow::createActions() {
 		"Global Shortcut");
 
 
-	gsResetAudio = new GlobalShortcut(this, idx++, tr("Reset Audio Processor", "Global Shortcut"));
+	gsResetAudio =
+		new GlobalShortcut(this, GlobalShortcutType::ResetAudio, tr("Reset Audio Processor", "Global Shortcut"));
 	gsResetAudio->setObjectName(QLatin1String("ResetAudio"));
 
-	gsMuteSelf = new GlobalShortcut(this, idx++, tr("Mute Self", "Global Shortcut"), 0);
+	gsMuteSelf = new GlobalShortcut(this, GlobalShortcutType::MuteSelf, tr("Mute Self", "Global Shortcut"), 0);
 	gsMuteSelf->setObjectName(QLatin1String("gsMuteSelf"));
 	gsMuteSelf->qsToolTip = tr("Set self-mute status.", "Global Shortcut");
 	gsMuteSelf->qsWhatsThis =
 		tr("This will set or toggle your muted status. If you turn this off, you will also disable self-deafen.",
 		   "Global Shortcut");
 
-	gsDeafSelf = new GlobalShortcut(this, idx++, tr("Deafen Self", "Global Shortcut"), 0);
+	gsDeafSelf = new GlobalShortcut(this, GlobalShortcutType::DeafenSelf, tr("Deafen Self", "Global Shortcut"), 0);
 	gsDeafSelf->setObjectName(QLatin1String("gsDeafSelf"));
 	gsDeafSelf->qsToolTip = tr("Set self-deafen status.", "Global Shortcut");
 	gsDeafSelf->qsWhatsThis =
 		tr("This will set or toggle your deafened status. If you turn this on, you will also enable self-mute.",
 		   "Global Shortcut");
 
-	gsUnlink = new GlobalShortcut(this, idx++, tr("Unlink Plugin", "Global Shortcut"));
+	gsUnlink = new GlobalShortcut(this, GlobalShortcutType::UnlinkPlugin, tr("Unlink Plugin", "Global Shortcut"));
 	gsUnlink->setObjectName(QLatin1String("UnlinkPlugin"));
 
-	gsPushMute = new GlobalShortcut(this, idx++, tr("Push-to-Mute", "Global Shortcut"));
+	gsPushMute = new GlobalShortcut(this, GlobalShortcutType::PushToMute, tr("Push-to-Mute", "Global Shortcut"));
 	gsPushMute->setObjectName(QLatin1String("PushToMute"));
 
-	gsJoinChannel = new GlobalShortcut(this, idx++, tr("Join Channel", "Global Shortcut"));
+	gsJoinChannel = new GlobalShortcut(this, GlobalShortcutType::JoinChannel, tr("Join Channel", "Global Shortcut"));
 	gsJoinChannel->setObjectName(QLatin1String("MetaChannel"));
 	gsJoinChannel->qsToolTip = tr("Use in conjunction with Whisper to.", "Global Shortcut");
 
 #ifdef USE_OVERLAY
-	gsToggleOverlay = new GlobalShortcut(this, idx++, tr("Toggle Overlay", "Global Shortcut"));
+	gsToggleOverlay =
+		new GlobalShortcut(this, GlobalShortcutType::ToggleOverlay, tr("Toggle Overlay", "Global Shortcut"));
 	gsToggleOverlay->setObjectName(QLatin1String("ToggleOverlay"));
 	gsToggleOverlay->qsToolTip   = tr("Toggle state of in-game overlay.", "Global Shortcut");
 	gsToggleOverlay->qsWhatsThis = tr("This will switch the states of the in-game overlay.", "Global Shortcut");
@@ -247,57 +249,66 @@ void MainWindow::createActions() {
 	connect(gsToggleOverlay, SIGNAL(down(QVariant)), Global::get().o, SLOT(toggleShow()));
 #endif
 
-	gsMinimal = new GlobalShortcut(this, idx++, tr("Toggle Minimal", "Global Shortcut"));
+	gsMinimal =
+		new GlobalShortcut(this, GlobalShortcutType::ToggleMinimalView, tr("Toggle Minimal", "Global Shortcut"));
 	gsMinimal->setObjectName(QLatin1String("ToggleMinimal"));
 
-	gsVolumeUp = new GlobalShortcut(this, idx++, tr("Volume Up (+10%)", "Global Shortcut"));
+	gsVolumeUp = new GlobalShortcut(this, GlobalShortcutType::VolumeUp, tr("Volume Up (+10%)", "Global Shortcut"));
 	gsVolumeUp->setObjectName(QLatin1String("VolumeUp"));
 
-	gsVolumeDown = new GlobalShortcut(this, idx++, tr("Volume Down (-10%)", "Global Shortcut"));
+	gsVolumeDown =
+		new GlobalShortcut(this, GlobalShortcutType::VolumeDown, tr("Volume Down (-10%)", "Global Shortcut"));
 	gsVolumeDown->setObjectName(QLatin1String("VolumeDown"));
 
 	qstiIcon = new QSystemTrayIcon(qiIcon, this);
 	qstiIcon->setToolTip(tr("Mumble -- %1").arg(Version::getRelease()));
 	qstiIcon->setObjectName(QLatin1String("Icon"));
 
-	gsWhisper = new GlobalShortcut(this, idx++, tr("Whisper/Shout"), QVariant::fromValue(ShortcutTarget()));
+	gsWhisper = new GlobalShortcut(this, GlobalShortcutType::Whisper_Shout, tr("Whisper/Shout"),
+								   QVariant::fromValue(ShortcutTarget()));
 	gsWhisper->setObjectName(QLatin1String("gsWhisper"));
 
-	gsLinkChannel = new GlobalShortcut(this, idx++, tr("Link Channel", "Global Shortcut"));
+	gsLinkChannel = new GlobalShortcut(this, GlobalShortcutType::LinkChannel, tr("Link Channel", "Global Shortcut"));
 	gsLinkChannel->setObjectName(QLatin1String("MetaLink"));
 	gsLinkChannel->qsToolTip = tr("Use in conjunction with Whisper to.", "Global Shortcut");
 
-	gsCycleTransmitMode = new GlobalShortcut(this, idx++, tr("Cycle Transmit Mode", "Global Shortcut"));
+	gsCycleTransmitMode =
+		new GlobalShortcut(this, GlobalShortcutType::CycleTransmitMode, tr("Cycle Transmit Mode", "Global Shortcut"));
 	gsCycleTransmitMode->setObjectName(QLatin1String("gsCycleTransmitMode"));
 
-	gsToggleMainWindowVisibility = new GlobalShortcut(this, idx++, tr("Hide/show main window", "Global Shortcut"));
+	gsToggleMainWindowVisibility = new GlobalShortcut(this, GlobalShortcutType::ToggleMainWindowVisibility,
+													  tr("Hide/show main window", "Global Shortcut"));
 	gsToggleMainWindowVisibility->setObjectName(QLatin1String("gsToggleMainWindowVisibility"));
 
-	gsTransmitModePushToTalk =
-		new GlobalShortcut(this, idx++, tr("Set Transmit Mode to Push-To-Talk", "Global Shortcut"));
+	gsTransmitModePushToTalk = new GlobalShortcut(this, GlobalShortcutType::UsePushToTalk,
+												  tr("Set Transmit Mode to Push-To-Talk", "Global Shortcut"));
 	gsTransmitModePushToTalk->setObjectName(QLatin1String("gsTransmitModePushToTalk"));
 
-	gsTransmitModeContinuous =
-		new GlobalShortcut(this, idx++, tr("Set Transmit Mode to Continuous", "Global Shortcut"));
+	gsTransmitModeContinuous = new GlobalShortcut(this, GlobalShortcutType::UseContinous,
+												  tr("Set Transmit Mode to Continuous", "Global Shortcut"));
 	gsTransmitModeContinuous->setObjectName(QLatin1String("gsTransmitModeContinuous"));
 
-	gsTransmitModeVAD = new GlobalShortcut(this, idx++, tr("Set Transmit Mode to VAD", "Global Shortcut"));
+	gsTransmitModeVAD =
+		new GlobalShortcut(this, GlobalShortcutType::UseVAD, tr("Set Transmit Mode to VAD", "Global Shortcut"));
 	gsTransmitModeVAD->setObjectName(QLatin1String("gsTransmitModeVAD"));
 
-	gsSendTextMessage =
-		new GlobalShortcut(this, idx++, tr("Send Text Message", "Global Shortcut"), QVariant(QString()));
+	gsSendTextMessage = new GlobalShortcut(this, GlobalShortcutType::SendTextMessage,
+										   tr("Send Text Message", "Global Shortcut"), QVariant(QString()));
 	gsSendTextMessage->setObjectName(QLatin1String("gsSendTextMessage"));
 
-	gsSendClipboardTextMessage = new GlobalShortcut(this, idx++, tr("Send Clipboard Text Message", "Global Shortcut"));
+	gsSendClipboardTextMessage = new GlobalShortcut(this, GlobalShortcutType::SendTextMessageClipboard,
+													tr("Send Clipboard Text Message", "Global Shortcut"));
 	gsSendClipboardTextMessage->setObjectName(QLatin1String("gsSendClipboardTextMessage"));
 	gsSendClipboardTextMessage->qsWhatsThis =
 		tr("This will send your Clipboard content to the channel you are currently in.", "Global Shortcut");
 
-	gsToggleTalkingUI = new GlobalShortcut(this, idx++, tr("Toggle TalkingUI", "Global shortcut"));
+	gsToggleTalkingUI =
+		new GlobalShortcut(this, GlobalShortcutType::ToggleTalkingUI, tr("Toggle TalkingUI", "Global shortcut"));
 	gsToggleTalkingUI->setObjectName(QLatin1String("gsToggleTalkingUI"));
 	gsToggleTalkingUI->qsWhatsThis = tr("Toggles the visibility of the TalkingUI.", "Global Shortcut");
 
-	gsToggleSearch = new GlobalShortcut(this, idx++, tr("Toggle search dialog", "Global Shortcut"));
+	gsToggleSearch =
+		new GlobalShortcut(this, GlobalShortcutType::ToggleSearch, tr("Toggle search dialog", "Global Shortcut"));
 	gsToggleSearch->setObjectName(QLatin1String("gsToggleSearch"));
 	gsToggleSearch->qsWhatsThis =
 		tr("This will open or close the search dialog depending on whether it is currently opened already");

--- a/src/mumble/MainWindow.h
+++ b/src/mumble/MainWindow.h
@@ -93,7 +93,7 @@ public:
 #ifdef USE_OVERLAY
 	GlobalShortcut *gsToggleOverlay;
 #endif
-	GlobalShortcut *gsMinimal, *gsVolumeUp, *gsVolumeDown, *gsWhisper, *gsLinkChannel;
+	GlobalShortcut *gsMinimal, *gsVolumeUp, *gsVolumeDown, *gsWhisper, *gsLinkChannel, *gsListenChannel;
 	GlobalShortcut *gsCycleTransmitMode, *gsToggleMainWindowVisibility, *gsTransmitModePushToTalk,
 		*gsTransmitModeContinuous, *gsTransmitModeVAD;
 	GlobalShortcut *gsSendTextMessage, *gsSendClipboardTextMessage;
@@ -296,6 +296,7 @@ public slots:
 	void on_gsWhisper_triggered(bool, QVariant);
 	void addTarget(ShortcutTarget *);
 	void removeTarget(ShortcutTarget *);
+	void on_gsListenChannel_triggered(bool, QVariant);
 	void on_gsCycleTransmitMode_triggered(bool, QVariant);
 	void on_gsToggleMainWindowVisibility_triggered(bool, QVariant);
 	void on_gsTransmitModePushToTalk_triggered(bool, QVariant);

--- a/src/mumble/Messages.cpp
+++ b/src/mumble/Messages.cpp
@@ -160,10 +160,6 @@ void MainWindow::msgServerSync(const MumbleProto::ServerSync &msg) {
 
 	QList< Shortcut > sc = Global::get().db->getShortcuts(Global::get().sh->qbaDigest);
 	if (!sc.isEmpty()) {
-		for (int i = 0; i < sc.count(); ++i) {
-			Shortcut &s = sc[i];
-			s.iIndex    = Global::get().mw->gsWhisper->idx;
-		}
 		Global::get().s.qlShortcuts << sc;
 		GlobalShortcutEngine::engine->bNeedRemap = true;
 	}

--- a/src/mumble/Settings.cpp
+++ b/src/mumble/Settings.cpp
@@ -59,6 +59,9 @@ bool Shortcut::isServerSpecific() const {
 		const ShortcutTarget &sc = qvariant_cast< ShortcutTarget >(qvData);
 		return sc.isServerSpecific();
 	}
+	if (qvData.canConvert< ChannelTarget >()) {
+		return true;
+	}
 	return false;
 }
 
@@ -378,6 +381,26 @@ QDataStream &operator>>(QDataStream &qds, ShortcutTarget &st) {
 	}
 }
 
+QDataStream &operator<<(QDataStream &qds, const ChannelTarget &target) {
+	return qds << target.channelID;
+}
+
+QDataStream &operator>>(QDataStream &qds, ChannelTarget &target) {
+	return qds >> target.channelID;
+}
+
+bool operator==(const ChannelTarget &lhs, const ChannelTarget &rhs) {
+	return lhs.channelID == rhs.channelID;
+}
+
+bool operator<(const ChannelTarget &lhs, const ChannelTarget &rhs) {
+	return lhs.channelID < rhs.channelID;
+}
+
+quint32 qHash(const ChannelTarget &target) {
+	return qHash(target.channelID);
+}
+
 const QString Settings::cqsDefaultPushClickOn  = QLatin1String(":/on.ogg");
 const QString Settings::cqsDefaultPushClickOff = QLatin1String(":/off.ogg");
 
@@ -492,6 +515,8 @@ Settings::Settings() {
 #endif
 	qRegisterMetaType< ShortcutTarget >("ShortcutTarget");
 	qRegisterMetaTypeStreamOperators< ShortcutTarget >("ShortcutTarget");
+	qRegisterMetaType< ChannelTarget >("ChannelTarget");
+	qRegisterMetaTypeStreamOperators< ChannelTarget >("ChannelTarget");
 	qRegisterMetaType< QVariant >("QVariant");
 	qRegisterMetaType< PluginSetting >("PluginSetting");
 	qRegisterMetaTypeStreamOperators< PluginSetting >("PluginSetting");

--- a/src/mumble/Settings.h
+++ b/src/mumble/Settings.h
@@ -23,6 +23,7 @@
 #include <QVariant>
 #include <Qt>
 
+#include "Channel.h"
 #include "EchoCancelOption.h"
 #include "SSL.h"
 #include "SearchDialog.h"
@@ -51,6 +52,20 @@ struct Shortcut {
 	bool isServerSpecific() const;
 	bool operator==(const Shortcut &) const;
 };
+
+struct ChannelTarget {
+	int channelID = Channel::ROOT_ID;
+
+	ChannelTarget() = default;
+	ChannelTarget(int id) : channelID(id) {}
+
+	friend bool operator==(const ChannelTarget &lhs, const ChannelTarget &rhs);
+	friend bool operator<(const ChannelTarget &lhs, const ChannelTarget &rhs);
+};
+
+Q_DECLARE_METATYPE(ChannelTarget)
+
+quint32 qHash(const ChannelTarget &);
 
 struct ShortcutTarget {
 	bool bCurrentSelection           = false;

--- a/src/mumble/mumble_ar.ts
+++ b/src/mumble/mumble_ar.ts
@@ -6361,6 +6361,16 @@ Valid options are:
         <source>This version of Mumble can&apos;t handle URLs for Mumble version %1</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Listen to Channel</source>
+        <comment>Global Shortcut</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Toggles listening to the given channel.</source>
+        <comment>Global Shortcut</comment>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>Manual</name>
@@ -8062,6 +8072,10 @@ You can register them again.</source>
     </message>
     <message>
         <source>Press to show button combination</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&lt; Unknown Channel &gt;</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/mumble/mumble_bg.ts
+++ b/src/mumble/mumble_bg.ts
@@ -6358,6 +6358,16 @@ Valid options are:
         <source>This version of Mumble can&apos;t handle URLs for Mumble version %1</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Listen to Channel</source>
+        <comment>Global Shortcut</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Toggles listening to the given channel.</source>
+        <comment>Global Shortcut</comment>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>Manual</name>
@@ -8059,6 +8069,10 @@ You can register them again.</source>
     </message>
     <message>
         <source>Press to show button combination</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&lt; Unknown Channel &gt;</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/mumble/mumble_br.ts
+++ b/src/mumble/mumble_br.ts
@@ -6357,6 +6357,16 @@ Valid options are:
         <source>This version of Mumble can&apos;t handle URLs for Mumble version %1</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Listen to Channel</source>
+        <comment>Global Shortcut</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Toggles listening to the given channel.</source>
+        <comment>Global Shortcut</comment>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>Manual</name>
@@ -8058,6 +8068,10 @@ You can register them again.</source>
     </message>
     <message>
         <source>Press to show button combination</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&lt; Unknown Channel &gt;</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/mumble/mumble_ca.ts
+++ b/src/mumble/mumble_ca.ts
@@ -6383,6 +6383,16 @@ Valid options are:
         <source>This version of Mumble can&apos;t handle URLs for Mumble version %1</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Listen to Channel</source>
+        <comment>Global Shortcut</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Toggles listening to the given channel.</source>
+        <comment>Global Shortcut</comment>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>Manual</name>
@@ -8084,6 +8094,10 @@ You can register them again.</source>
     </message>
     <message>
         <source>Press to show button combination</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&lt; Unknown Channel &gt;</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/mumble/mumble_cs.ts
+++ b/src/mumble/mumble_cs.ts
@@ -6417,6 +6417,16 @@ Valid options are:
         <source>This version of Mumble can&apos;t handle URLs for Mumble version %1</source>
         <translation type="unfinished">Tato verze Mumble neumí pracovat s URL pro verzi Mumble %1</translation>
     </message>
+    <message>
+        <source>Listen to Channel</source>
+        <comment>Global Shortcut</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Toggles listening to the given channel.</source>
+        <comment>Global Shortcut</comment>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>Manual</name>
@@ -8122,6 +8132,10 @@ You can register them again.</source>
     </message>
     <message>
         <source>Press to show button combination</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&lt; Unknown Channel &gt;</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/mumble/mumble_cy.ts
+++ b/src/mumble/mumble_cy.ts
@@ -6361,6 +6361,16 @@ Valid options are:
         <source>This version of Mumble can&apos;t handle URLs for Mumble version %1</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Listen to Channel</source>
+        <comment>Global Shortcut</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Toggles listening to the given channel.</source>
+        <comment>Global Shortcut</comment>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>Manual</name>
@@ -8062,6 +8072,10 @@ You can register them again.</source>
     </message>
     <message>
         <source>Press to show button combination</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&lt; Unknown Channel &gt;</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/mumble/mumble_da.ts
+++ b/src/mumble/mumble_da.ts
@@ -6413,6 +6413,16 @@ Valid options are:
         <source>This version of Mumble can&apos;t handle URLs for Mumble version %1</source>
         <translation type="unfinished">Denne version af Mumble kan ikke håndtere URLs for Mumble version %1</translation>
     </message>
+    <message>
+        <source>Listen to Channel</source>
+        <comment>Global Shortcut</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Toggles listening to the given channel.</source>
+        <comment>Global Shortcut</comment>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>Manual</name>
@@ -8118,6 +8128,10 @@ You can register them again.</source>
     </message>
     <message>
         <source>Press to show button combination</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&lt; Unknown Channel &gt;</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/mumble/mumble_de.ts
+++ b/src/mumble/mumble_de.ts
@@ -6504,6 +6504,16 @@ Gültige Optionen sind:
         <source>This version of Mumble can&apos;t handle URLs for Mumble version %1</source>
         <translation type="unfinished">Diese Version von Mumble kann keine URLs von Mumble Version %1 verarbeiten</translation>
     </message>
+    <message>
+        <source>Listen to Channel</source>
+        <comment>Global Shortcut</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Toggles listening to the given channel.</source>
+        <comment>Global Shortcut</comment>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>Manual</name>
@@ -8214,6 +8224,10 @@ Sie können sie jedoch erneut registrieren.</translation>
     <message>
         <source>Press to show button combination</source>
         <translation>Drücken um die Tastenkombination anzuzeigen</translation>
+    </message>
+    <message>
+        <source>&lt; Unknown Channel &gt;</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/src/mumble/mumble_el.ts
+++ b/src/mumble/mumble_el.ts
@@ -6451,6 +6451,16 @@ Valid options are:
         <source>This version of Mumble can&apos;t handle URLs for Mumble version %1</source>
         <translation type="unfinished">Αυτή η έκδοση του Mumble δεν μπορεί να χειριστεί διευθύνσεις URL για την έκδοση Mumble %1</translation>
     </message>
+    <message>
+        <source>Listen to Channel</source>
+        <comment>Global Shortcut</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Toggles listening to the given channel.</source>
+        <comment>Global Shortcut</comment>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>Manual</name>
@@ -8161,6 +8171,10 @@ You can register them again.</source>
     <message>
         <source>Press to show button combination</source>
         <translation>Πατήστε για εμφάνιση του συνδυασμού κουμπιών</translation>
+    </message>
+    <message>
+        <source>&lt; Unknown Channel &gt;</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/src/mumble/mumble_en.ts
+++ b/src/mumble/mumble_en.ts
@@ -6356,6 +6356,16 @@ Valid options are:
         <source>This version of Mumble can&apos;t handle URLs for Mumble version %1</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Listen to Channel</source>
+        <comment>Global Shortcut</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Toggles listening to the given channel.</source>
+        <comment>Global Shortcut</comment>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>Manual</name>
@@ -8057,6 +8067,10 @@ You can register them again.</source>
     </message>
     <message>
         <source>Press to show button combination</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&lt; Unknown Channel &gt;</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/mumble/mumble_en_GB.ts
+++ b/src/mumble/mumble_en_GB.ts
@@ -6393,6 +6393,16 @@ Valid options are:
         <source>This version of Mumble can&apos;t handle URLs for Mumble version %1</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Listen to Channel</source>
+        <comment>Global Shortcut</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Toggles listening to the given channel.</source>
+        <comment>Global Shortcut</comment>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>Manual</name>
@@ -8094,6 +8104,10 @@ You can register them again.</source>
     </message>
     <message>
         <source>Press to show button combination</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&lt; Unknown Channel &gt;</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/mumble/mumble_eo.ts
+++ b/src/mumble/mumble_eo.ts
@@ -6369,6 +6369,16 @@ Valid options are:
         <source>This version of Mumble can&apos;t handle URLs for Mumble version %1</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Listen to Channel</source>
+        <comment>Global Shortcut</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Toggles listening to the given channel.</source>
+        <comment>Global Shortcut</comment>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>Manual</name>
@@ -8070,6 +8080,10 @@ You can register them again.</source>
     </message>
     <message>
         <source>Press to show button combination</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&lt; Unknown Channel &gt;</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/mumble/mumble_es.ts
+++ b/src/mumble/mumble_es.ts
@@ -6429,6 +6429,16 @@ Valid options are:
         <source>This version of Mumble can&apos;t handle URLs for Mumble version %1</source>
         <translation type="unfinished">Esta versión de Mumble no puede manejar URLs para la versión %1 de Mumble</translation>
     </message>
+    <message>
+        <source>Listen to Channel</source>
+        <comment>Global Shortcut</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Toggles listening to the given channel.</source>
+        <comment>Global Shortcut</comment>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>Manual</name>
@@ -8139,6 +8149,10 @@ Puedes registrarlos otra vez.</translation>
     <message>
         <source>Press to show button combination</source>
         <translation>Presione para mostrar la combinación de botones</translation>
+    </message>
+    <message>
+        <source>&lt; Unknown Channel &gt;</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/src/mumble/mumble_et.ts
+++ b/src/mumble/mumble_et.ts
@@ -6358,6 +6358,16 @@ Valid options are:
         <source>This version of Mumble can&apos;t handle URLs for Mumble version %1</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Listen to Channel</source>
+        <comment>Global Shortcut</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Toggles listening to the given channel.</source>
+        <comment>Global Shortcut</comment>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>Manual</name>
@@ -8059,6 +8069,10 @@ You can register them again.</source>
     </message>
     <message>
         <source>Press to show button combination</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&lt; Unknown Channel &gt;</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/mumble/mumble_eu.ts
+++ b/src/mumble/mumble_eu.ts
@@ -6378,6 +6378,16 @@ Valid options are:
         <source>This version of Mumble can&apos;t handle URLs for Mumble version %1</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Listen to Channel</source>
+        <comment>Global Shortcut</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Toggles listening to the given channel.</source>
+        <comment>Global Shortcut</comment>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>Manual</name>
@@ -8079,6 +8089,10 @@ You can register them again.</source>
     </message>
     <message>
         <source>Press to show button combination</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&lt; Unknown Channel &gt;</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/mumble/mumble_fa_IR.ts
+++ b/src/mumble/mumble_fa_IR.ts
@@ -6356,6 +6356,16 @@ Valid options are:
         <source>This version of Mumble can&apos;t handle URLs for Mumble version %1</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Listen to Channel</source>
+        <comment>Global Shortcut</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Toggles listening to the given channel.</source>
+        <comment>Global Shortcut</comment>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>Manual</name>
@@ -8057,6 +8067,10 @@ You can register them again.</source>
     </message>
     <message>
         <source>Press to show button combination</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&lt; Unknown Channel &gt;</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/mumble/mumble_fi.ts
+++ b/src/mumble/mumble_fi.ts
@@ -6450,6 +6450,16 @@ Valid options are:
         <source>This version of Mumble can&apos;t handle URLs for Mumble version %1</source>
         <translation type="unfinished">Mumblen tämä versio ei pysty käsittelemään URL-osoitteita Mumblen versiosta %1</translation>
     </message>
+    <message>
+        <source>Listen to Channel</source>
+        <comment>Global Shortcut</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Toggles listening to the given channel.</source>
+        <comment>Global Shortcut</comment>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>Manual</name>
@@ -8160,6 +8170,10 @@ Voit rekisteröidä ne uudelleen.</translation>
     <message>
         <source>Press to show button combination</source>
         <translation>Paina näyttääksesi näppäinyhdistelmän</translation>
+    </message>
+    <message>
+        <source>&lt; Unknown Channel &gt;</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/src/mumble/mumble_fr.ts
+++ b/src/mumble/mumble_fr.ts
@@ -6512,6 +6512,16 @@ Les options valides sont&#xa0;:
         <source>This version of Mumble can&apos;t handle URLs for Mumble version %1</source>
         <translation type="unfinished">Cette version de Mumble ne peut pas manipuler les URLs pour Mumble version %1</translation>
     </message>
+    <message>
+        <source>Listen to Channel</source>
+        <comment>Global Shortcut</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Toggles listening to the given channel.</source>
+        <comment>Global Shortcut</comment>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>Manual</name>
@@ -8222,6 +8232,10 @@ Vous pouvez les enregistrer à nouveau.</translation>
     <message>
         <source>Press to show button combination</source>
         <translation>Appuyer pour montrer la combinaison de touches</translation>
+    </message>
+    <message>
+        <source>&lt; Unknown Channel &gt;</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/src/mumble/mumble_gl.ts
+++ b/src/mumble/mumble_gl.ts
@@ -6359,6 +6359,16 @@ Valid options are:
         <source>This version of Mumble can&apos;t handle URLs for Mumble version %1</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Listen to Channel</source>
+        <comment>Global Shortcut</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Toggles listening to the given channel.</source>
+        <comment>Global Shortcut</comment>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>Manual</name>
@@ -8060,6 +8070,10 @@ You can register them again.</source>
     </message>
     <message>
         <source>Press to show button combination</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&lt; Unknown Channel &gt;</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/mumble/mumble_he.ts
+++ b/src/mumble/mumble_he.ts
@@ -6409,6 +6409,16 @@ Valid options are:
         <source>This version of Mumble can&apos;t handle URLs for Mumble version %1</source>
         <translation type="unfinished">גירסא זו של Mumble לא יכולה לטפל בכתובות עבור Mumble גירסא %1</translation>
     </message>
+    <message>
+        <source>Listen to Channel</source>
+        <comment>Global Shortcut</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Toggles listening to the given channel.</source>
+        <comment>Global Shortcut</comment>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>Manual</name>
@@ -8114,6 +8124,10 @@ You can register them again.</source>
     </message>
     <message>
         <source>Press to show button combination</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&lt; Unknown Channel &gt;</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/mumble/mumble_hu.ts
+++ b/src/mumble/mumble_hu.ts
@@ -6409,6 +6409,16 @@ Valid options are:
         <source>This version of Mumble can&apos;t handle URLs for Mumble version %1</source>
         <translation type="unfinished">A Mumble jelen verziója nem képes kezelni a %1 verziójú Mumble címeket</translation>
     </message>
+    <message>
+        <source>Listen to Channel</source>
+        <comment>Global Shortcut</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Toggles listening to the given channel.</source>
+        <comment>Global Shortcut</comment>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>Manual</name>
@@ -8111,6 +8121,10 @@ You can register them again.</source>
     </message>
     <message>
         <source>Press to show button combination</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&lt; Unknown Channel &gt;</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/mumble/mumble_it.ts
+++ b/src/mumble/mumble_it.ts
@@ -6451,6 +6451,16 @@ Valid options are:
         <source>This version of Mumble can&apos;t handle URLs for Mumble version %1</source>
         <translation type="unfinished">Questa versione di Mumble non può utilizzare gli URL di Mumble versione %1</translation>
     </message>
+    <message>
+        <source>Listen to Channel</source>
+        <comment>Global Shortcut</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Toggles listening to the given channel.</source>
+        <comment>Global Shortcut</comment>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>Manual</name>
@@ -8161,6 +8171,10 @@ Puoi registrarle di nuovo.</translation>
     <message>
         <source>Press to show button combination</source>
         <translation>Premi per mostrare la combinazione di tasti</translation>
+    </message>
+    <message>
+        <source>&lt; Unknown Channel &gt;</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/src/mumble/mumble_ja.ts
+++ b/src/mumble/mumble_ja.ts
@@ -6407,6 +6407,16 @@ Valid options are:
         <source>This version of Mumble can&apos;t handle URLs for Mumble version %1</source>
         <translation type="unfinished">このバージョンのMumble は Mumble %1 のための URL を扱えません</translation>
     </message>
+    <message>
+        <source>Listen to Channel</source>
+        <comment>Global Shortcut</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Toggles listening to the given channel.</source>
+        <comment>Global Shortcut</comment>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>Manual</name>
@@ -8112,6 +8122,10 @@ You can register them again.</source>
     </message>
     <message>
         <source>Press to show button combination</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&lt; Unknown Channel &gt;</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/mumble/mumble_ko.ts
+++ b/src/mumble/mumble_ko.ts
@@ -6450,6 +6450,16 @@ Valid options are:
         <source>This version of Mumble can&apos;t handle URLs for Mumble version %1</source>
         <translation type="unfinished">이 버전의 Mumble은 Mumble 버전 %1 URL을 처리할 수 없음</translation>
     </message>
+    <message>
+        <source>Listen to Channel</source>
+        <comment>Global Shortcut</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Toggles listening to the given channel.</source>
+        <comment>Global Shortcut</comment>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>Manual</name>
@@ -8160,6 +8170,10 @@ You can register them again.</source>
     <message>
         <source>Press to show button combination</source>
         <translation>버튼 조합을 표시하려면 누르세요</translation>
+    </message>
+    <message>
+        <source>&lt; Unknown Channel &gt;</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/src/mumble/mumble_lt.ts
+++ b/src/mumble/mumble_lt.ts
@@ -6391,6 +6391,16 @@ Valid options are:
         <source>This version of Mumble can&apos;t handle URLs for Mumble version %1</source>
         <translation type="unfinished">Ši Mumble versija negali apdoroti URL, skirtus Mumble versijai %1</translation>
     </message>
+    <message>
+        <source>Listen to Channel</source>
+        <comment>Global Shortcut</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Toggles listening to the given channel.</source>
+        <comment>Global Shortcut</comment>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>Manual</name>
@@ -8096,6 +8106,10 @@ You can register them again.</source>
     </message>
     <message>
         <source>Press to show button combination</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&lt; Unknown Channel &gt;</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/mumble/mumble_nl.ts
+++ b/src/mumble/mumble_nl.ts
@@ -6451,6 +6451,16 @@ Valid options are:
         <source>This version of Mumble can&apos;t handle URLs for Mumble version %1</source>
         <translation type="unfinished">Mumble-versie kan URL&apos;s voor Mumble versie %1 niet aan</translation>
     </message>
+    <message>
+        <source>Listen to Channel</source>
+        <comment>Global Shortcut</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Toggles listening to the given channel.</source>
+        <comment>Global Shortcut</comment>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>Manual</name>
@@ -8161,6 +8171,10 @@ Je kunt ze opnieuw registreren.</translation>
     <message>
         <source>Press to show button combination</source>
         <translation>Druk om knoppencombinatie weer te geven</translation>
+    </message>
+    <message>
+        <source>&lt; Unknown Channel &gt;</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/src/mumble/mumble_no.ts
+++ b/src/mumble/mumble_no.ts
@@ -6466,6 +6466,16 @@ Valid options are:
         <source>This version of Mumble can&apos;t handle URLs for Mumble version %1</source>
         <translation type="unfinished">Denne versjonen av Mumble kan ikke håndtere URL-er for Mumble versjon %1</translation>
     </message>
+    <message>
+        <source>Listen to Channel</source>
+        <comment>Global Shortcut</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Toggles listening to the given channel.</source>
+        <comment>Global Shortcut</comment>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>Manual</name>
@@ -8176,6 +8186,10 @@ Du kan registrere dem igjen.</translation>
     <message>
         <source>Press to show button combination</source>
         <translation>Trykk for å vise tastekombinasjon</translation>
+    </message>
+    <message>
+        <source>&lt; Unknown Channel &gt;</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/src/mumble/mumble_oc.ts
+++ b/src/mumble/mumble_oc.ts
@@ -6358,6 +6358,16 @@ Valid options are:
         <source>This version of Mumble can&apos;t handle URLs for Mumble version %1</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Listen to Channel</source>
+        <comment>Global Shortcut</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Toggles listening to the given channel.</source>
+        <comment>Global Shortcut</comment>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>Manual</name>
@@ -8059,6 +8069,10 @@ You can register them again.</source>
     </message>
     <message>
         <source>Press to show button combination</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&lt; Unknown Channel &gt;</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/mumble/mumble_pl.ts
+++ b/src/mumble/mumble_pl.ts
@@ -6512,6 +6512,16 @@ Prawidłowe opcje to:
         <source>This version of Mumble can&apos;t handle URLs for Mumble version %1</source>
         <translation type="unfinished">Ta wersja Mumble nie obsługuje adresów URL starszych wersji Mumble %1</translation>
     </message>
+    <message>
+        <source>Listen to Channel</source>
+        <comment>Global Shortcut</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Toggles listening to the given channel.</source>
+        <comment>Global Shortcut</comment>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>Manual</name>
@@ -8222,6 +8232,10 @@ Możesz je ponownie zarejestrować.</translation>
     <message>
         <source>Press to show button combination</source>
         <translation>Naciśnij, aby wyświetlić kombinację przycisków</translation>
+    </message>
+    <message>
+        <source>&lt; Unknown Channel &gt;</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/src/mumble/mumble_pt_BR.ts
+++ b/src/mumble/mumble_pt_BR.ts
@@ -6451,6 +6451,16 @@ Valid options are:
         <source>This version of Mumble can&apos;t handle URLs for Mumble version %1</source>
         <translation type="unfinished">Esta versão do Mumble não pode lidar com URLs para o Mumble versão %1</translation>
     </message>
+    <message>
+        <source>Listen to Channel</source>
+        <comment>Global Shortcut</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Toggles listening to the given channel.</source>
+        <comment>Global Shortcut</comment>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>Manual</name>
@@ -8160,6 +8170,10 @@ You can register them again.</source>
     <message>
         <source>Press to show button combination</source>
         <translation>Pressione para mostrar a combinação de teclas</translation>
+    </message>
+    <message>
+        <source>&lt; Unknown Channel &gt;</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/src/mumble/mumble_pt_PT.ts
+++ b/src/mumble/mumble_pt_PT.ts
@@ -6429,6 +6429,16 @@ Valid options are:
         <source>This version of Mumble can&apos;t handle URLs for Mumble version %1</source>
         <translation type="unfinished">Esta versão do Mumble não consegue lidar com URLs para o Mumble versão %1</translation>
     </message>
+    <message>
+        <source>Listen to Channel</source>
+        <comment>Global Shortcut</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Toggles listening to the given channel.</source>
+        <comment>Global Shortcut</comment>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>Manual</name>
@@ -8138,6 +8148,10 @@ You can register them again.</source>
     <message>
         <source>Press to show button combination</source>
         <translation>Pressione para mostrar a combinação de teclas</translation>
+    </message>
+    <message>
+        <source>&lt; Unknown Channel &gt;</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/src/mumble/mumble_ro.ts
+++ b/src/mumble/mumble_ro.ts
@@ -6362,6 +6362,16 @@ Valid options are:
         <source>This version of Mumble can&apos;t handle URLs for Mumble version %1</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Listen to Channel</source>
+        <comment>Global Shortcut</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Toggles listening to the given channel.</source>
+        <comment>Global Shortcut</comment>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>Manual</name>
@@ -8063,6 +8073,10 @@ You can register them again.</source>
     </message>
     <message>
         <source>Press to show button combination</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&lt; Unknown Channel &gt;</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/mumble/mumble_ru.ts
+++ b/src/mumble/mumble_ru.ts
@@ -6452,6 +6452,16 @@ Valid options are:
         <source>This version of Mumble can&apos;t handle URLs for Mumble version %1</source>
         <translation type="unfinished">Эта версия Mumble не может использовать ссылки из Mumble версий %1</translation>
     </message>
+    <message>
+        <source>Listen to Channel</source>
+        <comment>Global Shortcut</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Toggles listening to the given channel.</source>
+        <comment>Global Shortcut</comment>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>Manual</name>
@@ -8162,6 +8172,10 @@ You can register them again.</source>
     <message>
         <source>Press to show button combination</source>
         <translation>Нажмите, чтобы показать комбинацию кнопок</translation>
+    </message>
+    <message>
+        <source>&lt; Unknown Channel &gt;</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/src/mumble/mumble_si.ts
+++ b/src/mumble/mumble_si.ts
@@ -6320,6 +6320,16 @@ Valid options are:
         <source>This version of Mumble can&apos;t handle URLs for Mumble version %1</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Listen to Channel</source>
+        <comment>Global Shortcut</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Toggles listening to the given channel.</source>
+        <comment>Global Shortcut</comment>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>Manual</name>
@@ -8017,6 +8027,10 @@ You can register them again.</source>
     </message>
     <message>
         <source>Press to show button combination</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&lt; Unknown Channel &gt;</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/mumble/mumble_sk.ts
+++ b/src/mumble/mumble_sk.ts
@@ -6321,6 +6321,16 @@ Otherwise abort and check your certificate and username.</source>
         <source>This version of Mumble can&apos;t handle URLs for Mumble version %1</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Listen to Channel</source>
+        <comment>Global Shortcut</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Toggles listening to the given channel.</source>
+        <comment>Global Shortcut</comment>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>Manual</name>
@@ -8018,6 +8028,10 @@ You can register them again.</source>
     </message>
     <message>
         <source>Press to show button combination</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&lt; Unknown Channel &gt;</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/mumble/mumble_sq.ts
+++ b/src/mumble/mumble_sq.ts
@@ -6322,6 +6322,16 @@ Valid options are:
         <source>This version of Mumble can&apos;t handle URLs for Mumble version %1</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Listen to Channel</source>
+        <comment>Global Shortcut</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Toggles listening to the given channel.</source>
+        <comment>Global Shortcut</comment>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>Manual</name>
@@ -8019,6 +8029,10 @@ You can register them again.</source>
     </message>
     <message>
         <source>Press to show button combination</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&lt; Unknown Channel &gt;</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/mumble/mumble_sv.ts
+++ b/src/mumble/mumble_sv.ts
@@ -6451,6 +6451,16 @@ Valid options are:
         <source>This version of Mumble can&apos;t handle URLs for Mumble version %1</source>
         <translation type="unfinished">Den här versionen av Mumble kan inte hantera URLer för Mumble version %1</translation>
     </message>
+    <message>
+        <source>Listen to Channel</source>
+        <comment>Global Shortcut</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Toggles listening to the given channel.</source>
+        <comment>Global Shortcut</comment>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>Manual</name>
@@ -8160,6 +8170,10 @@ You can register them again.</source>
     <message>
         <source>Press to show button combination</source>
         <translation>Tryck för att visa knappkombination</translation>
+    </message>
+    <message>
+        <source>&lt; Unknown Channel &gt;</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/src/mumble/mumble_te.ts
+++ b/src/mumble/mumble_te.ts
@@ -6369,6 +6369,16 @@ Valid options are:
         <source>This version of Mumble can&apos;t handle URLs for Mumble version %1</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Listen to Channel</source>
+        <comment>Global Shortcut</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Toggles listening to the given channel.</source>
+        <comment>Global Shortcut</comment>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>Manual</name>
@@ -8076,6 +8086,10 @@ You can register them again.</source>
     </message>
     <message>
         <source>Press to show button combination</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&lt; Unknown Channel &gt;</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/mumble/mumble_th.ts
+++ b/src/mumble/mumble_th.ts
@@ -6356,6 +6356,16 @@ Valid options are:
         <source>This version of Mumble can&apos;t handle URLs for Mumble version %1</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Listen to Channel</source>
+        <comment>Global Shortcut</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Toggles listening to the given channel.</source>
+        <comment>Global Shortcut</comment>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>Manual</name>
@@ -8057,6 +8067,10 @@ You can register them again.</source>
     </message>
     <message>
         <source>Press to show button combination</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&lt; Unknown Channel &gt;</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/mumble/mumble_tr.ts
+++ b/src/mumble/mumble_tr.ts
@@ -6510,6 +6510,16 @@ Geçerli seçenekler şunlardır:
         <source>This version of Mumble can&apos;t handle URLs for Mumble version %1</source>
         <translation type="unfinished">Mumble&apos;ın bu sürümü %1 sayılı sürümün URL&apos;lerini işleyemez</translation>
     </message>
+    <message>
+        <source>Listen to Channel</source>
+        <comment>Global Shortcut</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Toggles listening to the given channel.</source>
+        <comment>Global Shortcut</comment>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>Manual</name>
@@ -8220,6 +8230,10 @@ Bunları tekrar kaydedebilirsiniz.</translation>
     <message>
         <source>Press to show button combination</source>
         <translation>Düğme kombinasyonunu göstermek için basın</translation>
+    </message>
+    <message>
+        <source>&lt; Unknown Channel &gt;</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/src/mumble/mumble_uk.ts
+++ b/src/mumble/mumble_uk.ts
@@ -6358,6 +6358,16 @@ Valid options are:
         <source>This version of Mumble can&apos;t handle URLs for Mumble version %1</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Listen to Channel</source>
+        <comment>Global Shortcut</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Toggles listening to the given channel.</source>
+        <comment>Global Shortcut</comment>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>Manual</name>
@@ -8059,6 +8069,10 @@ You can register them again.</source>
     </message>
     <message>
         <source>Press to show button combination</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&lt; Unknown Channel &gt;</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/mumble/mumble_zh_CN.ts
+++ b/src/mumble/mumble_zh_CN.ts
@@ -6510,6 +6510,16 @@ mumble://[&lt;用户名&gt;[:&lt;密码&gt;]@]&lt;主机名&gt;[:&lt;端口&gt;]
         <source>This version of Mumble can&apos;t handle URLs for Mumble version %1</source>
         <translation type="unfinished">当前版本的 Mumble 无法处理用于 Mumble %1 的 URL</translation>
     </message>
+    <message>
+        <source>Listen to Channel</source>
+        <comment>Global Shortcut</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Toggles listening to the given channel.</source>
+        <comment>Global Shortcut</comment>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>Manual</name>
@@ -8220,6 +8230,10 @@ You can register them again.</source>
     <message>
         <source>Press to show button combination</source>
         <translation>点击显示组合键</translation>
+    </message>
+    <message>
+        <source>&lt; Unknown Channel &gt;</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/src/mumble/mumble_zh_HK.ts
+++ b/src/mumble/mumble_zh_HK.ts
@@ -6361,6 +6361,16 @@ Valid options are:
         <source>This version of Mumble can&apos;t handle URLs for Mumble version %1</source>
         <translation type="unfinished">目前的 Mumble 無法處理版本 %1 產生的網址</translation>
     </message>
+    <message>
+        <source>Listen to Channel</source>
+        <comment>Global Shortcut</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Toggles listening to the given channel.</source>
+        <comment>Global Shortcut</comment>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>Manual</name>
@@ -8066,6 +8076,10 @@ You can register them again.</source>
     </message>
     <message>
         <source>Press to show button combination</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&lt; Unknown Channel &gt;</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/mumble/mumble_zh_TW.ts
+++ b/src/mumble/mumble_zh_TW.ts
@@ -6384,6 +6384,16 @@ Valid options are:
         <source>This version of Mumble can&apos;t handle URLs for Mumble version %1</source>
         <translation type="unfinished">目前的 Mumble 無法處理版本 %1 產生的網址</translation>
     </message>
+    <message>
+        <source>Listen to Channel</source>
+        <comment>Global Shortcut</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Toggles listening to the given channel.</source>
+        <comment>Global Shortcut</comment>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>Manual</name>
@@ -8088,6 +8098,10 @@ You can register them again.</source>
     </message>
     <message>
         <source>Press to show button combination</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&lt; Unknown Channel &gt;</source>
         <translation type="unfinished"></translation>
     </message>
 </context>


### PR DESCRIPTION
<!-- Please make sure that you follow our commit guidelines specified at https://github.com/mumble-voip/mumble/blob/master/COMMIT_GUIDELINES.md -->

Added a global shortcut that toggles listening to a specific channel targeted by the client. 

Fixes #4486