### PR TITLE
CI(azure): Export BUILD_NUMBER_TOKEN correctly

### DIFF
--- a/.ci/azure-pipelines/build_linux.bash
+++ b/.ci/azure-pipelines/build_linux.bash
@@ -16,12 +16,12 @@
 #
 # Defined on Azure Pipelines:
 #
-#  BUILD_NUMBER_TOKEN      - Access token for the build number page on our server.
+#  MUMBLE_BUILD_NUMBER_TOKEN      - Access token for the build number page on our server.
 #
 
-if [[ -n "$BUILD_NUMBER_TOKEN" ]]; then
+if [[ -n "$MUMBLE_BUILD_NUMBER_TOKEN" ]]; then
 	VERSION=$(python "scripts/mumble-version.py" --project)
-	BUILD_NUMBER=$(curl "https://mumble.info/get-build-number?version=$VERSION_$AGENT_JOBNAME&token=$BUILD_NUMBER_TOKEN")
+	BUILD_NUMBER=$(curl "https://mumble.info/get-build-number?version=$VERSION_$AGENT_JOBNAME&token=$MUMBLE_BUILD_NUMBER_TOKEN")
 else
 	BUILD_NUMBER=0
 fi

--- a/.ci/azure-pipelines/build_macos.bash
+++ b/.ci/azure-pipelines/build_macos.bash
@@ -27,12 +27,12 @@
 #
 # Defined on Azure Pipelines:
 #
-#  BUILD_NUMBER_TOKEN           - Access token for the build number page on our server.
+#  MUMBLE_BUILD_NUMBER_TOKEN           - Access token for the build number page on our server.
 #
 
-if [[ -n "$BUILD_NUMBER_TOKEN" ]]; then
+if [[ -n "$MUMBLE_BUILD_NUMBER_TOKEN" ]]; then
 	VERSION=$(python "scripts/mumble-version.py" --project)
-	BUILD_NUMBER=$(curl "https://mumble.info/get-build-number?version=$VERSION_$AGENT_JOBNAME&token=$BUILD_NUMBER_TOKEN")
+	BUILD_NUMBER=$(curl "https://mumble.info/get-build-number?version=$VERSION_$AGENT_JOBNAME&token=$MUMBLE_BUILD_NUMBER_TOKEN")
 else
 	BUILD_NUMBER=0
 fi

--- a/.ci/azure-pipelines/build_windows.bat
+++ b/.ci/azure-pipelines/build_windows.bat
@@ -30,16 +30,16 @@
 ::
 :: Defined on Azure Pipelines:
 ::
-::  BUILD_NUMBER_TOKEN           - Access token for the build number page on our server.
+::  MUMBLE_BUILD_NUMBER_TOKEN           - Access token for the build number page on our server.
 ::
 
 @echo on
 
-if defined BUILD_NUMBER_TOKEN (
+if defined MUMBLE_BUILD_NUMBER_TOKEN (
 	:: The method we use to store a command's output into a variable:
 	:: https://stackoverflow.com/a/6362922
 	for /f "tokens=* USEBACKQ" %%g in (`python "scripts/mumble-version.py" --project`) do (set "VERSION=%%g")
-	for /f "tokens=* USEBACKQ" %%g in (`curl "https://mumble.info/get-build-number?version=%VERSION%_%AGENT_JOBNAME%&token=%BUILD_NUMBER_TOKEN%"`) do (set "BUILD_NUMBER=%%g")
+	for /f "tokens=* USEBACKQ" %%g in (`curl "https://mumble.info/get-build-number?version=%VERSION%_%AGENT_JOBNAME%&token=%MUMBLE_BUILD_NUMBER_TOKEN%"`) do (set "BUILD_NUMBER=%%g")
 ) else (
 	set BUILD_NUMBER=0
 )

--- a/.ci/azure-pipelines/main-pr.yml
+++ b/.ci/azure-pipelines/main-pr.yml
@@ -3,6 +3,10 @@ variables:
   MUMBLE_ENVIRONMENT_SOURCE: 'https://dl.mumble.info/build/vcpkg'
   MUMBLE_ENVIRONMENT_PATH: '$(MUMBLE_ENVIRONMENT_STORE)/$(MUMBLE_ENVIRONMENT_VERSION)'
   MUMBLE_ENVIRONMENT_TOOLCHAIN: '$(MUMBLE_ENVIRONMENT_PATH)/scripts/buildsystems/vcpkg.cmake'
+  # We set this to an empty String explicitly as the variable is not set for PR builds but it is required
+  # to be an empty String in that case. That's why we have to set it here. For Nightly builds the
+  # variable is set on Azure itself.
+  BUILD_NUMBER_TOKEN: ''
 
 jobs:
   - job: Windows_x86_64

--- a/.ci/azure-pipelines/main.yml
+++ b/.ci/azure-pipelines/main.yml
@@ -3,10 +3,8 @@ variables:
   MUMBLE_ENVIRONMENT_SOURCE: 'https://dl.mumble.info/build/vcpkg'
   MUMBLE_ENVIRONMENT_PATH: '$(MUMBLE_ENVIRONMENT_STORE)/$(MUMBLE_ENVIRONMENT_VERSION)'
   MUMBLE_ENVIRONMENT_TOOLCHAIN: '$(MUMBLE_ENVIRONMENT_PATH)/scripts/buildsystems/vcpkg.cmake'
-
-env:
-  # Secret variable, has to be exported manually.
-  BUILD_NUMBER_TOKEN: $(BUILD_NUMBER_TOKEN)
+  # On Azure we have a secret variable called BUILD_NUMBER_TOKEN that will be referenced in the following
+  # YAML files. As it is set there though, we don't have to specify it here.
 
 jobs:
   - job: Windows_x86_64

--- a/.ci/azure-pipelines/steps_linux.yml
+++ b/.ci/azure-pipelines/steps_linux.yml
@@ -4,6 +4,8 @@ steps:
   - script: .ci/azure-pipelines/install-environment_linux.bash
     displayName: 'Install build environment'
   - script: .ci/azure-pipelines/build_linux.bash
+    env:
+      MUMBLE_BUILD_NUMBER_TOKEN: $(BUILD_NUMBER_TOKEN)
     displayName: 'Build'
   - script: .ci/azure-pipelines/package_AppImage.bash
     displayName: 'Package AppImage'

--- a/.ci/azure-pipelines/steps_macos.yml
+++ b/.ci/azure-pipelines/steps_macos.yml
@@ -10,6 +10,8 @@ steps:
     - script: .ci/azure-pipelines/install-environment_macos.bash
       displayName: 'Install build environment'
   - script: .ci/azure-pipelines/build_macos.bash
+    env:
+      MUMBLE_BUILD_NUMBER_TOKEN: $(BUILD_NUMBER_TOKEN)
     displayName: 'Build'
   - template: task-publish-artifacts.yml
     parameters:

--- a/.ci/azure-pipelines/steps_windows.yml
+++ b/.ci/azure-pipelines/steps_windows.yml
@@ -4,6 +4,8 @@ steps:
   - powershell: .ci/azure-pipelines/install-environment_windows.ps1
     displayName: 'Install build environment'
   - script: .ci/azure-pipelines/build_windows.bat
+    env:
+      MUMBLE_BUILD_NUMBER_TOKEN: $(BUILD_NUMBER_TOKEN)
     displayName: 'Build'
   - template: task-publish-artifacts.yml
     parameters:


### PR DESCRIPTION
Turns out environment variables cannot be exported globally:

"/.ci/azure-pipelines/main.yml (Line: 7, Col: 1): Unexpected value 'env'"

It has to be done for each step that makes use of the variable.

Furthermore if a variable is not defined on Azure, the expansion
$(MY_VARIABLE) does not resolve to an empty String (as is the case e.g.
in Bash) but this expression is then taken literally without any
expansion at all. Therefore we have to make sure that the
BUILD_NUMBER_TOKEN variable is always defined. Thus we define it in
main-pr.yml as for PRs we don't define it on Azure.

In order for these variables to not interfere with each other, the
variable name inside the scripts was prefixed with MUMBLE_
