### PR TITLE
DOCS: Fix vcpkg paths in build documentation

### DIFF
--- a/docs/dev/build-instructions/ide_integration.md
+++ b/docs/dev/build-instructions/ide_integration.md
@@ -8,8 +8,8 @@
 * Start Visual Studio
 * Open the project folder (with the open folder option)
 * In the cmake configuration settings specify the cmake toolchain file
-  This file should be at `%USERPROFILE%/mumble-vcpkg/scripts/buildsystems/vcpkg.cmake` after using `get-mumble_deps.sh`.
-* As cmake command argument add `-DVCPKG_TARGET_TRIPLET=x64-windows-static-md -Dstatic=ON -DIce_HOME=%USERPROFILE%/mumble-vcpkg/installed/x64-windows-static-md`
+  This file should be at `%USERPROFILE%/vcpkg/scripts/buildsystems/vcpkg.cmake` after using `get-mumble_deps.sh`.
+* As cmake command argument add `-DVCPKG_TARGET_TRIPLET=x64-windows-static-md -Dstatic=ON -DIce_HOME=%USERPROFILE%/vcpkg/installed/x64-windows-static-md`
 * Save and cmake should generate the build files, which will take a bit of time
 * Use the build all action to build the project
 * On success the built binaries will be placed in `out\build\<configuration-name>\`


### PR DESCRIPTION
We used mumble-vcpkg while the get script was still being implemented in a separate repository.
When we integrated it in this repository in 2f45772c9c9ad90e480e50008419c598b19bf01e it was already, and still is, using `vcpkg`.
