### PR TITLE
FEAT(client): Implement a mute cue

### DIFF
--- a/src/mumble/AudioConfigDialog.cpp
+++ b/src/mumble/AudioConfigDialog.cpp
@@ -113,6 +113,7 @@ AudioInputDialog::AudioInputDialog(Settings &st) : ConfigWidget(st) {
 	qcbDevice->view()->setTextElideMode(Qt::ElideRight);
 
 	on_qcbPushClick_clicked(Global::get().s.bTxAudioCue);
+	on_qcbMuteCue_clicked(Global::get().s.bTxMuteCue);
 	on_Tick_timeout();
 	on_qcbIdleAction_currentIndexChanged(Global::get().s.iaeIdleAction);
 
@@ -156,6 +157,7 @@ void AudioInputDialog::load(const Settings &r) {
 
 	qlePushClickPathOn->setText(r.qsTxAudioCueOn);
 	qlePushClickPathOff->setText(r.qsTxAudioCueOff);
+	qleMuteCuePath->setText(r.qsTxMuteCue);
 
 	loadComboBox(qcbTransmit, r.atTransmit);
 	loadSlider(qsTransmitHold, r.iVoiceHold);
@@ -172,6 +174,7 @@ void AudioInputDialog::load(const Settings &r) {
 
 	loadCheckBox(qcbPushWindow, r.bShowPTTButtonWindow);
 	loadCheckBox(qcbPushClick, r.bTxAudioCue);
+	loadCheckBox(qcbMuteCue, r.bTxMuteCue);
 	loadSlider(qsQuality, r.iQuality);
 	loadCheckBox(qcbAllowLowDelay, r.bAllowLowDelay);
 	if (r.iSpeexNoiseCancelStrength != 0) {
@@ -296,6 +299,9 @@ void AudioInputDialog::save() const {
 	s.bTxAudioCue          = qcbPushClick->isChecked();
 	s.qsTxAudioCueOn       = qlePushClickPathOn->text();
 	s.qsTxAudioCueOff      = qlePushClickPathOff->text();
+
+	s.bTxMuteCue  = qcbMuteCue->isChecked();
+	s.qsTxMuteCue = qleMuteCuePath->text();
 
 	s.qsAudioInput    = qcbSystem->currentText();
 	s.echoOption      = static_cast< EchoCancelOptionID >(qcbEcho->currentData().toInt());
@@ -440,6 +446,26 @@ void AudioInputDialog::on_qpbPushClickPreview_clicked() {
 		else // If we fail to playback the first play on play at least off
 			ao->playSample(qlePushClickPathOff->text());
 	}
+}
+
+void AudioInputDialog::on_qcbMuteCue_clicked(bool b) {
+	qleMuteCuePath->setEnabled(b);
+	qpbMuteCueBrowse->setEnabled(b);
+	qpbMuteCuePreview->setEnabled(b);
+}
+
+void AudioInputDialog::on_qpbMuteCueBrowse_clicked() {
+	QString defaultpath(qleMuteCuePath->text());
+	QString qsnew = AudioOutputSample::browseForSndfile(defaultpath);
+	if (!qsnew.isEmpty())
+		qleMuteCuePath->setText(qsnew);
+}
+
+
+void AudioInputDialog::on_qpbMuteCuePreview_clicked() {
+	AudioOutputPtr ao = Global::get().ao;
+	if (ao)
+		ao->playSample(qleMuteCuePath->text());
 }
 
 void AudioInputDialog::continuePlayback() {

--- a/src/mumble/AudioConfigDialog.h
+++ b/src/mumble/AudioConfigDialog.h
@@ -44,6 +44,10 @@ public slots:
 	void on_qpbPushClickPreview_clicked();
 	void on_qpbPushClickReset_clicked();
 
+	void on_qcbMuteCue_clicked(bool);
+	void on_qpbMuteCueBrowse_clicked();
+	void on_qpbMuteCuePreview_clicked();
+
 	void on_qsTransmitHold_valueChanged(int v);
 	void on_qsFrames_valueChanged(int v);
 	void on_qsQuality_valueChanged(int v);

--- a/src/mumble/AudioInput.h
+++ b/src/mumble/AudioInput.h
@@ -6,6 +6,7 @@
 #ifndef MUMBLE_MUMBLE_AUDIOINPUT_H_
 #define MUMBLE_MUMBLE_AUDIOINPUT_H_
 
+#include <QElapsedTimer>
 #include <QtCore/QObject>
 #include <QtCore/QThread>
 #include <boost/array.hpp>
@@ -193,6 +194,8 @@ private:
 	int encodeOpusFrame(short *source, int size, EncodingOutputBuffer &buffer);
 	int encodeCELTFrame(short *pSource, EncodingOutputBuffer &buffer);
 
+	QElapsedTimer qetLastMuteCue;
+
 protected:
 	MessageHandler::UDPMessageType umtType;
 	SampleFormat eMicFormat, eEchoFormat;
@@ -226,6 +229,9 @@ protected:
 	bool bAllowLowDelay;
 	/// Number of 10ms audio "frames" per packet (!= frames in packet)
 	int iAudioFrames;
+
+	/// The minimum time in ms that has to pass between the playback of two consecutive mute cues.
+	static constexpr unsigned int iMuteCueDelay = 5000;
 
 	float *pfMicInput;
 	float *pfEchoInput;

--- a/src/mumble/AudioInput.ui
+++ b/src/mumble/AudioInput.ui
@@ -772,26 +772,6 @@
       <string>Misc</string>
      </property>
      <layout class="QGridLayout" name="_2">
-      <item row="2" column="5">
-       <widget class="QPushButton" name="qpbPushClickBrowseOff">
-        <property name="toolTip">
-         <string>Browse for off audio file</string>
-        </property>
-        <property name="text">
-         <string>B&amp;rowse...</string>
-        </property>
-       </widget>
-      </item>
-      <item row="2" column="3">
-       <widget class="QLabel" name="qlPushClickOff">
-        <property name="text">
-         <string>Off</string>
-        </property>
-        <property name="alignment">
-         <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-        </property>
-       </widget>
-      </item>
       <item row="1" column="3">
        <widget class="QLabel" name="qlPushClickOn">
         <property name="text">
@@ -799,6 +779,20 @@
         </property>
         <property name="alignment">
          <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="4">
+       <widget class="QLineEdit" name="qlePushClickPathOn">
+        <property name="toolTip">
+         <string>Gets played when starting to transmit</string>
+        </property>
+       </widget>
+      </item>
+      <item row="4" column="0" colspan="2">
+       <widget class="QLabel" name="qliIdle">
+        <property name="text">
+         <string>Idle action</string>
         </property>
        </widget>
       </item>
@@ -815,36 +809,6 @@
         </property>
        </widget>
       </item>
-      <item row="2" column="6">
-       <widget class="QPushButton" name="qpbPushClickReset">
-        <property name="toolTip">
-         <string>Reset audio cue to default</string>
-        </property>
-        <property name="whatsThis">
-         <string>&lt;b&gt;Reset&lt;/b&gt;&lt;br/&gt;Reset the paths for the files to their default.</string>
-        </property>
-        <property name="text">
-         <string>R&amp;eset</string>
-        </property>
-       </widget>
-      </item>
-      <item row="1" column="5">
-       <widget class="QPushButton" name="qpbPushClickBrowseOn">
-        <property name="toolTip">
-         <string>Browse for on audio file</string>
-        </property>
-        <property name="text">
-         <string>&amp;Browse...</string>
-        </property>
-       </widget>
-      </item>
-      <item row="1" column="4">
-       <widget class="QLineEdit" name="qlePushClickPathOn">
-        <property name="toolTip">
-         <string>Gets played when starting to transmit</string>
-        </property>
-       </widget>
-      </item>
       <item row="2" column="4">
        <widget class="QLineEdit" name="qlePushClickPathOff">
         <property name="toolTip">
@@ -852,37 +816,7 @@
         </property>
        </widget>
       </item>
-      <item row="1" column="0">
-       <widget class="QCheckBox" name="qcbPushClick">
-        <property name="toolTip">
-         <string>Audible audio cue when starting or stopping to transmit</string>
-        </property>
-        <property name="whatsThis">
-         <string>&lt;b&gt;This enables transmission audio cues.&lt;/b&gt;&lt;br /&gt;Setting this will give you a short audio beep when you start and stop transmitting.</string>
-        </property>
-        <property name="text">
-         <string>Audio cue</string>
-        </property>
-       </widget>
-      </item>
-      <item row="3" column="0" colspan="2">
-       <widget class="QLabel" name="qliIdle">
-        <property name="text">
-         <string>Idle action</string>
-        </property>
-       </widget>
-      </item>
       <item row="4" column="4">
-       <widget class="QCheckBox" name="qcbUndoIdleAction">
-        <property name="toolTip">
-         <string>The idle action will be reversed upon any key or mouse button input</string>
-        </property>
-        <property name="text">
-         <string>Undo Idle action upon activity</string>
-        </property>
-       </widget>
-      </item>
-      <item row="3" column="4">
        <layout class="QHBoxLayout" name="horizontalLayout">
         <item>
          <widget class="QSpinBox" name="qsbIdle">
@@ -944,10 +878,100 @@
         </item>
        </layout>
       </item>
-      <item row="3" column="3">
+      <item row="1" column="0">
+       <widget class="QCheckBox" name="qcbPushClick">
+        <property name="toolTip">
+         <string>Audible audio cue when starting or stopping to transmit</string>
+        </property>
+        <property name="whatsThis">
+         <string>&lt;b&gt;This enables transmission audio cues.&lt;/b&gt;&lt;br /&gt;Setting this will give you a short audio beep when you start and stop transmitting.</string>
+        </property>
+        <property name="text">
+         <string>Audio cue</string>
+        </property>
+       </widget>
+      </item>
+      <item row="5" column="4">
+       <widget class="QCheckBox" name="qcbUndoIdleAction">
+        <property name="toolTip">
+         <string>The idle action will be reversed upon any key or mouse button input</string>
+        </property>
+        <property name="text">
+         <string>Undo Idle action upon activity</string>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="3">
+       <widget class="QLabel" name="qlPushClickOff">
+        <property name="text">
+         <string>Off</string>
+        </property>
+        <property name="alignment">
+         <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="5">
+       <widget class="QPushButton" name="qpbPushClickBrowseOff">
+        <property name="toolTip">
+         <string>Browse for off audio file</string>
+        </property>
+        <property name="text">
+         <string>B&amp;rowse...</string>
+        </property>
+       </widget>
+      </item>
+      <item row="4" column="3">
        <widget class="QLabel" name="qlIdle2">
         <property name="text">
          <string>after</string>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="6">
+       <widget class="QPushButton" name="qpbPushClickReset">
+        <property name="toolTip">
+         <string>Reset audio cue to default</string>
+        </property>
+        <property name="whatsThis">
+         <string>&lt;b&gt;Reset&lt;/b&gt;&lt;br/&gt;Reset the paths for the files to their default.</string>
+        </property>
+        <property name="text">
+         <string>R&amp;eset</string>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="5">
+       <widget class="QPushButton" name="qpbPushClickBrowseOn">
+        <property name="toolTip">
+         <string>Browse for on audio file</string>
+        </property>
+        <property name="text">
+         <string>&amp;Browse...</string>
+        </property>
+       </widget>
+      </item>
+      <item row="3" column="0">
+       <widget class="QCheckBox" name="qcbMuteCue">
+        <property name="text">
+         <string>Mute cue</string>
+        </property>
+       </widget>
+      </item>
+      <item row="3" column="4">
+       <widget class="QLineEdit" name="qleMuteCuePath"/>
+      </item>
+      <item row="3" column="5">
+       <widget class="QPushButton" name="qpbMuteCueBrowse">
+        <property name="text">
+         <string>Br&amp;owse...</string>
+        </property>
+       </widget>
+      </item>
+      <item row="3" column="6">
+       <widget class="QPushButton" name="qpbMuteCuePreview">
+        <property name="text">
+         <string>Pre&amp;view</string>
         </property>
        </widget>
       </item>

--- a/src/mumble/Settings.cpp
+++ b/src/mumble/Settings.cpp
@@ -162,6 +162,8 @@ QDataStream &operator>>(QDataStream &qds, ShortcutTarget &st) {
 const QString Settings::cqsDefaultPushClickOn  = QLatin1String(":/on.ogg");
 const QString Settings::cqsDefaultPushClickOff = QLatin1String(":/off.ogg");
 
+const QString Settings::cqsDefaultMuteCue = QLatin1String(":/off.ogg");
+
 OverlaySettings::OverlaySettings() {
 	bEnable = false;
 
@@ -335,6 +337,9 @@ Settings::Settings() {
 	bTxAudioCue     = false;
 	qsTxAudioCueOn  = cqsDefaultPushClickOn;
 	qsTxAudioCueOff = cqsDefaultPushClickOff;
+
+	bTxMuteCue  = true;
+	qsTxMuteCue = cqsDefaultMuteCue;
 
 	bUserTop = true;
 
@@ -718,6 +723,8 @@ void Settings::load(QSettings *settings_ptr) {
 	LOAD(bTxAudioCue, "audio/pushclick");
 	LOAD(qsTxAudioCueOn, "audio/pushclickon");
 	LOAD(qsTxAudioCueOff, "audio/pushclickoff");
+	LOAD(bTxMuteCue, "audio/mutecue");
+	LOAD(qsTxMuteCue, "audio/mutecuepath");
 	LOAD(iQuality, "audio/quality");
 	LOAD(iMinLoudness, "audio/loudness");
 	LOAD(fVolume, "audio/volume");
@@ -1157,6 +1164,8 @@ void Settings::save() {
 	SAVE(bTxAudioCue, "audio/pushclick");
 	SAVE(qsTxAudioCueOn, "audio/pushclickon");
 	SAVE(qsTxAudioCueOff, "audio/pushclickoff");
+	SAVE(bTxMuteCue, "audio/mutecue");
+	SAVE(qsTxMuteCue, "audio/mutecuepath");
 	SAVE(iQuality, "audio/quality");
 	SAVE(iMinLoudness, "audio/loudness");
 	SAVE(fVolume, "audio/volume");

--- a/src/mumble/Settings.h
+++ b/src/mumble/Settings.h
@@ -176,6 +176,10 @@ struct Settings {
 	QString qsTxAudioCueOn;
 	QString qsTxAudioCueOff;
 
+	bool bTxMuteCue;
+	static const QString cqsDefaultMuteCue;
+	QString qsTxMuteCue;
+
 	bool bTransmitPosition;
 	bool bMute, bDeaf;
 	bool bTTS;

--- a/src/mumble/mumble_ar.ts
+++ b/src/mumble/mumble_ar.ts
@@ -1016,6 +1016,18 @@ This value allows you to set the maximum number of users allowed in the channel.
         <source>Speex suppression strength</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Mute cue</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Br&amp;owse...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Pre&amp;view</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AudioInputDialog</name>

--- a/src/mumble/mumble_bg.ts
+++ b/src/mumble/mumble_bg.ts
@@ -1017,6 +1017,18 @@ This value allows you to set the maximum number of users allowed in the channel.
         <source>Speex suppression strength</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Mute cue</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Br&amp;owse...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Pre&amp;view</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AudioInputDialog</name>

--- a/src/mumble/mumble_br.ts
+++ b/src/mumble/mumble_br.ts
@@ -1016,6 +1016,18 @@ This value allows you to set the maximum number of users allowed in the channel.
         <source>Speex suppression strength</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Mute cue</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Br&amp;owse...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Pre&amp;view</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AudioInputDialog</name>

--- a/src/mumble/mumble_ca.ts
+++ b/src/mumble/mumble_ca.ts
@@ -1022,6 +1022,18 @@ This value allows you to set the maximum number of users allowed in the channel.
         <source>Speex suppression strength</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Mute cue</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Br&amp;owse...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Pre&amp;view</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AudioInputDialog</name>

--- a/src/mumble/mumble_cs.ts
+++ b/src/mumble/mumble_cs.ts
@@ -1024,6 +1024,18 @@ Tato hodnota Vám umožňuje nastavit maximální počet povolených uživatelů
         <source>Speex suppression strength</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Mute cue</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Br&amp;owse...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Pre&amp;view</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AudioInputDialog</name>

--- a/src/mumble/mumble_cy.ts
+++ b/src/mumble/mumble_cy.ts
@@ -1017,6 +1017,18 @@ This value allows you to set the maximum number of users allowed in the channel.
         <source>Speex suppression strength</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Mute cue</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Br&amp;owse...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Pre&amp;view</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AudioInputDialog</name>

--- a/src/mumble/mumble_da.ts
+++ b/src/mumble/mumble_da.ts
@@ -1023,6 +1023,18 @@ This value allows you to set the maximum number of users allowed in the channel.
         <source>Speex suppression strength</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Mute cue</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Br&amp;owse...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Pre&amp;view</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AudioInputDialog</name>

--- a/src/mumble/mumble_de.ts
+++ b/src/mumble/mumble_de.ts
@@ -1025,6 +1025,18 @@ Zum Beispiel wäre für die Audigy 2 ZS &apos;&lt;i&gt;Mic L&lt;/i&gt;&apos; ein
         <source>Speex suppression strength</source>
         <translation>Speex Unterdrückungsstärke</translation>
     </message>
+    <message>
+        <source>Mute cue</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Br&amp;owse...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Pre&amp;view</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AudioInputDialog</name>

--- a/src/mumble/mumble_el.ts
+++ b/src/mumble/mumble_el.ts
@@ -1027,6 +1027,18 @@ This value allows you to set the maximum number of users allowed in the channel.
         <source>Speex suppression strength</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Mute cue</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Br&amp;owse...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Pre&amp;view</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AudioInputDialog</name>

--- a/src/mumble/mumble_en.ts
+++ b/src/mumble/mumble_en.ts
@@ -1016,6 +1016,18 @@ This value allows you to set the maximum number of users allowed in the channel.
         <source>Speex suppression strength</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Mute cue</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Br&amp;owse...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Pre&amp;view</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AudioInputDialog</name>

--- a/src/mumble/mumble_en_GB.ts
+++ b/src/mumble/mumble_en_GB.ts
@@ -1024,6 +1024,18 @@ This value allows you to set the maximum number of users allowed in the channel.
         <source>Speex suppression strength</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Mute cue</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Br&amp;owse...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Pre&amp;view</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AudioInputDialog</name>

--- a/src/mumble/mumble_eo.ts
+++ b/src/mumble/mumble_eo.ts
@@ -1021,6 +1021,18 @@ This value allows you to set the maximum number of users allowed in the channel.
         <source>Speex suppression strength</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Mute cue</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Br&amp;owse...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Pre&amp;view</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AudioInputDialog</name>

--- a/src/mumble/mumble_es.ts
+++ b/src/mumble/mumble_es.ts
@@ -1024,6 +1024,18 @@ Este valor permite fijar el número máximo de usuarios permitidos en el canal. 
         <source>Speex suppression strength</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Mute cue</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Br&amp;owse...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Pre&amp;view</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AudioInputDialog</name>

--- a/src/mumble/mumble_et.ts
+++ b/src/mumble/mumble_et.ts
@@ -1017,6 +1017,18 @@ This value allows you to set the maximum number of users allowed in the channel.
         <source>Speex suppression strength</source>
         <translation>Speex mürasummutuse tugevus</translation>
     </message>
+    <message>
+        <source>Mute cue</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Br&amp;owse...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Pre&amp;view</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AudioInputDialog</name>

--- a/src/mumble/mumble_eu.ts
+++ b/src/mumble/mumble_eu.ts
@@ -1026,6 +1026,18 @@ This value allows you to set the maximum number of users allowed in the channel.
         <source>Speex suppression strength</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Mute cue</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Br&amp;owse...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Pre&amp;view</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AudioInputDialog</name>

--- a/src/mumble/mumble_fa_IR.ts
+++ b/src/mumble/mumble_fa_IR.ts
@@ -1016,6 +1016,18 @@ This value allows you to set the maximum number of users allowed in the channel.
         <source>Speex suppression strength</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Mute cue</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Br&amp;owse...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Pre&amp;view</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AudioInputDialog</name>

--- a/src/mumble/mumble_fi.ts
+++ b/src/mumble/mumble_fi.ts
@@ -1025,6 +1025,18 @@ määritellyssä ajassa, lukitaan se päälle. Mumble jatkaa puheen lähettämis
         <source>Speex suppression strength</source>
         <translation>Speex vaimennuksen voimakkuus</translation>
     </message>
+    <message>
+        <source>Mute cue</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Br&amp;owse...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Pre&amp;view</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AudioInputDialog</name>

--- a/src/mumble/mumble_fr.ts
+++ b/src/mumble/mumble_fr.ts
@@ -1024,6 +1024,18 @@ Cette valeur vous permet de définir un nombre maximum d&apos;utilisateurs autor
         <source>Speex suppression strength</source>
         <translation>Puissance de suppression de Speex</translation>
     </message>
+    <message>
+        <source>Mute cue</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Br&amp;owse...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Pre&amp;view</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AudioInputDialog</name>

--- a/src/mumble/mumble_gl.ts
+++ b/src/mumble/mumble_gl.ts
@@ -1018,6 +1018,18 @@ This value allows you to set the maximum number of users allowed in the channel.
         <source>Speex suppression strength</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Mute cue</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Br&amp;owse...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Pre&amp;view</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AudioInputDialog</name>

--- a/src/mumble/mumble_he.ts
+++ b/src/mumble/mumble_he.ts
@@ -1025,6 +1025,18 @@ This value allows you to set the maximum number of users allowed in the channel.
         <source>Speex suppression strength</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Mute cue</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Br&amp;owse...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Pre&amp;view</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AudioInputDialog</name>

--- a/src/mumble/mumble_hu.ts
+++ b/src/mumble/mumble_hu.ts
@@ -1020,6 +1020,18 @@ This value allows you to set the maximum number of users allowed in the channel.
         <source>Speex suppression strength</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Mute cue</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Br&amp;owse...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Pre&amp;view</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AudioInputDialog</name>

--- a/src/mumble/mumble_it.ts
+++ b/src/mumble/mumble_it.ts
@@ -1024,6 +1024,18 @@ Questo valore ti permette di impostare il numero massimo di utenti consentiti ne
         <source>Speex suppression strength</source>
         <translation>Intensità riduzione rumore Speex</translation>
     </message>
+    <message>
+        <source>Mute cue</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Br&amp;owse...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Pre&amp;view</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AudioInputDialog</name>

--- a/src/mumble/mumble_ja.ts
+++ b/src/mumble/mumble_ja.ts
@@ -1024,6 +1024,18 @@ This value allows you to set the maximum number of users allowed in the channel.
         <source>Speex suppression strength</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Mute cue</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Br&amp;owse...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Pre&amp;view</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AudioInputDialog</name>

--- a/src/mumble/mumble_ko.ts
+++ b/src/mumble/mumble_ko.ts
@@ -1023,6 +1023,18 @@ This value allows you to set the maximum number of users allowed in the channel.
         <source>Speex suppression strength</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Mute cue</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Br&amp;owse...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Pre&amp;view</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AudioInputDialog</name>

--- a/src/mumble/mumble_lt.ts
+++ b/src/mumble/mumble_lt.ts
@@ -1018,6 +1018,18 @@ This value allows you to set the maximum number of users allowed in the channel.
         <source>Speex suppression strength</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Mute cue</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Br&amp;owse...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Pre&amp;view</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AudioInputDialog</name>

--- a/src/mumble/mumble_nl.ts
+++ b/src/mumble/mumble_nl.ts
@@ -1024,6 +1024,18 @@ Deze waarde laat je toe om een maximum aantal gebruikers in te stellen voor het 
         <source>Speex suppression strength</source>
         <translation>Speex-onderdrukkingssterkte</translation>
     </message>
+    <message>
+        <source>Mute cue</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Br&amp;owse...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Pre&amp;view</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AudioInputDialog</name>

--- a/src/mumble/mumble_no.ts
+++ b/src/mumble/mumble_no.ts
@@ -1024,6 +1024,18 @@ Denne verdien gjør at du setter maksimalt antall brukere tillatt i kanalen. Hvi
         <source>Speex suppression strength</source>
         <translation>Speex-undertrykkingsstyrke</translation>
     </message>
+    <message>
+        <source>Mute cue</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Br&amp;owse...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Pre&amp;view</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AudioInputDialog</name>

--- a/src/mumble/mumble_oc.ts
+++ b/src/mumble/mumble_oc.ts
@@ -1017,6 +1017,18 @@ This value allows you to set the maximum number of users allowed in the channel.
         <source>Speex suppression strength</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Mute cue</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Br&amp;owse...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Pre&amp;view</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AudioInputDialog</name>

--- a/src/mumble/mumble_pl.ts
+++ b/src/mumble/mumble_pl.ts
@@ -1024,6 +1024,18 @@ Określa maksymalną dozwoloną liczbę użytkowników na tym kanale. Jeżeli wa
         <source>Speex suppression strength</source>
         <translation>Siła tłumienia Speex</translation>
     </message>
+    <message>
+        <source>Mute cue</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Br&amp;owse...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Pre&amp;view</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AudioInputDialog</name>

--- a/src/mumble/mumble_pt_BR.ts
+++ b/src/mumble/mumble_pt_BR.ts
@@ -1024,6 +1024,18 @@ Este valor permite que você especifique o número máximo de usuárias permitid
         <source>Speex suppression strength</source>
         <translation>Intensidade da supressão Speex</translation>
     </message>
+    <message>
+        <source>Mute cue</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Br&amp;owse...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Pre&amp;view</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AudioInputDialog</name>

--- a/src/mumble/mumble_pt_PT.ts
+++ b/src/mumble/mumble_pt_PT.ts
@@ -1023,6 +1023,18 @@ Este valor permite definir o número máximo de utilizadores permitido no canal.
         <source>Speex suppression strength</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Mute cue</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Br&amp;owse...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Pre&amp;view</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AudioInputDialog</name>

--- a/src/mumble/mumble_ro.ts
+++ b/src/mumble/mumble_ro.ts
@@ -1020,6 +1020,18 @@ This value allows you to set the maximum number of users allowed in the channel.
         <source>Speex suppression strength</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Mute cue</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Br&amp;owse...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Pre&amp;view</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AudioInputDialog</name>

--- a/src/mumble/mumble_ru.ts
+++ b/src/mumble/mumble_ru.ts
@@ -1019,6 +1019,18 @@ This value allows you to set the maximum number of users allowed in the channel.
         <source>Speex suppression strength</source>
         <translation>Сила шумоподавления Speex</translation>
     </message>
+    <message>
+        <source>Mute cue</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Br&amp;owse...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Pre&amp;view</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AudioInputDialog</name>

--- a/src/mumble/mumble_si.ts
+++ b/src/mumble/mumble_si.ts
@@ -1012,6 +1012,18 @@ Contains the list of members inherited by the current channel. Uncheck &lt;i&gt;
         <source>Server maximum network bandwidth is only %1 kbit/s. Audio quality auto-adjusted to %2 kbit/s (%3 ms)</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Mute cue</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Br&amp;owse...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Pre&amp;view</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AudioInputDialog</name>

--- a/src/mumble/mumble_sv.ts
+++ b/src/mumble/mumble_sv.ts
@@ -1024,6 +1024,18 @@ Det värdet tillåter dig att ställa in ett maximalt antal av användare som ä
         <source>Speex suppression strength</source>
         <translation>Speex reduceringsstyrka</translation>
     </message>
+    <message>
+        <source>Mute cue</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Br&amp;owse...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Pre&amp;view</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AudioInputDialog</name>

--- a/src/mumble/mumble_te.ts
+++ b/src/mumble/mumble_te.ts
@@ -1022,6 +1022,18 @@ This value allows you to set the maximum number of users allowed in the channel.
         <source>Speex suppression strength</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Mute cue</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Br&amp;owse...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Pre&amp;view</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AudioInputDialog</name>

--- a/src/mumble/mumble_th.ts
+++ b/src/mumble/mumble_th.ts
@@ -1016,6 +1016,18 @@ This value allows you to set the maximum number of users allowed in the channel.
         <source>Speex suppression strength</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Mute cue</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Br&amp;owse...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Pre&amp;view</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AudioInputDialog</name>

--- a/src/mumble/mumble_tr.ts
+++ b/src/mumble/mumble_tr.ts
@@ -1024,6 +1024,18 @@ Bu değer kanalda izin verilen azami kullanıcı sayısını ayarlamanıza izin 
         <source>Speex suppression strength</source>
         <translation>Speex bastırma gücü</translation>
     </message>
+    <message>
+        <source>Mute cue</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Br&amp;owse...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Pre&amp;view</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AudioInputDialog</name>

--- a/src/mumble/mumble_uk.ts
+++ b/src/mumble/mumble_uk.ts
@@ -1016,6 +1016,18 @@ This value allows you to set the maximum number of users allowed in the channel.
         <source>Speex suppression strength</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Mute cue</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Br&amp;owse...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Pre&amp;view</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AudioInputDialog</name>

--- a/src/mumble/mumble_zh_CN.ts
+++ b/src/mumble/mumble_zh_CN.ts
@@ -1024,6 +1024,18 @@ This value allows you to set the maximum number of users allowed in the channel.
         <source>Speex suppression strength</source>
         <translation>Speex 抑制强度</translation>
     </message>
+    <message>
+        <source>Mute cue</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Br&amp;owse...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Pre&amp;view</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AudioInputDialog</name>

--- a/src/mumble/mumble_zh_HK.ts
+++ b/src/mumble/mumble_zh_HK.ts
@@ -1016,6 +1016,18 @@ This value allows you to set the maximum number of users allowed in the channel.
         <source>Speex suppression strength</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Mute cue</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Br&amp;owse...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Pre&amp;view</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AudioInputDialog</name>

--- a/src/mumble/mumble_zh_TW.ts
+++ b/src/mumble/mumble_zh_TW.ts
@@ -1019,6 +1019,18 @@ This value allows you to set the maximum number of users allowed in the channel.
         <source>Speex suppression strength</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Mute cue</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Br&amp;owse...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Pre&amp;view</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AudioInputDialog</name>


### PR DESCRIPTION
The mute cue is played when speech is detected while the local client is
muted. This reminds the user that they are still muted, which is
especially useful when the overlay/client indication is not available
(e.g. in full-screen games).

This currently reuses the existing "audio off" cue.

Implements #4866


### Checks

- [x] My commits follow the [commit guidelines](https://github.com/mumble-voip/mumble/blob/master/COMMIT_GUIDELINES.md)

