### PR TITLE
Backport "FIX(client): Only allow "http"/"https" for URLs in ConnectDialog"

### DIFF
--- a/src/mumble/ConnectDialog.cpp
+++ b/src/mumble/ConnectDialog.cpp
@@ -1265,11 +1265,25 @@ void ConnectDialog::on_qaFavoritePaste_triggered() {
 }
 
 void ConnectDialog::on_qaUrl_triggered() {
-	ServerItem *si = static_cast<ServerItem *>(qtwServers->currentItem());
-	if (! si || si->qsUrl.isEmpty())
+	auto *si = static_cast< const ServerItem * >(qtwServers->currentItem());
+	if (!si || si->qsUrl.isEmpty()) {
 		return;
+	}
 
-	QDesktopServices::openUrl(QUrl(si->qsUrl));
+	const QStringList allowedSchemes = { QLatin1String("http"), QLatin1String("https") };
+
+	const auto url = QUrl(si->qsUrl);
+	if (allowedSchemes.contains(url.scheme())) {
+		QDesktopServices::openUrl(url);
+	} else {
+		// Inform user that the requested URL has been blocked
+		QMessageBox msgBox;
+		msgBox.setText(QObject::tr("<b>Blocked URL scheme \"%1\"</b>").arg(url.scheme()));
+		msgBox.setInformativeText(QObject::tr("The URL uses a scheme that has been blocked for security reasons."));
+		msgBox.setDetailedText(QObject::tr("Blocked URL: \"%1\"").arg(url.toString()));
+		msgBox.setIcon(QMessageBox::Warning);
+		msgBox.exec();
+	}
 }
 
 void ConnectDialog::onFiltersTriggered(QAction *act) {

--- a/src/mumble/mumble_en.ts
+++ b/src/mumble/mumble_en.ts
@@ -7926,6 +7926,20 @@ To upgrade these files to their latest versions, click the button below.</source
     </message>
 </context>
 <context>
+    <message>
+        <source>&lt;b&gt;Blocked URL scheme &quot;%1&quot;&lt;/b&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The URL uses a scheme that has been blocked for security reasons.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Blocked URL: &quot;%1&quot;</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>RichTextEditor</name>
     <message>
         <location filename="RichTextEditor.cpp" line="+236"/>


### PR DESCRIPTION
Our public server list registration script doesn't have an URL scheme
whitelist for the website field.

Turns out a malicious server can register itself with a dangerous URL in
an attempt to attack a user's machine.

User interaction is required, as the URL has to be opened by
right-clicking on the server entry and clicking on "Open Webpage".

This commit introduces a client-side whitelist, which only allows "http"
and "https" schemes. We will also implement it in our public list.

In future we should probably add a warning QMessageBox informing the
user that there's no guarantee the URL is safe (regardless of the
scheme).

Thanks a lot to https://positive.security for reporting the RCE
vulnerability to us privately.

This is a backport of #4733