### PR TITLE
BUILD(versioning): Remove tag logic, implement "--revision", "--format" and "--type" options in mumble-version.py

### DIFF
--- a/.ci/azure-pipelines/build_linux.bash
+++ b/.ci/azure-pipelines/build_linux.bash
@@ -20,7 +20,7 @@
 #
 
 if [[ -n "$MUMBLE_BUILD_NUMBER_TOKEN" ]]; then
-	VERSION=$(python "scripts/mumble-version.py" --project)
+	VERSION=$(python "scripts/mumble-version.py" --format version)
 	BUILD_NUMBER=$(curl "https://mumble.info/get-build-number?commit=${BUILD_SOURCEVERSION}&version=${VERSION}&token=${MUMBLE_BUILD_NUMBER_TOKEN}")
 else
 	BUILD_NUMBER=0

--- a/.ci/azure-pipelines/build_macos.bash
+++ b/.ci/azure-pipelines/build_macos.bash
@@ -31,7 +31,7 @@
 #
 
 if [[ -n "$MUMBLE_BUILD_NUMBER_TOKEN" ]]; then
-	VERSION=$(python "scripts/mumble-version.py" --project)
+	VERSION=$(python "scripts/mumble-version.py" --format version)
 	BUILD_NUMBER=$(curl "https://mumble.info/get-build-number?commit=${BUILD_SOURCEVERSION}&version=${VERSION}&token=${MUMBLE_BUILD_NUMBER_TOKEN}")
 else
 	BUILD_NUMBER=0

--- a/.ci/azure-pipelines/build_windows.bat
+++ b/.ci/azure-pipelines/build_windows.bat
@@ -37,7 +37,7 @@
 
 :: The method we use to store a command's output into a variable:
 :: https://stackoverflow.com/a/6362922
-for /f "tokens=* USEBACKQ" %%g in (`python "scripts\mumble-version.py" --project`) do (set "VERSION=%%g")
+for /f "tokens=* USEBACKQ" %%g in (`python "scripts\mumble-version.py" --format version`) do (set "VERSION=%%g")
 
 :: For some really stupid reason we can't have this statement and the one where we set the VERSION variable in the same if body as
 :: in that case the variable substitution of that variable in the expression below fails (is replaced with empty string)


### PR DESCRIPTION
The tag logic is removed from the script.
Its purpose was to set the name of the tag associated to the latest version as version.

It was working as expected, however in some instances we don't want the script to take the tag into account.
For example, we had to rebuild the first 1.4.0 snapshot as the version was accidentally set to `1.4.0-snapshot1`.

As replacement, the `--revision`and `--type` options are implemened.
They allow to explicitly set the release type and its revision, when applicable.

Assuming the revision is set to 1 (default value), the output is currently as follows:

Type set to "snapshot": `1.4.0~2021-02-14~g973cee211~snapshot`
Type set to "beta": `1.4.0-beta1`
Type set to "rc": `1.4.0-rc1`
Type set to "stable": `1.4.0`

The `--format` option replaces `--project` and allows to specify the desired string format:

- `full`: The default. Prints version + suffix (e.g. `1.4.0~2021-02-14~g973cee211~snapshot`).
- `version`: Only prints the version (e.g. `1.4.0`).
- `suffix`: Only prints the suffix (e.g. `~2021-02-14~g973cee211~snapshot`).

The main reason for implementing this new option is the suffix-only output.
It will be passed to CMake in a future commit, for better filename control.