### PR TITLE
FIX(positional-audio): Update Among Us plugin to work with v2020.12.09s

### DIFF
--- a/plugins/amongus/Game.cpp
+++ b/plugins/amongus/Game.cpp
@@ -18,11 +18,13 @@ Game::Game(const procid_t id, const std::string name) : m_ok(false), m_proc(id, 
 		return;
 	}
 
-	// 74 89             jz     short loc_????????
+	// 74 39             jz     short loc_????????
 	// A1 ?? ?? ?? ??    mov    eax, AmongUsClient_c **
 	// 8B 40 5C          mov    eax, [eax+5Ch]
-	const std::vector< uint8_t > clientPattern = { 0x74, 0x39, 0xA1, '?', '?', '?', '?', 0x8B, 0x40, 0x5C };
+	// 8B 00             mov    eax, [eax]
+	const std::vector< uint8_t > clientPattern = { 0x74, 0x39, 0xA1, '?', '?', '?', '?', 0x8B, 0x40, 0x5C, 0x8B, 0x00 };
 	m_client                                   = m_proc.findPattern(clientPattern, iter->second);
+
 	if (!m_client) {
 		return;
 	}


### PR DESCRIPTION
The reason why the signature has to be stricter now is due to a very similar function being present at an earlier address:
```asm
il2cpp:10E99B02 83 C4 08          add     esp, 8
il2cpp:10E99B05 84 C0             test    al, al
il2cpp:10E99B07 74 39             jz      short loc_10E99B42
il2cpp:10E99B09 A1 AC 7C C5 11    mov     eax, HLBNNHFCNAJ__TypeInfo ; HLBNNHFCNAJ
il2cpp:10E99B0E 8B 40 5C          mov     eax, [eax+5Ch]
il2cpp:10E99B11 8B 38             mov     edi, [eax]

il2cpp:112CC4B8 83 C4 08          add     esp, 8
il2cpp:112CC4BB 84 C0             test    al, al
il2cpp:112CC4BD 74 39             jz      short loc_112CC4F8
il2cpp:112CC4BF A1 54 7F C5 11    mov     eax, FMLLKEACGIO__TypeInfo ; FMLLKEACGIO
il2cpp:112CC4C4 8B 40 5C          mov     eax, [eax+5Ch]
il2cpp:112CC4C7 8B 00             mov     eax, [eax]
```

`FMLLKEACGIO` is `AmongUsClient`, the object we need.

See https://wiki.weewoo.net/wiki/Translations for more info on the obfuscated names.