### PR TITLE
DOCS: Fixed typos

### DIFF
--- a/COMMIT_GUIDELINES.md
+++ b/COMMIT_GUIDELINES.md
@@ -47,7 +47,7 @@ The `TYPE` is one of the following:
 | DOCS     | Changes to the documentation (either in-source or out-of-source) | Add a Doxygen comment to a function |
 | TEST     | Adds, changes or removes a test-case | |
 | MAINT    | Maintenance - Change of non-code files | Change of the README |
-| CI       | Changed something for the CI (continous integration) | Update TravisCI to use newer ubuntu version |
+| CI       | Changed something for the CI (continuous integration) | Update TravisCI to use newer ubuntu version |
 | REFAC    | Code refactoring | Rename variable `x` to `y` |
 | BUILD    | Changes related to the build process / buildsystem | Fix cmake script |
 | TRANSLATION | Translation updates and changes | Update translation files |

--- a/docs/dev/build-instructions/build_static.md
+++ b/docs/dev/build-instructions/build_static.md
@@ -230,7 +230,7 @@ get a lot of debug information regarding the search for the needed dependencies.
 
 This can happen if you're using a system that doesn't support TLS 1.3 (which https://repo.msys2.org requires) such as Windows 7. In this case the only
 possible workaround is either to download the respective files manually using a brower that does support TLS 1.3 (e.g. Firefox) or to replace all
-occurences of `https://repo.msys2.org` in the vcpkg dir with `http://repo.msys2.org` and thereby forxing vcpkg to use the HTTP mirror instead. Note
+occurrences of `https://repo.msys2.org` in the vcpkg dir with `http://repo.msys2.org` and thereby forxing vcpkg to use the HTTP mirror instead. Note
 though that this is inherently unsafer than using HTTPS.
 
 A common error message for this scenario could be


### PR DESCRIPTION
Scope of changes is restricted to docs only. 

### Checks

- [x] My commits follow the [commit guidelines](https://github.com/mumble-voip/mumble/blob/master/COMMIT_GUIDELINES.md)

