### PR TITLE
CI(azure): Use version & commit hash as identifier for build number

### DIFF
--- a/.ci/azure-pipelines/build_linux.bash
+++ b/.ci/azure-pipelines/build_linux.bash
@@ -1,6 +1,6 @@
 #!/bin/bash -ex
 #
-# Copyright 2019-2020 The Mumble Developers. All rights reserved.
+# Copyright 2019-2021 The Mumble Developers. All rights reserved.
 # Use of this source code is governed by a BSD-style license
 # that can be found in the LICENSE file at the root of the
 # Mumble source tree or at <https://www.mumble.info/LICENSE>.
@@ -21,7 +21,7 @@
 
 if [[ -n "$MUMBLE_BUILD_NUMBER_TOKEN" ]]; then
 	VERSION=$(python "scripts/mumble-version.py" --project)
-	BUILD_NUMBER=$(curl "https://mumble.info/get-build-number?version=${VERSION}_${AGENT_JOBNAME}&token=${MUMBLE_BUILD_NUMBER_TOKEN}")
+	BUILD_NUMBER=$(curl "https://mumble.info/get-build-number?commit=${BUILD_SOURCEVERSION}&version=${VERSION}&token=${MUMBLE_BUILD_NUMBER_TOKEN}")
 else
 	BUILD_NUMBER=0
 fi

--- a/.ci/azure-pipelines/build_macos.bash
+++ b/.ci/azure-pipelines/build_macos.bash
@@ -1,6 +1,6 @@
 #!/bin/bash -ex
 #
-# Copyright 2019-2020 The Mumble Developers. All rights reserved.
+# Copyright 2019-2021 The Mumble Developers. All rights reserved.
 # Use of this source code is governed by a BSD-style license
 # that can be found in the LICENSE file at the root of the
 # Mumble source tree or at <https://www.mumble.info/LICENSE>.
@@ -32,7 +32,7 @@
 
 if [[ -n "$MUMBLE_BUILD_NUMBER_TOKEN" ]]; then
 	VERSION=$(python "scripts/mumble-version.py" --project)
-	BUILD_NUMBER=$(curl "https://mumble.info/get-build-number?version=${VERSION}_${AGENT_JOBNAME}&token=${MUMBLE_BUILD_NUMBER_TOKEN}")
+	BUILD_NUMBER=$(curl "https://mumble.info/get-build-number?commit=${BUILD_SOURCEVERSION}&version=${VERSION}&token=${MUMBLE_BUILD_NUMBER_TOKEN}")
 else
 	BUILD_NUMBER=0
 fi

--- a/.ci/azure-pipelines/build_windows.bat
+++ b/.ci/azure-pipelines/build_windows.bat
@@ -1,4 +1,4 @@
-:: Copyright 2020 The Mumble Developers. All rights reserved.
+:: Copyright 2020-2021 The Mumble Developers. All rights reserved.
 :: Use of this source code is governed by a BSD-style license
 :: that can be found in the LICENSE file at the root of the
 :: Mumble source tree or at <https://www.mumble.info/LICENSE>.
@@ -43,13 +43,13 @@ for /f "tokens=* USEBACKQ" %%g in (`python "scripts\mumble-version.py" --project
 :: in that case the variable substitution of that variable in the expression below fails (is replaced with empty string)
 :: Also we can't anything else inside the if body as this will cause the curl command to always be executed.
 if defined MUMBLE_BUILD_NUMBER_TOKEN (
-	for /f "tokens=* USEBACKQ" %%g in (`curl "https://mumble.info/get-build-number?version=%VERSION%_%AGENT_JOBNAME%&token=%MUMBLE_BUILD_NUMBER_TOKEN%"`) do (set "BUILD_NUMBER=%%g")
+	for /f "tokens=* USEBACKQ" %%g in (`curl "https://mumble.info/get-build-number?commit=%BUILD_SOURCEVERSION%&version=%VERSION%&token=%MUMBLE_BUILD_NUMBER_TOKEN%"`) do (set "BUILD_NUMBER=%%g")
 ) else (
 	echo Build number token not set - defaulting to 0
 	set BUILD_NUMBER=0
 )
 
-for /f "tokens=* USEBACKQ" %%g in (`python "scripts/mumble-version.py"`) do (set "RELEASE_ID=%%g")
+for /f "tokens=* USEBACKQ" %%g in (`python "scripts\mumble-version.py"`) do (set "RELEASE_ID=%%g")
 
 cd /d %BUILD_BINARIESDIRECTORY%
 


### PR DESCRIPTION
Our script on the server now bumps the build number for every new version.
A version is now associated to a unique build number and vice versa.

The previous system didn't cause collisions, but it was very fragile.
For example, the build number got de-synced between OSes a few days ago.
It probably happened due to at least a build being restarted after the build number bump.

With the new system there should be no problems anymore, as the build number is permanent for a given version.