### PR TITLE
REFAC(client): Transmission mode change events

### DIFF
--- a/src/mumble/MainWindow.h
+++ b/src/mumble/MainWindow.h
@@ -199,7 +199,7 @@ public slots:
 	void on_qaSelfComment_triggered();
 	void on_qaSelfRegister_triggered();
 	void qcbTransmitMode_activated(int index);
-	void updateTransmitModeComboBox();
+	void updateTransmitModeComboBox(Settings::AudioTransmit newMode);
 	void qmUser_aboutToShow();
 	void qmListener_aboutToShow();
 	void on_qaUserCommentReset_triggered();
@@ -312,6 +312,7 @@ public slots:
 	/// Updates the user's image directory to the given path (any included
 	/// filename is discarded).
 	void updateImagePath(QString filepath) const;
+	void setTransmissionMode(Settings::AudioTransmit mode);
 	/// Sets the local user's mute state
 	///
 	/// @param mute Whether to mute the user
@@ -328,6 +329,7 @@ signals:
 	void userAddedChannelListener(ClientUser *user, Channel *channel);
 	/// Signal emitted whenever a user removes a ChannelListener
 	void userRemovedChannelListener(ClientUser *user, Channel *channel);
+	void transmissionModeChanged(Settings::AudioTransmit newMode);
 
 public:
 	MainWindow(QWidget *parent);


### PR DESCRIPTION
Previously handling the change of transmission mode was done in many
different places causing code duplication.

This commit factors the common functionality out into its own function
and creates a new event for when the transmission mode is changed.


### Checks

- [x] My commits follow the [commit guidelines](https://github.com/mumble-voip/mumble/blob/master/COMMIT_GUIDELINES.md)

