### PR TITLE
FIX(installer) Remove ini file

### DIFF
--- a/installer/ServerInstaller.cs
+++ b/installer/ServerInstaller.cs
@@ -17,7 +17,6 @@ public class ServerInstaller : MumbleInstall {
 		string upgradeGuid = "03E9476F-0F75-4661-BFC9-A9DAEB23D3A0";
 		string[] binaries = {
 			"murmur.exe",
-			"murmur.ini",
 			"Murmur.ice"
 		};
 		


### PR DESCRIPTION
Since the ini file would be removed or overwritten by installs,
upgrades, and uninstalls it should be created at app runtime or manually
copied to the install path after install.

<!-- Please make sure that you follow our commit guidelines specified at https://github.com/mumble-voip/mumble/blob/master/COMMIT_GUIDELINES.md -->
