### PR TITLE
FEAT(server): Remove broadcast of new welcometext when changing via Ice

### DIFF
--- a/src/murmur/Server.cpp
+++ b/src/murmur/Server.cpp
@@ -596,9 +596,6 @@ void Server::setLiveConf(const QString &key, const QString &value) {
 		QString text = !v.isNull() ? v : Meta::mp.qsWelcomeText;
 		if (text != qsWelcomeText) {
 			qsWelcomeText = text;
-			MumbleProto::ServerConfig mpsc;
-			mpsc.set_welcome_text(u8(qsWelcomeText));
-			sendAll(mpsc);
 		}
 	} else if (key == "registername") {
 		QString text = !v.isNull() ? v : Meta::mp.qsRegName;


### PR DESCRIPTION
When changing the welcome text via Ice, Murmur would broadcast the new text to all connected clients. It is a matter of opinion if this is proper behavior or not, but it seems too proactive of an action. Let the clients see the new welcometext when they next connect, or let the Murmur administrator explicitly perfor a sendMessage() to all connected clients after changing the welcometext.

Closes: #4788


### Checks

- [x] My commits follow the [commit guidelines](https://github.com/mumble-voip/mumble/blob/master/COMMIT_GUIDELINES.md)

