### PR TITLE
MAINT: Add `CHANGE` commit type

### DIFF
--- a/COMMIT_GUIDELINES.md
+++ b/COMMIT_GUIDELINES.md
@@ -51,6 +51,7 @@ The `TYPE` is one of the following:
 | REFAC    | Code refactoring | Rename variable `x` to `y` |
 | BUILD    | Changes related to the build process / buildsystem | Fix cmake script |
 | TRANSLATION | Translation updates and changes | Update translation files |
+| CHANGE   | Something was changed without falling into existing categories | Changed the default of a setting |
 
 The `TYPE` has to be in **all-uppercase** in order for it to stand out.
 

--- a/scripts/commitMessage/CommitMessage.py
+++ b/scripts/commitMessage/CommitMessage.py
@@ -11,7 +11,7 @@ class CommitFormatError(Exception):
         Exception(msg)
 
 class CommitMessage:
-    knownTypes = ["BREAK", "FEAT", "FIX", "FORMAT", "DOCS", "TEST", "MAINT", "CI", "REFAC", "BUILD", "TRANSLATION"]
+    knownTypes = ["BREAK", "FEAT", "FIX", "FORMAT", "DOCS", "TEST", "MAINT", "CI", "REFAC", "BUILD", "TRANSLATION", "CHANGE"]
 
     def __init__(self, commitString):
         lines = commitString.strip().split("\n")

--- a/scripts/generateChangelog.py
+++ b/scripts/generateChangelog.py
@@ -92,6 +92,8 @@ def main():
                 prefix = "Added: "
             elif "FIX" in commit.m_types:
                 prefix = "Fixed: "
+            elif "CHANGED" in commit.m_types:
+                prefix = "Changed: "
             else:
                 prefix = "Unknown: "
 


### PR DESCRIPTION
This commit type is supposed to be used when e.g. a setting is changed.


### Checks

- [x] My commits follow the [commit guidelines](https://github.com/mumble-voip/mumble/blob/master/COMMIT_GUIDELINES.md)

