### PR TITLE
CI(azure): Show translation difference if assert no translation test failed

### DIFF
--- a/.ci/azure-pipelines/assertNoTranslationChanges.sh
+++ b/.ci/azure-pipelines/assertNoTranslationChanges.sh
@@ -30,6 +30,7 @@ if [[ "$oldHash" = "$newHash" ]]; then
 	echo "No translations have changed"
 	exit 0
 else
+	git diff HEAD^
 	echo "[ERROR]: There are unprocessed translation changes!"
 	exit 1
 fi


### PR DESCRIPTION
Translation test failed on #4676 even if update translation script run on some OS (my macOS 10.15).

This commit aims to provide more information on translation changes when this test failed.

