### PR TITLE
App strings reworked

### DIFF
--- a/src/mumble/mumble_en.ts
+++ b/src/mumble/mumble_en.ts
@@ -3163,7 +3163,7 @@ Label of the server. This is what the server will be named like in your server l
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Crash uploaded</source>
+        <source>Crash report uploaded</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/src/mumble/mumble_en.ts
+++ b/src/mumble/mumble_en.ts
@@ -339,7 +339,7 @@ These are all the groups currently defined for the channel. To create a new grou
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>&lt;b&gt;Remove&lt;/b&gt;&lt;br /&gt;This removes the currently selected group. If the group was inherited, it will not be removed from the list, but all local information about the group will be cleared.</source>
+        <source>&lt;b&gt;Remove&lt;/b&gt;&lt;br /&gt;This removes the currently selected group. If the group was inherited, it will not be removed from the list, but all local info about the group will be cleared.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -351,7 +351,7 @@ These are all the groups currently defined for the channel. To create a new grou
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>&lt;b&gt;Inherited&lt;/b&gt;&lt;br /&gt;This indicates that the group was inherited from the parent channel. You cannot edit this flag, it&apos;s just for information.</source>
+        <source>&lt;b&gt;Inherited&lt;/b&gt;&lt;br /&gt;This indicates that the group was inherited from the parent channel. You cannot edit this flag, it&apos;s just for info.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -742,7 +742,7 @@ This value allows you to set the maximum number of users allowed in the channel.
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>&lt;b&gt;This sets the trigger values for voice detection.&lt;/b&gt;&lt;br /&gt;Use this together with the Audio Statistics window to manually tune the trigger values for detecting speech. Input values below &quot;Silence Below&quot; always count as silence. Values above &quot;Speech Above&quot; always count as voice. Values in between will count as voice if you&apos;re already talking, but will not trigger a new detection.</source>
+        <source>&lt;b&gt;This sets the trigger values for voice detection.&lt;/b&gt;&lt;br /&gt;Use this together with the Audio Stats window to manually tune the trigger values for detecting speech. Input values below &quot;Silence Below&quot; always count as silence. Values above &quot;Speech Above&quot; always count as voice. Values in between will count as voice if you&apos;re already talking, but will not trigger a new detection.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -782,7 +782,7 @@ This value allows you to set the maximum number of users allowed in the channel.
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>&lt;b&gt;This shows peak outgoing bandwidth used.&lt;/b&gt;&lt;br /&gt;This shows the peak amount of bandwidth sent out from your machine. Audio bitrate is the maximum bitrate (as we use VBR) for the audio data alone. Position is the bitrate used for positional information. Overhead is our framing and the IP packet headers (IP and UDP is 75% of this overhead).</source>
+        <source>&lt;b&gt;This shows peak outgoing bandwidth used.&lt;/b&gt;&lt;br /&gt;This shows the peak amount of bandwidth sent out from your machine. Audio bitrate is the maximum bitrate (as we use VBR) for the audio data alone. Position is the bitrate used for positional info. Overhead is our framing and the IP packet headers (IP and UDP is 75% of this overhead).</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -802,7 +802,7 @@ This value allows you to set the maximum number of users allowed in the channel.
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>&lt;b&gt;Maximum amplification of input.&lt;/b&gt;&lt;br /&gt;Mumble normalizes the input volume before compressing, and this sets how much it&apos;s allowed to amplify.&lt;br /&gt;The actual level is continually updated based on your current speech pattern, but it will never go above the level specified here.&lt;br /&gt;If the &lt;i&gt;Microphone loudness&lt;/i&gt; level of the audio statistics hover around 100%, you probably want to set this to 2.0 or so, but if, like most people, you are unable to reach 100%, set this to something much higher.&lt;br /&gt;Ideally, set it so &lt;i&gt;Microphone Loudness * Amplification Factor &gt;= 100&lt;/i&gt;, even when you&apos;re speaking really soft.&lt;br /&gt;&lt;br /&gt;Note that there is no harm in setting this to maximum, but Mumble will start picking up other conversations if you leave it to auto-tune to that level.</source>
+        <source>&lt;b&gt;Maximum amplification of input.&lt;/b&gt;&lt;br /&gt;Mumble normalizes the input volume before compressing, and this sets how much it&apos;s allowed to amplify.&lt;br /&gt;The actual level is continually updated based on your current speech pattern, but it will never go above the level specified here.&lt;br /&gt;If the &lt;i&gt;Microphone loudness&lt;/i&gt; level of the audio stats hover around 100%, you probably want to set this to 2.0 or so, but if, like most people, you are unable to reach 100%, set this to something much higher.&lt;br /&gt;Ideally, set it so &lt;i&gt;Microphone Loudness * Amplification Factor &gt;= 100&lt;/i&gt;, even when you&apos;re speaking really soft.&lt;br /&gt;&lt;br /&gt;Note that there is no harm in setting this to maximum, but Mumble will start picking up other conversations if you leave it to auto-tune to that level.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -858,11 +858,11 @@ This value allows you to set the maximum number of users allowed in the channel.
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>&amp;Browse...</source>
+        <source>&amp;Browse…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>B&amp;rowse...</source>
+        <source>B&amp;rowse…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -970,7 +970,7 @@ This value allows you to set the maximum number of users allowed in the channel.
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>If checked, Mumble will enable Opus&apos; low-delay mode when the quality is set to &lt;b&gt;64 kbit/s&lt;/b&gt; or higher. Low-delay mode decreases latency by &lt;b&gt;~15 milliseconds&lt;/b&gt; in the round trip. This mode may require an higher bitrate to preserve the same quality, in comparison with the music and VOIP modes.</source>
+        <source>If checked, Mumble will enable Opus&apos; low-delay mode when the quality is set to &lt;b&gt;64 kbit/s&lt;/b&gt; or higher. Low-delay mode decreases latency by &lt;b&gt;~15 milliseconds&lt;/b&gt; in the round trip. This mode may require an higher bitrate to preserve the same quality, in comparison with the music and VOiP modes.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -1310,7 +1310,7 @@ This value allows you to set the maximum number of users allowed in the channel.
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Attenuate applications by...</source>
+        <source>Lower volume of applications by…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -1516,7 +1516,7 @@ This value allows you to set the maximum number of users allowed in the channel.
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Audio Statistics</source>
+        <source>Audio Stats</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -1801,7 +1801,7 @@ Speak loudly, as when you are annoyed or excited. Decrease the volume in the sou
 Congratulations. You should now be ready to enjoy a richer sound experience with Mumble.
 &lt;/p&gt;
 &lt;p&gt;
-Mumble is under continuous development, and the development team wants to focus on the features that benefit the most users. To this end, Mumble supports submitting anonymous statistics about your configuration to the developers. These statistics are essential for future development, and also make sure the features you use aren&apos;t deprecated.
+Mumble is under continuous development, and the development team wants to focus on the features that benefit the most users. To this end, Mumble supports submitting anonymous stats about your configuration to the developers. These stats are essential for future development, and also make sure the features you use aren&apos;t deprecated.
 &lt;/p&gt;
 </source>
         <translation type="unfinished"></translation>
@@ -1860,7 +1860,7 @@ Mumble is under continuous development, and the development team wants to focus 
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Submit anonymous statistics to the Mumble project</source>
+        <source>Submit anonymous stats to the Mumble project</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -2143,7 +2143,7 @@ Speak loudly, as when you are annoyed or excited. Decrease the volume in the sou
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Use this button if you want to update ban information.</source>
+        <source>Use this button if you want to update ban info.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -2239,7 +2239,7 @@ Speak loudly, as when you are annoyed or excited. Decrease the volume in the sou
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>The file could not be written successfully. Please use another file.</source>
+        <source>The file could not be written. Please use another file.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -2395,7 +2395,7 @@ Speak loudly, as when you are annoyed or excited. Decrease the volume in the sou
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Open...</source>
+        <source>Open…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -2475,7 +2475,7 @@ Are you sure you wish to replace your certificate?
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Save As...</source>
+        <source>Save As…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -2487,7 +2487,7 @@ Are you sure you wish to replace your certificate?
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>&lt;p&gt;Mumble will now generate a strong certificate for authentication to servers.&lt;/p&gt;&lt;p&gt;If you wish, you may provide some additional information to be stored in the certificate, which will be presented to servers when you connect. If you provide a valid email address, you can upgrade to a CA issued email certificate later on, which provides strong identification.&lt;/p&gt;</source>
+        <source>&lt;p&gt;Mumble will now generate a strong certificate for authentication to servers.&lt;/p&gt;&lt;p&gt;If you wish, you may provide some additional info to be stored in the certificate, which will be presented to servers when you connect. If you provide a valid email address, you can upgrade to a CA issued email certificate later on, which provides strong identification.&lt;/p&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -2536,7 +2536,7 @@ Are you sure you wish to replace your certificate?
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>&lt;p&gt;Mumble can use certificates to authenticate with servers. Using certificates avoids passwords, meaning you don&apos;t need to disclose any password to the remote site. It also enables very easy user registration and a client side friends list independent of servers.&lt;/p&gt;&lt;p&gt;While Mumble can work without certificates, the majority of servers will expect you to have one.&lt;/p&gt;&lt;p&gt;Creating a new certificate automatically is sufficient for most use cases. But Mumble also supports certificates representing trust in the users ownership of an email address. These certificates are issued by third parties. For more information see our &lt;a href=&quot;http://mumble.info/certificate.php&quot;&gt;user certificate documentation&lt;/a&gt;. &lt;/p&gt;</source>
+        <source>&lt;p&gt;Mumble can use certificates to authenticate with servers. Using certificates avoids passwords, meaning you don&apos;t need to disclose any password to the remote site. It also enables very easy user registration and a client side friends list independent of servers.&lt;/p&gt;&lt;p&gt;While Mumble can work without certificates, the majority of servers will expect you to have one.&lt;/p&gt;&lt;p&gt;Creating a new certificate automatically is sufficient for most use cases. But Mumble also supports certificates representing trust in the users ownership of an email address. These certificates are issued by third parties. More info in the &lt;a href=&quot;http://mumble.info/certificate.php&quot;&gt;user certificate documentation&lt;/a&gt;. &lt;/p&gt;</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -2579,7 +2579,7 @@ Are you sure you wish to replace your certificate?
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>This represents total access to the channel, including the ability to change group and ACL information. This privilege implies all other privileges.</source>
+        <source>This represents total access to the channel, including the ability to change group and ACL info. This privilege implies all other privileges.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -2730,11 +2730,11 @@ Are you sure you wish to replace your certificate?
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Muted (server)</source>
+        <source>Muted (by server)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Deafened (server)</source>
+        <source>Deafened (by server)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -2746,11 +2746,11 @@ Are you sure you wish to replace your certificate?
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Muted (self)</source>
+        <source>Muted (by self)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Deafened (self)</source>
+        <source>Deafened (by self)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -2876,11 +2876,11 @@ Are you sure you wish to replace your certificate?
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>&amp;Edit...</source>
+        <source>&amp;Edit…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>&amp;Add New...</source>
+        <source>&amp;Add New…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -2888,7 +2888,7 @@ Are you sure you wish to replace your certificate?
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Open &amp;Webpage</source>
+        <source>Open &amp;Website</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -3163,7 +3163,7 @@ Label of the server. This is what the server will be named like in your server l
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Crash upload successful</source>
+        <source>Crash uploaded</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -3171,15 +3171,15 @@ Label of the server. This is what the server will be named like in your server l
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Crash upload failed</source>
+        <source>Could not upload crash report</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>We&apos;re really sorry, but it appears the crash upload has failed with error %1 %2. Please inform a developer.</source>
+        <source>The crash upload has failed with error %1 %2. Please inform a developer.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>This really isn&apos;t funny, but apparently there&apos;s a bug in the crash reporting code, and we&apos;ve failed to upload the report. You may inform a developer about error %1</source>
+        <source>There&apos;s a bug in the crash reporting code, so the report could not be uploaded. Please inform a developer about error %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -3272,11 +3272,11 @@ Label of the server. This is what the server will be named like in your server l
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Mumble can currently only use mouse buttons and keyboard modifier keys (Alt, Ctrl, Cmd, etc.) for global shortcuts.&lt;/p&gt;&lt;p&gt;If you want more flexibility, you can enable &lt;span style=&quot; font-style:italic;&quot;&gt;Access for assistive devices&lt;/span&gt; in the system&apos;s Accessibility preferences. However, please note that this change also potentially allows malicious programs to read what is typed on your keyboard.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Mumble can currently only use mouse buttons and keyboard modifier keys (Alt, Ctrl, Cmd, etc.) for global shortcuts.&lt;/p&gt;&lt;p&gt;If you want more flexibility, you can turn on &lt;span style=&quot; font-style:italic;&quot;&gt;Access for assistive devices&lt;/span&gt; in the system&apos;s Accessibility preferences. However, please note that this change also potentially allows malicious programs to read what is typed on your keyboard.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Open Accessibility Preferences</source>
+        <source>Open Accessibility</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -3284,7 +3284,7 @@ Label of the server. This is what the server will be named like in your server l
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Enable Global Shortcuts</source>
+        <source>Shortcuts that work anywhere</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -3296,37 +3296,37 @@ Label of the server. This is what the server will be named like in your server l
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>&lt;b&gt;Enable Windows hooks&lt;/b&gt;.&lt;br /&gt;This enables the Windows hooks shortcut engine. Using this engine allows Mumble to suppress keypresses and mouse clicks.</source>
+        <source>&lt;b&gt;Turn on Windows hooks&lt;/b&gt;.&lt;br /&gt;This enables the Windows hooks shortcut engine. Using this engine allows Mumble to suppress keypresses and mouse clicks.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Enable Windows hooks</source>
+        <source>Windows hooks</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>&lt;b&gt;Enable GKey&lt;/b&gt;.&lt;br /&gt;This setting enables support for the GKey shortcut engine, for &quot;G&quot;-keys found on Logitech keyboards.</source>
+        <source>&lt;b&gt;Turn on GKey&lt;/b&gt;.&lt;br /&gt;This setting turns on support for the GKey shortcut engine, for &quot;G&quot;-keys found on Logitech keyboards.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Enable GKey</source>
+        <source>GKey</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>&lt;b&gt;Enable XInput&lt;/b&gt;&lt;br /&gt;This setting enables support for the XInput shortcut engine, for Xbox compatible controllers.</source>
+        <source>&lt;b&gt;Turn on XInput&lt;/b&gt;&lt;br /&gt;This setting turns on support for the XInput shortcut engine, for Xbox compatible controllers.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Enable XInput</source>
+        <source>XInput</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>&lt;b&gt;Enable shortcuts in privileged applications&lt;/b&gt;.&lt;br /&gt;Also known as &quot;UIAccess&quot;. This allows Mumble to receive global shortcut events from programs running at high privilege levels, such as an Admin Command Prompt or older games that run with admin privileges.
+        <source>&lt;b&gt;Turn on shortcuts in privileged applications&lt;/b&gt;.&lt;br /&gt;Also known as &quot;UIAccess&quot;. This allows Mumble to receive global shortcut events from programs running at high privilege levels, such as an Admin Command Prompt or older games that run with admin privileges.
 &lt;br /&gt;&lt;br /&gt;
-Without this option enabled, using Mumble&apos;s global shortcuts in privileged applications will not work. This can seem inconsistent: for example, if the Push-to-Talk button is pressed in a non-privileged program, but released in a privileged application, Mumble will not observe that it has been released and you will continue to talk until you press the Push-to-Talk button again.</source>
+Without this option on, using Mumble&apos;s global shortcuts in privileged applications will not work. This can seem inconsistent: for example, if the Push-to-Talk button is pressed in a non-privileged program, but released in a privileged application, Mumble will not observe that it has been released and you will continue to talk until you press the Push-to-Talk button again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Enable shortcuts in privileged applications</source>
+        <source>Shortcuts in privileged applications</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -3368,8 +3368,8 @@ Without this option enabled, using Mumble&apos;s global shortcuts in privileged 
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>&lt;b&gt;This is the global shortcut key combination.&lt;/b&gt;&lt;br /&gt;Click this field and then press the desired key/button combo to rebind. Double-click to clear.</source>
-        <oldsource>&lt;b&gt;This is the global shortcut key combination.&lt;/b&gt;&lt;br /&gt;Double-click this field and then the desired key/button combo to rebind.</oldsource>
+        <source>&lt;b&gt;This is the the combination for the shortcut that works anywhere.&lt;/b&gt;&lt;br /&gt;Click this field and then press the desired key/button combo to rebind. Double-click to clear.</source>
+        <oldsource>&lt;b&gt;This is a shortcut key combination.&lt;/b&gt;&lt;br /&gt;Double-click this field and then the desired key/button combo to rebind.</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -3438,7 +3438,7 @@ Without this option enabled, using Mumble&apos;s global shortcuts in privileged 
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Do not send positional audio information when using this whisper shortcut.</source>
+        <source>Do not send positional audio info when using this whisper shortcut.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -3548,7 +3548,7 @@ Without this option enabled, using Mumble&apos;s global shortcuts in privileged 
         <source>&lt;p&gt;This is the list of available LCD devices on your system.  It lists devices by name, but also includes the size of the display. Mumble supports outputting to several LCD devices at a time.&lt;/p&gt;
 &lt;h3&gt;Size:&lt;/h3&gt;
 &lt;p&gt;
-This field describes the size of an LCD device. The size is given either in pixels (for Graphic LCDs) or in characters (for Character LCDs).&lt;/p&gt;
+This field describes the size of an LCD device. The size is given either in pixels (for graphic LCDs) or in characters (for character LCDs).&lt;/p&gt;
 &lt;h3&gt;Enabled:&lt;/h3&gt;
 &lt;p&gt;This decides whether Mumble should draw to a particular LCD device.&lt;/p&gt;</source>
         <translation type="unfinished"></translation>
@@ -3558,7 +3558,7 @@ This field describes the size of an LCD device. The size is given either in pixe
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Enabled</source>
+        <source>On</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -3614,7 +3614,7 @@ This field describes the size of an LCD device. The size is given either in pixe
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Information</source>
+        <source>Info</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -3626,7 +3626,7 @@ This field describes the size of an LCD device. The size is given either in pixe
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>User kicked (you or by you)</source>
+        <source>User kicked (yourself or by you)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -3638,7 +3638,7 @@ This field describes the size of an LCD device. The size is given either in pixe
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>User muted (you)</source>
+        <source>User muted (by you)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -3646,7 +3646,7 @@ This field describes the size of an LCD device. The size is given either in pixe
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>User muted (other)</source>
+        <source>User muted (by someone else)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -3766,23 +3766,23 @@ This field describes the size of an LCD device. The size is given either in pixe
 <context>
     <name>LogConfig</name>
     <message>
-        <source>Toggle console for %1 events</source>
+        <source>Turn on or off console for %1 events</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Toggle pop-up notifications for %1 events</source>
+        <source>Turn on or off  pop-up notifications for %1 events</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Toggle Text-To-Speech for %1 events</source>
+        <source>Turn on or off  Text-To-Speech for %1 events</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Click here to toggle sound notification for %1 events</source>
+        <source>Click here to turn on or off sound notification for %1 events</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Toggle window highlight (if not active) for %1 events</source>
+        <source>Turn on or off  window highlight (if not active) for %1 events</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -3790,30 +3790,30 @@ This field describes the size of an LCD device. The size is given either in pixe
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Click here to toggle console output for %1 events.&lt;br /&gt;If checked, this option makes Mumble output all %1 events in its message log.</source>
+        <source>Click here to turn on or off console output for %1 events.&lt;br /&gt;If checked, this option makes Mumble output all %1 events in its message log.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Click here to toggle pop-up notifications for %1 events.&lt;br /&gt;If checked, a notification pop-up will be created by Mumble for every %1 event.</source>
+        <source>Click here to turn on or offpop-up notifications for %1 events.&lt;br /&gt;If checked, a notification pop-up will be created by Mumble for every %1 event.</source>
         <oldsource>Click here to toggle pop-up notifications for %1 events.&lt;br /&gt;If checked, a notification pop-up will be created by mumble for every %1 event.</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Click here to toggle window highlight for %1 events.&lt;br /&gt;If checked, Mumble&apos;s window will be highlighted for every %1 event, if not active.</source>
+        <source>Click here to turn on or off window highlight for %1 events.&lt;br /&gt;If checked, Mumble&apos;s window will be highlighted for every %1 event, if not active.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Path to sound file used for sound notifications in the case of %1 events.&lt;br /&gt;Single click to play&lt;br /&gt;Double-click to change&lt;br /&gt;Ensure that sound notifications for these events are enabled or this field will not have any effect.</source>
+        <source>Path to sound file used for sound notifications in the case of %1 events.&lt;br /&gt;Single click to play&lt;br /&gt;Double-click to change&lt;br /&gt;Ensure that sound notifications for these events are on, or this field will not have any effect.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Click here to toggle Text-To-Speech for %1 events.&lt;br /&gt;If checked, Mumble uses Text-To-Speech to read %1 events out loud to you. Text-To-Speech is also able to read the contents of the event which is not true for sound files. Text-To-Speech and sound files cannot be used at the same time.</source>
-        <oldsource>Click here to toggle sound notification for %1 events.&lt;br /&gt;If checked, Mumble uses a soundfile predefined by you to indicate %1 events. Soundfiles and Text-To-Speech cannot be used at the same time.</oldsource>
+        <source>Click here to turn on or off Text-To-Speech for %1 events.&lt;br /&gt;If checked, Mumble uses Text-To-Speech to read %1 events out loud to you. Text-To-Speech is also able to read the contents of the event which is not true for sound files. Text-To-Speech and sound files cannot be used at the same time.</source>
+        <oldsource>Click here to toggle sound notification for %1 events.&lt;br /&gt;If checked, Mumble uses a soundfile predefined by you to indicate %1 events. Sound files and Text-To-Speech cannot be used at the same time.</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Click here to toggle sound notification for %1 events.&lt;br /&gt;If checked, Mumble uses a sound file predefined by you to indicate %1 events. Sound files and Text-To-Speech cannot be used at the same time.</source>
-        <oldsource>Path to soundfile used for sound notifications in the case of %1 events.&lt;br /&gt;Single click to play&lt;br /&gt;Doubleclick to change&lt;br /&gt;Be sure that sound notifications for these events are enabled or this field will not have any effect.</oldsource>
+        <source>Click here to turn on or off sound notification for %1 events.&lt;br /&gt;If checked, Mumble uses a sound file predefined by you to indicate %1 events. Sound files and Text-To-Speech cannot be used at the same time.</source>
+        <oldsource>Path to sound file used for sound notifications in the case of %1 events.&lt;br /&gt;Single click to play&lt;br /&gt;Double-click to change&lt;br /&gt;Be sure that sound notifications for these events are enabled or this field will not have any effect.</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -3917,7 +3917,7 @@ This field describes the size of an LCD device. The size is given either in pixe
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>If enabled, TTS will not dictate the message scope.</source>
+        <source>Prevents TTS from dictating the message scope.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -3925,7 +3925,7 @@ This field describes the size of an LCD device. The size is given either in pixe
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>If enabled, TTS will not dictate the message author.</source>
+        <source>Prevents TTS from dictating the message author.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -4035,7 +4035,7 @@ The setting only applies for new messages, the already shown ones will retain th
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Language to use (requires restart)</source>
+        <source>Language to use (requires restarting Mumble)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -4418,7 +4418,7 @@ The setting only applies for new messages, the already shown ones will retain th
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Toggle Overlay</source>
+        <source>Turn on or off Overlay</source>
         <comment>Global Shortcut</comment>
         <translation type="unfinished"></translation>
     </message>
@@ -4467,7 +4467,7 @@ The setting only applies for new messages, the already shown ones will retain th
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Mumble is currently connected to a server. Do you want to Close or Minimize it?</source>
+        <source>Mumble is currently connected to a server. Do you want to close or minimize it?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -4481,7 +4481,7 @@ The setting only applies for new messages, the already shown ones will retain th
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>This will set or toggle your muted status. If you turn this off, you will also disable self-deafen.</source>
+        <source>This will set or change your muted status. If you turn this off, self-deafen will also be off.</source>
         <comment>Global Shortcut</comment>
         <translation type="unfinished"></translation>
     </message>
@@ -4496,7 +4496,7 @@ The setting only applies for new messages, the already shown ones will retain th
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>This will set or toggle your deafened status. If you turn this on, you will also enable self-mute.</source>
+        <source>This will set or change your deafened status. If you turn this on, you will also enable self-mute.</source>
         <comment>Global Shortcut</comment>
         <translation type="unfinished"></translation>
     </message>
@@ -4519,11 +4519,11 @@ The setting only applies for new messages, the already shown ones will retain th
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>File does not exist</source>
+        <source>The file does not exist</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>File is not a configuration file.</source>
+        <source>the file is not a configuration file.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -4535,7 +4535,7 @@ The setting only applies for new messages, the already shown ones will retain th
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>This version of Mumble can&apos;t handle URLs for Mumble version %1.%2.%3</source>
+        <source>This version of Mumble can&apos;t handle URLs from Mumble version %1.%2.%3</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -4547,11 +4547,11 @@ The setting only applies for new messages, the already shown ones will retain th
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Connecting to server %1.</source>
+        <source>Connecting to server %1…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Reconnecting.</source>
+        <source>Reconnecting…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -4579,7 +4579,7 @@ The setting only applies for new messages, the already shown ones will retain th
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>&lt;p&gt;No build information or OS version available&lt;/p&gt;</source>
+        <source>&lt;p&gt;No build info or OS version available&lt;/p&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -4673,7 +4673,7 @@ The setting only applies for new messages, the already shown ones will retain th
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Failed to load image</source>
+        <source>Could not load image</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -4681,7 +4681,7 @@ The setting only applies for new messages, the already shown ones will retain th
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Image format not recognized.</source>
+        <source>Unrecognized image format.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -4693,7 +4693,7 @@ The setting only applies for new messages, the already shown ones will retain th
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Use in conjunction with Whisper to.</source>
+        <source>Use in conjunction with &quot;Whisper to&quot;.</source>
         <comment>Global Shortcut</comment>
         <translation type="unfinished"></translation>
     </message>
@@ -4708,22 +4708,22 @@ The setting only applies for new messages, the already shown ones will retain th
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Cycle Transmit Mode</source>
+        <source>Transmit on/off</source>
+        <comment>Shortcut you can use anywhere</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Set &quot;Transmit Mode&quot; to &quot;Push-To-Talk&quot;</source>
         <comment>Global Shortcut</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Set Transmit Mode to Push-To-Talk</source>
+        <source>Set &quot;Transmit Mode&quot; to &quot;Continuous&quot;</source>
         <comment>Global Shortcut</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Set Transmit Mode to Continuous</source>
-        <comment>Global Shortcut</comment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Set Transmit Mode to VAD</source>
+        <source>Set &quot;Transmit Mode&quot; to &quot;VAD&quot;</source>
         <comment>Global Shortcut</comment>
         <translation type="unfinished"></translation>
     </message>
@@ -4738,7 +4738,7 @@ The setting only applies for new messages, the already shown ones will retain th
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>This will send your Clipboard content to the channel you are currently in.</source>
+        <source>Send your clipboard content to the channel you are currently in.</source>
         <comment>Global Shortcut</comment>
         <translation type="unfinished"></translation>
     </message>
@@ -4763,7 +4763,7 @@ The setting only applies for new messages, the already shown ones will retain th
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Save Image As...</source>
+        <source>Save Image As…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -4779,11 +4779,11 @@ The setting only applies for new messages, the already shown ones will retain th
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Transmit Mode set to Voice Activity</source>
+        <source>&quot;Transmit Mode&quot; set to &quot;Voice Activity&quot;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Transmit Mode set to Push-to-Talk</source>
+        <source>&quot;Transmit Mode&quot; set to &quot;Push-to-Talk&quot;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -4791,7 +4791,7 @@ The setting only applies for new messages, the already shown ones will retain th
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>UDP Statistics</source>
+        <source>UDP Stats</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -4823,7 +4823,7 @@ The setting only applies for new messages, the already shown ones will retain th
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Mumble Server Information</source>
+        <source>Mumble Server Info</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -4916,7 +4916,7 @@ The setting only applies for new messages, the already shown ones will retain th
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>&lt;b&gt;WARNING:&lt;/b&gt; The server presented a certificate that was different from the stored one.</source>
+        <source>&lt;b&gt;Warning:&lt;/b&gt; The server presented a certificate that was different from the stored one.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -4944,7 +4944,7 @@ The setting only applies for new messages, the already shown ones will retain th
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>That username is already in use, please try another username.</source>
+        <source>That username is already in use, please try another one.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -4982,7 +4982,7 @@ Otherwise abort and check your certificate and username.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>This shows all recent activity. Connecting to servers, errors and information messages all show up here.&lt;br /&gt;To configure exactly which messages show up here, use the &lt;b&gt;Settings&lt;/b&gt; command from the menu.</source>
+        <source>This shows all recent activity. Connecting to servers, errors and info messages all show up here.&lt;br /&gt;To configure exactly which messages show up here, use the &lt;b&gt;Settings&lt;/b&gt; command from the menu.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -5018,11 +5018,11 @@ Otherwise abort and check your certificate and username.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Show information about the server connection</source>
+        <source>Show info about the server connection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>This will show extended information about the connection to the server.</source>
+        <source>This will show extended info about the connection to the server.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -5086,7 +5086,7 @@ Otherwise abort and check your certificate and username.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Shows a dialog of registered servers, and also allows quick-connect.</source>
+        <source>Shows a dialog of registered servers, and also allows quick-connection.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -5130,7 +5130,7 @@ Otherwise abort and check your certificate and username.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>This links your current channel to the selected channel. If users in a channel have permission to speak in the other channel, users can now hear each other. This is a permanent link, and will last until manually unlinked or the server is restarted. Please see the shortcuts for push-to-link.</source>
+        <source>Links your current channel to the selected one. If users in a channel have permission to speak in the other one, users can now hear each other. This is a permanent link, and will last until manually unlinked or the server is restarted. Please see the shortcuts for push-to-link.</source>
         <oldsource>This links your current channel to the selected channel. If they have permission to speak in the other channel, users can now hear each other. This is a permanent link, and will last until manually unlinked or the server is restarted. Please see the shortcuts for push-to-link.</oldsource>
         <translation type="unfinished"></translation>
     </message>
@@ -5164,7 +5164,7 @@ Otherwise abort and check your certificate and username.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>This will reset the audio preprocessor, including noise cancellation, automatic gain and voice activity detection. If something suddenly worsens the audio environment (like dropping the microphone) and it was temporary, use this to avoid having to wait for the preprocessor to readjust.</source>
+        <source>Resets the audio preprocessor, including noise cancellation, automatic gain and voice activity detection. If something suddenly worsens the audio environment (like dropping the microphone) and it was temporary, you can use this to avoid having to wait for the pre-processor to readjust.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -5204,11 +5204,11 @@ Otherwise abort and check your certificate and username.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Display audio statistics</source>
+        <source>Display audio stats</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Pops up a small dialog with information about your current audio input.</source>
+        <source>Pops up a small dialog with info about your current audio input.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -5248,31 +5248,31 @@ Otherwise abort and check your certificate and username.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Information about Mumble</source>
+        <source>Info about Mumble</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Shows a small dialog with information and license for Mumble.</source>
+        <source>Shows a small dialog with info and the BSD-3 license for Mumble.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Information about Speex</source>
+        <source>Info about Speex</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Shows a small dialog with information about Speex.</source>
+        <source>Shows a small dialog with info about Speex.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Information about Qt</source>
+        <source>Info about Qt</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Shows a small dialog with information about Qt.</source>
+        <source>Shows a small dialog with info about Qt.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Check for &amp;Updates</source>
+        <source>Check for &amp;Upgrades</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -5280,7 +5280,7 @@ Otherwise abort and check your certificate and username.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Connects to the Mumble webpage to check if a new version is available, and notifies you with an appropriate download URL if this is the case.</source>
+        <source>Connects to the Mumble website to check if a new version is available, and notifies you with an appropriate download URL if this is the case.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -5320,7 +5320,7 @@ Otherwise abort and check your certificate and username.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Removes a user from your friends.</source>
+        <source>Removes a user from your friend list.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -5412,7 +5412,7 @@ Otherwise abort and check your certificate and username.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Your account information can not be verified currently. Please try again later</source>
+        <source>Your account info can not be verified. Please try again later.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -5602,7 +5602,7 @@ Otherwise abort and check your certificate and username.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Failed to load Opus, it will not be available for audio encoding/decoding.</source>
+        <source>Could not load Opus, it will not be available for audio encoding/decoding.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -5610,19 +5610,19 @@ Otherwise abort and check your certificate and username.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>The server requests positional audio be enabled.</source>
+        <source>The server wants you to turn on &quot;Positional audio&quot;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>The server requests positional audio be disabled.</source>
+        <source>The server wants you to turn off &quot;Positional audio&quot;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>The server requests Push-to-Talk be enabled.</source>
+        <source>The server wants you to turn on &quot;Push-to-Talk&quot;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>The server requests Push-to-Talk be disabled.</source>
+        <source>The server wants you to turn off &quot;Push-to-Talk&quot;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -5699,7 +5699,7 @@ Otherwise abort and check your certificate and username.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>%1 left channel and disconnected.</source>
+        <source>%1 left the channel and disconnected.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -5707,19 +5707,19 @@ Otherwise abort and check your certificate and username.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>You have User Dragging set to &quot;Do Nothing&quot; so the user wasn&apos;t moved.</source>
+        <source>You have &quot;User Dragging&quot; set to &quot;Do Nothing&quot; so the user wasn&apos;t moved.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>You have Channel Dragging set to &quot;Do Nothing&quot; so the channel wasn&apos;t moved.</source>
+        <source>You have &quot;Channel Dragging&quot; set to &quot;Do Nothing&quot; so the channel wasn&apos;t moved.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Unknown Channel Drag mode in UserModel::dropMimeData.</source>
+        <source>Unknown channel drag mode in UserModel::dropMimeData.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Remote controlling Mumble:
+        <source>Controlling Mumble remotely:
 
 </source>
         <translation type="unfinished"></translation>
@@ -5773,7 +5773,7 @@ Otherwise abort and check your certificate and username.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Query server for connection information for user</source>
+        <source>Query server for connection info for user</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -5857,10 +5857,10 @@ Otherwise abort and check your certificate and username.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Enable or disable the filtering of select channels.
+        <source>Turn on or off filtering of select channels.
 By default all empty channels will be filtered.
-You can mark additional channels for filtering from
-the channel&apos;s context menu.</source>
+Mark additional channels for filtering from the
+channel&apos;s context menu.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -5896,123 +5896,123 @@ the channel&apos;s context menu.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Hides the main Mumble window. Restore by clicking on the tray icon or starting Mumble again.</source>
+        <source>Hides the main Mumble window. Restore by clicking the tray icon or restarting Mumble.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Show the Developer Console</source>
+        <source>Show developer console</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Shows the Mumble Developer Console, where Mumble&apos;s log output can be inspected.</source>
+        <source>Shows the Mumble developer console, where Mumble&apos;s log output can be inspected.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>&amp;Connect...</source>
+        <source>&amp;Connect…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>&amp;Ban list...</source>
+        <source>&amp;Ban list…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>&amp;Information...</source>
+        <source>&amp;Info…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>&amp;Kick...</source>
+        <source>&amp;Kick…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>&amp;Ban...</source>
+        <source>&amp;Ban…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Local Volume Adjustment...</source>
+        <source>Local Volume Adjustment…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Send &amp;Message...</source>
+        <source>Send &amp;Message…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>&amp;Add...</source>
+        <source>&amp;Add…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>&amp;Remove...</source>
+        <source>&amp;Remove…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>&amp;Edit...</source>
+        <source>&amp;Edit…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Audio S&amp;tatistics...</source>
+        <source>Audio S&amp;tats…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>&amp;Settings...</source>
+        <source>&amp;Settings…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>&amp;Audio Wizard...</source>
+        <source>&amp;Audio Wizard…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Developer &amp;Console...</source>
+        <source>Developer &amp;Console…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>&amp;About...</source>
+        <source>&amp;About…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>About &amp;Speex...</source>
+        <source>About &amp;Speex…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>About &amp;Qt...</source>
+        <source>About &amp;Qt…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>&amp;Certificate Wizard...</source>
+        <source>&amp;Certificate Wizard…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>&amp;Register...</source>
+        <source>&amp;Register…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Registered &amp;Users...</source>
+        <source>Registered &amp;Users…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Change &amp;Avatar...</source>
+        <source>Change &amp;Avatar…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>&amp;Access Tokens...</source>
+        <source>&amp;Access Tokens…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Reset &amp;Comment...</source>
+        <source>Reset &amp;Comment…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Reset &amp;Avatar...</source>
+        <source>Reset &amp;Avatar…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>View Comment...</source>
+        <source>View Comment…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>&amp;Change Comment...</source>
+        <source>&amp;Change Comment…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>R&amp;egister...</source>
+        <source>R&amp;egister…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -6040,7 +6040,7 @@ the channel&apos;s context menu.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Locally adjust the volume for this virtual ear.</source>
+        <source>Adjust the volume for this virtual ear as it sounds to you.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -6048,7 +6048,7 @@ the channel&apos;s context menu.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>No action available...</source>
+        <source>No action available…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -6108,15 +6108,15 @@ the channel&apos;s context menu.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Disable Text-To-Speech</source>
+        <source>Disable text-to-speech</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Locally disable Text-To-Speech for this user&apos;s text chat messages.</source>
+        <source>Locally disable text-to-speech for this user&apos;s text chat messages.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Silently disables Text-To-Speech for all text messages from the user.</source>
+        <source>Silently disables text-to-speech for all text messages from the user.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -6140,7 +6140,7 @@ the channel&apos;s context menu.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Configuration file %1 does not exist or is not writable.
+        <source>The configuration file %1 does not exist or is not writable.
 </source>
         <translation type="unfinished"></translation>
     </message>
@@ -6167,9 +6167,9 @@ Valid options are:
   -jn, --jackname &lt;arg&gt;
                 Set custom Jack client name.
   --license
-                Show the Mumble license.
+                Show the Mumble (BSD-3) license.
   --authors
-                Show the Mumble authors.
+                Show Mumble authors.
   --third-party-licenses
                 Show licenses for third-party software used by Mumble.
   --window-title-ext &lt;arg&gt;
@@ -6193,7 +6193,7 @@ Valid options are:
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>&amp;Set Nickname...</source>
+        <source>&amp;Set Nickname…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -6201,14 +6201,14 @@ Valid options are:
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Sets a local nickname for another user.</source>
+        <source>Nickname for another user as shown to you.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Usage: mumble rpc &lt;action&gt; [options]
 
-It is possible to remote control a running instance of Mumble by using
-the &apos;mumble rpc&apos; command.
+It is possible to control a running instance of Mumble remotely
+by using the &apos;mumble rpc&apos; command.
 
 Valid actions are:
   mute
@@ -6311,7 +6311,7 @@ Valid actions are:
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>How long silent user&apos;s positions should stay marked after they have stopped talking (in seconds).</source>
+        <source>How many seconds users should be marked after they stop talking.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -6335,7 +6335,7 @@ Valid actions are:
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>&lt;b&gt;Enable TCP compatibility mode&lt;/b&gt;.&lt;br /&gt;This will make Mumble use only TCP when communicating with the server. This will increase overhead and cause lost packets to produce noticeable pauses in communication, so this should only be used if you are unable to use the default (which uses UDP for voice and TCP for control).</source>
+        <source>&lt;b&gt;TCP compatibility mode&lt;/b&gt;.&lt;br /&gt;Uses only TCP when communicating with the server. Increases overhead and causes lost packets to produce noticeable pauses in communication, so should only be used if you are unable to use the default (which uses UDP for voice and TCP for control).</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -6343,11 +6343,11 @@ Valid actions are:
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>&lt;b&gt;Reconnect when disconnected&lt;/b&gt;.&lt;br /&gt;This will make Mumble try to automatically reconnect after 10 seconds if your server connection fails.</source>
+        <source>&lt;b&gt;Reconnect when disconnected&lt;/b&gt;.&lt;br /&gt;Attempts automatic reconnection after 10 seconds if your server connection fails.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Reconnect automatically</source>
+        <source>Auto-reconnect</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -6391,7 +6391,7 @@ Valid actions are:
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>This will enable QoS, which will attempt to prioritize voice packets over other traffic.</source>
+        <source>Attempt using quality of service to prioritize voice packets over other traffic.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -6403,7 +6403,7 @@ Valid actions are:
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>&lt;b&gt;This will suppress identity information from the client.&lt;/b&gt;&lt;p&gt;The client will not identify itself with a certificate, even if defined, and will not cache passwords for connections. This is primarily a test-option and is not saved.&lt;/p&gt;</source>
+        <source>&lt;b&gt;Turns off sending identity.&lt;/b&gt;&lt;p&gt;The client will not identify itself with a certificate, even if defined, and will not cache passwords for connections. This is primarily a test-option and is not saved.&lt;/p&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -6411,7 +6411,7 @@ Valid actions are:
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>&lt;b&gt;Type of proxy to connect through.&lt;/b&gt;&lt;br /&gt;This makes Mumble connect through a proxy for all outgoing connections. Note: Proxy tunneling forces Mumble into TCP compatibility mode, causing all voice data to be sent via the control channel.</source>
+        <source>&lt;b&gt;Type of proxy to connect through.&lt;/b&gt;&lt;br /&gt;This makes Mumble connect through a proxy for all outgoing connections. Note: Proxy tunneling forces Mumble into TCP compatibility mode, sending all voice data via the control channel.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -6427,7 +6427,7 @@ Valid actions are:
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>&lt;b&gt;Port number of the proxy.&lt;/b&gt;&lt;br /&gt;This field specifies the port number that the proxy expects connections on.</source>
+        <source>&lt;b&gt;Port number of the proxy.&lt;/b&gt;&lt;br /&gt;Specifies the port number the proxy expects connections on.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -6439,7 +6439,7 @@ Valid actions are:
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>&lt;b&gt;Username for proxy authentication.&lt;/b&gt;&lt;br /&gt;This specifies the username you use for authenticating yourself with the proxy. In case the proxy does not use authentication, or you want to connect anonymously, simply leave this field blank.</source>
+        <source>&lt;b&gt;Username for proxy authentication.&lt;/b&gt;&lt;br /&gt;This specifies the username you use for authenticating yourself with the proxy. Leave blank to connect anonymously, or if the proxy doesn't support it.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -6451,7 +6451,7 @@ Valid actions are:
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>&lt;b&gt;Password for proxy authentication.&lt;/b&gt;&lt;br /&gt;This specifies the password you use for authenticating yourself with the proxy. In case the proxy does not use authentication, or you want to connect anonymously, simply leave this field blank.</source>
+        <source>&lt;b&gt;Password for proxy authentication.&lt;/b&gt;&lt;br /&gt;This specifies the password you use for authenticating yourself with the proxy. Leave blank to connect anonymously, or if the proxy doesn't support it.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -6459,15 +6459,15 @@ Valid actions are:
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Check for new releases of Mumble automatically.</source>
+        <source>Look for new releases of Mumble.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>This will check for new releases of Mumble every time you start the program, and notify you if one is available.</source>
+        <source>Looks for and notifies of new releases of Mumble every time you start the program.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Check for application updates on startup</source>
+        <source>Look for new versions</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -6475,19 +6475,19 @@ Valid actions are:
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>This will check for new releases of plugins every time you start the program, and download them automatically.</source>
+        <source>Looks for and downloads new releases of plugins every time you start the program.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>&lt;b&gt;Submit anonymous statistics.&lt;/b&gt;&lt;br /&gt;Mumble has a small development team, and as such needs to focus its development where it is needed most. By submitting a bit of statistics you help the project determine where to focus development.</source>
+        <source>&lt;b&gt;Submit anonymous stats.&lt;/b&gt;&lt;br /&gt;Helps the project focus its development.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Submit anonymous statistics to the Mumble project</source>
+        <source>Submit anonymous stats to the Mumble project</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Submit anonymous statistics</source>
+        <source>Send anonymous stats</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -6495,11 +6495,11 @@ Valid actions are:
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Reconnect to last server on startup</source>
+        <source>Reconnect to last used server</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Download plugin and overlay updates on startup</source>
+        <source>Auto-download new plugin and overlay versions</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -6507,16 +6507,16 @@ Valid actions are:
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Prevent OS information being sent to Mumble servers and web servers</source>
+        <source>Prevent sending OS info to web- and Mumble servers</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>&lt;b&gt;Don&apos;t send OS information to servers&lt;/b&gt;&lt;br/&gt;
-Prevents the client from sending potentially identifying information about the operating system to the Mumble server and web servers.</source>
+        <source>&lt;b&gt;Don&apos;t send OS info to servers&lt;/b&gt;&lt;br/&gt;
+Prevents the client from sending info about the operating system to the Mumble server and web servers.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Do not send OS information to Mumble servers and web servers</source>
+        <source>Don&apos;t send OS info to web- and Mumble servers</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -6551,7 +6551,7 @@ Prevents the client from sending potentially identifying information about the o
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Failed to create communication with overlay at %2: %1. No overlay will be available.</source>
+        <source>Could not create communication with overlay at %2: %1. No overlay will be available.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -6582,7 +6582,7 @@ Prevents the client from sending potentially identifying information about the o
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Configure recently active time (%1 seconds)...</source>
+        <source>Configure recently active time (%1 seconds)…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -6602,7 +6602,7 @@ Prevents the client from sending potentially identifying information about the o
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Edit...</source>
+        <source>Edit…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -6621,16 +6621,16 @@ Prevents the client from sending potentially identifying information about the o
 <context>
     <name>OverlayConfig</name>
     <message>
-        <source>To move the users, drag the little red dot.</source>
+        <source>Drag the red dot to move users.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>To resize the users, mouse wheel over a user.</source>
+        <source>Mouse wheel over users to resize them.</source>
         <oldsource>To resize the users, mousewheel over a user.</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>For more options, right click a user.</source>
+        <source>Right-click users for more options.</source>
         <oldsource>For more options, rightclick a user.</oldsource>
         <translation type="unfinished"></translation>
     </message>
@@ -6704,9 +6704,9 @@ Prevents the client from sending potentially identifying information about the o
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Mumble has detected that you do not have the Mumble Overlay installed.
+        <source>You do not have the Mumble Overlay installed.
 
-Click the button below to install the overlay.</source>
+Click the button below to install it.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -6720,7 +6720,7 @@ Click the button below to install the overlay.</source>
     <message>
         <source>Mumble has detected an old version of the overlay support files installed on your computer.
 
-To upgrade these files to their latest versions, click the button below.</source>
+Click the button below to upgrade these files to their latest versions.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -6962,11 +6962,11 @@ To upgrade these files to their latest versions, click the button below.</source
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Color...</source>
+        <source>Color…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Font...</source>
+        <source>Font…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -7025,7 +7025,7 @@ To upgrade these files to their latest versions, click the button below.</source
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Enable plugins and transmit positional information</source>
+        <source>Enable plugins and transmit positional info</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -7049,11 +7049,11 @@ To upgrade these files to their latest versions, click the button below.</source
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Information about plugin</source>
+        <source>Info about plugin</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>This shows a small information message about the plugin.</source>
+        <source>This shows a small info message about the plugin.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -7125,11 +7125,11 @@ To upgrade these files to their latest versions, click the button below.</source
 <context>
     <name>QApplication</name>
     <message>
-        <source>Failed to restart mumble</source>
+        <source>Could not restart mumble</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Mumble failed to restart itself. Please restart it manually.</source>
+        <source>Mumble could not restart itself. Please restart it manually.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -7140,7 +7140,7 @@ To upgrade these files to their latest versions, click the button below.</source
 <context>
     <name>QObject</name>
     <message>
-        <source>CodecInit: Failed to load Opus, it will not be available for encoding/decoding audio.</source>
+        <source>CodecInit: Could not load Opus, it will not be available for encoding/decoding audio.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -7152,12 +7152,12 @@ To upgrade these files to their latest versions, click the button below.</source
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>&lt;p&gt;If you&apos;re using Linux this is most likely because you are using a version from your distribution&apos;s package repository that have their own update cycles.&lt;/p&gt;&lt;p&gt;If you want to always have the most recent Mumble version, you should consider using a different method of installation.
+        <source>&lt;p&gt;If you&apos;re using Linux this is most likely because you are using a version from your distribution&apos;s package repository that have their own upgrade cycles.&lt;/p&gt;&lt;p&gt;If you want to always have the most recent Mumble version, you should consider using a different method of installation.
 See &lt;a href=&quot;https://wiki.mumble.info/wiki/Installing_Mumble&quot;&gt;the Mumble wiki&lt;/a&gt; for what alternatives there are.&lt;/p&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Local Mute</source>
+        <source>Mute for You</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -7165,7 +7165,7 @@ See &lt;a href=&quot;https://wiki.mumble.info/wiki/Installing_Mumble&quot;&gt;th
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Disable Text-To-Speech</source>
+        <source>No Text-To-Speech</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -7173,7 +7173,7 @@ See &lt;a href=&quot;https://wiki.mumble.info/wiki/Installing_Mumble&quot;&gt;th
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Local Volume Adjustment...</source>
+        <source>Volume you hear…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -7189,23 +7189,23 @@ See &lt;a href=&quot;https://wiki.mumble.info/wiki/Installing_Mumble&quot;&gt;th
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Toggle console for all events</source>
+        <source>Turn on or off console for all events</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Toggle pop-up notifications for all events</source>
+        <source>Turn on or off pop-up notifications for all events</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Toggle window highlight (if not active) for all events</source>
+        <source>Turn on or off window highlight (if not active) for all events</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Click here to toggle sound notifications for all events</source>
+        <source>Click here to turn on or off sound notifications for all events</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Toggle Text-to-Speech for all events</source>
+        <source>Turn on or off Text-to-Speech for all events</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -7221,7 +7221,7 @@ See &lt;a href=&quot;https://wiki.mumble.info/wiki/Installing_Mumble&quot;&gt;th
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Local Nickname Adjustment...</source>
+        <source>Local Nickname…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -7249,23 +7249,23 @@ See &lt;a href=&quot;https://wiki.mumble.info/wiki/Installing_Mumble&quot;&gt;th
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Access to the microphone was denied due to system restrictions. You will not be ableto use the microphone in this session.</source>
+        <source>Access to the microphone was denied due to system restrictions. You will not be able to use the microphone in this session.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>If enabled this tries to cancel out echo from the audio stream.</source>
+        <source>Tries to cancel out echo from the audio stream.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Disabled</source>
+        <source>Turned off</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Echo cancellation is disabled.</source>
+        <source>Echo cancellation off.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Mixed echo cancellation (speex)</source>
+        <source>Mixed echo cancellation (Speex)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -7292,11 +7292,11 @@ See &lt;a href=&quot;https://wiki.mumble.info/wiki/Installing_Mumble&quot;&gt;th
 <context>
     <name>RichTextEditor</name>
     <message>
-        <source>Failed to load image</source>
+        <source>Could not load image</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Image file too large to embed in document. Please use images smaller than %1 kB.</source>
+        <source>Please use images smaller than %1 kB to embed it in the document.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -7378,7 +7378,7 @@ See &lt;a href=&quot;https://wiki.mumble.info/wiki/Installing_Mumble&quot;&gt;th
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Server is not responding to TCP pings</source>
+        <source>The server is not responding to TCP pings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -7473,7 +7473,7 @@ See &lt;a href=&quot;https://wiki.mumble.info/wiki/Installing_Mumble&quot;&gt;th
 <context>
     <name>ShortcutTargetWidget</name>
     <message>
-        <source>...</source>
+        <source>…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -7642,11 +7642,11 @@ An access token is a text string, which can be used as a password for very simpl
 <context>
     <name>UserInformation</name>
     <message>
-        <source>User Information</source>
+        <source>User Info</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Connection Information</source>
+        <source>Connection Info</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -7670,11 +7670,11 @@ An access token is a text string, which can be used as a password for very simpl
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Details...</source>
+        <source>Details…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Ping Statistics</source>
+        <source>Ping Stats</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -7694,7 +7694,7 @@ An access token is a text string, which can be used as a password for very simpl
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>UDP Network statistics</source>
+        <source>UDP Network Stats</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -7827,7 +7827,7 @@ An access token is a text string, which can be used as a password for very simpl
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>&lt;b&gt;Adjust the nickname of other users locally&lt;/b&gt;&lt;br /&gt;</source>
+        <source>&lt;b&gt;Change the nickname of individual users as they appear to you&lt;/b&gt;&lt;br /&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -7846,7 +7846,7 @@ An access token is a text string, which can be used as a password for very simpl
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>&lt;b&gt;Adjust the volume of other users locally&lt;/b&gt;&lt;br /&gt;Mumble supports adjusting the volume of other users locally.</source>
+        <source>&lt;b&gt;Volume of individual users as they sound to you;/b&gt;&lt;br /&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -7869,7 +7869,7 @@ An access token is a text string, which can be used as a password for very simpl
 <context>
     <name>UserModel</name>
     <message>
-        <source>This is a user connected to the server. The icon to the left of the user indicates whether or not they are talking:</source>
+        <source>If this user talks an icon to to the left of it will be lit:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -7898,15 +7898,15 @@ An access token is a text string, which can be used as a password for very simpl
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>A channel that is linked with your channel. Linked channels can talk to each other.</source>
+        <source>A channel linked with your channel, meaning you can talk to each other.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>A channel on the server that you are not linked to.</source>
+        <source>A channel on the server you are not linked to.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>This shows the flags the user has on the server, if any:</source>
+        <source>This shows any flags the user has on the server:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -7918,11 +7918,11 @@ An access token is a text string, which can be used as a password for very simpl
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Muted (manually muted by self)</source>
+        <source>Muted (manually by self)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Muted (manually muted by admin)</source>
+        <source>Muted (manually by admin)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -7930,7 +7930,7 @@ An access token is a text string, which can be used as a password for very simpl
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Muted (muted by you, only on your machine)</source>
+        <source>Muted (by you, only on your machine)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -7946,11 +7946,11 @@ An access token is a text string, which can be used as a password for very simpl
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>User has a new comment set (click to show)</source>
+        <source>The user has a new comment (Click to show.)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>User has a comment set, which you&apos;ve already seen. (click to show)</source>
+        <source>The user has a comment you&apos;ve already seen. (Click to show.)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -7958,19 +7958,19 @@ An access token is a text string, which can be used as a password for very simpl
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>This shows the flags the channel has, if any:</source>
+        <source>This shows any flags the channel has:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Channel has a new comment set (click to show)</source>
+        <source>The channel has a new comment (Click to show.)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Channel has a comment set, which you&apos;ve already seen. (click to show)</source>
+        <source>The channel has a comment you&apos;ve already seen. (Click to show.)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Channel will be hidden when filtering is enabled</source>
+        <source>The channel will be hidden when filtering is on</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -7982,11 +7982,11 @@ An access token is a text string, which can be used as a password for very simpl
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Are you sure you want to drag this user?</source>
+        <source>Drag this user over?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Are you sure you want to drag this channel?</source>
+        <source>Drag this channel over?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -7994,7 +7994,7 @@ An access token is a text string, which can be used as a password for very simpl
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Talking while being muted on your end</source>
+        <source>You are talking, but have muted yourself.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -8002,11 +8002,11 @@ An access token is a text string, which can be used as a password for very simpl
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Channel has access restrictions so that you can&apos;t enter it</source>
+        <source>The channel has access restrictions, so you can&apos;t enter it.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Channel has access restrictions but you can enter nonetheless</source>
+        <source>The channel has access restrictions but you can still enter it.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -8017,7 +8017,7 @@ An access token is a text string, which can be used as a password for very simpl
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>A new version of Mumble has been detected and automatically downloaded. It is recommended that you either upgrade to this version, or downgrade to the latest stable release. Do you want to launch the installer now?</source>
+        <source>Do you want to install the new downloaded version?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -8025,7 +8025,7 @@ An access token is a text string, which can be used as a password for very simpl
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Corrupt download of new version detected. Automatically removed.</source>
+        <source>The new downloaded version was automatically removed since it was damaged.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -8033,12 +8033,12 @@ An access token is a text string, which can be used as a password for very simpl
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Failed to write new version to disk.</source>
+        <source>Could not write new version to disk.</source>
         <oldsource>Failed to write new version to disc.</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Mumble failed to retrieve version information from the central server.</source>
+        <source>Mumble could not retrieve version info from the central server.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -8132,11 +8132,11 @@ An access token is a text string, which can be used as a password for very simpl
 <context>
     <name>VoiceRecorder</name>
     <message>
-        <source>Recorder failed to create directory &apos;%1&apos;</source>
+        <source>Recorder could not create the directory &apos;%1&apos;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Recorder failed to open file &apos;%1&apos;</source>
+        <source>Recorder could not open the file &apos;%1&apos;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -8203,7 +8203,7 @@ An access token is a text string, which can be used as a password for very simpl
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>&amp;Browse...</source>
+        <source>&amp;Browse…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -8240,7 +8240,7 @@ An access token is a text string, which can be used as a password for very simpl
     </message>
     <message>
         <source>The server you are currently connected to is version 1.2.2 or older. For privacy reasons, recording on servers of versions older than 1.2.3 is not possible.
-Please contact your server administrator for further information.</source>
+Please contact your server administrator for further info.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -8267,7 +8267,7 @@ Please contact your server administrator for further information.</source>
 <context>
     <name>WASAPIInput</name>
     <message>
-        <source>Access to the microphone was denied. Please check that your operating system&apos;s microphone settings allow Mumble to use the microphone.</source>
+        <source>Please grant Mumble access to your microphone in the system settings first.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/mumble/mumble_en.ts
+++ b/src/mumble/mumble_en.ts
@@ -171,7 +171,7 @@ This value enables you to change the way mumble arranges the channels in the tre
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>This sets whether or not the ACL up the chain of parent channels are applied to this object. Only those entries that are marked in the parent as &quot;Apply to sub-channels&quot; will be inherited.</source>
+        <source>This sets whether or not the ACL up the chain of parent channels are applied to this object. Only entries marked in the parent as &quot;Apply to sub-channels&quot; will be inherited.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -970,7 +970,7 @@ This value allows you to set the maximum number of users allowed in the channel.
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>If checked, Mumble will enable Opus&apos; low-delay mode when the quality is set to &lt;b&gt;64 kbit/s&lt;/b&gt; or higher. Low-delay mode decreases latency by &lt;b&gt;~15 milliseconds&lt;/b&gt; in the round trip. This mode may require an higher bitrate to preserve the same quality, in comparison with the music and VoIP modes.</source>
+        <source>Opus&apos; low-delay mode when the quality is set to &lt;b&gt;64 kbit/s&lt;/b&gt; or higher. It decreases latency by &lt;b&gt;~15 milliseconds&lt;/b&gt; for the round trip. This mode may require an higher bitrate to preserve the same quality, in comparison with the music and VoIP modes.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -1237,7 +1237,7 @@ This value allows you to set the maximum number of users allowed in the channel.
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>How much should sound volume increase for sources that are really close?</source>
+        <source>How much should sound volume increase for really close sources?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -1314,7 +1314,7 @@ This value allows you to set the maximum number of users allowed in the channel.
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Attenuation of other applications during speech</source>
+        <source>Lower volume of other applications during speech</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -1322,11 +1322,11 @@ This value allows you to set the maximum number of users allowed in the channel.
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>If checked Mumble lowers the volume of other applications while other users talk</source>
+        <source>Lowers the volume of other applications while others talk</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>&lt;b&gt;Attenuate applications while other users talk&lt;/b&gt;&lt;br /&gt;Mumble supports decreasing the volume of other applications during incoming and/or outgoing speech. This makes mumble activate the feature while other users talk to you.</source>
+        <source>&lt;b&gt;Attenuate applications while others talk&lt;/b&gt;&lt;br /&gt;Mumble supports decreasing the volume of other applications during incoming and/or outgoing speech. This makes mumble activate the feature while other users talk to you.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -1334,7 +1334,7 @@ This value allows you to set the maximum number of users allowed in the channel.
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>If checked Mumble lowers the volume of other applications while you talk</source>
+        <source>Lowers the volume of other applications while you talk</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -1358,23 +1358,23 @@ This value allows you to set the maximum number of users allowed in the channel.
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>If checked Mumble lowers the volume of other users while you talk if you have the &quot;Priority Speaker&quot; status.</source>
+        <source>Lowers the volume of others while you talk if you are the &quot;Priority Speaker&quot;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>If checked, Mumble will only attenuate applications that are using the same output source as Mumble</source>
+        <source>Lower the volume of applications using the same output source as Mumble</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>&lt;b&gt;Attenuate only applications using the same output as Mumble&lt;/b&gt;&lt;br /&gt;If checked, applications that use a different output than Mumble will not be attenuated.</source>
+        <source>&lt;b&gt;Attenuate only applications using the same output as Mumble&lt;/b&gt;&lt;br /&gt;Applications using a different output than Mumble will not be attenuated.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Only attenuate applications using the same output device</source>
+        <source>Only lower the volume of applications using the same output device</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>If checked, PulseAudio loopback modules will be attenuated</source>
+        <source>Lowers the volume of the PulseAudio loopback modules</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -1382,7 +1382,7 @@ This value allows you to set the maximum number of users allowed in the channel.
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Attenuate PulseAudio loopback modules</source>
+        <source>Lower the volume of PulseAudio loopback modules</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -1398,7 +1398,7 @@ This value allows you to set the maximum number of users allowed in the channel.
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Attenuate other users while talking as Priority Speaker</source>
+        <source>Lower the output volume of others while talking as Priority Speaker</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -3790,16 +3790,16 @@ This field describes the size of an LCD device. The size is given either in pixe
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Click here to turn on or off console output for %1 events.&lt;br /&gt;If checked, this option makes Mumble output all %1 events in its message log.</source>
+        <source>Click here to turn on or off console output for %1 events.&lt;br /&gt;This option makes Mumble output all %1 events in its message log.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Click here to turn on or offpop-up notifications for %1 events.&lt;br /&gt;If checked, a notification pop-up will be created by Mumble for every %1 event.</source>
-        <oldsource>Click here to toggle pop-up notifications for %1 events.&lt;br /&gt;If checked, a notification pop-up will be created by mumble for every %1 event.</oldsource>
+        <source>Click here to turn on or offpop-up notifications for %1 events.&lt;br /&gt;A notification pop-up will be created by Mumble for every %1 event.</source>
+        <oldsource>Click here to toggle pop-up notifications for %1 events.&lt;br /&gt;A notification pop-up will be created by mumble for every %1 event.</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Click here to turn on or off window highlight for %1 events.&lt;br /&gt;If checked, Mumble&apos;s window will be highlighted for every %1 event, if not active.</source>
+        <source>Click here to turn on or off window highlight for %1 events.&lt;br /&gt;Mumble&apos;s window will be highlighted for every %1 event, if not active.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -3807,12 +3807,12 @@ This field describes the size of an LCD device. The size is given either in pixe
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Click here to turn on or off Text-To-Speech for %1 events.&lt;br /&gt;If checked, Mumble uses Text-To-Speech to read %1 events out loud to you. Text-To-Speech is also able to read the contents of the event which is not true for sound files. Text-To-Speech and sound files cannot be used at the same time.</source>
-        <oldsource>Click here to toggle sound notification for %1 events.&lt;br /&gt;If checked, Mumble uses a soundfile predefined by you to indicate %1 events. Sound files and Text-To-Speech cannot be used at the same time.</oldsource>
+        <source>Click here to turn on or off Text-To-Speech for %1 events.&lt;br /&gt;Uses Text-To-Speech to read %1 events out loud to you. Text-To-Speech is also able to read the contents of the event which is not true for sound files. Text-To-Speech and sound files cannot be used at the same time.</source>
+        <oldsource>Click here to toggle sound notification for %1 events.&lt;br /&gt;Uses a sound file predefined by you to indicate %1 events. Sound files and Text-To-Speech cannot be used at the same time.</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Click here to turn on or off sound notification for %1 events.&lt;br /&gt;If checked, Mumble uses a sound file predefined by you to indicate %1 events. Sound files and Text-To-Speech cannot be used at the same time.</source>
+        <source>Click here to turn on or off sound notification for %1 events.&lt;br /&gt;Uses a sound file predefined by you to indicate %1 events. Sound files and Text-To-Speech cannot be used at the same time.</source>
         <oldsource>Path to sound file used for sound notifications in the case of %1 events.&lt;br /&gt;Single click to play&lt;br /&gt;Double-click to change&lt;br /&gt;Be sure that sound notifications for these events are enabled or this field will not have any effect.</oldsource>
         <translation type="unfinished"></translation>
     </message>
@@ -3881,7 +3881,7 @@ This field describes the size of an LCD device. The size is given either in pixe
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>If checked you will only hear whispers from users you added to your friend list.</source>
+        <source>Will only let you hear whispers from users in your friend list.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -3889,7 +3889,7 @@ This field describes the size of an LCD device. The size is given either in pixe
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>If enabled text messages you send will be read back to you with TTS</source>
+        <source>Reads text messages you send back to you using TTS</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -3933,7 +3933,7 @@ This field describes the size of an LCD device. The size is given either in pixe
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>If checked the time at the beginning of a message will be displayed in the 24-hour format.
+        <source>Displays message timestamps in 24-hour format.
 
 The setting only applies for new messages, the already shown ones will retain the previous time format.</source>
         <translation type="unfinished"></translation>
@@ -4228,7 +4228,7 @@ The setting only applies for new messages, the already shown ones will retain th
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>A user that is silent for the given amount of seconds will be removed from the Talkin UI.</source>
+        <source>Amount of seconds before silent users are removed from the Talking UI.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -4236,7 +4236,7 @@ The setting only applies for new messages, the already shown ones will retain th
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>If this is checked, the local user (yourself) will always be visible in the TalkingUI (regardless of talking state).</source>
+        <source>Keeps the local user (yourself) visible in the Talking UI at all times (regardless of talking state).</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -4260,7 +4260,7 @@ The setting only applies for new messages, the already shown ones will retain th
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>The names of how many parent channels should be included in the channel&apos;s name when displaying it in the TalkingUI?</source>
+        <source>The names of how many parent channels should be included in the channel&apos;s name when displaying it in the Talking UI?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -4360,7 +4360,7 @@ The setting only applies for new messages, the already shown ones will retain th
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Whether to show all of the local user&apos;s listeners (ears) in the TalkingUI (and thereby also the channels they are in). </source>
+        <source>Whether to show all of the local user&apos;s listeners (ears) in the Talking UI (and thereby also the channels they are in). </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -6084,7 +6084,7 @@ channel&apos;s context menu.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Toggles the visibility of the TalkingUI.</source>
+        <source>Toggles the visibility of the Talking UI.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -7532,11 +7532,11 @@ See &lt;a href=&quot;https://wiki.mumble.info/wiki/Installing_Mumble&quot;&gt;th
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>If checked the message is recursively sent to all subchannels</source>
+        <source>Sends the message (recursively) to all subchannels</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Send recursively to subchannels</source>
+        <source>Send to subchannels</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/src/mumble/mumble_en.ts
+++ b/src/mumble/mumble_en.ts
@@ -20,7 +20,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Mumble - Add channel</source>
+        <source>Mumble — Add channel</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -28,11 +28,11 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Failed: Invalid channel</source>
+        <source>Invalid channel</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Mumble - Edit %1</source>
+        <source>Mumble — Edit %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -183,7 +183,7 @@ This value enables you to change the way mumble arranges the channels in the tre
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>This moves the entry up in the list. As entries are evaluated in order, this may change the effective permissions of users. You cannot move an entry above an inherited entry, if you really need that you&apos;ll have to duplicate the inherited entry.</source>
+        <source>This moves the entry up in the list. As entries are evaluated in order, this may change the effective permissions of users. You cannot move an entry above an inherited entry. Duplicate the inherited entry if you really need that.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -446,7 +446,7 @@ This value allows you to set the maximum number of users allowed in the channel.
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Opening chosen ALSA Input failed: %1</source>
+        <source>Could not open the chosen ALSA input: %1</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -457,7 +457,7 @@ This value allows you to set the maximum number of users allowed in the channel.
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Opening chosen ALSA Output failed: %1</source>
+        <source>Could not open the chosen ALSA output: %1</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -477,7 +477,7 @@ This value allows you to set the maximum number of users allowed in the channel.
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Failed to instantiate ASIO driver</source>
+        <source>Could not instantiate ASIO driver</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -537,7 +537,7 @@ This value allows you to set the maximum number of users allowed in the channel.
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>This will configure the input channels for ASIO. Make sure you select at least one channel as microphone and speaker. &lt;i&gt;Microphone&lt;/i&gt; should be where your microphone is attached, and &lt;i&gt;Speaker&lt;/i&gt; should be a channel that samples &apos;&lt;i&gt;What you hear&lt;/i&gt;&apos;.&lt;br /&gt;For example, on the Audigy 2 ZS, a good selection for Microphone would be &apos;&lt;i&gt;Mic L&lt;/i&gt;&apos; while Speaker should be &apos;&lt;i&gt;Mix L&lt;/i&gt;&apos; and &apos;&lt;i&gt;Mix R&lt;/i&gt;&apos;.</source>
+        <source>This will configure the input channels for ASIO. Make sure you select at least one channel as microphone and loudspeaker. &lt;i&gt;Microphone&lt;/i&gt; should be where your microphone is attached, and &lt;i&gt;Loudspeaker&lt;/i&gt; should be a channel that samples &apos;&lt;i&gt;What you hear&lt;/i&gt;&apos;.&lt;br /&gt;For example, on the Audigy 2 ZS, a good selection for Microphone would be &apos;&lt;i&gt;Mic L&lt;/i&gt;&apos; while Loudspeaker should be &apos;&lt;i&gt;Mix L&lt;/i&gt;&apos; and &apos;&lt;i&gt;Mix R&lt;/i&gt;&apos;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -565,7 +565,7 @@ This value allows you to set the maximum number of users allowed in the channel.
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Speakers</source>
+        <source>Loudspeakers</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -580,11 +580,11 @@ This value allows you to set the maximum number of users allowed in the channel.
 <context>
     <name>ASIOInput</name>
     <message>
-        <source>You need to select at least one microphone and one speaker source to use ASIO.</source>
+        <source>Select at least one microphone and one loudspeaker source to use ASIO.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Opening selected ASIO device failed. No input will be done.</source>
+        <source>Could not open the selected ASIO device. No input will be done.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -627,7 +627,7 @@ This value allows you to set the maximum number of users allowed in the channel.
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>&lt;h3&gt;Mumble (%1)&lt;/h3&gt;&lt;p&gt;%3&lt;/p&gt;&lt;p&gt;&lt;b&gt;An Open Source, low-latency, high quality voice-chat utility&lt;/b&gt;&lt;/p&gt;&lt;p&gt;&lt;tt&gt;&lt;a href=&quot;%2&quot;&gt;%2&lt;/a&gt;&lt;/tt&gt;&lt;/p&gt;</source>
+        <source>&lt;h3&gt;Mumble (%1)&lt;/h3&gt;&lt;p&gt;%3&lt;/p&gt;&lt;p&gt;&lt;b&gt;An libre software, low-latency, high quality voice-chat utility&lt;/b&gt;&lt;/p&gt;&lt;p&gt;&lt;tt&gt;&lt;a href=&quot;%2&quot;&gt;%2&lt;/a&gt;&lt;/tt&gt;&lt;/p&gt;</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -654,7 +654,7 @@ This value allows you to set the maximum number of users allowed in the channel.
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>&lt;b&gt;This is the input device to use for audio.&lt;/b&gt;</source>
+        <source>&lt;b&gt;This is the microphone input device to use for audio.&lt;/b&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -670,7 +670,7 @@ This value allows you to set the maximum number of users allowed in the channel.
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>&lt;b&gt;This sets when speech should be transmitted.&lt;/b&gt;&lt;br /&gt;&lt;i&gt;Continuous&lt;/i&gt; - All the time&lt;br /&gt;&lt;i&gt;Voice Activity&lt;/i&gt; - When you are speaking clearly.&lt;br /&gt;&lt;i&gt;Push To Talk&lt;/i&gt; - When you hold down the hotkey set under &lt;i&gt;Shortcuts&lt;/i&gt;.</source>
+        <source>&lt;b&gt;This sets when speech should be transmitted.&lt;/b&gt;&lt;br /&gt;&lt;i&gt;Continuous&lt;/i&gt; - All the time&lt;br /&gt;&lt;i&gt;Voice Activity&lt;/i&gt; - When you are speaking clearly.&lt;br /&gt;&lt;i&gt;Push-To-Talk&lt;/i&gt; - When you hold down the hotkey set under &lt;i&gt;Shortcuts&lt;/i&gt;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -678,7 +678,7 @@ This value allows you to set the maximum number of users allowed in the channel.
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>If you press the PTT key twice in this time it will get locked.</source>
+        <source>Press the PTT key twice in the span of this timeframe locks it.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -810,11 +810,11 @@ This value allows you to set the maximum number of users allowed in the channel.
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Enabling this will cancel the echo from your speakers. Mixed has low CPU impact, but only works well if your speakers are equally loud and equidistant from the microphone. Multichannel echo cancellation provides much better echo cancellation, but at a higher CPU cost.</source>
+        <source>Enabling this will cancel the echo from your loudspeakers. Mixed has low CPU impact, but only works well if your loudspeakers are equally loud and equidistant from the microphone. Multichannel echo cancellation provides much better echo cancellation, but at a higher CPU cost.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Disabled</source>
+        <source>Off</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -874,11 +874,11 @@ This value allows you to set the maximum number of users allowed in the channel.
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Displays an always on top window with a push to talk button in it</source>
+        <source>Displays an always on top window with a push-to-talk button in it</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Display push to talk window</source>
+        <source>Display push-to-talk window</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -890,7 +890,7 @@ This value allows you to set the maximum number of users allowed in the channel.
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>&lt;b&gt;This enables transmission audio cues.&lt;/b&gt;&lt;br /&gt;Setting this will give you a short audio beep when you start and stop transmitting.</source>
+        <source>&lt;b&gt;Turns on transmission audio cues.&lt;/b&gt;&lt;br /&gt;Gives you a short audio beep when you start and stop transmitting.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -898,11 +898,11 @@ This value allows you to set the maximum number of users allowed in the channel.
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Gets played when starting to transmit</source>
+        <source>Gets played when starting transmission</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Gets played when stopping to transmit</source>
+        <source>Gets played when stopping transmission</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -966,7 +966,7 @@ This value allows you to set the maximum number of users allowed in the channel.
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Enable Opus&apos; low-delay mode when the quality is set to &lt;b&gt;64 kb/s&lt;/b&gt; or higher. </source>
+        <source>Turn on Opus&apos; low-delay mode when the quality is set to &lt;b&gt;64 kb/s&lt;/b&gt; or higher. </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -978,7 +978,7 @@ This value allows you to set the maximum number of users allowed in the channel.
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Don&apos;t use noise suppression.</source>
+        <source>Don&apos;t noise suppression.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -990,7 +990,7 @@ This value allows you to set the maximum number of users allowed in the channel.
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Use a combination of Speex and RNNoise to do noise suppression.</source>
+        <source>Use a combination of Speex and RNNoise to supress noise.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -998,7 +998,7 @@ This value allows you to set the maximum number of users allowed in the channel.
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>This controls the amount by which Speex will suppress noise.</source>
+        <source>Controls how aggressively Speex suppresses noise.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -1017,7 +1017,7 @@ This value allows you to set the maximum number of users allowed in the channel.
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Push To Talk</source>
+        <source>Push-To-Talk</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -1057,7 +1057,7 @@ This value allows you to set the maximum number of users allowed in the channel.
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Echo cancellation mode</source>
+        <source>Echo-cancellation mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -1121,19 +1121,19 @@ This value allows you to set the maximum number of users allowed in the channel.
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Access to the microphone was denied. Please allow Mumble to use the microphone by changing the settings in System Preferences -&gt; Security &amp; Privacy -&gt; Privacy -&gt; Microphone.</source>
+        <source>Please grant Mumble access to the microphone by changing the settings in System Preferences → Security → Privacy → Privacy → Microphone.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Access to the microphone was denied. Please check that your operating system&apos;s microphone settings allow Mumble to use the microphone.</source>
+        <source>Ensure it is not the operating system&apos;s microphone settings that prevent Mumble from using the microphone.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Disabled</source>
+        <source>Off</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Disable echo cancellation.</source>
+        <source>Turn off echo cancellation.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -1196,7 +1196,7 @@ This value allows you to set the maximum number of users allowed in the channel.
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>&lt;b&gt;This enables one of the loopback test modes.&lt;/b&gt;&lt;br /&gt;&lt;i&gt;None&lt;/i&gt; - Loopback disabled&lt;br /&gt;&lt;i&gt;Local&lt;/i&gt; - Emulate a local server.&lt;br /&gt;&lt;i&gt;Server&lt;/i&gt; - Request loopback from server.&lt;br /&gt;Please note than when loopback is enabled, no other users will hear your voice. This setting is not saved on application exit.</source>
+        <source>&lt;b&gt;This turns on one of the loopback test modes.&lt;/b&gt;&lt;br /&gt;&lt;i&gt;None&lt;/i&gt; - Loopback off&lt;br /&gt;&lt;i&gt;Local&lt;/i&gt; - Emulate a local server.&lt;br /&gt;&lt;i&gt;Server&lt;/i&gt; - Request loopback from server.&lt;br /&gt;Please note than when loopback is on, no other users will hear your voice. This setting is not saved on application exit.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -1208,7 +1208,7 @@ This value allows you to set the maximum number of users allowed in the channel.
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>&lt;b&gt;This adjusts the volume of incoming speech.&lt;/b&gt;&lt;br /&gt;Note that if you increase this beyond 100%, audio will be distorted.</source>
+        <source>&lt;b&gt;Adjusts the volume of incoming speech.&lt;/b&gt;&lt;br /&gt;Beyond 100% audio will be distorted.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -1220,8 +1220,8 @@ This value allows you to set the maximum number of users allowed in the channel.
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>The connected &quot;speakers&quot; are actually headphones</source>
-        <oldsource>The connected &quot;speakers&quot; are actually headphones.</oldsource>
+        <source>The connected &quot;loudspeakers&quot; are actually headphones</source>
+        <oldsource>The connected &quot;loudspeakers&quot; are actually headphones.</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -1241,7 +1241,7 @@ This value allows you to set the maximum number of users allowed in the channel.
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Checking this indicates that you don&apos;t have speakers connected, just headphones. This is important, as speakers are usually in front of you, while headphones are directly to your left/right.</source>
+        <source>Indicates you don&apos;t have loudspeakers connected, just headphones. Important to get the direction of sound right.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -1285,8 +1285,8 @@ This value allows you to set the maximum number of users allowed in the channel.
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>&lt;b&gt;This sets the packet latency variance for loopback testing.&lt;/b&gt;&lt;br /&gt;Most audio paths contain some variable latency. This allows you to set that variance for loopback mode testing. For example, if you set this to 15ms, this will emulate a network with 20-35ms ping latency or one with 80-95ms latency. Most domestic net connections have a variance of about 5ms.</source>
-        <oldsource>&lt;b&gt;This sets the packet latency variance for loopback testing.&lt;/b&gt;&lt;br /&gt;Most audio paths contain some variable latency. This allows you set that variance for loopback mode testing. For example, if you set this to 15ms, this will emulate a network with 20-35ms ping latency or one with 80-95ms latency. Most domestic net connections have a variance of about 5ms.</oldsource>
+        <source>&lt;b&gt;Sets the packet latency variance for loopback testing.&lt;/b&gt;&lt;br /&gt;Most audio paths contain some variable latency. Allows setting that variance for loopback mode testing. For example, if you set this to 15ms, this will emulate a network with 20-35ms ping latency or one with 80-95ms latency. Most domestic net connections have a variance of about 5ms.</source>
+        <oldsource>&lt;b&gt;Sets the packet latency variance for loopback testing.&lt;/b&gt;&lt;br /&gt;Most audio paths contain some variable latency. Allows setting that variance for loopback mode testing. For example, if you set this to 15ms, this will emulate a network with 20-35ms ping latency or one with 80-95ms latency. Most domestic net connections have a variance of about 5ms.</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -1298,7 +1298,7 @@ This value allows you to set the maximum number of users allowed in the channel.
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>&lt;b&gt;This sets the packet loss for loopback mode.&lt;/b&gt;&lt;br /&gt;This will be the ratio of packets lost. Unless your outgoing bandwidth is peaked or there&apos;s something wrong with your network connection, this will be 0%</source>
+        <source>&lt;b&gt;Sets the packet loss for loopback mode.&lt;/b&gt;&lt;br /&gt;This will be the ratio of packets lost. Unless your outgoing bandwidth is peaked or there&apos;s something wrong with your network connection, this will be 0%</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -1318,7 +1318,7 @@ This value allows you to set the maximum number of users allowed in the channel.
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>&lt;b&gt;Attenuate volume of other applications during speech&lt;/b&gt;&lt;br /&gt;Mumble supports decreasing the volume of other applications during incoming and/or outgoing speech. This sets the attenuation of other applications if the feature is enabled.</source>
+        <source>&lt;b&gt;Attenuate volume of other applications during speech&lt;/b&gt;&lt;br /&gt;Mumble supports decreasing the volume of other applications during incoming and/or outgoing speech. Also sets the attenuation of other applications.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -1326,7 +1326,7 @@ This value allows you to set the maximum number of users allowed in the channel.
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>&lt;b&gt;Attenuate applications while others talk&lt;/b&gt;&lt;br /&gt;Mumble supports decreasing the volume of other applications during incoming and/or outgoing speech. This makes mumble activate the feature while other users talk to you.</source>
+        <source>&lt;b&gt;Attenuate applications while others talk&lt;/b&gt;&lt;br /&gt;Mumble supports decreasing the volume of other applications during incoming and/or outgoing speech. Activate the feature while others talk to you.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -1350,7 +1350,7 @@ This value allows you to set the maximum number of users allowed in the channel.
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>&lt;b&gt;This opens the device in exclusive mode.&lt;/b&gt;&lt;br /&gt;No other application will be able to use the device.</source>
+        <source>&lt;b&gt;Opens the device in exclusive mode.&lt;/b&gt;&lt;br /&gt;No other application will be able to use the device.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -1390,7 +1390,7 @@ This value allows you to set the maximum number of users allowed in the channel.
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>&lt;b&gt;This is the output method to use for audio.&lt;/b&gt;</source>
+        <source>&lt;b&gt;The output method to use for audio.&lt;/b&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -1532,7 +1532,7 @@ This value allows you to set the maximum number of users allowed in the channel.
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>This shows the peak power in the last frame (20 ms), and is the same measurement as you would usually find displayed as &quot;input power&quot;. Please disregard this and look at &lt;b&gt;Microphone power&lt;/b&gt; instead, which is much more steady and disregards outliers.</source>
+        <source>Shows the peak power in the last frame (20 ms), and is the same measurement as you would usually find displayed as &quot;input power&quot;. Please disregard this and look at &lt;b&gt;Microphone power&lt;/b&gt; instead, which is much more steady and disregards outliers.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -1540,8 +1540,8 @@ This value allows you to set the maximum number of users allowed in the channel.
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>This shows the peak power of the speakers in the last frame (20 ms). Unless you are using a multi-channel sampling method (such as ASIO) with speaker channels configured, this will be 0. If you have such a setup configured, and this still shows 0 while you&apos;re playing audio from other programs, your setup is not working.</source>
-        <oldsource>This shows the peak power in the last frame (20 ms) of the speakers. Unless you are using a multi-channel sampling method (such as ASIO) with speaker channels configured, this will be 0. If you have such a setup configured, and this still shows 0 while you&apos;re playing audio from other programs, your setup is not working.</oldsource>
+        <source>Shows the peak power of the speakers in the last frame (20 ms). Unless you are using a multi-channel sampling method (such as ASIO) with speaker channels configured, this will be 0. If you have such a setup configured, and this still shows 0 while you&apos;re playing audio from other programs, your setup is not working.</source>
+        <oldsource>Shows the peak power in the last frame (20 ms) of the speakers. Unless you are using a multi-channel sampling method (such as ASIO) with speaker channels configured, this will be 0. If you have such a setup configured, and this still shows 0 while you&apos;re playing audio from other programs, your setup is not working.</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -1549,7 +1549,7 @@ This value allows you to set the maximum number of users allowed in the channel.
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>This shows the peak power in the last frame (20 ms) after all processing. Ideally, this should be -96 dB when you&apos;re not talking. In reality, a sound studio should see -60 dB, and you should hopefully see somewhere around -20 dB. When you are talking, this should rise to somewhere between -5 and -10 dB.&lt;br /&gt;If you are using echo cancellation, and this rises to more than -15 dB when you&apos;re not talking, your setup is not working, and you&apos;ll annoy other users with echoes.</source>
+        <source>Shows the peak power in the last frame (20 ms) after all processing. Ideally, this should be -96 dB when you&apos;re not talking. In reality, a sound studio should see -60 dB, and you should hopefully see somewhere around -20 dB. When you are talking, this should rise to somewhere between -5 and -10 dB.&lt;br /&gt;If you are using echo cancellation, and this rises to more than -15 dB when you&apos;re not talking, your setup is not working, and you&apos;ll annoy other users with echoes.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -1565,7 +1565,7 @@ This value allows you to set the maximum number of users allowed in the channel.
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>This shows how close your current input volume is to the ideal. To adjust your microphone level, open whatever program you use to adjust the recording volume, and look at the value here while talking.&lt;br /&gt;&lt;b&gt;Talk loud, as you would when you&apos;re upset over getting fragged by a noob.&lt;/b&gt;&lt;br /&gt;Adjust the volume until this value is close to 100%, but make sure it doesn&apos;t go above. If it does go above, you are likely to get clipping in parts of your speech, which will degrade sound quality.</source>
+        <source>Shows how close your current input volume is to the ideal. To adjust your microphone level, open whatever program you use to adjust the recording volume, and look at the value here while talking.&lt;br /&gt;&lt;b&gt;Talk loud, as you would when you&apos;re upset over getting fragged by a noob.&lt;/b&gt;&lt;br /&gt;Adjust the volume until this value is close to 100%, but make sure it doesn&apos;t go above. If it does go above, you are likely to get clipping in parts of your speech, which will degrade sound quality.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -1577,7 +1577,7 @@ This value allows you to set the maximum number of users allowed in the channel.
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>This is the Signal-To-Noise Ratio (SNR) of the microphone in the last frame (20 ms). It shows how much clearer the voice is compared to the noise.&lt;br /&gt;If this value is below 1.0, there&apos;s more noise than voice in the signal, and so quality is reduced.&lt;br /&gt;There is no upper limit to this value, but don&apos;t expect to see much above 40-50 without a sound studio.</source>
+        <source>The Signal-To-Noise Ratio (SNR) of the microphone in the last frame (20 ms). It shows how much clearer the voice is compared to the noise.&lt;br /&gt;If this value is below 1.0, there&apos;s more noise than voice in the signal, and so quality is reduced.&lt;br /&gt;There is no upper limit to this value, but don&apos;t expect to see much above 40-50 without a sound studio.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -1589,7 +1589,7 @@ This value allows you to set the maximum number of users allowed in the channel.
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>This is the probability that the last frame (20 ms) was speech and not environment noise.&lt;br /&gt;Voice activity transmission depends on this being right. The trick with this is that the middle of a sentence is always detected as speech; the problem is the pauses between words and the start of speech. It&apos;s hard to distinguish a sigh from a word starting with &apos;h&apos;.&lt;br /&gt;If this is in bold font, it means Mumble is currently transmitting (if you&apos;re connected).</source>
+        <source>The probability of the last frame (20 ms) being speech and not environment noise.&lt;br /&gt;Voice activity transmission depends on this being right. The trick with this is that the middle of a sentence is always detected as speech; the problem is the pauses between words and the start of speech. It&apos;s hard to distinguish a sigh from a word starting with &apos;h&apos;.&lt;br /&gt;If this is in bold font, it means Mumble is currently transmitting (if you&apos;re connected).</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -1621,7 +1621,7 @@ This value allows you to set the maximum number of users allowed in the channel.
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>&lt;b&gt;This shows the current speech detection settings.&lt;/b&gt;&lt;br /&gt;You can change the settings from the Settings dialog or from the Audio Wizard.</source>
+        <source>&lt;b&gt;Shows the current speech detection settings.&lt;/b&gt;&lt;br /&gt;Change this settings from the Settings dialog or by using the Audio Wizard.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -1633,7 +1633,7 @@ This value allows you to set the maximum number of users allowed in the channel.
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>This shows the power spectrum of the current input signal (red line) and the current noise estimate (filled blue).&lt;br /&gt;All amplitudes are multiplied by 30 to show the interesting parts (how much more signal than noise is present in each waveband).&lt;br /&gt;This is probably only of interest if you&apos;re trying to fine-tune noise conditions on your microphone. Under good conditions, there should be just a tiny flutter of blue at the bottom. If the blue is more than halfway up on the graph, you have a seriously noisy environment.</source>
+        <source>Shows the power spectrum of the current input signal (red line) and the current noise estimate (filled blue).&lt;br /&gt;All amplitudes are multiplied by 30 to show the interesting parts (how much more signal than noise is present in each waveband).&lt;br /&gt;This is probably only of interest if you&apos;re trying to fine-tune noise conditions on your microphone. Under good conditions, there should be just a tiny flutter of blue at the bottom. If the blue is more than halfway up on the graph, you have a seriously noisy environment.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -1645,11 +1645,11 @@ This value allows you to set the maximum number of users allowed in the channel.
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>This shows the weights of the echo canceller, with time increasing downwards and frequency increasing to the right.&lt;br /&gt;Ideally, this should be black, indicating no echo exists at all. More commonly, you&apos;ll have one or more horizontal stripes of bluish color representing time delayed echo. You should be able to see the weights updated in real time.&lt;br /&gt;Please note that as long as you have nothing to echo off, you won&apos;t see much useful data here. Play some music and things should stabilize. &lt;br /&gt;You can choose to view the real or imaginary parts of the frequency-domain weights, or alternately the computed modulus and phase. The most useful of these will likely be modulus, which is the amplitude of the echo, and shows you how much of the outgoing signal is being removed at that time step. The other viewing modes are mostly useful to people who want to tune the echo cancellation algorithms.&lt;br /&gt;Please note: If the entire image fluctuates massively while in modulus mode, the echo canceller fails to find any correlation whatsoever between the two input sources (speakers and microphone). Either you have a very long delay on the echo, or one of the input sources is configured wrong.</source>
+        <source>Shows the weights of the echo canceller, with time increasing downwards and frequency increasing to the right.&lt;br /&gt;Ideally, this should be black, indicating no echo exists at all. More commonly, you&apos;ll have one or more horizontal stripes of bluish color representing time delayed echo. You should be able to see the weights updated in real time.&lt;br /&gt;Please note that as long as you have nothing to echo off, you won&apos;t see much useful data here. Play some music and things should stabilize. &lt;br /&gt;You can choose to view the real or imaginary parts of the frequency-domain weights, or alternately the computed modulus and phase. The most useful of these will likely be modulus, which is the amplitude of the echo, and shows you how much of the outgoing signal is being removed at that time step. The other viewing modes are mostly useful to people who want to tune the echo cancellation algorithms.&lt;br /&gt;Please note: If the entire image fluctuates massively while in modulus mode, the echo canceller fails to find any correlation whatsoever between the two input sources (speakers and microphone). Either you have a very long delay on the echo, or one of the input sources is configured wrong.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>This is the audio bitrate of the last compressed frame (20 ms), and as such will jump up and down as the VBR adjusts the quality. The peak bitrate can be adjusted in the Settings dialog.</source>
+        <source>The audio bitrate of the last compressed frame (20 ms), and as such will jump up and down as the VBR adjusts the quality. The peak bitrate can be adjusted in the Settings dialog.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -1684,7 +1684,7 @@ This value allows you to set the maximum number of users allowed in the channel.
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>This is the device your microphone is connected to.</source>
+        <source>The device your microphone is connected to.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -1716,11 +1716,11 @@ This value allows you to set the maximum number of users allowed in the channel.
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>This enables echo cancellation of outgoing audio, which helps both on speakers and on headsets.</source>
+        <source>Turns on echo cancellation of outgoing audio, which helps both on speakers and on headsets.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>This is the device your speakers or headphones are connected to.</source>
+        <source>The device your speakers or headphones are connected to.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -1753,7 +1753,7 @@ This value allows you to set the maximum number of users allowed in the channel.
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>This allows Mumble to use positional audio to place voices.</source>
+        <source>Allows Mumble to use positional audio to place voices.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -1761,7 +1761,7 @@ This value allows you to set the maximum number of users allowed in the channel.
 To keep latency to an absolute minimum, it&apos;s important to buffer as little audio as possible on the soundcard. However, many soundcards report that they require a much smaller buffer than what they can actually work with, so the only way to set this value is to try and fail.
 &lt;/p&gt;
 &lt;p&gt;
-You should hear a voice sample. Change the slider below to the lowest value which gives &lt;b&gt;no&lt;/b&gt; interruptions or jitter in the sound. Please note that local echo is disabled during this test.
+You should hear a voice sample. Change the slider below to the lowest value which gives &lt;b&gt;no&lt;/b&gt; interruptions or jitter in the sound. Please note that local echo is off during this test.
 &lt;/p&gt;
 </source>
         <translation type="unfinished"></translation>
@@ -1771,7 +1771,7 @@ You should hear a voice sample. Change the slider below to the lowest value whic
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>This sets the amount of data to pre-buffer in the output buffer. Experiment with different values and set it to the lowest which doesn&apos;t cause rapid jitter in the sound.</source>
+        <source>Sets the amount of data to pre-buffer in the output buffer. Experiment with different values and set it to the lowest which doesn&apos;t cause rapid jitter in the sound.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -1798,10 +1798,7 @@ Speak loudly, as when you are annoyed or excited. Decrease the volume in the sou
     </message>
     <message>
         <source>&lt;p&gt;
-Congratulations. You should now be ready to enjoy a richer sound experience with Mumble.
-&lt;/p&gt;
-&lt;p&gt;
-Mumble is under continuous development, and the development team wants to focus on the features that benefit the most users. To this end, Mumble supports submitting anonymous stats about your configuration to the developers. These stats are essential for future development, and also make sure the features you use aren&apos;t deprecated.
+The hard working development team wants to focus on features benefitting the most users. You can send in anonymous stats to help, also ensuring the features you use aren&apos;t removed.
 &lt;/p&gt;
 </source>
         <translation type="unfinished"></translation>
@@ -1811,7 +1808,7 @@ Mumble is under continuous development, and the development team wants to focus 
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>This ignores the OS speaker configuration and configures the positioning for headphones instead.</source>
+        <source>Ignores the speaker configuration of the operating system and configures the positioning for headphones instead.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -1835,7 +1832,7 @@ Mumble is under continuous development, and the development team wants to focus 
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>This will help Mumble figure out when you are talking. The first step is selecting which data value to use.</source>
+        <source>Helps Mumble figure out when you are talking. The first step is selecting which data value to use.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -1864,11 +1861,11 @@ Mumble is under continuous development, and the development team wants to focus 
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Push To Talk:</source>
+        <source>Push-To-Talk:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Quality &amp; Notifications</source>
+        <source>Quality and Notifications</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -1924,7 +1921,7 @@ Mumble is under continuous development, and the development team wants to focus 
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Enables attenuation of other applications while users talk to you. This means that as soon someone starts to speak to you in Mumble, the sound of all other applications (like audio players) will get attenuated so you can hear them more clearly.</source>
+        <source>Enables attenuation of other applications while users talk to you. As soon someone starts to speak to you in Mumble, the sound of all other applications (like audio players) will get attenuated so you can hear them more clearly.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -1968,27 +1965,27 @@ Speak loudly, as when you are annoyed or excited. Decrease the volume in the sou
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>In this configuration Mumble will use a &lt;b&gt;low amount of bandwidth&lt;/b&gt;. This will inevitably result in high latency and poor quality. Choose this only if your connection cannot handle the other settings. (16kbit/s, 60ms per packet)</source>
+        <source>In this configuration Mumble uses a &lt;b&gt;low amount of bandwidth&lt;/b&gt;. Results in high latency and poor quality. Only use it if your connection cannot handle the other settings. (16kbit/s, 60ms per packet)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>This is the &lt;b&gt;recommended default&lt;/b&gt; configuration. It provides a good balance between quality, latency, and bandwidth usage. (40kbit/s, 20ms per packet)</source>
+        <source>The &lt;b&gt;recommended default&lt;/b&gt; configuration. It provides a good balance between quality, latency, and bandwidth usage. (40kbit/s, 20ms per packet)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>This configuration is only recommended for use in setups where bandwidth is not an issue, like a LAN. It provides the lowest latency supported by Mumble and &lt;b&gt;high quality&lt;/b&gt;. (72kbit/s, 10ms per packet)</source>
+        <source>Configuration only recommended for use in setups where bandwidth is not an issue, like a LAN. It provides the lowest latency supported by Mumble and &lt;b&gt;high quality&lt;/b&gt;. (72kbit/s, 10ms per packet)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>&lt;b&gt;This is the input method to use for audio.&lt;/b&gt;</source>
+        <source>&lt;b&gt;The input method to use for audio.&lt;/b&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>&lt;b&gt;This is the Output method to use for audio.&lt;/b&gt;</source>
+        <source>&lt;b&gt;The output method to use for audio.&lt;/b&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;This is the audio tuning wizard for Mumble. This will help you correctly set the input levels of your sound card, and also set the correct parameters for sound processing in Mumble. &lt;/p&gt;&lt;p&gt;Please be aware that as long as this wizard is active, audio will be looped locally to allow you to listen to it, and no audio will be sent to the server. &lt;/p&gt;&lt;p&gt;Note that you can cancel this wizard at any time without it having an effect on your current audio systems. The settings are only once this wizard has been completed.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;The audio tuning wizard for Mumble. Help you correctly set the input levels of your sound card and the correct parameters for sound processing in Mumble. &lt;/p&gt;&lt;p&gt;Please be aware that as long as this wizard is active, audio will be looped locally to allow you to listen to it, and no audio will be sent to the server. &lt;/p&gt;&lt;p&gt;Note that you can cancel this wizard at any time without it having an effect on your current audio systems. The settings are only once this wizard has been completed.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -2035,7 +2032,7 @@ Speak loudly, as when you are annoyed or excited. Decrease the volume in the sou
 <context>
     <name>BanEditor</name>
     <message>
-        <source>Mumble - Edit Bans</source>
+        <source>Mumble — Edit Bans</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -2087,7 +2084,7 @@ Speak loudly, as when you are annoyed or excited. Decrease the volume in the sou
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>This is the search field. Use it to find bans that have this username set in the username field.</source>
+        <source>Use this field to find bans with this username set in the username field.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -2135,7 +2132,7 @@ Speak loudly, as when you are annoyed or excited. Decrease the volume in the sou
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>This is a list with banned users.</source>
+        <source>List with banned users.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -2163,7 +2160,7 @@ Speak loudly, as when you are annoyed or excited. Decrease the volume in the sou
         <translation type="unfinished"></translation>
     </message>
     <message numerus="yes">
-        <source>Ban List - %n Ban(s)</source>
+        <source>Ban List — %n Ban(s)</source>
         <translation type="unfinished">
             <numerusform></numerusform>
         </translation>
@@ -2196,7 +2193,7 @@ Speak loudly, as when you are annoyed or excited. Decrease the volume in the sou
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Email</source>
+        <source>E-mail</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -2219,7 +2216,7 @@ Speak loudly, as when you are annoyed or excited. Decrease the volume in the sou
 <context>
     <name>CertWizard</name>
     <message>
-        <source>Unable to validate email.&lt;br /&gt;Enter a valid (or blank) email to continue.</source>
+        <source>Unable to validate e-mail address.&lt;br /&gt;Enter a valid (or blank) e-mail address to continue.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -2295,7 +2292,7 @@ Speak loudly, as when you are annoyed or excited. Decrease the volume in the sou
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Email address</source>
+        <source>E-mail address</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -2432,7 +2429,7 @@ Speak loudly, as when you are annoyed or excited. Decrease the volume in the sou
     </message>
     <message>
         <source>&lt;p&gt;You already have a certificate stored in Mumble, and you are about to replace it.&lt;/p&gt;
-&lt;p&gt;If you are upgrading to a certificate issued to you by a trusted CA and the email addresses match your current certificate, this is completely safe, and servers you connect to will automatically recognize the strong certificate for your email address.
+&lt;p&gt;If you are upgrading to a certificate issued to you by a trusted CA and the e-mail addresses match your current certificate, this is completely safe, and servers you connect to will automatically recognize the strong certificate for your e-mail address.
 &lt;/p&gt;
 &lt;p&gt;If this is not the case, you will no longer be recognized by any server you previously have authenticated with. If you haven&apos;t been registered on any server yet, this is nothing to worry about.
 &lt;/p&gt;
@@ -2487,7 +2484,7 @@ Are you sure you wish to replace your certificate?
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>&lt;p&gt;Mumble will now generate a strong certificate for authentication to servers.&lt;/p&gt;&lt;p&gt;If you wish, you may provide some additional info to be stored in the certificate, which will be presented to servers when you connect. If you provide a valid email address, you can upgrade to a CA issued email certificate later on, which provides strong identification.&lt;/p&gt;</source>
+        <source>&lt;p&gt;Mumble will now generate a strong certificate for authentication to servers.&lt;/p&gt;&lt;p&gt;If you wish, you may provide some additional info to be stored in the certificate, which will be presented to servers when you connect. If you provide a valid e-mail address, you can upgrade to a CA issued e-mail certificate later on, which provides strong identification.&lt;/p&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -2495,15 +2492,15 @@ Are you sure you wish to replace your certificate?
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Email</source>
+        <source>E-mail</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Your email address (e.g. johndoe@mumble.info)</source>
+        <source>Your e-mail address (e.g. johndoe@mumble.info)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>This is your email address. It is strongly recommended to provide a valid email address, as this will allow you to upgrade to a strong certificate without authentication problems.</source>
+        <source>This is your e-mail address. It is strongly recommended to provide a valid e-mail address, as this will allow you to upgrade to a strong certificate without authentication problems.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -2536,7 +2533,7 @@ Are you sure you wish to replace your certificate?
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>&lt;p&gt;Mumble can use certificates to authenticate with servers. Using certificates avoids passwords, meaning you don&apos;t need to disclose any password to the remote site. It also enables very easy user registration and a client side friends list independent of servers.&lt;/p&gt;&lt;p&gt;While Mumble can work without certificates, the majority of servers will expect you to have one.&lt;/p&gt;&lt;p&gt;Creating a new certificate automatically is sufficient for most use cases. But Mumble also supports certificates representing trust in the users ownership of an email address. These certificates are issued by third parties. More info in the &lt;a href=&quot;http://mumble.info/certificate.php&quot;&gt;user certificate documentation&lt;/a&gt;. &lt;/p&gt;</source>
+        <source>&lt;p&gt;Mumble can use certificates to authenticate with servers. Using certificates avoids passwords, meaning you don&apos;t need to disclose any password to the remote site. It also enables very easy user registration and a client side friends list independent of servers.&lt;/p&gt;&lt;p&gt;While Mumble can work without certificates, the majority of servers will expect you to have one.&lt;/p&gt;&lt;p&gt;Creating a new certificate automatically is sufficient for most use cases. But Mumble also supports certificates representing trust in the users ownership of an e-mail address. These certificates are issued by third parties. More info in the &lt;a href=&quot;http://mumble.info/certificate.php&quot;&gt;user certificate documentation&lt;/a&gt;. &lt;/p&gt;</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -2699,11 +2696,11 @@ Are you sure you wish to replace your certificate?
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Unable to send image: too large.</source>
+        <source>Could not send image because it was too large.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Unable to send image %1: too large.</source>
+        <source>Could not send the image &quot;%1&quot; because it was too large.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -2805,7 +2802,7 @@ Are you sure you wish to replace your certificate?
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>This button will restore the defaults for the settings on the current page. Other pages will not be changed.&lt;br /&gt;To restore all settings to their defaults, you can press the &quot;Defaults (All)&quot; button.</source>
+        <source>This button will restore the defaults for the settings on the current page. Other pages will not be changed.&lt;br /&gt;To restore all settings to their defaults, press the &quot;Defaults (All)&quot; button.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -2840,7 +2837,7 @@ Are you sure you wish to replace your certificate?
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Failed to fetch server list</source>
+        <source>Could not fetch server list</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -2952,7 +2949,7 @@ Are you sure you wish to replace your certificate?
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>&lt;p&gt;To measure the latency (ping) of public servers and determine the number of active users, your IP address must be transmitted to each public server.&lt;/p&gt;&lt;p&gt;Do you consent to the transmission of your IP address? If you answer no, the public server list will be deactivated. However, you can reactivate it at any time in the network settings.&lt;/p&gt;</source>
+        <source>&lt;p&gt;To measure the latency (ping) of public servers and determine the number of active users, your IP address must be transmitted to each public server.&lt;/p&gt;&lt;p&gt;Do you consent to the transmission of your IP address? If you answer no, the public server list will be deactivated. Reactivate it at any time in the network settings.&lt;/p&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -3146,7 +3143,7 @@ Label of the server. This is what the server will be named like in your server l
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Email address (optional)</source>
+        <source>E-mail address (optional)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -3175,7 +3172,7 @@ Label of the server. This is what the server will be named like in your server l
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>The crash upload has failed with error %1 %2. Please inform a developer.</source>
+        <source>The crash uploader has failed with the error %1 %2. Please inform a developer.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -3203,7 +3200,7 @@ Label of the server. This is what the server will be named like in your server l
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Mumble failed to initialize a database in any of the possible locations.</source>
+        <source>Could not initialize a database in any of the possible locations.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -3272,7 +3269,7 @@ Label of the server. This is what the server will be named like in your server l
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Mumble can currently only use mouse buttons and keyboard modifier keys (Alt, Ctrl, Cmd, etc.) for global shortcuts.&lt;/p&gt;&lt;p&gt;If you want more flexibility, you can turn on &lt;span style=&quot; font-style:italic;&quot;&gt;Access for assistive devices&lt;/span&gt; in the system&apos;s Accessibility preferences. However, please note that this change also potentially allows malicious programs to read what is typed on your keyboard.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Mumble can currently only use mouse buttons and keyboard modifier keys (Alt, Ctrl, Cmd, etc.) for global shortcuts.&lt;/p&gt;&lt;p&gt;Turn on &lt;span style=&quot; font-style:italic;&quot;&gt;Access for assistive devices&lt;/span&gt; in the system&apos;s Accessibility preferences for more adjustability. This also potentially allows malicious programs to read what is typed on your keyboard.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -3349,7 +3346,7 @@ Without this option on, using Mumble&apos;s global shortcuts in privileged appli
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Remove the currently selected items</source>
+        <source>Remove selected items</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -3360,7 +3357,7 @@ Without this option on, using Mumble&apos;s global shortcuts in privileged appli
 <context>
     <name>GlobalShortcutConfig</name>
     <message>
-        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Mumble can currently only use mouse buttons and keyboard modifier keys (Alt, Ctrl, Cmd, etc.) for global shortcuts.&lt;/p&gt;&lt;p&gt;If you want more flexibility, you can add Mumble as a trusted accessibility program in the Security &amp; Privacy section of your Mac&apos;s System Preferences.&lt;/p&gt;&lt;p&gt;In the Security &amp; Privacy preference pane, change to the Privacy tab. Then choose Accessibility (near the bottom) in the list to the left. Finally, add Mumble to the list of trusted accessibility programs.&lt;/body&gt;&lt;/html&gt;</source>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Mumble can currently only use mouse buttons and keyboard modifier keys (Alt, Ctrl, Cmd, etc.) for global shortcuts.&lt;/p&gt;&lt;p&gt;For more flexibility, you can add Mumble as a trusted accessibility program in the Security &amp; Privacy section of your Mac&apos;s System Preferences.&lt;/p&gt;&lt;p&gt;In the Security &amp; Privacy preference pane, change to the Privacy tab. Then choose Accessibility (near the bottom) in the list to the left. Finally, add Mumble to the list of trusted accessibility programs.&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -3549,7 +3546,7 @@ Without this option on, using Mumble&apos;s global shortcuts in privileged appli
 &lt;h3&gt;Size:&lt;/h3&gt;
 &lt;p&gt;
 This field describes the size of an LCD device. The size is given either in pixels (for graphic LCDs) or in characters (for character LCDs).&lt;/p&gt;
-&lt;h3&gt;Enabled:&lt;/h3&gt;
+&lt;h3&gt;On:&lt;/h3&gt;
 &lt;p&gt;This decides whether Mumble should draw to a particular LCD device.&lt;/p&gt;</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3571,7 +3568,7 @@ This field describes the size of an LCD device. The size is given either in pixe
     </message>
     <message>
         <source>&lt;p&gt;This option decides the minimum width a column in the User View.&lt;/p&gt;
-&lt;p&gt;If too many people are speaking at once, the User View will split itself into columns. You can use this option to pick a compromise between number of users shown on the LCD, and width of user names.&lt;/p&gt;
+&lt;p&gt;If too many people are speaking at once, the User View will split itself into columns. Use it to pick a compromise between number of users shown on the LCD, and width of user names.&lt;/p&gt;
 </source>
         <translation type="unfinished"></translation>
     </message>
@@ -3686,7 +3683,7 @@ This field describes the size of an LCD device. The size is given either in pixe
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>[[ Text object too large to display ]]</source>
+        <source>[[ The text object is too large to display ]]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -3813,7 +3810,7 @@ This field describes the size of an LCD device. The size is given either in pixe
     </message>
     <message>
         <source>Click here to turn on or off sound notification for %1 events.&lt;br /&gt;Uses a sound file predefined by you to indicate %1 events. Sound files and Text-To-Speech cannot be used at the same time.</source>
-        <oldsource>Path to sound file used for sound notifications in the case of %1 events.&lt;br /&gt;Single click to play&lt;br /&gt;Double-click to change&lt;br /&gt;Be sure that sound notifications for these events are enabled or this field will not have any effect.</oldsource>
+        <oldsource>Path to sound file used for sound notifications in the case of %1 events.&lt;br /&gt;Single click to play&lt;br /&gt;Double-click to change&lt;br /&gt;Ensure sound notifications for these events are on, or this field will not have any effect.</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -4088,11 +4085,11 @@ The setting only applies for new messages, the already shown ones will retain th
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Ask whether to close or minimize when quitting Mumble.</source>
+        <source>Ask to close or minimize when quitting.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Ask on quit while connected</source>
+        <source>Ask upon quitting while connected</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -4100,19 +4097,19 @@ The setting only applies for new messages, the already shown ones will retain th
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>&lt;b&gt;If set, minimizing the Mumble main window will cause it to be hidden and accessible only from the tray. Otherwise, it will be minimized as a window normally would.&lt;/b&gt;</source>
+        <source>&lt;b&gt;Hides the main window in the system tray when Mumble is minimized. Otherwise it is minimized as a window normally would.&lt;/b&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Hide in tray when minimized</source>
+        <source>Minimize to tray</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Hide the main Mumble window in the tray when it is minimized.</source>
+        <source>Hide the main Mumble window in the system tray when minimized.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>This setting controls when the application will be always on top.</source>
+        <source>Controlss when the application will be always on top.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -4136,19 +4133,19 @@ The setting only applies for new messages, the already shown ones will retain th
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Show talking status in tray icon</source>
+        <source>Talking status in tray icon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>This setting controls in which situations the application will stay always on top. If you select &lt;i&gt;Never&lt;/i&gt; the application will not stay on top. &lt;i&gt;Always&lt;/i&gt; will always keep the application on top. &lt;i&gt;In minimal view&lt;/i&gt; / &lt;i&gt;In normal view&lt;/i&gt; will only keep the application always on top when minimal view is activated / deactivated.</source>
+        <source>Controls in which situations the application will stay always on top. If you select &lt;i&gt;Never&lt;/i&gt; the application will not stay on top. &lt;i&gt;Always&lt;/i&gt; will always keep the application on top. &lt;i&gt;In minimal view&lt;/i&gt; / &lt;i&gt;In normal view&lt;/i&gt; will only keep the application always on top when minimal view is activated / deactivated.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Show context menu in menu bar</source>
+        <source>Context menu in menu bar</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Apply some high contrast optimizations for visually impaired users</source>
+        <source>High contrast optimizations for vision impaired users</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -4208,11 +4205,11 @@ The setting only applies for new messages, the already shown ones will retain th
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>&lt;b&gt;Enable Developer menu&lt;/b&gt;&lt;br /&gt;This enables the &quot;Developer&quot;-menu in Mumble. This menu is used for developer-specific features, such as the Developer Console.</source>
+        <source>&lt;b&gt;Developer menu&lt;/b&gt;&lt;br /&gt;Shows the &quot;Developer&quot;-menu containing developer-specific features (like the developer console) in Mumble.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Enable Developer menu</source>
+        <source>Developer menu</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -4300,7 +4297,7 @@ The setting only applies for new messages, the already shown ones will retain th
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Max. channel name length</source>
+        <source>Max. channel-name length</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -4643,7 +4640,7 @@ The setting only applies for new messages, the already shown ones will retain th
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Server presented a certificate which failed verification.</source>
+        <source>The server presented a certificate which failed verification.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -4755,7 +4752,7 @@ The setting only applies for new messages, the already shown ones will retain th
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Mumble - Minimal View -- %1</source>
+        <source>Mumble — Minimal View — %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -5200,7 +5197,7 @@ Otherwise abort and check your certificate and username.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Enable or disable the text-to-speech engine. Only messages enabled for TTS in the Configuration dialog will actually be spoken.</source>
+        <source>Enable or disable the text-to-speech engine. Only messages set up for TTS in the Configuration dialog will actually be spoken.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -5312,7 +5309,7 @@ Otherwise abort and check your certificate and username.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>This will add the user as a friend, so you can recognize him on this and other servers.</source>
+        <source>This will add the user as a friend, so you can recognize the person on this and other servers.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -5737,7 +5734,7 @@ Otherwise abort and check your certificate and username.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Welcome to Mumble.</source>
+        <source>Welcome.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -6048,11 +6045,11 @@ channel&apos;s context menu.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>No action available…</source>
+        <source>No available actions…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Unable to %1 into %2 - Adding the respective access (password) token might grant you access.</source>
+        <source>Unable to %1 into %2 — Adding the respective access (password) token might grant you access.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -6679,8 +6676,8 @@ Prevents the client from sending info about the operating system to the Mumble s
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>This sets whether the overlay is enabled or not. This setting is only checked when applications are started, so make sure Mumble is running and this option is on before you start the application.&lt;br /&gt;Please note that if you start Mumble after starting the application, or if you disable the overlay while the application is running, there is no safe way to restart the overlay without also restarting the application.</source>
-        <oldsource>This sets whether the overlay is enabled or not. This setting is only checked when applications are started, so make sure Mumble is running and this option is on before you start the application.&lt;br /&gt;Please note that if you start the application after starting Mumble, or if you disable the overlay while running, there is no safe way to restart the overlay without also restarting the application.</oldsource>
+        <source>This sets whether the overlay is on or not. This setting is only checked when applications are started, so make sure Mumble is running and this option is on before you start the application.&lt;br /&gt;Please note that if you start Mumble after starting the application, or if you disable the overlay while the application is running, there is no safe way to restart the overlay without also restarting the application.</source>
+        <oldsource>This sets whether the overlay is on or not. This setting is only checked when applications are started, so make sure Mumble is running and this option is on before you start the application.&lt;br /&gt;Please note that if you start the application after starting Mumble, or if you disable the overlay while running, there is no safe way to restart the overlay without also restarting the application.</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -6732,7 +6729,7 @@ Click the button below to upgrade these files to their latest versions.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Show FPS counter</source>
+        <source>FPS counter</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -6780,7 +6777,7 @@ Click the button below to upgrade these files to their latest versions.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Show Clock</source>
+        <source>Clock</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -7029,7 +7026,7 @@ Click the button below to upgrade these files to their latest versions.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>This allows plugins for supported games to fetch your in-game position and transmit it with each voice packet. This enables other users to hear your voice in-game from the direction your character is in relation to their own.</source>
+        <source>This allows plugins for supported games to fetch your in-game position and transmit it with each voice packet. This lets others hear your voice in-game from the direction your character is in relation to their own.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -7077,7 +7074,7 @@ Click the button below to upgrade these files to their latest versions.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Enabled</source>
+        <source>On</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -7092,7 +7089,7 @@ Click the button below to upgrade these files to their latest versions.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Failed to install new plugin to %1.</source>
+        <source>Could not install the new plugin to %1.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -7177,7 +7174,7 @@ See &lt;a href=&quot;https://wiki.mumble.info/wiki/Installing_Mumble&quot;&gt;th
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>&lt;p&gt;You&apos;re using a Mumble version that &lt;b&gt;explicitly disabled&lt;/b&gt; update-checks.&lt;/p&gt;&lt;p&gt;This means that the update notification you might receive by using this option will &lt;b&gt;most likely be meaningless&lt;/b&gt; for you.&lt;/p&gt;</source>
+        <source>&lt;p&gt;You&apos;re using a Mumble version where update-checks is turned off.&lt;/p&gt;&lt;p&gt;The update notification you might receive by using this option will &lt;b&gt;most likely be meaningless&lt;/b&gt; for you.&lt;/p&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -7551,7 +7548,7 @@ See &lt;a href=&quot;https://wiki.mumble.info/wiki/Installing_Mumble&quot;&gt;th
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Mumble - Access Tokens</source>
+        <source>Mumble — Access Tokens</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -8006,7 +8003,7 @@ An access token is a text string, which can be used as a password for very simpl
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>The channel has access restrictions but you can still enter it.</source>
+        <source>The channel has access restrictions, but you can still enter it.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -8021,7 +8018,7 @@ An access token is a text string, which can be used as a password for very simpl
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Failed to launch snapshot installer.</source>
+        <source>Could not launch snapshot installer.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -8033,8 +8030,8 @@ An access token is a text string, which can be used as a password for very simpl
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Could not write new version to disk.</source>
-        <oldsource>Failed to write new version to disc.</oldsource>
+        <source>Could not save the new version.</source>
+        <oldsource>Could not write new version to disc.</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -8113,7 +8110,7 @@ An access token is a text string, which can be used as a password for very simpl
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Email: %1</source>
+        <source>E-mail: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -8140,19 +8137,19 @@ An access token is a text string, which can be used as a password for very simpl
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>.wav - Uncompressed</source>
+        <source>.wav — Uncompressed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>.ogg (Vorbis) - Compressed</source>
+        <source>.ogg (Vorbis) — Compressed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>.au - Uncompressed</source>
+        <source>.au — Uncompressed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>.flac - Lossless compressed</source>
+        <source>.flac — Lossless compressed</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -8285,7 +8282,7 @@ Please contact your server administrator for further info.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Push to talk</source>
+        <source>Push-to-talk</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/mumble/mumble_en.ts
+++ b/src/mumble/mumble_en.ts
@@ -485,7 +485,7 @@ This value allows you to set the maximum number of users allowed in the channel.
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Device selection</source>
+        <source>Pick your sound sources</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -638,7 +638,7 @@ This value allows you to set the maximum number of users allowed in the channel.
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>System</source>
+        <source>Sound server</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -1144,7 +1144,7 @@ This value allows you to set the maximum number of users allowed in the channel.
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>System</source>
+        <source>Sound server</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -1152,7 +1152,7 @@ This value allows you to set the maximum number of users allowed in the channel.
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Device</source>
+        <source>Output device</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -1660,15 +1660,15 @@ This value allows you to set the maximum number of users allowed in the channel.
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Introduction</source>
+        <source>Make sure you sound great</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Welcome to the Mumble Audio Wizard</source>
+        <source>Adjust sound processing and sound card input levels</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Finished</source>
+        <source>Setup completed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -1680,7 +1680,7 @@ This value allows you to set the maximum number of users allowed in the channel.
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Selecting the input and output device to use with Mumble.</source>
+        <source>Select what sends audio, and then what plays it.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -1696,7 +1696,7 @@ This value allows you to set the maximum number of users allowed in the channel.
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Device</source>
+        <source>Input device</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -1712,7 +1712,7 @@ This value allows you to set the maximum number of users allowed in the channel.
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Use echo cancellation</source>
+        <source>Echo cancellation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -1736,7 +1736,7 @@ This value allows you to set the maximum number of users allowed in the channel.
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Enable positional audio</source>
+        <source>Positional audio</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -1758,10 +1758,8 @@ This value allows you to set the maximum number of users allowed in the channel.
     </message>
     <message>
         <source>&lt;p&gt;
-To keep latency to an absolute minimum, it&apos;s important to buffer as little audio as possible on the soundcard. However, many soundcards report that they require a much smaller buffer than what they can actually work with, so the only way to set this value is to try and fail.
-&lt;/p&gt;
-&lt;p&gt;
-You should hear a voice sample. Change the slider below to the lowest value which gives &lt;b&gt;no&lt;/b&gt; interruptions or jitter in the sound. Please note that local echo is off during this test.
+Some sound cards claim to require storing less audio in their buffer than they actually work with.
+Move the slider to the lowest without interruption in the voice you hear.
 &lt;/p&gt;
 </source>
         <translation type="unfinished"></translation>
@@ -1776,10 +1774,10 @@ You should hear a voice sample. Change the slider below to the lowest value whic
     </message>
     <message>
         <source>&lt;p&gt;
-Open your sound control panel and go to the recording settings. Make sure the microphone is selected as active input with maximum recording volume. If there&apos;s an option to enable a &quot;Microphone boost&quot; make sure it&apos;s checked.
+Select your microhpone and set it to 100% recording volume sound control panel of your operating system. Turn on &quot;Microphone boost&quot; if it is available.
 &lt;/p&gt;
 &lt;p&gt;
-Speak loudly, as when you are annoyed or excited. Decrease the volume in the sound control panel until the bar below stays as high as possible in the blue and green but &lt;b&gt;not&lt;/b&gt; the red zone while you speak.
+Ensure the level is as as high as possible by only entering the red zone when speaking louder than you ever would.
 &lt;/p&gt;
 </source>
         <translation type="unfinished"></translation>
@@ -1789,22 +1787,22 @@ Speak loudly, as when you are annoyed or excited. Decrease the volume in the sou
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Adjusting attenuation of positional audio.</source>
+        <source>Adjust how others sound as they move around you.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Use headphones instead of speakers</source>
+        <source>Headphones instead of speakers</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <source>&lt;p&gt;
-The hard working development team wants to focus on features benefitting the most users. You can send in anonymous stats to help, also ensuring the features you use aren&apos;t removed.
+The hard-working development team wants to focus on features benefitting the most users. You can help, and ensure features you use aren&apos;t removed.
 &lt;/p&gt;
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Use headphones</source>
+        <source>Headphones instead of speakers</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -1812,48 +1810,51 @@ The hard working development team wants to focus on features benefitting the mos
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Volume tuning</source>
+        <source>Adjust how loud and clear you sound</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Tuning microphone hardware volume to optimal settings.</source>
+        <source>Fine-tune the best signal-to-noise ratio.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Now talk softly, as you would when talking late at night and you don&apos;t want to disturb anyone. Adjust the slider below so that the bar moves into green when you talk, but stays blue while you&apos;re silent.</source>
+        <source>Ensure the blue cutoff area only covers being silent by shrinking it below speaking softly and quietly.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Voice Activity Detection</source>
+        <source>Select when to send audio</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Letting Mumble figure out when you&apos;re talking and when you&apos;re silent.</source>
+        <source>This decides when to send your voice to others.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Helps Mumble figure out when you are talking. The first step is selecting which data value to use.</source>
+        <source>I want to talk:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Raw amplitude from input</source>
+        <source>Always</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Signal-To-Noise ratio</source>
+        <source>When detected</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Next you need to adjust the following slider. The first few utterances you say should end up in the green area (definitive speech). While talking, you should stay inside the yellow (might be speech) and when you&apos;re not talking, everything should be in the red (definitively not speech).</source>
+        <source>Ensure your speech is divided into the following areas.&lt;br /&gt;
+The first thing you say. Grønt (Speech)&lt;br /&gt;
+Regular talking. Yellow (Could be speech)&lt;br /&gt;
+Silence. Red (Not talking)</source>
         <oldsource>Next you need to adjust the following two sliders. The first few utterances you say should end up in the green area (definitive speech). While talking, you should stay inside the yellow (might be speech) and when you&apos;re not talking, everything should be in the red (definitively not speech).</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Device tuning</source>
+        <source>Minimize playback latency</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Changing hardware output delays to their minimum value.</source>
+        <source>Set how immediately sound can be played without issue.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -1865,15 +1866,15 @@ The hard working development team wants to focus on features benefitting the mos
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Quality and Notifications</source>
+        <source>Set the amount of data to use</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Adjust quality and notification settings.</source>
+        <source>Pick a good tradeoff between quality and cost.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Quality settings</source>
+        <source>Sound quality</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -1885,15 +1886,15 @@ The hard working development team wants to focus on features benefitting the mos
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Notification settings</source>
+        <source>Notifications</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Use Text-To-Speech to read notifications and messages to you.</source>
+        <source>Read with Text-To-Speech.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Disable Text-To-Speech and use sounds instead.</source>
+        <source>Sounds instead of Text-To-Speech.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -1905,7 +1906,7 @@ The hard working development team wants to focus on features benefitting the mos
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Attenuate applications while other users talk</source>
+        <source>Lower the volume of other applications while others talk</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -1929,7 +1930,7 @@ The hard working development team wants to focus on features benefitting the mos
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Use high contrast graphics</source>
+        <source>High contrast bars</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -1938,10 +1939,10 @@ The hard working development team wants to focus on features benefitting the mos
     </message>
     <message>
         <source>&lt;p&gt;
-Open your sound control panel and go to the recording settings. Make sure the microphone is selected as active input with maximum recording volume. If there&apos;s an option to enable a &quot;Microphone boost&quot; make sure it&apos;s checked.
+Select your microhpone and set it to 100% recording volume sound control panel of your operating system. Turn on &quot;Microphone boost&quot; if it is available.
 &lt;/p&gt;
 &lt;p&gt;
-Speak loudly, as when you are annoyed or excited. Decrease the volume in the sound control panel until the bar below stays as high as possible in the striped and the empty but &lt;b&gt;not&lt;/b&gt; the crisscrossed zone while you speak.
+Ensure the level is as as high as possible by only entering the red zone when speaking louder than you ever would.
 &lt;/p&gt;
 </source>
         <oldsource>&lt;p&gt;
@@ -1955,25 +1956,27 @@ Speak loudly, as when you are annoyed or excited. Decrease the volume in the sou
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Now talk softly, as you would when talking late at night and you don&apos;t want to disturb anyone. Adjust the slider below so that the bar moves into empty zone when you talk, but stays in the striped one while you&apos;re silent.</source>
+        <source>Ensure the striped cutoff area only covers being silent by shrinking it below speaking softly and quietly.</source>
         <comment>For high contrast mode</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Next you need to adjust the following slider. The first few utterances you say should end up in the empty area (definitive speech). While talking, you should stay inside the striped (might be speech) and when you&apos;re not talking, everything should be in the crisscrossed (definitively not speech).</source>
-        <comment>For high contrast mode</comment>
+        <source>Ensure your speech is divided into the following areas.&lt;br /&gt;
+The first thing you say. Empty (Speech)&lt;br /&gt;
+Regular talking. Empty (Could be speech)&lt;br /&gt;
+Silence. Crisscrossed (Not talking)</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>In this configuration Mumble uses a &lt;b&gt;low amount of bandwidth&lt;/b&gt;. Results in high latency and poor quality. Only use it if your connection cannot handle the other settings. (16kbit/s, 60ms per packet)</source>
+        <source>Poor quality, worst latency, lowest data usage. For costly and bad connections. (16kbit/s, 60ms per packet)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>The &lt;b&gt;recommended default&lt;/b&gt; configuration. It provides a good balance between quality, latency, and bandwidth usage. (40kbit/s, 20ms per packet)</source>
+        <source>OK quality, OK latency, medium data usage. Safe for most connections. (40kbit/s, 20ms per packet)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Configuration only recommended for use in setups where bandwidth is not an issue, like a LAN. It provides the lowest latency supported by Mumble and &lt;b&gt;high quality&lt;/b&gt;. (72kbit/s, 10ms per packet)</source>
+        <source>Great quality, lowest latency, highest data use. For faster and unrestricted networks. (72kbit/s, 10ms per packet)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -1985,11 +1988,11 @@ Speak loudly, as when you are annoyed or excited. Decrease the volume in the sou
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;The audio tuning wizard for Mumble. Help you correctly set the input levels of your sound card and the correct parameters for sound processing in Mumble. &lt;/p&gt;&lt;p&gt;Please be aware that as long as this wizard is active, audio will be looped locally to allow you to listen to it, and no audio will be sent to the server. &lt;/p&gt;&lt;p&gt;Note that you can cancel this wizard at any time without it having an effect on your current audio systems. The settings are only once this wizard has been completed.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Your audio input is played back to you so you can listen to yourself (while the wizard is open). Settings are only saved once the wizard finishes.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Mumble supports positional audio for some games, and will position the voice of other users relative to their position in game. Depending on their position, the volume of the voice will be changed between the speakers to simulate the direction and distance the other user is at. Such positioning depends on your speaker configuration being correct in your operating system, so a test is done here. &lt;/p&gt;&lt;p&gt;The graph below shows the position of &lt;span style=&quot; color:#56b4e9;&quot;&gt;you&lt;/span&gt;, the &lt;span style=&quot; color:#d55e00;&quot;&gt;speakers&lt;/span&gt; and a &lt;span style=&quot; color:#009e73;&quot;&gt;moving sound source&lt;/span&gt; as if seen from above. You should hear the audio move between the channels. &lt;/p&gt;&lt;p&gt;You can also use your mouse to position the &lt;span style=&quot; color:#009e73;&quot;&gt;sound source&lt;/span&gt; manually.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;This is how others will sound when they move around you in virtual surroundings (like supported games). &lt;/p&gt;&lt;p&gt;Here you hear &lt;span style=&quot; color:#d55e00;&quot;&gt;ears&lt;/span&gt; and a &lt;span style=&quot; color:#009e73;&quot;&gt;moving sound source&lt;/span&gt; you can position, as you see &lt;span style=&quot; color:#56b4e9;&quot;&gt;yourself&lt;/span&gt; from above.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -1997,7 +2000,7 @@ Speak loudly, as when you are annoyed or excited. Decrease the volume in the sou
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Input device</source>
+        <source>Recording 🎤</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -2005,7 +2008,7 @@ Speak loudly, as when you are annoyed or excited. Decrease the volume in the sou
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Output device</source>
+        <source>Playback 🔊 🎧</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -2668,7 +2671,7 @@ Are you sure you wish to replace your certificate?
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>This represents the permission to use the listen-feature allowing to listen to a channel without being in it.</source>
+        <source>Allows listening to a channel without being in it.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -6478,7 +6481,7 @@ Valid actions are:
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Submit anonymous stats to the Mumble project</source>
+        <source>Send anonymous stats</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/src/mumble/mumble_en.ts
+++ b/src/mumble/mumble_en.ts
@@ -970,7 +970,7 @@ This value allows you to set the maximum number of users allowed in the channel.
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>If checked, Mumble will enable Opus&apos; low-delay mode when the quality is set to &lt;b&gt;64 kbit/s&lt;/b&gt; or higher. Low-delay mode decreases latency by &lt;b&gt;~15 milliseconds&lt;/b&gt; in the round trip. This mode may require an higher bitrate to preserve the same quality, in comparison with the music and VOiP modes.</source>
+        <source>If checked, Mumble will enable Opus&apos; low-delay mode when the quality is set to &lt;b&gt;64 kbit/s&lt;/b&gt; or higher. Low-delay mode decreases latency by &lt;b&gt;~15 milliseconds&lt;/b&gt; in the round trip. This mode may require an higher bitrate to preserve the same quality, in comparison with the music and VoIP modes.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/src/mumble/mumble_en.ts
+++ b/src/mumble/mumble_en.ts
@@ -1394,7 +1394,7 @@ This value allows you to set the maximum number of users allowed in the channel.
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>&lt;b&gt;Attenuate other users while talking as Priority Speaker&lt;/b&gt;&lt;br /&gt;Mumble supports decreasing the volume of other users while you talk as the &lt;i&gt;Priority Speaker&lt;/i&gt; to avoid getting disturbed. Checking this checkbox will enable this feature.</source>
+        <source>&lt;b&gt;Attenuate other users while talking as Priority Speaker&lt;/b&gt;&lt;br /&gt;Mumble supports decreasing the volume of other users while you talk as the &lt;i&gt;Priority Speaker&lt;/i&gt; to avoid getting disturbed.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -2802,22 +2802,22 @@ Are you sure you wish to replace your certificate?
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>This button will restore the defaults for the settings on the current page. Other pages will not be changed.&lt;br /&gt;To restore all settings to their defaults, press the &quot;Defaults (All)&quot; button.</source>
+        <source>Resets all settings on the current page.&lt;br /&gt;Press the &quot;Defaults (All)&quot; to reset all settings.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Restore all defaults</source>
+        <source>Reset to defaults</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>This button will restore the defaults for all settings.</source>
+        <source>Resets all settings to their defaults.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>ConnectDialog</name>
     <message>
-        <source>Connecting to %1</source>
+        <source>Connecting to %1…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -2825,7 +2825,7 @@ Are you sure you wish to replace your certificate?
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Servername</source>
+        <source>Server name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -2957,7 +2957,7 @@ Are you sure you wish to replace your certificate?
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Adding host %1</source>
+        <source>Adding host %1…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -3016,7 +3016,7 @@ Are you sure you wish to replace your certificate?
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Name of the server</source>
+        <source>Server name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -3030,7 +3030,7 @@ Are you sure you wish to replace your certificate?
     </message>
     <message>
         <source>&lt;b&gt;Address&lt;/b&gt;&lt;br/&gt;
-Internet address of the server. This can be a normal hostname, an IPv4/IPv6 address or a Bonjour service identifier. Bonjour service identifiers have to be prefixed with a &apos;@&apos; to be recognized by Mumble.</source>
+Internet address of the server. This can be a normal hostname, an IPv4/IPv6 address, or a Bonjour service identifier prefixed with a &apos;@&apos;.</source>
         <oldsource>&lt;b&gt;Address&lt;/b&gt;&lt;/br&gt;
 Internet address of the server. This can be a normal hostname, an ipv4/6 address or a bonjour service identifier. Bonjour service identifiers have to be prefixed with a &apos;@&apos; to be recognized by Mumble.</oldsource>
         <translation type="unfinished"></translation>
@@ -3070,14 +3070,12 @@ Username to send to the server. Be aware that the server can impose restrictions
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>You are currently connected to a server.
-Do you want to fill the dialog with the connection data of this server?
+        <source>Do you to use the data of the server you are connected to?
 Host: %1 Port: %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>You have an URL in your clipboard.
-Do you want to fill the dialog with this data?
+        <source>Do you want to use the URL in your clipboard?
 Host: %1 Port: %2</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3091,7 +3089,7 @@ Host: %1 Port: %2</source>
     </message>
     <message>
         <source>&lt;b&gt;Password&lt;/b&gt;&lt;br/&gt;
-Password to be sent to the server on connect. This password is needed when connecting as &lt;i&gt;SuperUser&lt;/i&gt; or to a server using password authentication. If not entered here the password will be queried on connect.</source>
+Password to be sent to the server when connecting. This password is needed when connecting as &lt;i&gt;SuperUser&lt;/i&gt; or to a server using password authentication. If not entered here the password will be queried on connect.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -3100,7 +3098,7 @@ Password to be sent to the server on connect. This password is needed when conne
     </message>
     <message>
         <source>&lt;b&gt;Label&lt;/b&gt;&lt;br/&gt;
-Label of the server. This is what the server will be named like in your server list and can be chosen freely.</source>
+Label of the server. This is what the server will be named in your server list and can be chosen freely.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -3249,7 +3247,7 @@ Label of the server. This is what the server will be named like in your server l
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>This will add a new global shortcut</source>
+        <source>This will add a new shortcut that works everywhere</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -3269,7 +3267,7 @@ Label of the server. This is what the server will be named like in your server l
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Mumble can currently only use mouse buttons and keyboard modifier keys (Alt, Ctrl, Cmd, etc.) for global shortcuts.&lt;/p&gt;&lt;p&gt;Turn on &lt;span style=&quot; font-style:italic;&quot;&gt;Access for assistive devices&lt;/span&gt; in the system&apos;s Accessibility preferences for more adjustability. This also potentially allows malicious programs to read what is typed on your keyboard.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Mumble can currently only use mouse buttons and keyboard modifier keys (Alt, Ctrl, Cmd, etc.) for shortcuts that works everywhere.&lt;/p&gt;&lt;p&gt;Turn on &lt;span style=&quot; font-style:italic;&quot;&gt;Access for assistive devices&lt;/span&gt; in the system&apos;s Accessibility preferences for more adjustability. This also potentially allows malicious programs to read what is typed on your keyboard.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -3317,9 +3315,9 @@ Label of the server. This is what the server will be named like in your server l
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>&lt;b&gt;Turn on shortcuts in privileged applications&lt;/b&gt;.&lt;br /&gt;Also known as &quot;UIAccess&quot;. This allows Mumble to receive global shortcut events from programs running at high privilege levels, such as an Admin Command Prompt or older games that run with admin privileges.
+        <source>&lt;b&gt;Turn on shortcuts in privileged applications&lt;/b&gt;.&lt;br /&gt;Also known as &quot;UIAccess&quot;. This allows Mumble to receive events for shortcuts that works everywhere from programs running at high privilege levels, such as an Admin Command Prompt or older games that run with admin privileges.
 &lt;br /&gt;&lt;br /&gt;
-Without this option on, using Mumble&apos;s global shortcuts in privileged applications will not work. This can seem inconsistent: for example, if the Push-to-Talk button is pressed in a non-privileged program, but released in a privileged application, Mumble will not observe that it has been released and you will continue to talk until you press the Push-to-Talk button again.</source>
+Without this option on, using Mumble&apos;s shortcuts that works everywhere in privileged applications will not work. This can seem inconsistent: for example, if the Push-to-Talk button is pressed in a non-privileged program, but released in a privileged application, Mumble will not observe that it has been released and you will continue to talk until you press the Push-to-Talk button again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -3338,7 +3336,7 @@ Without this option on, using Mumble&apos;s global shortcuts in privileged appli
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Starts the capture process: all buttons you press will be added to the tree.&lt;/p&gt;&lt;p&gt;Once all buttons are released, the capture process stops automatically.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Starts the capture process: All buttons you press will be added to the tree.&lt;/p&gt;&lt;p&gt;Once all buttons are released, the capture process stops.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -3357,7 +3355,7 @@ Without this option on, using Mumble&apos;s global shortcuts in privileged appli
 <context>
     <name>GlobalShortcutConfig</name>
     <message>
-        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Mumble can currently only use mouse buttons and keyboard modifier keys (Alt, Ctrl, Cmd, etc.) for global shortcuts.&lt;/p&gt;&lt;p&gt;For more flexibility, you can add Mumble as a trusted accessibility program in the Security &amp; Privacy section of your Mac&apos;s System Preferences.&lt;/p&gt;&lt;p&gt;In the Security &amp; Privacy preference pane, change to the Privacy tab. Then choose Accessibility (near the bottom) in the list to the left. Finally, add Mumble to the list of trusted accessibility programs.&lt;/body&gt;&lt;/html&gt;</source>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Mumble can currently only use mouse buttons and keyboard modifier keys (Alt, Ctrl, Cmd, etc.) for shortcuts that work everywhere.&lt;/p&gt;&lt;p&gt;For more flexibility, you can add Mumble as a trusted accessibility program in the Security &amp; Privacy section of your Mac&apos;s System Preferences.&lt;/p&gt;&lt;p&gt;In the Security &amp; Privacy preference pane, change to the Privacy tab. Then choose Accessibility (near the bottom) in the list to the left. Finally, add Mumble to the list of trusted accessibility programs.&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -4213,7 +4211,7 @@ The setting only applies for new messages, the already shown ones will retain th
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>When in custom layout mode, checking this disables rearranging.</source>
+        <source>Turns off rearranging in custom layout mode.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -4357,7 +4355,7 @@ The setting only applies for new messages, the already shown ones will retain th
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Whether to show all of the local user&apos;s listeners (ears) in the Talking UI (and thereby also the channels they are in). </source>
+        <source>Show all of the local user&apos;s listeners (ears) in the Talking UI (and thereby also the channels they are in). </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -4365,7 +4363,7 @@ The setting only applies for new messages, the already shown ones will retain th
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Hide the username for each user if they have a nickname.</source>
+        <source>Hide the username of nicknamed users.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -4381,62 +4379,62 @@ The setting only applies for new messages, the already shown ones will retain th
     </message>
     <message>
         <source>Push-to-Talk</source>
-        <comment>Global Shortcut</comment>
+        <comment>Shortcut that works everywhere</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Push and hold this button to send voice.</source>
-        <comment>Global Shortcut</comment>
+        <comment>Shortcut that works everywhere</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <source>This configures the push-to-talk button, and as long as you hold this button down, you will transmit voice.</source>
-        <comment>Global Shortcut</comment>
+        <comment>Shortcut that works everywhere</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Reset Audio Processor</source>
-        <comment>Global Shortcut</comment>
+        <comment>Shortcut that works everywhere</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Unlink Plugin</source>
-        <comment>Global Shortcut</comment>
+        <comment>Shortcut that works everywhere</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Push-to-Mute</source>
-        <comment>Global Shortcut</comment>
+        <comment>Shortcut that works everywhere</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Join Channel</source>
-        <comment>Global Shortcut</comment>
+        <comment>Shortcut that works everywhere</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Turn on or off Overlay</source>
-        <comment>Global Shortcut</comment>
+        <comment>Shortcut that works everywhere</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Toggle state of in-game overlay.</source>
-        <comment>Global Shortcut</comment>
+        <comment>Shortcut that works everywhere</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Toggle Minimal</source>
-        <comment>Global Shortcut</comment>
+        <comment>Shortcut that works everywhere</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Volume Up (+10%)</source>
-        <comment>Global Shortcut</comment>
+        <comment>Shortcut that works everywhere</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Volume Down (-10%)</source>
-        <comment>Global Shortcut</comment>
+        <comment>Shortcut that works everywhere</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -4464,37 +4462,37 @@ The setting only applies for new messages, the already shown ones will retain th
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Mumble is currently connected to a server. Do you want to close or minimize it?</source>
+        <source>Do you want to close or minimize Mumble even if you are connected to a server?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Mute Self</source>
-        <comment>Global Shortcut</comment>
+        <comment>Shortcut that works everywhere</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Set self-mute status.</source>
-        <comment>Global Shortcut</comment>
+        <comment>Shortcut that works everywhere</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <source>This will set or change your muted status. If you turn this off, self-deafen will also be off.</source>
-        <comment>Global Shortcut</comment>
+        <comment>Shortcut that works everywhere</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Deafen Self</source>
-        <comment>Global Shortcut</comment>
+        <comment>Shortcut that works everywhere</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Set self-deafen status.</source>
-        <comment>Global Shortcut</comment>
+        <comment>Shortcut that works everywhere</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <source>This will set or change your deafened status. If you turn this on, you will also enable self-mute.</source>
-        <comment>Global Shortcut</comment>
+        <comment>Shortcut that works everywhere</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -4691,17 +4689,17 @@ The setting only applies for new messages, the already shown ones will retain th
     </message>
     <message>
         <source>Use in conjunction with &quot;Whisper to&quot;.</source>
-        <comment>Global Shortcut</comment>
+        <comment>Shortcut that works everywhere</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <source>This will switch the states of the in-game overlay.</source>
-        <comment>Global Shortcut</comment>
+        <comment>Shortcut that works everywhere</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Link Channel</source>
-        <comment>Global Shortcut</comment>
+        <comment>Shortcut that works everywhere</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -4711,32 +4709,32 @@ The setting only applies for new messages, the already shown ones will retain th
     </message>
     <message>
         <source>Set &quot;Transmit Mode&quot; to &quot;Push-To-Talk&quot;</source>
-        <comment>Global Shortcut</comment>
+        <comment>Shortcut that works everywhere</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Set &quot;Transmit Mode&quot; to &quot;Continuous&quot;</source>
-        <comment>Global Shortcut</comment>
+        <comment>Shortcut that works everywhere</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Set &quot;Transmit Mode&quot; to &quot;VAD&quot;</source>
-        <comment>Global Shortcut</comment>
+        <comment>Shortcut that works everywhere</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Send Text Message</source>
-        <comment>Global Shortcut</comment>
+        <comment>Shortcut that works everywhere</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Send Clipboard Text Message</source>
-        <comment>Global Shortcut</comment>
+        <comment>Shortcut that works everywhere</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Send your clipboard content to the channel you are currently in.</source>
-        <comment>Global Shortcut</comment>
+        <source>Paste your clipboard content to the channel you are in.</source>
+        <comment>Shortcut that works everywhere</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -6186,7 +6184,7 @@ Valid options are:
     </message>
     <message>
         <source>Hide/show main window</source>
-        <comment>Global Shortcut</comment>
+        <comment>Shortcut that works everywhere</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>


### PR DESCRIPTION
### Checks

- [ ] My commits follow the [commit guidelines](https://github.com/mumble-voip/mumble/blob/master/COMMIT_GUIDELINES.md)
- [x] No

Are these changes OK? With the translation now handled on [Hosted Weblate](https://hosted.weblate.org/projects/mumble/), something along the lines of this would help everyone greatly.

