### PR TITLE
FIX(client, talking-ui): No users being added

### DIFF
--- a/src/mumble/TalkingUI.cpp
+++ b/src/mumble/TalkingUI.cpp
@@ -380,7 +380,7 @@ TalkingUIUser *TalkingUI::findOrAddUser(const ClientUser *user) {
 		bool isSelf = Global::get().uiSession == user->uiSession;
 
 		int channelIndex = findContainer(user->cChannel->iId, ContainerType::CHANNEL);
-		if (channelIndex) {
+		if (channelIndex < 0) {
 			qCritical("TalkingUI::findOrAddUser User's channel does not exist!");
 			return nullptr;
 		}


### PR DESCRIPTION
993f640e0d16d01e2de34c9dfd1edea181414e16 fixed a crash caused by being
renamed. However it did mess up a conditional check that now prevents
any users from being added to the TalkingUI.

This is fixed by this commit.


### Checks

- [x] My commits follow the [commit guidelines](https://github.com/mumble-voip/mumble/blob/master/COMMIT_GUIDELINES.md)

