### PR TITLE
CI: Update to FreeBSD 12.2

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,5 +1,5 @@
 freebsd_instance:
-  image: freebsd-12-1-release-amd64
+  image: freebsd-12-2-release-amd64
 
 freebsd_task:
   pkg_script:


### PR DESCRIPTION
According to https://www.freebsd.org/releases/ 12.1 is no longer
supported.

This also seemed to cause some problems in the most recent runs of the
Cirrus CI tasks.

Thus this commit updates the used version to 12.2

<!-- Please make sure that you follow our commit guidelines specified at https://github.com/mumble-voip/mumble/blob/master/COMMIT_GUIDELINES.md -->
