### PR TITLE
BUILD(cmake): Fix unity build failure

### DIFF
--- a/cmake/qt-utils.cmake
+++ b/cmake/qt-utils.cmake
@@ -8,7 +8,6 @@ function(include_qt_plugin TARGET SCOPE PLUGIN)
 	if(NOT EXISTS ${PATH})
 		file(WRITE ${PATH} "#include <QtPlugin>\n")
 		set_property(SOURCE ${PATH} PROPERTY GENERATED TRUE SKIP_AUTOGEN TRUE)
-		set_property(SOURCE ${PATH} PROPERTY SKIP_UNITY_BUILD_INCLUSION TRUE)
 	else()
 		file(READ ${PATH} CONTENT)
 		string(FIND ${CONTENT} ${PLUGIN} INDEX)
@@ -16,6 +15,13 @@ function(include_qt_plugin TARGET SCOPE PLUGIN)
 			set(FOUND TRUE)
 		endif()
 	endif()
+
+	# We have to exclude these files from unity builds since we have one of that for the client
+	# and one for the server. If they happen to get included in the same build or just with some
+	# other code that happens to include one of the plugins statically, then there'll be errors.
+	# We set the property on existing files as well in order to ensure that it is set even
+	# if the file existed already (and setting the property multiple times should not hurt).
+	set_property(SOURCE ${PATH} PROPERTY SKIP_UNITY_BUILD_INCLUSION TRUE)
 
 	if(NOT FOUND)
 		file(APPEND ${PATH} "Q_IMPORT_PLUGIN(${PLUGIN})\n")


### PR DESCRIPTION
If the *_plugin_import.cpp files already exist before the latest cmake
changes for unity builds are pulled, the necessary property does not get
set on these files, which can cause build failure.


### Checks

- [x] My commits follow the [commit guidelines](https://github.com/mumble-voip/mumble/blob/master/COMMIT_GUIDELINES.md)

