### PR TITLE
Fix url version

### DIFF
--- a/src/Version.cpp
+++ b/src/Version.cpp
@@ -23,7 +23,7 @@ QString MumbleVersion::toString(unsigned int v) {
 }
 
 bool MumbleVersion::get(int *major, int *minor, int *patch, const QString &version) {
-	QRegExp rx(QLatin1String("(\\d+)\\.(\\d+)\\.(\\d+).(\\d+)"));
+	QRegExp rx(QLatin1String("(\\d+)\\.(\\d+)\\.(\\d+)(?:\\.(\\d+))?"));
 
 	if (rx.exactMatch(version)) {
 		if (major)

--- a/src/mumble/MainWindow.cpp
+++ b/src/mumble/MainWindow.cpp
@@ -946,7 +946,13 @@ void MainWindow::openUrl(const QUrl &url) {
 
 	QUrlQuery query(url);
 	QString version = query.queryItemValue(QLatin1String("version"));
-	MumbleVersion::get(&major, &minor, &patch, version);
+	if (version.size() > 0) {
+		if (!MumbleVersion::get(&major, &minor, &patch, version)) {
+			// The version format is invalid
+			g.l->log(Log::Warning, QObject::tr("The provided URL uses an invalid version format: \"%1\"").arg(version));
+			return;
+		}
+	}
 
 	if ((major < 1) ||                                       // No pre 1.2.0
 		(major == 1 && minor <= 1) || (major > thismajor) || // No future version

--- a/src/mumble/MainWindow.cpp
+++ b/src/mumble/MainWindow.cpp
@@ -940,9 +940,9 @@ void MainWindow::openUrl(const QUrl &url) {
 	MumbleVersion::get(&thismajor, &thisminor, &thispatch);
 
 	// With no version parameter given assume the link refers to our version
-	major = 1;
-	minor = 2;
-	patch = 0;
+	major = thismajor;
+	minor = thisminor;
+	patch = thispatch;
 
 	QUrlQuery query(url);
 	QString version = query.queryItemValue(QLatin1String("version"));

--- a/src/mumble/MainWindow.cpp
+++ b/src/mumble/MainWindow.cpp
@@ -954,9 +954,17 @@ void MainWindow::openUrl(const QUrl &url) {
 		}
 	}
 
-	if ((major < 1) ||                                       // No pre 1.2.0
-		(major == 1 && minor <= 1) || (major > thismajor) || // No future version
-		(major == thismajor && minor > thisminor) || (major == thismajor && minor == thisminor && patch > thispatch)) {
+	// We can't handle URLs for versions < 1.2.0
+	const int minMajor = 1;
+	const int minMinor = 2;
+	const int minPatch = 0;
+	const bool isPre_120 = major < minMajor || (major == minMajor && minor < minMinor)
+		|| (major == minMajor && minor == minMinor && patch < minPatch);
+	// We also can't handle URLs for versions newer than the running Mumble instance
+	const bool isFuture  = major > thismajor || (major == thismajor && minor > thisminor)
+		|| (major == thismajor && minor == thisminor && patch > thispatch);
+
+	if (isPre_120 || isFuture) {
 		g.l->log(Log::Warning, tr("This version of Mumble can't handle URLs for Mumble version %1.%2.%3")
 								   .arg(major)
 								   .arg(minor)

--- a/src/mumble/mumble_en.ts
+++ b/src/mumble/mumble_en.ts
@@ -7296,6 +7296,10 @@ See &lt;a href=&quot;https://wiki.mumble.info/wiki/Installing_Mumble&quot;&gt;th
         <source>Version</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>The provided URL uses an invalid version format: &quot;%1&quot;</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>RichTextEditor</name>


### PR DESCRIPTION
This PR contains multiple fixes and refactorings related to the version handling
for versions specified in URLs.

See the individual commits for details

Fixes #4684

### Checks

- [x] My commits follow the [commit guidelines](https://github.com/mumble-voip/mumble/blob/master/COMMIT_GUIDELINES.md)

