### PR TITLE
FIX(server): Make max bandwidth the highest supported

### DIFF
--- a/scripts/murmur.ini
+++ b/scripts/murmur.ini
@@ -133,7 +133,7 @@ serverpassword=
 
 ; Maximum bandwidth (in bits per second) clients are allowed
 ; to send speech at.
-bandwidth=72000
+bandwidth=558000
 
 ; Murmur and Mumble are usually pretty good about cleaning up hung clients, but
 ; occasionally one will get stuck on the server. The timeout setting will cause

--- a/src/murmur/Meta.cpp
+++ b/src/murmur/Meta.cpp
@@ -47,10 +47,13 @@ HANDLE Meta::hQoS = nullptr;
 #endif
 
 MetaParams::MetaParams() {
-	qsPassword                 = QString();
-	usPort                     = DEFAULT_MUMBLE_PORT;
-	iTimeout                   = 30;
-	iMaxBandwidth              = 72000;
+	qsPassword = QString();
+	usPort     = DEFAULT_MUMBLE_PORT;
+	iTimeout   = 30;
+	// This represents the maximum possible bandwidth using 10 ms audio TCP packets with position data
+	// (restricted by the maximum bitrate Opus supports)
+	// 558000 = 510000 (Opus) + 9600 (position) + 38400 (TCP overhead)
+	iMaxBandwidth              = 558000;
 	iMaxUsers                  = 1000;
 	iMaxUsersPerChannel        = 0;
 	iMaxListenersPerChannel    = -1;


### PR DESCRIPTION
558000 = 510000 (Opus) + 9600 (position) + 38400 (TCP overhead)

Closes https://github.com/mumble-voip/mumble/issues/3895
