### PR TITLE
FIX(server): Older clients not being warned about ChannelListener

### DIFF
--- a/src/murmur/Messages.cpp
+++ b/src/murmur/Messages.cpp
@@ -512,8 +512,8 @@ void Server::msgAuthenticate(ServerUser *uSource, MumbleProto::Authenticate &msg
 		sendMessage(uSource, mpsug);
 	}
 
-	if (uSource->uiVersion < 0x010400 && Meta::mp.iMaxListenersPerChannel > 0
-		&& Meta::mp.iMaxListenerProxiesPerUser > 0) {
+	if (uSource->uiVersion < 0x010400 && Meta::mp.iMaxListenersPerChannel != 0
+		&& Meta::mp.iMaxListenerProxiesPerUser != 0) {
 		// The server has the ChannelListener feature enabled but the client that connects doesn't have version 1.4.0 or
 		// newer meaning that this client doesn't know what ChannelListeners are. Thus we'll send that user a
 		// text-message informing about this.


### PR DESCRIPTION
Clients < 1.4.0 don't know about the new ChannelListener feature and
thus there is no indication in the UI for them. In order to make sure
that users know that they could potentially be listened to without
seeing anything in the UI, a warning message was introduced in #4097.

There was an error in the implementation however causing this warning to
not be sent by the server if there are no explicit limits on the amount
of channel listeners via the server configuration.

The bug was that "no limit" was expressed as -1 but the check for
whether these features are enabled checked for > 0. The fix is simply to
check for != 0 instead.

Fixes #4687

<!-- Please make sure that you follow our commit guidelines specified at https://github.com/mumble-voip/mumble/blob/master/COMMIT_GUIDELINES.md -->
