### PR TITLE
CI(macOS): Use mutliple attempts for downloads

### DIFF
--- a/.ci/azure-pipelines/install-environment_macos.bash
+++ b/.ci/azure-pipelines/install-environment_macos.bash
@@ -23,7 +23,22 @@ echo "Environment not cached. Downloading..."
 
 environmentArchive="$MUMBLE_ENVIRONMENT_VERSION.tar.xz"
 
-axel -n 10 --output="$environmentArchive" "$MUMBLE_ENVIRONMENT_SOURCE/$MUMBLE_ENVIRONMENT_VERSION.tar.xz"
+iteration=0
+maxIterations=3
+
+while [ $iteration -lt $maxIterations ]; do
+	# By using && we avoid Bash exiting if the command fails even if the -e flag is set
+	axel -n 10 --output="$environmentArchive" "$MUMBLE_ENVIRONMENT_SOURCE/$MUMBLE_ENVIRONMENT_VERSION.tar.xz" && break
+
+	iteration=$(( $iteration + 1 ))
+
+	sleep 5
+done
+
+if [ $iteration -ge $maxIterations ]; then
+	echo "Failed at downloading the build environment"
+	exit 1
+fi
 
 echo "Extracting build environment to $MUMBLE_ENVIRONMENT_STORE..."
 


### PR DESCRIPTION
ba5e7bc352c979b1b90ca1cb8771d180cd6293f0 introduced such a hardening of
the CI scripts for the Windows runs. This commit adds this
functionality to the macOS script as well.

This simply causes the script to retry a download several times before
giving up. This mitigates temporary network errors (saving us a manual
restart of the CI).

### Checks

- [x] My commits follow the [commit guidelines](https://github.com/mumble-voip/mumble/blob/master/COMMIT_GUIDELINES.md)

