### PR TITLE
CI(macOS): Fix test cases not being found

### DIFF
--- a/.ci/azure-pipelines/steps_macos.yml
+++ b/.ci/azure-pipelines/steps_macos.yml
@@ -18,7 +18,7 @@ steps:
     env:
       MUMBLE_BUILD_NUMBER_TOKEN: $(BUILD_NUMBER_TOKEN)
     displayName: 'Build'
-  - script: 'cd $BUILD_BINARIES_DIRECTORY; ctest --verbose'
+  - script: 'cd $BUILD_BINARIESDIRECTORY; ctest --verbose'
     displayName: 'Test'
   - script: .ci/azure-pipelines/release_macos.bash
     displayName: 'Release'


### PR DESCRIPTION
The variable holding the directory to change into to run the tests in,
had a typo in its name, causing the cd to fail. Therefore no tests were
found and run.


### Checks

- [x] My commits follow the [commit guidelines](https://github.com/mumble-voip/mumble/blob/master/COMMIT_GUIDELINES.md)

