### PR TITLE
FEAT(client): Add "starttalking" and "stoptalking" to the socket RPC interface

### DIFF
--- a/src/mumble/SocketRPC.cpp
+++ b/src/mumble/SocketRPC.cpp
@@ -163,6 +163,14 @@ void SocketRPCClient::processXml() {
 					g.mw->qaAudioDeaf->trigger();
 				}
 			}
+			iter = qmRequest.find(QLatin1String("starttalking"));
+			if (iter != qmRequest.constEnd()) {
+				g.mw->on_PushToTalk_triggered(true, QVariant());
+			}
+			iter = qmRequest.find(QLatin1String("stoptalking"));
+			if (iter != qmRequest.constEnd()) {
+				g.mw->on_PushToTalk_triggered(false, QVariant());
+			}
 			ack = true;
 		} else if (request.nodeName() == QLatin1String("url")) {
 			if (g.sh && g.sh->isRunning() && g.uiSession) {

--- a/src/mumble/main.cpp
+++ b/src/mumble/main.cpp
@@ -298,6 +298,10 @@ int main(int argc, char **argv) {
 								   "                Undeafen self\n"
 								   "  toggledeaf\n"
 								   "                Toggle self-deafen status\n"
+								   "  starttalking\n"
+								   "                Start talking\n"
+								   "  stoptalking\n"
+								   "                Stop talking\n"
 								   "\n");
 
 				QString helpOutput = helpMessage + rpcHelpBanner + rpcHelpMessage;

--- a/src/mumble/mumble_en.ts
+++ b/src/mumble/mumble_en.ts
@@ -5725,29 +5725,6 @@ Otherwise abort and check your certificate and username.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Usage: mumble rpc &lt;action&gt; [options]
-
-It is possible to remote control a running instance of Mumble by using
-the &apos;mumble rpc&apos; command.
-
-Valid actions are:
-  mute
-                Mute self
-  unmute
-                Unmute self
-  togglemute
-                Toggle self-mute status
-  deaf
-                Deafen self
-  undeaf
-                Undeafen self
-  toggledeaf
-                Toggle self-deafen status
-
-</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Invocation</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6225,6 +6202,33 @@ Valid options are:
     </message>
     <message>
         <source>Sets a local nickname for another user.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Usage: mumble rpc &lt;action&gt; [options]
+
+It is possible to remote control a running instance of Mumble by using
+the &apos;mumble rpc&apos; command.
+
+Valid actions are:
+  mute
+                Mute self
+  unmute
+                Unmute self
+  togglemute
+                Toggle self-mute status
+  deaf
+                Deafen self
+  undeaf
+                Undeafen self
+  toggledeaf
+                Toggle self-deafen status
+  starttalking
+                Start talking
+  stoptalking
+                Stop talking
+
+</source>
         <translation type="unfinished"></translation>
     </message>
 </context>


### PR DESCRIPTION
FEAT(client): add starttalking and stoptalking to the socket rpc interface

If mumble isn't allowed to listen to all input from an input device, for example when running as wayland client, ptt events can be sent via socket rpc, and, in the case of wayland, the keybinding can be done by the compositor. #3675 implements this for dbus.
To avoid executing the rather large mumble binary to do the rpc, one could also do something like this:
 `echo '<self><starttalking>starttalking</starttalking></self>' | socat - UNIX-CONNECT:/tmp/MumbleSocket`

Fixes  #1594