### PR TITLE
FIX(server): Fix undefined behvior on Linux hosts

### DIFF
--- a/src/murmur/UnixMurmur.cpp
+++ b/src/murmur/UnixMurmur.cpp
@@ -27,6 +27,8 @@
 #include <sys/stat.h>
 #include <unistd.h>
 
+#include <limits>
+
 QMutex *LimitTest::qm;
 QWaitCondition *LimitTest::qw;
 QWaitCondition *LimitTest::qstartw;
@@ -340,7 +342,12 @@ void UnixMurmur::finalcap() {
 	if (getrlimit(RLIMIT_RTPRIO, &r) != 0) {
 		qCritical("Failed to get priority limits.");
 	} else {
-		qWarning("Resource limits were %ld %ld", r.rlim_cur, r.rlim_max);
+		using ulong_t = unsigned long long int;
+		static_assert(std::numeric_limits< ulong_t >::max() >= std::numeric_limits< rlim_t >::max(), "rlim_t is unexpectedly large");
+		ulong_t current = r.rlim_cur;
+		ulong_t max     = r.rlim_max;
+		qWarning("Resource limits were %llu %llu", current, max);
+
 		r.rlim_cur = r.rlim_max = 1;
 		if (setrlimit(RLIMIT_RTPRIO, &r) != 0) {
 			qCritical("Failed to set priority limits.");


### PR DESCRIPTION
The fields of the rlimit struct were assumed to be of type long int when
printing via the qWarning function. This seems to be correct on e.g.
Ubuntu but at least on Alpine Linux this is not true.

In that case the wrong format specifiers are being used for printing
these values, which causes undefined behavior.

The fix is to always copy the values into variables of type long long
unsigned int and then printing these. The code also adds an assertion
making sure that within this copy operation the values won't overflow
the variable's size.

Fixes #4897


### Checks

- [x] My commits follow the [commit guidelines](https://github.com/mumble-voip/mumble/blob/master/COMMIT_GUIDELINES.md)

