### PR TITLE
MAINT: Fix broken links in AppStream meatinfo file

### DIFF
--- a/scripts/org.mumble_voip.mumble.appdata.xml
+++ b/scripts/org.mumble_voip.mumble.appdata.xml
@@ -17,11 +17,11 @@
 	<screenshots>
 		<screenshot type="default">
 			<caption>Light Theme</caption>
-			<image>https://screenshots.debian.net/screenshots/000/017/126/large.png</image>
+			<image>https://www.mumble.info/blog/mumble-1.3.0-release-announcement/theme-lite.png</image>
 		</screenshot>
 		<screenshot>
 			<caption>Dark Theme</caption>
-			<image>https://screenshots.debian.net/screenshots/000/017/125/large.png</image>
+			<image>https://www.mumble.info/blog/mumble-1.3.0-release-announcement/theme-dark.png</image>
 		</screenshot>
 	</screenshots>
 


### PR DESCRIPTION
The referenced links on debian.net seem to have died. Thus they were
replaced with links to our own website.


### Checks

- [x] My commits follow the [commit guidelines](https://github.com/mumble-voip/mumble/blob/master/COMMIT_GUIDELINES.md)

