### PR TITLE
FIX(grpc): Replace call to processEvents to circumvent exceeding 100ms timeout freezing murmur.

### DIFF
--- a/src/murmur_grpcwrapper_protoc_plugin/main.cpp
+++ b/src/murmur_grpcwrapper_protoc_plugin/main.cpp
@@ -143,7 +143,7 @@ public:
 		};
 		stream.Write(response, callback(cb));
 		while (!processed) {
-			QCoreApplication::processEvents(QEventLoop::ExcludeSocketNotifiers, 100);
+			QCoreApplication::sendPostedEvents();
 		}
 		return success;
 	}
@@ -157,7 +157,7 @@ public:
 		};
 		stream.Read(&request, callback(cb));
 		while (!processed) {
-			QCoreApplication::processEvents(QEventLoop::ExcludeSocketNotifiers, 100);
+			QCoreApplication::sendPostedEvents();
 		}
 		return success;
 	}


### PR DESCRIPTION
While working with gRPC I ran up against an issue where using the bidirectional streams results in the server freezing after some time. I believe this is the result of the 100ms timeout on the call to processEvents. I changed out the method to one recommended by the Qt docs when using a local loop, but I believe the core of the issue to be with the timeout. With this change applied, my server has been running for 5+ days without running into the issue (normal use) where previously the longest it ever lasted was 2 days.

### Checks

- [x] My commits follow the [commit guidelines](https://github.com/mumble-voip/mumble/blob/master/COMMIT_GUIDELINES.md)