### PR TITLE
FIX(client, ui): Ordering of Users inconsistent

### DIFF
--- a/src/User.cpp
+++ b/src/User.cpp
@@ -18,5 +18,8 @@ User::User() {
 }
 
 bool User::lessThan(const User *first, const User *second) {
-	return (QString::localeAwareCompare(first->qsName, second->qsName) < 0);
+	// We explicitly don't use localeAwareCompare as this would result in a different
+	// ordering of users on clients with different locales. This is not what one would
+	// expect and thus we don't take the locale into account for comparing users.
+	return QString::compare(first->qsName, second->qsName) < 0;
 }


### PR DESCRIPTION
If two persons are reading out the users in a channel in the order they
are rendered, chances are that they will read the names in a different
order. This is because the ordering of users takes the currently used
locale into account that can differ from machine to machine.

This is an inconsistency that one probably does not expect.

Therefore this commit changes back to using a lexicographical comparison
that should be the same on all machines, regardless of the locale.

Fixes #4873


### Checks

- [x] My commits follow the [commit guidelines](https://github.com/mumble-voip/mumble/blob/master/COMMIT_GUIDELINES.md)

