### PR TITLE
Backport "Use qInfo instead of qFatal for normal logging"

### DIFF
--- a/src/murmur/main.cpp
+++ b/src/murmur/main.cpp
@@ -295,14 +295,16 @@ int main(int argc, char **argv) {
 			bVerbose = true;
 		} else if ((arg == "-version") || (arg == "--version")) {
 			detach = false;
-			qFatal("%s -- %s", qPrintable(args.at(0)), MUMBLE_RELEASE);
+			qInfo("%s -- %s", qPrintable(args.at(0)), MUMBLE_RELEASE);
+			return 0;
 		} else if (args.at(i) == QLatin1String("-license") || args.at(i) == QLatin1String("--license")) {
 #ifdef Q_OS_WIN
 			AboutDialog ad(NULL, AboutDialogOptionsShowLicense);
 			ad.exec();
 			return 0;
 #else
-			qFatal("%s\n", qPrintable(License::license()));
+			qInfo("%s\n", qPrintable(License::license()));
+			return 0;
 #endif
 		} else if (args.at(i) == QLatin1String("-authors") || args.at(i) == QLatin1String("--authors")) {
 #ifdef Q_OS_WIN
@@ -310,7 +312,8 @@ int main(int argc, char **argv) {
 			ad.exec();
 			return 0;
 #else
-			qFatal("%s\n", qPrintable(License::authors()));
+			qInfo("%s\n", qPrintable(License::authors()));
+			return 0;
 #endif
 		} else if (args.at(i) == QLatin1String("-third-party-licenses") || args.at(i) == QLatin1String("--third-party-licenses")) {
 #ifdef Q_OS_WIN
@@ -318,11 +321,12 @@ int main(int argc, char **argv) {
 			ad.exec();
 			return 0;
 #else
-			qFatal("%s", qPrintable(License::printableThirdPartyLicenseInfo()));
+			qInfo("%s", qPrintable(License::printableThirdPartyLicenseInfo()));
+			return 0;
 #endif
 		} else if ((arg == "-h") || (arg == "-help") || (arg == "--help")) {
 			detach = false;
-			qFatal("Usage: %s [-ini <inifile>] [-supw <password>]\n"
+			qInfo("Usage: %s [-ini <inifile>] [-supw <password>]\n"
 			       "  -ini <inifile>         Specify ini file to use.\n"
 			       "  -supw <pw> [srv]       Set password for 'SuperUser' account on server srv.\n"
 #ifdef Q_OS_UNIX
@@ -350,6 +354,7 @@ int main(int argc, char **argv) {
 			       "\n"
 			       "If no inifile is provided, murmur will search for one in \n"
 			       "default locations.", qPrintable(args.at(0)));
+			return 0;
 #ifdef Q_OS_UNIX
 		} else if (arg == "-limits") {
 			detach = false;
@@ -369,7 +374,7 @@ int main(int argc, char **argv) {
 	}
 
 	if (QSslSocket::supportsSsl()) {
-		qWarning("SSL: OpenSSL version is '%s'", SSLeay_version(SSLEAY_VERSION));
+		qInfo("SSL: OpenSSL version is '%s'", SSLeay_version(SSLEAY_VERSION));
 	} else {
 		qFatal("SSL: this version of Murmur is built against Qt without SSL Support. Aborting.");
 	}
@@ -451,12 +456,14 @@ int main(int argc, char **argv) {
 			qFatal("Superuser password can not be empty");
 		}
 		ServerDB::setSUPW(sunum, supw);
-		qFatal("Superuser password set on server %d", sunum);
+		qInfo("Superuser password set on server %d", sunum);
+		return 0;
 	}
 
 	if (disableSu) {
 	        ServerDB::disableSU(sunum);
-	        qFatal("SuperUser password disabled on server %d", sunum);
+	        qInfo("SuperUser password disabled on server %d", sunum);
+			return 0;
 	}
 
 	if (wipeSsl) {


### PR DESCRIPTION
For some reason qFatal has been used to log information such as the
version requested by the --version argument.
abdb5004bb92b28271673e33df9cc3e314f5711a made qFatal exit with an
exit status of one leading to successful operations that happened
to contain some print-out to leave an exit status of 1 (#3911).

Note: This is a backport of #3998