### PR TITLE
FEAT(client): Implement raw input, get rid of hooks and DirectInput (Windows)

### DIFF
--- a/src/mumble/CMakeLists.txt
+++ b/src/mumble/CMakeLists.txt
@@ -533,8 +533,8 @@ if(WIN32)
 	target_link_libraries(mumble
 		PRIVATE
 			dbghelp.lib
-			dinput8.lib
 			dxguid.lib
+			hid.lib
 			wintrust.lib
 	)
 else()

--- a/src/mumble/GlobalShortcut.cpp
+++ b/src/mumble/GlobalShortcut.cpp
@@ -686,7 +686,6 @@ void GlobalShortcutConfig::load(const Settings &r) {
 	}
 
 	qcbEnableUIAccess->setChecked(r.bEnableUIAccess);
-	qcbEnableWinHooks->setChecked(r.bEnableWinHooks);
 	qcbEnableGKey->setChecked(r.bEnableGKey);
 	qcbEnableXboxInput->setChecked(r.bEnableXboxInput);
 
@@ -702,17 +701,13 @@ void GlobalShortcutConfig::save() const {
 	bool oldUIAccess  = s.bEnableUIAccess;
 	s.bEnableUIAccess = qcbEnableUIAccess->checkState() == Qt::Checked;
 
-	bool oldWinHooks  = s.bEnableWinHooks;
-	s.bEnableWinHooks = qcbEnableWinHooks->checkState() == Qt::Checked;
-
 	bool oldGKey  = s.bEnableGKey;
 	s.bEnableGKey = qcbEnableGKey->checkState() == Qt::Checked;
 
 	bool oldXboxInput  = s.bEnableXboxInput;
 	s.bEnableXboxInput = qcbEnableXboxInput->checkState() == Qt::Checked;
 
-	if (s.bEnableUIAccess != oldUIAccess || s.bEnableWinHooks != oldWinHooks || s.bEnableGKey != oldGKey
-		|| s.bEnableXboxInput != oldXboxInput) {
+	if (s.bEnableUIAccess != oldUIAccess || s.bEnableGKey != oldGKey || s.bEnableXboxInput != oldXboxInput) {
 		s.requireRestartToApply = true;
 	}
 }

--- a/src/mumble/GlobalShortcut.ui
+++ b/src/mumble/GlobalShortcut.ui
@@ -127,11 +127,11 @@
           <property name="uniformRowHeights">
            <bool>true</bool>
           </property>
-          <attribute name="headerDefaultSectionSize">
-           <number>100</number>
-          </attribute>
           <attribute name="headerMinimumSectionSize">
            <number>50</number>
+          </attribute>
+          <attribute name="headerDefaultSectionSize">
+           <number>100</number>
           </attribute>
           <attribute name="headerStretchLastSection">
            <bool>false</bool>
@@ -224,16 +224,6 @@ Without this option enabled, using Mumble's global shortcuts in privileged appli
            </property>
            <property name="text">
             <string>Enable shortcuts in privileged applications</string>
-           </property>
-          </widget>
-         </item>
-         <item>
-          <widget class="QCheckBox" name="qcbEnableWinHooks">
-           <property name="whatsThis">
-            <string>&lt;b&gt;Enable Windows hooks&lt;/b&gt;.&lt;br /&gt;This enables the Windows hooks shortcut engine. Using this engine allows Mumble to suppress keypresses and mouse clicks.</string>
-           </property>
-           <property name="text">
-            <string>Enable Windows hooks</string>
            </property>
           </widget>
          </item>

--- a/src/mumble/Settings.cpp
+++ b/src/mumble/Settings.cpp
@@ -516,8 +516,6 @@ Settings::Settings() {
 	bEnableXInput2              = true;
 	bEnableGKey                 = false;
 	bEnableXboxInput            = true;
-	bEnableWinHooks             = true;
-	bDirectInputVerboseLogging  = false;
 	bEnableUIAccess             = true;
 
 	for (int i = Log::firstMsgType; i <= Log::lastMsgType; ++i) {
@@ -975,8 +973,6 @@ void Settings::load(QSettings *settings_ptr) {
 	LOAD(bEnableXInput2, "shortcut/x11/xinput2/enable");
 	LOAD(bEnableGKey, "shortcut/gkey");
 	LOAD(bEnableXboxInput, "shortcut/windows/xbox/enable");
-	LOAD(bEnableWinHooks, "winhooks");
-	LOAD(bDirectInputVerboseLogging, "shortcut/windows/directinput/verboselogging");
 	LOAD(bEnableUIAccess, "shortcut/windows/uiaccess/enable");
 
 	int nshorts = settings_ptr->beginReadArray(QLatin1String("shortcuts"));
@@ -1371,8 +1367,6 @@ void Settings::save() {
 	SAVE(bEnableXInput2, "shortcut/x11/xinput2/enable");
 	SAVE(bEnableGKey, "shortcut/gkey");
 	SAVE(bEnableXboxInput, "shortcut/windows/xbox/enable");
-	SAVE(bEnableWinHooks, "winhooks");
-	SAVE(bDirectInputVerboseLogging, "shortcut/windows/directinput/verboselogging");
 	SAVE(bEnableUIAccess, "shortcut/windows/uiaccess/enable");
 
 	settings_ptr->beginWriteArray(QLatin1String("shortcuts"));

--- a/src/mumble/Settings.h
+++ b/src/mumble/Settings.h
@@ -284,11 +284,8 @@ struct Settings {
 	bool bEnableXInput2;
 	bool bEnableGKey;
 	bool bEnableXboxInput;
-	bool bEnableWinHooks;
-	/// Enable verbose logging in GlobalShortcutWin's DirectInput backend.
-	bool bDirectInputVerboseLogging;
-	/// Enable use of UIAccess (Windows's UI automation feature). This allows
-	/// Mumble greater access to global shortcuts.
+	/// Enable use of UIAccess (Windows's UI automation feature). This allows Mumble to receive WM_INPUT messages when
+	/// an application with elevated privileges is in foreground.
 	bool bEnableUIAccess;
 	QList< Shortcut > qlShortcuts;
 

--- a/src/mumble/main.cpp
+++ b/src/mumble/main.cpp
@@ -680,8 +680,8 @@ int main(int argc, char **argv) {
 
 #ifdef Q_OS_WIN
 	// Set mumble_mw_hwnd in os_win.cpp.
-	// Used by APIs in ASIOInput and GlobalShortcut_win that require a HWND.
-	mumble_mw_hwnd = GetForegroundWindow();
+	// Used in ASIOInput and GlobalShortcut_win by APIs that require a HWND.
+	mumble_mw_hwnd = reinterpret_cast< HWND >(Global::get().mw->winId());
 #endif
 
 #ifdef USE_DBUS

--- a/src/mumble/mumble_ar.ts
+++ b/src/mumble/mumble_ar.ts
@@ -3328,14 +3328,6 @@ Label of the server. This is what the server will be named like in your server l
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>&lt;b&gt;Enable Windows hooks&lt;/b&gt;.&lt;br /&gt;This enables the Windows hooks shortcut engine. Using this engine allows Mumble to suppress keypresses and mouse clicks.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Enable Windows hooks</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>&lt;b&gt;Enable GKey&lt;/b&gt;.&lt;br /&gt;This setting enables support for the GKey shortcut engine, for &quot;G&quot;-keys found on Logitech keyboards.</source>
         <translation type="unfinished"></translation>
     </message>

--- a/src/mumble/mumble_bg.ts
+++ b/src/mumble/mumble_bg.ts
@@ -3325,14 +3325,6 @@ Label of the server. This is what the server will be named like in your server l
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>&lt;b&gt;Enable Windows hooks&lt;/b&gt;.&lt;br /&gt;This enables the Windows hooks shortcut engine. Using this engine allows Mumble to suppress keypresses and mouse clicks.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Enable Windows hooks</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>&lt;b&gt;Enable GKey&lt;/b&gt;.&lt;br /&gt;This setting enables support for the GKey shortcut engine, for &quot;G&quot;-keys found on Logitech keyboards.</source>
         <translation type="unfinished"></translation>
     </message>

--- a/src/mumble/mumble_br.ts
+++ b/src/mumble/mumble_br.ts
@@ -3324,14 +3324,6 @@ Label of the server. This is what the server will be named like in your server l
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>&lt;b&gt;Enable Windows hooks&lt;/b&gt;.&lt;br /&gt;This enables the Windows hooks shortcut engine. Using this engine allows Mumble to suppress keypresses and mouse clicks.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Enable Windows hooks</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>&lt;b&gt;Enable GKey&lt;/b&gt;.&lt;br /&gt;This setting enables support for the GKey shortcut engine, for &quot;G&quot;-keys found on Logitech keyboards.</source>
         <translation type="unfinished"></translation>
     </message>

--- a/src/mumble/mumble_ca.ts
+++ b/src/mumble/mumble_ca.ts
@@ -3330,14 +3330,6 @@ Label of the server. This is what the server will be named like in your server l
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>&lt;b&gt;Enable Windows hooks&lt;/b&gt;.&lt;br /&gt;This enables the Windows hooks shortcut engine. Using this engine allows Mumble to suppress keypresses and mouse clicks.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Enable Windows hooks</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>&lt;b&gt;Enable GKey&lt;/b&gt;.&lt;br /&gt;This setting enables support for the GKey shortcut engine, for &quot;G&quot;-keys found on Logitech keyboards.</source>
         <translation type="unfinished"></translation>
     </message>

--- a/src/mumble/mumble_cs.ts
+++ b/src/mumble/mumble_cs.ts
@@ -3371,14 +3371,6 @@ Jmenovka serveru. Takto se bude server jmenovat ve Vašem seznamu serverů a mů
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>&lt;b&gt;Enable Windows hooks&lt;/b&gt;.&lt;br /&gt;This enables the Windows hooks shortcut engine. Using this engine allows Mumble to suppress keypresses and mouse clicks.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Enable Windows hooks</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>&lt;b&gt;Enable GKey&lt;/b&gt;.&lt;br /&gt;This setting enables support for the GKey shortcut engine, for &quot;G&quot;-keys found on Logitech keyboards.</source>
         <translation type="unfinished"></translation>
     </message>

--- a/src/mumble/mumble_cy.ts
+++ b/src/mumble/mumble_cy.ts
@@ -3328,14 +3328,6 @@ Label of the server. This is what the server will be named like in your server l
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>&lt;b&gt;Enable Windows hooks&lt;/b&gt;.&lt;br /&gt;This enables the Windows hooks shortcut engine. Using this engine allows Mumble to suppress keypresses and mouse clicks.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Enable Windows hooks</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>&lt;b&gt;Enable GKey&lt;/b&gt;.&lt;br /&gt;This setting enables support for the GKey shortcut engine, for &quot;G&quot;-keys found on Logitech keyboards.</source>
         <translation type="unfinished"></translation>
     </message>

--- a/src/mumble/mumble_da.ts
+++ b/src/mumble/mumble_da.ts
@@ -3369,14 +3369,6 @@ Etikette for serveren. Dette er, hvad serveren vil blive navngivet som i din ser
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>&lt;b&gt;Enable Windows hooks&lt;/b&gt;.&lt;br /&gt;This enables the Windows hooks shortcut engine. Using this engine allows Mumble to suppress keypresses and mouse clicks.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Enable Windows hooks</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>&lt;b&gt;Enable GKey&lt;/b&gt;.&lt;br /&gt;This setting enables support for the GKey shortcut engine, for &quot;G&quot;-keys found on Logitech keyboards.</source>
         <translation type="unfinished"></translation>
     </message>

--- a/src/mumble/mumble_de.ts
+++ b/src/mumble/mumble_de.ts
@@ -3420,14 +3420,6 @@ Der Absturz-Bericht enthält eine Teilkopie von Mumbles Speicher zum Zeitpunkt d
         <translation>Zusätzliche Verknüpfungen</translation>
     </message>
     <message>
-        <source>&lt;b&gt;Enable Windows hooks&lt;/b&gt;.&lt;br /&gt;This enables the Windows hooks shortcut engine. Using this engine allows Mumble to suppress keypresses and mouse clicks.</source>
-        <translation>&lt;b&gt;Windows Hooks Verknüpfungen aktivieren&lt;/b&gt;.&lt;br /&gt;Dies aktiviert den Windows-hooks Verknüpfungen. Mit dieser Aktion unterdrückt Mumble zu Tastendrücke und Mausklicks.</translation>
-    </message>
-    <message>
-        <source>Enable Windows hooks</source>
-        <translation>Windows hooks aktivieren</translation>
-    </message>
-    <message>
         <source>&lt;b&gt;Enable GKey&lt;/b&gt;.&lt;br /&gt;This setting enables support for the GKey shortcut engine, for &quot;G&quot;-keys found on Logitech keyboards.</source>
         <translation>&lt;b&gt;GKey aktivieren&lt;/b&gt;.&lt;br /&gt;Diese Einstellung ermöglicht die Unterstützung für GKey Verknüpfungen, die mit Logitech-Tastaturen bereitgestellt werden.</translation>
     </message>

--- a/src/mumble/mumble_el.ts
+++ b/src/mumble/mumble_el.ts
@@ -3373,14 +3373,6 @@ Label of the server. This is what the server will be named like in your server l
         <translation>Επιπλέον Μηχανές Συντομεύσεων</translation>
     </message>
     <message>
-        <source>&lt;b&gt;Enable Windows hooks&lt;/b&gt;.&lt;br /&gt;This enables the Windows hooks shortcut engine. Using this engine allows Mumble to suppress keypresses and mouse clicks.</source>
-        <translation>&lt;b&gt;Ενεργοποίηση των Windows hooks&lt;/b&gt;.&lt;br /&gt;Αυτό ενεργοποιεί τα hooks στο μηχανισμό συντομεύσεων των Windows. Χρησιμοποιώντας αυτόν τον μηχανισμό, επιτρέπται στο Mumble να καταστέλλει πατήματα πλήκτρων και κλικ του ποντικιού.</translation>
-    </message>
-    <message>
-        <source>Enable Windows hooks</source>
-        <translation>Ενεργοποίηση των hooks των Windows</translation>
-    </message>
-    <message>
         <source>&lt;b&gt;Enable GKey&lt;/b&gt;.&lt;br /&gt;This setting enables support for the GKey shortcut engine, for &quot;G&quot;-keys found on Logitech keyboards.</source>
         <translation>&lt;b&gt;Ενεργοποίηση του GKey&lt;/b&gt;.&lt;br /&gt;Αυτή η ρύθμιση παρέχει υποστήριξη για τη μηχανή συντομεύσεων GKey, για πλήκτρα &quot;G&quot; που βρίσκονται στα πληκτρολόγια Logitech.</translation>
     </message>

--- a/src/mumble/mumble_en.ts
+++ b/src/mumble/mumble_en.ts
@@ -3323,14 +3323,6 @@ Label of the server. This is what the server will be named like in your server l
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>&lt;b&gt;Enable Windows hooks&lt;/b&gt;.&lt;br /&gt;This enables the Windows hooks shortcut engine. Using this engine allows Mumble to suppress keypresses and mouse clicks.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Enable Windows hooks</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>&lt;b&gt;Enable GKey&lt;/b&gt;.&lt;br /&gt;This setting enables support for the GKey shortcut engine, for &quot;G&quot;-keys found on Logitech keyboards.</source>
         <translation type="unfinished"></translation>
     </message>

--- a/src/mumble/mumble_en_GB.ts
+++ b/src/mumble/mumble_en_GB.ts
@@ -3358,14 +3358,6 @@ Label of the server. This is what the server will be named like in your server l
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>&lt;b&gt;Enable Windows hooks&lt;/b&gt;.&lt;br /&gt;This enables the Windows hooks shortcut engine. Using this engine allows Mumble to suppress keypresses and mouse clicks.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Enable Windows hooks</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>&lt;b&gt;Enable GKey&lt;/b&gt;.&lt;br /&gt;This setting enables support for the GKey shortcut engine, for &quot;G&quot;-keys found on Logitech keyboards.</source>
         <translation type="unfinished"></translation>
     </message>

--- a/src/mumble/mumble_eo.ts
+++ b/src/mumble/mumble_eo.ts
@@ -3331,14 +3331,6 @@ Label of the server. This is what the server will be named like in your server l
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>&lt;b&gt;Enable Windows hooks&lt;/b&gt;.&lt;br /&gt;This enables the Windows hooks shortcut engine. Using this engine allows Mumble to suppress keypresses and mouse clicks.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Enable Windows hooks</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>&lt;b&gt;Enable GKey&lt;/b&gt;.&lt;br /&gt;This setting enables support for the GKey shortcut engine, for &quot;G&quot;-keys found on Logitech keyboards.</source>
         <translation type="unfinished"></translation>
     </message>

--- a/src/mumble/mumble_es.ts
+++ b/src/mumble/mumble_es.ts
@@ -3374,14 +3374,6 @@ Etiqueta de este servidor. Así es como se llamará el servidor en su lista del 
         <translation>Motor de métodos abreviados adicionales</translation>
     </message>
     <message>
-        <source>&lt;b&gt;Enable Windows hooks&lt;/b&gt;.&lt;br /&gt;This enables the Windows hooks shortcut engine. Using this engine allows Mumble to suppress keypresses and mouse clicks.</source>
-        <translation>&lt;b&gt;Habilitar los hooks de Windows&lt;/b&gt;. &lt;br /&gt;Esto habilita el motor de métodos abreviados de los hooks de Windows. Este motor permite a Mumble suprimir las pulsaciones de teclas y los clicks del ratón.</translation>
-    </message>
-    <message>
-        <source>Enable Windows hooks</source>
-        <translation>Habilitar Windows hooks</translation>
-    </message>
-    <message>
         <source>&lt;b&gt;Enable GKey&lt;/b&gt;.&lt;br /&gt;This setting enables support for the GKey shortcut engine, for &quot;G&quot;-keys found on Logitech keyboards.</source>
         <translation>&lt;b&gt;Habilitar GKey&lt;/b&gt;. &lt;br /&gt;Esta configuración habilita la compatibilidad con el motor de métodos abreviados GKey, para las teclas &quot;Gamer&quot; que se encuentran en los teclados Logitech.</translation>
     </message>

--- a/src/mumble/mumble_et.ts
+++ b/src/mumble/mumble_et.ts
@@ -3325,14 +3325,6 @@ Label of the server. This is what the server will be named like in your server l
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>&lt;b&gt;Enable Windows hooks&lt;/b&gt;.&lt;br /&gt;This enables the Windows hooks shortcut engine. Using this engine allows Mumble to suppress keypresses and mouse clicks.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Enable Windows hooks</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>&lt;b&gt;Enable GKey&lt;/b&gt;.&lt;br /&gt;This setting enables support for the GKey shortcut engine, for &quot;G&quot;-keys found on Logitech keyboards.</source>
         <translation type="unfinished"></translation>
     </message>

--- a/src/mumble/mumble_eu.ts
+++ b/src/mumble/mumble_eu.ts
@@ -3341,14 +3341,6 @@ Zerbitzariaren etika. Zerbitzari zerrendan agertuko zaizun izena ezartzen du, ed
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>&lt;b&gt;Enable Windows hooks&lt;/b&gt;.&lt;br /&gt;This enables the Windows hooks shortcut engine. Using this engine allows Mumble to suppress keypresses and mouse clicks.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Enable Windows hooks</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>&lt;b&gt;Enable GKey&lt;/b&gt;.&lt;br /&gt;This setting enables support for the GKey shortcut engine, for &quot;G&quot;-keys found on Logitech keyboards.</source>
         <translation type="unfinished"></translation>
     </message>

--- a/src/mumble/mumble_fa_IR.ts
+++ b/src/mumble/mumble_fa_IR.ts
@@ -3323,14 +3323,6 @@ Label of the server. This is what the server will be named like in your server l
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>&lt;b&gt;Enable Windows hooks&lt;/b&gt;.&lt;br /&gt;This enables the Windows hooks shortcut engine. Using this engine allows Mumble to suppress keypresses and mouse clicks.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Enable Windows hooks</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>&lt;b&gt;Enable GKey&lt;/b&gt;.&lt;br /&gt;This setting enables support for the GKey shortcut engine, for &quot;G&quot;-keys found on Logitech keyboards.</source>
         <translation type="unfinished"></translation>
     </message>

--- a/src/mumble/mumble_fi.ts
+++ b/src/mumble/mumble_fi.ts
@@ -3375,14 +3375,6 @@ Palvelimen nimike. Vapaasti valittava nimike, jolla palvelin tulee esiintymään
         <translation type="unfinished">Muut pikanäppäimet</translation>
     </message>
     <message>
-        <source>&lt;b&gt;Enable Windows hooks&lt;/b&gt;.&lt;br /&gt;This enables the Windows hooks shortcut engine. Using this engine allows Mumble to suppress keypresses and mouse clicks.</source>
-        <translation type="unfinished">&lt;b&gt;Ota käyttöön Windows hooks&lt;/b&gt;.&lt;br /&gt;Tämä ottaa käyttöön Windows Hooks pikanäppäinmoottorin. Tämän moottorin käyttö mahdollistaa näppäinpainallusten ja hiirenklikkausten vaimennuksen Mumblessa.</translation>
-    </message>
-    <message>
-        <source>Enable Windows hooks</source>
-        <translation type="unfinished">Ota käyttöön Windows Hooks</translation>
-    </message>
-    <message>
         <source>&lt;b&gt;Enable GKey&lt;/b&gt;.&lt;br /&gt;This setting enables support for the GKey shortcut engine, for &quot;G&quot;-keys found on Logitech keyboards.</source>
         <translation>&lt;b&gt;Käytä GKeyta&lt;/b&gt;.&lt;br /&gt;Tämä asetus ottaa käyttöön tuen GKey pikanäppäimille voidaksesi käyttää &quot;G&quot;-näppäimiä Logitechin näppäimistöillä.</translation>
     </message>

--- a/src/mumble/mumble_fr.ts
+++ b/src/mumble/mumble_fr.ts
@@ -3374,14 +3374,6 @@ Nom du serveur. C&apos;est le nom du serveur tel qu&apos;il apparaîtra dans vos
         <translation>Moteurs de raccourcis additionnels</translation>
     </message>
     <message>
-        <source>&lt;b&gt;Enable Windows hooks&lt;/b&gt;.&lt;br /&gt;This enables the Windows hooks shortcut engine. Using this engine allows Mumble to suppress keypresses and mouse clicks.</source>
-        <translation>&lt;b&gt;Activer les événements Windows&lt;/b&gt;. &lt;br /&gt;Ceci active le système de surveillance d&apos;événements Windows. Utiliser ce système permet à Mumble d&apos;étouffer les bruits de touches de claviers et de clics de souris.</translation>
-    </message>
-    <message>
-        <source>Enable Windows hooks</source>
-        <translation>Activer les événements Windows</translation>
-    </message>
-    <message>
         <source>&lt;b&gt;Enable GKey&lt;/b&gt;.&lt;br /&gt;This setting enables support for the GKey shortcut engine, for &quot;G&quot;-keys found on Logitech keyboards.</source>
         <translation>&lt;b&gt;Activer G-Key&lt;/b&gt;.&lt;br /&gt;Cela active le support du système de raccourcis G-Key, pour les touches &quot;G&quot; trouvées sur les claviers Logitech.</translation>
     </message>

--- a/src/mumble/mumble_gl.ts
+++ b/src/mumble/mumble_gl.ts
@@ -3326,14 +3326,6 @@ Label of the server. This is what the server will be named like in your server l
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>&lt;b&gt;Enable Windows hooks&lt;/b&gt;.&lt;br /&gt;This enables the Windows hooks shortcut engine. Using this engine allows Mumble to suppress keypresses and mouse clicks.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Enable Windows hooks</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>&lt;b&gt;Enable GKey&lt;/b&gt;.&lt;br /&gt;This setting enables support for the GKey shortcut engine, for &quot;G&quot;-keys found on Logitech keyboards.</source>
         <translation type="unfinished"></translation>
     </message>

--- a/src/mumble/mumble_he.ts
+++ b/src/mumble/mumble_he.ts
@@ -3368,14 +3368,6 @@ Label of the server. This is what the server will be named like in your server l
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>&lt;b&gt;Enable Windows hooks&lt;/b&gt;.&lt;br /&gt;This enables the Windows hooks shortcut engine. Using this engine allows Mumble to suppress keypresses and mouse clicks.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Enable Windows hooks</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>&lt;b&gt;Enable GKey&lt;/b&gt;.&lt;br /&gt;This setting enables support for the GKey shortcut engine, for &quot;G&quot;-keys found on Logitech keyboards.</source>
         <translation type="unfinished"></translation>
     </message>

--- a/src/mumble/mumble_hu.ts
+++ b/src/mumble/mumble_hu.ts
@@ -3362,14 +3362,6 @@ Label of the server. This is what the server will be named like in your server l
         <translation>További modulok</translation>
     </message>
     <message>
-        <source>&lt;b&gt;Enable Windows hooks&lt;/b&gt;.&lt;br /&gt;This enables the Windows hooks shortcut engine. Using this engine allows Mumble to suppress keypresses and mouse clicks.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Enable Windows hooks</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>&lt;b&gt;Enable GKey&lt;/b&gt;.&lt;br /&gt;This setting enables support for the GKey shortcut engine, for &quot;G&quot;-keys found on Logitech keyboards.</source>
         <translation>&lt;b&gt;Logitech G-Key támogatása&lt;/b&gt;.&lt;br /&gt;Ez a beállítás lehetővé teszi a Logitech billentyűzetek dedikált G-Key billentyűinek használatát.</translation>
     </message>

--- a/src/mumble/mumble_it.ts
+++ b/src/mumble/mumble_it.ts
@@ -3374,14 +3374,6 @@ Nome del server. Questo è il nome che apparirà sulla tua lista dei server pref
         <translation>Motori di Scorciatoie Aggiuntivi</translation>
     </message>
     <message>
-        <source>&lt;b&gt;Enable Windows hooks&lt;/b&gt;.&lt;br /&gt;This enables the Windows hooks shortcut engine. Using this engine allows Mumble to suppress keypresses and mouse clicks.</source>
-        <translation>&lt;b&gt;Abilita Hook di Windows&lt;/b&gt;.&lt;br /&gt;Abilita il motore di scorciatoie Windows hook. Utilizzare questo motore permette a Mumble di sopprimere gli input di mouse e tastiera.</translation>
-    </message>
-    <message>
-        <source>Enable Windows hooks</source>
-        <translation>Abilita Hook di Windows</translation>
-    </message>
-    <message>
         <source>&lt;b&gt;Enable GKey&lt;/b&gt;.&lt;br /&gt;This setting enables support for the GKey shortcut engine, for &quot;G&quot;-keys found on Logitech keyboards.</source>
         <translation>&lt;b&gt;Abilita GKey&lt;/b&gt;.&lt;br /&gt;Abilita il motore di scorciatoie Gkey, per i tasti &quot;G&quot; che si trovano nelle tastiere Logitech.</translation>
     </message>

--- a/src/mumble/mumble_ja.ts
+++ b/src/mumble/mumble_ja.ts
@@ -3365,14 +3365,6 @@ Label of the server. This is what the server will be named like in your server l
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>&lt;b&gt;Enable Windows hooks&lt;/b&gt;.&lt;br /&gt;This enables the Windows hooks shortcut engine. Using this engine allows Mumble to suppress keypresses and mouse clicks.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Enable Windows hooks</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>&lt;b&gt;Enable GKey&lt;/b&gt;.&lt;br /&gt;This setting enables support for the GKey shortcut engine, for &quot;G&quot;-keys found on Logitech keyboards.</source>
         <translation type="unfinished"></translation>
     </message>

--- a/src/mumble/mumble_ko.ts
+++ b/src/mumble/mumble_ko.ts
@@ -3350,14 +3350,6 @@ Label of the server. This is what the server will be named like in your server l
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>&lt;b&gt;Enable Windows hooks&lt;/b&gt;.&lt;br /&gt;This enables the Windows hooks shortcut engine. Using this engine allows Mumble to suppress keypresses and mouse clicks.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Enable Windows hooks</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>&lt;b&gt;Enable GKey&lt;/b&gt;.&lt;br /&gt;This setting enables support for the GKey shortcut engine, for &quot;G&quot;-keys found on Logitech keyboards.</source>
         <translation type="unfinished"></translation>
     </message>

--- a/src/mumble/mumble_lt.ts
+++ b/src/mumble/mumble_lt.ts
@@ -3354,14 +3354,6 @@ Label of the server. This is what the server will be named like in your server l
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>&lt;b&gt;Enable Windows hooks&lt;/b&gt;.&lt;br /&gt;This enables the Windows hooks shortcut engine. Using this engine allows Mumble to suppress keypresses and mouse clicks.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Enable Windows hooks</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>&lt;b&gt;Enable GKey&lt;/b&gt;.&lt;br /&gt;This setting enables support for the GKey shortcut engine, for &quot;G&quot;-keys found on Logitech keyboards.</source>
         <translation type="unfinished"></translation>
     </message>

--- a/src/mumble/mumble_nl.ts
+++ b/src/mumble/mumble_nl.ts
@@ -3374,14 +3374,6 @@ Naam van server. Zelfgekozen naam van server die in serverlijst wordt weergegeve
         <translation>Extra snelkoppelingsverwerkers</translation>
     </message>
     <message>
-        <source>&lt;b&gt;Enable Windows hooks&lt;/b&gt;.&lt;br /&gt;This enables the Windows hooks shortcut engine. Using this engine allows Mumble to suppress keypresses and mouse clicks.</source>
-        <translation>&lt;b&gt;Installeer Windows-hooks&lt;/b&gt;.&lt;br /&gt;Dit schakelt de Windows-hooks snelkoppelingsverwerking in. Dit laat Mumble toe om het indrukken van toetsen of het klikken met de muis te onderdrukken.</translation>
-    </message>
-    <message>
-        <source>Enable Windows hooks</source>
-        <translation>Windows-hooks inschakelen</translation>
-    </message>
-    <message>
         <source>&lt;b&gt;Enable GKey&lt;/b&gt;.&lt;br /&gt;This setting enables support for the GKey shortcut engine, for &quot;G&quot;-keys found on Logitech keyboards.</source>
         <translation>&lt;b&gt;GKey inschakelen&lt;/b&gt;.&lt;br /&gt;Deze instelling schakelt de ondersteuning voor de GKey-snelkoppelingsverwerking in, voor &quot;G&quot;-knoppen die zich op Logitech-toetsenborden bevinden.</translation>
     </message>

--- a/src/mumble/mumble_no.ts
+++ b/src/mumble/mumble_no.ts
@@ -3388,14 +3388,6 @@ Hva tjeneren er beskrevet som. Dette er hva tjeneren vil bli navngitt som i din 
         <translation>Ytterligere snarveismotorer</translation>
     </message>
     <message>
-        <source>&lt;b&gt;Enable Windows hooks&lt;/b&gt;.&lt;br /&gt;This enables the Windows hooks shortcut engine. Using this engine allows Mumble to suppress keypresses and mouse clicks.</source>
-        <translation>&lt;b&gt;Skru på Windows-kroker&lt;/b&gt;.&lt;br /&gt;Dette skrur på snarveismotoren for Windows-kroker. Bruk av denne motoren lar Mumble undertrykke tastetrykk og museklikk.</translation>
-    </message>
-    <message>
-        <source>Enable Windows hooks</source>
-        <translation>Skru på Windows-kroker</translation>
-    </message>
-    <message>
         <source>&lt;b&gt;Enable GKey&lt;/b&gt;.&lt;br /&gt;This setting enables support for the GKey shortcut engine, for &quot;G&quot;-keys found on Logitech keyboards.</source>
         <translation>&lt;b&gt;Skru på GKey&lt;/b&gt;.&lt;br /&gt;Denne innstillinger skrur på støtte for GKey-snarveismotorer for &quot;G&quot;-taster på Logitech-tastatur.</translation>
     </message>

--- a/src/mumble/mumble_oc.ts
+++ b/src/mumble/mumble_oc.ts
@@ -3325,14 +3325,6 @@ Label of the server. This is what the server will be named like in your server l
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>&lt;b&gt;Enable Windows hooks&lt;/b&gt;.&lt;br /&gt;This enables the Windows hooks shortcut engine. Using this engine allows Mumble to suppress keypresses and mouse clicks.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Enable Windows hooks</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>&lt;b&gt;Enable GKey&lt;/b&gt;.&lt;br /&gt;This setting enables support for the GKey shortcut engine, for &quot;G&quot;-keys found on Logitech keyboards.</source>
         <translation type="unfinished"></translation>
     </message>

--- a/src/mumble/mumble_pl.ts
+++ b/src/mumble/mumble_pl.ts
@@ -3375,14 +3375,6 @@ Etykieta serwera. Określa, pod jaką nazwą twój serwer będzie wyświetlany n
         <translation>Dodatkowe mechanizmy skrótów</translation>
     </message>
     <message>
-        <source>&lt;b&gt;Enable Windows hooks&lt;/b&gt;.&lt;br /&gt;This enables the Windows hooks shortcut engine. Using this engine allows Mumble to suppress keypresses and mouse clicks.</source>
-        <translation>&lt;b&gt;Włącz zaczepy Windows&lt;/b&gt;.&lt;br /&gt;Włącza to mechanizm skrótów zaczepów Windows. Używanie tego mechanizmu pozwala Mumble na tłumienie wciskanych klawiszy i kliknięć myszą.</translation>
-    </message>
-    <message>
-        <source>Enable Windows hooks</source>
-        <translation>Włącz zaczepy Windows</translation>
-    </message>
-    <message>
         <source>&lt;b&gt;Enable GKey&lt;/b&gt;.&lt;br /&gt;This setting enables support for the GKey shortcut engine, for &quot;G&quot;-keys found on Logitech keyboards.</source>
         <translation>&lt;b&gt;Włącz GKey&lt;/b&gt;.&lt;br /&gt;To ustawienie włącza obsługę mechanizmu skrótów GKey dla klawiszy &quot;G&quot; dostępnych w klawiaturach Logitech.</translation>
     </message>

--- a/src/mumble/mumble_pt_BR.ts
+++ b/src/mumble/mumble_pt_BR.ts
@@ -3374,14 +3374,6 @@ Etiqueta do favorito. É como o favorito será exibido na lista de favoritos, e 
         <translation>Motores de Atalho Adicionais</translation>
     </message>
     <message>
-        <source>&lt;b&gt;Enable Windows hooks&lt;/b&gt;.&lt;br /&gt;This enables the Windows hooks shortcut engine. Using this engine allows Mumble to suppress keypresses and mouse clicks.</source>
-        <translation>&lt;b&gt;Ativar ganchos de janela&lt;/b&gt;.&lt;br /&gt;Isso permite ganchos de Janela no motor de atalho. Usar esse motor permite ao Mumble suprimir pressionamento de teclas e cliques de mouse.</translation>
-    </message>
-    <message>
-        <source>Enable Windows hooks</source>
-        <translation>Permitir gatilhos de janela</translation>
-    </message>
-    <message>
         <source>&lt;b&gt;Enable GKey&lt;/b&gt;.&lt;br /&gt;This setting enables support for the GKey shortcut engine, for &quot;G&quot;-keys found on Logitech keyboards.</source>
         <translation>&lt;b&gt;Ativar GKey&lt;/b&gt;.&lt;br /&gt;Essa opção ativa o suporte para o motor de atalhos GKey, para &quot;G&quot;-keys/teclas encontradas em teclados Logitech.</translation>
     </message>

--- a/src/mumble/mumble_pt_PT.ts
+++ b/src/mumble/mumble_pt_PT.ts
@@ -3364,14 +3364,6 @@ Etiqueta do servidor. É como o servidor será exibido na lista de favoritos, e 
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>&lt;b&gt;Enable Windows hooks&lt;/b&gt;.&lt;br /&gt;This enables the Windows hooks shortcut engine. Using this engine allows Mumble to suppress keypresses and mouse clicks.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Enable Windows hooks</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>&lt;b&gt;Enable GKey&lt;/b&gt;.&lt;br /&gt;This setting enables support for the GKey shortcut engine, for &quot;G&quot;-keys found on Logitech keyboards.</source>
         <translation type="unfinished"></translation>
     </message>

--- a/src/mumble/mumble_ro.ts
+++ b/src/mumble/mumble_ro.ts
@@ -3329,14 +3329,6 @@ Label of the server. This is what the server will be named like in your server l
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>&lt;b&gt;Enable Windows hooks&lt;/b&gt;.&lt;br /&gt;This enables the Windows hooks shortcut engine. Using this engine allows Mumble to suppress keypresses and mouse clicks.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Enable Windows hooks</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>&lt;b&gt;Enable GKey&lt;/b&gt;.&lt;br /&gt;This setting enables support for the GKey shortcut engine, for &quot;G&quot;-keys found on Logitech keyboards.</source>
         <translation type="unfinished"></translation>
     </message>

--- a/src/mumble/mumble_ru.ts
+++ b/src/mumble/mumble_ru.ts
@@ -3336,14 +3336,6 @@ Label of the server. This is what the server will be named like in your server l
         <translation>Дополнительные программы горячих клавиш</translation>
     </message>
     <message>
-        <source>&lt;b&gt;Enable Windows hooks&lt;/b&gt;.&lt;br /&gt;This enables the Windows hooks shortcut engine. Using this engine allows Mumble to suppress keypresses and mouse clicks.</source>
-        <translation>&lt;b&gt;Включить обработчики Windows&lt;/b&gt;.&lt;br /&gt; Эта функция включает механизм обработчиков Windows. Использование этого режима позволяет Mumble подавлять нажатия клавиш и клики мыши.</translation>
-    </message>
-    <message>
-        <source>Enable Windows hooks</source>
-        <translation>Включить обработчики Windows.</translation>
-    </message>
-    <message>
         <source>&lt;b&gt;Enable GKey&lt;/b&gt;.&lt;br /&gt;This setting enables support for the GKey shortcut engine, for &quot;G&quot;-keys found on Logitech keyboards.</source>
         <translation>&lt;b&gt;Включить GKey&lt;/b&gt;.&lt;br /&gt; Эта настройка включает поддержку &quot;G&quot;-клавиш, располагаемых на клавиатурах Logitech.</translation>
     </message>

--- a/src/mumble/mumble_si.ts
+++ b/src/mumble/mumble_si.ts
@@ -3310,14 +3310,6 @@ Without this option enabled, using Mumble&apos;s global shortcuts in privileged 
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>&lt;b&gt;Enable Windows hooks&lt;/b&gt;.&lt;br /&gt;This enables the Windows hooks shortcut engine. Using this engine allows Mumble to suppress keypresses and mouse clicks.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Enable Windows hooks</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>&lt;b&gt;Enable GKey&lt;/b&gt;.&lt;br /&gt;This setting enables support for the GKey shortcut engine, for &quot;G&quot;-keys found on Logitech keyboards.</source>
         <translation type="unfinished"></translation>
     </message>

--- a/src/mumble/mumble_sv.ts
+++ b/src/mumble/mumble_sv.ts
@@ -3374,14 +3374,6 @@ Serverns namn. Detta är vad servern kommer att kallas i din serverlista, som du
         <translation>Ytterligare genvägsmotorer</translation>
     </message>
     <message>
-        <source>&lt;b&gt;Enable Windows hooks&lt;/b&gt;.&lt;br /&gt;This enables the Windows hooks shortcut engine. Using this engine allows Mumble to suppress keypresses and mouse clicks.</source>
-        <translation>&lt;b&gt;Aktivera Windows Hooks&lt;/b&gt;.&lt;br /&gt;Detta aktiverar genvägsmotorn för Windows Hooks. Om du använder denna motor kan Mumble undertrycka tangenttryckningar och musklick.</translation>
-    </message>
-    <message>
-        <source>Enable Windows hooks</source>
-        <translation>Aktivera Windows hooks</translation>
-    </message>
-    <message>
         <source>&lt;b&gt;Enable GKey&lt;/b&gt;.&lt;br /&gt;This setting enables support for the GKey shortcut engine, for &quot;G&quot;-keys found on Logitech keyboards.</source>
         <translation>&lt;b&gt;Aktivera GKey&lt;/b&gt;.&lt;br /&gt;Den här inställningen aktiverar stöd för GKey-genvägsmotorn, för &quot;G&quot;-tangenter som finns på Logitech-tangentbord.</translation>
     </message>

--- a/src/mumble/mumble_te.ts
+++ b/src/mumble/mumble_te.ts
@@ -3336,14 +3336,6 @@ Label of the server. This is what the server will be named like in your server l
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>&lt;b&gt;Enable Windows hooks&lt;/b&gt;.&lt;br /&gt;This enables the Windows hooks shortcut engine. Using this engine allows Mumble to suppress keypresses and mouse clicks.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Enable Windows hooks</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>&lt;b&gt;Enable GKey&lt;/b&gt;.&lt;br /&gt;This setting enables support for the GKey shortcut engine, for &quot;G&quot;-keys found on Logitech keyboards.</source>
         <translation type="unfinished"></translation>
     </message>

--- a/src/mumble/mumble_th.ts
+++ b/src/mumble/mumble_th.ts
@@ -3323,14 +3323,6 @@ Label of the server. This is what the server will be named like in your server l
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>&lt;b&gt;Enable Windows hooks&lt;/b&gt;.&lt;br /&gt;This enables the Windows hooks shortcut engine. Using this engine allows Mumble to suppress keypresses and mouse clicks.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Enable Windows hooks</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>&lt;b&gt;Enable GKey&lt;/b&gt;.&lt;br /&gt;This setting enables support for the GKey shortcut engine, for &quot;G&quot;-keys found on Logitech keyboards.</source>
         <translation type="unfinished"></translation>
     </message>

--- a/src/mumble/mumble_tr.ts
+++ b/src/mumble/mumble_tr.ts
@@ -3373,14 +3373,6 @@ Sunucunun etiketi. Bu, sunucu listenizde sunucunun ismidir ve istediğinizi seç
         <translation>Ek Kısayol Motorları</translation>
     </message>
     <message>
-        <source>&lt;b&gt;Enable Windows hooks&lt;/b&gt;.&lt;br /&gt;This enables the Windows hooks shortcut engine. Using this engine allows Mumble to suppress keypresses and mouse clicks.</source>
-        <translation>&lt;b&gt;Windows kancalarını etkinleştir&lt;/b&gt;.&lt;br /&gt;Bu, Windows kancları (hooks) kısayol motorunu etkinleştirir. Bu motoru kullanmak, Mumble&apos;ın tuş basımlarını ve fare tıklamalarını bastırmasına imkân sağlar.</translation>
-    </message>
-    <message>
-        <source>Enable Windows hooks</source>
-        <translation>Windows kancalarını etkinleştir</translation>
-    </message>
-    <message>
         <source>&lt;b&gt;Enable GKey&lt;/b&gt;.&lt;br /&gt;This setting enables support for the GKey shortcut engine, for &quot;G&quot;-keys found on Logitech keyboards.</source>
         <translation>&lt;b&gt;GKey&apos;i etkinleştir&lt;/b&gt;.&lt;br /&gt;Bu ayar, Gkey kısayol motoru için desteği etkinleştirir, ki bu Logitech klavyelerinde bulunan &quot;G&quot; tuşları içindir.</translation>
     </message>

--- a/src/mumble/mumble_uk.ts
+++ b/src/mumble/mumble_uk.ts
@@ -3325,14 +3325,6 @@ Label of the server. This is what the server will be named like in your server l
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>&lt;b&gt;Enable Windows hooks&lt;/b&gt;.&lt;br /&gt;This enables the Windows hooks shortcut engine. Using this engine allows Mumble to suppress keypresses and mouse clicks.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Enable Windows hooks</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>&lt;b&gt;Enable GKey&lt;/b&gt;.&lt;br /&gt;This setting enables support for the GKey shortcut engine, for &quot;G&quot;-keys found on Logitech keyboards.</source>
         <translation type="unfinished"></translation>
     </message>

--- a/src/mumble/mumble_zh_CN.ts
+++ b/src/mumble/mumble_zh_CN.ts
@@ -3373,14 +3373,6 @@ Label of the server. This is what the server will be named like in your server l
         <translation>其他快捷键引擎</translation>
     </message>
     <message>
-        <source>&lt;b&gt;Enable Windows hooks&lt;/b&gt;.&lt;br /&gt;This enables the Windows hooks shortcut engine. Using this engine allows Mumble to suppress keypresses and mouse clicks.</source>
-        <translation>&lt;b&gt;启用 Windows 钩子&lt;/b&gt;。&lt;br /&gt;这将启用 Windows 钩子快捷键引擎。 启用此引擎可使 Mumble 屏蔽按键和鼠标点击。</translation>
-    </message>
-    <message>
-        <source>Enable Windows hooks</source>
-        <translation>启用 Windows 钩子</translation>
-    </message>
-    <message>
         <source>&lt;b&gt;Enable GKey&lt;/b&gt;.&lt;br /&gt;This setting enables support for the GKey shortcut engine, for &quot;G&quot;-keys found on Logitech keyboards.</source>
         <translation>&lt;b&gt;启用 GKey&lt;/b&gt;。&lt;br /&gt;此设置启用对 GKey 快捷键引擎的支持，用于 Logitech 键盘上的 G 键。</translation>
     </message>

--- a/src/mumble/mumble_zh_HK.ts
+++ b/src/mumble/mumble_zh_HK.ts
@@ -3323,14 +3323,6 @@ Label of the server. This is what the server will be named like in your server l
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>&lt;b&gt;Enable Windows hooks&lt;/b&gt;.&lt;br /&gt;This enables the Windows hooks shortcut engine. Using this engine allows Mumble to suppress keypresses and mouse clicks.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Enable Windows hooks</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>&lt;b&gt;Enable GKey&lt;/b&gt;.&lt;br /&gt;This setting enables support for the GKey shortcut engine, for &quot;G&quot;-keys found on Logitech keyboards.</source>
         <translation type="unfinished"></translation>
     </message>

--- a/src/mumble/mumble_zh_TW.ts
+++ b/src/mumble/mumble_zh_TW.ts
@@ -3346,14 +3346,6 @@ Label of the server. This is what the server will be named like in your server l
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>&lt;b&gt;Enable Windows hooks&lt;/b&gt;.&lt;br /&gt;This enables the Windows hooks shortcut engine. Using this engine allows Mumble to suppress keypresses and mouse clicks.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Enable Windows hooks</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>&lt;b&gt;Enable GKey&lt;/b&gt;.&lt;br /&gt;This setting enables support for the GKey shortcut engine, for &quot;G&quot;-keys found on Logitech keyboards.</source>
         <translation type="unfinished"></translation>
     </message>


### PR DESCRIPTION
Several users complained about the global shortcuts engine on Windows, mainly because it affects the keyboard and mouse behavior for all applications:

1. It reportedly causes the polling rate to drop significantly.
2. Causes accessibility programs such as NVDA to read Mumble's UI slow. Workaround implemented in #3896.
3. Using the debugger's "pause" function is nearly impossible: the OS has to wait for the callback to timeout before registering the input, causing a consistent and heavy slowdown.

Disabling hooks fixes all issues described above, however it only leaves DirectInput for standard devices (i.e. not relying on XInput and G-keys).

This commit completely rewrites `GlobalShortcutWin`, implementing raw input and getting rid of hooks and DirectInput.

Controllers are supported, but only basic buttons are handled for now. Support for analog input (including d-pad) will be added in the future.
XInput can still be enabled, in order for input from triggers and d-pad on Xbox controllers to be registered.

As a bonus, the main thread doesn't wait for the input processing function(s) to return anymore.
The reason why this wasn't the case before is because we needed to know whether to block the message (returning true) from reaching other applications ("suppress" feature).
That cannot work with raw input due to its nature. Returning `true` simply tells Windows that we didn't process the message.