### PR TITLE
MAINT: Update copyright notice to 2021 (Part II)

### DIFF
--- a/.ci/azure-pipelines/build_linux.bash
+++ b/.ci/azure-pipelines/build_linux.bash
@@ -1,6 +1,6 @@
 #!/bin/bash -ex
 #
-# Copyright 2019-2021 The Mumble Developers. All rights reserved.
+# Copyright 2020-2021 The Mumble Developers. All rights reserved.
 # Use of this source code is governed by a BSD-style license
 # that can be found in the LICENSE file at the root of the
 # Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/.ci/azure-pipelines/build_macos.bash
+++ b/.ci/azure-pipelines/build_macos.bash
@@ -1,6 +1,6 @@
 #!/bin/bash -ex
 #
-# Copyright 2019-2021 The Mumble Developers. All rights reserved.
+# Copyright 2020-2021 The Mumble Developers. All rights reserved.
 # Use of this source code is governed by a BSD-style license
 # that can be found in the LICENSE file at the root of the
 # Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/.ci/azure-pipelines/install-environment_linux.bash
+++ b/.ci/azure-pipelines/install-environment_linux.bash
@@ -1,6 +1,6 @@
 #!/bin/bash -ex
 #
-# Copyright 2019-2021 The Mumble Developers. All rights reserved.
+# Copyright 2020-2021 The Mumble Developers. All rights reserved.
 # Use of this source code is governed by a BSD-style license
 # that can be found in the LICENSE file at the root of the
 # Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/.ci/azure-pipelines/install-environment_linux_translations.bash
+++ b/.ci/azure-pipelines/install-environment_linux_translations.bash
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# Copyright 2009-2021 The Mumble Developers. All rights reserved.
+# Copyright 2020-2021 The Mumble Developers. All rights reserved.
 # Use of this source code is governed by a BSD-style license
 # that can be found in the LICENSE file at the root of the
 # Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/.ci/azure-pipelines/install-environment_macos.bash
+++ b/.ci/azure-pipelines/install-environment_macos.bash
@@ -1,6 +1,6 @@
 #!/bin/bash -ex
 #
-# Copyright 2009-2021 The Mumble Developers. All rights reserved.
+# Copyright 2020-2021 The Mumble Developers. All rights reserved.
 # Use of this source code is governed by a BSD-style license
 # that can be found in the LICENSE file at the root of the
 # Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/.ci/azure-pipelines/main-pr.yml
+++ b/.ci/azure-pipelines/main-pr.yml
@@ -1,4 +1,4 @@
-# Copyright 2019-2021 The Mumble Developers. All rights reserved.
+# Copyright 2020-2021 The Mumble Developers. All rights reserved.
 # Use of this source code is governed by a BSD-style license
 # that can be found in the LICENSE file at the root of the
 # Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/.ci/azure-pipelines/main.yml
+++ b/.ci/azure-pipelines/main.yml
@@ -1,4 +1,4 @@
-# Copyright 2019-2021 The Mumble Developers. All rights reserved.
+# Copyright 2020-2021 The Mumble Developers. All rights reserved.
 # Use of this source code is governed by a BSD-style license
 # that can be found in the LICENSE file at the root of the
 # Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/.ci/azure-pipelines/package_AppImage.bash
+++ b/.ci/azure-pipelines/package_AppImage.bash
@@ -1,6 +1,6 @@
 #!/bin/bash -ex
 #
-# Copyright 2019-2021 The Mumble Developers. All rights reserved.
+# Copyright 2020-2021 The Mumble Developers. All rights reserved.
 # Use of this source code is governed by a BSD-style license
 # that can be found in the LICENSE file at the root of the
 # Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright 2019-2020 The Mumble Developers. All rights reserved.
+# Copyright 2020-2021 The Mumble Developers. All rights reserved.
 # Use of this source code is governed by a BSD-style license
 # that can be found in the LICENSE file at the root of the
 # Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/g15helper/CMakeLists.txt
+++ b/g15helper/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright 2019 The Mumble Developers. All rights reserved.
+# Copyright 2020-2021 The Mumble Developers. All rights reserved.
 # Use of this source code is governed by a BSD-style license
 # that can be found in the LICENSE file at the root of the
 # Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/g15helper/g15helper.h
+++ b/g15helper/g15helper.h
@@ -1,4 +1,4 @@
-// Copyright 2005-2021 The Mumble Developers. All rights reserved.
+// Copyright 2008-2021 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/g15helper/g15helper_macx.c
+++ b/g15helper/g15helper_macx.c
@@ -1,4 +1,4 @@
-// Copyright 2008-2021 The Mumble Developers. All rights reserved.
+// Copyright 2009-2021 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/macx/osax/CMakeLists.txt
+++ b/macx/osax/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright 2020 The Mumble Developers. All rights reserved.
+# Copyright 2020-2021 The Mumble Developers. All rights reserved.
 # Use of this source code is governed by a BSD-style license
 # that can be found in the LICENSE file at the root of the
 # Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/macx/scripts/gendmg.pl
+++ b/macx/scripts/gendmg.pl
@@ -1,6 +1,6 @@
 #!/usr/bin/perl
 #
-# Copyright 2009-2021 The Mumble Developers. All rights reserved.
+# Copyright 2010-2021 The Mumble Developers. All rights reserved.
 # Use of this source code is governed by a BSD-style license
 # that can be found in the LICENSE file at the root of the
 # Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/macx/scripts/osxdist.py
+++ b/macx/scripts/osxdist.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 #
-# Copyright 2008-2021 The Mumble Developers. All rights reserved.
+# Copyright 2010-2021 The Mumble Developers. All rights reserved.
 # Use of this source code is governed by a BSD-style license
 # that can be found in the LICENSE file at the root of the
 # Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/overlay/CMakeLists.txt
+++ b/overlay/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright 2019-2020 The Mumble Developers. All rights reserved.
+# Copyright 2020-2021 The Mumble Developers. All rights reserved.
 # Use of this source code is governed by a BSD-style license
 # that can be found in the LICENSE file at the root of the
 # Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/overlay/D11StateBlock.h
+++ b/overlay/D11StateBlock.h
@@ -1,4 +1,4 @@
-// Copyright 2005-2021 The Mumble Developers. All rights reserved.
+// Copyright 2014-2021 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/overlay/HardHook.h
+++ b/overlay/HardHook.h
@@ -1,4 +1,4 @@
-// Copyright 2005-2021 The Mumble Developers. All rights reserved.
+// Copyright 2010-2021 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/overlay/HardHook_minhook.h
+++ b/overlay/HardHook_minhook.h
@@ -1,4 +1,4 @@
-// Copyright 2005-2021 The Mumble Developers. All rights reserved.
+// Copyright 2015-2021 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/overlay/HardHook_x86.cpp
+++ b/overlay/HardHook_x86.cpp
@@ -1,4 +1,4 @@
-// Copyright 2010-2021 The Mumble Developers. All rights reserved.
+// Copyright 2015-2021 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/overlay/HardHook_x86.h
+++ b/overlay/HardHook_x86.h
@@ -1,4 +1,4 @@
-// Copyright 2005-2021 The Mumble Developers. All rights reserved.
+// Copyright 2015-2021 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/overlay/d3d9.cpp
+++ b/overlay/d3d9.cpp
@@ -1,4 +1,4 @@
-// Copyright 2005-2021 The Mumble Developers. All rights reserved.
+// Copyright 2007-2021 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/overlay/excludecheck.h
+++ b/overlay/excludecheck.h
@@ -1,4 +1,4 @@
-// Copyright 2005-2021 The Mumble Developers. All rights reserved.
+// Copyright 2017-2021 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/overlay/lib.h
+++ b/overlay/lib.h
@@ -1,4 +1,4 @@
-// Copyright 2005-2021 The Mumble Developers. All rights reserved.
+// Copyright 2007-2021 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/overlay/ods.cpp
+++ b/overlay/ods.cpp
@@ -1,4 +1,4 @@
-// Copyright 2005-2021 The Mumble Developers. All rights reserved.
+// Copyright 2011-2021 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/overlay/ods.h
+++ b/overlay/ods.h
@@ -1,4 +1,4 @@
-// Copyright 2005-2021 The Mumble Developers. All rights reserved.
+// Copyright 2011-2021 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/overlay/overlay11-common.hlsl
+++ b/overlay/overlay11-common.hlsl
@@ -1,4 +1,4 @@
-// Copyright 2005-2021 The Mumble Developers. All rights reserved.
+// Copyright 2015-2021 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/overlay/overlay11.ps
+++ b/overlay/overlay11.ps
@@ -1,4 +1,4 @@
-// Copyright 2010-2021 The Mumble Developers. All rights reserved.
+// Copyright 2015-2021 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/overlay/overlay11.vs
+++ b/overlay/overlay11.vs
@@ -1,4 +1,4 @@
-// Copyright 2005-2021 The Mumble Developers. All rights reserved.
+// Copyright 2015-2021 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/overlay/overlay_blacklist.h
+++ b/overlay/overlay_blacklist.h
@@ -1,4 +1,4 @@
-// Copyright 2005-2021 The Mumble Developers. All rights reserved.
+// Copyright 2011-2021 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/overlay/overlay_exe/CMakeLists.txt
+++ b/overlay/overlay_exe/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright 2019-2020 The Mumble Developers. All rights reserved.
+# Copyright 2020-2021 The Mumble Developers. All rights reserved.
 # Use of this source code is governed by a BSD-style license
 # that can be found in the LICENSE file at the root of the
 # Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/overlay/overlay_whitelist.h
+++ b/overlay/overlay_whitelist.h
@@ -1,4 +1,4 @@
-// Copyright 2005-2021 The Mumble Developers. All rights reserved.
+// Copyright 2017-2021 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/overlay_gl/CMakeLists.txt
+++ b/overlay_gl/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright 2019-2020 The Mumble Developers. All rights reserved.
+# Copyright 2020-2021 The Mumble Developers. All rights reserved.
 # Use of this source code is governed by a BSD-style license
 # that can be found in the LICENSE file at the root of the
 # Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/overlay_gl/avail_mac.h
+++ b/overlay_gl/avail_mac.h
@@ -1,4 +1,4 @@
-// Copyright 2010-2021 The Mumble Developers. All rights reserved.
+// Copyright 2015-2021 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/plugins/CMakeLists.txt
+++ b/plugins/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright 2019-2020 The Mumble Developers. All rights reserved.
+# Copyright 2020-2021 The Mumble Developers. All rights reserved.
 # Use of this source code is governed by a BSD-style license
 # that can be found in the LICENSE file at the root of the
 # Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/plugins/amongus/CMakeLists.txt
+++ b/plugins/amongus/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright 2020 The Mumble Developers. All rights reserved.
+# Copyright 2020-2021 The Mumble Developers. All rights reserved.
 # Use of this source code is governed by a BSD-style license
 # that can be found in the LICENSE file at the root of the
 # Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/plugins/aoc/CMakeLists.txt
+++ b/plugins/aoc/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright 2019-2020 The Mumble Developers. All rights reserved.
+# Copyright 2020-2021 The Mumble Developers. All rights reserved.
 # Use of this source code is governed by a BSD-style license
 # that can be found in the LICENSE file at the root of the
 # Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/plugins/arma2/CMakeLists.txt
+++ b/plugins/arma2/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright 2019-2020 The Mumble Developers. All rights reserved.
+# Copyright 2020-2021 The Mumble Developers. All rights reserved.
 # Use of this source code is governed by a BSD-style license
 # that can be found in the LICENSE file at the root of the
 # Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/plugins/arma2/arma2.cpp
+++ b/plugins/arma2/arma2.cpp
@@ -1,4 +1,4 @@
-// Copyright 2005-2021 The Mumble Developers. All rights reserved.
+// Copyright 2010-2021 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/plugins/bf1/CMakeLists.txt
+++ b/plugins/bf1/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright 2019-2020 The Mumble Developers. All rights reserved.
+# Copyright 2020-2021 The Mumble Developers. All rights reserved.
 # Use of this source code is governed by a BSD-style license
 # that can be found in the LICENSE file at the root of the
 # Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/plugins/bf1942/CMakeLists.txt
+++ b/plugins/bf1942/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright 2019-2020 The Mumble Developers. All rights reserved.
+# Copyright 2020-2021 The Mumble Developers. All rights reserved.
 # Use of this source code is governed by a BSD-style license
 # that can be found in the LICENSE file at the root of the
 # Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/plugins/bf1942/bf1942.cpp
+++ b/plugins/bf1942/bf1942.cpp
@@ -1,4 +1,4 @@
-// Copyright 2005-2021 The Mumble Developers. All rights reserved.
+// Copyright 2010-2021 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/plugins/bf2/CMakeLists.txt
+++ b/plugins/bf2/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright 2019-2020 The Mumble Developers. All rights reserved.
+# Copyright 2020-2021 The Mumble Developers. All rights reserved.
 # Use of this source code is governed by a BSD-style license
 # that can be found in the LICENSE file at the root of the
 # Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/plugins/bf2142/CMakeLists.txt
+++ b/plugins/bf2142/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright 2019-2020 The Mumble Developers. All rights reserved.
+# Copyright 2020-2021 The Mumble Developers. All rights reserved.
 # Use of this source code is governed by a BSD-style license
 # that can be found in the LICENSE file at the root of the
 # Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/plugins/bf2142/bf2142.cpp
+++ b/plugins/bf2142/bf2142.cpp
@@ -1,4 +1,4 @@
-// Copyright 2005-2021 The Mumble Developers. All rights reserved.
+// Copyright 2009-2021 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/plugins/bf3/CMakeLists.txt
+++ b/plugins/bf3/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright 2019-2020 The Mumble Developers. All rights reserved.
+# Copyright 2020-2021 The Mumble Developers. All rights reserved.
 # Use of this source code is governed by a BSD-style license
 # that can be found in the LICENSE file at the root of the
 # Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/plugins/bf3/bf3.cpp
+++ b/plugins/bf3/bf3.cpp
@@ -1,4 +1,4 @@
-// Copyright 2005-2021 The Mumble Developers. All rights reserved.
+// Copyright 2011-2021 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/plugins/bf4/CMakeLists.txt
+++ b/plugins/bf4/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright 2019-2020 The Mumble Developers. All rights reserved.
+# Copyright 2020-2021 The Mumble Developers. All rights reserved.
 # Use of this source code is governed by a BSD-style license
 # that can be found in the LICENSE file at the root of the
 # Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/plugins/bf4_x86/CMakeLists.txt
+++ b/plugins/bf4_x86/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright 2019-2020 The Mumble Developers. All rights reserved.
+# Copyright 2020-2021 The Mumble Developers. All rights reserved.
 # Use of this source code is governed by a BSD-style license
 # that can be found in the LICENSE file at the root of the
 # Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/plugins/bfbc2/CMakeLists.txt
+++ b/plugins/bfbc2/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright 2019-2020 The Mumble Developers. All rights reserved.
+# Copyright 2020-2021 The Mumble Developers. All rights reserved.
 # Use of this source code is governed by a BSD-style license
 # that can be found in the LICENSE file at the root of the
 # Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/plugins/bfbc2/bfbc2.cpp
+++ b/plugins/bfbc2/bfbc2.cpp
@@ -1,4 +1,4 @@
-// Copyright 2005-2021 The Mumble Developers. All rights reserved.
+// Copyright 2010-2021 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/plugins/bfheroes/CMakeLists.txt
+++ b/plugins/bfheroes/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright 2019-2020 The Mumble Developers. All rights reserved.
+# Copyright 2020-2021 The Mumble Developers. All rights reserved.
 # Use of this source code is governed by a BSD-style license
 # that can be found in the LICENSE file at the root of the
 # Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/plugins/bfheroes/bfheroes.cpp
+++ b/plugins/bfheroes/bfheroes.cpp
@@ -1,4 +1,4 @@
-// Copyright 2005-2021 The Mumble Developers. All rights reserved.
+// Copyright 2009-2021 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/plugins/blacklight/CMakeLists.txt
+++ b/plugins/blacklight/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright 2019-2020 The Mumble Developers. All rights reserved.
+# Copyright 2020-2021 The Mumble Developers. All rights reserved.
 # Use of this source code is governed by a BSD-style license
 # that can be found in the LICENSE file at the root of the
 # Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/plugins/borderlands/CMakeLists.txt
+++ b/plugins/borderlands/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright 2019-2020 The Mumble Developers. All rights reserved.
+# Copyright 2020-2021 The Mumble Developers. All rights reserved.
 # Use of this source code is governed by a BSD-style license
 # that can be found in the LICENSE file at the root of the
 # Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/plugins/borderlands2/CMakeLists.txt
+++ b/plugins/borderlands2/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright 2019-2020 The Mumble Developers. All rights reserved.
+# Copyright 2020-2021 The Mumble Developers. All rights reserved.
 # Use of this source code is governed by a BSD-style license
 # that can be found in the LICENSE file at the root of the
 # Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/plugins/borderlands2/borderlands2.cpp
+++ b/plugins/borderlands2/borderlands2.cpp
@@ -1,4 +1,4 @@
-// Copyright 2005-2021 The Mumble Developers. All rights reserved.
+// Copyright 2013-2021 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/plugins/breach/CMakeLists.txt
+++ b/plugins/breach/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright 2019-2020 The Mumble Developers. All rights reserved.
+# Copyright 2020-2021 The Mumble Developers. All rights reserved.
 # Use of this source code is governed by a BSD-style license
 # that can be found in the LICENSE file at the root of the
 # Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/plugins/breach/breach.cpp
+++ b/plugins/breach/breach.cpp
@@ -1,4 +1,4 @@
-// Copyright 2005-2021 The Mumble Developers. All rights reserved.
+// Copyright 2011-2021 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/plugins/cod2/CMakeLists.txt
+++ b/plugins/cod2/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright 2019-2021 The Mumble Developers. All rights reserved.
+# Copyright 2020-2021 The Mumble Developers. All rights reserved.
 # Use of this source code is governed by a BSD-style license
 # that can be found in the LICENSE file at the root of the
 # Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/plugins/cod4/CMakeLists.txt
+++ b/plugins/cod4/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright 2019-2020 The Mumble Developers. All rights reserved.
+# Copyright 2020-2021 The Mumble Developers. All rights reserved.
 # Use of this source code is governed by a BSD-style license
 # that can be found in the LICENSE file at the root of the
 # Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/plugins/cod5/CMakeLists.txt
+++ b/plugins/cod5/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright 2019-2020 The Mumble Developers. All rights reserved.
+# Copyright 2020-2021 The Mumble Developers. All rights reserved.
 # Use of this source code is governed by a BSD-style license
 # that can be found in the LICENSE file at the root of the
 # Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/plugins/codmw2/CMakeLists.txt
+++ b/plugins/codmw2/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright 2019-2020 The Mumble Developers. All rights reserved.
+# Copyright 2020-2021 The Mumble Developers. All rights reserved.
 # Use of this source code is governed by a BSD-style license
 # that can be found in the LICENSE file at the root of the
 # Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/plugins/codmw2/codmw2.cpp
+++ b/plugins/codmw2/codmw2.cpp
@@ -1,4 +1,4 @@
-// Copyright 2008-2021 The Mumble Developers. All rights reserved.
+// Copyright 2009-2021 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/plugins/codmw2so/CMakeLists.txt
+++ b/plugins/codmw2so/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright 2019-2020 The Mumble Developers. All rights reserved.
+# Copyright 2020-2021 The Mumble Developers. All rights reserved.
 # Use of this source code is governed by a BSD-style license
 # that can be found in the LICENSE file at the root of the
 # Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/plugins/codmw2so/codmw2so.cpp
+++ b/plugins/codmw2so/codmw2so.cpp
@@ -1,4 +1,4 @@
-// Copyright 2008-2021 The Mumble Developers. All rights reserved.
+// Copyright 2009-2021 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/plugins/cs/CMakeLists.txt
+++ b/plugins/cs/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright 2019-2020 The Mumble Developers. All rights reserved.
+# Copyright 2020-2021 The Mumble Developers. All rights reserved.
 # Use of this source code is governed by a BSD-style license
 # that can be found in the LICENSE file at the root of the
 # Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/plugins/css/CMakeLists.txt
+++ b/plugins/css/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright 2019-2020 The Mumble Developers. All rights reserved.
+# Copyright 2020-2021 The Mumble Developers. All rights reserved.
 # Use of this source code is governed by a BSD-style license
 # that can be found in the LICENSE file at the root of the
 # Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/plugins/dods/CMakeLists.txt
+++ b/plugins/dods/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright 2019-2020 The Mumble Developers. All rights reserved.
+# Copyright 2020-2021 The Mumble Developers. All rights reserved.
 # Use of this source code is governed by a BSD-style license
 # that can be found in the LICENSE file at the root of the
 # Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/plugins/dys/CMakeLists.txt
+++ b/plugins/dys/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright 2019-2020 The Mumble Developers. All rights reserved.
+# Copyright 2020-2021 The Mumble Developers. All rights reserved.
 # Use of this source code is governed by a BSD-style license
 # that can be found in the LICENSE file at the root of the
 # Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/plugins/etqw/CMakeLists.txt
+++ b/plugins/etqw/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright 2019-2020 The Mumble Developers. All rights reserved.
+# Copyright 2020-2021 The Mumble Developers. All rights reserved.
 # Use of this source code is governed by a BSD-style license
 # that can be found in the LICENSE file at the root of the
 # Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/plugins/etqw/etqw.cpp
+++ b/plugins/etqw/etqw.cpp
@@ -1,4 +1,4 @@
-// Copyright 2008-2021 The Mumble Developers. All rights reserved.
+// Copyright 2009-2021 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/plugins/ffxiv/CMakeLists.txt
+++ b/plugins/ffxiv/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright 2019-2020 The Mumble Developers. All rights reserved.
+# Copyright 2020-2021 The Mumble Developers. All rights reserved.
 # Use of this source code is governed by a BSD-style license
 # that can be found in the LICENSE file at the root of the
 # Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/plugins/ffxiv_x64/CMakeLists.txt
+++ b/plugins/ffxiv_x64/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright 2019-2020 The Mumble Developers. All rights reserved.
+# Copyright 2020-2021 The Mumble Developers. All rights reserved.
 # Use of this source code is governed by a BSD-style license
 # that can be found in the LICENSE file at the root of the
 # Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/plugins/gmod/CMakeLists.txt
+++ b/plugins/gmod/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright 2019-2020 The Mumble Developers. All rights reserved.
+# Copyright 2020-2021 The Mumble Developers. All rights reserved.
 # Use of this source code is governed by a BSD-style license
 # that can be found in the LICENSE file at the root of the
 # Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/plugins/gtaiv/CMakeLists.txt
+++ b/plugins/gtaiv/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright 2019-2020 The Mumble Developers. All rights reserved.
+# Copyright 2020-2021 The Mumble Developers. All rights reserved.
 # Use of this source code is governed by a BSD-style license
 # that can be found in the LICENSE file at the root of the
 # Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/plugins/gtasa/CMakeLists.txt
+++ b/plugins/gtasa/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright 2019-2020 The Mumble Developers. All rights reserved.
+# Copyright 2020-2021 The Mumble Developers. All rights reserved.
 # Use of this source code is governed by a BSD-style license
 # that can be found in the LICENSE file at the root of the
 # Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/plugins/gtav/CMakeLists.txt
+++ b/plugins/gtav/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright 2019-2020 The Mumble Developers. All rights reserved.
+# Copyright 2020-2021 The Mumble Developers. All rights reserved.
 # Use of this source code is governed by a BSD-style license
 # that can be found in the LICENSE file at the root of the
 # Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/plugins/gw/CMakeLists.txt
+++ b/plugins/gw/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright 2019-2020 The Mumble Developers. All rights reserved.
+# Copyright 2020-2021 The Mumble Developers. All rights reserved.
 # Use of this source code is governed by a BSD-style license
 # that can be found in the LICENSE file at the root of the
 # Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/plugins/hl2dm/CMakeLists.txt
+++ b/plugins/hl2dm/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright 2019-2020 The Mumble Developers. All rights reserved.
+# Copyright 2020-2021 The Mumble Developers. All rights reserved.
 # Use of this source code is governed by a BSD-style license
 # that can be found in the LICENSE file at the root of the
 # Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/plugins/insurgency/CMakeLists.txt
+++ b/plugins/insurgency/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright 2019-2020 The Mumble Developers. All rights reserved.
+# Copyright 2020-2021 The Mumble Developers. All rights reserved.
 # Use of this source code is governed by a BSD-style license
 # that can be found in the LICENSE file at the root of the
 # Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/plugins/jc2/CMakeLists.txt
+++ b/plugins/jc2/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright 2019-2020 The Mumble Developers. All rights reserved.
+# Copyright 2020-2021 The Mumble Developers. All rights reserved.
 # Use of this source code is governed by a BSD-style license
 # that can be found in the LICENSE file at the root of the
 # Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/plugins/jc2/jc2.cpp
+++ b/plugins/jc2/jc2.cpp
@@ -1,4 +1,4 @@
-// Copyright 2011-2021 The Mumble Developers. All rights reserved.
+// Copyright 2012-2021 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/plugins/l4d/CMakeLists.txt
+++ b/plugins/l4d/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright 2019-2020 The Mumble Developers. All rights reserved.
+# Copyright 2020-2021 The Mumble Developers. All rights reserved.
 # Use of this source code is governed by a BSD-style license
 # that can be found in the LICENSE file at the root of the
 # Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/plugins/l4d2/CMakeLists.txt
+++ b/plugins/l4d2/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright 2019-2020 The Mumble Developers. All rights reserved.
+# Copyright 2020-2021 The Mumble Developers. All rights reserved.
 # Use of this source code is governed by a BSD-style license
 # that can be found in the LICENSE file at the root of the
 # Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/plugins/link/CMakeLists.txt
+++ b/plugins/link/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright 2019-2020 The Mumble Developers. All rights reserved.
+# Copyright 2020-2021 The Mumble Developers. All rights reserved.
 # Use of this source code is governed by a BSD-style license
 # that can be found in the LICENSE file at the root of the
 # Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/plugins/lol/CMakeLists.txt
+++ b/plugins/lol/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright 2019-2020 The Mumble Developers. All rights reserved.
+# Copyright 2020-2021 The Mumble Developers. All rights reserved.
 # Use of this source code is governed by a BSD-style license
 # that can be found in the LICENSE file at the root of the
 # Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/plugins/lotro/CMakeLists.txt
+++ b/plugins/lotro/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright 2019-2020 The Mumble Developers. All rights reserved.
+# Copyright 2020-2021 The Mumble Developers. All rights reserved.
 # Use of this source code is governed by a BSD-style license
 # that can be found in the LICENSE file at the root of the
 # Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/plugins/lotro/lotro.cpp
+++ b/plugins/lotro/lotro.cpp
@@ -1,4 +1,4 @@
-// Copyright 2005-2021 The Mumble Developers. All rights reserved.
+// Copyright 2010-2021 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/plugins/null_plugin.cpp
+++ b/plugins/null_plugin.cpp
@@ -1,4 +1,4 @@
-// Copyright 2005-2021 The Mumble Developers. All rights reserved.
+// Copyright 2013-2021 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/plugins/ql/CMakeLists.txt
+++ b/plugins/ql/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright 2019-2020 The Mumble Developers. All rights reserved.
+# Copyright 2020-2021 The Mumble Developers. All rights reserved.
 # Use of this source code is governed by a BSD-style license
 # that can be found in the LICENSE file at the root of the
 # Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/plugins/rl/CMakeLists.txt
+++ b/plugins/rl/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright 2019-2020 The Mumble Developers. All rights reserved.
+# Copyright 2020-2021 The Mumble Developers. All rights reserved.
 # Use of this source code is governed by a BSD-style license
 # that can be found in the LICENSE file at the root of the
 # Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/plugins/rl/rl.cpp
+++ b/plugins/rl/rl.cpp
@@ -1,4 +1,4 @@
-// Copyright 2016-2021 The Mumble Developers. All rights reserved.
+// Copyright 2018-2021 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/plugins/se/CMakeLists.txt
+++ b/plugins/se/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright 2020 The Mumble Developers. All rights reserved.
+# Copyright 2020-2021 The Mumble Developers. All rights reserved.
 # Use of this source code is governed by a BSD-style license
 # that can be found in the LICENSE file at the root of the
 # Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/plugins/sr/CMakeLists.txt
+++ b/plugins/sr/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright 2019-2020 The Mumble Developers. All rights reserved.
+# Copyright 2020-2021 The Mumble Developers. All rights reserved.
 # Use of this source code is governed by a BSD-style license
 # that can be found in the LICENSE file at the root of the
 # Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/plugins/sr/sr.cpp
+++ b/plugins/sr/sr.cpp
@@ -1,4 +1,4 @@
-// Copyright 2005-2021 The Mumble Developers. All rights reserved.
+// Copyright 2013-2021 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/plugins/sto/CMakeLists.txt
+++ b/plugins/sto/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright 2019-2020 The Mumble Developers. All rights reserved.
+# Copyright 2020-2021 The Mumble Developers. All rights reserved.
 # Use of this source code is governed by a BSD-style license
 # that can be found in the LICENSE file at the root of the
 # Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/plugins/tf2/CMakeLists.txt
+++ b/plugins/tf2/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright 2019-2020 The Mumble Developers. All rights reserved.
+# Copyright 2020-2021 The Mumble Developers. All rights reserved.
 # Use of this source code is governed by a BSD-style license
 # that can be found in the LICENSE file at the root of the
 # Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/plugins/ut2004/CMakeLists.txt
+++ b/plugins/ut2004/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright 2019-2020 The Mumble Developers. All rights reserved.
+# Copyright 2020-2021 The Mumble Developers. All rights reserved.
 # Use of this source code is governed by a BSD-style license
 # that can be found in the LICENSE file at the root of the
 # Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/plugins/ut2004/ut2004.cpp
+++ b/plugins/ut2004/ut2004.cpp
@@ -1,4 +1,4 @@
-// Copyright 2005-2021 The Mumble Developers. All rights reserved.
+// Copyright 2010-2021 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/plugins/ut3/CMakeLists.txt
+++ b/plugins/ut3/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright 2019-2020 The Mumble Developers. All rights reserved.
+# Copyright 2020-2021 The Mumble Developers. All rights reserved.
 # Use of this source code is governed by a BSD-style license
 # that can be found in the LICENSE file at the root of the
 # Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/plugins/ut3/ut3.cpp
+++ b/plugins/ut3/ut3.cpp
@@ -1,4 +1,4 @@
-// Copyright 2008-2021 The Mumble Developers. All rights reserved.
+// Copyright 2010-2021 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/plugins/ut99/CMakeLists.txt
+++ b/plugins/ut99/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright 2019-2020 The Mumble Developers. All rights reserved.
+# Copyright 2020-2021 The Mumble Developers. All rights reserved.
 # Use of this source code is governed by a BSD-style license
 # that can be found in the LICENSE file at the root of the
 # Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/plugins/wolfet/CMakeLists.txt
+++ b/plugins/wolfet/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright 2019-2020 The Mumble Developers. All rights reserved.
+# Copyright 2020-2021 The Mumble Developers. All rights reserved.
 # Use of this source code is governed by a BSD-style license
 # that can be found in the LICENSE file at the root of the
 # Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/plugins/wow/CMakeLists.txt
+++ b/plugins/wow/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright 2019-2020 The Mumble Developers. All rights reserved.
+# Copyright 2020-2021 The Mumble Developers. All rights reserved.
 # Use of this source code is governed by a BSD-style license
 # that can be found in the LICENSE file at the root of the
 # Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/plugins/wow_x64/CMakeLists.txt
+++ b/plugins/wow_x64/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright 2019-2020 The Mumble Developers. All rights reserved.
+# Copyright 2020-2021 The Mumble Developers. All rights reserved.
 # Use of this source code is governed by a BSD-style license
 # that can be found in the LICENSE file at the root of the
 # Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/scripts/development/IconSync.cpp
+++ b/scripts/development/IconSync.cpp
@@ -1,4 +1,4 @@
-// Copyright 2010-2021 The Mumble Developers. All rights reserved.
+// Copyright 2013-2021 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/scripts/server/dbus/ListUsers.cs
+++ b/scripts/server/dbus/ListUsers.cs
@@ -1,4 +1,4 @@
-// Copyright 2009-2021 The Mumble Developers. All rights reserved.
+// Copyright 2013-2021 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/scripts/server/dbus/dbusauth.pl
+++ b/scripts/server/dbus/dbusauth.pl
@@ -1,6 +1,6 @@
 #! /usr/bin/perl
 
-# Copyright 2007-2021 The Mumble Developers. All rights reserved.
+# Copyright 2013-2021 The Mumble Developers. All rights reserved.
 # Use of this source code is governed by a BSD-style license
 # that can be found in the LICENSE file at the root of the
 # Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/scripts/server/dbus/murmur.pl
+++ b/scripts/server/dbus/murmur.pl
@@ -1,6 +1,6 @@
 #! /usr/bin/perl
 
-# Copyright 2005-2021 The Mumble Developers. All rights reserved.
+# Copyright 2013-2021 The Mumble Developers. All rights reserved.
 # Use of this source code is governed by a BSD-style license
 # that can be found in the LICENSE file at the root of the
 # Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/scripts/server/dbus/weblist.pl
+++ b/scripts/server/dbus/weblist.pl
@@ -1,6 +1,6 @@
 #! /usr/bin/perl
 
-# Copyright 2007-2021 The Mumble Developers. All rights reserved.
+# Copyright 2013-2021 The Mumble Developers. All rights reserved.
 # Use of this source code is governed by a BSD-style license
 # that can be found in the LICENSE file at the root of the
 # Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/scripts/server/ice/mumble-auth.py
+++ b/scripts/server/ice/mumble-auth.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 
-# Copyright 2009-2021 The Mumble Developers. All rights reserved.
+# Copyright 2013-2021 The Mumble Developers. All rights reserved.
 # Use of this source code is governed by a BSD-style license
 # that can be found in the LICENSE file at the root of the
 # Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/scripts/server/ice/rubytest.rb
+++ b/scripts/server/ice/rubytest.rb
@@ -1,6 +1,6 @@
 #!/usr/bin/env ruby
 
-# Copyright 2009-2021 The Mumble Developers. All rights reserved.
+# Copyright 2013-2021 The Mumble Developers. All rights reserved.
 # Use of this source code is governed by a BSD-style license
 # that can be found in the LICENSE file at the root of the
 # Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/scripts/server/ice/testauth.py
+++ b/scripts/server/ice/testauth.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 
-# Copyright 2009-2021 The Mumble Developers. All rights reserved.
+# Copyright 2013-2021 The Mumble Developers. All rights reserved.
 # Use of this source code is governed by a BSD-style license
 # that can be found in the LICENSE file at the root of the
 # Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/scripts/server/ice/testcallback.py
+++ b/scripts/server/ice/testcallback.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 
-# Copyright 2009-2021 The Mumble Developers. All rights reserved.
+# Copyright 2013-2021 The Mumble Developers. All rights reserved.
 # Use of this source code is governed by a BSD-style license
 # that can be found in the LICENSE file at the root of the
 # Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/scripts/server/ice/testdynamic.py
+++ b/scripts/server/ice/testdynamic.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 
-# Copyright 2010-2021 The Mumble Developers. All rights reserved.
+# Copyright 2013-2021 The Mumble Developers. All rights reserved.
 # Use of this source code is governed by a BSD-style license
 # that can be found in the LICENSE file at the root of the
 # Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/scripts/updateLicenseHeaders.py
+++ b/scripts/updateLicenseHeaders.py
@@ -1,5 +1,11 @@
 #!/usr/bin/env python3
 
+# Copyright 2021 The Mumble Developers. All rights reserved.
+# Use of this source code is governed by a BSD-style license
+# that can be found in the LICENSE file at the root of the
+# Mumble source tree or at <https://www.mumble.info/LICENSE>.
+
+
 import argparse
 import os
 import platform
@@ -51,7 +57,7 @@ def generateHeaderForFile(filePath):
         raise InvalidFileError("Can't handle extension: \"" + extension + "\"")
 
     # Get file's creation date
-    creationDateStr = cmd(["git", "log", "--diff-filter=A", "--follow", "--format=%ci", "-1", "--", filePath]).strip()
+    creationDateStr = cmd(["git", "log", "--diff-filter=A", "--format=%ci", "-1", "--", filePath]).strip()
 
     if not creationDateStr:
         raise InvalidFileError("File not in git index: \"" + filePath + "\"")

--- a/src/ACL.cpp
+++ b/src/ACL.cpp
@@ -1,4 +1,4 @@
-// Copyright 2005-2021 The Mumble Developers. All rights reserved.
+// Copyright 2007-2021 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/ACL.h
+++ b/src/ACL.h
@@ -1,4 +1,4 @@
-// Copyright 2005-2021 The Mumble Developers. All rights reserved.
+// Copyright 2007-2021 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/Ban.cpp
+++ b/src/Ban.cpp
@@ -1,4 +1,4 @@
-// Copyright 2009-2021 The Mumble Developers. All rights reserved.
+// Copyright 2017-2021 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/Ban.h
+++ b/src/Ban.h
@@ -1,4 +1,4 @@
-// Copyright 2005-2021 The Mumble Developers. All rights reserved.
+// Copyright 2017-2021 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright 2019-2020 The Mumble Developers. All rights reserved.
+# Copyright 2020-2021 The Mumble Developers. All rights reserved.
 # Use of this source code is governed by a BSD-style license
 # that can be found in the LICENSE file at the root of the
 # Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/Channel.cpp
+++ b/src/Channel.cpp
@@ -1,4 +1,4 @@
-// Copyright 2005-2021 The Mumble Developers. All rights reserved.
+// Copyright 2007-2021 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/Channel.h
+++ b/src/Channel.h
@@ -1,4 +1,4 @@
-// Copyright 2005-2021 The Mumble Developers. All rights reserved.
+// Copyright 2007-2021 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/Connection.cpp
+++ b/src/Connection.cpp
@@ -1,4 +1,4 @@
-// Copyright 2005-2021 The Mumble Developers. All rights reserved.
+// Copyright 2007-2021 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/Connection.h
+++ b/src/Connection.h
@@ -1,4 +1,4 @@
-// Copyright 2005-2021 The Mumble Developers. All rights reserved.
+// Copyright 2007-2021 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/CryptState.h
+++ b/src/CryptState.h
@@ -1,4 +1,4 @@
-// Copyright 2005-2021 The Mumble Developers. All rights reserved.
+// Copyright 2007-2021 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/Group.cpp
+++ b/src/Group.cpp
@@ -1,4 +1,4 @@
-// Copyright 2005-2021 The Mumble Developers. All rights reserved.
+// Copyright 2007-2021 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/Group.h
+++ b/src/Group.h
@@ -1,4 +1,4 @@
-// Copyright 2005-2021 The Mumble Developers. All rights reserved.
+// Copyright 2007-2021 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/HTMLFilter.cpp
+++ b/src/HTMLFilter.cpp
@@ -1,4 +1,4 @@
-// Copyright 2005-2021 The Mumble Developers. All rights reserved.
+// Copyright 2016-2021 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/HTMLFilter.h
+++ b/src/HTMLFilter.h
@@ -1,4 +1,4 @@
-// Copyright 2005-2021 The Mumble Developers. All rights reserved.
+// Copyright 2016-2021 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/HostAddress.cpp
+++ b/src/HostAddress.cpp
@@ -1,4 +1,4 @@
-// Copyright 2009-2021 The Mumble Developers. All rights reserved.
+// Copyright 2017-2021 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/HostAddress.h
+++ b/src/HostAddress.h
@@ -1,4 +1,4 @@
-// Copyright 2005-2021 The Mumble Developers. All rights reserved.
+// Copyright 2017-2021 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/LogEmitter.cpp
+++ b/src/LogEmitter.cpp
@@ -1,4 +1,4 @@
-// Copyright 2005-2021 The Mumble Developers. All rights reserved.
+// Copyright 2016-2021 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/LogEmitter.h
+++ b/src/LogEmitter.h
@@ -1,4 +1,4 @@
-// Copyright 2005-2021 The Mumble Developers. All rights reserved.
+// Copyright 2016-2021 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/Message.h
+++ b/src/Message.h
@@ -1,4 +1,4 @@
-// Copyright 2005-2021 The Mumble Developers. All rights reserved.
+// Copyright 2007-2021 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/Net.h
+++ b/src/Net.h
@@ -1,4 +1,4 @@
-// Copyright 2005-2021 The Mumble Developers. All rights reserved.
+// Copyright 2009-2021 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/OSInfo.cpp
+++ b/src/OSInfo.cpp
@@ -1,4 +1,4 @@
-// Copyright 2007-2021 The Mumble Developers. All rights reserved.
+// Copyright 2009-2021 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/OSInfo.h
+++ b/src/OSInfo.h
@@ -1,4 +1,4 @@
-// Copyright 2008-2021 The Mumble Developers. All rights reserved.
+// Copyright 2009-2021 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/PasswordGenerator.h
+++ b/src/PasswordGenerator.h
@@ -1,4 +1,4 @@
-// Copyright 2005-2021 The Mumble Developers. All rights reserved.
+// Copyright 2017-2021 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/PlatformCheck.cpp
+++ b/src/PlatformCheck.cpp
@@ -1,4 +1,4 @@
-// Copyright 2005-2021 The Mumble Developers. All rights reserved.
+// Copyright 2018-2021 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/PlatformCheck.h
+++ b/src/PlatformCheck.h
@@ -1,4 +1,4 @@
-// Copyright 2005-2021 The Mumble Developers. All rights reserved.
+// Copyright 2018-2021 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/QtUtils.cpp
+++ b/src/QtUtils.cpp
@@ -1,4 +1,4 @@
-// Copyright 2016-2021 The Mumble Developers. All rights reserved.
+// Copyright 2021 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/SSL.cpp
+++ b/src/SSL.cpp
@@ -1,4 +1,4 @@
-// Copyright 2005-2021 The Mumble Developers. All rights reserved.
+// Copyright 2009-2021 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/SSL.h
+++ b/src/SSL.h
@@ -1,4 +1,4 @@
-// Copyright 2005-2021 The Mumble Developers. All rights reserved.
+// Copyright 2009-2021 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/SSLCipherInfo.cpp
+++ b/src/SSLCipherInfo.cpp
@@ -1,4 +1,4 @@
-// Copyright 2005-2021 The Mumble Developers. All rights reserved.
+// Copyright 2015-2021 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/SSLCipherInfo.h
+++ b/src/SSLCipherInfo.h
@@ -1,4 +1,4 @@
-// Copyright 2005-2021 The Mumble Developers. All rights reserved.
+// Copyright 2015-2021 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/SSLLocks.h
+++ b/src/SSLLocks.h
@@ -1,4 +1,4 @@
-// Copyright 2007-2021 The Mumble Developers. All rights reserved.
+// Copyright 2017-2021 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/ServerResolver.cpp
+++ b/src/ServerResolver.cpp
@@ -1,4 +1,4 @@
-// Copyright 2017-2021 The Mumble Developers. All rights reserved.
+// Copyright 2019-2021 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/SignalCurry.h
+++ b/src/SignalCurry.h
@@ -1,4 +1,4 @@
-// Copyright 2005-2021 The Mumble Developers. All rights reserved.
+// Copyright 2012-2021 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/Timer.cpp
+++ b/src/Timer.cpp
@@ -1,4 +1,4 @@
-// Copyright 2005-2021 The Mumble Developers. All rights reserved.
+// Copyright 2007-2021 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/Timer.h
+++ b/src/Timer.h
@@ -1,4 +1,4 @@
-// Copyright 2005-2021 The Mumble Developers. All rights reserved.
+// Copyright 2007-2021 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/User.cpp
+++ b/src/User.cpp
@@ -1,4 +1,4 @@
-// Copyright 2005-2021 The Mumble Developers. All rights reserved.
+// Copyright 2009-2021 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/User.h
+++ b/src/User.h
@@ -1,4 +1,4 @@
-// Copyright 2005-2021 The Mumble Developers. All rights reserved.
+// Copyright 2009-2021 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/Version.h
+++ b/src/Version.h
@@ -1,4 +1,4 @@
-// Copyright 2005-2021 The Mumble Developers. All rights reserved.
+// Copyright 2008-2021 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/crypto/CryptStateOCB2.cpp
+++ b/src/crypto/CryptStateOCB2.cpp
@@ -1,4 +1,4 @@
-// Copyright 2007-2021 The Mumble Developers. All rights reserved.
+// Copyright 2020-2021 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/crypto/CryptographicHash.cpp
+++ b/src/crypto/CryptographicHash.cpp
@@ -1,4 +1,4 @@
-// Copyright 2017-2021 The Mumble Developers. All rights reserved.
+// Copyright 2020-2021 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/crypto/CryptographicHash.h
+++ b/src/crypto/CryptographicHash.h
@@ -1,4 +1,4 @@
-// Copyright 2017-2021 The Mumble Developers. All rights reserved.
+// Copyright 2020-2021 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/crypto/CryptographicRandom.cpp
+++ b/src/crypto/CryptographicRandom.cpp
@@ -1,4 +1,4 @@
-// Copyright 2017-2021 The Mumble Developers. All rights reserved.
+// Copyright 2020-2021 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/crypto/CryptographicRandom.h
+++ b/src/crypto/CryptographicRandom.h
@@ -1,4 +1,4 @@
-// Copyright 2017-2021 The Mumble Developers. All rights reserved.
+// Copyright 2020-2021 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/licenses.h
+++ b/src/licenses.h
@@ -1,4 +1,4 @@
-// Copyright 2005-2021 The Mumble Developers. All rights reserved.
+// Copyright 2016-2021 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/mumble/ACLEditor.cpp
+++ b/src/mumble/ACLEditor.cpp
@@ -1,4 +1,4 @@
-// Copyright 2005-2021 The Mumble Developers. All rights reserved.
+// Copyright 2007-2021 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/mumble/ACLEditor.h
+++ b/src/mumble/ACLEditor.h
@@ -1,4 +1,4 @@
-// Copyright 2005-2021 The Mumble Developers. All rights reserved.
+// Copyright 2007-2021 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/mumble/ALSAAudio.cpp
+++ b/src/mumble/ALSAAudio.cpp
@@ -1,4 +1,4 @@
-// Copyright 2005-2021 The Mumble Developers. All rights reserved.
+// Copyright 2007-2021 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/mumble/ALSAAudio.h
+++ b/src/mumble/ALSAAudio.h
@@ -1,4 +1,4 @@
-// Copyright 2005-2021 The Mumble Developers. All rights reserved.
+// Copyright 2007-2021 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/mumble/ASIOInput.cpp
+++ b/src/mumble/ASIOInput.cpp
@@ -1,4 +1,4 @@
-// Copyright 2005-2021 The Mumble Developers. All rights reserved.
+// Copyright 2007-2021 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/mumble/ASIOInput.h
+++ b/src/mumble/ASIOInput.h
@@ -1,4 +1,4 @@
-// Copyright 2005-2021 The Mumble Developers. All rights reserved.
+// Copyright 2007-2021 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/mumble/About.cpp
+++ b/src/mumble/About.cpp
@@ -1,4 +1,4 @@
-// Copyright 2005-2021 The Mumble Developers. All rights reserved.
+// Copyright 2007-2021 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/mumble/About.h
+++ b/src/mumble/About.h
@@ -1,4 +1,4 @@
-// Copyright 2005-2021 The Mumble Developers. All rights reserved.
+// Copyright 2007-2021 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/mumble/AppNap.h
+++ b/src/mumble/AppNap.h
@@ -1,4 +1,4 @@
-// Copyright 2010-2021 The Mumble Developers. All rights reserved.
+// Copyright 2015-2021 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/mumble/AppNap.mm
+++ b/src/mumble/AppNap.mm
@@ -1,4 +1,4 @@
-// Copyright 2005-2021 The Mumble Developers. All rights reserved.
+// Copyright 2015-2021 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/mumble/Audio.cpp
+++ b/src/mumble/Audio.cpp
@@ -1,4 +1,4 @@
-// Copyright 2005-2021 The Mumble Developers. All rights reserved.
+// Copyright 2007-2021 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/mumble/Audio.h
+++ b/src/mumble/Audio.h
@@ -1,4 +1,4 @@
-// Copyright 2005-2021 The Mumble Developers. All rights reserved.
+// Copyright 2007-2021 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/mumble/AudioConfigDialog.cpp
+++ b/src/mumble/AudioConfigDialog.cpp
@@ -1,4 +1,4 @@
-// Copyright 2005-2021 The Mumble Developers. All rights reserved.
+// Copyright 2007-2021 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/mumble/AudioConfigDialog.h
+++ b/src/mumble/AudioConfigDialog.h
@@ -1,4 +1,4 @@
-// Copyright 2005-2021 The Mumble Developers. All rights reserved.
+// Copyright 2007-2021 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/mumble/AudioInput.cpp
+++ b/src/mumble/AudioInput.cpp
@@ -1,4 +1,4 @@
-// Copyright 2005-2021 The Mumble Developers. All rights reserved.
+// Copyright 2007-2021 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/mumble/AudioInput.h
+++ b/src/mumble/AudioInput.h
@@ -1,4 +1,4 @@
-// Copyright 2005-2021 The Mumble Developers. All rights reserved.
+// Copyright 2007-2021 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/mumble/AudioOutput.cpp
+++ b/src/mumble/AudioOutput.cpp
@@ -1,4 +1,4 @@
-// Copyright 2005-2021 The Mumble Developers. All rights reserved.
+// Copyright 2007-2021 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/mumble/AudioOutput.h
+++ b/src/mumble/AudioOutput.h
@@ -1,4 +1,4 @@
-// Copyright 2005-2021 The Mumble Developers. All rights reserved.
+// Copyright 2007-2021 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/mumble/AudioOutputSample.h
+++ b/src/mumble/AudioOutputSample.h
@@ -1,4 +1,4 @@
-// Copyright 2008-2021 The Mumble Developers. All rights reserved.
+// Copyright 2011-2021 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/mumble/AudioOutputSpeech.h
+++ b/src/mumble/AudioOutputSpeech.h
@@ -1,4 +1,4 @@
-// Copyright 2005-2021 The Mumble Developers. All rights reserved.
+// Copyright 2011-2021 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/mumble/AudioOutputUser.cpp
+++ b/src/mumble/AudioOutputUser.cpp
@@ -1,4 +1,4 @@
-// Copyright 2005-2021 The Mumble Developers. All rights reserved.
+// Copyright 2011-2021 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/mumble/AudioOutputUser.h
+++ b/src/mumble/AudioOutputUser.h
@@ -1,4 +1,4 @@
-// Copyright 2005-2021 The Mumble Developers. All rights reserved.
+// Copyright 2011-2021 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/mumble/AudioStats.cpp
+++ b/src/mumble/AudioStats.cpp
@@ -1,4 +1,4 @@
-// Copyright 2005-2021 The Mumble Developers. All rights reserved.
+// Copyright 2007-2021 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/mumble/AudioStats.h
+++ b/src/mumble/AudioStats.h
@@ -1,4 +1,4 @@
-// Copyright 2005-2021 The Mumble Developers. All rights reserved.
+// Copyright 2007-2021 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/mumble/BanEditor.cpp
+++ b/src/mumble/BanEditor.cpp
@@ -1,4 +1,4 @@
-// Copyright 2005-2021 The Mumble Developers. All rights reserved.
+// Copyright 2007-2021 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/mumble/BanEditor.h
+++ b/src/mumble/BanEditor.h
@@ -1,4 +1,4 @@
-// Copyright 2005-2021 The Mumble Developers. All rights reserved.
+// Copyright 2007-2021 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/mumble/CELTCodec.cpp
+++ b/src/mumble/CELTCodec.cpp
@@ -1,4 +1,4 @@
-// Copyright 2005-2021 The Mumble Developers. All rights reserved.
+// Copyright 2012-2021 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/mumble/CELTCodec.h
+++ b/src/mumble/CELTCodec.h
@@ -1,4 +1,4 @@
-// Copyright 2005-2021 The Mumble Developers. All rights reserved.
+// Copyright 2012-2021 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/mumble/CMakeLists.txt
+++ b/src/mumble/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright 2019-2020 The Mumble Developers. All rights reserved.
+# Copyright 2020-2021 The Mumble Developers. All rights reserved.
 # Use of this source code is governed by a BSD-style license
 # that can be found in the LICENSE file at the root of the
 # Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/mumble/Cert.h
+++ b/src/mumble/Cert.h
@@ -1,4 +1,4 @@
-// Copyright 2005-2021 The Mumble Developers. All rights reserved.
+// Copyright 2009-2021 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/mumble/ClientUser.cpp
+++ b/src/mumble/ClientUser.cpp
@@ -1,4 +1,4 @@
-// Copyright 2005-2021 The Mumble Developers. All rights reserved.
+// Copyright 2009-2021 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/mumble/ClientUser.h
+++ b/src/mumble/ClientUser.h
@@ -1,4 +1,4 @@
-// Copyright 2005-2021 The Mumble Developers. All rights reserved.
+// Copyright 2009-2021 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/mumble/ConfigDialog.cpp
+++ b/src/mumble/ConfigDialog.cpp
@@ -1,4 +1,4 @@
-// Copyright 2005-2021 The Mumble Developers. All rights reserved.
+// Copyright 2007-2021 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/mumble/ConfigDialog.h
+++ b/src/mumble/ConfigDialog.h
@@ -1,4 +1,4 @@
-// Copyright 2005-2021 The Mumble Developers. All rights reserved.
+// Copyright 2007-2021 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/mumble/ConfigWidget.cpp
+++ b/src/mumble/ConfigWidget.cpp
@@ -1,4 +1,4 @@
-// Copyright 2005-2021 The Mumble Developers. All rights reserved.
+// Copyright 2009-2021 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/mumble/ConfigWidget.h
+++ b/src/mumble/ConfigWidget.h
@@ -1,4 +1,4 @@
-// Copyright 2005-2021 The Mumble Developers. All rights reserved.
+// Copyright 2009-2021 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/mumble/ConnectDialog.cpp
+++ b/src/mumble/ConnectDialog.cpp
@@ -1,4 +1,4 @@
-// Copyright 2005-2021 The Mumble Developers. All rights reserved.
+// Copyright 2007-2021 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/mumble/ConnectDialog.h
+++ b/src/mumble/ConnectDialog.h
@@ -1,4 +1,4 @@
-// Copyright 2005-2021 The Mumble Developers. All rights reserved.
+// Copyright 2007-2021 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/mumble/CoreAudio.h
+++ b/src/mumble/CoreAudio.h
@@ -1,4 +1,4 @@
-// Copyright 2005-2021 The Mumble Developers. All rights reserved.
+// Copyright 2009-2021 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/mumble/CoreAudio.mm
+++ b/src/mumble/CoreAudio.mm
@@ -1,4 +1,4 @@
-// Copyright 2009-2021 The Mumble Developers. All rights reserved.
+// Copyright 2021 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/mumble/CrashReporter.cpp
+++ b/src/mumble/CrashReporter.cpp
@@ -1,4 +1,4 @@
-// Copyright 2005-2021 The Mumble Developers. All rights reserved.
+// Copyright 2009-2021 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/mumble/CrashReporter.h
+++ b/src/mumble/CrashReporter.h
@@ -1,4 +1,4 @@
-// Copyright 2005-2021 The Mumble Developers. All rights reserved.
+// Copyright 2009-2021 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/mumble/CustomElements.h
+++ b/src/mumble/CustomElements.h
@@ -1,4 +1,4 @@
-// Copyright 2005-2021 The Mumble Developers. All rights reserved.
+// Copyright 2009-2021 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/mumble/DBus.cpp
+++ b/src/mumble/DBus.cpp
@@ -1,4 +1,4 @@
-// Copyright 2005-2021 The Mumble Developers. All rights reserved.
+// Copyright 2007-2021 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/mumble/DBus.h
+++ b/src/mumble/DBus.h
@@ -1,4 +1,4 @@
-// Copyright 2005-2021 The Mumble Developers. All rights reserved.
+// Copyright 2007-2021 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/mumble/Database.cpp
+++ b/src/mumble/Database.cpp
@@ -1,4 +1,4 @@
-// Copyright 2005-2021 The Mumble Developers. All rights reserved.
+// Copyright 2007-2021 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/mumble/Database.h
+++ b/src/mumble/Database.h
@@ -1,4 +1,4 @@
-// Copyright 2005-2021 The Mumble Developers. All rights reserved.
+// Copyright 2007-2021 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/mumble/G15LCDEngine_helper.cpp
+++ b/src/mumble/G15LCDEngine_helper.cpp
@@ -1,4 +1,4 @@
-// Copyright 2008-2021 The Mumble Developers. All rights reserved.
+// Copyright 2010-2021 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/mumble/G15LCDEngine_helper.h
+++ b/src/mumble/G15LCDEngine_helper.h
@@ -1,4 +1,4 @@
-// Copyright 2005-2021 The Mumble Developers. All rights reserved.
+// Copyright 2010-2021 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/mumble/G15LCDEngine_lglcd.cpp
+++ b/src/mumble/G15LCDEngine_lglcd.cpp
@@ -1,4 +1,4 @@
-// Copyright 2008-2021 The Mumble Developers. All rights reserved.
+// Copyright 2009-2021 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/mumble/G15LCDEngine_lglcd.h
+++ b/src/mumble/G15LCDEngine_lglcd.h
@@ -1,4 +1,4 @@
-// Copyright 2005-2021 The Mumble Developers. All rights reserved.
+// Copyright 2009-2021 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/mumble/G15LCDEngine_unix.cpp
+++ b/src/mumble/G15LCDEngine_unix.cpp
@@ -1,4 +1,4 @@
-// Copyright 2005-2021 The Mumble Developers. All rights reserved.
+// Copyright 2008-2021 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/mumble/G15LCDEngine_unix.h
+++ b/src/mumble/G15LCDEngine_unix.h
@@ -1,4 +1,4 @@
-// Copyright 2005-2021 The Mumble Developers. All rights reserved.
+// Copyright 2008-2021 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/mumble/Global.cpp
+++ b/src/mumble/Global.cpp
@@ -1,4 +1,4 @@
-// Copyright 2005-2021 The Mumble Developers. All rights reserved.
+// Copyright 2007-2021 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/mumble/Global.h
+++ b/src/mumble/Global.h
@@ -1,4 +1,4 @@
-// Copyright 2005-2021 The Mumble Developers. All rights reserved.
+// Copyright 2007-2021 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/mumble/GlobalShortcut.h
+++ b/src/mumble/GlobalShortcut.h
@@ -1,4 +1,4 @@
-// Copyright 2005-2021 The Mumble Developers. All rights reserved.
+// Copyright 2007-2021 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/mumble/GlobalShortcut_macx.h
+++ b/src/mumble/GlobalShortcut_macx.h
@@ -1,4 +1,4 @@
-// Copyright 2005-2021 The Mumble Developers. All rights reserved.
+// Copyright 2007-2021 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/mumble/GlobalShortcut_macx.mm
+++ b/src/mumble/GlobalShortcut_macx.mm
@@ -1,4 +1,4 @@
-// Copyright 2007-2021 The Mumble Developers. All rights reserved.
+// Copyright 2010-2021 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/mumble/GlobalShortcut_unix.cpp
+++ b/src/mumble/GlobalShortcut_unix.cpp
@@ -1,4 +1,4 @@
-// Copyright 2005-2021 The Mumble Developers. All rights reserved.
+// Copyright 2007-2021 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/mumble/GlobalShortcut_unix.h
+++ b/src/mumble/GlobalShortcut_unix.h
@@ -1,4 +1,4 @@
-// Copyright 2005-2021 The Mumble Developers. All rights reserved.
+// Copyright 2007-2021 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/mumble/GlobalShortcut_win.cpp
+++ b/src/mumble/GlobalShortcut_win.cpp
@@ -1,4 +1,4 @@
-// Copyright 2005-2021 The Mumble Developers. All rights reserved.
+// Copyright 2007-2021 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/mumble/GlobalShortcut_win.h
+++ b/src/mumble/GlobalShortcut_win.h
@@ -1,4 +1,4 @@
-// Copyright 2005-2021 The Mumble Developers. All rights reserved.
+// Copyright 2007-2021 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/mumble/LCD.h
+++ b/src/mumble/LCD.h
@@ -1,4 +1,4 @@
-// Copyright 2005-2021 The Mumble Developers. All rights reserved.
+// Copyright 2008-2021 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/mumble/Log.cpp
+++ b/src/mumble/Log.cpp
@@ -1,4 +1,4 @@
-// Copyright 2005-2021 The Mumble Developers. All rights reserved.
+// Copyright 2007-2021 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/mumble/Log.h
+++ b/src/mumble/Log.h
@@ -1,4 +1,4 @@
-// Copyright 2005-2021 The Mumble Developers. All rights reserved.
+// Copyright 2007-2021 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/mumble/Log_win.cpp
+++ b/src/mumble/Log_win.cpp
@@ -1,4 +1,4 @@
-// Copyright 2005-2021 The Mumble Developers. All rights reserved.
+// Copyright 2012-2021 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/mumble/LookConfig.cpp
+++ b/src/mumble/LookConfig.cpp
@@ -1,4 +1,4 @@
-// Copyright 2006-2021 The Mumble Developers. All rights reserved.
+// Copyright 2007-2021 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/mumble/LookConfig.h
+++ b/src/mumble/LookConfig.h
@@ -1,4 +1,4 @@
-// Copyright 2005-2021 The Mumble Developers. All rights reserved.
+// Copyright 2007-2021 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/mumble/MainWindow.cpp
+++ b/src/mumble/MainWindow.cpp
@@ -1,4 +1,4 @@
-// Copyright 2005-2021 The Mumble Developers. All rights reserved.
+// Copyright 2007-2021 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/mumble/MainWindow.h
+++ b/src/mumble/MainWindow.h
@@ -1,4 +1,4 @@
-// Copyright 2005-2021 The Mumble Developers. All rights reserved.
+// Copyright 2007-2021 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/mumble/ManualPlugin.cpp
+++ b/src/mumble/ManualPlugin.cpp
@@ -1,4 +1,4 @@
-// Copyright 2009-2021 The Mumble Developers. All rights reserved.
+// Copyright 2016-2021 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/mumble/ManualPlugin.h
+++ b/src/mumble/ManualPlugin.h
@@ -1,4 +1,4 @@
-// Copyright 2009-2021 The Mumble Developers. All rights reserved.
+// Copyright 2016-2021 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/mumble/MumbleApplication.h
+++ b/src/mumble/MumbleApplication.h
@@ -1,4 +1,4 @@
-// Copyright 2005-2021 The Mumble Developers. All rights reserved.
+// Copyright 2014-2021 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/mumble/NetworkConfig.h
+++ b/src/mumble/NetworkConfig.h
@@ -1,4 +1,4 @@
-// Copyright 2005-2021 The Mumble Developers. All rights reserved.
+// Copyright 2008-2021 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/mumble/OSS.h
+++ b/src/mumble/OSS.h
@@ -1,4 +1,4 @@
-// Copyright 2005-2021 The Mumble Developers. All rights reserved.
+// Copyright 2007-2021 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/mumble/Overlay.cpp
+++ b/src/mumble/Overlay.cpp
@@ -1,4 +1,4 @@
-// Copyright 2005-2021 The Mumble Developers. All rights reserved.
+// Copyright 2007-2021 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/mumble/Overlay.h
+++ b/src/mumble/Overlay.h
@@ -1,4 +1,4 @@
-// Copyright 2005-2021 The Mumble Developers. All rights reserved.
+// Copyright 2007-2021 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/mumble/OverlayClient.h
+++ b/src/mumble/OverlayClient.h
@@ -1,4 +1,4 @@
-// Copyright 2005-2021 The Mumble Developers. All rights reserved.
+// Copyright 2014-2021 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/mumble/OverlayConfig.h
+++ b/src/mumble/OverlayConfig.h
@@ -1,4 +1,4 @@
-// Copyright 2008-2021 The Mumble Developers. All rights reserved.
+// Copyright 2014-2021 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/mumble/OverlayEditor.h
+++ b/src/mumble/OverlayEditor.h
@@ -1,4 +1,4 @@
-// Copyright 2005-2021 The Mumble Developers. All rights reserved.
+// Copyright 2014-2021 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/mumble/OverlayEditorScene.h
+++ b/src/mumble/OverlayEditorScene.h
@@ -1,4 +1,4 @@
-// Copyright 2005-2021 The Mumble Developers. All rights reserved.
+// Copyright 2014-2021 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/mumble/OverlayText.h
+++ b/src/mumble/OverlayText.h
@@ -1,4 +1,4 @@
-// Copyright 2005-2021 The Mumble Developers. All rights reserved.
+// Copyright 2010-2021 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/mumble/OverlayUser.h
+++ b/src/mumble/OverlayUser.h
@@ -1,4 +1,4 @@
-// Copyright 2005-2021 The Mumble Developers. All rights reserved.
+// Copyright 2014-2021 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/mumble/OverlayUserGroup.h
+++ b/src/mumble/OverlayUserGroup.h
@@ -1,4 +1,4 @@
-// Copyright 2005-2021 The Mumble Developers. All rights reserved.
+// Copyright 2014-2021 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/mumble/Overlay_unix.cpp
+++ b/src/mumble/Overlay_unix.cpp
@@ -1,4 +1,4 @@
-// Copyright 2005-2021 The Mumble Developers. All rights reserved.
+// Copyright 2007-2021 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/mumble/Overlay_win.cpp
+++ b/src/mumble/Overlay_win.cpp
@@ -1,4 +1,4 @@
-// Copyright 2005-2021 The Mumble Developers. All rights reserved.
+// Copyright 2007-2021 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/mumble/Overlay_win.h
+++ b/src/mumble/Overlay_win.h
@@ -1,4 +1,4 @@
-// Copyright 2005-2021 The Mumble Developers. All rights reserved.
+// Copyright 2015-2021 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/mumble/Plugins.cpp
+++ b/src/mumble/Plugins.cpp
@@ -1,4 +1,4 @@
-// Copyright 2005-2021 The Mumble Developers. All rights reserved.
+// Copyright 2007-2021 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/mumble/Plugins.h
+++ b/src/mumble/Plugins.h
@@ -1,4 +1,4 @@
-// Copyright 2005-2021 The Mumble Developers. All rights reserved.
+// Copyright 2007-2021 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/mumble/PulseAudio.h
+++ b/src/mumble/PulseAudio.h
@@ -1,4 +1,4 @@
-// Copyright 2005-2021 The Mumble Developers. All rights reserved.
+// Copyright 2007-2021 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/mumble/RichTextEditor.h
+++ b/src/mumble/RichTextEditor.h
@@ -1,4 +1,4 @@
-// Copyright 2005-2021 The Mumble Developers. All rights reserved.
+// Copyright 2009-2021 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/mumble/ServerHandler.cpp
+++ b/src/mumble/ServerHandler.cpp
@@ -1,4 +1,4 @@
-// Copyright 2005-2021 The Mumble Developers. All rights reserved.
+// Copyright 2007-2021 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/mumble/ServerHandler.h
+++ b/src/mumble/ServerHandler.h
@@ -1,4 +1,4 @@
-// Copyright 2005-2021 The Mumble Developers. All rights reserved.
+// Copyright 2007-2021 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/mumble/Settings.cpp
+++ b/src/mumble/Settings.cpp
@@ -1,4 +1,4 @@
-// Copyright 2005-2021 The Mumble Developers. All rights reserved.
+// Copyright 2007-2021 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/mumble/Settings.h
+++ b/src/mumble/Settings.h
@@ -1,4 +1,4 @@
-// Copyright 2005-2021 The Mumble Developers. All rights reserved.
+// Copyright 2007-2021 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/mumble/SharedMemory.cpp
+++ b/src/mumble/SharedMemory.cpp
@@ -1,4 +1,4 @@
-// Copyright 2005-2021 The Mumble Developers. All rights reserved.
+// Copyright 2010-2021 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/mumble/SharedMemory.h
+++ b/src/mumble/SharedMemory.h
@@ -1,4 +1,4 @@
-// Copyright 2005-2021 The Mumble Developers. All rights reserved.
+// Copyright 2010-2021 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/mumble/SharedMemory_unix.cpp
+++ b/src/mumble/SharedMemory_unix.cpp
@@ -1,4 +1,4 @@
-// Copyright 2005-2021 The Mumble Developers. All rights reserved.
+// Copyright 2010-2021 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/mumble/SocketRPC.h
+++ b/src/mumble/SocketRPC.h
@@ -1,4 +1,4 @@
-// Copyright 2005-2021 The Mumble Developers. All rights reserved.
+// Copyright 2010-2021 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/mumble/TaskList.h
+++ b/src/mumble/TaskList.h
@@ -1,4 +1,4 @@
-// Copyright 2005-2021 The Mumble Developers. All rights reserved.
+// Copyright 2009-2021 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/mumble/TextMessage.cpp
+++ b/src/mumble/TextMessage.cpp
@@ -1,4 +1,4 @@
-// Copyright 2005-2021 The Mumble Developers. All rights reserved.
+// Copyright 2007-2021 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/mumble/TextMessage.h
+++ b/src/mumble/TextMessage.h
@@ -1,4 +1,4 @@
-// Copyright 2005-2021 The Mumble Developers. All rights reserved.
+// Copyright 2007-2021 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/mumble/TextToSpeech.cpp
+++ b/src/mumble/TextToSpeech.cpp
@@ -1,4 +1,4 @@
-// Copyright 2005-2021 The Mumble Developers. All rights reserved.
+// Copyright 2017-2021 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/mumble/TextToSpeech.h
+++ b/src/mumble/TextToSpeech.h
@@ -1,4 +1,4 @@
-// Copyright 2005-2021 The Mumble Developers. All rights reserved.
+// Copyright 2007-2021 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/mumble/TextToSpeech_macx.mm
+++ b/src/mumble/TextToSpeech_macx.mm
@@ -1,4 +1,4 @@
-// Copyright 2005-2021 The Mumble Developers. All rights reserved.
+// Copyright 2014-2021 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/mumble/TextToSpeech_unix.cpp
+++ b/src/mumble/TextToSpeech_unix.cpp
@@ -1,4 +1,4 @@
-// Copyright 2005-2021 The Mumble Developers. All rights reserved.
+// Copyright 2007-2021 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/mumble/TextToSpeech_win.cpp
+++ b/src/mumble/TextToSpeech_win.cpp
@@ -1,4 +1,4 @@
-// Copyright 2005-2021 The Mumble Developers. All rights reserved.
+// Copyright 2007-2021 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/mumble/Themes.h
+++ b/src/mumble/Themes.h
@@ -1,4 +1,4 @@
-// Copyright 2005-2021 The Mumble Developers. All rights reserved.
+// Copyright 2015-2021 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/mumble/Tokens.cpp
+++ b/src/mumble/Tokens.cpp
@@ -1,4 +1,4 @@
-// Copyright 2005-2021 The Mumble Developers. All rights reserved.
+// Copyright 2009-2021 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/mumble/Tokens.h
+++ b/src/mumble/Tokens.h
@@ -1,4 +1,4 @@
-// Copyright 2005-2021 The Mumble Developers. All rights reserved.
+// Copyright 2009-2021 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/mumble/Usage.cpp
+++ b/src/mumble/Usage.cpp
@@ -1,4 +1,4 @@
-// Copyright 2007-2021 The Mumble Developers. All rights reserved.
+// Copyright 2009-2021 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/mumble/Usage.h
+++ b/src/mumble/Usage.h
@@ -1,4 +1,4 @@
-// Copyright 2005-2021 The Mumble Developers. All rights reserved.
+// Copyright 2009-2021 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/mumble/UserEdit.cpp
+++ b/src/mumble/UserEdit.cpp
@@ -1,4 +1,4 @@
-// Copyright 2005-2021 The Mumble Developers. All rights reserved.
+// Copyright 2009-2021 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/mumble/UserEdit.h
+++ b/src/mumble/UserEdit.h
@@ -1,4 +1,4 @@
-// Copyright 2005-2021 The Mumble Developers. All rights reserved.
+// Copyright 2009-2021 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/mumble/UserInformation.h
+++ b/src/mumble/UserInformation.h
@@ -1,4 +1,4 @@
-// Copyright 2005-2021 The Mumble Developers. All rights reserved.
+// Copyright 2010-2021 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/mumble/UserLocalVolumeDialog.cpp
+++ b/src/mumble/UserLocalVolumeDialog.cpp
@@ -1,4 +1,4 @@
-// Copyright 2005-2021 The Mumble Developers. All rights reserved.
+// Copyright 2015-2021 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/mumble/UserLocalVolumeDialog.h
+++ b/src/mumble/UserLocalVolumeDialog.h
@@ -1,4 +1,4 @@
-// Copyright 2005-2021 The Mumble Developers. All rights reserved.
+// Copyright 2015-2021 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/mumble/UserLockFile.h
+++ b/src/mumble/UserLockFile.h
@@ -1,4 +1,4 @@
-// Copyright 2005-2021 The Mumble Developers. All rights reserved.
+// Copyright 2015-2021 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/mumble/UserLockFile_win.cpp
+++ b/src/mumble/UserLockFile_win.cpp
@@ -1,4 +1,4 @@
-// Copyright 2005-2021 The Mumble Developers. All rights reserved.
+// Copyright 2015-2021 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/mumble/UserModel.cpp
+++ b/src/mumble/UserModel.cpp
@@ -1,4 +1,4 @@
-// Copyright 2005-2021 The Mumble Developers. All rights reserved.
+// Copyright 2009-2021 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/mumble/UserModel.h
+++ b/src/mumble/UserModel.h
@@ -1,4 +1,4 @@
-// Copyright 2005-2021 The Mumble Developers. All rights reserved.
+// Copyright 2009-2021 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/mumble/UserView.h
+++ b/src/mumble/UserView.h
@@ -1,4 +1,4 @@
-// Copyright 2005-2021 The Mumble Developers. All rights reserved.
+// Copyright 2009-2021 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/mumble/VersionCheck.cpp
+++ b/src/mumble/VersionCheck.cpp
@@ -1,4 +1,4 @@
-// Copyright 2005-2021 The Mumble Developers. All rights reserved.
+// Copyright 2007-2021 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/mumble/VersionCheck.h
+++ b/src/mumble/VersionCheck.h
@@ -1,4 +1,4 @@
-// Copyright 2005-2021 The Mumble Developers. All rights reserved.
+// Copyright 2007-2021 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/mumble/ViewCert.h
+++ b/src/mumble/ViewCert.h
@@ -1,4 +1,4 @@
-// Copyright 2005-2021 The Mumble Developers. All rights reserved.
+// Copyright 2007-2021 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/mumble/VoiceRecorder.h
+++ b/src/mumble/VoiceRecorder.h
@@ -1,4 +1,4 @@
-// Copyright 2005-2021 The Mumble Developers. All rights reserved.
+// Copyright 2010-2021 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/mumble/WASAPI.h
+++ b/src/mumble/WASAPI.h
@@ -1,4 +1,4 @@
-// Copyright 2005-2021 The Mumble Developers. All rights reserved.
+// Copyright 2008-2021 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/mumble/WebFetch.h
+++ b/src/mumble/WebFetch.h
@@ -1,4 +1,4 @@
-// Copyright 2005-2021 The Mumble Developers. All rights reserved.
+// Copyright 2011-2021 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/mumble/Zeroconf.cpp
+++ b/src/mumble/Zeroconf.cpp
@@ -1,4 +1,4 @@
-// Copyright 2005-2021 The Mumble Developers. All rights reserved.
+// Copyright 2020-2021 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/mumble/Zeroconf.h
+++ b/src/mumble/Zeroconf.h
@@ -1,4 +1,4 @@
-// Copyright 2005-2021 The Mumble Developers. All rights reserved.
+// Copyright 2020-2021 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/mumble/main.cpp
+++ b/src/mumble/main.cpp
@@ -1,4 +1,4 @@
-// Copyright 2005-2021 The Mumble Developers. All rights reserved.
+// Copyright 2007-2021 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/mumble/os_early_win.cpp
+++ b/src/mumble/os_early_win.cpp
@@ -1,4 +1,4 @@
-// Copyright 2016-2021 The Mumble Developers. All rights reserved.
+// Copyright 2017-2021 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/mumble/os_macx.mm
+++ b/src/mumble/os_macx.mm
@@ -1,4 +1,4 @@
-// Copyright 2008-2021 The Mumble Developers. All rights reserved.
+// Copyright 2010-2021 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/mumble/os_win.cpp
+++ b/src/mumble/os_win.cpp
@@ -1,4 +1,4 @@
-// Copyright 2006-2021 The Mumble Developers. All rights reserved.
+// Copyright 2007-2021 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/mumble/widgets/CompletablePage.cpp
+++ b/src/mumble/widgets/CompletablePage.cpp
@@ -1,4 +1,4 @@
-// Copyright 2016-2021 The Mumble Developers. All rights reserved.
+// Copyright 2021 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/mumble/widgets/MUComboBox.h
+++ b/src/mumble/widgets/MUComboBox.h
@@ -1,4 +1,4 @@
-// Copyright 2005-2021 The Mumble Developers. All rights reserved.
+// Copyright 2016-2021 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/mumble_exe/CMakeLists.txt
+++ b/src/mumble_exe/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright 2019-2020 The Mumble Developers. All rights reserved.
+# Copyright 2020-2021 The Mumble Developers. All rights reserved.
 # Use of this source code is governed by a BSD-style license
 # that can be found in the LICENSE file at the root of the
 # Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/mumble_exe/Overlay.cpp
+++ b/src/mumble_exe/Overlay.cpp
@@ -1,4 +1,4 @@
-// Copyright 2008-2021 The Mumble Developers. All rights reserved.
+// Copyright 2013-2021 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/murmur/About.cpp
+++ b/src/murmur/About.cpp
@@ -1,4 +1,4 @@
-// Copyright 2005-2021 The Mumble Developers. All rights reserved.
+// Copyright 2016-2021 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/murmur/About.h
+++ b/src/murmur/About.h
@@ -1,4 +1,4 @@
-// Copyright 2005-2021 The Mumble Developers. All rights reserved.
+// Copyright 2016-2021 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/murmur/CMakeLists.txt
+++ b/src/murmur/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright 2019-2020 The Mumble Developers. All rights reserved.
+# Copyright 2020-2021 The Mumble Developers. All rights reserved.
 # Use of this source code is governed by a BSD-style license
 # that can be found in the LICENSE file at the root of the
 # Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/murmur/DBus.cpp
+++ b/src/murmur/DBus.cpp
@@ -1,4 +1,4 @@
-// Copyright 2005-2021 The Mumble Developers. All rights reserved.
+// Copyright 2007-2021 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/murmur/DBus.h
+++ b/src/murmur/DBus.h
@@ -1,4 +1,4 @@
-// Copyright 2005-2021 The Mumble Developers. All rights reserved.
+// Copyright 2007-2021 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/murmur/Meta.h
+++ b/src/murmur/Meta.h
@@ -1,4 +1,4 @@
-// Copyright 2005-2021 The Mumble Developers. All rights reserved.
+// Copyright 2007-2021 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/murmur/MurmurGRPCImpl.h
+++ b/src/murmur/MurmurGRPCImpl.h
@@ -1,4 +1,4 @@
-// Copyright 2005-2021 The Mumble Developers. All rights reserved.
+// Copyright 2016-2021 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/murmur/Server.cpp
+++ b/src/murmur/Server.cpp
@@ -1,4 +1,4 @@
-// Copyright 2005-2021 The Mumble Developers. All rights reserved.
+// Copyright 2007-2021 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/murmur/Server.h
+++ b/src/murmur/Server.h
@@ -1,4 +1,4 @@
-// Copyright 2005-2021 The Mumble Developers. All rights reserved.
+// Copyright 2007-2021 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/murmur/ServerDB.cpp
+++ b/src/murmur/ServerDB.cpp
@@ -1,4 +1,4 @@
-// Copyright 2005-2021 The Mumble Developers. All rights reserved.
+// Copyright 2007-2021 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/murmur/ServerDB.h
+++ b/src/murmur/ServerDB.h
@@ -1,4 +1,4 @@
-// Copyright 2005-2021 The Mumble Developers. All rights reserved.
+// Copyright 2007-2021 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/murmur/Tray.h
+++ b/src/murmur/Tray.h
@@ -1,4 +1,4 @@
-// Copyright 2005-2021 The Mumble Developers. All rights reserved.
+// Copyright 2007-2021 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/murmur/UnixMurmur.h
+++ b/src/murmur/UnixMurmur.h
@@ -1,4 +1,4 @@
-// Copyright 2005-2021 The Mumble Developers. All rights reserved.
+// Copyright 2007-2021 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/murmur/Zeroconf.cpp
+++ b/src/murmur/Zeroconf.cpp
@@ -1,4 +1,4 @@
-// Copyright 2005-2021 The Mumble Developers. All rights reserved.
+// Copyright 2020-2021 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/murmur/Zeroconf.h
+++ b/src/murmur/Zeroconf.h
@@ -1,4 +1,4 @@
-// Copyright 2005-2021 The Mumble Developers. All rights reserved.
+// Copyright 2020-2021 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/murmur/main.cpp
+++ b/src/murmur/main.cpp
@@ -1,4 +1,4 @@
-// Copyright 2005-2021 The Mumble Developers. All rights reserved.
+// Copyright 2008-2021 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/murmur/murmur_pch.h
+++ b/src/murmur/murmur_pch.h
@@ -1,4 +1,4 @@
-// Copyright 2006-2021 The Mumble Developers. All rights reserved.
+// Copyright 2007-2021 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/murmur_grpcwrapper_protoc_plugin/CMakeLists.txt
+++ b/src/murmur_grpcwrapper_protoc_plugin/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright 2019-2020 The Mumble Developers. All rights reserved.
+# Copyright 2020-2021 The Mumble Developers. All rights reserved.
 # Use of this source code is governed by a BSD-style license
 # that can be found in the LICENSE file at the root of the
 # Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/tests/CMakeLists.txt
+++ b/src/tests/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright 2019-2020 The Mumble Developers. All rights reserved.
+# Copyright 2020-2021 The Mumble Developers. All rights reserved.
 # Use of this source code is governed by a BSD-style license
 # that can be found in the LICENSE file at the root of the
 # Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/tests/TestCrypt/CMakeLists.txt
+++ b/src/tests/TestCrypt/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright 2019-2020 The Mumble Developers. All rights reserved.
+# Copyright 2020-2021 The Mumble Developers. All rights reserved.
 # Use of this source code is governed by a BSD-style license
 # that can be found in the LICENSE file at the root of the
 # Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/tests/TestCrypt/TestCrypt.cpp
+++ b/src/tests/TestCrypt/TestCrypt.cpp
@@ -1,4 +1,4 @@
-// Copyright 2007-2021 The Mumble Developers. All rights reserved.
+// Copyright 2017-2021 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/tests/TestCryptographicHash/CMakeLists.txt
+++ b/src/tests/TestCryptographicHash/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright 2019-2020 The Mumble Developers. All rights reserved.
+# Copyright 2020-2021 The Mumble Developers. All rights reserved.
 # Use of this source code is governed by a BSD-style license
 # that can be found in the LICENSE file at the root of the
 # Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/tests/TestCryptographicRandom/CMakeLists.txt
+++ b/src/tests/TestCryptographicRandom/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright 2019-2020 The Mumble Developers. All rights reserved.
+# Copyright 2020-2021 The Mumble Developers. All rights reserved.
 # Use of this source code is governed by a BSD-style license
 # that can be found in the LICENSE file at the root of the
 # Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/tests/TestFFDHE/CMakeLists.txt
+++ b/src/tests/TestFFDHE/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright 2019-2020 The Mumble Developers. All rights reserved.
+# Copyright 2020-2021 The Mumble Developers. All rights reserved.
 # Use of this source code is governed by a BSD-style license
 # that can be found in the LICENSE file at the root of the
 # Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/tests/TestPacketDataStream/CMakeLists.txt
+++ b/src/tests/TestPacketDataStream/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright 2019-2020 The Mumble Developers. All rights reserved.
+# Copyright 2020-2021 The Mumble Developers. All rights reserved.
 # Use of this source code is governed by a BSD-style license
 # that can be found in the LICENSE file at the root of the
 # Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/tests/TestPacketDataStream/TestPacketDataStream.cpp
+++ b/src/tests/TestPacketDataStream/TestPacketDataStream.cpp
@@ -1,4 +1,4 @@
-// Copyright 2007-2021 The Mumble Developers. All rights reserved.
+// Copyright 2017-2021 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/tests/TestPasswordGenerator/CMakeLists.txt
+++ b/src/tests/TestPasswordGenerator/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright 2019-2020 The Mumble Developers. All rights reserved.
+# Copyright 2020-2021 The Mumble Developers. All rights reserved.
 # Use of this source code is governed by a BSD-style license
 # that can be found in the LICENSE file at the root of the
 # Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/tests/TestSSLLocks/CMakeLists.txt
+++ b/src/tests/TestSSLLocks/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright 2019-2020 The Mumble Developers. All rights reserved.
+# Copyright 2020-2021 The Mumble Developers. All rights reserved.
 # Use of this source code is governed by a BSD-style license
 # that can be found in the LICENSE file at the root of the
 # Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/tests/TestSelfSignedCertificate/CMakeLists.txt
+++ b/src/tests/TestSelfSignedCertificate/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright 2019-2020 The Mumble Developers. All rights reserved.
+# Copyright 2020-2021 The Mumble Developers. All rights reserved.
 # Use of this source code is governed by a BSD-style license
 # that can be found in the LICENSE file at the root of the
 # Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/tests/TestServerAddress/CMakeLists.txt
+++ b/src/tests/TestServerAddress/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright 2019-2020 The Mumble Developers. All rights reserved.
+# Copyright 2020-2021 The Mumble Developers. All rights reserved.
 # Use of this source code is governed by a BSD-style license
 # that can be found in the LICENSE file at the root of the
 # Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/tests/TestServerResolver/CMakeLists.txt
+++ b/src/tests/TestServerResolver/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright 2019-2020 The Mumble Developers. All rights reserved.
+# Copyright 2020-2021 The Mumble Developers. All rights reserved.
 # Use of this source code is governed by a BSD-style license
 # that can be found in the LICENSE file at the root of the
 # Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/tests/TestStdAbs/CMakeLists.txt
+++ b/src/tests/TestStdAbs/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright 2019-2020 The Mumble Developers. All rights reserved.
+# Copyright 2020-2021 The Mumble Developers. All rights reserved.
 # Use of this source code is governed by a BSD-style license
 # that can be found in the LICENSE file at the root of the
 # Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/tests/TestTimer/CMakeLists.txt
+++ b/src/tests/TestTimer/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright 2019-2020 The Mumble Developers. All rights reserved.
+# Copyright 2020-2021 The Mumble Developers. All rights reserved.
 # Use of this source code is governed by a BSD-style license
 # that can be found in the LICENSE file at the root of the
 # Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/tests/TestTimer/TestTimer.cpp
+++ b/src/tests/TestTimer/TestTimer.cpp
@@ -1,4 +1,4 @@
-// Copyright 2007-2021 The Mumble Developers. All rights reserved.
+// Copyright 2017-2021 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/tests/TestUnresolvedServerAddress/CMakeLists.txt
+++ b/src/tests/TestUnresolvedServerAddress/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright 2019-2020 The Mumble Developers. All rights reserved.
+# Copyright 2020-2021 The Mumble Developers. All rights reserved.
 # Use of this source code is governed by a BSD-style license
 # that can be found in the LICENSE file at the root of the
 # Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/tests/TestXMLTools/CMakeLists.txt
+++ b/src/tests/TestXMLTools/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright 2019-2020 The Mumble Developers. All rights reserved.
+# Copyright 2020-2021 The Mumble Developers. All rights reserved.
 # Use of this source code is governed by a BSD-style license
 # that can be found in the LICENSE file at the root of the
 # Mumble source tree or at <https://www.mumble.info/LICENSE>.


### PR DESCRIPTION
Apparently the first commit (59ae429972c16c377135bcccfee646b7df446933)
did not include all files.


### Checks

- [x] My commits follow the [commit guidelines](https://github.com/mumble-voip/mumble/blob/master/COMMIT_GUIDELINES.md)

