### PR TITLE
FIX(client): Use Utf8 for name field in certificat

### DIFF
--- a/src/SelfSignedCertificate.cpp
+++ b/src/SelfSignedCertificate.cpp
@@ -141,7 +141,7 @@ bool SelfSignedCertificate::generate(CertificateType certificateType, QString cl
 		}
 	}
 
-	if (X509_NAME_add_entry_by_txt(name, "CN", MBSTRING_ASC,
+	if (X509_NAME_add_entry_by_txt(name, "CN", MBSTRING_UTF8,
 								   reinterpret_cast< unsigned char * >(commonName.toUtf8().data()), -1, -1, 0)
 		== 0) {
 		ok = false;


### PR DESCRIPTION
Otherwise names using non-ASCII characters won't be handled properly.

Fixes #4871


### Checks

- [x] My commits follow the [commit guidelines](https://github.com/mumble-voip/mumble/blob/master/COMMIT_GUIDELINES.md)

