### PR TITLE
MAINT: Add TRANSLATION type to commit guidelines

### DIFF
--- a/COMMIT_GUIDELINES.md
+++ b/COMMIT_GUIDELINES.md
@@ -50,6 +50,7 @@ The `TYPE` is one of the following:
 | CI       | Changed something for the CI (continous integration) | Update TravisCI to use newer ubuntu version |
 | REFAC    | Code refactoring | Renamed variable `x` to `y` |
 | BUILD    | Changes related to the build process / buildsystem | Fixed cmake script |
+| TRANSLATION | Translation updates and changes | Update translation files |
 
 The `TYPE` has to be in **all-uppercase** in order for it to stand out.
 


### PR DESCRIPTION
The TRANSLATION type has been used for example in 9e8b9afaadbaff342000deb69a1a228f5f9a4073 and 38215622f48f85e5b7cd9d7dec164fea5edbafee, for updating the translated strings and source strings respectively.