### PR TITLE
FIX(client, server): Load native mDNS/DNS-SD symbols at runtime

### DIFF
--- a/src/mumble/Zeroconf.h
+++ b/src/mumble/Zeroconf.h
@@ -11,7 +11,7 @@
 
 #include <memory>
 
-#ifdef Q_OS_WIN64
+#ifdef Q_OS_WIN
 #	include <windns.h>
 #endif
 
@@ -20,7 +20,7 @@ private:
 	Q_OBJECT
 	Q_DISABLE_COPY(Zeroconf)
 protected:
-#ifdef Q_OS_WIN64
+#ifdef Q_OS_WIN
 	struct Resolver {
 		Zeroconf *m_zeroconf;
 		BonjourRecord m_record;
@@ -35,7 +35,7 @@ protected:
 	QList< BonjourRecord > m_records;
 	std::unique_ptr< BonjourServiceBrowser > m_helperBrowser;
 	std::unique_ptr< BonjourServiceResolver > m_helperResolver;
-#ifdef Q_OS_WIN64
+#ifdef Q_OS_WIN
 	QList< Resolver > m_resolvers;
 	std::unique_ptr< DNS_SERVICE_CANCEL > m_cancelBrowser;
 
@@ -51,7 +51,13 @@ protected:
 	void helperResolverRecordResolved(const BonjourRecord record, const QString hostname, const int port);
 	void helperBrowserError(const DNSServiceErrorType error) const;
 	void helperResolverError(const BonjourRecord record, const DNSServiceErrorType error);
-
+#ifdef Q_OS_WIN
+	DNS_STATUS(WINAPI *DnsServiceBrowse)(PDNS_SERVICE_BROWSE_REQUEST pRequest, PDNS_SERVICE_CANCEL pCancel);
+	DNS_STATUS(WINAPI *DnsServiceBrowseCancel)(PDNS_SERVICE_CANCEL pCancelHandle);
+	DNS_STATUS(WINAPI *DnsServiceResolve)(PDNS_SERVICE_RESOLVE_REQUEST pRequest, PDNS_SERVICE_CANCEL pCancel);
+	DNS_STATUS(WINAPI *DnsServiceResolveCancel)(PDNS_SERVICE_CANCEL pCancelHandle);
+	VOID(WINAPI *DnsServiceFreeInstance)(PDNS_SERVICE_INSTANCE pInstance);
+#endif
 public:
 	inline bool isOk() const { return m_ok; }
 	inline QList< BonjourRecord > currentRecords() const {
@@ -62,7 +68,7 @@ public:
 	bool stopBrowser();
 
 	bool startResolver(const BonjourRecord &record);
-#ifdef Q_OS_WIN64
+#ifdef Q_OS_WIN
 	bool stopResolver(const BonjourRecord &record);
 #endif
 	bool cleanupResolvers();

--- a/src/murmur/Zeroconf.h
+++ b/src/murmur/Zeroconf.h
@@ -10,7 +10,7 @@
 
 #include <memory>
 
-#ifdef Q_OS_WIN64
+#ifdef Q_OS_WIN
 #	include <windns.h>
 #endif
 
@@ -21,14 +21,22 @@ private:
 protected:
 	bool m_ok;
 	std::unique_ptr< BonjourServiceRegister > m_helper;
-#ifdef Q_OS_WIN64
+#ifdef Q_OS_WIN
 	std::unique_ptr< DNS_SERVICE_CANCEL > m_cancel;
 	std::unique_ptr< DNS_SERVICE_REGISTER_REQUEST > m_request;
 
 	static void WINAPI callbackRegisterComplete(const DWORD status, void *context, DNS_SERVICE_INSTANCE *instance);
 #endif
 	void helperError(const DNSServiceErrorType error);
-
+#ifdef Q_OS_WIN
+	PDNS_SERVICE_INSTANCE(WINAPI *DnsServiceConstructInstance)
+	(PCWSTR pServiceName, PCWSTR pHostName, PIP4_ADDRESS pIp4, PIP6_ADDRESS pIp6, WORD wPort, WORD wPriority,
+	 WORD wWeight, DWORD dwPropertiesCount, PCWSTR *keys, PCWSTR *values);
+	VOID(WINAPI *DnsServiceFreeInstance)(PDNS_SERVICE_INSTANCE pInstance);
+	DWORD(WINAPI *DnsServiceRegister)(PDNS_SERVICE_REGISTER_REQUEST pRequest, PDNS_SERVICE_CANCEL pCancel);
+	DWORD(WINAPI *DnsServiceDeRegister)(PDNS_SERVICE_REGISTER_REQUEST pRequest, PDNS_SERVICE_CANCEL pCancel);
+	DWORD(WINAPI *DnsServiceRegisterCancel)(PDNS_SERVICE_CANCEL pCancelHandle);
+#endif
 public:
 	inline bool isOk() const { return m_ok; }
 


### PR DESCRIPTION
This change:
- Fixes binaries failing to start on versions of Windows where `dnsapi.dll` doesn't export the symbols we need.
- Allows us to use the native API in x86 builds.
See https://developercommunity.visualstudio.com/content/problem/1191345/some-dns-api-functions-cause-lnk2019-errors-in-32.html for more info.