### PR TITLE
FIX(client): Make button in config dialog translatable

### DIFF
--- a/src/mumble/ConfigDialog.cpp
+++ b/src/mumble/ConfigDialog.cpp
@@ -75,7 +75,7 @@ ConfigDialog::ConfigDialog(QWidget *p) : QDialog(p) {
 		   "To restore all settings to their defaults, you can press the \"Defaults (All)\" button."));
 
 	QPushButton *restoreAllButton =
-		pageButtonBox->addButton(QString::fromLatin1("Defaults (All)"), QDialogButtonBox::ResetRole);
+		pageButtonBox->addButton(tr("Defaults (All)"), QDialogButtonBox::ResetRole);
 	restoreAllButton->setToolTip(tr("Restore all defaults"));
 	restoreAllButton->setWhatsThis(tr("This button will restore the defaults for all settings."));
 

--- a/src/mumble/mumble_ar.ts
+++ b/src/mumble/mumble_ar.ts
@@ -2821,6 +2821,10 @@ Are you sure you wish to replace your certificate?
         <source>This button will restore the defaults for all settings.</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Defaults (All)</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ConnectDialog</name>

--- a/src/mumble/mumble_bg.ts
+++ b/src/mumble/mumble_bg.ts
@@ -2818,6 +2818,10 @@ Are you sure you wish to replace your certificate?
         <source>This button will restore the defaults for all settings.</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Defaults (All)</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ConnectDialog</name>

--- a/src/mumble/mumble_br.ts
+++ b/src/mumble/mumble_br.ts
@@ -2817,6 +2817,10 @@ Are you sure you wish to replace your certificate?
         <source>This button will restore the defaults for all settings.</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Defaults (All)</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ConnectDialog</name>

--- a/src/mumble/mumble_ca.ts
+++ b/src/mumble/mumble_ca.ts
@@ -2823,6 +2823,10 @@ Are you sure you wish to replace your certificate?
         <source>This button will restore the defaults for all settings.</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Defaults (All)</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ConnectDialog</name>

--- a/src/mumble/mumble_cs.ts
+++ b/src/mumble/mumble_cs.ts
@@ -2859,6 +2859,10 @@ Jste si jisti, že chcete certifikát nahradit?
         <source>This button will restore the defaults for all settings.</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Defaults (All)</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ConnectDialog</name>

--- a/src/mumble/mumble_cy.ts
+++ b/src/mumble/mumble_cy.ts
@@ -2821,6 +2821,10 @@ Are you sure you wish to replace your certificate?
         <source>This button will restore the defaults for all settings.</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Defaults (All)</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ConnectDialog</name>

--- a/src/mumble/mumble_da.ts
+++ b/src/mumble/mumble_da.ts
@@ -2857,6 +2857,10 @@ Er du sikker på du vil erstatte dit certifikat?
         <source>This button will restore the defaults for all settings.</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Defaults (All)</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ConnectDialog</name>

--- a/src/mumble/mumble_de.ts
+++ b/src/mumble/mumble_de.ts
@@ -2901,6 +2901,10 @@ Man benötigt Verbindungsrechte in beiden Kanälen um eine Verbindung aufzubauen
         <source>This button will restore the defaults for all settings.</source>
         <translation>Dieser Button stellt die Standardwerte für alle Einstellungen wieder her.</translation>
     </message>
+    <message>
+        <source>Defaults (All)</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ConnectDialog</name>

--- a/src/mumble/mumble_el.ts
+++ b/src/mumble/mumble_el.ts
@@ -2861,6 +2861,10 @@ Are you sure you wish to replace your certificate?
         <source>This button will restore the defaults for all settings.</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Defaults (All)</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ConnectDialog</name>

--- a/src/mumble/mumble_en.ts
+++ b/src/mumble/mumble_en.ts
@@ -2816,6 +2816,10 @@ Are you sure you wish to replace your certificate?
         <source>This button will restore the defaults for all settings.</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Defaults (All)</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ConnectDialog</name>

--- a/src/mumble/mumble_en_GB.ts
+++ b/src/mumble/mumble_en_GB.ts
@@ -2850,6 +2850,10 @@ Are you sure you wish to replace your certificate?
         <source>This button will restore the defaults for all settings.</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Defaults (All)</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ConnectDialog</name>

--- a/src/mumble/mumble_eo.ts
+++ b/src/mumble/mumble_eo.ts
@@ -2822,6 +2822,10 @@ Are you sure you wish to replace your certificate?
         <source>This button will restore the defaults for all settings.</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Defaults (All)</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ConnectDialog</name>

--- a/src/mumble/mumble_es.ts
+++ b/src/mumble/mumble_es.ts
@@ -2858,6 +2858,10 @@ Are you sure you wish to replace your certificate?
         <source>This button will restore the defaults for all settings.</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Defaults (All)</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ConnectDialog</name>

--- a/src/mumble/mumble_et.ts
+++ b/src/mumble/mumble_et.ts
@@ -2818,6 +2818,10 @@ Are you sure you wish to replace your certificate?
         <source>This button will restore the defaults for all settings.</source>
         <translation>See nupp taastab kõigi seadete vaikeväärtused.</translation>
     </message>
+    <message>
+        <source>Defaults (All)</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ConnectDialog</name>

--- a/src/mumble/mumble_eu.ts
+++ b/src/mumble/mumble_eu.ts
@@ -2828,6 +2828,10 @@ adierazten du.</translation>
         <source>This button will restore the defaults for all settings.</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Defaults (All)</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ConnectDialog</name>

--- a/src/mumble/mumble_fa_IR.ts
+++ b/src/mumble/mumble_fa_IR.ts
@@ -2816,6 +2816,10 @@ Are you sure you wish to replace your certificate?
         <source>This button will restore the defaults for all settings.</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Defaults (All)</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ConnectDialog</name>

--- a/src/mumble/mumble_fi.ts
+++ b/src/mumble/mumble_fi.ts
@@ -2859,6 +2859,10 @@ Haluatko varmasti korvata varmenteen?
         <source>This button will restore the defaults for all settings.</source>
         <translation>Tämä nappi palauttaa kaikkien asetusten oletusarvot.</translation>
     </message>
+    <message>
+        <source>Defaults (All)</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ConnectDialog</name>

--- a/src/mumble/mumble_fr.ts
+++ b/src/mumble/mumble_fr.ts
@@ -2858,6 +2858,10 @@ Are you sure you wish to replace your certificate?
         <source>This button will restore the defaults for all settings.</source>
         <translation>Ce bouton restaurera tous les paramètres à leur valeur par défaut.</translation>
     </message>
+    <message>
+        <source>Defaults (All)</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ConnectDialog</name>

--- a/src/mumble/mumble_gl.ts
+++ b/src/mumble/mumble_gl.ts
@@ -2819,6 +2819,10 @@ Are you sure you wish to replace your certificate?
         <source>This button will restore the defaults for all settings.</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Defaults (All)</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ConnectDialog</name>

--- a/src/mumble/mumble_he.ts
+++ b/src/mumble/mumble_he.ts
@@ -2856,6 +2856,10 @@ Are you sure you wish to replace your certificate?
         <source>This button will restore the defaults for all settings.</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Defaults (All)</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ConnectDialog</name>

--- a/src/mumble/mumble_hu.ts
+++ b/src/mumble/mumble_hu.ts
@@ -2847,6 +2847,10 @@ Biztos abban, hogy le akarja cserélni a tanúsítványát?
         <source>This button will restore the defaults for all settings.</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Defaults (All)</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ConnectDialog</name>

--- a/src/mumble/mumble_it.ts
+++ b/src/mumble/mumble_it.ts
@@ -2858,6 +2858,10 @@ Sei sicuro di voler sostituire il tuo certificato?
         <source>This button will restore the defaults for all settings.</source>
         <translation>Ripristina i valori predefiniti per tutte le impostazioni.</translation>
     </message>
+    <message>
+        <source>Defaults (All)</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ConnectDialog</name>

--- a/src/mumble/mumble_ja.ts
+++ b/src/mumble/mumble_ja.ts
@@ -2852,6 +2852,10 @@ Are you sure you wish to replace your certificate?
         <source>This button will restore the defaults for all settings.</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Defaults (All)</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ConnectDialog</name>

--- a/src/mumble/mumble_ko.ts
+++ b/src/mumble/mumble_ko.ts
@@ -2843,6 +2843,10 @@ Are you sure you wish to replace your certificate?
         <source>This button will restore the defaults for all settings.</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Defaults (All)</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ConnectDialog</name>

--- a/src/mumble/mumble_lt.ts
+++ b/src/mumble/mumble_lt.ts
@@ -2847,6 +2847,10 @@ Ar tikrai norite pakeisti savo liudijimą?
         <source>This button will restore the defaults for all settings.</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Defaults (All)</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ConnectDialog</name>

--- a/src/mumble/mumble_nl.ts
+++ b/src/mumble/mumble_nl.ts
@@ -2858,6 +2858,10 @@ Zeker dat je jouw certificaat wilt vervangen?
         <source>This button will restore the defaults for all settings.</source>
         <translation>Deze knop herstelt terug naar standaardwaarden doch voor alle instellingen.</translation>
     </message>
+    <message>
+        <source>Defaults (All)</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ConnectDialog</name>

--- a/src/mumble/mumble_no.ts
+++ b/src/mumble/mumble_no.ts
@@ -2873,6 +2873,10 @@ Er du sikker på at du vil erstatte ditt sertifikat?
         <source>This button will restore the defaults for all settings.</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Defaults (All)</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ConnectDialog</name>

--- a/src/mumble/mumble_oc.ts
+++ b/src/mumble/mumble_oc.ts
@@ -2818,6 +2818,10 @@ Are you sure you wish to replace your certificate?
         <source>This button will restore the defaults for all settings.</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Defaults (All)</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ConnectDialog</name>

--- a/src/mumble/mumble_pl.ts
+++ b/src/mumble/mumble_pl.ts
@@ -2854,6 +2854,10 @@ Czy na pewno chcesz zastąpić swój bieżący certyfikat?
         <source>This button will restore the defaults for all settings.</source>
         <translation>Ten przycisk przywróci domyślne wartości wszystkich ustawień.</translation>
     </message>
+    <message>
+        <source>Defaults (All)</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ConnectDialog</name>

--- a/src/mumble/mumble_pt_BR.ts
+++ b/src/mumble/mumble_pt_BR.ts
@@ -2855,6 +2855,10 @@ Você tem certeza de que quer substituir o seu certificado?
         <source>This button will restore the defaults for all settings.</source>
         <translation>Este botão restaurará os padrões para todas as configurações.</translation>
     </message>
+    <message>
+        <source>Defaults (All)</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ConnectDialog</name>

--- a/src/mumble/mumble_pt_PT.ts
+++ b/src/mumble/mumble_pt_PT.ts
@@ -2852,6 +2852,10 @@ Tem certeza de que quer substituir o seu certificado?
         <source>This button will restore the defaults for all settings.</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Defaults (All)</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ConnectDialog</name>

--- a/src/mumble/mumble_ro.ts
+++ b/src/mumble/mumble_ro.ts
@@ -2822,6 +2822,10 @@ Are you sure you wish to replace your certificate?
         <source>This button will restore the defaults for all settings.</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Defaults (All)</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ConnectDialog</name>

--- a/src/mumble/mumble_ru.ts
+++ b/src/mumble/mumble_ru.ts
@@ -2825,6 +2825,10 @@ Are you sure you wish to replace your certificate?
         <source>This button will restore the defaults for all settings.</source>
         <translation>Эта кнопка восстановит стандартные настройки для всех параметров.</translation>
     </message>
+    <message>
+        <source>Defaults (All)</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ConnectDialog</name>

--- a/src/mumble/mumble_si.ts
+++ b/src/mumble/mumble_si.ts
@@ -2798,6 +2798,10 @@ Are you sure you wish to replace your certificate?
         <source>This button will restore the defaults for all settings.</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Defaults (All)</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ConnectDialog</name>

--- a/src/mumble/mumble_sv.ts
+++ b/src/mumble/mumble_sv.ts
@@ -2855,6 +2855,10 @@ Are you sure you wish to replace your certificate?
         <source>This button will restore the defaults for all settings.</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Defaults (All)</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ConnectDialog</name>

--- a/src/mumble/mumble_te.ts
+++ b/src/mumble/mumble_te.ts
@@ -2829,6 +2829,10 @@ Are you sure you wish to replace your certificate?
         <source>This button will restore the defaults for all settings.</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Defaults (All)</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ConnectDialog</name>

--- a/src/mumble/mumble_th.ts
+++ b/src/mumble/mumble_th.ts
@@ -2816,6 +2816,10 @@ Are you sure you wish to replace your certificate?
         <source>This button will restore the defaults for all settings.</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Defaults (All)</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ConnectDialog</name>

--- a/src/mumble/mumble_tr.ts
+++ b/src/mumble/mumble_tr.ts
@@ -2857,6 +2857,10 @@ Sertifikanızı değiştirmek istediğinize emin misiniz?
         <source>This button will restore the defaults for all settings.</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Defaults (All)</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ConnectDialog</name>

--- a/src/mumble/mumble_uk.ts
+++ b/src/mumble/mumble_uk.ts
@@ -2818,6 +2818,10 @@ Are you sure you wish to replace your certificate?
         <source>This button will restore the defaults for all settings.</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Defaults (All)</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ConnectDialog</name>

--- a/src/mumble/mumble_zh_CN.ts
+++ b/src/mumble/mumble_zh_CN.ts
@@ -2857,6 +2857,10 @@ Are you sure you wish to replace your certificate?
         <source>This button will restore the defaults for all settings.</source>
         <translation>将所有设置恢复为默认值。</translation>
     </message>
+    <message>
+        <source>Defaults (All)</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ConnectDialog</name>

--- a/src/mumble/mumble_zh_HK.ts
+++ b/src/mumble/mumble_zh_HK.ts
@@ -2816,6 +2816,10 @@ Are you sure you wish to replace your certificate?
         <source>This button will restore the defaults for all settings.</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Defaults (All)</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ConnectDialog</name>

--- a/src/mumble/mumble_zh_TW.ts
+++ b/src/mumble/mumble_zh_TW.ts
@@ -2834,6 +2834,10 @@ Are you sure you wish to replace your certificate?
         <source>This button will restore the defaults for all settings.</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Defaults (All)</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ConnectDialog</name>


### PR DESCRIPTION
### Checks

- [x] My commits follow the [commit guidelines](https://github.com/mumble-voip/mumble/blob/master/COMMIT_GUIDELINES.md)

