### PR TITLE
BUILD: Bumped overlay version to 1.3.4 as well

### DIFF
--- a/overlay_gl/overlay_gl.pro
+++ b/overlay_gl/overlay_gl.pro
@@ -10,7 +10,7 @@ include(../qmake/compiler.pri)
 TEMPLATE = lib
 CONFIG -= qt gui
 CONFIG *= debug_and_release
-VERSION = 1.3.3
+VERSION = 1.3.4
 SOURCES = overlay.c
 
 CONFIG(static) {


### PR DESCRIPTION
Fixes #4857


### Checks

- [x] My commits follow the [commit guidelines](https://github.com/mumble-voip/mumble/blob/master/COMMIT_GUIDELINES.md)

