### PR TITLE
MAINT: Add new language 'si' to CMake list of translations

### DIFF
--- a/src/mumble/CMakeLists.txt
+++ b/src/mumble/CMakeLists.txt
@@ -737,6 +737,7 @@ if(translations)
 		"mumble_pt_PT.ts"
 		"mumble_ro.ts"
 		"mumble_ru.ts"
+		"mumble_si.ts"
 		"mumble_sv.ts"
 		"mumble_te.ts"
 		"mumble_th.ts"


### PR DESCRIPTION
PR #4839 with commit 2767a40aae0c13fdc70876946433e24c64579617 added 'si' as a new language.
But did not add the language to CMakeLists.txt ts_files which bundles it into the application.

This change adds the missing file reference.


### Checks

- [x] My commits follow the [commit guidelines](https://github.com/mumble-voip/mumble/blob/master/COMMIT_GUIDELINES.md)

