### PR TITLE
CI(azure): Fix build number system

### DIFF
--- a/.ci/azure-pipelines/build_linux.bash
+++ b/.ci/azure-pipelines/build_linux.bash
@@ -21,7 +21,7 @@
 
 if [[ -n "$BUILD_NUMBER_TOKEN" ]]; then
 	VERSION=$(python "scripts/mumble-version.py" --project)
-	BUILD_NUMBER=$(curl "https://mumble.info/get-build-number?version=$VERSION&token=$BUILD_NUMBER_TOKEN")
+	BUILD_NUMBER=$(curl "https://mumble.info/get-build-number?version=$VERSION_$AGENT_JOBNAME&token=$BUILD_NUMBER_TOKEN")
 else
 	BUILD_NUMBER=0
 fi

--- a/.ci/azure-pipelines/build_macos.bash
+++ b/.ci/azure-pipelines/build_macos.bash
@@ -32,7 +32,7 @@
 
 if [[ -n "$BUILD_NUMBER_TOKEN" ]]; then
 	VERSION=$(python "scripts/mumble-version.py" --project)
-	BUILD_NUMBER=$(curl "https://mumble.info/get-build-number?version=$VERSION&token=$BUILD_NUMBER_TOKEN")
+	BUILD_NUMBER=$(curl "https://mumble.info/get-build-number?version=$VERSION_$AGENT_JOBNAME&token=$BUILD_NUMBER_TOKEN")
 else
 	BUILD_NUMBER=0
 fi

--- a/.ci/azure-pipelines/build_windows.bat
+++ b/.ci/azure-pipelines/build_windows.bat
@@ -39,7 +39,7 @@ if defined BUILD_NUMBER_TOKEN (
 	:: The method we use to store a command's output into a variable:
 	:: https://stackoverflow.com/a/6362922
 	for /f "tokens=* USEBACKQ" %%g in (`python "scripts/mumble-version.py" --project`) do (set "VERSION=%%g")
-	for /f "tokens=* USEBACKQ" %%g in (`curl "https://mumble.info/get-build-number?version=%VERSION%&token=%BUILD_NUMBER_TOKEN%"`) do (set "BUILD_NUMBER=%%g")
+	for /f "tokens=* USEBACKQ" %%g in (`curl "https://mumble.info/get-build-number?version=%VERSION%_%AGENT_JOBNAME%&token=%BUILD_NUMBER_TOKEN%"`) do (set "BUILD_NUMBER=%%g")
 ) else (
 	set BUILD_NUMBER=0
 )

--- a/.ci/azure-pipelines/main.yml
+++ b/.ci/azure-pipelines/main.yml
@@ -4,6 +4,10 @@ variables:
   MUMBLE_ENVIRONMENT_PATH: '$(MUMBLE_ENVIRONMENT_STORE)/$(MUMBLE_ENVIRONMENT_VERSION)'
   MUMBLE_ENVIRONMENT_TOOLCHAIN: '$(MUMBLE_ENVIRONMENT_PATH)/scripts/buildsystems/vcpkg.cmake'
 
+env:
+  # Secret variable, has to be exported manually.
+  BUILD_NUMBER_TOKEN: $(BUILD_NUMBER_TOKEN)
+
 jobs:
   - job: Windows_x86_64
     displayName: Windows (x86_64)


### PR DESCRIPTION
`BUILD_NUMBER_TOKEN` has to be manually exported because it's a secret variable: https://docs.microsoft.com/en-us/azure/devops/pipelines/process/variables?view=azure-devops&tabs=yaml%2Cbatch#secret-variables

Also, the version sent to our endpoint has to be different for each job, we want the build number to increase a single time for each pipeline.