### PR TITLE
CI(windows): Use clang-cl instead of MSVC, for a potentially better experience

### DIFF
--- a/.ci/azure-pipelines/build_windows.bat
+++ b/.ci/azure-pipelines/build_windows.bat
@@ -23,6 +23,7 @@
 ::
 :: Defined in .azure-pipelines.yml:
 ::
+::  COMPILER_PATH                - Path to the compiler's binary.
 ::  MUMBLE_ENVIRONMENT_PATH      - Path to the environment's root directory.
 ::  MUMBLE_ENVIRONMENT_TOOLCHAIN - Path to the vcpkg CMake toolchain, used for CMake.
 ::  MUMBLE_ENVIRONMENT_TRIPLET   - vcpkg triplet.
@@ -68,7 +69,8 @@ del C:\Strawberry\c\bin\c++.exe
 
 cmake -G Ninja -DCMAKE_TOOLCHAIN_FILE="%MUMBLE_ENVIRONMENT_TOOLCHAIN%" -DVCPKG_TARGET_TRIPLET=%MUMBLE_ENVIRONMENT_TRIPLET% ^
       -DIce_HOME="%MUMBLE_ENVIRONMENT_PATH%\installed\%MUMBLE_ENVIRONMENT_TRIPLET%" ^
-      -DCMAKE_BUILD_TYPE=Release -DRELEASE_ID=%RELEASE_ID% -DBUILD_NUMBER=%BUILD_NUMBER% ^
+      -DCMAKE_BUILD_TYPE=Release -DCMAKE_C_COMPILER="%COMPILER_PATH%" -DCMAKE_CXX_COMPILER="%COMPILER_PATH%" ^
+      -DRELEASE_ID=%RELEASE_ID% -DBUILD_NUMBER=%BUILD_NUMBER% ^
       -Dpackaging=ON -Dtests=ON -Donline-tests=ON -Dstatic=ON -Dsymbols=ON -Dgrpc=ON -Dasio=ON -Dg15=ON ^
       -Ddisplay-install-paths=ON "%BUILD_SOURCESDIRECTORY%"
 

--- a/.ci/azure-pipelines/main-pr.yml
+++ b/.ci/azure-pipelines/main-pr.yml
@@ -19,6 +19,7 @@ jobs:
     pool:
       vmImage: 'windows-latest'
     variables:
+      COMPILER_PATH: 'C:/Program Files (x86)/Microsoft Visual Studio/2019/Enterprise/VC/Tools/Llvm/x64/bin/clang-cl.exe'
       MUMBLE_ENVIRONMENT_VERSION: 'windows-static-1.4.x~2021-02-16~gcd7e9f9d.x64'
       MUMBLE_ENVIRONMENT_TRIPLET: 'x64-windows-static-md'
       VCVARS_PATH: 'C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Auxiliary\Build\vcvars64.bat'
@@ -31,6 +32,7 @@ jobs:
     pool:
       vmImage: 'windows-latest'
     variables:
+      COMPILER_PATH: 'C:/Program Files (x86)/Microsoft Visual Studio/2019/Enterprise/VC/Tools/Llvm/bin/clang-cl.exe'
       MUMBLE_ENVIRONMENT_VERSION: 'windows-static-1.4.x~2021-02-16~gcd7e9f9d.x86'
       MUMBLE_ENVIRONMENT_TRIPLET: 'x86-windows-static-md'
       VCVARS_PATH: 'C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Auxiliary\Build\vcvarsamd64_x86.bat'

--- a/.ci/azure-pipelines/main.yml
+++ b/.ci/azure-pipelines/main.yml
@@ -17,6 +17,7 @@ jobs:
     pool:
       vmImage: 'windows-latest'
     variables:
+      COMPILER_PATH: 'C:/Program Files (x86)/Microsoft Visual Studio/2019/Enterprise/VC/Tools/Llvm/x64/bin/clang-cl.exe'
       MUMBLE_ENVIRONMENT_VERSION: 'windows-static-1.4.x~2021-02-16~gcd7e9f9d.x64'
       MUMBLE_ENVIRONMENT_TRIPLET: 'x64-windows-static-md'
       VCVARS_PATH: 'C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Auxiliary\Build\vcvars64.bat'
@@ -29,6 +30,7 @@ jobs:
     pool:
       vmImage: 'windows-latest'
     variables:
+      COMPILER_PATH: 'C:/Program Files (x86)/Microsoft Visual Studio/2019/Enterprise/VC/Tools/Llvm/bin/clang-cl.exe'
       MUMBLE_ENVIRONMENT_VERSION: 'windows-static-1.4.x~2021-02-16~gcd7e9f9d.x86'
       MUMBLE_ENVIRONMENT_TRIPLET: 'x86-windows-static-md'
       VCVARS_PATH: 'C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Auxiliary\Build\vcvarsamd64_x86.bat'

--- a/overlay/CMakeLists.txt
+++ b/overlay/CMakeLists.txt
@@ -158,8 +158,8 @@ if(64_BIT AND MSVC)
 				"-DMUMBLE_BINARY_DIR=${CMAKE_BINARY_DIR}"
 				"-DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}"
 				# Force MSVC, because CMake prioritizes MinGW over it.
-				"-DCMAKE_C_COMPILER=cl.exe"
-				"-DCMAKE_CXX_COMPILER=cl.exe"
+				"-DCMAKE_C_COMPILER=${CMAKE_C_COMPILER}"
+				"-DCMAKE_CXX_COMPILER=${CMAKE_CXX_COMPILER}"
 				"-DBUILD_OVERLAY_XCOMPILE=ON"
 				"-Dsymbols=${symbols}"
 				"-Dversion=${PROJECT_VERSION}"
@@ -180,9 +180,8 @@ if(64_BIT AND MSVC)
 				"-DMUMBLE_SOURCE_DIR=${CMAKE_SOURCE_DIR}/src/mumble"
 				"-DMUMBLE_BINARY_DIR=${CMAKE_BINARY_DIR}"
 				"-DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}"
-				# Force MSVC, because CMake prioritizes MinGW over it.
-				"-DCMAKE_C_COMPILER=cl.exe"
-				"-DCMAKE_CXX_COMPILER=cl.exe"
+				"-DCMAKE_C_COMPILER=${CMAKE_C_COMPILER}"
+				"-DCMAKE_CXX_COMPILER=${CMAKE_CXX_COMPILER}"
 				"-DBUILD_OVERLAY_XCOMPILE=ON"
 				"-Dsymbols=${symbols}"
 				"-Dversion=${PROJECT_VERSION}"


### PR DESCRIPTION
Binary compatibility is maintained, for reference: https://clang.llvm.org/docs/MSVCCompatibility.html