### PR TITLE
CI(azure): Clean entire workspace before starting

### DIFF
--- a/.ci/azure-pipelines/main-pr.yml
+++ b/.ci/azure-pipelines/main-pr.yml
@@ -15,6 +15,8 @@ variables:
 
 jobs:
   - job: Windows_x64
+    workspace:
+      clean: all
     timeoutInMinutes: 90
     pool:
       vmImage: 'windows-latest'
@@ -26,7 +28,10 @@ jobs:
     - template: steps_windows.yml
       parameters:
         arch: 'x64'
+
   - job: Windows_x86
+    workspace:
+      clean: all
     timeoutInMinutes: 120
     pool:
       vmImage: 'windows-latest'
@@ -38,12 +43,18 @@ jobs:
     - template: steps_windows.yml
       parameters:
         arch: 'x86'
+
   - job: Linux
+    workspace:
+      clean: all
     pool:
       vmImage: 'ubuntu-18.04'
     steps:
     - template: steps_linux.yml
+
   - job: macOS
+    workspace:
+      clean: all
     pool:
       vmImage: 'macOS-latest'
     variables:
@@ -52,6 +63,7 @@ jobs:
     - template: steps_macos.yml
       parameters:
         installEnvironment: true
+
   - job: Translations
     pool:
       vmImage: 'ubuntu-latest'
@@ -60,6 +72,7 @@ jobs:
       displayName: 'Install Qt tools'
     - script: .ci/azure-pipelines/assertNoTranslationChanges.sh
       displayName: 'Checking for translation changes'
+
   - job: Docs
     pool:
       vmImage: 'ubuntu-latest'

--- a/.ci/azure-pipelines/main.yml
+++ b/.ci/azure-pipelines/main.yml
@@ -13,6 +13,8 @@ variables:
 
 jobs:
   - job: Windows_x64
+    workspace:
+      clean: all
     timeoutInMinutes: 90
     pool:
       vmImage: 'windows-latest'
@@ -24,7 +26,10 @@ jobs:
     - template: steps_windows.yml
       parameters:
         arch: 'x64'
+
   - job: Windows_x86
+    workspace:
+      clean: all
     timeoutInMinutes: 120
     pool:
       vmImage: 'windows-latest'
@@ -36,12 +41,18 @@ jobs:
     - template: steps_windows.yml
       parameters:
         arch: 'x86'
+
   - job: Linux
+    workspace:
+      clean: all
     pool:
       vmImage: 'ubuntu-18.04'
     steps:
     - template: steps_linux.yml
+
   - job: macOS
+    workspace:
+      clean: all
     pool:
       name: "Default"
       demands:


### PR DESCRIPTION
On our self-hosted macOS runner we were seeing issues due to the
workspace not being cleaned up after each run, causing the next one to
fail.

This commit makes sure that Azure will clean the entire workspace of any
remaining files, before starting a new job.

Ref: https://docs.microsoft.com/en-us/azure/devops/pipelines/process/phases?view=azure-devops&tabs=yaml#workspace


### Checks

- [x] My commits follow the [commit guidelines](https://github.com/mumble-voip/mumble/blob/master/COMMIT_GUIDELINES.md)

