### PR TITLE
Fixes for building on ARM Macs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -111,6 +111,13 @@ if(g15 AND WIN32)
 	add_subdirectory(g15helper)
 endif()
 
+if(APPLE AND CMAKE_SYSTEM_PROCESSOR MATCHES "arm64")
+	# mach_override doesn't support ARM
+	# https://github.com/rentzsch/mach_override/issues/6
+	set(overlay OFF CACHE BOOL "" FORCE)
+	message(STATUS "Disabling the overlay on ARM macOS")
+endif()
+
 if(overlay AND client)
 	if(WIN32)
 		add_subdirectory(overlay)

--- a/src/mumble/CoreAudio.mm
+++ b/src/mumble/CoreAudio.mm
@@ -557,8 +557,8 @@ CoreAudioInput::CoreAudioInput() {
 }
 
 bool CoreAudioInput::openAUHAL(AudioStreamBasicDescription &streamDescription){
-	Component comp;
-	ComponentDescription desc;
+	AudioComponent comp;
+	AudioComponentDescription desc;
 	UInt32 val, len;
 
 	desc.componentType         = kAudioUnitType_Output;
@@ -569,13 +569,13 @@ bool CoreAudioInput::openAUHAL(AudioStreamBasicDescription &streamDescription){
 
 	qDebug("CoreAudioInput: Use AUHAL as IO AudioUnit.");
 
-	comp = FindNextComponent(nullptr, &desc);
+	comp = AudioComponentFindNext(nullptr, &desc);
 	if (!comp) {
 		qWarning("CoreAudioInput: Unable to find AUHAL.");
 		return false;
 	}
 
-	CHECK_RETURN_FALSE(OpenAComponent(comp, &auHAL), "CoreAudioInput: Unable to open AUHAL component.");
+	CHECK_RETURN_FALSE(AudioComponentInstanceNew(comp, &auHAL), "CoreAudioInput: Unable to open AUHAL component.");
 
 	val = 1;
 	CHECK_RETURN_FALSE(AudioUnitSetProperty(auHAL, kAudioOutputUnitProperty_EnableIO, kAudioUnitScope_Input,
@@ -932,8 +932,8 @@ void CoreAudioOutput::run() {
 		qWarning() << "CoreAudioOutput: " << e.what();
 	}
 
-	Component comp;
-	ComponentDescription desc;
+	AudioComponent comp;
+	AudioComponentDescription desc;
 
 	desc.componentType         = kAudioUnitType_Output;
 	desc.componentSubType      = kAudioUnitSubType_HALOutput;
@@ -941,13 +941,13 @@ void CoreAudioOutput::run() {
 	desc.componentFlags        = 0;
 	desc.componentFlagsMask    = 0;
 
-	comp = FindNextComponent(nullptr, &desc);
+	comp = AudioComponentFindNext(nullptr, &desc);
 	if (!comp) {
 		qWarning("CoreAudioOuput: Unable to find AudioUnit.");
 		return;
 	}
 
-	CHECK_RETURN(OpenAComponent(comp, &auHAL),
+	CHECK_RETURN(AudioComponentInstanceNew(comp, &auHAL),
 	             "CoreAudioOutput: Unable to open AudioUnit component.");
 
 	CHECK_RETURN(AudioUnitInitialize(auHAL),

--- a/src/mumble/GlobalShortcut_macx.mm
+++ b/src/mumble/GlobalShortcut_macx.mm
@@ -237,8 +237,10 @@ void GlobalShortcutMac::forwardEvent(void *evt) {
 #ifdef USE_OVERLAY
 	SEL sel = nil;
 
-	if (! g.ocIntercept)
+	if (! g.ocIntercept) {
+		[event release];
 		return;
+	}
 
 	QWidget *vp = g.ocIntercept->qgv.viewport();
 	NSView *view = (NSView *) vp->winId();

--- a/src/mumble/GlobalShortcut_macx.mm
+++ b/src/mumble/GlobalShortcut_macx.mm
@@ -7,7 +7,9 @@
 #import <Carbon/Carbon.h>
 
 #include "GlobalShortcut_macx.h"
-#include "OverlayClient.h"
+#ifdef USE_OVERLAY
+#	include "OverlayClient.h"
+#endif
 
 #define MOD_OFFSET   0x10000
 #define MOUSE_OFFSET 0x20000
@@ -48,6 +50,7 @@ CGEventRef GlobalShortcutMac::callback(CGEventTapProxy proxy, CGEventType type,
 		case kCGEventLeftMouseDragged:
 		case kCGEventRightMouseDragged:
 		case kCGEventOtherMouseDragged: {
+#ifdef USE_OVERLAY
 			if (g.ocIntercept) {
 				int64_t dx = CGEventGetIntegerValueField(event, kCGMouseEventDeltaX);
 				int64_t dy = CGEventGetIntegerValueField(event, kCGMouseEventDeltaY);
@@ -56,6 +59,7 @@ CGEventRef GlobalShortcutMac::callback(CGEventTapProxy proxy, CGEventType type,
 				QMetaObject::invokeMethod(g.ocIntercept, "updateMouse", Qt::QueuedConnection);
 				forward = true;
 			}
+#endif
 			break;
 		}
 
@@ -107,6 +111,7 @@ CGEventRef GlobalShortcutMac::callback(CGEventTapProxy proxy, CGEventType type,
 			break;
 	}
 
+#ifdef USE_OVERLAY
 		if (forward && g.ocIntercept) {
 			NSAutoreleasePool *pool = [[NSAutoreleasePool alloc] init];
 			NSEvent *evt = [[NSEvent eventWithCGEvent:event] retain];
@@ -114,7 +119,7 @@ CGEventRef GlobalShortcutMac::callback(CGEventTapProxy proxy, CGEventType type,
 			[pool release];
 			return nullptr;
 		}
-
+#endif
 	return suppress ? nullptr : event;
 }
 
@@ -229,6 +234,7 @@ void GlobalShortcutMac::dumpEventTaps() {
 
 void GlobalShortcutMac::forwardEvent(void *evt) {
 	NSEvent *event = (NSEvent *)evt;
+#ifdef USE_OVERLAY
 	SEL sel = nil;
 
 	if (! g.ocIntercept)
@@ -312,7 +318,7 @@ void GlobalShortcutMac::forwardEvent(void *evt) {
 		if ([view respondsToSelector:sel])
 				[view performSelector:sel withObject:event];
 	}
-
+#endif
 	[event release];
 }
 

--- a/src/mumble/MainWindow.cpp
+++ b/src/mumble/MainWindow.cpp
@@ -538,8 +538,8 @@ void MainWindow::hideEvent(QHideEvent *e) {
 #	endif
 		if (g.s.bHideInTray && qstiIcon->isSystemTrayAvailable() && e->spontaneous())
 			QMetaObject::invokeMethod(this, "hide", Qt::QueuedConnection);
-	QMainWindow::hideEvent(e);
 #endif
+	QMainWindow::hideEvent(e);
 }
 
 void MainWindow::showEvent(QShowEvent *e) {

--- a/src/mumble/mumble.plist.in
+++ b/src/mumble/mumble.plist.in
@@ -33,5 +33,7 @@
 	<string>NSApplication</string>
 	<key>NSHighResolutionCapable</key>
 	<true/>
+	<key>NSMicrophoneUsageDescription</key>
+	<string>Mumble uses your microphone to allow you to talk to other people</string>
 </dict>
 </plist>

--- a/src/mumble/os_macx.mm
+++ b/src/mumble/os_macx.mm
@@ -5,7 +5,9 @@
 
 #include "LogEmitter.h"
 #include "MainWindow.h"
-#include "Overlay.h"
+#ifdef USE_OVERLAY
+#	include "Overlay.h"
+#endif
 #include "Utils.h"
 
 #include <CoreFoundation/CoreFoundation.h>


### PR DESCRIPTION
## Summary
I've been working on getting Mumble to build natively on ARM Macs (testing on an M1 MacBook Air.)

I've gotten Mumble and murmur to build, and everything except echo cancellation and shortcuts seems to work. (see caveats)

## Commit Explanations

Detailed explanations are also in the commit messages.

- Some fixes to make `-Doverlay=OFF` compile cleanly on macOS:
  - FIX(overlay): add missing ifdefs for USE_OVERLAY  …
  - FIX(overlay, mac): handle hideEvent without USE_OVERLAY  …
- Fix missing permissions
  - FEAT(mumble.plist, mac): add NSMicrophoneUsageDescription  …
- Replace usage of deprecated (and now disabled) APIs
  -  FEAT(audio, mac): migrate to Audio Component API  …
- FIX(build): disable overlay on ARM macs  …

## Caveats

- CMake only seems to search for libraries in `/usr/local/opt`.  
   Homebrew installs everything into `/opt/homebrew/opt` on aarch64,
   my current solution is to **completely remove** any x86_64 homebrew from /usr/local, and symlink `/usr/local/opt` to `/opt/homebrew/opt`. 
- I've added a CMake check that disables `overlay` on ARM macs, since https://github.com/mumble-voip/mach_override doesn't support ARM at all. 
- I have to build with `-Dice=off` right now, which just seems to be a problem of CMake not finding the library without additional trickery.
- Shortcuts do not work yet.
  - Haven't figured it out, it breaks with `GlobalShortcutMac: Unable to create EventTap. Global Shortcuts will not be available.`
- When I try to enable the echo cancellation introduced in #4694, I get a weird loop opening 
- I have to build with Xcode instead of Make, otherwise I get a crash on start (something about UCKeyTranslate getting an invalid pointer)

I used this script to make a build: https://gist.github.com/cfstras/f741087c77a899d5f77eb4664c5b4a70
Warning: this script tries to make the above mentioned link. This will probably cause problems if you already have an x86_64 homebrew installation. I recommend to nuke that first.

## Review Notes

One thing about c4a2930: in the `g.ocIntercept == null` case, it looks like `[event release]` is not called. is this a memory leak?
Or are we certain that the method is not even called in that case? If yes, then why is that guard even there?
Should there be an `[event release]` here?
https://github.com/mumble-voip/mumble/blob/master/src/mumble/GlobalShortcut_macx.mm#L230-L235

## Checks

- [x] My commits follow the [commit guidelines](https://github.com/mumble-voip/mumble/blob/master/COMMIT_GUIDELINES.md)

