### PR TITLE
FIX(client): Update rnnoise-src submodule

### DIFF
--- a/src/mumble/AudioInput.cpp
+++ b/src/mumble/AudioInput.cpp
@@ -241,7 +241,7 @@ AudioInput::AudioInput() : opusBuffer(Global::get().s.iFramesPerPacket * (SAMPLE
 #endif
 
 #ifdef USE_RNNOISE
-	denoiseState = rnnoise_create();
+	denoiseState = rnnoise_create(nullptr);
 #endif
 
 	qWarning("AudioInput: %d bits/s, %d hz, %d sample", iAudioQuality, iSampleRate, iFrameSize);


### PR DESCRIPTION
This fixes a heap corruption that was originally discovered by @PaulDana on `#mumble-dev`.

In addition to that, all upstream changes are integrated.