### PR TITLE
MAINT: Added VSCode's .devcontainer directory to .gitignore for when developing in a remote container

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,4 @@ doxygen/
 .directory
 build/
 compile_commands.json
+.devcontainer/*


### PR DESCRIPTION
VSCode's Remote Container feature allows developers to spin up a container of their choosing to develop in. To facilitate ease of use, VSCode writes files to track the Dockerfile which generates the container, as well as config for how VSCode should handle the created container.

Some projects suggest to include these files, as it helps all developers have a consistent development experience, but I'll leave that topic for a future debate and instead only suggest to incorporate the ignoring of this data for now.


### Checks

- [x] My commits follow the [commit guidelines](https://github.com/mumble-voip/mumble/blob/master/COMMIT_GUIDELINES.md)

