### PR TITLE
Fix echo cancellation setting not saved

### DIFF
--- a/src/mumble/Settings.cpp
+++ b/src/mumble/Settings.cpp
@@ -401,7 +401,16 @@ Settings::Settings() {
 	bJackStartServer  = false;
 	bJackAutoConnect  = true;
 
-	echoOption = EchoCancelOptionID::DISABLED;
+#ifdef Q_OS_MAC
+	// On macOS Speex can't be used, so we default to Apple's custom echo cancellation mode
+	// Note that this only seems to work with when using the builtin microphone and the builtin speakers. It
+	// doesn't make it worse for other combinations of input and output devices though. Thus it should be
+	// safe to enable this by default.
+	echoOption = EchoCancelOptionID::APPLE_AEC;
+#else
+	// Everywhere else Speex works and thus we default to using that
+	echoOption = EchoCancelOptionID::SPEEX_MIXED;
+#endif
 
 	bExclusiveInput  = false;
 	bExclusiveOutput = false;

--- a/src/mumble/Settings.cpp
+++ b/src/mumble/Settings.cpp
@@ -1124,7 +1124,7 @@ void Settings::save() {
 	SAVELOAD(fAudioMaxDistance, "audio/maxdistance");
 	SAVELOAD(fAudioMaxDistVolume, "audio/maxdistancevolume");
 	SAVELOAD(fAudioBloom, "audio/bloom");
-	LOADFLAG(echoOption, "audio/echooptionid");
+	SAVEFLAG(echoOption, "audio/echooptionid");
 	SAVELOAD(bExclusiveInput, "audio/exclusiveinput");
 	SAVELOAD(bExclusiveOutput, "audio/exclusiveoutput");
 	SAVELOAD(bPositionalAudio, "audio/positional");

--- a/src/mumble/Settings.cpp
+++ b/src/mumble/Settings.cpp
@@ -170,7 +170,7 @@ OverlaySettings::OverlaySettings() {
 	fY    = 0.0f;
 	fZoom = 0.875f;
 
-#ifdef Q_OS_MAC
+#ifdef Q_OS_MACOS
 	qsStyle = QLatin1String("Cleanlooks");
 #endif
 
@@ -211,7 +211,7 @@ void OverlaySettings::setPreset(const OverlayPresets preset) {
 			fMutedDeafened = 0.5f;
 			fAvatar        = 1.0f;
 
-#if defined(Q_OS_WIN) || defined(Q_OS_MAC)
+#if defined(Q_OS_WIN) || defined(Q_OS_MACOS)
 			qfUserName = QFont(QLatin1String("Verdana"), 20);
 #else
 			qfUserName = QFont(QLatin1String("Arial"), 20);
@@ -251,7 +251,7 @@ void OverlaySettings::setPreset(const OverlayPresets preset) {
 			fMutedDeafened = (7.0f / 8.0f);
 			fAvatar        = 1.0f;
 
-#if defined(Q_OS_WIN) || defined(Q_OS_MAC)
+#if defined(Q_OS_WIN) || defined(Q_OS_MACOS)
 			qfUserName = QFont(QLatin1String("Verdana"), 20);
 #else
 			qfUserName = QFont(QLatin1String("Arial"), 20);
@@ -615,7 +615,7 @@ BOOST_TYPEOF_REGISTER_TEMPLATE(QList, 1)
 // it. This causes such settings to fall back
 // to their defaults, instead of being set to
 // a zero value.
-#ifdef Q_OS_MAC
+#ifdef Q_OS_MACOS
 #	undef SAVELOAD
 #	define SAVELOAD(var, name)                                                                          \
 		do {                                                                                             \
@@ -1039,7 +1039,7 @@ void OverlaySettings::save(QSettings *settings_ptr) {
 	settings_ptr->setValue(QLatin1String("version"), QLatin1String(MUMTEXT(MUMBLE_VERSION)));
 	settings_ptr->sync();
 
-#if defined(Q_OS_WIN) || defined(Q_OS_MAC)
+#if defined(Q_OS_WIN) || defined(Q_OS_MACOS)
 	if (settings_ptr->format() == QSettings::IniFormat)
 #endif
 	{


### PR DESCRIPTION
This fixes a few regressions introduced in #4694 affecting the echo cancellation settings.

Fixes #4761

### Checks

- [x] My commits follow the [commit guidelines](https://github.com/mumble-voip/mumble/blob/master/COMMIT_GUIDELINES.md)

