### PR TITLE
FEAT(installer): Add support for snapshot builds

### DIFF
--- a/docs/dev/build-instructions/build_installer.md
+++ b/docs/dev/build-instructions/build_installer.md
@@ -2,11 +2,9 @@
 
 Currently, the installer creation has been tested on Windows only.
 
-For creating the installer, the [WiX Toolset](https://wixtoolset.org/) has to be installed on your system.
+For creating the installer, [WixSharp](https://github.com/oleg-shilo/wixsharp/releases/tag/v1.15.0.0) has to be present on your system. Please see the following [README](https://github.com/oleg-shilo/wixsharp/blob/master/README.md) for install information.
 
-An installer can be created after invoking cmake with the `-Dpackaging=ON` option and building.
+An installer can be created after invoking cmake with the `-Dpackaging=ON` and `-Dtranslations=OFF` options, and building. This creates a *single-language* installer.
 
-To create a *single-language* installer (default English) run `cpack -C Release`.
-
-To create a *multi-language* installer run the script `scripts/Create-Win32InstallerMUI.ps1` from the root of this repository.
+To create a *multi-language* installer, make sure the following option is set `-Dpackaging=ON` and (re-)run the cmake configure step. Multi-language packaging is the default.
 

--- a/src/mumble_exe/CMakeLists.txt
+++ b/src/mumble_exe/CMakeLists.txt
@@ -49,22 +49,27 @@ install(TARGETS mumble_exe RUNTIME DESTINATION "${MUMBLE_INSTALL_EXECUTABLEDIR}"
 if(packaging)
 	set(overlay ON)
 	set(plugins ON)
-	
+
 	if(translations)
-		set(installer_vars "--all-languages")
+		list(APPEND installer_vars "--all-languages")
 	endif()
-	
+
+	list(APPEND installer_vars
+		"--version" ${PROJECT_VERSION}
+		"--arch" ${ARCH}
+	)
+
 	file(COPY 
 		${CMAKE_SOURCE_DIR}/installer/MumbleInstall.cs
 		${CMAKE_SOURCE_DIR}/installer/ClientInstaller.cs
 		DESTINATION
 			${CMAKE_BINARY_DIR}/installer/client
 	)
-	
+
 	add_custom_command(TARGET mumble_exe
 		POST_BUILD
 		COMMAND cscs.exe -cd MumbleInstall.cs 
-		COMMAND cscs.exe ClientInstaller.cs --version ${PROJECT_VERSION} --arch ${ARCH} ${installer_vars}
+		COMMAND cscs.exe ClientInstaller.cs ${installer_vars}
 		WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/installer/client
 	)
 endif()

--- a/src/murmur/CMakeLists.txt
+++ b/src/murmur/CMakeLists.txt
@@ -342,20 +342,25 @@ endif()
 if(packaging)
 	if(WIN32)
 		if(translations)
-			set(installer_vars "--all-languages")
+			list(APPEND installer_vars "--all-languages")
 		endif()
-		
-	file(COPY 
-		${CMAKE_SOURCE_DIR}/installer/MumbleInstall.cs
-		${CMAKE_SOURCE_DIR}/installer/ServerInstaller.cs
-		DESTINATION
-			${CMAKE_BINARY_DIR}/installer/server
+
+		list(APPEND installer_vars
+			"--version" ${PROJECT_VERSION}
+			"--arch" ${ARCH}
 		)
-		
+
+		file(COPY
+			${CMAKE_SOURCE_DIR}/installer/MumbleInstall.cs
+			${CMAKE_SOURCE_DIR}/installer/ServerInstaller.cs
+			DESTINATION
+				${CMAKE_BINARY_DIR}/installer/server
+		)
+
 		add_custom_command(TARGET murmur
 			POST_BUILD
 			COMMAND cscs.exe -cd MumbleInstall.cs 
-			COMMAND cscs.exe ServerInstaller.cs --version ${PROJECT_VERSION} --arch ${ARCH} ${installer_vars}
+			COMMAND cscs.exe ServerInstaller.cs ${installer_vars}
 			WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/installer/server
 		)
 	endif()


### PR DESCRIPTION
This pull request:

- Adds null checks and error messages for "--arch" and "--version" to WixSharp projects.

- Sets cabinet file name to "Mumble.cab", for consistency with our previous installers.

- Cleans up ClientInstaller.

- Fixes regex patterns for string input safety and to simplify conditions.