### PR TITLE
BUILD(cmake): Fix pkg search on case-insensitive filesystems

### DIFF
--- a/cmake/pkg-utils.cmake
+++ b/cmake/pkg-utils.cmake
@@ -163,7 +163,6 @@ macro(find_pkg ARG_ALIASES)
 		endif()
 	endforeach()
 
-	unset(ALIASES)
 	unset(LAST_ALIAS)
 	unset(FIND_PACKAGE_ARGUMENTS)
 
@@ -182,11 +181,33 @@ macro(find_pkg ARG_ALIASES)
 
 			unset(NAME_UPPER)
 		endif()
+
+		# If multiple capitalizations are searched for this will ensure that the
+		# lowercase name of the library's variables are set as well.
+		# Simplifying usage of find_pkg on case-insensitive file systems.
+		string(TOLOWER ${NAME} NAME_LOWER)
+		if(NOT ${NAME} STREQUAL NAME_LOWER AND ${NAME_LOWER} IN_LIST ALIASES)
+
+			if(NOT ${NAME_LOWER}_VERSION)
+				set(${NAME_LOWER}_VERSION ${${NAME}_VERSION})
+			endif()
+
+			if(NOT ${NAME_LOWER}_LIBRARIES)
+				set(${NAME_LOWER}_LIBRARIES ${${NAME}_LIBRARIES})
+			endif()
+
+			if(NOT ${NAME_LOWER}_FOUND)
+				set(${NAME_LOWER}_FOUND ${${NAME}_FOUND})
+			endif()
+
+		endif()
+		unset(NAME_LOWER)
 	elseif(NOT FIND_PACKAGE_QUIET)
 		if(NOT PkgConfig_FOUND)
 			message(WARNING "pkg-config was not found, consider installing it for better chances of finding a package")
 		endif()
 	endif()
 
+	unset(ALIASES)
 	unset(NAME)
 endmacro()


### PR DESCRIPTION
If a package is searched for with multiple casings (as is currently the
case for libsndfile), it will be very hard to use the resulting cmake variables
(e.g. <name>_FOUND) as one does not know which casing was 
eventually found.

This issue actually broke the build on macOS when installing libsndfile
via homebrew.

The solution is to always also set the all-lowercase version of the package
name variables (if the all-lowercase package name is contained in the
package's aliases) so that this can then be used further down to reference
the result.

Fixes #4790

### Checks

- [X] My commits follow the [commit guidelines](https://github.com/mumble-voip/mumble/blob/master/COMMIT_GUIDELINES.md)

