### PR TITLE
Backport "FIX(client): Ancient notification icon names"

### DIFF
--- a/src/mumble/Log_unix.cpp
+++ b/src/mumble/Log_unix.cpp
@@ -18,16 +18,16 @@ void Log::postNotification(MsgType mt, const QString &plain) {
 	switch (mt) {
 		case DebugInfo:
 		case CriticalError:
-			qsIcon=QLatin1String("gtk-dialog-error");
+			qsIcon = QLatin1String("dialog-error");
 			break;
 		case Warning:
-			qsIcon=QLatin1String("gtk-dialog-warning");
+			qsIcon = QLatin1String("dialog-warning");
 			break;
 		case TextMessage:
-			qsIcon=QLatin1String("gtk-edit");
+			qsIcon = QLatin1String("accessories-text-editor");
 			break;
 		default:
-			qsIcon=QLatin1String("gtk-dialog-info");
+			qsIcon = QLatin1String("dialog-information");
 			break;
 	}
 


### PR DESCRIPTION
These no longer exist in contemporary icon themes like Adwaita.

Per https://developer.gnome.org/gtk3/stable/gtk3-Stock-Items.html
and https://specifications.freedesktop.org/icon-naming-spec/latest/ar01s04.html

This is a backport of #4705
