### PR TITLE
FEAT(client): Added DBus calls to toggle mute and deaf state.

### DIFF
--- a/src/mumble/DBus.cpp
+++ b/src/mumble/DBus.cpp
@@ -109,6 +109,14 @@ unsigned int MumbleDBus::getTransmitMode() {
 	return g.s.atTransmit;
 }
 
+void MumbleDBus::toggleSelfMuted() {
+	g.mw->qaAudioMute->trigger();
+}
+
+void MumbleDBus::toggleSelfDeaf() {
+	g.mw->qaAudioDeaf->trigger();
+}
+
 void MumbleDBus::setSelfMuted(bool mute) {
 	g.mw->qaAudioMute->setChecked(!mute);
 	g.mw->qaAudioMute->trigger();

--- a/src/mumble/DBus.h
+++ b/src/mumble/DBus.h
@@ -35,6 +35,8 @@ public slots:
 	/// @return The current transmit mode (0 = continous, 1 = voice activity, 2 = push-to-talk)
 	unsigned int getTransmitMode();
 
+	void toggleSelfMuted();
+	void toggleSelfDeaf();
 	void setSelfMuted(bool mute);
 	void setSelfDeaf(bool deafen);
 	bool isSelfMuted();


### PR DESCRIPTION
I initially tried using the toggle() function, but that did not work.
Reading the check state and setting the same value ended up actually
inverting the state.