### PR TITLE
FIX(ice): Use the encoded array size to construct the base64 string

### DIFF
--- a/src/murmur/MurmurIce.cpp
+++ b/src/murmur/MurmurIce.cpp
@@ -87,7 +87,7 @@ static std::string iceBase64(const std::string &s) {
 	QByteArray ba(s.data(), static_cast< int >(s.size()));
 	QByteArray ba64 = ba.toBase64();
 
-	return std::string(ba64.data(), static_cast< size_t >(ba.size()));
+	return std::string(ba64.data(), static_cast< size_t >(ba64.size()));
 }
 
 static void logToLog(const ServerDB::LogRecord &r, Murmur::LogEntry &le) {


### PR DESCRIPTION
Previously, the un-encoded array length was used to construct a string from the encoded byte array, resulting in truncated base64.

### Checks

- [x] My commits follow the [commit guidelines](https://github.com/mumble-voip/mumble/blob/master/COMMIT_GUIDELINES.md)

