### PR TITLE
WIP FEAT: Close quietly to system tray

### DIFF
--- a/src/mumble/LookConfig.cpp
+++ b/src/mumble/LookConfig.cpp
@@ -176,6 +176,7 @@ void LookConfig::load(const Settings &r) {
 	loadComboBox(qcbUserDrag, r.ceUserDrag);
 	loadCheckBox(qcbUsersTop, r.bUserTop);
 	loadCheckBox(qcbAskOnQuit, r.bAskOnQuit);
+    loadCheckBox(qcbCloseToTray, r.bCloseToTray);
 	loadCheckBox(qcbEnableDeveloperMenu, r.bEnableDeveloperMenu);
 	loadCheckBox(qcbLockLayout, (r.wlWindowLayout == Settings::LayoutCustom) && r.bLockLayout);
 	loadCheckBox(qcbHideTray, r.bHideInTray);
@@ -239,8 +240,9 @@ void LookConfig::save() const {
 
 	s.aotbAlwaysOnTop           = static_cast< Settings::AlwaysOnTopBehaviour >(qcbAlwaysOnTop->currentIndex());
 	s.bAskOnQuit                = qcbAskOnQuit->isChecked();
+    s.bCloseToTray              = qcbCloseToTray->isChecked();
 	s.bEnableDeveloperMenu      = qcbEnableDeveloperMenu->isChecked();
-	s.bLockLayout               = qcbLockLayout->isChecked();
+    s.bLockLayout               = qcbLockLayout->isChecked();
 	s.bHideInTray               = qcbHideTray->isChecked();
 	s.bStateInTray              = qcbStateInTray->isChecked();
 	s.bShowUserCount            = qcbShowUserCount->isChecked();

--- a/src/mumble/LookConfig.ui
+++ b/src/mumble/LookConfig.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>728</width>
-    <height>1148</height>
+    <width>753</width>
+    <height>1158</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -579,10 +579,23 @@
       <string>Application</string>
      </property>
      <layout class="QGridLayout" name="gridLayout_3" columnstretch="0,0">
-      <item row="0" column="0">
-       <widget class="QLabel" name="qliAlwaysOnTop">
+      <item row="1" column="0" colspan="2">
+       <widget class="QCheckBox" name="qcbShowContextMenuInMenuBar">
+        <property name="toolTip">
+         <string>Adds user and channel context menus into the menu bar</string>
+        </property>
         <property name="text">
-         <string>Always On Top</string>
+         <string>Show context menu in menu bar</string>
+        </property>
+       </widget>
+      </item>
+      <item row="4" column="0" colspan="2">
+       <widget class="QCheckBox" name="qcbEnableDeveloperMenu">
+        <property name="whatsThis">
+         <string>&lt;b&gt;Enable Developer menu&lt;/b&gt;&lt;br /&gt;This enables the &quot;Developer&quot;-menu in Mumble. This menu is used for developer-specific features, such as the Developer Console.</string>
+        </property>
+        <property name="text">
+         <string>Enable Developer menu</string>
         </property>
        </widget>
       </item>
@@ -616,13 +629,10 @@
         </item>
        </widget>
       </item>
-      <item row="1" column="0" colspan="2">
-       <widget class="QCheckBox" name="qcbShowContextMenuInMenuBar">
-        <property name="toolTip">
-         <string>Adds user and channel context menus into the menu bar</string>
-        </property>
+      <item row="0" column="0">
+       <widget class="QLabel" name="qliAlwaysOnTop">
         <property name="text">
-         <string>Show context menu in menu bar</string>
+         <string>Always On Top</string>
         </property>
        </widget>
       </item>
@@ -639,23 +649,23 @@
         </property>
        </widget>
       </item>
-      <item row="3" column="0" colspan="2">
-       <widget class="QCheckBox" name="qcbEnableDeveloperMenu">
-        <property name="whatsThis">
-         <string>&lt;b&gt;Enable Developer menu&lt;/b&gt;&lt;br /&gt;This enables the &quot;Developer&quot;-menu in Mumble. This menu is used for developer-specific features, such as the Developer Console.</string>
-        </property>
-        <property name="text">
-         <string>Enable Developer menu</string>
-        </property>
-       </widget>
-      </item>
-      <item row="4" column="0" colspan="2">
+      <item row="5" column="0" colspan="2">
        <widget class="QCheckBox" name="qcbLockLayout">
         <property name="whatsThis">
          <string>When in custom layout mode, checking this disables rearranging.</string>
         </property>
         <property name="text">
          <string>Lock layout</string>
+        </property>
+       </widget>
+      </item>
+      <item row="3" column="0">
+       <widget class="QCheckBox" name="qcbCloseQuietly">
+        <property name="toolTip">
+         <string>This setting controls that should mumble go to tray when closed</string>
+        </property>
+        <property name="text">
+         <string>Close quietly to tray</string>
         </property>
        </widget>
       </item>

--- a/src/mumble/LookConfig.ui
+++ b/src/mumble/LookConfig.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>753</width>
-    <height>1158</height>
+    <height>1186</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -660,12 +660,12 @@
        </widget>
       </item>
       <item row="3" column="0">
-       <widget class="QCheckBox" name="qcbCloseQuietly">
+       <widget class="QCheckBox" name="qcbCloseToTray">
         <property name="toolTip">
          <string>This setting controls that should mumble go to tray when closed</string>
         </property>
         <property name="text">
-         <string>Close quietly to tray</string>
+         <string>Minimize instead of close</string>
         </property>
        </widget>
       </item>

--- a/src/mumble/Settings.cpp
+++ b/src/mumble/Settings.cpp
@@ -359,6 +359,7 @@ Settings::Settings() {
 	bHideFrame           = false;
 	aotbAlwaysOnTop      = OnTopNever;
 	bAskOnQuit           = true;
+    bCloseToTray         = false;
 	bEnableDeveloperMenu = false;
 	bLockLayout          = false;
 #ifdef Q_OS_WIN
@@ -842,7 +843,8 @@ void Settings::load(QSettings *settings_ptr) {
 	LOADENUM(ceChannelDrag, "ui/drag");
 	LOADENUM(ceUserDrag, "ui/userdrag");
 	LOADENUM(aotbAlwaysOnTop, "ui/alwaysontop");
-	SAVELOAD(bAskOnQuit, "ui/askonquit");
+    SAVELOAD(bAskOnQuit, "ui/askonquit");
+    SAVELOAD(bCloseToTray, "ui/close_to_tray");
 	SAVELOAD(bEnableDeveloperMenu, "ui/developermenu");
 	SAVELOAD(bLockLayout, "ui/locklayout");
 	SAVELOAD(bMinimalView, "ui/minimalview");
@@ -1216,6 +1218,7 @@ void Settings::save() {
 	SAVELOAD(ceUserDrag, "ui/userdrag");
 	SAVELOAD(aotbAlwaysOnTop, "ui/alwaysontop");
 	SAVELOAD(bAskOnQuit, "ui/askonquit");
+    SAVELOAD(bCloseToTray, "ui/close_to_tray");
 	SAVELOAD(bEnableDeveloperMenu, "ui/developermenu");
 	SAVELOAD(bLockLayout, "ui/locklayout");
 	SAVELOAD(bMinimalView, "ui/minimalview");

--- a/src/mumble/Settings.h
+++ b/src/mumble/Settings.h
@@ -328,6 +328,7 @@ struct Settings {
 	enum AlwaysOnTopBehaviour { OnTopNever, OnTopAlways, OnTopInMinimal, OnTopInNormal };
 	AlwaysOnTopBehaviour aotbAlwaysOnTop;
 	bool bAskOnQuit;
+    bool bCloseToTray;
 	bool bEnableDeveloperMenu;
 	bool bLockLayout;
 	bool bHideInTray;


### PR DESCRIPTION
This pull request is for feedback and assistance for my implementation of a close quietly -feature #4682 
All help and tips are very appreciated as this is my first time contributing.

Implements #4682

<!-- Please make sure that you follow our commit guidelines specified at https://github.com/mumble-voip/mumble/blob/master/COMMIT_GUIDELINES.md -->

----

ToDo:
- [x] Add new entry in UI (checkbox)
- [ ] Create new settings variable in `Settings.h`
- [ ] Implement saving and loading of that setting in `Settings.cpp`
- [ ] Set a default value for the new setting (`false`) in `Settings.cpp` (constructor)
- [ ] Add logic for minimize instead of close in `MainWindow::closeEvent` (make sure to differentiate between a user clicking the x icon in the window and a user explicitly choosing `Quit` from Mumble's menu. In the latter case we always want to quit regardless of the new setting)
- [ ] Test that it is working as intended
- [ ] Get changes in PR reviewed
- [ ] Squash all commits
- [ ] Update translations (execute `scripts/updatetranslations.sh`)
