### PR TITLE
CI(macos): Fix release ID not being set for macOS package

### DIFF
--- a/.ci/azure-pipelines/build_macos.bash
+++ b/.ci/azure-pipelines/build_macos.bash
@@ -49,6 +49,6 @@ cmake -G Ninja -DCMAKE_TOOLCHAIN_FILE=$MUMBLE_ENVIRONMENT_TOOLCHAIN -DIce_HOME="
 cmake --build .
 ctest --verbose
 
-$BUILD_SOURCESDIRECTORY/macx/scripts/osxdist.py --version=$VER --source-dir=$BUILD_SOURCESDIRECTORY --binary-dir=.
+$BUILD_SOURCESDIRECTORY/macx/scripts/osxdist.py --version=$RELEASE_ID --source-dir=$BUILD_SOURCESDIRECTORY --binary-dir=.
 
 mv *.dmg $BUILD_ARTIFACTSTAGINGDIRECTORY


### PR DESCRIPTION
The issue was introduced in #4669 and is only cosmetic.

More specifically, the volume name is set to `Mumble `  (trailing space at the end) because the version string is empty.