### PR TITLE
FIX(client): Update copyright notice

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,5 +1,5 @@
 freebsd_instance:
-  image: freebsd-12-1-release-amd64
+  image: freebsd-12-2-release-amd64
 
 freebsd_task:
   update_script: pkg update && pkg upgrade -y

--- a/src/licenses.h
+++ b/src/licenses.h
@@ -19,7 +19,7 @@ struct ThirdPartyLicense {
 };
 
 static const char *licenseMumble = 
-	"Copyright (C) 2005-2019 The Mumble Developers\n"
+	"Copyright (C) 2005-2021 The Mumble Developers\n"
 	"\n"
 	"A list of The Mumble Developers can be found in the\n"
 	"AUTHORS file at the root of the Mumble source tree\n"

--- a/src/mumble/About.cpp
+++ b/src/mumble/About.cpp
@@ -56,7 +56,7 @@ AboutDialog::AboutDialog(QWidget *p) : QDialog(p) {
 		"<p><tt><a href=\"%2\">%2</a></tt></p>"
 	).arg(QLatin1String(MUMBLE_RELEASE))
 	 .arg(QLatin1String("http://www.mumble.info/"))
-	 .arg(QLatin1String("Copyright 2005-2019 The Mumble Developers")));
+	 .arg(QLatin1String("Copyright 2005-2021 The Mumble Developers")));
 	QHBoxLayout *qhbl = new QHBoxLayout(about);
 	qhbl->addWidget(icon);
 	qhbl->addWidget(text);


### PR DESCRIPTION
In the About dialog Mumble was claiming that the copyright ended in
2019, which is obviously wrong.

Fixes #4784 (for the 1.3.x branch)


### Checks

- [x] My commits follow the [commit guidelines](https://github.com/mumble-voip/mumble/blob/master/COMMIT_GUIDELINES.md)

