### PR TITLE
FIX(client, server): Fix protocol version not being set correctly

### DIFF
--- a/src/OSInfo.cpp
+++ b/src/OSInfo.cpp
@@ -536,7 +536,7 @@ void OSInfo::fillXml(QDomDocument &doc, QDomElement &root, const QString &os, co
 
 	tag = doc.createElement(QLatin1String("version"));
 	root.appendChild(tag);
-	t = doc.createTextNode(QLatin1String(MUMTEXT(MUMBLE_VERSION_STRING)));
+	t = doc.createTextNode(QLatin1String(MUMTEXT(MUMBLE_VERSION)));
 	tag.appendChild(t);
 
 	tag = doc.createElement(QLatin1String("release"));

--- a/src/Version.cpp
+++ b/src/Version.cpp
@@ -23,7 +23,7 @@ QString MumbleVersion::toString(unsigned int v) {
 }
 
 bool MumbleVersion::get(int *major, int *minor, int *patch, const QString &version) {
-	QRegExp rx(QLatin1String("(\\d+)\\.(\\d+)\\.(\\d+)"));
+	QRegExp rx(QLatin1String("(\\d+)\\.(\\d+)\\.(\\d+).(\\d+)"));
 
 	if (rx.exactMatch(version)) {
 		if (major)

--- a/src/Version.h
+++ b/src/Version.h
@@ -22,7 +22,7 @@ public:
 	static unsigned int getRaw(const QString &version = QLatin1String(MUMTEXT(MUMBLE_VERSION)));
 	static QString toString(unsigned int version);
 	static bool get(int *major, int *minor, int *patch,
-					const QString &version = QLatin1String(MUMTEXT(MUMBLE_RELEASE_ID)));
+					const QString &version = QLatin1String(MUMTEXT(MUMBLE_VERSION)));
 
 	static unsigned int toRaw(int major, int minor, int patch);
 	static void fromRaw(unsigned int version, int *major, int *minor, int *patch);

--- a/src/mumble/ConnectDialog.cpp
+++ b/src/mumble/ConnectDialog.cpp
@@ -1347,7 +1347,7 @@ void ConnectDialog::initList() {
 	url.setPath(QLatin1String("/v1/list"));
 
 	QUrlQuery query;
-	query.addQueryItem(QLatin1String("version"), QLatin1String(MUMTEXT(MUMBLE_VERSION_STRING)));
+	query.addQueryItem(QLatin1String("version"), QLatin1String(MUMTEXT(MUMBLE_VERSION)));
 	url.setQuery(query);
 
 	WebFetch::fetch(QLatin1String("publist"), url, this, SLOT(fetched(QByteArray, QUrl, QMap< QString, QString >)));

--- a/src/mumble/CrashReporter.cpp
+++ b/src/mumble/CrashReporter.cpp
@@ -200,7 +200,7 @@ void CrashReporter::run() {
 						 .arg(boundary, OSInfo::getOS(), OSInfo::getOSVersion());
 		QString ver = QString::fromLatin1("--%1\r\nContent-Disposition: form-data; "
 										  "name=\"ver\"\r\nContent-Transfer-Encoding: 8bit\r\n\r\n%2 %3\r\n")
-						  .arg(boundary, QLatin1String(MUMTEXT(MUMBLE_VERSION_STRING)), QLatin1String(MUMBLE_RELEASE));
+						  .arg(boundary, QLatin1String(MUMTEXT(MUMBLE_VERSION)), QLatin1String(MUMBLE_RELEASE));
 		QString email = QString::fromLatin1("--%1\r\nContent-Disposition: form-data; "
 											"name=\"email\"\r\nContent-Transfer-Encoding: 8bit\r\n\r\n%2\r\n")
 							.arg(boundary, qleEmail->text());

--- a/src/mumble/NetworkConfig.cpp
+++ b/src/mumble/NetworkConfig.cpp
@@ -191,13 +191,13 @@ void Network::prepareRequest(QNetworkRequest &req) {
 	if (g.s.bHideOS) {
 		req.setRawHeader(QString::fromLatin1("User-Agent").toUtf8(),
 						 QString::fromLatin1("Mozilla/5.0 Mumble/%1 %2")
-							 .arg(QLatin1String(MUMTEXT(MUMBLE_VERSION_STRING)), QLatin1String(MUMBLE_RELEASE))
+							 .arg(QLatin1String(MUMTEXT(MUMBLE_VERSION)), QLatin1String(MUMBLE_RELEASE))
 							 .toUtf8());
 	} else {
 		req.setRawHeader(QString::fromLatin1("User-Agent").toUtf8(),
 						 QString::fromLatin1("Mozilla/5.0 (%1; %2) Mumble/%3 %4")
 							 .arg(OSInfo::getOS(), OSInfo::getOSVersion(),
-								  QLatin1String(MUMTEXT(MUMBLE_VERSION_STRING)), QLatin1String(MUMBLE_RELEASE))
+								  QLatin1String(MUMTEXT(MUMBLE_VERSION)), QLatin1String(MUMBLE_RELEASE))
 							 .toUtf8());
 	}
 }

--- a/src/mumble/Overlay_macx.mm
+++ b/src/mumble/Overlay_macx.mm
@@ -305,7 +305,7 @@ static bool isInstallerNewer(QString path, NSUInteger curVer) {
 		QRegExp rx(QLatin1String("(\\d+)\\.(\\d+)\\.(\\d+)"));
 		int major, minor, patch;
 		int minmajor, minminor, minpatch;
-		if (! rx.exactMatch(QLatin1String(MUMTEXT(MUMBLE_VERSION_STRING))))
+		if (! rx.exactMatch(QLatin1String(MUMTEXT(MUMBLE_VERSION))))
 			goto out;
 		major = rx.cap(1).toInt();
 		minor = rx.cap(2).toInt();

--- a/src/mumble/Settings.cpp
+++ b/src/mumble/Settings.cpp
@@ -1008,7 +1008,7 @@ void OverlaySettings::save() {
 void OverlaySettings::save(QSettings *settings_ptr) {
 	OverlaySettings def;
 
-	settings_ptr->setValue(QLatin1String("version"), QLatin1String(MUMTEXT(MUMBLE_VERSION_STRING)));
+	settings_ptr->setValue(QLatin1String("version"), QLatin1String(MUMTEXT(MUMBLE_VERSION)));
 	settings_ptr->sync();
 
 #if defined(Q_OS_WIN) || defined(Q_OS_MAC)

--- a/src/mumble/os_win.cpp
+++ b/src/mumble/os_win.cpp
@@ -283,7 +283,7 @@ void os_init() {
 
 	QString comment =
 		QString::fromLatin1("%1\n%2\n%3")
-			.arg(QString::fromLatin1(MUMBLE_RELEASE), QString::fromLatin1(MUMTEXT(MUMBLE_VERSION_STRING)), hash);
+			.arg(QString::fromLatin1(MUMBLE_RELEASE), QString::fromLatin1(MUMTEXT(MUMBLE_VERSION)), hash);
 
 	wcscpy_s(wcComment, DUMP_BUFFER_SIZE, comment.toStdWString().c_str());
 	musComment.Type       = CommentStreamW;


### PR DESCRIPTION
#4669 introduced support for the 4th part (build/tweak) of the version, however:

1. It didn't replace all instances of `MUMBLE_VERSION_STRING` with `MUMBLE_VERSION`.
2. It accidentally replaced `MUMBLE_VERSION_STRING` with `MUMBLE_RELEASE_ID` in `MumbleVersion::get()`'s signature.
3. It didn't update the regex expression in `MumbleVersion::get()` to support 4 digits.

This pull request fixes all issues listed above.

---

Thanks to @Natenom for reporting the issue.