### PR TITLE
FIX(client, markdown): Wrong line break HTML code

### DIFF
--- a/src/mumble/MainWindow.cpp
+++ b/src/mumble/MainWindow.cpp
@@ -1952,6 +1952,10 @@ void MainWindow::on_qaQuit_triggered() {
 
 void MainWindow::sendChatbarText(QString qsText) {
 	qsText = qsText.toHtmlEscaped();
+	// Markdown::markdownToHTML also takes care of replacing line breaks (\n) with the respective
+	// HTML code <br/>. Therefore if Markdown support is ever going to be removed from this
+	// function, this job has to be done explicitly as otherwise line breaks won't be shown on
+	// the receiving end of this text message.
 	qsText = Markdown::markdownToHTML(qsText);
 	sendChatbarMessage(qsText);
 

--- a/src/mumble/Markdown.cpp
+++ b/src/mumble/Markdown.cpp
@@ -351,7 +351,7 @@ QString markdownToHTML(const QString &markdownInput) {
 	// Replace linebreaks afterwards in order to not mess up the RegEx used by the
 	// different functions.
 	static const QRegularExpression s_lineBreakRegEx(QLatin1String("\r\n|\n|\r"));
-	htmlString.replace(s_lineBreakRegEx, QLatin1String("</br>"));
+	htmlString.replace(s_lineBreakRegEx, QLatin1String("<br/>"));
 
 	// Resore linebreaks in <pre> blocks
 	htmlString.replace(regularLineBreakPlaceholder, QLatin1String("\n"));


### PR DESCRIPTION
The Markdown code was using \</br> instead of the correct \<br/>.

This error was introduced in 2da3f0d39e37e6bf10318d174744bb7e7924794b.

Fixes #4899


### Checks

- [x] My commits follow the [commit guidelines](https://github.com/mumble-voip/mumble/blob/master/COMMIT_GUIDELINES.md)

