### PR TITLE
BUILD(cmake): Fix overlay link option being overwritten 2.0

### DIFF
--- a/overlay_gl/CMakeLists.txt
+++ b/overlay_gl/CMakeLists.txt
@@ -62,7 +62,7 @@ if(NOT APPLE)
 		# If it doesn't, the program will not start at all.
 		#
 		# Instead, explicitly use '-z lazy' to defer libGL symbol resolution until first use, which is never for non-libGL users.
-		target_link_options(overlay_gl_x86
+		target_link_options(overlay_gl_x86 BEFORE
 			PRIVATE
 				"-m32"
 				"-Wl,-z,lazy"


### PR DESCRIPTION
This is a follow-up on #4629 that also adds the BEFORE link option to
the x86 build of the overlay.