### PR TITLE
FIX(positional-audio): Fix and revamp Call of Duty 2 plugin

### DIFF
--- a/plugins/cod2/CMakeLists.txt
+++ b/plugins/cod2/CMakeLists.txt
@@ -1,6 +1,18 @@
-# Copyright 2019-2020 The Mumble Developers. All rights reserved.
+# Copyright 2019-2021 The Mumble Developers. All rights reserved.
 # Use of this source code is governed by a BSD-style license
 # that can be found in the LICENSE file at the root of the
 # Mumble source tree or at <https://www.mumble.info/LICENSE>.
 
-add_library(cod2 SHARED "cod2.cpp")
+add_library(cod2 SHARED
+	"cod2.cpp"
+
+	"../Module.cpp"
+	"../Process.cpp"
+	"../ProcessWindows.cpp"
+)
+
+if(WIN32)
+	target_sources(cod2 PRIVATE "../HostWindows.cpp")
+else()
+	target_sources(cod2 PRIVATE "../HostLinux.cpp")
+endif()

--- a/plugins/cod2/cod2.cpp
+++ b/plugins/cod2/cod2.cpp
@@ -3,121 +3,111 @@
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.
 
-#include "../mumble_plugin_main.h"
+#include "ProcessWindows.h"
 
-static int fetch(float *avatar_pos, float *avatar_front, float *avatar_top, float *camera_pos, float *camera_front,
-				 float *camera_top, std::string &, std::wstring &) {
-	float viewHor, viewVer;
-	char state;
+#include "mumble_plugin.h"
+#include "mumble_plugin_utils.h"
 
-	for (int i = 0; i < 3; i++)
-		avatar_pos[i] = avatar_front[i] = avatar_top[i] = camera_pos[i] = camera_front[i] = camera_top[i] = 0.0f;
+std::unique_ptr< ProcessWindows > process;
 
-	bool ok;
-
-	/*
-		This plugin uses the following Variables:
-
-			Address			Type	Description
-			===================================
-			0x01516608		float	Z-Coordinate (=0 out-of-game)
-			0x0151660C		float	X-Coordinate (=0 out-of-game)
-			0x01516610		float	Y-Coordinate (=0 out-of-game)
-			0x0151A114		float	Horizontal view (degrees) (=0 out-of-game)
-			0x0151A110		float	Vertical view (degrees) (=0 out-of-game)
-			0x0096B688		byte	Magic value (0=ingame/out-of-game, 4=spectator)
-	*/
-	ok = peekProc(0x0096B688, &state, 1);
-	if (!ok)
+static inline bool inGame() {
+	uint8_t state;
+	if (!process->peek(0x96B688, &state, sizeof(state))) {
 		return false;
+	}
 
-	if (state == 4)
-		return true; // If this magic value is 4 we are spectating, so switch of PA
+	// 0 = in-game/out-of-game
+	// 4 = spectator
+	return state != 4;
+}
 
-	ok = peekProc(0x01516608, avatar_pos + 2, 4) && // Z
-		 peekProc(0x0151660C, avatar_pos, 4) &&     // X
-		 peekProc(0x01516610, avatar_pos + 1, 4) && // Y
-		 peekProc(0x0151A114, &viewHor, 4) &&       // Hor
-		 peekProc(0x0151A110, &viewVer, 4);         // Ver
+static int fetch(float *avatarPos, float *avatarFront, float *avatarTop, float *cameraPos, float *cameraFront,
+				 float *cameraTop, std::string &, std::wstring &) {
+	for (uint8_t i = 0; i < 3; ++i) {
+		avatarPos[i] = avatarFront[i] = avatarTop[i] = cameraPos[i] = cameraFront[i] = cameraTop[i] = 0.0f;
+	}
 
-	if (!ok)
+	if (!inGame()) {
+		return true;
+	}
+
+	float position[3];
+	if (!process->peek(0x1516608, position, sizeof(position))) {
 		return false;
+	}
 
-	// Scale Coordinates
-	/*
-	   Z-Value is increasing when heading north
-				  decreasing when heading south
-	   X-Value is increasing when heading west
-				  decreasing when heading east
-	   Y-Value is increasing when going up
-				  decreasing when going down
-	   40 units = 1 meter (not confirmed)
-	*/
-	for (int i = 0; i < 3; i++)
-		avatar_pos[i] /= 40.0f; // Scale to meters
-	avatar_pos[0] *= (-1.0f);   // Convert right to left handed
+	float rotation[2];
+	if (!process->peek(0x151A110, rotation, sizeof(rotation))) {
+		return false;
+	}
 
-	avatar_top[2] = -1; // Head movement is in front vector
+	// Mumble | Game
+	// X      | -Y
+	// Y      | Z
+	// Z      | X
+	//
+	// 40 units = 1 meter (not confirmed)
+	avatarPos[0] = -position[1] / 40.0f;
+	avatarPos[1] = position[2] / 40.0f;
+	avatarPos[2] = position[0] / 40.0f;
 
-	// Calculate view unit vector
-	/*
-	   Vertical view 0 when centered
-					85	when looking down
-				   275 when looking up
-	   Decreasing when looking up.
 
-	   Horizontal is 0 when facing North
-					90 when facing West
-				   180 when facing South
-				   270 when facing East
-	   Increasing when turning left.
-	*/
-	viewVer *= static_cast< float >(M_PI / 180.0f);
-	viewHor *= static_cast< float >(M_PI / 180.0f);
+	rotation[0] = degreesToRadians(rotation[0]);
+	rotation[1] = degreesToRadians(rotation[1]);
 
-	avatar_front[0] = -sin(viewHor) * cos(viewVer);
-	avatar_front[1] = -sin(viewVer);
-	avatar_front[2] = cos(viewHor) * cos(viewVer);
+	avatarFront[0] = -sin(rotation[1]) * cos(rotation[0]);
+	avatarFront[1] = -sin(rotation[0]);
+	avatarFront[2] = cos(rotation[0]) * cos(rotation[1]);
+
+	// Sync camera vectors with avatar ones.
+	for (uint8_t i = 0; i < 3; ++i) {
+		cameraPos[i]   = avatarPos[i];
+		cameraFront[i] = avatarFront[i];
+	}
 
 	return true;
 }
 
-static int trylock(const std::multimap< std::wstring, unsigned long long int > &pids) {
-	if (!initialize(pids, L"CoD2MP_s.exe"))
-		return false;
+static int tryLock(const std::multimap< std::wstring, unsigned long long int > &pids) {
+	const std::string name = "CoD2MP_s.exe";
 
-	float apos[3], afront[3], atop[3], cpos[3], cfront[3], ctop[3];
-	std::string context;
-	std::wstring identity;
-
-	if (fetch(apos, afront, atop, cpos, cfront, ctop, context, identity)) {
-		return true;
-	} else {
-		generic_unlock();
+	const auto id = Process::find(name, pids);
+	if (!id) {
 		return false;
 	}
+
+	process = std::make_unique< ProcessWindows >(id, name);
+	if (!process->isOk()) {
+		process.reset();
+		return false;
+	}
+
+	return true;
 }
 
-static const std::wstring longdesc() {
+static const std::wstring longDesc() {
 	return std::wstring(L"Supports Call of Duty 2 v1.3. No context or identity support yet.");
 }
 
 static std::wstring description(L"Call of Duty 2 v1.3");
-static std::wstring shortname(L"Call of Duty 2");
+static std::wstring shortName(L"Call of Duty 2");
 
-static int trylock1() {
-	return trylock(std::multimap< std::wstring, unsigned long long int >());
+static int tryLock1() {
+	return tryLock(std::multimap< std::wstring, unsigned long long int >());
 }
 
-static MumblePlugin cod2plug = { MUMBLE_PLUGIN_MAGIC, description, shortname, nullptr, nullptr, trylock1,
-								 generic_unlock,      longdesc,    fetch };
+static void nullUnlock() {
+}
 
-static MumblePlugin2 cod2plug2 = { MUMBLE_PLUGIN_MAGIC_2, MUMBLE_PLUGIN_VERSION, trylock };
+static MumblePlugin cod2Plug = { MUMBLE_PLUGIN_MAGIC, description, shortName, nullptr, nullptr, tryLock1,
+								 nullUnlock,          longDesc,    fetch };
+
+static MumblePlugin2 cod2Plug2 = { MUMBLE_PLUGIN_MAGIC_2, MUMBLE_PLUGIN_VERSION, tryLock };
 
 extern "C" MUMBLE_PLUGIN_EXPORT MumblePlugin *getMumblePlugin() {
-	return &cod2plug;
+	return &cod2Plug;
 }
 
 extern "C" MUMBLE_PLUGIN_EXPORT MumblePlugin2 *getMumblePlugin2() {
-	return &cod2plug2;
+	return &cod2Plug2;
 }


### PR DESCRIPTION
It was not working because the camera position values were all set to 0.

This commit fixes the issue while also revamping the code.