### PR TITLE
CI(windows): Increase timeout

### DIFF
--- a/.ci/azure-pipelines/main-pr.yml
+++ b/.ci/azure-pipelines/main-pr.yml
@@ -10,6 +10,7 @@ variables:
 
 jobs:
   - job: Windows_x64
+    timeoutInMinutes: 90
     pool:
       vmImage: 'windows-latest'
     variables:
@@ -21,6 +22,7 @@ jobs:
       parameters:
         arch: 'x64'
   - job: Windows_x86
+    timeoutInMinutes: 120
     pool:
       vmImage: 'windows-latest'
     variables:

--- a/.ci/azure-pipelines/main.yml
+++ b/.ci/azure-pipelines/main.yml
@@ -8,6 +8,7 @@ variables:
 
 jobs:
   - job: Windows_x64
+    timeoutInMinutes: 90
     pool:
       vmImage: 'windows-latest'
     variables:
@@ -19,6 +20,7 @@ jobs:
       parameters:
         arch: 'x64'
   - job: Windows_x86
+    timeoutInMinutes: 120
     pool:
       vmImage: 'windows-latest'
     variables:


### PR DESCRIPTION
The timeout has been increased for the Windows CI builds. The new
timeouts are:
- x64: 90 minutes
- x86: 120 minutes

x86 has the higher timeout because it always takes quite a bit longer
than the x64 build.

The timeout was increased as we frequently see the CI job being
cancelled because it did not finish within the default 60 minutes
timeout.


### Checks

- [x] My commits follow the [commit guidelines](https://github.com/mumble-voip/mumble/blob/master/COMMIT_GUIDELINES.md)

