### PR TITLE
CI: Added commit-style check

### DIFF
--- a/.github/workflows/check_commit_style.py
+++ b/.github/workflows/check_commit_style.py
@@ -1,0 +1,66 @@
+#!/usr/bin/env python3
+
+import sys
+import os
+import platform
+import subprocess
+
+sys.path.append(os.path.realpath(__file__ + "/../../../scripts/commitMessage"))
+
+from CommitMessage import CommitMessage, CommitFormatError
+
+def cmd(args):
+    shell = platform.system() == 'Windows'
+    p = subprocess.Popen(args, shell=shell, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    stdout, stderr = p.communicate()
+    if p.returncode != 0:
+        raise Exception('cmd(): {0} failed with status {1}: {2}'.format(args, p.returncode, stderr))
+    return stdout.decode('utf-8')
+
+
+def main():
+    try:
+        # Set up remote 
+        remoteName = "mumble-upstream"
+        cmd(["git", "remote", "add", remoteName, "https://github.com/mumble-voip/mumble.git"])
+
+        # Fetch remote
+        cmd(["git", "fetch", remoteName])
+
+        # get new commits
+        commitHashes = [x for x in cmd(["git", "rev-list", "{}/master..HEAD".format(remoteName)]).split("\n") if x]
+        # Reverse the order of the commits so that oldest comes first
+        commitHashes.reverse()
+
+        encounteredErrors = False
+
+        for currentHash in commitHashes:
+            description = cmd(["git", "show", "-s", "--format=%B", currentHash])
+            
+            try:
+                # If we can create a commit message object, this means that the commit message does follow all our
+                # requirements
+                CommitMessage(description)
+
+                print("Commit {} passed all checks".format(currentHash))
+            except CommitFormatError as e:
+                encounteredErrors = True
+                
+                print()
+                print("Commit {} does NOT follow the required commit style:".format(currentHash))
+                print("  " + str(e))
+                print("    The commit message was:")
+                print("    \"" + description.replace("\n", "\n    ").strip() + "\"")
+                print()
+
+
+        if encounteredErrors:
+            print("[ERROR]: There were commits in invalid format!")
+            sys.exit(1)
+
+    finally:
+        # remove remote again
+        cmd(["git", "remote", "remove", remoteName])
+
+if __name__ == "__main__":
+    main()

--- a/.github/workflows/check_commit_style.yml
+++ b/.github/workflows/check_commit_style.yml
@@ -1,0 +1,26 @@
+name: Commit style check
+
+on: [pull_request]
+
+jobs:
+  commit-check:
+    runs-on: ubuntu-20.04
+
+    steps:
+
+    - name: Install Python
+      run: sudo apt install python3
+      shell: bash
+
+    - uses: actions/checkout@v2
+      with:
+          # Assume that there are not >200 new commits that need checking
+          fetch-depth: 200
+          # Don't checkout submodules
+          submodules: 'false'
+          # Don't create a merge commit
+          ref: ${{ github.event.pull_request.head.sha }}
+
+    - name: Verify commits
+      run: $GITHUB_WORKSPACE/.github/workflows/check_commit_style.py
+      shell: bash

--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,4 @@ doxygen/
 build/
 compile_commands.json
 .devcontainer/*
+__pycache__/


### PR DESCRIPTION
This PR adds a CI check (on GitHub Actions) that checks every commit
in a PR for accordance to our commit guidelines.

### Checks

- [x] My commits follow the [commit guidelines](https://github.com/mumble-voip/mumble/blob/master/COMMIT_GUIDELINES.md)

