### PR TITLE
CI(azure): Fix VERSION variable not being expanded correctly in curl call

### DIFF
--- a/.ci/azure-pipelines/build_linux.bash
+++ b/.ci/azure-pipelines/build_linux.bash
@@ -21,7 +21,7 @@
 
 if [[ -n "$MUMBLE_BUILD_NUMBER_TOKEN" ]]; then
 	VERSION=$(python "scripts/mumble-version.py" --project)
-	BUILD_NUMBER=$(curl "https://mumble.info/get-build-number?version=$VERSION_$AGENT_JOBNAME&token=$MUMBLE_BUILD_NUMBER_TOKEN")
+	BUILD_NUMBER=$(curl "https://mumble.info/get-build-number?version=${VERSION}_${AGENT_JOBNAME}&token=${MUMBLE_BUILD_NUMBER_TOKEN}")
 else
 	BUILD_NUMBER=0
 fi

--- a/.ci/azure-pipelines/build_macos.bash
+++ b/.ci/azure-pipelines/build_macos.bash
@@ -32,7 +32,7 @@
 
 if [[ -n "$MUMBLE_BUILD_NUMBER_TOKEN" ]]; then
 	VERSION=$(python "scripts/mumble-version.py" --project)
-	BUILD_NUMBER=$(curl "https://mumble.info/get-build-number?version=$VERSION_$AGENT_JOBNAME&token=$MUMBLE_BUILD_NUMBER_TOKEN")
+	BUILD_NUMBER=$(curl "https://mumble.info/get-build-number?version=${VERSION}_${AGENT_JOBNAME}&token=${MUMBLE_BUILD_NUMBER_TOKEN}")
 else
 	BUILD_NUMBER=0
 fi

--- a/.ci/azure-pipelines/build_windows.bat
+++ b/.ci/azure-pipelines/build_windows.bat
@@ -38,7 +38,7 @@
 if defined MUMBLE_BUILD_NUMBER_TOKEN (
 	:: The method we use to store a command's output into a variable:
 	:: https://stackoverflow.com/a/6362922
-	for /f "tokens=* USEBACKQ" %%g in (`python "scripts/mumble-version.py" --project`) do (set "VERSION=%%g")
+	for /f "tokens=* USEBACKQ" %%g in (`python "scripts\mumble-version.py" --project`) do (set "VERSION=%%g")
 	for /f "tokens=* USEBACKQ" %%g in (`curl "https://mumble.info/get-build-number?version=%VERSION%_%AGENT_JOBNAME%&token=%MUMBLE_BUILD_NUMBER_TOKEN%"`) do (set "BUILD_NUMBER=%%g")
 ) else (
 	set BUILD_NUMBER=0


### PR DESCRIPTION
On Windows (Batch) the syntax was correct, but `mumble-version.py` was not being executed due to the path using a slash instead of a backslash.

On UNIX (Bash) the syntax was incorrect: https://unix.stackexchange.com/questions/88452/concatenating-two-variables-with-an-underscore