### PR TITLE
FEAT(client, mac): Prompt user for microphone permission if not granted.

### DIFF
--- a/src/mumble/ALSAAudio.cpp
+++ b/src/mumble/ALSAAudio.cpp
@@ -35,6 +35,7 @@ public:
 	virtual const QList< audioDevice > getDeviceChoices();
 	virtual void setDeviceChoice(const QVariant &, Settings &);
 	virtual bool canEcho(const QString &) const;
+	virtual bool isMicrophoneAccessDeniedByOS() { return false; };
 };
 
 

--- a/src/mumble/ASIOInput.cpp
+++ b/src/mumble/ASIOInput.cpp
@@ -28,6 +28,7 @@ public:
 	virtual const QList< audioDevice > getDeviceChoices();
 	virtual void setDeviceChoice(const QVariant &, Settings &);
 	virtual bool canEcho(const QString &) const;
+	virtual bool isMicrophoneAccessDeniedByOS() { return false; };
 };
 
 ASIOAudioInputRegistrar::ASIOAudioInputRegistrar() : AudioInputRegistrar(QLatin1String("ASIO")) {

--- a/src/mumble/AudioConfigDialog.h
+++ b/src/mumble/AudioConfigDialog.h
@@ -36,6 +36,7 @@ public slots:
 	void load(const Settings &r) Q_DECL_OVERRIDE;
 	void updateBitrate();
 	void continuePlayback();
+	void verifyMicrophonePermission();
 
 	void on_qcbPushClick_clicked(bool);
 	void on_qpbPushClickBrowseOn_clicked();

--- a/src/mumble/AudioInput.cpp
+++ b/src/mumble/AudioInput.cpp
@@ -197,6 +197,10 @@ bool AudioInputRegistrar::canExclusive() const {
 	return false;
 }
 
+bool AudioInputRegistrar::isMicrophoneAccessDeniedByOS() {
+	return false;
+}
+
 AudioInput::AudioInput() : opusBuffer(g.s.iFramesPerPacket * (SAMPLE_RATE / 100)) {
 	bDebugDumpInput         = g.bDebugDumpInput;
 	resync.bDebugPrintQueue = g.bDebugPrintQueue;

--- a/src/mumble/AudioInput.h
+++ b/src/mumble/AudioInput.h
@@ -137,6 +137,18 @@ public:
 	virtual void setDeviceChoice(const QVariant &, Settings &) = 0;
 	virtual bool canEcho(const QString &outputsys) const       = 0;
 	virtual bool canExclusive() const;
+
+	/**
+	 * Check if Mumble's microphone access has been denied by the OS.
+	 * Both Windows and macOS have builtin privacy safeguards that display a message asking for users'
+	 * consent when apps are trying to use the microphone, and/or provide ways to deny the microphone
+	 * access of some apps.
+	 * This function should check if Mumble has the permission to use the microphone.
+	 * Note: It is possible that this result could only be known after trying to initialize the audio backend.
+	 * Generally, call this function after attempts to initialize the AudioInput have been made.
+	 * @return true if microphone access is denied.
+	 */
+	virtual bool isMicrophoneAccessDeniedByOS() = 0;
 };
 
 class AudioInput : public QThread {

--- a/src/mumble/AudioInput.ui
+++ b/src/mumble/AudioInput.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>588</width>
-    <height>940</height>
+    <height>953</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -20,13 +20,13 @@
       <string>Interface</string>
      </property>
      <layout class="QGridLayout" name="gridLayout">
-      <item row="0" column="0">
-       <widget class="QLabel" name="qliSystem">
+      <item row="0" column="3">
+       <widget class="QLabel" name="qliDevice">
         <property name="text">
-         <string>System</string>
+         <string>Device</string>
         </property>
         <property name="buddy">
-         <cstring>qcbSystem</cstring>
+         <cstring>qcbDevice</cstring>
         </property>
        </widget>
       </item>
@@ -46,29 +46,13 @@
         </property>
        </widget>
       </item>
-      <item row="0" column="2">
-       <spacer>
-        <property name="orientation">
-         <enum>Qt::Horizontal</enum>
-        </property>
-        <property name="sizeType">
-         <enum>QSizePolicy::Maximum</enum>
-        </property>
-        <property name="sizeHint" stdset="0">
-         <size>
-          <width>24</width>
-          <height>16</height>
-         </size>
-        </property>
-       </spacer>
-      </item>
-      <item row="0" column="3">
-       <widget class="QLabel" name="qliDevice">
+      <item row="0" column="0">
+       <widget class="QLabel" name="qliSystem">
         <property name="text">
-         <string>Device</string>
+         <string>System</string>
         </property>
         <property name="buddy">
-         <cstring>qcbDevice</cstring>
+         <cstring>qcbSystem</cstring>
         </property>
        </widget>
       </item>
@@ -94,7 +78,7 @@
         </property>
        </widget>
       </item>
-      <item row="1" column="4">
+      <item row="2" column="4">
        <widget class="QCheckBox" name="qcbExclusive">
         <property name="minimumSize">
          <size>
@@ -110,6 +94,41 @@
         </property>
         <property name="text">
          <string>Exclusive</string>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="2">
+       <spacer>
+        <property name="orientation">
+         <enum>Qt::Horizontal</enum>
+        </property>
+        <property name="sizeType">
+         <enum>QSizePolicy::Maximum</enum>
+        </property>
+        <property name="sizeHint" stdset="0">
+         <size>
+          <width>24</width>
+          <height>16</height>
+         </size>
+        </property>
+       </spacer>
+      </item>
+      <item row="3" column="0" colspan="5">
+       <widget class="QLabel" name="qlInputHelp">
+        <property name="enabled">
+         <bool>true</bool>
+        </property>
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="text">
+         <string/>
+        </property>
+        <property name="wordWrap">
+         <bool>true</bool>
         </property>
        </widget>
       </item>

--- a/src/mumble/CMakeLists.txt
+++ b/src/mumble/CMakeLists.txt
@@ -904,7 +904,7 @@ if(coreaudio)
 
 	target_sources(mumble
 		PRIVATE
-			"CoreAudio.cpp"
+			"CoreAudio.mm"
 			"CoreAudio.h"
 	)
 
@@ -912,6 +912,7 @@ if(coreaudio)
 		PRIVATE
 			${LIB_AUDIOUNIT}
 			${LIB_COREAUDIO}
+			"-framework AVFoundation"
 	)
 endif()
 

--- a/src/mumble/CoreAudio.h
+++ b/src/mumble/CoreAudio.h
@@ -41,8 +41,6 @@ public:
 	CoreAudioInput();
 	~CoreAudioInput() Q_DECL_OVERRIDE;
 	void run() Q_DECL_OVERRIDE;
-private:
-	bool checkOSMicrophonePermission();
 };
 
 class CoreAudioOutput : public AudioOutput {
@@ -63,13 +61,14 @@ public:
 	void run() Q_DECL_OVERRIDE;
 };
 
-class CoreAudioInputRegistrar : public AudioInputRegistrar {
+class CoreAudioInputRegistrar : public AudioInputRegistrar, public QObject {
 public:
 	CoreAudioInputRegistrar() : AudioInputRegistrar(QLatin1String("CoreAudio"), 10) {}
 	virtual AudioInput *create();
 	virtual const QList< audioDevice > getDeviceChoices();
 	virtual void setDeviceChoice(const QVariant &, Settings &);
 	virtual bool canEcho(const QString &) const;
+	virtual bool isMicrophoneAccessDeniedByOS();
 };
 
 class CoreAudioOutputRegistrar : public AudioOutputRegistrar {

--- a/src/mumble/CoreAudio.h
+++ b/src/mumble/CoreAudio.h
@@ -41,6 +41,8 @@ public:
 	CoreAudioInput();
 	~CoreAudioInput() Q_DECL_OVERRIDE;
 	void run() Q_DECL_OVERRIDE;
+private:
+	bool checkOSMicrophonePermission();
 };
 
 class CoreAudioOutput : public AudioOutput {

--- a/src/mumble/CoreAudio.mm
+++ b/src/mumble/CoreAudio.mm
@@ -3,9 +3,10 @@
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.
 
-#include "CoreAudio.h"
+#include <AVFoundation/AVFoundation.h>
+#include "MainWindow.h"
 
-#include "User.h"
+#include "CoreAudio.h"
 
 // We define a global macro called 'g'. This can lead to issues when included code uses 'g' as a type or parameter name
 // (like protobuf 3.7 does). As such, for now, we have to make this our last include.
@@ -171,6 +172,9 @@ bool CoreAudioOutputRegistrar::canMuteOthers() const {
 }
 
 CoreAudioInput::CoreAudioInput() {
+}
+
+void CoreAudioInput::run() {
 	OSStatus err;
 	AudioStreamBasicDescription fmt;
 	AudioDeviceID devId = 0;
@@ -180,6 +184,10 @@ CoreAudioInput::CoreAudioInput() {
 												   kAudioObjectPropertyElementMaster };
 
 	memset(&buflist, 0, sizeof(AudioBufferList));
+
+	if (!checkOSMicrophonePermission()) {
+		return;
+	}
 
 	if (!g.s.qsCoreAudioInput.isEmpty()) {
 		qWarning("CoreAudioInput: Set device to '%s'.", qPrintable(g.s.qsCoreAudioInput));
@@ -366,6 +374,54 @@ CoreAudioInput::CoreAudioInput() {
 	bRunning = true;
 }
 
+bool CoreAudioInput::checkOSMicrophonePermission() {
+	// Only available after macOS 10.14
+	// See https://developer.apple.com/documentation/avfoundation/cameras_and_media_capture/
+	// requesting_authorization_for_media_capture_on_macos?language=objc
+	if(@available(macOS 10.14, *)){
+		qDebug("CoreAudioInput: Checking microphone permission....");
+		// Request permission to access the camera and microphone.
+		switch ([AVCaptureDevice authorizationStatusForMediaType:AVMediaTypeAudio])
+		{
+			case AVAuthorizationStatusAuthorized: {
+				// The user has previously granted access to the camera.
+				qDebug("CoreAudioInput: Checking microphone permission passed.");
+				return true;
+			}
+			case AVAuthorizationStatusNotDetermined: {
+				// The app hasn't yet asked the user for microphone access.
+				qWarning("CoreAudioInput: Mumble hasn't asked the user for microphone access. Asking for it now.");
+				[AVCaptureDevice requestAccessForMediaType:AVMediaTypeAudio completionHandler: ^(BOOL _granted) {
+					if (_granted) {
+						Audio::stopInput();
+						Audio::startInput();
+					} else {
+						qWarning("CoreAudioInput: Microphone access denied by user.");
+					}
+				}];
+				return false;
+			}
+			case AVAuthorizationStatusDenied: {
+				// The user has previously denied access.
+				qWarning("CoreAudioInput: Microphone access has been previously denied by user.");
+				g.mw->msgBox(tr("Access to the microphone was denied. Please allow Mumble to use the microphone "
+								"by changing the settings in System Preferences -> Security & Privacy -> Privacy -> "
+								"Microphone."));
+				return false;
+			}
+			case AVAuthorizationStatusRestricted: {
+				// The user can't grant access due to restrictions.
+				qWarning("CoreAudioInput: Microphone access denied due to system restrictions.");
+				g.mw->msgBox(tr("Access to the microphone was denied due to system restrictions. You will not be able"
+							    "to use the microphone in this session."));
+				return false;
+			}
+		}
+	} else {
+		return true;
+	}
+}
+
 CoreAudioInput::~CoreAudioInput() {
 	OSStatus err;
 
@@ -419,9 +475,6 @@ void CoreAudioInput::propertyChange(void *udata, AudioUnit au, AudioUnitProperty
 	} else {
 		qWarning("CoreAudioInput: Unexpected property changed event received.");
 	}
-}
-
-void CoreAudioInput::run() {
 }
 
 CoreAudioOutput::CoreAudioOutput() {

--- a/src/mumble/JackAudio.cpp
+++ b/src/mumble/JackAudio.cpp
@@ -83,6 +83,7 @@ private:
 	const QList< audioDevice > getDeviceChoices() Q_DECL_OVERRIDE;
 	void setDeviceChoice(const QVariant &, Settings &) Q_DECL_OVERRIDE;
 	bool canEcho(const QString &) const Q_DECL_OVERRIDE;
+	bool isMicrophoneAccessDeniedByOS() Q_DECL_OVERRIDE { return false; };
 
 public:
 	JackAudioInputRegistrar();

--- a/src/mumble/OSS.cpp
+++ b/src/mumble/OSS.cpp
@@ -46,6 +46,7 @@ public:
 	virtual const QList< audioDevice > getDeviceChoices();
 	virtual void setDeviceChoice(const QVariant &, Settings &);
 	virtual bool canEcho(const QString &) const;
+	virtual bool isMicrophoneAccessDeniedByOS() { return false; };
 };
 
 

--- a/src/mumble/PAAudio.cpp
+++ b/src/mumble/PAAudio.cpp
@@ -33,6 +33,7 @@ private:
 	const QList< audioDevice > getDeviceChoices() Q_DECL_OVERRIDE;
 	void setDeviceChoice(const QVariant &, Settings &) Q_DECL_OVERRIDE;
 	bool canEcho(const QString &) const Q_DECL_OVERRIDE;
+	bool isMicrophoneAccessDeniedByOS() Q_DECL_OVERRIDE { return false; };
 
 public:
 	PortAudioInputRegistrar();

--- a/src/mumble/PulseAudio.cpp
+++ b/src/mumble/PulseAudio.cpp
@@ -43,6 +43,7 @@ public:
 	virtual const QList< audioDevice > getDeviceChoices();
 	virtual void setDeviceChoice(const QVariant &, Settings &);
 	virtual bool canEcho(const QString &) const;
+	virtual bool isMicrophoneAccessDeniedByOS() { return false; };
 };
 
 

--- a/src/mumble/mumble_en.ts
+++ b/src/mumble/mumble_en.ts
@@ -1128,6 +1128,14 @@ This value allows you to set the maximum number of users allowed in the channel.
         <source>Idle action</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Access to the microphone was denied. Please allow Mumble to use the microphone by changing the settings in System Preferences -&gt; Security &amp; Privacy -&gt; Privacy -&gt; Microphone.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Access to the microphone was denied. Please check that your operating system&apos;s microphone settings allow Mumble to use the microphone.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AudioOutput</name>
@@ -3120,13 +3128,6 @@ Label of the server. This is what the server will be named like in your server l
     </message>
     <message>
         <source>&amp;Ignore</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>CoreAudioSystem</name>
-    <message>
-        <source>Default Device</source>
         <translation type="unfinished"></translation>
     </message>
 </context>


### PR DESCRIPTION
This commit utilized the internal permission check function to examine
if the user has granted mumble the microphone permission when initializing
CoreAudioInput backend. If the user hasn't granted the permission, it will
request it through macOS's interface. If being denied, a warning message
will appear in the chat log.

This commit addressed #4547 and #4580. However, self-compiled unsigned
mumble binary still cannot access microphone because this is denied by
Apple's policy. The workaround is to start mumble binary from a terminal,
which is properly signed (e.g. the Terminal app pre-installed).

Fixes #4547
Fixes #4580

