### PR TITLE
FIX(Server): Prevent multiple Sessions with ID 0

### DIFF
--- a/src/murmur/Server.cpp
+++ b/src/murmur/Server.cpp
@@ -1671,7 +1671,7 @@ void Server::connectionClosed(QAbstractSocket::SocketError err, const QString &r
 		QCoreApplication::instance()->postEvent(this,
 												new ExecEvent(boost::bind(&Server::removeChannel, this, old->iId)));
 
-	if (static_cast< int >(u->uiSession) < iMaxUsers * 2)
+	if (u->uiSession > 0 && static_cast< int >(u->uiSession) < iMaxUsers * 2)
 		qqIds.enqueue(u->uiSession); // Reinsert session id into pool
 
 	if (u->sState == ServerUser::Authenticated) {


### PR DESCRIPTION
fixes bug introduced in eabfbab4

When an unauthenticated connection is terminated, the session ID still got enqueued into `qqIds`.
The session ID of unauthenticated clients is always 0 when it's not assigned. This means that
whenever an unauthenticated connection is terminated, 0 will be enqueued into `qqIds`. If this
happens multiple times, multiple clients will later be assigned session ID 0. All connections
with the same session ID are displayed as the same user for all clients. As a result of that
users might be listening to what you are saying in your channel without you noticing. If one
connection with session ID 0 gets terminated, all other connections with the same ID will
be terminated as well. This potentially enables denial of service.

Thanks to the Zom.bi community for fixing the bug.

Co-Authored-by: madmaurice <madmaurice@zom.bi>


### Checks

- [x] My commits follow the [commit guidelines](https://github.com/mumble-voip/mumble/blob/master/COMMIT_GUIDELINES.md)

