### PR TITLE
CI(azure): Simplify and improve job name for Windows builds

### DIFF
--- a/.ci/azure-pipelines/main-pr.yml
+++ b/.ci/azure-pipelines/main-pr.yml
@@ -9,8 +9,7 @@ variables:
   BUILD_NUMBER_TOKEN: ''
 
 jobs:
-  - job: Windows_x86_64
-    displayName: Windows (x86_64)
+  - job: Windows_x64
     pool:
       vmImage: 'windows-latest'
     variables:
@@ -22,7 +21,6 @@ jobs:
       parameters:
         arch: 'x64'
   - job: Windows_x86
-    displayName: Windows (x86)
     pool:
       vmImage: 'windows-latest'
     variables:

--- a/.ci/azure-pipelines/main.yml
+++ b/.ci/azure-pipelines/main.yml
@@ -7,8 +7,7 @@ variables:
   # YAML files. As it is set there though, we don't have to specify it here.
 
 jobs:
-  - job: Windows_x86_64
-    displayName: Windows (x86_64)
+  - job: Windows_x64
     pool:
       vmImage: 'windows-latest'
     variables:
@@ -20,7 +19,6 @@ jobs:
       parameters:
         arch: 'x64'
   - job: Windows_x86
-    displayName: Windows (x86)
     pool:
       vmImage: 'windows-latest'
     variables:


### PR DESCRIPTION
This fixes the last build failure, which was due to the job's display name containing spaces.

`x86_64` is changed to `x64` as the latter appears to be the most common identifier for the architecture, at least for Windows.