### PR TITLE
FIX(client, accessibility): Duplicate keyboard shortcuts

### DIFF
--- a/src/mumble/ConnectDialog.cpp
+++ b/src/mumble/ConnectDialog.cpp
@@ -950,7 +950,7 @@ ConnectDialog::ConnectDialog(QWidget *p, bool autoconnect) : QDialog(p), bAutoCo
 	}
 
 	qdbbButtonBox->button(QDialogButtonBox::Ok)->setEnabled(false);
-	qdbbButtonBox->button(QDialogButtonBox::Ok)->setText(tr("&Connect"));
+	qdbbButtonBox->button(QDialogButtonBox::Ok)->setText(tr("C&onnect"));
 
 	QPushButton *qpbAdd = new QPushButton(tr("&Add New..."), this);
 	qpbAdd->setDefault(false);

--- a/src/mumble/ConnectDialog.cpp
+++ b/src/mumble/ConnectDialog.cpp
@@ -410,8 +410,8 @@ ServerItem *ServerItem::fromUrl(QUrl url, QWidget *p) {
 		if (g.s.qsUsername.isEmpty()) {
 			bool ok;
 			QString defUserName =
-				QInputDialog::getText(p, ConnectDialog::tr("Adding host %1").arg(url.host()),
-									  ConnectDialog::tr("Enter username"), QLineEdit::Normal, g.s.qsUsername, &ok)
+				QInputDialog::getText(p, QObject::tr("Adding host %1").arg(url.host()),
+									  QObject::tr("Enter username"), QLineEdit::Normal, g.s.qsUsername, &ok)
 					.trimmed();
 			if (!ok)
 				return nullptr;
@@ -485,45 +485,45 @@ QVariant ServerItem::data(int column, int role) const {
 			QString qs;
 			qs += QLatin1String("<table>")
 				  + QString::fromLatin1("<tr><th align=left>%1</th><td>%2</td></tr>")
-						.arg(ConnectDialog::tr("Servername"), qsName.toHtmlEscaped())
+						.arg(QObject::tr("Servername"), qsName.toHtmlEscaped())
 				  + QString::fromLatin1("<tr><th align=left>%1</th><td>%2</td></tr>")
-						.arg(ConnectDialog::tr("Hostname"), qsHostname.toHtmlEscaped());
+						.arg(QObject::tr("Hostname"), qsHostname.toHtmlEscaped());
 #ifdef USE_ZEROCONF
 			if (!zeroconfHost.isEmpty())
 				qs += QString::fromLatin1("<tr><th align=left>%1</th><td>%2</td></tr>")
-						  .arg(ConnectDialog::tr("Bonjour name"), zeroconfHost.toHtmlEscaped());
+						  .arg(QObject::tr("Bonjour name"), zeroconfHost.toHtmlEscaped());
 #endif
 			qs += QString::fromLatin1("<tr><th align=left>%1</th><td>%2</td></tr>")
-					  .arg(ConnectDialog::tr("Port"))
+					  .arg(QObject::tr("Port"))
 					  .arg(usPort)
 				  + QString::fromLatin1("<tr><th align=left>%1</th><td>%2</td></tr>")
-						.arg(ConnectDialog::tr("Addresses"), qsl.join(QLatin1String(", ")));
+						.arg(QObject::tr("Addresses"), qsl.join(QLatin1String(", ")));
 
 			if (!qsUrl.isEmpty())
 				qs += QString::fromLatin1("<tr><th align=left>%1</th><td>%2</td></tr>")
-						  .arg(ConnectDialog::tr("Website"), qsUrl.toHtmlEscaped());
+						  .arg(QObject::tr("Website"), qsUrl.toHtmlEscaped());
 
 			if (uiSent > 0) {
 				qs += QString::fromLatin1("<tr><th align=left>%1</th><td>%2</td></tr>")
-						  .arg(ConnectDialog::tr("Packet loss"),
+						  .arg(QObject::tr("Packet loss"),
 							   QString::fromLatin1("%1% (%2/%3)").arg(ploss, 0, 'f', 1).arg(uiRecv).arg(uiSent));
 				if (uiRecv > 0) {
 					qs += QString::fromLatin1("<tr><th align=left>%1</th><td>%2</td></tr>")
-							  .arg(ConnectDialog::tr("Ping (80%)"),
-								   ConnectDialog::tr("%1 ms").arg(
+							  .arg(QObject::tr("Ping (80%)"),
+								   QObject::tr("%1 ms").arg(
 									   boost::accumulators::extended_p_square(*asQuantile)[1] / 1000., 0, 'f', 2))
 						  + QString::fromLatin1("<tr><th align=left>%1</th><td>%2</td></tr>")
-								.arg(ConnectDialog::tr("Ping (95%)"),
-									 ConnectDialog::tr("%1 ms").arg(
+								.arg(QObject::tr("Ping (95%)"),
+									 QObject::tr("%1 ms").arg(
 										 boost::accumulators::extended_p_square(*asQuantile)[2] / 1000., 0, 'f', 2))
 						  + QString::fromLatin1("<tr><th align=left>%1</th><td>%2</td></tr>")
-								.arg(ConnectDialog::tr("Bandwidth"),
-									 ConnectDialog::tr("%1 kbit/s").arg(uiBandwidth / 1000))
+								.arg(QObject::tr("Bandwidth"),
+									 QObject::tr("%1 kbit/s").arg(uiBandwidth / 1000))
 						  + QString::fromLatin1("<tr><th align=left>%1</th><td>%2</td></tr>")
-								.arg(ConnectDialog::tr("Users"),
+								.arg(QObject::tr("Users"),
 									 QString::fromLatin1("%1/%2").arg(uiUsers).arg(uiMaxUsers))
 						  + QString::fromLatin1("<tr><th align=left>%1</th><td>%2</td></tr>")
-								.arg(ConnectDialog::tr("Version"))
+								.arg(QObject::tr("Version"))
 								.arg(MumbleVersion::toString(uiVersion));
 				}
 			}

--- a/src/mumble/mumble_en.ts
+++ b/src/mumble/mumble_en.ts
@@ -2828,59 +2828,7 @@ Are you sure you wish to replace your certificate?
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Adding host %1</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Servername</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Hostname</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Bonjour name</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Port</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Addresses</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Website</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Packet loss</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Ping (80%)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>%1 ms</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Ping (95%)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Bandwidth</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>%1 kbit/s</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>&amp;Connect</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -2889,10 +2837,6 @@ Are you sure you wish to replace your certificate?
     </message>
     <message>
         <source>Users</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Version</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -3009,6 +2953,10 @@ Are you sure you wish to replace your certificate?
     </message>
     <message>
         <source>&lt;p&gt;To measure the latency (ping) of public servers and determine the number of active users, your IP address must be transmitted to each public server.&lt;/p&gt;&lt;p&gt;Do you consent to the transmission of your IP address? If you answer no, the public server list will be deactivated. However, you can reactivate it at any time in the network settings.&lt;/p&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>C&amp;onnect</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -7282,6 +7230,70 @@ See &lt;a href=&quot;https://wiki.mumble.info/wiki/Installing_Mumble&quot;&gt;th
     </message>
     <message>
         <source>Acoustic echo cancellation provided by Apple.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Adding host %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Enter username</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Servername</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hostname</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Bonjour name</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Port</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Addresses</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Website</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Packet loss</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Ping (80%)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>%1 ms</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Ping (95%)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Bandwidth</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>%1 kbit/s</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Users</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Version</source>
         <translation type="unfinished"></translation>
     </message>
 </context>


### PR DESCRIPTION
In the server connect dialog the buttons for Cancel and Connect were
accessible through the same keyboard shortcut "C".

Thus this commit changes the shortcut for Connect to "O".

Fixes #4726

### Checks

- [x] My commits follow the [commit guidelines](https://github.com/mumble-voip/mumble/blob/master/COMMIT_GUIDELINES.md)

