### PR TITLE
FIX(client): Make translations work again

### DIFF
--- a/src/mumble/Translations.h
+++ b/src/mumble/Translations.h
@@ -10,15 +10,37 @@
 
 class QApplication;
 class QLocale;
+class QTranslator;
 
 namespace Mumble {
 namespace Translations {
+
+	/**
+	 * A lifetime guard for translators. Basically a smart-pointer for an ensemble of translators
+	 */
+	struct LifetimeGuard {
+		QTranslator *m_bundledTranslator = nullptr;
+		QTranslator *m_overwriteTranslator = nullptr;
+		QTranslator *m_qtTranslator = nullptr;
+
+		LifetimeGuard() = default;
+		LifetimeGuard(LifetimeGuard &&old);
+		LifetimeGuard(const LifetimeGuard &) = delete;
+		~LifetimeGuard();
+	};
 
 	QStringList getDefaultTranslationDirectories();
 
 	QStringList getTranslationDirectories(const QApplication &app, const QStringList &extraDirectories);
 
-	void installTranslators(const QLocale &locale, QApplication &app, const QStringList &extraDirectories);
+	/**
+	 * Installs translators for the given locale to the given application. If extraDirectories are provided,
+	 * they will be used for the overwrite translator.
+	 *
+	 * @returns The lifetime guard of the created translators. This object must not be destroyed before
+	 *   the given application has terminated.
+	 */
+	LifetimeGuard installTranslators(const QLocale &locale, QApplication &app, const QStringList &extraDirectories);
 
 }; // namespace Translations
 }; // namespace Mumble

--- a/src/mumble/main.cpp
+++ b/src/mumble/main.cpp
@@ -585,7 +585,7 @@ int main(int argc, char **argv) {
 
 	qWarning("Locale is \"%s\" (System: \"%s\")", qUtf8Printable(settingsLocale.name()), qUtf8Printable(systemLocale.name()));
 
-	Mumble::Translations::installTranslators(settingsLocale, a, extraTranslationDirs);
+	Mumble::Translations::LifetimeGuard translationGuard = Mumble::Translations::installTranslators(settingsLocale, a, extraTranslationDirs);
 
 	// Initialize proxy settings
 	NetworkConfig::SetupProxy();


### PR DESCRIPTION
Commit 0dcc1f614b2ab4f0d4bbac5fd29676595072a133 introduced a regression
that caused translations to no longer work (the UI would always remain
in English).

The reason for this is that the translator objects installed into the
application have to remain alive in order to function. By moving them
into a dedicated function they went out of scope very quickly after
their creation and thus none of them actually performed any work.

This commit fixes this by creating the translator objects on the heap
and using a smart-pointer-like structure for making sure they are only
deleted once they are really not needed anymore.

Fixes #4856


### Checks

- [x] My commits follow the [commit guidelines](https://github.com/mumble-voip/mumble/blob/master/COMMIT_GUIDELINES.md)

