### PR TITLE
FEAT(client): Allow gemini:// in chat messages

### DIFF
--- a/src/mumble/Log.cpp
+++ b/src/mumble/Log.cpp
@@ -419,6 +419,7 @@ const QStringList Log::allowedSchemes() {
 	qslAllowedSchemeNames << QLatin1String("mumble");
 	qslAllowedSchemeNames << QLatin1String("http");
 	qslAllowedSchemeNames << QLatin1String("https");
+	qslAllowedSchemeNames << QLatin1String("gemini");
 	qslAllowedSchemeNames << QLatin1String("ftp");
 	qslAllowedSchemeNames << QLatin1String("clientid");
 	qslAllowedSchemeNames << QLatin1String("channelid");


### PR DESCRIPTION
This commit adds support for the Gemini protocol in chat messages.


### Checks

- [x] My commits follow the [commit guidelines](https://github.com/mumble-voip/mumble/blob/master/COMMIT_GUIDELINES.md)

