### PR TITLE
FIX(audio): Avoid silence to be transferred

### DIFF
--- a/src/mumble/AudioInput.cpp
+++ b/src/mumble/AudioInput.cpp
@@ -1156,6 +1156,11 @@ void AudioInput::encodeAudioFrame(AudioChunk chunk) {
 		++iBufferedFrames;
 	} else if (umtType == MessageHandler::UDPVoiceOpus) {
 		encoded = false;
+
+		// after noise suppressor, frames with full of zeros might be transferred
+		// check if the frame encoded is almost zeros and simply dump those frames
+		if (!iBufferedFrames && abs(sum) < 1.0f) return;
+
 		opusBuffer.insert(opusBuffer.end(), psSource, psSource + iFrameSize);
 		++iBufferedFrames;
 


### PR DESCRIPTION
> I'm in action.

This commit will pre-screen audio samples returned by audio backends and remove
trailing zeros before adding these samples to the audio processing chain.

It seems that silent samples will actually be encoded into zeros by opus.
First of all, transferring packets with zeros doesn't make sense but
occupying unnecessary network bandwidth.
Also, in #4385, we try to avoid produce packets ending with zeros in order to
circumvent some subtle encryption problem of OCB2.

Fix #4385.

