### PR TITLE
FIX(talking-ui): Crash after rename

### DIFF
--- a/src/mumble/TalkingUI.cpp
+++ b/src/mumble/TalkingUI.cpp
@@ -362,10 +362,8 @@ TalkingUIUser *TalkingUI::findOrAddUser(const ClientUser *user) {
 		nameMatches = oldUserEntry->getName() == user->qsName;
 
 		if (!nameMatches) {
-			// Hide the stale user
+			// Hide and remove the stale user
 			hideUser(user->uiSession);
-			// Remove the old user
-			removeUser(user->uiSession);
 
 			// reset pointer
 			oldUserEntry = nullptr;

--- a/src/mumble/TalkingUI.cpp
+++ b/src/mumble/TalkingUI.cpp
@@ -347,17 +347,11 @@ void TalkingUI::addChannel(const Channel *channel) {
 
 		layout()->addWidget(channelWidget);
 
-
 		m_containers.push_back(std::move(channelContainer));
 	}
 }
 
 TalkingUIUser *TalkingUI::findOrAddUser(const ClientUser *user) {
-	// In a first step, it has to be made sure that the user's channel
-	// exists in this UI.
-	addChannel(user->cChannel);
-
-
 	TalkingUIUser *oldUserEntry = findUser(user->uiSession);
 	bool nameMatches            = true;
 
@@ -378,14 +372,24 @@ TalkingUIUser *TalkingUI::findOrAddUser(const ClientUser *user) {
 		}
 	}
 
-	if (!oldUserEntry || !nameMatches) {
-		bool isSelf = g.uiSession == user->uiSession;
-		// Create an Entry for this user (alongside the respective labels)
-		// We initially set the labels to not be visible, so that we'll
-		// enter the code-block further down.
+	// Make sure that the user's channel exists in this UI.
+	// Note that this has to be done **after** the name check above as
+	// the user might have been renamed in which case the abovementioned
+	// code block removes the old user entry. If that user was the only
+	// client in its channel, the channel gets removed as well. However
+	// the code below expects the user's channel to exist.
+	addChannel(user->cChannel);
 
-		std::unique_ptr< TalkingUIContainer > &channelContainer =
-			m_containers[findContainer(user->cChannel->iId, ContainerType::CHANNEL)];
+	if (!oldUserEntry || !nameMatches) {
+		// Create an entry for this user
+		bool isSelf = g.uiSession == user->uiSession;
+
+		int channelIndex = findContainer(user->cChannel->iId, ContainerType::CHANNEL);
+		if (channelIndex) {
+			qCritical("TalkingUI::findOrAddUser User's channel does not exist!");
+			return nullptr;
+		}
+		std::unique_ptr< TalkingUIContainer > &channelContainer = m_containers[channelIndex];
 		if (!channelContainer) {
 			qCritical("TalkingUI::findOrAddUser requesting unknown channel!");
 			return nullptr;


### PR DESCRIPTION
If the local user was added to the TalkingUI, renamed after that and
then changes its talking status, the client would crash.

The reason for this is that in TalkingUI::findOrAddUser we first create
the user's channel. Therefore we expect the channel to exist at a later
point in this function. However we also check whether the current name
of the user matches the name we have stored for it. If not (which is the
case after a rename), we remove that user. If the user was the only one
in its channel, the channel gets removed as well. In this case however
the original assumption of the user's channel already existing is not
valid anymore, ultimately leading to the crash.

The fix is to only create the user's channel **after** the name check in
order to make sure the assumption is always correct. Furthermore we also
explicitly check for the existence of the channel instead of simply
relying on it being present.

(For reproducing the bug it might be relevant to have the local user
always be shown in the TalkingUI.)

### Checks

- [x] My commits follow the [commit guidelines](https://github.com/mumble-voip/mumble/blob/master/COMMIT_GUIDELINES.md)

