### PR TITLE
REFAC(client): Move CompletablePage class into dedicated file set

### DIFF
--- a/src/mumble/AudioWizard.cpp
+++ b/src/mumble/AudioWizard.cpp
@@ -20,19 +20,6 @@
 // (like protobuf 3.7 does). As such, for now, we have to make this our last include.
 #include "Global.h"
 
-CompletablePage::CompletablePage(QWizard *p) : QWizardPage(p) {
-	bComplete = true;
-}
-
-void CompletablePage::setComplete(bool b) {
-	bComplete = b;
-	emit completeChanged();
-}
-
-bool CompletablePage::isComplete() const {
-	return bComplete;
-}
-
 AudioWizard::AudioWizard(QWidget *p) : QWizard(p) {
 	bInit            = true;
 	bLastActive      = false;

--- a/src/mumble/AudioWizard.h
+++ b/src/mumble/AudioWizard.h
@@ -6,27 +6,12 @@
 #ifndef MUMBLE_MUMBLE_AUDIOWIZARD_H_
 #define MUMBLE_MUMBLE_AUDIOWIZARD_H_
 
-#include <QtCore/QtGlobal>
-#include <QtWidgets/QWizard>
-#include <QtWidgets/QWizardPage>
+#include "ui_AudioWizard.h"
 
 #include "AudioOutput.h"
 #include "AudioStats.h"
 #include "Settings.h"
 #include "GlobalShortcut.h"
-
-class CompletablePage : public QWizardPage {
-	Q_OBJECT
-protected:
-	bool bComplete;
-
-public:
-	CompletablePage(QWizard *p = nullptr);
-	void setComplete(bool);
-	bool isComplete() const Q_DECL_OVERRIDE;
-};
-
-#include "ui_AudioWizard.h"
 
 class AudioWizard : public QWizard, public Ui::AudioWizard {
 private:

--- a/src/mumble/AudioWizard.ui
+++ b/src/mumble/AudioWizard.ui
@@ -890,15 +890,15 @@ Mumble is under continuous development, and the development team wants to focus 
  </widget>
  <customwidgets>
   <customwidget>
-   <class>AudioBar</class>
-   <extends>QWidget</extends>
-   <header>AudioStats.h</header>
+   <class>CompletablePage</class>
+   <extends>QWizardPage</extends>
+   <header>CompletablePage.h</header>
    <container>1</container>
   </customwidget>
   <customwidget>
-   <class>CompletablePage</class>
-   <extends>QWizardPage</extends>
-   <header>AudioWizard.h</header>
+   <class>AudioBar</class>
+   <extends>QWidget</extends>
+   <header>AudioStats.h</header>
    <container>1</container>
   </customwidget>
   <customwidget>

--- a/src/mumble/CMakeLists.txt
+++ b/src/mumble/CMakeLists.txt
@@ -233,6 +233,8 @@ set(MUMBLE_SOURCES
 	"XMLTools.cpp"
 	"XMLTools.h"
 
+	"widgets/CompletablePage.cpp"
+	"widgets/CompletablePage.h"
 	"widgets/MUComboBox.cpp"
 	"widgets/MUComboBox.h"
 	"widgets/MultiStyleWidgetWrapper.cpp"

--- a/src/mumble/Cert.ui
+++ b/src/mumble/Cert.ui
@@ -232,14 +232,14 @@
         <italic>true</italic>
        </font>
       </property>
-      <property name="wordWrap">
-       <bool>true</bool>
-      </property>
       <property name="styleSheet">
        <string notr="true">color:#ff0000;</string>
       </property>
       <property name="text">
        <string/>
+      </property>
+      <property name="wordWrap">
+       <bool>true</bool>
       </property>
      </widget>
     </item>
@@ -496,7 +496,7 @@ Are you sure you wish to replace your certificate?
   <customwidget>
    <class>CompletablePage</class>
    <extends>QWizardPage</extends>
-   <header>AudioWizard.h</header>
+   <header>CompletablePage.h</header>
    <container>1</container>
   </customwidget>
   <customwidget>

--- a/src/mumble/widgets/CompletablePage.cpp
+++ b/src/mumble/widgets/CompletablePage.cpp
@@ -1,0 +1,15 @@
+// Copyright 2021 The Mumble Developers. All rights reserved.
+// Use of this source code is governed by a BSD-style license
+// that can be found in the LICENSE file at the root of the
+// Mumble source tree or at <https://www.mumble.info/LICENSE>.
+
+#include "CompletablePage.h"
+
+CompletablePage::CompletablePage(QWizard *parent) : QWizardPage(parent) {
+	m_complete = true;
+}
+
+void CompletablePage::setComplete(const bool complete) {
+	m_complete = complete;
+	emit completeChanged();
+}

--- a/src/mumble/widgets/CompletablePage.h
+++ b/src/mumble/widgets/CompletablePage.h
@@ -1,0 +1,24 @@
+// Copyright 2021 The Mumble Developers. All rights reserved.
+// Use of this source code is governed by a BSD-style license
+// that can be found in the LICENSE file at the root of the
+// Mumble source tree or at <https://www.mumble.info/LICENSE>.
+
+#ifndef MUMBLE_MUMBLE_WIDGETS_COMPLETABLEPAGE_H_
+#define MUMBLE_MUMBLE_WIDGETS_COMPLETABLEPAGE_H_
+
+#include <QtWidgets/QWizardPage>
+
+class CompletablePage : public QWizardPage {
+	Q_OBJECT
+protected:
+	bool m_complete;
+
+public:
+	virtual inline bool isComplete() const { return m_complete; }
+
+	void setComplete(const bool complete);
+
+	CompletablePage(QWizard *parent = nullptr);
+};
+
+#endif


### PR DESCRIPTION
The class was defined in `AudioWizard.cpp`/`.h`, however `AudioWizard` is not the only user.

In fact, `Cert.ui` had to include `AudioWizard.h` in order to make use of `CompletablePage`.

This pull request moves the class into a dedicated file set and changes the include header in `AudioWizard.ui`and `Cert.ui`.