### PR TITLE
BUILD(macOS): Only include ".dylib" files in bundle's "Plugins" directory

### DIFF
--- a/macx/scripts/osxdist.py
+++ b/macx/scripts/osxdist.py
@@ -13,7 +13,7 @@
 # by Thomas Keller).
 #
 
-import sys, os, string, re, shutil, plistlib, tempfile, exceptions, datetime, tarfile
+import sys, os, string, re, shutil, plistlib, tempfile, exceptions, datetime, tarfile, glob
 from subprocess import Popen, PIPE
 from optparse import OptionParser
 
@@ -149,9 +149,10 @@ class AppBundle(object):
 		'''
 		print ' * Copying positional audio plugins'
 		dst = os.path.join(self.bundle, 'Contents', 'Plugins')
-		if os.path.exists(dst):
-			shutil.rmtree(dst)
-		shutil.copytree(os.path.join(options.binary_dir, 'plugins'), dst, symlinks=True)
+		if not os.path.exists(dst):
+			os.makedirs(dst)
+		for plugin in glob.glob('plugins/*.dylib'):
+			shutil.copy(plugin, dst)
 
 	def update_plist(self):
 		'''


### PR DESCRIPTION
In addition to the plugins, the `plugins` folder in the build directory also contains temporary build files.

As the script was copying the entire tree, those files made their way into the bundle.

This commit fixes the issue by explicitly copying only files that end with `.dylib`.