### PR TITLE
FIX(client): Memory leak in ALSA implementation

### DIFF
--- a/src/mumble/ALSAAudio.cpp
+++ b/src/mumble/ALSAAudio.cpp
@@ -252,8 +252,10 @@ ALSAEnumerator::ALSAEnumerator() {
 			}
 			snd_pcm_info_free(info);
 			snd_ctl_close(ctl);
+			free(cname);
 		}
 		snd_card_next(&card);
+		free(name);
 	}
 #endif
 }


### PR DESCRIPTION
The functions snd_card_get_name and snd_card_get_longname allocate a
String for the caller that needs to be freed once it is no longer needed.
This was not done in the current implementation and thus this was causing
a memory leak.

This commit fixes this by explicitly `free`ing the resources after usage.

Fixes #4910

Ref: https://www.alsa-project.org/alsa-doc/alsa-lib/group___control.html#ga547dcead4a72f24db4a0f9f530f75228