### PR TITLE
TEST: Enforce Opus usage on client

### DIFF
--- a/src/mumble/Messages.cpp
+++ b/src/mumble/Messages.cpp
@@ -1204,6 +1204,14 @@ void MainWindow::msgPermissionQuery(const MumbleProto::PermissionQuery &msg) {
 ///
 /// @param msg The message object
 void MainWindow::msgCodecVersion(const MumbleProto::CodecVersion &msg) {
+	if (!msg.opus()) {
+		qWarning() << "Client was instructed to not use Opus!";
+	}
+
+	// Always use Opus
+	Global::get().bOpus = true;
+
+	return;
 	int alpha = msg.has_alpha() ? msg.alpha() : -1;
 	int beta  = msg.has_beta() ? msg.beta() : -1;
 	bool pref = msg.prefer_alpha();


### PR DESCRIPTION
This is a test to see if this fixes #4538

### Checks

- [x] My commits follow the [commit guidelines](https://github.com/mumble-voip/mumble/blob/master/COMMIT_GUIDELINES.md)

