### PR TITLE
FIX(client): Qt translations not found

### DIFF
--- a/src/mumble/Translations.cpp
+++ b/src/mumble/Translations.cpp
@@ -121,9 +121,9 @@ namespace Translations {
 			app.installTranslator(guard.m_qtTranslator);
 		} else if (guard.m_qtTranslator->load(locale, ":/mumble_overwrite_qtbase_")) {
 			app.installTranslator(guard.m_qtTranslator);
-		} else if (guard.m_qtTranslator->load(locale, "qt_", QLibraryInfo::location(QLibraryInfo::TranslationsPath))) {
+		} else if (guard.m_qtTranslator->load(locale, "qt_", prefix, QLibraryInfo::location(QLibraryInfo::TranslationsPath))) {
 			app.installTranslator(guard.m_qtTranslator);
-		} else if (guard.m_qtTranslator->load(locale, "qtbase_", QLibraryInfo::location(QLibraryInfo::TranslationsPath))) {
+		} else if (guard.m_qtTranslator->load(locale, "qtbase_", prefix, QLibraryInfo::location(QLibraryInfo::TranslationsPath))) {
 			app.installTranslator(guard.m_qtTranslator);
 		} else if (guard.m_qtTranslator->load(locale, ":/qt_")) {
 			app.installTranslator(guard.m_qtTranslator);


### PR DESCRIPTION
Commit 0dcc1f614b2ab4f0d4bbac5fd29676595072a133 changed the used
function for loading translation files. The new overload requires an
extra parameter when specifying the directory in which to search for
translation files. This was not provided though and thus the provided
directory path was mis-interpreted as something else.

Fixes #4856


### Checks

- [x] My commits follow the [commit guidelines](https://github.com/mumble-voip/mumble/blob/master/COMMIT_GUIDELINES.md)

