### PR TITLE
FIX(installer): Change version regex so that it accepts multiple digits

### DIFF
--- a/installer/ClientInstaller.cs
+++ b/installer/ClientInstaller.cs
@@ -172,7 +172,7 @@ class BuildInstaller
 		bool isAllLangs = false;
 
 		for (int i = 0; i < args.Length; i++) {
-			if (args[i] == "--version" && Regex.IsMatch(args[i + 1], @"^[0-9]\.[0-9]\.[0-9]\.[0-9]$")) {
+			if (args[i] == "--version" && Regex.IsMatch(args[i + 1], @"^([0-9]+\.){3}[0-9]+$")) {
 				version = args[i + 1];
 			}
 

--- a/installer/ServerInstaller.cs
+++ b/installer/ServerInstaller.cs
@@ -88,7 +88,7 @@ class BuildInstaller
 		bool isAllLangs = false;
 
 		for (int i = 0; i < args.Length; i++) {
-			if (args[i] == "--version" && Regex.IsMatch(args[i + 1], @"^[0-9]\.[0-9]\.[0-9]\.[0-9]$")) {
+			if (args[i] == "--version" && Regex.IsMatch(args[i + 1], @"^([0-9]+\.){3}[0-9]+$")) {
 				version = args[i + 1];
 			}
 


### PR DESCRIPTION
Now that we reached build number 10 the current expression is not valid anymore.

As a result, the version is not set and the build fails.

This PR rewrites the regex so that it accepts multiple digits and is also shorter.