### PR TITLE
FIX(Server): Unauthenticated connections no longer add to user count

### DIFF
--- a/src/murmur/Messages.cpp
+++ b/src/murmur/Messages.cpp
@@ -379,7 +379,10 @@ void Server::msgAuthenticate(ServerUser *uSource, MumbleProto::Authenticate &msg
 
 	{
 		QWriteLocker wl(&qrwlVoiceThread);
+		uSource->uiSession = qqIds.dequeue();
 		uSource->sState = ServerUser::Authenticated;
+		qhUsers.insert(uSource->uiSession, uSource);
+		qhHostUsers[uSource->haAddress].insert(uSource);
 	}
 
 	mpus.set_session(uSource->uiSession);

--- a/src/murmur/Server.cpp
+++ b/src/murmur/Server.cpp
@@ -1450,15 +1450,8 @@ void Server::newClient() {
 		}
 
 		ServerUser *u = new ServerUser(this, sock);
-		u->uiSession  = qqIds.dequeue();
 		u->haAddress  = ha;
 		HostAddress(sock->localAddress()).toSockaddr(&u->saiTcpLocalAddress);
-
-		{
-			QWriteLocker wl(&qrwlVoiceThread);
-			qhUsers.insert(u->uiSession, u);
-			qhHostUsers[ha].insert(u);
-		}
 
 		connect(u, SIGNAL(connectionClosed(QAbstractSocket::SocketError, const QString &)), this,
 				SLOT(connectionClosed(QAbstractSocket::SocketError, const QString &)));


### PR DESCRIPTION
This commit fixes both issues discussed in #4277 which were related to
the fact that any socket connection was allocated an ID and marked as
a user. This bug allowed for a malicious user to lock out all users of
a server regardless of server password usage. This change simply moves ID
allocation to after a connection is marked as Authenticated.

FIXES: #4277

This is a modification and reopening of #4812 because I accidentally killed it.


### Checks

- [x] My commits follow the [commit guidelines](https://github.com/mumble-voip/mumble/blob/master/COMMIT_GUIDELINES.md)

