### PR TITLE
CHANGE(server): Allow spaces in username by default

### DIFF
--- a/src/murmur/Messages.cpp
+++ b/src/murmur/Messages.cpp
@@ -180,7 +180,7 @@ void Server::msgAuthenticate(ServerUser *uSource, MumbleProto::Authenticate &msg
 	Channel *root = qhChannels.value(0);
 	Channel *c;
 
-	uSource->qsName = u8(msg.username());
+	uSource->qsName = u8(msg.username()).trimmed();
 
 	bool ok     = false;
 	bool nameok = validateUserName(uSource->qsName);
@@ -1939,7 +1939,7 @@ void Server::msgUserList(ServerUser *uSource, MumbleProto::UserList &msg) {
 				log(uSource, QString::fromLatin1("Unregistered user %1").arg(id));
 				unregisterUser(id);
 			} else {
-				const QString &name = u8(user.name());
+				const QString &name = u8(user.name()).trimmed();
 				if (validateUserName(name)) {
 					log(uSource, QString::fromLatin1("Renamed user %1 to '%2'").arg(QString::number(id), name));
 

--- a/src/murmur/Meta.cpp
+++ b/src/murmur/Meta.cpp
@@ -98,8 +98,8 @@ MetaParams::MetaParams() {
 	iChannelNestingLimit = 10;
 	iChannelCountLimit   = 1000;
 
-	qrUserName    = QRegExp(QLatin1String("[-=\\w\\[\\]\\{\\}\\(\\)\\@\\|\\.]+"));
-	qrChannelName = QRegExp(QLatin1String("[ \\-=\\w\\#\\[\\]\\{\\}\\(\\)\\@\\|]+"));
+	qrUserName    = QRegExp(QLatin1String("[ -=\\w\\[\\]\\{\\}\\(\\)\\@\\|\\.]+"));
+	qrChannelName = QRegExp(QLatin1String("[ -=\\w\\#\\[\\]\\{\\}\\(\\)\\@\\|]+"));
 
 	iMessageLimit = 1;
 	iMessageBurst = 5;

--- a/src/murmur/Server.cpp
+++ b/src/murmur/Server.cpp
@@ -2092,7 +2092,9 @@ QString Server::addressToString(const QHostAddress &adr, unsigned short port) {
 }
 
 bool Server::validateUserName(const QString &name) {
-	return (qrUserName.exactMatch(name) && (name.length() <= 512));
+	// We expect the name passed to this function to be fully trimmed already. This way we
+	// prevent "empty" names (at least with the default username restriction).
+	return (name.trimmed().length() == name.length() && qrUserName.exactMatch(name) && (name.length() <= 512));
 }
 
 bool Server::validateChannelName(const QString &name) {


### PR DESCRIPTION
The first commits in this PR deal with making sure that usernames
will only be used in a trimmed version, so that the allowance of spaces
in usernames will not allow for "empty" (pure whitespace) names.

Fixes #1202

### Checks

- [x] My commits follow the [commit guidelines](https://github.com/mumble-voip/mumble/blob/master/COMMIT_GUIDELINES.md)

