### PR TITLE
FIX: Replace RAND_bytes with CryptographicRandom::fillBuffer

### DIFF
--- a/src/crypto/CryptStateOCB2.cpp
+++ b/src/crypto/CryptStateOCB2.cpp
@@ -25,6 +25,7 @@
 
 #include "ByteSwap.h"
 #include "CryptStateOCB2.h"
+#include "CryptographicRandom.h"
 
 #include <cstring>
 #include <openssl/rand.h>
@@ -42,9 +43,9 @@ bool CryptStateOCB2::isValid() const {
 }
 
 void CryptStateOCB2::genKey() {
-	RAND_bytes(raw_key, AES_KEY_SIZE_BYTES);
-	RAND_bytes(encrypt_iv, AES_BLOCK_SIZE);
-	RAND_bytes(decrypt_iv, AES_BLOCK_SIZE);
+	CryptographicRandom::fillBuffer(raw_key, AES_KEY_SIZE_BYTES);
+	CryptographicRandom::fillBuffer(encrypt_iv, AES_BLOCK_SIZE);
+	CryptographicRandom::fillBuffer(decrypt_iv, AES_BLOCK_SIZE);
 	AES_set_encrypt_key(raw_key, AES_KEY_SIZE_BITS, &encrypt_key);
 	AES_set_decrypt_key(raw_key, AES_KEY_SIZE_BITS, &decrypt_key);
 	bInit = true;

--- a/src/crypto/CryptographicRandom.cpp
+++ b/src/crypto/CryptographicRandom.cpp
@@ -24,7 +24,7 @@ void CryptographicRandom::fillBuffer(void *buf, int numBytes) {
 	// OpenSSL needs at least 32-bytes of high-entropy random data to seed its CSPRNG.
 	// If OpenSSL cannot acquire enough random data to seed its CSPRNG at the time Mumble and Murmur
 	// are running, there is not much we can do about it other than aborting the program.
-	if (RAND_bytes(reinterpret_cast< unsigned char * >(buf), static_cast< int >(numBytes)) != 1) {
+	if (RAND_bytes(reinterpret_cast< unsigned char * >(buf), numBytes) != 1) {
 		qFatal("CryptographicRandom::fillBuffer(): internal error in OpenSSL's RAND_bytes or entropy pool not yet "
 			   "filled.");
 	}

--- a/src/murmur/PBKDF2.cpp
+++ b/src/murmur/PBKDF2.cpp
@@ -45,6 +45,7 @@
 #endif
 
 #include "PBKDF2.h"
+#include "crypto/CryptographicRandom.h"
 
 #include <QtCore/QElapsedTimer>
 #include <QtCore/QLatin1String>
@@ -109,10 +110,7 @@ QString PBKDF2::getHash(const QString &hexSalt, const QString &password, int ite
 QString PBKDF2::getSalt() {
 	QByteArray salt(SALT_LENGTH, 0);
 
-	if (RAND_bytes(reinterpret_cast< unsigned char * >(salt.data()), salt.size()) != 1) {
-		qFatal("PBKDF2: RAND_bytes for salt failed: %s", ERR_error_string(ERR_get_error(), nullptr));
-		return QString();
-	}
+	CryptographicRandom::fillBuffer(salt.data(), salt.size());
 
 	return QString::fromLatin1(salt.toHex());
 }


### PR DESCRIPTION
https://www.openssl.org/docs/man1.1.1/man3/RAND_bytes.html:
If the entropy source fails or is not available, the CSPRNG will enter an error state and refuse to generate random bytes. For that reason, it is important to always check the error return value of RAND_bytes() and RAND_priv_bytes() and not take randomness for granted.

Also remove unnecessary cast.

### Checks

- [x] My commits follow the [commit guidelines](https://github.com/mumble-voip/mumble/blob/master/COMMIT_GUIDELINES.md)

