### PR TITLE
CI: Add check for source-code formatting

### DIFF
--- a/.github/workflows/check_commit_style.py
+++ b/.github/workflows/check_commit_style.py
@@ -25,7 +25,7 @@ def main():
         cmd(["git", "remote", "add", remoteName, "https://github.com/mumble-voip/mumble.git"])
 
         # Fetch remote
-        cmd(["git", "fetch", remoteName])
+        cmd(["git", "fetch", "--no-recurse-submodules", remoteName])
 
         # get new commits
         commitHashes = [x for x in cmd(["git", "rev-list", "{}/master..HEAD".format(remoteName)]).split("\n") if x]

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -29,3 +29,20 @@ jobs:
       uses: erclu/check-crlf@v1
       with:
           exclude: '3rdparty/'
+
+    - uses: ./.github/actions/install-dependencies
+      with:
+          type: shared
+          os: ubuntu-20.04
+          arch: 64bit
+
+    - name: Generate compile-command DB
+      run: mkdir build; cd build; cmake -DCMAKE_EXPORT_COMPILE_COMMANDS=ON ..; cd ..; ln -s build/compile_commands.json .
+      shell: bash
+
+    - name: Check code formatting
+      uses: jidicula/clang-format-action@v3.3.0
+      with:
+          clang-format-version: '10'
+          check-path: '.'
+          exclude-regex: '(3rdparty/*|build/*)'

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -1,9 +1,9 @@
-name: Checks
+name: PR-Checks
 
 on: [pull_request]
 
 jobs:
-  commit-check:
+  pr-checks:
     runs-on: ubuntu-20.04
 
     steps:

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -17,7 +17,7 @@ jobs:
           # Assume that there are not >200 new commits that need checking
           fetch-depth: 200
           # Don't checkout submodules
-          submodules: 'false'
+          submodules: 'recursive'
           # Don't create a merge commit
           ref: ${{ github.event.pull_request.head.sha }}
 
@@ -27,3 +27,5 @@ jobs:
 
     - name: Check line endings
       uses: erclu/check-crlf@v1
+      with:
+          exclude: '3rdparty/'


### PR DESCRIPTION
This is to make sure that new patches will actually follow the code
formatting rules that we set up. The used check will make the CI fail if
that was not the case.


### Checks

- [x] My commits follow the [commit guidelines](https://github.com/mumble-voip/mumble/blob/master/COMMIT_GUIDELINES.md)

