### PR TITLE
Experimental Echo Cancellation for MacOS

### DIFF
--- a/scripts/updatetranslations.sh
+++ b/scripts/updatetranslations.sh
@@ -75,7 +75,7 @@ function main
 	echo "TRANSLATION: Update translation files" > $tmpfile
 	echo "" >> $tmpfile
 	
-	lupdate -no-ui-lines -disable-heuristic similartext -locations none -no-obsolete -no-recursive "./src" "./src/mumble" -ts "$filePath" \
+	lupdate -no-ui-lines -disable-heuristic similartext -locations none -no-obsolete -no-recursive -extensions "ui,c,cpp,h,mm" "./src" "./src/mumble" -ts "$filePath" \
 		| tee -a $tmpfile || fatal "lupdate failed"
 	echo ""
 

--- a/src/mumble/ALSAAudio.cpp
+++ b/src/mumble/ALSAAudio.cpp
@@ -34,7 +34,7 @@ public:
 	virtual AudioInput *create();
 	virtual const QList< audioDevice > getDeviceChoices();
 	virtual void setDeviceChoice(const QVariant &, Settings &);
-	virtual bool canEcho(const QString &) const;
+	virtual bool canEcho(int ,const QString &) const;
 	virtual bool isMicrophoneAccessDeniedByOS() { return false; };
 };
 
@@ -113,7 +113,7 @@ void ALSAAudioInputRegistrar::setDeviceChoice(const QVariant &choice, Settings &
 	s.qsALSAInput = choice.toString();
 }
 
-bool ALSAAudioInputRegistrar::canEcho(const QString &) const {
+bool ALSAAudioInputRegistrar::canEcho(int, const QString &) const {
 	return false;
 }
 

--- a/src/mumble/ALSAAudio.cpp
+++ b/src/mumble/ALSAAudio.cpp
@@ -34,7 +34,7 @@ public:
 	virtual AudioInput *create();
 	virtual const QList< audioDevice > getDeviceChoices();
 	virtual void setDeviceChoice(const QVariant &, Settings &);
-	virtual bool canEcho(int ,const QString &) const;
+	virtual bool canEcho(EchoCancelOptionID echoCancelID, const QString &outputSystem) const;
 	virtual bool isMicrophoneAccessDeniedByOS() { return false; };
 };
 
@@ -113,7 +113,7 @@ void ALSAAudioInputRegistrar::setDeviceChoice(const QVariant &choice, Settings &
 	s.qsALSAInput = choice.toString();
 }
 
-bool ALSAAudioInputRegistrar::canEcho(int, const QString &) const {
+bool ALSAAudioInputRegistrar::canEcho(EchoCancelOptionID, const QString &) const {
 	return false;
 }
 

--- a/src/mumble/ASIOInput.cpp
+++ b/src/mumble/ASIOInput.cpp
@@ -27,11 +27,12 @@ public:
 	virtual AudioInput *create();
 	virtual const QList< audioDevice > getDeviceChoices();
 	virtual void setDeviceChoice(const QVariant &, Settings &);
-	virtual bool canEcho(const QString &) const;
+	virtual bool canEcho(int, const QString &) const;
 	virtual bool isMicrophoneAccessDeniedByOS() { return false; };
 };
 
 ASIOAudioInputRegistrar::ASIOAudioInputRegistrar() : AudioInputRegistrar(QLatin1String("ASIO")) {
+	useSpeexEchoCancellation();
 }
 
 AudioInput *ASIOAudioInputRegistrar::create() {
@@ -42,8 +43,10 @@ const QList< audioDevice > ASIOAudioInputRegistrar::getDeviceChoices() {
 	return qlReturn;
 }
 
-bool ASIOAudioInputRegistrar::canEcho(const QString &) const {
-	return true;
+bool ASIOAudioInputRegistrar::canEcho(int echoOption, const QString &) const {
+	return (echoOption == ECHO_CANCEL_DISABLED
+	        || echoOption == ECHO_CANCEL_SPEEX_MIXED
+	        || echoOption == ECHO_CANCEL_SPEEX_MULTICHANNEL);
 }
 
 void ASIOAudioInputRegistrar::setDeviceChoice(const QVariant &, Settings &) {

--- a/src/mumble/ASIOInput.cpp
+++ b/src/mumble/ASIOInput.cpp
@@ -27,12 +27,13 @@ public:
 	virtual AudioInput *create();
 	virtual const QList< audioDevice > getDeviceChoices();
 	virtual void setDeviceChoice(const QVariant &, Settings &);
-	virtual bool canEcho(int, const QString &) const;
+	virtual bool canEcho(EchoCancelOptionID echoCancelID, const QString &outputSystem) const;
 	virtual bool isMicrophoneAccessDeniedByOS() { return false; };
 };
 
 ASIOAudioInputRegistrar::ASIOAudioInputRegistrar() : AudioInputRegistrar(QLatin1String("ASIO")) {
-	useSpeexEchoCancellation();
+	echoOptions.push_back(EchoCancelOptionID::SPEEX_MIXED);
+	echoOptions.push_back(EchoCancelOptionID::SPEEX_MULTICHANNEL);
 }
 
 AudioInput *ASIOAudioInputRegistrar::create() {
@@ -43,10 +44,9 @@ const QList< audioDevice > ASIOAudioInputRegistrar::getDeviceChoices() {
 	return qlReturn;
 }
 
-bool ASIOAudioInputRegistrar::canEcho(int echoOption, const QString &) const {
-	return (echoOption == ECHO_CANCEL_DISABLED
-	        || echoOption == ECHO_CANCEL_SPEEX_MIXED
-	        || echoOption == ECHO_CANCEL_SPEEX_MULTICHANNEL);
+bool ASIOAudioInputRegistrar::canEcho(EchoCancelOptionID echoOption, const QString &) const {
+	return (echoOption == EchoCancelOptionID::SPEEX_MIXED
+	        || echoOption == EchoCancelOptionID::SPEEX_MULTICHANNEL);
 }
 
 void ASIOAudioInputRegistrar::setDeviceChoice(const QVariant &, Settings &) {

--- a/src/mumble/AudioConfigDialog.cpp
+++ b/src/mumble/AudioConfigDialog.cpp
@@ -246,12 +246,12 @@ void AudioInputDialog::verifyMicrophonePermission() {
 		if (air->name == QLatin1String("CoreAudio")) {
 			qlInputHelp->setVisible(true);
 			qlInputHelp->setText(tr("Access to the microphone was denied. Please allow Mumble to use the microphone "
-									"by changing the settings in System Preferences -> Security & Privacy -> Privacy -> "
-									"Microphone."));
+			                        "by changing the settings in System Preferences -> Security & Privacy -> Privacy -> "
+			                        "Microphone."));
 		} else if (air->name == QLatin1String("WASAPI")) {
 			qlInputHelp->setVisible(true);
 			qlInputHelp->setText( tr("Access to the microphone was denied. Please check that your operating system's "
-									 "microphone settings allow Mumble to use the microphone."));
+			                         "microphone settings allow Mumble to use the microphone."));
 		}
 	} else {
 		qcbDevice->setEnabled(true);
@@ -297,8 +297,7 @@ void AudioInputDialog::save() const {
 	s.qsTxAudioCueOff      = qlePushClickPathOff->text();
 
 	s.qsAudioInput    = qcbSystem->currentText();
-	s.iEchoOption    = qcbEcho->currentData().toInt();
-	s.bEcho           = s.iEchoOption != ECHO_CANCEL_DISABLED;
+	s.echoOption    = static_cast<EchoCancelOptionID>(qcbEcho->currentData().toInt());
 	s.bExclusiveInput = qcbExclusive->isChecked();
 
 	if (AudioInputRegistrar::qmNew) {
@@ -516,14 +515,16 @@ void AudioInputDialog::updateEchoEnableState() {
 	qcbEcho->insertItem(0, tr("Disabled"), "disabled");
 	qcbEcho->setItemData(0, tr("Disable echo cancellation."), Qt::ToolTipRole);
 
-	for (int i=0; i<air->echoOptions.count(); ++i) {
-		EchoCancellationOption eco = air->echoOptions[i];
-		if (air->canEcho(eco.id, outputInterface)) {
+	int i = 0;
+	for (EchoCancelOptionID ecoid : air->echoOptions) {
+		if (air->canEcho(ecoid, outputInterface)) {
+			++i;
 			hasUsableEchoOption = true;
-			qcbEcho->insertItem(i+1, eco.description, eco.id);
-			qcbEcho->setItemData(i+1, eco.explanation, Qt::ToolTipRole);
-			if (s.iEchoOption == eco.id) {
-				qcbEcho->setCurrentIndex(i+1);
+			const EchoCancelOption &echoOption = echoCancelOptions[static_cast<int>(ecoid)];
+			qcbEcho->insertItem(i, echoOption.description, static_cast<int>(ecoid));
+			qcbEcho->setItemData(i, echoOption.explanation, Qt::ToolTipRole);
+			if (s.echoOption == ecoid) {
+				qcbEcho->setCurrentIndex(i);
 			}
 		}
 	}

--- a/src/mumble/AudioConfigDialog.cpp
+++ b/src/mumble/AudioConfigDialog.cpp
@@ -523,9 +523,9 @@ void AudioInputDialog::updateEchoEnableState() {
 		qcbEcho->setCurrentIndex(0);
 		qcbEcho->setEnabled(false);
 		qcbEcho->setToolTip(QObject::tr("Echo cancellation is not supported for the interface "
-										"combination \"%1\" (in) and \"%2\" (out).")
-								.arg(air->name)
-								.arg(outputInterface));
+		                                "combination \"%1\" (in) and \"%2\" (out).")
+			                    .arg(air->name)
+			                    .arg(outputInterface));
 	}
 }
 

--- a/src/mumble/AudioInput.cpp
+++ b/src/mumble/AudioInput.cpp
@@ -167,19 +167,6 @@ AudioInputRegistrar::~AudioInputRegistrar() {
 	qmNew->remove(name);
 }
 
-void AudioInputRegistrar::useSpeexEchoCancellation() {
-	echoOptions.append(EchoCancellationOption(ECHO_CANCEL_SPEEX_MIXED,
-						  tr("Mixed echo cancellation (speex)"),
-						  tr("Mixed has low CPU impact, but only works well if your "
-						     "speakers are equally loud and equidistant from the microphone.")));
-	echoOptions.append(EchoCancellationOption(ECHO_CANCEL_SPEEX_MULTICHANNEL,
-						  tr("Multichannel echo cancellation (speex)"),
-						  tr("Multichannel echo cancellation provides much better echo "
-						     "cancellation, but at a higher CPU cost. "
-						     "Multichannel echo cancellation requires more CPU, so you should try mixed first.")));
-
-}
-
 AudioInputPtr AudioInputRegistrar::newFromChoice(QString choice) {
 	if (!qmNew)
 		return AudioInputPtr();
@@ -527,7 +514,7 @@ void AudioInput::initializeMixer() {
 	pfMicInput = new float[iMicLength];
 
 	if (iEchoChannels > 0) {
-		bEchoMulti = (g.s.iEchoOption == ECHO_CANCEL_SPEEX_MULTICHANNEL);
+		bEchoMulti = (g.s.echoOption == EchoCancelOptionID::SPEEX_MULTICHANNEL);
 		if (iEchoFreq != iSampleRate)
 			srsEcho = speex_resampler_init(bEchoMulti ? iEchoChannels : 1, iEchoFreq, iSampleRate, 3, &err);
 		iEchoLength    = (iFrameSize * iEchoFreq) / iSampleRate;

--- a/src/mumble/AudioInput.cpp
+++ b/src/mumble/AudioInput.cpp
@@ -157,7 +157,7 @@ void Resynchronizer::printQueue(char who) {
 QMap< QString, AudioInputRegistrar * > *AudioInputRegistrar::qmNew;
 QString AudioInputRegistrar::current = QString();
 
-AudioInputRegistrar::AudioInputRegistrar(const QString &n, int p) : name(n), priority(p) {
+AudioInputRegistrar::AudioInputRegistrar(const QString &n, int p) : name(n), priority(p), echoOptions() {
 	if (!qmNew)
 		qmNew = new QMap< QString, AudioInputRegistrar * >();
 	qmNew->insert(name, this);
@@ -165,6 +165,19 @@ AudioInputRegistrar::AudioInputRegistrar(const QString &n, int p) : name(n), pri
 
 AudioInputRegistrar::~AudioInputRegistrar() {
 	qmNew->remove(name);
+}
+
+void AudioInputRegistrar::useSpeexEchoCancellation() {
+	echoOptions.append(EchoCancellationOption(ECHO_CANCEL_SPEEX_MIXED,
+						  tr("Mixed echo cancellation (speex)"),
+						  tr("Mixed has low CPU impact, but only works well if your "
+						     "speakers are equally loud and equidistant from the microphone.")));
+	echoOptions.append(EchoCancellationOption(ECHO_CANCEL_SPEEX_MULTICHANNEL,
+						  tr("Multichannel echo cancellation (speex)"),
+						  tr("Multichannel echo cancellation provides much better echo "
+						     "cancellation, but at a higher CPU cost. "
+						     "Multichannel echo cancellation requires more CPU, so you should try mixed first.")));
+
 }
 
 AudioInputPtr AudioInputRegistrar::newFromChoice(QString choice) {
@@ -514,7 +527,7 @@ void AudioInput::initializeMixer() {
 	pfMicInput = new float[iMicLength];
 
 	if (iEchoChannels > 0) {
-		bEchoMulti = g.s.bEchoMulti;
+		bEchoMulti = (g.s.iEchoOption == ECHO_CANCEL_SPEEX_MULTICHANNEL);
 		if (iEchoFreq != iSampleRate)
 			srsEcho = speex_resampler_init(bEchoMulti ? iEchoChannels : 1, iEchoFreq, iSampleRate, 3, &err);
 		iEchoLength    = (iFrameSize * iEchoFreq) / iSampleRate;

--- a/src/mumble/AudioInput.h
+++ b/src/mumble/AudioInput.h
@@ -20,6 +20,7 @@
 #include <vector>
 
 #include "Audio.h"
+#include "EchoCancelOption.h"
 #include "Message.h"
 #include "Settings.h"
 #include "Timer.h"
@@ -119,18 +120,8 @@ private:
 	enum { S0, S1a, S1b, S2, S3, S4a, S4b, S5 } state = S0; ///< Queue fill control statemachine
 };
 
-struct EchoCancellationOption {
-	EchoCancellationOption(int id, QString description, QString explanation) : id(id),
-	                                                                           description(description),
-	                                                                           explanation(explanation) {};
-	int id;
-	QString description;
-	QString explanation;
-};
-
-class AudioInputRegistrar : public QObject {
+class AudioInputRegistrar {
 private:
-	Q_OBJECT
 	Q_DISABLE_COPY(AudioInputRegistrar)
 public:
 	static QMap< QString, AudioInputRegistrar * > *qmNew;
@@ -140,8 +131,8 @@ public:
 	const QString name;
 	int priority;
 
-	// A list of echo cancellation options available for this backend.
-	QList<EchoCancellationOption> echoOptions;
+	/// A list of echo cancellation options available for this backend.
+	std::vector< EchoCancelOptionID > echoOptions;
 
 	AudioInputRegistrar(const QString &n, int priority = 0);
 	virtual ~AudioInputRegistrar();
@@ -149,13 +140,9 @@ public:
 	virtual const QList< audioDevice > getDeviceChoices()      = 0;
 	virtual void setDeviceChoice(const QVariant &, Settings &) = 0;
 
-	// Check that is the given echoOption and outputSystem combination is available for echo cancellation
-	virtual bool canEcho(int echoOptionId, const QString &outputSystem) const = 0;
+	/// Check that given combination of echoOption and outputSystem combination is suitable for echo cancellation
+	virtual bool canEcho(EchoCancelOptionID echoOptionId, const QString &outputSystem) const = 0;
 	virtual bool canExclusive() const;
-
-	// add speex echo cancellation as into the echoOptions if this backend supports
-	// tapping the system's audio output.
-	void useSpeexEchoCancellation();
 
 	/**
 	 * Check if Mumble's microphone access has been denied by the OS.
@@ -299,10 +286,5 @@ public:
 	virtual bool isAlive() const;
 	bool isTransmitting() const;
 };
-
-#define ECHO_CANCEL_DISABLED 0
-#define ECHO_CANCEL_DEFAULT 1
-#define ECHO_CANCEL_SPEEX_MIXED 10
-#define ECHO_CANCEL_SPEEX_MULTICHANNEL 11
 
 #endif

--- a/src/mumble/AudioInput.ui
+++ b/src/mumble/AudioInput.ui
@@ -761,21 +761,6 @@
         <property name="whatsThis">
          <string>Enabling this will cancel the echo from your speakers. Mixed has low CPU impact, but only works well if your speakers are equally loud and equidistant from the microphone. Multichannel echo cancellation provides much better echo cancellation, but at a higher CPU cost.</string>
         </property>
-        <item>
-         <property name="text">
-          <string>Disabled</string>
-         </property>
-        </item>
-        <item>
-         <property name="text">
-          <string>Mixed echo cancellation</string>
-         </property>
-        </item>
-        <item>
-         <property name="text">
-          <string>Multichannel echo cancellation</string>
-         </property>
-        </item>
        </widget>
       </item>
      </layout>

--- a/src/mumble/AudioWizard.h
+++ b/src/mumble/AudioWizard.h
@@ -9,6 +9,7 @@
 #include "ui_AudioWizard.h"
 
 #include "AudioOutput.h"
+#include "AudioInput.h"
 #include "AudioStats.h"
 #include "Settings.h"
 
@@ -16,6 +17,8 @@ class AudioWizard : public QWizard, public Ui::AudioWizard {
 private:
 	Q_OBJECT
 	Q_DISABLE_COPY(AudioWizard)
+
+	bool hasUsableEchoCancellation(AudioInputRegistrar *air, QString outputSys);
 protected:
 	QList< QVariant > pttButtons;
 	bool bTransmitChanged;

--- a/src/mumble/AudioWizard.h
+++ b/src/mumble/AudioWizard.h
@@ -8,8 +8,8 @@
 
 #include "ui_AudioWizard.h"
 
-#include "AudioOutput.h"
 #include "AudioInput.h"
+#include "AudioOutput.h"
 #include "AudioStats.h"
 #include "Settings.h"
 
@@ -18,7 +18,11 @@ private:
 	Q_OBJECT
 	Q_DISABLE_COPY(AudioWizard)
 
-	bool hasUsableEchoCancellation(AudioInputRegistrar *air, QString outputSys);
+	/// Which echo cancellation is usable depends on the audio backend and the device combination.
+	/// This function will iterate through the list of available echo cancellation in the audio backend and check with
+	/// the backend whether this echo cancellation option works for current device combination.
+	EchoCancelOptionID firstUsableEchoCancellation(AudioInputRegistrar *air, QString outputSys);
+
 protected:
 	QList< QVariant > pttButtons;
 	bool bTransmitChanged;

--- a/src/mumble/CMakeLists.txt
+++ b/src/mumble/CMakeLists.txt
@@ -129,6 +129,7 @@ set(MUMBLE_SOURCES
 	"Database.h"
 	"DeveloperConsole.cpp"
 	"DeveloperConsole.h"
+	"EchoCancelOption.h"
 	"Global.cpp"
 	"Global.h"
 	"GlobalShortcut.cpp"

--- a/src/mumble/CoreAudio.h
+++ b/src/mumble/CoreAudio.h
@@ -6,12 +6,11 @@
 #ifndef MUMBLE_MUMBLE_COREAUDIO_H_
 #	define MUMBLE_MUMBLE_COREAUDIO_H_
 
-#	include <AudioToolbox/AudioToolbox.h>
-
 #	include "AudioInput.h"
 #	include "AudioOutput.h"
+#	include <AudioToolbox/AudioToolbox.h>
 
-enum AUElement { OUTPUT = 0, INPUT = 1 };
+enum AUDirection { OUTPUT = 0, INPUT = 1 };
 
 class CoreAudioSystem : public QObject {
 private:
@@ -26,28 +25,28 @@ class CoreAudioInput : public AudioInput {
 private:
 	Q_OBJECT
 	Q_DISABLE_COPY(CoreAudioInput)
-	// Open HAL AU as input and pass back the output stream description.
+	/// Open HAL AU as input and pass back the output stream description.
 	bool openAUHAL(AudioStreamBasicDescription &streamDescription);
 
-	// Open VoiceProcessingIO AU as input, utilizing macOS's builtin echo cancellation,
-	// and pass back the output stream description.
+	/// Open VoiceProcessingIO AU as input, utilizing macOS's builtin echo cancellation,
+	/// and pass back the output stream description.
 	bool openAUVoip(AudioStreamBasicDescription &streamDescription);
 
-	// Initialize input AU with preferred parameters of Mumble
+	/// Initialize input AU with preferred parameters of Mumble
 	bool initializeInputAU(AudioUnit au, AudioStreamBasicDescription &streamDescription, int &actualBufferLength);
 
 protected:
-	// Hardware Abstraction Layer's AudioUnit, directly interacts with the hardware
-	AudioUnit auHAL {};
-	// VoiceProcessingIO AU, provides audio input and echo cancellation
-	AudioUnit auVoip {};
-	AudioDeviceID inputDevId {};
-	AudioDeviceID echoOutputDevId {};
-	AudioBufferList buflist {};
+	/// Hardware Abstraction Layer's AudioUnit, directly interacts with the hardware
+	AudioUnit auHAL{};
+	/// VoiceProcessingIO AU, provides audio input and echo cancellation
+	AudioUnit auVoip{};
+	AudioDeviceID inputDevId{};
+	AudioDeviceID echoOutputDevId{};
+	AudioBufferList buflist{};
 	static void propertyChange(void *udata, AudioUnit au, AudioUnitPropertyID prop, AudioUnitScope scope,
-	                           AudioUnitElement element);
+							   AudioUnitElement element);
 	static OSStatus inputCallback(void *udata, AudioUnitRenderActionFlags *flags, const AudioTimeStamp *ts,
-	                              UInt32 busnum, UInt32 npackets, AudioBufferList *buflist);
+								  UInt32 busnum, UInt32 npackets, AudioBufferList *buflist);
 
 public:
 	CoreAudioInput();
@@ -61,8 +60,8 @@ private:
 	Q_OBJECT
 	Q_DISABLE_COPY(CoreAudioOutput)
 protected:
-	// Hardware Abstraction Layer's AudioOutputUnit, directly interacts with the hardware
-	AudioUnit auHAL {};
+	/// Hardware Abstraction Layer's AudioOutputUnit, directly interacts with the hardware
+	AudioUnit auHAL{};
 	static void propertyChange(void *udata, AudioUnit au, AudioUnitPropertyID prop, AudioUnitScope scope,
 							   AudioUnitElement element);
 	static OSStatus outputCallback(void *udata, AudioUnitRenderActionFlags *flags, const AudioTimeStamp *ts,
@@ -81,7 +80,7 @@ public:
 	virtual AudioInput *create();
 	virtual const QList< audioDevice > getDeviceChoices();
 	virtual void setDeviceChoice(const QVariant &, Settings &);
-	virtual bool canEcho(int, const QString &) const;
+	virtual bool canEcho(EchoCancelOptionID echoCancelID, const QString &outputSystem) const;
 	virtual bool isMicrophoneAccessDeniedByOS();
 };
 
@@ -93,8 +92,6 @@ public:
 	virtual void setDeviceChoice(const QVariant &, Settings &);
 	bool canMuteOthers() const;
 };
-
-#define ECHO_CANCEL_APPLE 100
 
 #else
 class CoreAudioSystem;

--- a/src/mumble/CoreAudio.h
+++ b/src/mumble/CoreAudio.h
@@ -6,13 +6,10 @@
 #ifndef MUMBLE_MUMBLE_COREAUDIO_H_
 #	define MUMBLE_MUMBLE_COREAUDIO_H_
 
+#	include <AudioToolbox/AudioToolbox.h>
+
 #	include "AudioInput.h"
 #	include "AudioOutput.h"
-
-#	include <AudioToolbox/AudioToolbox.h>
-#	include <Carbon/Carbon.h>
-
-#	include "Global.h"
 
 class CoreAudioSystem : public QObject {
 private:
@@ -28,8 +25,15 @@ class CoreAudioInput : public AudioInput {
 private:
 	Q_OBJECT
 	Q_DISABLE_COPY(CoreAudioInput)
+	static bool getInputDeviceId(CFStringRef devUid, AudioDeviceID &devId);
+	static bool getDefaultInputDeviceId(CFStringRef devUid, AudioDeviceID &devId);
+	bool openAUHAL(AudioStreamBasicDescription &streamDescription);
+	bool initializeAUHAL(AudioStreamBasicDescription &streamDescription, int &actualBufferLength);
+
 protected:
-	AudioUnit au;
+	// Hardware Abstraction Layer's AudioOutputUnit, directly interacts with the hardware
+	AudioUnit auHAL;
+	AudioDeviceID devId;
 	AUEventListenerRef el;
 	AudioBufferList buflist;
 	static void propertyChange(void *udata, AudioUnit au, AudioUnitPropertyID prop, AudioUnitScope scope,
@@ -48,7 +52,8 @@ private:
 	Q_OBJECT
 	Q_DISABLE_COPY(CoreAudioOutput)
 protected:
-	AudioUnit au;
+	// Hardware Abstraction Layer's AudioOutputUnit, directly interacts with the hardware
+	AudioUnit auHAL;
 	AUEventListenerRef el;
 	static void propertyChange(void *udata, AudioUnit au, AudioUnitPropertyID prop, AudioUnitScope scope,
 							   AudioUnitElement element);
@@ -78,16 +83,6 @@ public:
 	virtual const QList< audioDevice > getDeviceChoices();
 	virtual void setDeviceChoice(const QVariant &, Settings &);
 	bool canMuteOthers() const;
-};
-
-class CoreAudioInit : public DeferInit {
-	CoreAudioInputRegistrar *cairReg;
-	CoreAudioOutputRegistrar *caorReg;
-
-public:
-	CoreAudioInit() : cairReg(nullptr), caorReg(nullptr) {}
-	void initialize();
-	void destroy();
 };
 
 #else

--- a/src/mumble/CoreAudio.h
+++ b/src/mumble/CoreAudio.h
@@ -11,13 +11,14 @@
 #	include "AudioInput.h"
 #	include "AudioOutput.h"
 
+enum AUElement { OUTPUT = 0, INPUT = 1 };
+
 class CoreAudioSystem : public QObject {
 private:
 	Q_OBJECT
 	Q_DISABLE_COPY(CoreAudioSystem)
 public:
-	static CFStringRef QStringToCFString(const QString &str);
-	static const QHash< QString, QString > getDevices(bool input);
+	static const QHash< QString, QString > getDevices(bool input, bool echo);
 	static const QList< audioDevice > getDeviceChoices(bool input);
 };
 
@@ -25,26 +26,34 @@ class CoreAudioInput : public AudioInput {
 private:
 	Q_OBJECT
 	Q_DISABLE_COPY(CoreAudioInput)
-	static bool getInputDeviceId(CFStringRef devUid, AudioDeviceID &devId);
-	static bool getDefaultInputDeviceId(CFStringRef devUid, AudioDeviceID &devId);
+	// Open HAL AU as input and pass back the output stream description.
 	bool openAUHAL(AudioStreamBasicDescription &streamDescription);
-	bool initializeAUHAL(AudioStreamBasicDescription &streamDescription, int &actualBufferLength);
+
+	// Open VoiceProcessingIO AU as input, utilizing macOS's builtin echo cancellation,
+	// and pass back the output stream description.
+	bool openAUVoip(AudioStreamBasicDescription &streamDescription);
+
+	// Initialize input AU with preferred parameters of Mumble
+	bool initializeInputAU(AudioUnit au, AudioStreamBasicDescription &streamDescription, int &actualBufferLength);
 
 protected:
-	// Hardware Abstraction Layer's AudioOutputUnit, directly interacts with the hardware
-	AudioUnit auHAL;
-	AudioDeviceID devId;
-	AUEventListenerRef el;
-	AudioBufferList buflist;
+	// Hardware Abstraction Layer's AudioUnit, directly interacts with the hardware
+	AudioUnit auHAL {};
+	// VoiceProcessingIO AU, provides audio input and echo cancellation
+	AudioUnit auVoip {};
+	AudioDeviceID inputDevId {};
+	AudioDeviceID echoOutputDevId {};
+	AudioBufferList buflist {};
 	static void propertyChange(void *udata, AudioUnit au, AudioUnitPropertyID prop, AudioUnitScope scope,
-							   AudioUnitElement element);
+	                           AudioUnitElement element);
 	static OSStatus inputCallback(void *udata, AudioUnitRenderActionFlags *flags, const AudioTimeStamp *ts,
-								  UInt32 busnum, UInt32 npackets, AudioBufferList *buflist);
+	                              UInt32 busnum, UInt32 npackets, AudioBufferList *buflist);
 
 public:
 	CoreAudioInput();
 	~CoreAudioInput() Q_DECL_OVERRIDE;
 	void run() Q_DECL_OVERRIDE;
+	void stop();
 };
 
 class CoreAudioOutput : public AudioOutput {
@@ -53,8 +62,7 @@ private:
 	Q_DISABLE_COPY(CoreAudioOutput)
 protected:
 	// Hardware Abstraction Layer's AudioOutputUnit, directly interacts with the hardware
-	AudioUnit auHAL;
-	AUEventListenerRef el;
+	AudioUnit auHAL {};
 	static void propertyChange(void *udata, AudioUnit au, AudioUnitPropertyID prop, AudioUnitScope scope,
 							   AudioUnitElement element);
 	static OSStatus outputCallback(void *udata, AudioUnitRenderActionFlags *flags, const AudioTimeStamp *ts,
@@ -64,15 +72,16 @@ public:
 	CoreAudioOutput();
 	~CoreAudioOutput() Q_DECL_OVERRIDE;
 	void run() Q_DECL_OVERRIDE;
+	void stop();
 };
 
-class CoreAudioInputRegistrar : public AudioInputRegistrar, public QObject {
+class CoreAudioInputRegistrar : public AudioInputRegistrar {
 public:
-	CoreAudioInputRegistrar() : AudioInputRegistrar(QLatin1String("CoreAudio"), 10) {}
+	CoreAudioInputRegistrar();
 	virtual AudioInput *create();
 	virtual const QList< audioDevice > getDeviceChoices();
 	virtual void setDeviceChoice(const QVariant &, Settings &);
-	virtual bool canEcho(const QString &) const;
+	virtual bool canEcho(int, const QString &) const;
 	virtual bool isMicrophoneAccessDeniedByOS();
 };
 
@@ -84,6 +93,8 @@ public:
 	virtual void setDeviceChoice(const QVariant &, Settings &);
 	bool canMuteOthers() const;
 };
+
+#define ECHO_CANCEL_APPLE 100
 
 #else
 class CoreAudioSystem;

--- a/src/mumble/CoreAudio.mm
+++ b/src/mumble/CoreAudio.mm
@@ -4,8 +4,12 @@
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.
 
 #include <AVFoundation/AVFoundation.h>
+#include <IOKit/audio/IOAudioTypes.h>
+#include <CoreAudio/AudioHardware.h>
 #include "MainWindow.h"
 
+#include <exception>
+#include <sstream>
 #include "CoreAudio.h"
 
 // We define a global macro called 'g'. This can lead to issues when included code uses 'g' as a type or parameter name
@@ -14,6 +18,370 @@
 
 // Ignore deprecation warnings for the whole file, for now.
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+
+
+namespace {
+extern "C" {
+// The dirty hack used to disable the "compulsory" ducking offered by VoiceProcessingAU.
+// A popular variant of this hack is `printf "p *(char*)(void(*)())AudioDeviceDuck=0xc3\nq" | lldb -n FaceTime`
+// See https://github.com/chromium/chromium/blob/6acb61fb1f335a720c51ed20acec5b3a4a19f308/media/audio/mac/audio_low_latency_input_mac.cc#L38
+// for reference.
+OSStatus AudioDeviceDuck(AudioDeviceID inDevice,
+		     Float32 inDuckedLevel,
+		     const AudioTimeStamp* __nullable inStartTime,
+		     Float32 inRampDuration) __attribute__((weak_import));
+}
+
+void UndoDucking(AudioDeviceID output_device_id) {
+    if (AudioDeviceDuck != nullptr) {
+	    // Ramp the volume back up over half a second.
+	    qDebug() << "CoreAudioInput: Undo Ducking caused by VoIP AU.";
+	    AudioDeviceDuck(output_device_id, 1.0, nullptr, 0.5);
+    }
+}
+}
+
+
+namespace core_audio_utils {
+
+class CoreAudioException : public std::exception {
+private:
+	QString msg_;
+public:
+	explicit CoreAudioException(const QString& msg) : msg_(msg) {}
+	~CoreAudioException() = default;
+
+	const char* what() const noexcept { return msg_.toUtf8().constData(); }
+	QString getMessage() const noexcept { return msg_; }
+};
+
+
+
+CFStringRef QStringToCFString(const QString &str) {
+	return CFStringCreateWithCharacters(kCFAllocatorDefault, reinterpret_cast< const UniChar * >(str.unicode()),
+	                                    str.length());
+}
+
+QString GetDeviceStringProperty(AudioObjectID device_id, AudioObjectPropertySelector property_selector) {
+	CFStringRef property_value = nullptr;
+	UInt32 size = sizeof(property_value);
+	AudioObjectPropertyAddress property_address = {
+		property_selector,
+		kAudioObjectPropertyScopeGlobal,
+		kAudioObjectPropertyElementMaster
+	};
+
+	OSStatus result = AudioObjectGetPropertyData(
+		device_id, &property_address, 0,
+		nullptr, &size, &property_value);
+	if (result != noErr) {
+		throw CoreAudioException(QString("Unable to get string property %1 of %2.").arg(property_selector, device_id));
+	}
+
+	char buf[4096];
+	CFStringGetCString(property_value, buf, 4096, kCFStringEncodingUTF8);
+	return QString::fromUtf8(buf);
+}
+
+UInt32 GetDeviceUint32Property(AudioObjectID device_id, AudioObjectPropertySelector property_selector, AudioObjectPropertyScope property_scope) {
+    AudioObjectPropertyAddress property_address = {
+	    property_selector,
+	    property_scope,
+	    kAudioObjectPropertyElementMaster};
+    UInt32 property_value;
+    UInt32 size = sizeof(property_value);
+    OSStatus result = AudioObjectGetPropertyData(device_id, &property_address, 0, nullptr, &size, &property_value);
+    if (result != noErr) {
+	    throw CoreAudioException(QString("Unable to get uint32 property %1 of %2.").arg(property_selector, device_id));
+    }
+
+    return property_value;
+}
+
+UInt32 GetDevicePropertySize(AudioObjectID device_id, AudioObjectPropertySelector property_selector, AudioObjectPropertyScope property_scope) {
+    AudioObjectPropertyAddress property_address = {
+	    property_selector,
+	    property_scope,
+	    kAudioObjectPropertyElementMaster};
+    UInt32 size = 0;
+    OSStatus result = AudioObjectGetPropertyDataSize(device_id, &property_address, 0, nullptr, &size);
+    if (result != noErr) {
+	    throw CoreAudioException(QString("Unable to get property size of %1 of %2.").arg(property_selector, device_id));
+    }
+    return size;
+}
+
+QVector<AudioObjectID> GetAudioObjectIDs(AudioObjectID audio_object_id, AudioObjectPropertySelector property_selector) {
+	AudioObjectPropertyAddress property_address = {
+		property_selector,
+		kAudioObjectPropertyScopeGlobal,
+		kAudioObjectPropertyElementMaster
+	};
+
+	UInt32 size = GetDevicePropertySize(audio_object_id, property_selector, kAudioObjectPropertyScopeGlobal);
+
+	if (size == 0)
+		return {};
+
+	int device_count = size / sizeof(AudioObjectID);
+
+	QVector<AudioObjectID> device_ids(device_count);
+	OSStatus result = AudioObjectGetPropertyData(audio_object_id, &property_address, 0,
+	                                             nullptr , &size, device_ids.data());
+	if (result != noErr) {
+		throw CoreAudioException(QString("Unable to get object ids from %1.").arg(audio_object_id));
+		return {};
+	}
+
+	return device_ids;
+}
+
+AudioBufferList* GetDeviceStreamConfiguration(AudioObjectID device_id, AUElement type) {
+	AudioBufferList *bufs = nullptr;
+	OSStatus err;
+	auto scope = (type == AUElement::INPUT) ? kAudioDevicePropertyScopeInput : kAudioDevicePropertyScopeOutput;
+	unsigned int len = GetDevicePropertySize(
+		device_id,
+		kAudioDevicePropertyStreamConfiguration,
+		scope);
+
+	AudioObjectPropertyAddress propertyAddress = { kAudioHardwarePropertyDevices, scope,
+	                                               kAudioObjectPropertyElementMaster };
+
+	bufs                      = reinterpret_cast< AudioBufferList * >(malloc(len));
+	propertyAddress.mSelector = kAudioDevicePropertyStreamConfiguration;
+	err = AudioObjectGetPropertyData(device_id, &propertyAddress, 0, nullptr, &len, bufs);
+	if (!bufs || err != noErr) {
+		free(bufs);
+		throw CoreAudioException(QString("Failed to get AudioStreamConfiguration from device %1.").arg(device_id));
+	}
+
+	return bufs;
+}
+
+AudioDeviceID GetDeviceID(const QString& devUid, AUElement type) {
+	OSStatus err;
+	UInt32 len;
+	CFStringRef csDevUid = QStringToCFString(devUid);
+	AudioDeviceID devId;
+
+	// Struct used to query information of the system audio setup
+	AudioObjectPropertyAddress propertyAddress = {
+		.mSelector = 0, // this attribute will be specified later
+		.mScope = (type == AUElement::INPUT) ? kAudioDevicePropertyScopeInput : kAudioDevicePropertyScopeOutput,
+		.mElement = kAudioObjectPropertyElementMaster
+	};
+
+	AudioValueTranslation avt;
+	avt.mInputData      = const_cast< struct __CFString ** >(&csDevUid);
+	avt.mInputDataSize  = sizeof(CFStringRef *);
+	avt.mOutputData     = &devId;
+	avt.mOutputDataSize = sizeof(AudioDeviceID);
+
+	len                       = sizeof(AudioValueTranslation);
+	propertyAddress.mSelector = kAudioHardwarePropertyDeviceForUID;
+	err = AudioObjectGetPropertyData(kAudioObjectSystemObject, &propertyAddress, 0, nullptr, &len, &avt);
+	if (err != noErr) {
+		throw CoreAudioException(QString("Unable to query AudioDeviceID of %1.").arg(devUid));
+	}
+
+	return devId;
+}
+
+AudioDeviceID GetDefaultDeviceID(AUElement type) {
+	OSStatus err;
+	UInt32 len;
+	AudioDeviceID devId;
+
+	// Struct used to query information of the system audio setup
+	AudioObjectPropertyAddress propertyAddress = {
+		.mSelector = 0, // this attribute will be specified later
+		.mScope = (type == AUElement::INPUT) ? kAudioDevicePropertyScopeInput : kAudioDevicePropertyScopeOutput,
+		.mElement = kAudioObjectPropertyElementMaster
+	};
+
+	len                       = sizeof(AudioDeviceID);
+	propertyAddress.mSelector = (type == AUElement::INPUT) ? kAudioHardwarePropertyDefaultInputDevice : kAudioHardwarePropertyDefaultOutputDevice;
+	err = AudioObjectGetPropertyData(kAudioObjectSystemObject, &propertyAddress, 0, nullptr, &len, &devId);
+	if (err != noErr) {
+		throw CoreAudioException("Unable to query for default AudioDeviceID.");
+	}
+
+    return devId;
+}
+
+UInt32 GetDeviceTransportType(AudioObjectID devId){
+	return core_audio_utils::GetDeviceUint32Property(devId,
+	                                                 kAudioDevicePropertyTransportType,
+	                                                 kAudioObjectPropertyScopeGlobal);
+}
+
+bool IsInputDevice(AudioObjectID device_id) {
+	// This part of the code is modified from Chromium. Original comments are kept.
+	// See https://github.com/chromium/chromium/blob/6acb61fb1f335a720c51ed20acec5b3a4a19f308/media/audio/mac/core_audio_util_mac.cc
+	// for reference.
+	QVector<AudioObjectID> streams = GetAudioObjectIDs(device_id, kAudioDevicePropertyStreams);
+
+	int num_undefined_input_streams = 0;
+	int num_defined_input_streams = 0;
+	int num_output_streams = 0;
+
+	for (auto stream_id : streams) {
+		auto direction = GetDeviceUint32Property(stream_id, kAudioStreamPropertyDirection,
+		                                         kAudioObjectPropertyScopeGlobal);
+		const UInt32 kDirectionOutput = 0;
+		const UInt32 kDirectionInput = 1;
+		if (direction == kDirectionOutput) {
+			++num_output_streams;
+		} else if (direction == kDirectionInput) {
+			// Filter input streams based on what terminal it claims to be attached
+			// to. Note that INPUT_UNDEFINED comes from a set of terminals declared
+			// in IOKit. CoreAudio defines a number of terminals in
+			// AudioHardwareBase.h but none of them match any of the values I've
+			// seen used in practice, though I've only tested a few devices.
+			auto terminal = GetDeviceUint32Property(stream_id, kAudioStreamPropertyTerminalType,
+			                                        kAudioObjectPropertyScopeGlobal);
+			if (terminal == INPUT_UNDEFINED) {
+				++num_undefined_input_streams;
+			} else {
+				++num_defined_input_streams;
+			}
+		}
+	}
+
+	// I've only seen INPUT_UNDEFINED introduced by the VoiceProcessing AudioUnit,
+	// but to err on the side of caution, let's allow a device with only undefined
+	// input streams and no output streams as well.
+	return num_defined_input_streams > 0 ||
+	       (num_undefined_input_streams > 0 && num_output_streams == 0);
+}
+
+
+#ifdef DEBUG
+
+static void LogStreamDescription(AudioStreamBasicDescription format) {
+    std::stringstream ss;
+    unsigned char formatID[5];
+    *(UInt32 *) formatID = OSSwapHostToBigInt32(format.mFormatID);
+    formatID[4] = '\0';
+
+    // General description
+    ss << format.mChannelsPerFrame << " ch, " << format.mSampleRate << " Hz, '" << formatID << "' (0x"
+       << std::hex << std::setw(8) << std::setfill('0') << format.mFormatFlags << std::dec << ") ";
+
+    if (kAudioFormatLinearPCM == format.mFormatID) {
+	    // Bit depth
+	    UInt32 fractionalBits =
+		    ((0x3f << 7)/*kLinearPCMFormatFlagsSampleFractionMask*/ & format.mFormatFlags)
+			    >> 7/*kLinearPCMFormatFlagsSampleFractionShift*/;
+	    if (0 < fractionalBits)
+		    ss << (format.mBitsPerChannel - fractionalBits) << "." << fractionalBits;
+	    else
+		    ss << format.mBitsPerChannel;
+
+	    ss << "-bit";
+
+	    // Endianness
+	    bool isInterleaved = !(kAudioFormatFlagIsNonInterleaved & format.mFormatFlags);
+	    UInt32 interleavedChannelCount = (isInterleaved ? format.mChannelsPerFrame : 1);
+	    UInt32 sampleSize = (0 < format.mBytesPerFrame && 0 < interleavedChannelCount ?
+				 format.mBytesPerFrame / interleavedChannelCount : 0);
+	    if (1 < sampleSize)
+		    ss << ((kLinearPCMFormatFlagIsBigEndian & format.mFormatFlags) ? " big-endian"
+										   : " little-endian");
+
+	    // Sign
+	    bool isInteger = !(kLinearPCMFormatFlagIsFloat & format.mFormatFlags);
+	    if (isInteger)
+		    ss << ((kLinearPCMFormatFlagIsSignedInteger & format.mFormatFlags) ? " signed"
+										       : " unsigned");
+
+	    // Integer or floating
+	    ss << (isInteger ? " integer" : " float");
+
+	    // Packedness
+	    if (0 < sampleSize && ((sampleSize << 3) != format.mBitsPerChannel))
+		    ss << ((kLinearPCMFormatFlagIsPacked & format.mFormatFlags) ? ", packed in "
+										: ", unpacked in ")
+		       << sampleSize << " bytes";
+
+	    // Alignment
+	    if ((0 < sampleSize && ((sampleSize << 3) != format.mBitsPerChannel)) ||
+		(0 != (format.mBitsPerChannel & 7)))
+		    ss << ((kLinearPCMFormatFlagIsAlignedHigh & format.mFormatFlags) ? " high-aligned"
+										     : " low-aligned");
+
+	    if (!isInterleaved)
+		    ss << ", deinterleaved";
+    } else if (kAudioFormatAppleLossless == format.mFormatID) {
+	    UInt32 sourceBitDepth = 0;
+	    switch (format.mFormatFlags) {
+		    case kAppleLosslessFormatFlag_16BitSourceData:
+			    sourceBitDepth = 16;
+			    break;
+		    case kAppleLosslessFormatFlag_20BitSourceData:
+			    sourceBitDepth = 20;
+			    break;
+		    case kAppleLosslessFormatFlag_24BitSourceData:
+			    sourceBitDepth = 24;
+			    break;
+		    case kAppleLosslessFormatFlag_32BitSourceData:
+			    sourceBitDepth = 32;
+			    break;
+	    }
+
+	    if (0 != sourceBitDepth)
+		    ss << "from " << sourceBitDepth << "-bit source, ";
+	    else
+		    ss << "from UNKNOWN source bit depth, ";
+
+	    ss << format.mFramesPerPacket << " frames/packet";
+    } else
+	    ss << format.mBitsPerChannel << " bits/channel, " << format.mBytesPerPacket << " bytes/packet, "
+	       << format.mFramesPerPacket << " frames/packet, " << format.mBytesPerFrame << " bytes/frame";
+
+    qDebug("CoreAudioStreamDescription: %s", ss.str().c_str());
+}
+
+static void LogAUStreamDescription(AudioUnit au) {
+    AudioStreamBasicDescription description;
+    UInt32 len = sizeof(AudioStreamBasicDescription);
+    OSStatus err;
+    err = AudioUnitGetProperty(au, kAudioUnitProperty_StreamFormat, kAudioUnitScope_Input, 1, &description,
+			       &len);
+    if (err == noErr) {
+	    LogStreamDescription(description);
+    }
+}
+
+#endif
+};
+
+#define CHECK_RETURN_FALSE(statement, warning_msg) \
+{ \
+	OSStatus _err = statement; \
+	if (_err != noErr) { \
+		qWarning(warning_msg); \
+		return false; \
+	} \
+} \
+
+#define CHECK_RETURN(statement, warning_msg) \
+{ \
+	OSStatus _err = statement; \
+	if (_err != noErr) { \
+		qWarning(warning_msg); \
+		return; \
+	} \
+} \
+
+#define CHECK_WARN(statement, warning_msg) \
+{ \
+	OSStatus _err = statement; \
+	if (_err != noErr) { \
+		qWarning(warning_msg); \
+	} \
+} \
 
 class CoreAudioInit : public DeferInit {
 	CoreAudioInputRegistrar *cairReg;
@@ -24,7 +392,6 @@ public:
 	void initialize();
 	void destroy();
 };
-
 
 static CoreAudioInit cainit;
 
@@ -38,17 +405,13 @@ void CoreAudioInit::destroy() {
 	delete caorReg;
 }
 
-CFStringRef CoreAudioSystem::QStringToCFString(const QString &str) {
-	return CFStringCreateWithCharacters(kCFAllocatorDefault, reinterpret_cast< const UniChar * >(str.unicode()),
-										str.length());
-}
-
 const QList< audioDevice > CoreAudioSystem::getDeviceChoices(bool input) {
-	QHash< QString, QString > qhDevices = CoreAudioSystem::getDevices(input);
+	bool doEcho = (g.s.iEchoOption == ECHO_CANCEL_APPLE || g.s.iEchoOption == ECHO_CANCEL_DEFAULT);
+	QHash< QString, QString > qhDevices = CoreAudioSystem::getDevices(input, doEcho);
 	QList< audioDevice > qlReturn;
 	QStringList qlDevices;
 
-	qhDevices.insert(QString(), tr("Default Device"));
+	qhDevices.insert(QString(), QObject::tr("Default Device"));
 	qlDevices = qhDevices.keys();
 
 	const QString &qsDev = input ? g.s.qsCoreAudioInput : g.s.qsCoreAudioOutput;
@@ -64,89 +427,43 @@ const QList< audioDevice > CoreAudioSystem::getDeviceChoices(bool input) {
 	return qlReturn;
 }
 
-const QHash< QString, QString > CoreAudioSystem::getDevices(bool input) {
+const QHash< QString, QString > CoreAudioSystem::getDevices(bool input, bool echo) {
 	QHash< QString, QString > qhReturn;
-	UInt32 len, ndevs;
-	OSStatus err;
+	try {
+		auto devs = core_audio_utils::GetAudioObjectIDs(kAudioObjectSystemObject,
+		                                                kAudioHardwarePropertyDevices);
 
-	AudioObjectPropertyAddress propertyAddress = { kAudioHardwarePropertyDevices, kAudioObjectPropertyScopeGlobal,
-												   kAudioObjectPropertyElementMaster };
+		for (int i = 0; i < devs.count(); i++) {
 
-	err = AudioObjectGetPropertyDataSize(kAudioObjectSystemObject, &propertyAddress, 0, nullptr, &len);
-	if (err != noErr)
-		return qhReturn;
+			// Mac's native echo cancellation doesn't support aggregate device
+			// since it will create aggregate devices itself.
+			if (echo && core_audio_utils::GetDeviceTransportType(devs[i]) == kAudioDeviceTransportTypeAggregate) {
+				continue;
+			}
 
-	ndevs = len / sizeof(AudioDeviceID);
-	AudioDeviceID devs[ndevs];
+			bool isInput = core_audio_utils::IsInputDevice(devs[i]);
 
-	err = AudioObjectGetPropertyData(kAudioObjectSystemObject, &propertyAddress, 0, nullptr, &len, devs);
-	if (err != noErr)
-		return qhReturn;
+			if (isInput != input) continue;
 
-	propertyAddress.mScope = input ? kAudioDevicePropertyScopeInput : kAudioDevicePropertyScopeOutput;
+			QString qsDeviceName = core_audio_utils::GetDeviceStringProperty(devs[i], kAudioDevicePropertyDeviceNameCFString);
+			QString qsDeviceIdentifier = core_audio_utils::GetDeviceStringProperty(devs[i], kAudioDevicePropertyDeviceUID);
 
-	for (UInt32 i = 0; i < ndevs; i++) {
-		QString qsDeviceName;
-		QString qsDeviceIdentifier;
-		char buf[4096];
-
-		/* Get number of channels, to determine whether we're an input or an output... */
-		AudioBufferList *bufs     = nullptr;
-		propertyAddress.mSelector = kAudioDevicePropertyStreamConfiguration;
-		err                       = AudioObjectGetPropertyDataSize(devs[i], &propertyAddress, 0, nullptr, &len);
-		if (err != noErr) {
-			qWarning("CoreAudioSystem: Failed to get length of AudioStreamConfiguration. Unable to allocate.");
-			continue;
+			qhReturn.insert(qsDeviceIdentifier, qsDeviceName);
 		}
-
-		bufs                      = reinterpret_cast< AudioBufferList * >(malloc(len));
-		propertyAddress.mSelector = kAudioDevicePropertyStreamConfiguration;
-		err                       = AudioObjectGetPropertyData(devs[i], &propertyAddress, 0, nullptr, &len, bufs);
-		if (!bufs || err != noErr) {
-			qWarning("CoreAudioSystem: Failed to get AudioStreamConfiguration from device.");
-			free(bufs);
-			continue;
-		}
-
-		UInt32 channels = 0;
-		for (UInt32 j = 0; j < bufs->mNumberBuffers; j++) {
-			channels += bufs->mBuffers[j].mNumberChannels;
-		}
-
-		free(bufs);
-
-		if (!channels)
-			continue;
-
-		/* Get device name. */
-		len                       = sizeof(CFStringRef);
-		CFStringRef devName       = nullptr;
-		propertyAddress.mSelector = kAudioDevicePropertyDeviceNameCFString;
-		err                       = AudioObjectGetPropertyData(devs[i], &propertyAddress, 0, nullptr, &len, &devName);
-		if (!devName || err != noErr) {
-			qWarning("CoreAudioSystem: Failed to get device name. Skipping device.");
-		}
-		CFStringGetCString(devName, buf, 4096, kCFStringEncodingUTF8);
-		qsDeviceName = QString::fromUtf8(buf);
-		CFRelease(devName);
-
-		/* Device UID. */
-		CFStringRef devUid        = nullptr;
-		propertyAddress.mSelector = kAudioDevicePropertyDeviceUID;
-		err                       = AudioObjectGetPropertyData(devs[i], &propertyAddress, 0, nullptr, &len, &devUid);
-		if (!devUid || err != noErr) {
-			qWarning("CoreAudioSystem: Failed to get device UID. Skipping device.");
-		}
-		CFStringGetCString(devUid, buf, 4096, kCFStringEncodingUTF8);
-		qsDeviceIdentifier = QString::fromUtf8(buf);
-		CFRelease(devUid);
-
-		qhReturn.insert(qsDeviceIdentifier, qsDeviceName);
+	} catch (core_audio_utils::CoreAudioException& e) {
+		qWarning() << "CoreAudioSystem: " << e.what();
 	}
 
 	return qhReturn;
 }
 
+CoreAudioInputRegistrar::CoreAudioInputRegistrar() : AudioInputRegistrar(QLatin1String("CoreAudio"), 10) {
+	echoOptions.append(EchoCancellationOption(
+		ECHO_CANCEL_APPLE,
+		QObject::tr("Acoustic echo cancellation provided by Apple"),
+		QObject::tr("This option works best when using built-in microphone and speaker.")
+	));
+}
 
 AudioInput *CoreAudioInputRegistrar::create() {
 	if (!isMicrophoneAccessDeniedByOS()) {
@@ -164,10 +481,11 @@ void CoreAudioInputRegistrar::setDeviceChoice(const QVariant &choice, Settings &
 	s.qsCoreAudioInput = choice.toString();
 }
 
-bool CoreAudioInputRegistrar::canEcho(const QString &outputsys) const {
-	Q_UNUSED(outputsys);
-
-	return true;
+bool CoreAudioInputRegistrar::canEcho(int echoOption, const QString &) const {
+	if (@available(macOS 10.14, *)) {
+		if (echoOption == ECHO_CANCEL_APPLE || echoOption == ECHO_CANCEL_DEFAULT) return true;
+	}
+	return false;
 }
 
 bool CoreAudioInputRegistrar::isMicrophoneAccessDeniedByOS() {
@@ -200,16 +518,16 @@ bool CoreAudioInputRegistrar::isMicrophoneAccessDeniedByOS() {
 			case AVAuthorizationStatusDenied: {
 				// The user has previously denied access.
 				qWarning("CoreAudioInput: Microphone access has been previously denied by user.");
-				g.mw->msgBox(tr("Access to the microphone was denied. Please allow Mumble to use the microphone "
-								"by changing the settings in System Preferences -> Security & Privacy -> Privacy -> "
-								"Microphone."));
+				g.mw->msgBox(QObject::tr("Access to the microphone was denied. Please allow Mumble to use the microphone "
+				                         "by changing the settings in System Preferences -> Security & Privacy -> Privacy -> "
+				                         "Microphone."));
 				return true;
 			}
 			case AVAuthorizationStatusRestricted: {
 				// The user can't grant access due to restrictions.
 				qWarning("CoreAudioInput: Microphone access denied due to system restrictions.");
-				g.mw->msgBox(tr("Access to the microphone was denied due to system restrictions. You will not be able"
-								"to use the microphone in this session."));
+				g.mw->msgBox(QObject::tr("Access to the microphone was denied due to system restrictions. You will not be able"
+				                         "to use the microphone in this session."));
 				return true;
 			}
 			default: {
@@ -220,7 +538,6 @@ bool CoreAudioInputRegistrar::isMicrophoneAccessDeniedByOS() {
 		return false;
 	}
 }
-
 
 AudioOutput *CoreAudioOutputRegistrar::create() {
 	return new CoreAudioOutput();
@@ -241,66 +558,7 @@ bool CoreAudioOutputRegistrar::canMuteOthers() const {
 CoreAudioInput::CoreAudioInput() {
 }
 
- bool CoreAudioInput::getInputDeviceId(CFStringRef devUid, AudioDeviceID &devId) {
-	OSStatus err;
-	UInt32 len;
-
-	// Struct used to query information of the system audio setup
-	AudioObjectPropertyAddress propertyAddress = {
-			.mSelector = 0, // this attribute will be specified later
-			.mScope = kAudioDevicePropertyScopeInput,
-			.mElement = kAudioObjectPropertyElementMaster
-	};
-
-	AudioValueTranslation avt;
-	avt.mInputData      = const_cast< struct __CFString ** >(&devUid);
-	avt.mInputDataSize  = sizeof(CFStringRef *);
-	avt.mOutputData     = &devId;
-	avt.mOutputDataSize = sizeof(AudioDeviceID);
-
-	len                       = sizeof(AudioValueTranslation);
-	propertyAddress.mSelector = kAudioHardwarePropertyDeviceForUID;
-	err = AudioObjectGetPropertyData(kAudioObjectSystemObject, &propertyAddress, 0, nullptr, &len, &avt);
-	if (err != noErr) {
-		qWarning("CoreAudioInput: Unable to query for AudioDeviceID.");
-		return false;
-	}
-
-	return true;
-}
-
-bool CoreAudioInput::getDefaultInputDeviceId(CFStringRef devUid, AudioDeviceID &devId) {
-	OSStatus err;
-	UInt32 len;
-
-	// Struct used to query information of the system audio setup
-	AudioObjectPropertyAddress propertyAddress = {
-			.mSelector = 0, // this attribute will be specified later
-			.mScope = kAudioDevicePropertyScopeInput,
-			.mElement = kAudioObjectPropertyElementMaster
-	};
-
-	len                       = sizeof(AudioDeviceID);
-	propertyAddress.mSelector = kAudioHardwarePropertyDefaultInputDevice;
-	err = AudioObjectGetPropertyData(kAudioObjectSystemObject, &propertyAddress, 0, nullptr, &len, &devId);
-	if (err != noErr) {
-		qWarning("CoreAudioInput: Unable to query for default input AudioDeviceID.");
-		return false;
-	}
-
-	len                       = sizeof(CFStringRef);
-	propertyAddress.mSelector = kAudioDevicePropertyDeviceUID;
-	err                       = AudioObjectGetPropertyData(devId, &propertyAddress, 0, nullptr, &len, &devUid);
-	if (err != noErr) {
-		qWarning("CoreAudioInput: Unable to get default device UID.");
-		return false;
-	}
-
-	return true;
-}
-
 bool CoreAudioInput::openAUHAL(AudioStreamBasicDescription &streamDescription){
-	OSStatus err;
 	Component comp;
 	ComponentDescription desc;
 	UInt32 val, len;
@@ -311,143 +569,192 @@ bool CoreAudioInput::openAUHAL(AudioStreamBasicDescription &streamDescription){
 	desc.componentFlags        = 0;
 	desc.componentFlagsMask    = 0;
 
+	qDebug("CoreAudioInput: Use AUHAL as IO AudioUnit.");
+
 	comp = FindNextComponent(nullptr, &desc);
 	if (!comp) {
 		qWarning("CoreAudioInput: Unable to find AUHAL.");
 		return false;
 	}
 
-	err = OpenAComponent(comp, &auHAL);
-	if (err != noErr) {
-		qWarning("CoreAudioInput: Unable to open AUHAL component.");
-		return false;
-	}
-
-	err = AudioUnitInitialize(auHAL);
-	if (err != noErr) {
-		qWarning("CoreAudioInput: Unable to initialize AUHAL.");
-		return false;
-	}
+	CHECK_RETURN_FALSE(OpenAComponent(comp, &auHAL), "CoreAudioInput: Unable to open AUHAL component.");
 
 	val = 1;
-	err = AudioUnitSetProperty(auHAL, kAudioOutputUnitProperty_EnableIO, kAudioUnitScope_Input, 1, &val, sizeof(UInt32));
-	if (err != noErr) {
-		qWarning("CoreAudioInput: Unable to configure input scope on AUHAL.");
-		return false;
-	}
+	CHECK_RETURN_FALSE(AudioUnitSetProperty(auHAL, kAudioOutputUnitProperty_EnableIO, kAudioUnitScope_Input,
+	                                        AUElement::INPUT, &val, sizeof(UInt32)),
+	                   "CoreAudioInput: Unable to configure input scope on AUHAL.");
 
 	val = 0;
-	err = AudioUnitSetProperty(auHAL, kAudioOutputUnitProperty_EnableIO, kAudioUnitScope_Output, 0, &val, sizeof(UInt32));
-	if (err != noErr) {
-		qWarning("CoreAudioInput: Unable to configure output scope on AUHAL.");
-		return false;
-	}
+	CHECK_RETURN_FALSE(AudioUnitSetProperty(auHAL, kAudioOutputUnitProperty_EnableIO, kAudioUnitScope_Output,
+	                                        AUElement::OUTPUT, &val, sizeof(UInt32)),
+	                   "CoreAudioInput: Unable to configure output scope on AUHAL.");
 
 	len = sizeof(AudioDeviceID);
-	err = AudioUnitSetProperty(auHAL, kAudioOutputUnitProperty_CurrentDevice, kAudioUnitScope_Global, 0, &devId, len);
-	if (err != noErr) {
-		qWarning("CoreAudioInput: Unable to set device of AUHAL.");
-		return false;
-	}
+	CHECK_RETURN_FALSE(AudioUnitSetProperty(auHAL, kAudioOutputUnitProperty_CurrentDevice, kAudioUnitScope_Global,
+	                                        AUElement::OUTPUT, &inputDevId, len),
+	                   "CoreAudioInput: Unable to set device of AUHAL.");
 
 	len = sizeof(AudioStreamBasicDescription);
-	err = AudioUnitGetProperty(auHAL, kAudioUnitProperty_StreamFormat, kAudioUnitScope_Input, 1, &streamDescription, &len);
-	if (err != noErr) {
-		qWarning("CoreAudioInput: Unable to query device for stream info.");
-		return false;
-	}
+	CHECK_RETURN_FALSE(AudioUnitGetProperty(auHAL, kAudioUnitProperty_StreamFormat, kAudioUnitScope_Input,
+	                                        AUElement::INPUT, &streamDescription, &len),
+	                   "CoreAudioInput: Unable to query device for stream info.");
 
 	return true;
 }
 
-bool CoreAudioInput::initializeAUHAL(AudioStreamBasicDescription &streamDescription, int &actualBufferLength) {
+bool CoreAudioInput::openAUVoip(AudioStreamBasicDescription &streamDescription) {
+	// Initialize VoiceProcessingIO AU, utilizing macOS's builtin echo cancellation.
+	// This AU is poorly documented by Apple. See Chromium's code for more information:
+	// https://github.com/chromium/chromium/blob/master/media/audio/mac/audio_low_latency_input_mac.cc
+	if(@available(macOS 10.12, *)) {
+		UInt32 len, val;
+		AudioComponentDescription desc = {
+				.componentType = kAudioUnitType_Output,
+				.componentSubType = kAudioUnitSubType_VoiceProcessingIO,
+				.componentManufacturer = kAudioUnitManufacturer_Apple,
+				.componentFlags = 0,
+				.componentFlagsMask = 0
+		};
+
+		qDebug("CoreAudioInput: Use VoiceProcessingIO as IO AudioUnit.");
+
+		AudioComponent inputComponent = AudioComponentFindNext(nullptr, &desc);
+
+		CHECK_RETURN_FALSE(AudioComponentInstanceNew(inputComponent, &auVoip),
+		                   "CoreAudioInput: Unable to create VoiceProcessingIO AudioUnit.");
+
+		try {
+			if (core_audio_utils::GetDeviceTransportType(inputDevId) == kAudioDeviceTransportTypeAggregate) {
+				qWarning("CoreAudioInput: Aggregated devices are not supported by VoiceProcessingIO AudioUnit.");
+				return false;
+			}
+		} catch (core_audio_utils::CoreAudioException& e) {
+			qWarning() << "CoreAudioInput: " << e.what();
+			return false;
+		}
+
+		len = sizeof(AudioDeviceID);
+		CHECK_RETURN_FALSE(AudioUnitSetProperty(auVoip, kAudioOutputUnitProperty_CurrentDevice, kAudioUnitScope_Global,
+		                                        AUElement::INPUT, &inputDevId, len),
+		                   "CoreAudioInput: Unable to set device of VoiceProcessingIO AudioUnit.");
+
+		// It is reported that the echo source need to be specified as the output device.
+		// If no output device is specified, MacOS would take the default output device as echo source.
+		CHECK_RETURN_FALSE(AudioUnitSetProperty(auVoip, kAudioOutputUnitProperty_CurrentDevice, kAudioUnitScope_Global,
+		                                        AUElement::OUTPUT, &echoOutputDevId, len),
+		                   "CoreAudioInput: Unable to set device of VoiceProcessingIO AudioUnit.");
+
+
+		len = sizeof(AudioStreamBasicDescription);
+		CHECK_RETURN_FALSE(AudioUnitGetProperty(auVoip, kAudioUnitProperty_StreamFormat, kAudioUnitScope_Input,
+		                                        AUElement::INPUT, &streamDescription, &len),
+		                   "CoreAudioInput: Unable to query device for stream info from VoiceProcessingIO AudioUnit.");
+
+#ifdef DEBUG
+		qDebug("CoreAudioInput: VOIP Input stream description:");
+		core_audio_utils::LogAUStreamDescription(auVoip);
+#endif
+
+		// Mute the VoiceProcessing AU (Value 0 stands for "mute")
+		// VoiceProcessing AU is a output node and has the ability of playing things out. We simply don't want that.
+		val = 0;
+		len = sizeof(val);
+		AudioUnitSetProperty(auVoip, kAUVoiceIOProperty_MuteOutput, kAudioUnitScope_Global, 1, &val, len);
+
+		return true;
+	} else {
+		return false;
+	}
+}
+
+
+
+bool CoreAudioInput::initializeInputAU(AudioUnit au, AudioStreamBasicDescription &streamDescription, int &actualBufferLength) {
 	OSStatus err;
 	UInt32 len, val;
 
 	len = sizeof(AudioStreamBasicDescription);
-	err = AudioUnitSetProperty(auHAL, kAudioUnitProperty_StreamFormat, kAudioUnitScope_Output, 1, &streamDescription, len);
-	if (err != noErr) {
-		qWarning("CoreAudioInput: Unable to set stream format for AUHAL.");
-		return false;
-	}
+	CHECK_RETURN_FALSE(AudioUnitSetProperty(au, kAudioUnitProperty_StreamFormat, kAudioUnitScope_Output,
+	                                        AUElement::INPUT, &streamDescription, len),
+	                   "CoreAudioInput: Unable to set stream format for Input AU - 1.")
 
-	err = AudioUnitAddPropertyListener(auHAL, kAudioUnitProperty_StreamFormat, CoreAudioInput::propertyChange, this);
-	if (err != noErr) {
-		qWarning("CoreAudioInput: Unable to create input property change listener for AUHAL. Unable to listen to property change "
-				 "events.");
-	}
-
-	AURenderCallbackStruct cb;
-	cb.inputProc       = CoreAudioInput::inputCallback;
-	cb.inputProcRefCon = this;
-	len                = sizeof(AURenderCallbackStruct);
-	err = AudioUnitSetProperty(auHAL, kAudioOutputUnitProperty_SetInputCallback, kAudioUnitScope_Global, 0, &cb, len);
-	if (err != noErr) {
-		qWarning("CoreAudioInput: Unable to setup input callback for AUHAL.");
-		return false;
-	}
+	CHECK_RETURN_FALSE(AudioUnitSetProperty(au, kAudioUnitProperty_StreamFormat, kAudioUnitScope_Input,
+	                                        AUElement::OUTPUT, &streamDescription, len),
+	                   "CoreAudioInput: Unable to set stream format for Input AU - 2.");
+#ifdef DEBUG
+	qDebug("CoreAudioInput: Input stream description:");
+	core_audio_utils::LogAUStreamDescription(au);
+#endif
 
 	// Struct used to query information of the system audio setup
 	AudioObjectPropertyAddress propertyAddress = {
-			.mSelector = 0, // this attribute will be specified later
-			.mScope = kAudioDevicePropertyScopeInput,
-			.mElement = kAudioObjectPropertyElementMaster
+		.mSelector = 0, // this attribute will be specified later
+		.mScope = kAudioDevicePropertyScopeInput,
+		.mElement = kAudioObjectPropertyElementMaster
 	};
 
 	AudioValueRange range;
 	len                       = sizeof(AudioValueRange);
 	propertyAddress.mSelector = kAudioDevicePropertyBufferFrameSizeRange;
-	err                       = AudioObjectGetPropertyData(devId, &propertyAddress, 0, nullptr, &len, &range);
-	if (err != noErr) {
-		qWarning("CoreAudioInput: Unable to query for allowed buffer size ranges of AUHAL.");
-	} else {
-		qWarning("CoreAudioInput: AUHAL's BufferFrameSizeRange = (%.2f, %.2f)", range.mMinimum, range.mMaximum);
-	}
+	CHECK_WARN(AudioObjectGetPropertyData(inputDevId, &propertyAddress, 0, nullptr, &len, &range),
+	           "CoreAudioInput: Unable to query for allowed buffer size ranges of input device.");
+
+	qWarning("CoreAudioInput: BufferFrameSizeRange = (%.2f, %.2f)", range.mMinimum, range.mMaximum);
 
 	actualBufferLength        = iMicLength;
 	val                       = iMicLength;
 	propertyAddress.mSelector = kAudioDevicePropertyBufferFrameSize;
-	err                       = AudioObjectSetPropertyData(devId, &propertyAddress, 0, nullptr, sizeof(UInt32), &val);
+	err                       = AudioObjectSetPropertyData(inputDevId, &propertyAddress, 0, nullptr, sizeof(UInt32), &val);
 	if (err != noErr) {
-		qWarning("CoreAudioInput: Unable to set preferred buffer size on device. Querying AUHAL for device default.");
+		qWarning("CoreAudioInput: Unable to set preferred buffer size on device. Querying for device default.");
 		len = sizeof(UInt32);
-		err = AudioDeviceGetProperty(devId, 0, true, kAudioDevicePropertyBufferFrameSize, &len, &val);
-		if (err != noErr) {
-			qWarning("CoreAudioInput: Unable to query AUHAL for device's buffer size.");
-			return false;
-		}
+		CHECK_RETURN_FALSE(AudioDeviceGetProperty(inputDevId, 0, true, kAudioDevicePropertyBufferFrameSize, &len, &val),
+		                   "CoreAudioInput: Unable to query for device's buffer size.");
 
 		actualBufferLength = (int) val;
 	}
 
+	CHECK_RETURN_FALSE(AudioUnitInitialize(au), "CoreAudioInput: Unable to initialize VoiceProcessingIO AudioUnit.");
+
 	return true;
 }
 
-
 void CoreAudioInput::run() {
 	OSStatus err;
+	UInt32 len;
 	AudioStreamBasicDescription fmt;
-	CFStringRef devUid  = nullptr;
-	devId = 0;
+	inputDevId = 0;
+	echoOutputDevId = 0;
+	bool doEcho  = (g.s.iEchoOption == ECHO_CANCEL_APPLE || g.s.iEchoOption == ECHO_CANCEL_DEFAULT);
+
+	auHAL = nullptr;
+	auVoip = nullptr;
 
 	memset(&buflist, 0, sizeof(AudioBufferList));
 
-	if (!g.s.qsCoreAudioInput.isEmpty()) {
-		qWarning("CoreAudioInput: Set device to '%s'.", qPrintable(g.s.qsCoreAudioInput));
-		devUid = CoreAudioSystem::QStringToCFString(g.s.qsCoreAudioInput);
-		if (!getInputDeviceId(devUid, devId)) {
-			return;
+	try {
+		if (!g.s.qsCoreAudioInput.isEmpty()) {
+			qWarning("CoreAudioInput: Set device to '%s'.", qPrintable(g.s.qsCoreAudioInput));
+			inputDevId = core_audio_utils::GetDeviceID(g.s.qsCoreAudioInput, AUElement::INPUT);
+		} else {
+			qWarning("CoreAudioInput: Set device to 'Default Device'.");
+			inputDevId = core_audio_utils::GetDefaultDeviceID(AUElement::INPUT);
 		}
-	} else {
-		qWarning("CoreAudioInput: Set device to 'Default Device'.");
-		if (!getDefaultInputDeviceId(devUid, devId)) {
-			return;
+
+		if (doEcho) {
+			echoOutputDevId = core_audio_utils::GetDeviceID(g.s.qsCoreAudioOutput, AUElement::OUTPUT);
+			if (!openAUVoip(fmt)) { return; };
+		} else {
+			if (!openAUHAL(fmt)) { return; };
 		}
+	} catch (core_audio_utils::CoreAudioException& e) {
+		qWarning() << "CoreAudioInput: " << e.getMessage();
 	}
 
-	if (!openAUHAL(fmt)) {
-		return;
-	};
+#ifdef DEBUG
+	qDebug("CoreAudioInput: Original input stream description:");
+	core_audio_utils::LogStreamDescription(fmt);
+#endif
 
 	if (fmt.mFormatFlags & kAudioFormatFlagIsFloat) {
 		eMicFormat = SampleFloat;
@@ -471,6 +778,8 @@ void CoreAudioInput::run() {
 		fmt.mBitsPerChannel = sizeof(short) * 8;
 	}
 
+	AudioUnit auFinal = auHAL;
+
 	fmt.mFormatID         = kAudioFormatLinearPCM;
 	fmt.mSampleRate       = iMicFreq;
 	fmt.mChannelsPerFrame = iMicChannels;
@@ -479,9 +788,33 @@ void CoreAudioInput::run() {
 	fmt.mFramesPerPacket  = 1;
 
 	int actualBufferLength;
-	if (!initializeAUHAL(fmt, actualBufferLength)) {
-		return;
-	};
+
+	if (doEcho) {
+		// Initialize macOS's builtin echo cancellation AU.
+		if(initializeInputAU(auVoip, fmt, actualBufferLength)) {
+			auFinal = auVoip;
+		} else {
+			qWarning("CoreAudioInput: Unable to initialize VoiceProcessing AU for echo cancellation.");
+			return;
+		}
+	} else {
+		if(!initializeInputAU(auHAL, fmt, actualBufferLength)) {
+			return;
+		};
+	}
+
+	AURenderCallbackStruct cb;
+	cb.inputProc       = CoreAudioInput::inputCallback;
+	cb.inputProcRefCon = this;
+	len                = sizeof(AURenderCallbackStruct);
+	CHECK_RETURN(AudioUnitSetProperty(auFinal, kAudioOutputUnitProperty_SetInputCallback, kAudioUnitScope_Global, 0, &cb, len),
+	             "CoreAudioInput: Unable to setup input callback.");
+
+	err = AudioUnitAddPropertyListener(auFinal, kAudioUnitProperty_StreamFormat, CoreAudioInput::propertyChange, this);
+	if (err != noErr) {
+		qWarning("CoreAudioInput: Unable to create input property change listener for AUHAL. Unable to listen to property change "
+				 "events.");
+	}
 
 	buflist.mNumberBuffers = 1;
 	AudioBuffer *b         = buflist.mBuffers;
@@ -490,26 +823,34 @@ void CoreAudioInput::run() {
 	b->mData               = calloc(1, b->mDataByteSize);
 
 	// Start!
-	err = AudioOutputUnitStart(auHAL);
-	if (err != noErr) {
-		qWarning("CoreAudioInput: Unable to start AudioUnit.");
-		return;
+	CHECK_RETURN(AudioOutputUnitStart(auFinal), "CoreAudioInput: Unable to start AudioUnit.");
+
+	if (doEcho) {
+		UndoDucking(echoOutputDevId);
 	}
 
 	bRunning = true;
 }
 
-CoreAudioInput::~CoreAudioInput() {
-	OSStatus err;
-
+void CoreAudioInput::stop() {
 	bRunning = false;
-	wait();
 
 	if (auHAL) {
-		err = AudioOutputUnitStop(auHAL);
-		if (err != noErr) {
-			qWarning("CoreAudioInput: Unable to stop AudioUnit.");
-		}
+		CHECK_WARN(AudioOutputUnitStop(auHAL),
+		           "CoreAudioInput: Unable to stop AudioUnit.");
+		CHECK_WARN(AudioUnitUninitialize(auHAL),
+		           "CoreAudioInput: Unable to uninitialize AudioUnit.");
+		auHAL = nullptr;
+	}
+
+	if (auVoip) {
+		CHECK_WARN(AudioOutputUnitStop(auVoip),
+		           "CoreAudioInput: Unable to stop AudioUnit.");
+		CHECK_WARN(AudioUnitUninitialize(auVoip),
+		           "CoreAudioInput: Unable to uninitialize AudioUnit.");
+		CHECK_WARN(AudioComponentInstanceDispose(auVoip),
+		           "CoreAudioInput: Unable to dispose AudioUnit.");
+		auVoip = nullptr;
 	}
 
 	AudioBuffer *b = buflist.mBuffers;
@@ -519,15 +860,25 @@ CoreAudioInput::~CoreAudioInput() {
 	qWarning("CoreAudioInput: Shutting down.");
 }
 
+CoreAudioInput::~CoreAudioInput() {
+	bRunning = false;
+	wait();
+	stop();
+}
+
 OSStatus CoreAudioInput::inputCallback(void *udata, AudioUnitRenderActionFlags *flags, const AudioTimeStamp *ts,
-									   UInt32 busnum, UInt32 nframes, AudioBufferList *buflist) {
+                                       UInt32 busnum, UInt32 nframes, AudioBufferList *buflist) {
 	Q_UNUSED(udata);
 	Q_UNUSED(buflist);
 
 	CoreAudioInput *i = reinterpret_cast< CoreAudioInput * >(udata);
 	OSStatus err;
 
-	err = AudioUnitRender(i->auHAL, flags, ts, busnum, nframes, &i->buflist);
+	if (i->auVoip) {
+		err = AudioUnitRender(i->auVoip, flags, ts, busnum, nframes, &i->buflist);
+	} else {
+		err = AudioUnitRender(i->auHAL, flags, ts, busnum, nframes, &i->buflist);
+	}
 	if (err != noErr) {
 		qWarning("CoreAudioInput: AudioUnitRender failed.");
 		return err;
@@ -545,6 +896,8 @@ void CoreAudioInput::propertyChange(void *udata, AudioUnit auHAL, AudioUnitPrope
 	Q_UNUSED(scope);
 	Q_UNUSED(element);
 
+	CoreAudioInput *o = reinterpret_cast< CoreAudioInput * >(udata);
+	if (!o->bRunning) { return; }
 	if (prop == kAudioUnitProperty_StreamFormat) {
 		qWarning("CoreAudioInput: Stream format change detected. Restarting AudioInput.");
 		Audio::stopInput();
@@ -555,50 +908,30 @@ void CoreAudioInput::propertyChange(void *udata, AudioUnit auHAL, AudioUnitPrope
 }
 
 CoreAudioOutput::CoreAudioOutput() {
+}
+
+
+void CoreAudioOutput::run() {
 	OSStatus err;
 	AudioStreamBasicDescription fmt;
 	unsigned int chanmasks[32];
 	AudioDeviceID devId = 0;
-	CFStringRef devUid  = nullptr;
 	UInt32 len;
 	AudioObjectPropertyAddress propertyAddress = { 0, kAudioDevicePropertyScopeOutput,
-												   kAudioObjectPropertyElementMaster };
+	                                               kAudioObjectPropertyElementMaster };
 
-	if (!g.s.qsCoreAudioOutput.isEmpty()) {
-		devUid = CoreAudioSystem::QStringToCFString(g.s.qsCoreAudioOutput);
-		qWarning("CoreAudioOutput: Set device to '%s'.", qPrintable(g.s.qsCoreAudioOutput));
+	try {
+		if (!g.s.qsCoreAudioOutput.isEmpty()) {
+			qWarning("CoreAudioOutput: Set device to '%s'.", qPrintable(g.s.qsCoreAudioOutput));
 
-		AudioValueTranslation avt;
-		avt.mInputData      = const_cast< struct __CFString ** >(&devUid);
-		avt.mInputDataSize  = sizeof(CFStringRef *);
-		avt.mOutputData     = &devId;
-		avt.mOutputDataSize = sizeof(AudioDeviceID);
+			devId = core_audio_utils::GetDeviceID(g.s.qsCoreAudioOutput, AUElement::OUTPUT);
+		} else {
+			qWarning("CoreAudioOutput: Set device to 'Default Device'.");
 
-		len                       = sizeof(AudioValueTranslation);
-		propertyAddress.mSelector = kAudioHardwarePropertyDeviceForUID;
-		err = AudioObjectGetPropertyData(kAudioObjectSystemObject, &propertyAddress, 0, nullptr, &len, &avt);
-		if (err != noErr) {
-			qWarning("CoreAudioOutput: Unable to query for AudioDeviceID.");
-			return;
+			devId = core_audio_utils::GetDefaultDeviceID(AUElement::OUTPUT);
 		}
-	} else {
-		qWarning("CoreAudioOutput: Set device to 'Default Device'.");
-
-		len                       = sizeof(AudioDeviceID);
-		propertyAddress.mSelector = kAudioHardwarePropertyDefaultOutputDevice;
-		err = AudioObjectGetPropertyData(kAudioObjectSystemObject, &propertyAddress, 0, nullptr, &len, &devId);
-		if (err != noErr) {
-			qWarning("CoreAudioOutput: Unable to query for default output AudioDeviceID");
-			return;
-		}
-
-		len                       = sizeof(CFStringRef);
-		propertyAddress.mSelector = kAudioDevicePropertyDeviceUID;
-		err                       = AudioObjectGetPropertyData(devId, &propertyAddress, 0, nullptr, &len, &devUid);
-		if (err != noErr) {
-			qWarning("CoreAudioOutput: Unable to get default device UID.");
-			return;
-		}
+	} catch (core_audio_utils::CoreAudioException& e) {
+		qWarning() << "CoreAudioOutput: " << e.what();
 	}
 
 	Component comp;
@@ -616,33 +949,26 @@ CoreAudioOutput::CoreAudioOutput() {
 		return;
 	}
 
-	err = OpenAComponent(comp, &auHAL);
-	if (err != noErr) {
-		qWarning("CoreAudioOutput: Unable to open AudioUnit component.");
-		return;
-	}
+	CHECK_RETURN(OpenAComponent(comp, &auHAL),
+	             "CoreAudioOutput: Unable to open AudioUnit component.");
 
-	err = AudioUnitInitialize(auHAL);
-	if (err != noErr) {
-		qWarning("CoreAudioOutput: Unable to initialize output AudioUnit");
-		return;
-	}
+	CHECK_RETURN(AudioUnitInitialize(auHAL),
+	             "CoreAudioOutput: Unable to initialize output AudioUnit");
 
 	len = sizeof(AudioDeviceID);
-	err = AudioUnitSetProperty(auHAL, kAudioOutputUnitProperty_CurrentDevice, kAudioUnitScope_Global, 0, &devId, len);
-	if (err != noErr) {
-		qWarning("CoreAudioOutput: Unable to set CurrentDevice property on AudioUnit.");
-		return;
-	}
+	CHECK_RETURN(AudioUnitSetProperty(auHAL, kAudioOutputUnitProperty_CurrentDevice, kAudioUnitScope_Global, 0, &devId, len),
+	             "CoreAudioOutput: Unable to set CurrentDevice property on AudioUnit.");
 
 	len = sizeof(AudioStreamBasicDescription);
-	err = AudioUnitGetProperty(auHAL, kAudioUnitProperty_StreamFormat, kAudioUnitScope_Output, 0, &fmt, &len);
-	if (err != noErr) {
-		qWarning("CoreAudioOuptut: Unable to query device for stream info.");
-		return;
-	}
+	CHECK_RETURN(AudioUnitGetProperty(auHAL, kAudioUnitProperty_StreamFormat, kAudioUnitScope_Output, 0, &fmt, &len),
+	             "CoreAudioOuptut: Unable to query device for stream info.");
 
-	iMixerFreq = static_cast< int >(fmt.mSampleRate);
+#ifdef DEBUG
+	qDebug("CoreAudioOutput: Original output stream description:");
+	core_audio_utils::LogAUStreamDescription(auHAL);
+#endif
+
+	iMixerFreq = static_cast< unsigned int >(fmt.mSampleRate);
 	iChannels  = static_cast< int >(fmt.mChannelsPerFrame);
 
 	if (fmt.mFormatFlags & kAudioFormatFlagIsFloat) {
@@ -671,27 +997,23 @@ CoreAudioOutput::CoreAudioOutput() {
 	fmt.mFramesPerPacket  = 1;
 
 	len = sizeof(AudioStreamBasicDescription);
-	err = AudioUnitSetProperty(auHAL, kAudioUnitProperty_StreamFormat, kAudioUnitScope_Input, 0, &fmt, len);
-	if (err != noErr) {
-		qWarning("CoreAudioOutput: Unable to set stream format for output device.");
-		return;
-	}
+	CHECK_RETURN(AudioUnitSetProperty(auHAL, kAudioUnitProperty_StreamFormat, kAudioUnitScope_Input, 0, &fmt, len),
+	             "CoreAudioOutput: Unable to set stream format for output device.");
 
-	err = AudioUnitAddPropertyListener(auHAL, kAudioUnitProperty_StreamFormat, CoreAudioOutput::propertyChange, this);
-	if (err != noErr) {
-		qWarning("CoreAudioOutput: Unable to create output property change listener. Unable to listen to property "
-				 "change events.");
-	}
+#ifdef DEBUG
+	qDebug("CoreAudioOutput: Finalized output stream description:");
+	core_audio_utils::LogAUStreamDescription(auHAL);
+#endif
+
+	CHECK_WARN(AudioUnitAddPropertyListener(auHAL, kAudioUnitProperty_StreamFormat, CoreAudioOutput::propertyChange, this),
+	           "CoreAudioOutput: Unable to create output property change listener. Unable to listen to property changes.");
 
 	AURenderCallbackStruct cb;
 	cb.inputProc       = CoreAudioOutput::outputCallback;
 	cb.inputProcRefCon = this;
 	len                = sizeof(AURenderCallbackStruct);
-	err = AudioUnitSetProperty(auHAL, kAudioUnitProperty_SetRenderCallback, kAudioUnitScope_Global, 0, &cb, len);
-	if (err != noErr) {
-		qWarning("CoreAudioOutput: Unable to setup callback.");
-		return;
-	}
+	CHECK_RETURN(AudioUnitSetProperty(auHAL, kAudioUnitProperty_SetRenderCallback, kAudioUnitScope_Global, 0, &cb, len),
+	             "CoreAudioOutput: Unable to setup callback.");
 
 	AudioValueRange range;
 	len                       = sizeof(AudioValueRange);
@@ -706,38 +1028,38 @@ CoreAudioOutput::CoreAudioOutput() {
 
 	UInt32 val                = (iFrameSize * iMixerFreq) / SAMPLE_RATE;
 	propertyAddress.mSelector = kAudioDevicePropertyBufferFrameSize;
-	err                       = AudioObjectSetPropertyData(devId, &propertyAddress, 0, nullptr, sizeof(UInt32), &val);
-	if (err != noErr) {
-		qWarning("CoreAudioOutput: Could not set requested buffer size for device. Continuing with default.");
-	}
+	CHECK_WARN(AudioObjectSetPropertyData(devId, &propertyAddress, 0, nullptr, sizeof(UInt32), &val),
+	           "CoreAudioOutput: Could not set requested buffer size for device. Continuing with default.");
 
-	err = AudioOutputUnitStart(auHAL);
-	if (err != noErr) {
-		qWarning("CoreAudioOutput: Unable to start AudioUnit");
-		return;
-	}
+	CHECK_RETURN(AudioOutputUnitStart(auHAL),
+	             "CoreAudioOutput: Unable to start AudioUnit");
 
 	bRunning = true;
 }
 
-CoreAudioOutput::~CoreAudioOutput() {
-	OSStatus err;
-
+void CoreAudioOutput::stop() {
 	bRunning = false;
-	wait();
 
 	if (auHAL) {
-		err = AudioOutputUnitStop(auHAL);
-		if (err != noErr) {
-			qWarning("CoreAudioOutput: Unable to stop AudioUnit.");
-		}
+		CHECK_WARN(AudioOutputUnitStop(auHAL),
+		           "CoreAudioOutput: Unable to stop AudioUnit.");
+		CHECK_WARN(AudioUnitUninitialize(auHAL),
+		           "CoreAudioOutput: Unable to uninitialize AudioUnit.");
+		auHAL = nullptr;
 	}
 
 	qWarning("CoreAudioOutput: Shutting down.");
 }
 
+CoreAudioOutput::~CoreAudioOutput() {
+	bRunning = false;
+
+	wait();
+	stop();
+}
+
 OSStatus CoreAudioOutput::outputCallback(void *udata, AudioUnitRenderActionFlags *flags, const AudioTimeStamp *ts,
-										 UInt32 busnum, UInt32 nframes, AudioBufferList *buflist) {
+                                         UInt32 busnum, UInt32 nframes, AudioBufferList *buflist) {
 	Q_UNUSED(flags);
 	Q_UNUSED(ts);
 	Q_UNUSED(busnum);
@@ -745,10 +1067,14 @@ OSStatus CoreAudioOutput::outputCallback(void *udata, AudioUnitRenderActionFlags
 	CoreAudioOutput *o = reinterpret_cast< CoreAudioOutput * >(udata);
 	AudioBuffer *buf   = buflist->mBuffers;
 
-	bool done = o->mix(buf->mData, nframes);
-	if (!done) {
+	if (o->bRunning) {
+		bool done = o->mix(buf->mData, nframes);
+		if (!done) {
+			buf->mDataByteSize = 0;
+			return -1;
+		}
+	} else {
 		buf->mDataByteSize = 0;
-		return -1;
 	}
 
 	return noErr;
@@ -761,14 +1087,15 @@ void CoreAudioOutput::propertyChange(void *udata, AudioUnit auHAL, AudioUnitProp
 	Q_UNUSED(scope);
 	Q_UNUSED(element);
 
+	CoreAudioOutput *o = reinterpret_cast< CoreAudioOutput * >(udata);
+	if (!o->bRunning) return;
+
 	if (prop == kAudioUnitProperty_StreamFormat) {
-		qWarning("CoreAudioOuptut: Stream format change detected. Restarting AudioOutput.");
+		qWarning("CoreAudioOutput: Stream format change detected. Restarting AudioOutput.");
+		o->stop();
 		Audio::stopOutput();
 		Audio::startOutput();
 	} else {
 		qWarning("CoreAudioOutput: Unexpected property changed event received.");
 	}
-}
-
-void CoreAudioOutput::run() {
 }

--- a/src/mumble/EchoCancelOption.h
+++ b/src/mumble/EchoCancelOption.h
@@ -1,0 +1,49 @@
+// Copyright 2021 The Mumble Developers. All rights reserved.
+// Use of this source code is governed by a BSD-style license
+// that can be found in the LICENSE file at the root of the
+// Mumble source tree or at <https://www.mumble.info/LICENSE>.
+
+#ifndef MUMBLE_MUMBLE_ECHOCANCELLATIONOPTION_H
+#define MUMBLE_MUMBLE_ECHOCANCELLATIONOPTION_H
+
+#include <QtCore/QObject>
+
+
+/// This enum lists a series of echo cancellation options
+/// Each audio backend will determine which option is indeed available to that backend and
+/// to the specific device combination
+enum class EchoCancelOptionID {
+    DISABLED = 0,
+    SPEEX_MIXED = 1,
+    SPEEX_MULTICHANNEL = 2,
+    APPLE_AEC = 3  // Apple's Acoustic Echo Cancellation support for macOS and iOS.
+};
+
+struct EchoCancelOption {
+	EchoCancelOptionID id;
+	QString description;
+	QString explanation;
+};
+
+// Please strictly follow the order of the EchoCancelOptionID when adding items to this array.
+static const EchoCancelOption echoCancelOptions[] = {
+	{ EchoCancelOptionID::DISABLED,
+	  QObject::tr("Disabled"),
+	  QObject::tr("Echo cancellation is disabled.") },
+	{ EchoCancelOptionID::SPEEX_MIXED,
+	  QObject::tr("Mixed echo cancellation (speex)"),
+	  QObject::tr("Mixed has low CPU impact, but only works well if your "
+						 "speakers are equally loud and equidistant from the microphone.") },
+	{ EchoCancelOptionID::SPEEX_MULTICHANNEL,
+	  QObject::tr("Multichannel echo cancellation (speex)"),
+	  QObject::tr("Multichannel echo cancellation provides much better echo "
+								 "cancellation, but at a higher CPU cost. "
+								 "Multichannel echo cancellation requires more CPU, so "
+								 "you should try mixed first.") },
+	// Available only on Apple devices
+	{ EchoCancelOptionID::APPLE_AEC,
+	  QObject::tr("Acoustic echo cancellation provided by Apple."),
+	  QObject::tr("This option works best when using built-in microphone and speaker.") }
+};
+
+#endif // MUMBLE_ECHOCANCELLATIONOPTION_H

--- a/src/mumble/JackAudio.cpp
+++ b/src/mumble/JackAudio.cpp
@@ -82,7 +82,7 @@ private:
 	AudioInput *create() Q_DECL_OVERRIDE;
 	const QList< audioDevice > getDeviceChoices() Q_DECL_OVERRIDE;
 	void setDeviceChoice(const QVariant &, Settings &) Q_DECL_OVERRIDE;
-	bool canEcho(const QString &) const Q_DECL_OVERRIDE;
+	bool canEcho(int, const QString &) const Q_DECL_OVERRIDE;
 	bool isMicrophoneAccessDeniedByOS() Q_DECL_OVERRIDE { return false; };
 
 public:
@@ -131,7 +131,7 @@ const QList< audioDevice > JackAudioInputRegistrar::getDeviceChoices() {
 void JackAudioInputRegistrar::setDeviceChoice(const QVariant &, Settings &) {
 }
 
-bool JackAudioInputRegistrar::canEcho(const QString &) const {
+bool JackAudioInputRegistrar::canEcho(int, const QString &) const {
 	return false;
 }
 

--- a/src/mumble/JackAudio.cpp
+++ b/src/mumble/JackAudio.cpp
@@ -82,7 +82,7 @@ private:
 	AudioInput *create() Q_DECL_OVERRIDE;
 	const QList< audioDevice > getDeviceChoices() Q_DECL_OVERRIDE;
 	void setDeviceChoice(const QVariant &, Settings &) Q_DECL_OVERRIDE;
-	bool canEcho(int, const QString &) const Q_DECL_OVERRIDE;
+	bool canEcho(EchoCancelOptionID echoCancelID, const QString &outputSystem) const Q_DECL_OVERRIDE;
 	bool isMicrophoneAccessDeniedByOS() Q_DECL_OVERRIDE { return false; };
 
 public:
@@ -131,7 +131,7 @@ const QList< audioDevice > JackAudioInputRegistrar::getDeviceChoices() {
 void JackAudioInputRegistrar::setDeviceChoice(const QVariant &, Settings &) {
 }
 
-bool JackAudioInputRegistrar::canEcho(int, const QString &) const {
+bool JackAudioInputRegistrar::canEcho(EchoCancelOptionID, const QString &) const {
 	return false;
 }
 

--- a/src/mumble/OSS.cpp
+++ b/src/mumble/OSS.cpp
@@ -45,7 +45,7 @@ public:
 	virtual AudioInput *create();
 	virtual const QList< audioDevice > getDeviceChoices();
 	virtual void setDeviceChoice(const QVariant &, Settings &);
-	virtual bool canEcho(int, const QString &) const;
+	virtual bool canEcho(EchoCancelOptionID echoCancelID, const QString &outputSystem) const;
 	virtual bool isMicrophoneAccessDeniedByOS() { return false; };
 };
 
@@ -88,7 +88,7 @@ void OSSInputRegistrar::setDeviceChoice(const QVariant &choice, Settings &s) {
 	s.qsOSSInput = choice.toString();
 }
 
-bool OSSInputRegistrar::canEcho(int, const QString &) const {
+bool OSSInputRegistrar::canEcho(EchoCancelOptionID, const QString &) const {
 	return false;
 }
 

--- a/src/mumble/OSS.cpp
+++ b/src/mumble/OSS.cpp
@@ -45,7 +45,7 @@ public:
 	virtual AudioInput *create();
 	virtual const QList< audioDevice > getDeviceChoices();
 	virtual void setDeviceChoice(const QVariant &, Settings &);
-	virtual bool canEcho(const QString &) const;
+	virtual bool canEcho(int, const QString &) const;
 	virtual bool isMicrophoneAccessDeniedByOS() { return false; };
 };
 
@@ -88,7 +88,7 @@ void OSSInputRegistrar::setDeviceChoice(const QVariant &choice, Settings &s) {
 	s.qsOSSInput = choice.toString();
 }
 
-bool OSSInputRegistrar::canEcho(const QString &) const {
+bool OSSInputRegistrar::canEcho(int, const QString &) const {
 	return false;
 }
 

--- a/src/mumble/PAAudio.cpp
+++ b/src/mumble/PAAudio.cpp
@@ -32,7 +32,7 @@ private:
 	AudioInput *create() Q_DECL_OVERRIDE;
 	const QList< audioDevice > getDeviceChoices() Q_DECL_OVERRIDE;
 	void setDeviceChoice(const QVariant &, Settings &) Q_DECL_OVERRIDE;
-	bool canEcho(int, const QString &) const Q_DECL_OVERRIDE;
+	bool canEcho(EchoCancelOptionID echoCancelID, const QString &outputSystem) const Q_DECL_OVERRIDE;
 	bool isMicrophoneAccessDeniedByOS() Q_DECL_OVERRIDE { return false; };
 
 public:
@@ -72,7 +72,7 @@ void PortAudioInputRegistrar::setDeviceChoice(const QVariant &choice, Settings &
 	s.iPortAudioInput = choice.toInt();
 }
 
-bool PortAudioInputRegistrar::canEcho(int, const QString &) const {
+bool PortAudioInputRegistrar::canEcho(EchoCancelOptionID, const QString &) const {
 	return false;
 }
 

--- a/src/mumble/PAAudio.cpp
+++ b/src/mumble/PAAudio.cpp
@@ -32,7 +32,7 @@ private:
 	AudioInput *create() Q_DECL_OVERRIDE;
 	const QList< audioDevice > getDeviceChoices() Q_DECL_OVERRIDE;
 	void setDeviceChoice(const QVariant &, Settings &) Q_DECL_OVERRIDE;
-	bool canEcho(const QString &) const Q_DECL_OVERRIDE;
+	bool canEcho(int, const QString &) const Q_DECL_OVERRIDE;
 	bool isMicrophoneAccessDeniedByOS() Q_DECL_OVERRIDE { return false; };
 
 public:
@@ -72,7 +72,7 @@ void PortAudioInputRegistrar::setDeviceChoice(const QVariant &choice, Settings &
 	s.iPortAudioInput = choice.toInt();
 }
 
-bool PortAudioInputRegistrar::canEcho(const QString &) const {
+bool PortAudioInputRegistrar::canEcho(int, const QString &) const {
 	return false;
 }
 

--- a/src/mumble/PulseAudio.cpp
+++ b/src/mumble/PulseAudio.cpp
@@ -42,7 +42,7 @@ public:
 	virtual AudioInput *create();
 	virtual const QList< audioDevice > getDeviceChoices();
 	virtual void setDeviceChoice(const QVariant &, Settings &);
-	virtual bool canEcho(int, const QString &) const;
+	virtual bool canEcho(EchoCancelOptionID echoCancelID, const QString &outputSystem) const;
 	virtual bool isMicrophoneAccessDeniedByOS() { return false; };
 };
 
@@ -334,9 +334,9 @@ void PulseAudioSystem::eventCallback(pa_mainloop_api *api, pa_defer_event *) {
 		bool do_stop        = false;
 		bool do_start       = false;
 
-		if ((!pai || g.s.iEchoOption == ECHO_CANCEL_DISABLED) && (est == PA_STREAM_READY)) {
+		if ((!pai || g.s.echoOption == EchoCancelOptionID::DISABLED) && (est == PA_STREAM_READY)) {
 			do_stop = true;
-		} else if (pai && g.s.iEchoOption != ECHO_CANCEL_DISABLED) {
+		} else if (pai && g.s.echoOption != EchoCancelOptionID::DISABLED) {
 			switch (est) {
 				case PA_STREAM_TERMINATED: {
 					if (pasSpeaker)
@@ -347,7 +347,7 @@ void PulseAudioSystem::eventCallback(pa_mainloop_api *api, pa_defer_event *) {
 					if ((pss.format != PA_SAMPLE_FLOAT32NE) && (pss.format != PA_SAMPLE_S16NE))
 						pss.format = PA_SAMPLE_FLOAT32NE;
 					pss.rate = SAMPLE_RATE;
-					if ((pss.channels == 0) || (g.s.iEchoOption != ECHO_CANCEL_SPEEX_MULTICHANNEL))
+					if ((pss.channels == 0) || (g.s.echoOption != EchoCancelOptionID::SPEEX_MULTICHANNEL))
 						pss.channels = 1;
 
 					pasSpeaker =
@@ -360,7 +360,7 @@ void PulseAudioSystem::eventCallback(pa_mainloop_api *api, pa_defer_event *) {
 					do_start = true;
 					break;
 				case PA_STREAM_READY: {
-					if ((g.s.iEchoOption == ECHO_CANCEL_SPEEX_MULTICHANNEL) != bEchoMultiCache) {
+					if ((g.s.echoOption == EchoCancelOptionID::SPEEX_MULTICHANNEL) != bEchoMultiCache) {
 						do_stop = true;
 					} else if (edev != qsEchoCache) {
 						do_stop = true;
@@ -386,7 +386,7 @@ void PulseAudioSystem::eventCallback(pa_mainloop_api *api, pa_defer_event *) {
 			buff.prebuf                  = -1;
 			buff.fragsize                = iBlockLen;
 
-			bEchoMultiCache = (g.s.iEchoOption == ECHO_CANCEL_SPEEX_MULTICHANNEL);
+			bEchoMultiCache = (g.s.echoOption == EchoCancelOptionID::SPEEX_MULTICHANNEL);
 			qsEchoCache     = edev;
 
 			m_pulseAudio.stream_connect_record(pasSpeaker, qPrintable(edev), &buff, PA_STREAM_ADJUST_LATENCY);
@@ -894,7 +894,8 @@ void PulseAudioSystem::contextCallback(pa_context *c) {
 }
 
 PulseAudioInputRegistrar::PulseAudioInputRegistrar() : AudioInputRegistrar(QLatin1String("PulseAudio"), 10) {
-	useSpeexEchoCancellation();
+	echoOptions.push_back(EchoCancelOptionID::SPEEX_MIXED);
+	echoOptions.push_back(EchoCancelOptionID::SPEEX_MULTICHANNEL);
 }
 
 AudioInput *PulseAudioInputRegistrar::create() {
@@ -921,10 +922,9 @@ void PulseAudioInputRegistrar::setDeviceChoice(const QVariant &choice, Settings 
 	s.qsPulseAudioInput = choice.toString();
 }
 
-bool PulseAudioInputRegistrar::canEcho(int echoOption, const QString &osys) const {
-	return (echoOption == ECHO_CANCEL_DEFAULT
-	        || echoOption == ECHO_CANCEL_SPEEX_MIXED
-	        || echoOption == ECHO_CANCEL_SPEEX_MULTICHANNEL) && (osys == name);
+bool PulseAudioInputRegistrar::canEcho(EchoCancelOptionID echoOption, const QString &osys) const {
+	return (echoOption == EchoCancelOptionID::SPEEX_MIXED
+	        || echoOption == EchoCancelOptionID::SPEEX_MULTICHANNEL) && (osys == name);
 }
 
 PulseAudioOutputRegistrar::PulseAudioOutputRegistrar() : AudioOutputRegistrar(QLatin1String("PulseAudio"), 10) {

--- a/src/mumble/Settings.cpp
+++ b/src/mumble/Settings.cpp
@@ -401,14 +401,8 @@ Settings::Settings() {
 	bJackStartServer  = false;
 	bJackAutoConnect  = true;
 
-#ifndef Q_OS_MAC
-	// Enable echo cancellation by default everywhere except for Macs as we currently
-	// on't support echo cancelling on Macs
-	bEcho = true;
-#else
 	bEcho = false;
-#endif
-	bEchoMulti = false;
+	iEchoOption = 0;  // ECHO_CANCEL_DISABLED = 0
 
 	bExclusiveInput  = false;
 	bExclusiveOutput = false;
@@ -558,7 +552,7 @@ bool Settings::doEcho() const {
 	if (AudioInputRegistrar::qmNew) {
 		AudioInputRegistrar *air = AudioInputRegistrar::qmNew->value(qsAudioInput);
 		if (air) {
-			if (air->canEcho(qsAudioOutput))
+			if (g.s.iEchoOption && air->canEcho(g.s.iEchoOption, qsAudioOutput))
 				return true;
 		}
 	}
@@ -760,7 +754,7 @@ void Settings::load(QSettings *settings_ptr) {
 	SAVELOAD(fAudioMaxDistVolume, "audio/maxdistancevolume");
 	SAVELOAD(fAudioBloom, "audio/bloom");
 	SAVELOAD(bEcho, "audio/echo");
-	SAVELOAD(bEchoMulti, "audio/echomulti");
+	SAVELOAD(iEchoOption, "audio/echooptionid");
 	SAVELOAD(bExclusiveInput, "audio/exclusiveinput");
 	SAVELOAD(bExclusiveOutput, "audio/exclusiveoutput");
 	SAVELOAD(bPositionalAudio, "audio/positional");
@@ -1134,7 +1128,7 @@ void Settings::save() {
 	SAVELOAD(fAudioMaxDistVolume, "audio/maxdistancevolume");
 	SAVELOAD(fAudioBloom, "audio/bloom");
 	SAVELOAD(bEcho, "audio/echo");
-	SAVELOAD(bEchoMulti, "audio/echomulti");
+	SAVELOAD(iEchoOption, "audio/echooptionid");
 	SAVELOAD(bExclusiveInput, "audio/exclusiveinput");
 	SAVELOAD(bExclusiveOutput, "audio/exclusiveoutput");
 	SAVELOAD(bPositionalAudio, "audio/positional");

--- a/src/mumble/Settings.cpp
+++ b/src/mumble/Settings.cpp
@@ -401,8 +401,7 @@ Settings::Settings() {
 	bJackStartServer  = false;
 	bJackAutoConnect  = true;
 
-	bEcho = false;
-	iEchoOption = 0;  // ECHO_CANCEL_DISABLED = 0
+	echoOption = EchoCancelOptionID::DISABLED;
 
 	bExclusiveInput  = false;
 	bExclusiveOutput = false;
@@ -546,13 +545,11 @@ Settings::Settings() {
 }
 
 bool Settings::doEcho() const {
-	if (!bEcho)
-		return false;
-
 	if (AudioInputRegistrar::qmNew) {
 		AudioInputRegistrar *air = AudioInputRegistrar::qmNew->value(qsAudioInput);
 		if (air) {
-			if (g.s.iEchoOption && air->canEcho(g.s.iEchoOption, qsAudioOutput))
+			if ((g.s.echoOption != EchoCancelOptionID::DISABLED)
+			    && air->canEcho(g.s.echoOption, qsAudioOutput))
 				return true;
 		}
 	}
@@ -584,6 +581,7 @@ BOOST_TYPEOF_REGISTER_TYPE(QByteArray)
 BOOST_TYPEOF_REGISTER_TYPE(QColor)
 BOOST_TYPEOF_REGISTER_TYPE(QVariant)
 BOOST_TYPEOF_REGISTER_TYPE(QFont)
+BOOST_TYPEOF_REGISTER_TYPE(EchoCancelOptionID)
 BOOST_TYPEOF_REGISTER_TEMPLATE(QList, 1)
 
 #define SAVELOAD(var, name) var = qvariant_cast< BOOST_TYPEOF(var) >(settings_ptr->value(QLatin1String(name), var))
@@ -753,8 +751,6 @@ void Settings::load(QSettings *settings_ptr) {
 	SAVELOAD(fAudioMaxDistance, "audio/maxdistance");
 	SAVELOAD(fAudioMaxDistVolume, "audio/maxdistancevolume");
 	SAVELOAD(fAudioBloom, "audio/bloom");
-	SAVELOAD(bEcho, "audio/echo");
-	SAVELOAD(iEchoOption, "audio/echooptionid");
 	SAVELOAD(bExclusiveInput, "audio/exclusiveinput");
 	SAVELOAD(bExclusiveOutput, "audio/exclusiveoutput");
 	SAVELOAD(bPositionalAudio, "audio/positional");
@@ -763,6 +759,7 @@ void Settings::load(QSettings *settings_ptr) {
 	SAVELOAD(qsAudioOutput, "audio/output");
 	SAVELOAD(bWhisperFriends, "audio/whisperfriends");
 	SAVELOAD(bTransmitPosition, "audio/postransmit");
+	LOADFLAG(echoOption, "audio/echooptionid");
 
 	SAVELOAD(iJitterBufferSize, "net/jitterbuffer");
 	SAVELOAD(iFramesPerPacket, "net/framesperpacket");
@@ -1127,8 +1124,7 @@ void Settings::save() {
 	SAVELOAD(fAudioMaxDistance, "audio/maxdistance");
 	SAVELOAD(fAudioMaxDistVolume, "audio/maxdistancevolume");
 	SAVELOAD(fAudioBloom, "audio/bloom");
-	SAVELOAD(bEcho, "audio/echo");
-	SAVELOAD(iEchoOption, "audio/echooptionid");
+	LOADFLAG(echoOption, "audio/echooptionid");
 	SAVELOAD(bExclusiveInput, "audio/exclusiveinput");
 	SAVELOAD(bExclusiveOutput, "audio/exclusiveoutput");
 	SAVELOAD(bPositionalAudio, "audio/positional");

--- a/src/mumble/Settings.h
+++ b/src/mumble/Settings.h
@@ -17,6 +17,8 @@
 #include <QtNetwork/QSslCertificate>
 #include <QtNetwork/QSslKey>
 
+#include "EchoCancelOption.h"
+
 // Global helper classes to spread variables around across threads
 // especially helpful to initialize things like the stored
 // preference for audio transmission, since the GUI elements
@@ -243,8 +245,7 @@ struct Settings {
 	QString qsWASAPIRole;
 
 	bool bExclusiveInput, bExclusiveOutput;
-	bool bEcho;
-	int iEchoOption;  // _id_ of EchoCancellationOption, or "default" to use the default option of the audio backend
+	EchoCancelOptionID echoOption;
 	bool bPositionalAudio;
 	bool bPositionalHeadphone;
 	float fAudioMinDistance, fAudioMaxDistance, fAudioMaxDistVolume, fAudioBloom;

--- a/src/mumble/Settings.h
+++ b/src/mumble/Settings.h
@@ -244,7 +244,7 @@ struct Settings {
 
 	bool bExclusiveInput, bExclusiveOutput;
 	bool bEcho;
-	bool bEchoMulti;
+	int iEchoOption;  // _id_ of EchoCancellationOption, or "default" to use the default option of the audio backend
 	bool bPositionalAudio;
 	bool bPositionalHeadphone;
 	float fAudioMinDistance, fAudioMaxDistance, fAudioMaxDistVolume, fAudioBloom;

--- a/src/mumble/WASAPI.cpp
+++ b/src/mumble/WASAPI.cpp
@@ -54,7 +54,7 @@ public:
 	virtual AudioInput *create();
 	virtual const QList< audioDevice > getDeviceChoices();
 	virtual void setDeviceChoice(const QVariant &, Settings &);
-	virtual bool canEcho(int, const QString &) const;
+	virtual bool canEcho(EchoCancelOptionID echoCancelID, const QString &outputSystem) const;
 	virtual bool canExclusive() const;
 	virtual bool isMicrophoneAccessDeniedByOS();
 
@@ -118,7 +118,8 @@ void WASAPIInit::destroy() {
 
 
 WASAPIInputRegistrar::WASAPIInputRegistrar() : AudioInputRegistrar(QLatin1String("WASAPI"), 10) {
-	useSpeexEchoCancellation();
+	echoOptions.push_back(EchoCancelOptionID::SPEEX_MIXED);
+	echoOptions.push_back(EchoCancelOptionID::SPEEX_MULTICHANNEL);
 }
 
 bool WASAPIInputRegistrar::isMicrophoneAccessDeniedByOS() {
@@ -207,10 +208,9 @@ void WASAPIInputRegistrar::setDeviceChoice(const QVariant &choice, Settings &s) 
 	s.qsWASAPIInput = choice.toString();
 }
 
-bool WASAPIInputRegistrar::canEcho(int echoOption, const QString &outputSys) const {
-	return (echoOption == ECHO_CANCEL_DEFAULT
-	        || echoOption == ECHO_CANCEL_SPEEX_MIXED
-	        || echoOption == ECHO_CANCEL_SPEEX_MULTICHANNEL) && (outputSys == name);
+bool WASAPIInputRegistrar::canEcho(EchoCancelOptionID echoOptionIDs, const QString &outputSystem) const {
+	return (echoOptionIDs == EchoCancelOptionID::SPEEX_MIXED
+	        || echoOptionIDs == EchoCancelOptionID::SPEEX_MULTICHANNEL) && (outputSystem == name);
 }
 
 bool WASAPIInputRegistrar::canExclusive() const {

--- a/src/mumble/WASAPI.cpp
+++ b/src/mumble/WASAPI.cpp
@@ -54,7 +54,7 @@ public:
 	virtual AudioInput *create();
 	virtual const QList< audioDevice > getDeviceChoices();
 	virtual void setDeviceChoice(const QVariant &, Settings &);
-	virtual bool canEcho(const QString &) const;
+	virtual bool canEcho(int, const QString &) const;
 	virtual bool canExclusive() const;
 	virtual bool isMicrophoneAccessDeniedByOS();
 
@@ -118,6 +118,7 @@ void WASAPIInit::destroy() {
 
 
 WASAPIInputRegistrar::WASAPIInputRegistrar() : AudioInputRegistrar(QLatin1String("WASAPI"), 10) {
+	useSpeexEchoCancellation();
 }
 
 bool WASAPIInputRegistrar::isMicrophoneAccessDeniedByOS() {
@@ -206,8 +207,10 @@ void WASAPIInputRegistrar::setDeviceChoice(const QVariant &choice, Settings &s) 
 	s.qsWASAPIInput = choice.toString();
 }
 
-bool WASAPIInputRegistrar::canEcho(const QString &outputsys) const {
-	return (outputsys == name);
+bool WASAPIInputRegistrar::canEcho(int echoOption, const QString &outputSys) const {
+	return (echoOption == ECHO_CANCEL_DEFAULT
+	        || echoOption == ECHO_CANCEL_SPEEX_MIXED
+	        || echoOption == ECHO_CANCEL_SPEEX_MULTICHANNEL) && (outputSys == name);
 }
 
 bool WASAPIInputRegistrar::canExclusive() const {

--- a/src/mumble/mumble_en.ts
+++ b/src/mumble/mumble_en.ts
@@ -950,14 +950,6 @@ This value allows you to set the maximum number of users allowed in the channel.
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Mixed echo cancellation</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Multichannel echo cancellation</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>The idle action will be reversed upon any key or mouse button input</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1134,6 +1126,33 @@ This value allows you to set the maximum number of users allowed in the channel.
     </message>
     <message>
         <source>Access to the microphone was denied. Please check that your operating system&apos;s microphone settings allow Mumble to use the microphone.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Disabled</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Disable echo cancellation.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>AudioInputRegistrar</name>
+    <message>
+        <source>Mixed echo cancellation (speedx)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Multichannel echo cancellation (speedx)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Mixed has low CPU impact, but only works well if your speakers are equally loud and equidistant from the microphone.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Multichannel echo cancellation provides much better echo cancellation, but at a higher CPU cost. Multichannel echo cancellation requires more CPU, so you should try mixed first.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -7130,12 +7149,6 @@ To upgrade these files to their latest versions, click the button below.</source
     </message>
     <message>
         <source>Echo cancellation is not supported for the interface combination &quot;%1&quot; (in) and &quot;%2&quot; (out).</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>If enabled this tries to cancel out echo from the audio stream.
-Mixed echo cancellation mixes all speaker outputs in one mono stream and passes that stream to the echo canceller, while multichannel echo cancellation passes all audio channels to the echo canceller directly.
-Multichannel echo cancellation requires more CPU, so you should try mixed first</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/src/mumble/mumble_en.ts
+++ b/src/mumble/mumble_en.ts
@@ -1138,25 +1138,6 @@ This value allows you to set the maximum number of users allowed in the channel.
     </message>
 </context>
 <context>
-    <name>AudioInputRegistrar</name>
-    <message>
-        <source>Mixed echo cancellation (speedx)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Multichannel echo cancellation (speedx)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Mixed has low CPU impact, but only works well if your speakers are equally loud and equidistant from the microphone.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Multichannel echo cancellation provides much better echo cancellation, but at a higher CPU cost. Multichannel echo cancellation requires more CPU, so you should try mixed first.</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
     <name>AudioOutput</name>
     <message>
         <source>Interface</source>
@@ -3408,6 +3389,17 @@ Without this option enabled, using Mumble&apos;s global shortcuts in privileged 
     <name>GlobalShortcutEngine</name>
     <message>
         <source>Unknown</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>GlobalShortcutMac</name>
+    <message>
+        <source>Mouse</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Keyboard</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -7136,6 +7128,10 @@ To upgrade these files to their latest versions, click the button below.</source
         <source>Mumble failed to restart itself. Please restart it manually.</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Mumble is currently connected to a server</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>QObject</name>
@@ -7234,6 +7230,54 @@ See &lt;a href=&quot;https://wiki.mumble.info/wiki/Installing_Mumble&quot;&gt;th
     </message>
     <message>
         <source>Blocked URL: &quot;%1&quot;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Default Device</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>This option works best when using built-in microphone and speaker.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Access to the microphone was denied. Please allow Mumble to use the microphone by changing the settings in System Preferences -&gt; Security &amp; Privacy -&gt; Privacy -&gt; Microphone.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Access to the microphone was denied due to system restrictions. You will not be ableto use the microphone in this session.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>If enabled this tries to cancel out echo from the audio stream.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Disabled</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Echo cancellation is disabled.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Mixed echo cancellation (speex)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Mixed has low CPU impact, but only works well if your speakers are equally loud and equidistant from the microphone.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Multichannel echo cancellation (speex)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Multichannel echo cancellation provides much better echo cancellation, but at a higher CPU cost. Multichannel echo cancellation requires more CPU, so you should try mixed first.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Acoustic echo cancellation provided by Apple.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>


### PR DESCRIPTION
Apple doesn't provide a way to hijack the system audio stream into Mumble
so speex's echo cancellation cannot work for Mac.
It was reported in https://developers.google.com/web/updates/2018/03/macos-native-echo-cancellation
that Mac has a native echo cancellation AU. This commit uses this
native AU to enable echo cancellation for Mac users.
Unfortunately, this function is poorly documented by Apple. The best
reference of this function is from Chromium's code,
https://github.com/chromium/chromium/blob/master/media/audio/mac/audio_low_latency_input_mac.cc

Limited support from Apple made invoking this AU a very unfriendly
task. Also, the subtleness of echo cancellation made it hard to be
tested. I would just submit this PR and see the reactions from other
testers.

Implement #1775.

> Me: I think I have a problem with Mac's native echo cancellation...
> David: Does it simply not work?
> Me: Hmmm... Let me check...
> _15 minutes later_
> Me: Aw, doesn't work at all.
> _another 15 minutes later_
> Me: Eh, maybe it just works, in a subtle way...

**Welcome, all Mac users! Have a try and give me some feedback!**