### PR TITLE
CHANGE(client): Default min volume to 25%

### DIFF
--- a/src/mumble/AudioOutput.ui
+++ b/src/mumble/AudioOutput.ui
@@ -551,7 +551,7 @@
       <item row="4" column="2">
        <widget class="QSlider" name="qsMaxDistVolume">
         <property name="toolTip">
-         <string>Factor for sound volume decrease</string>
+         <string>The minimum volume a player's audio will fade out to with increasing distance. Set to 0% for it to fade into complete silence for a realistic maximum hearing distance.</string>
         </property>
         <property name="whatsThis">
          <string>What should the volume be at the maximum distance?</string>

--- a/src/mumble/Settings.cpp
+++ b/src/mumble/Settings.cpp
@@ -428,7 +428,7 @@ Settings::Settings() {
 	bPositionalHeadphone = false;
 	fAudioMinDistance    = 1.0f;
 	fAudioMaxDistance    = 15.0f;
-	fAudioMaxDistVolume  = 0.80f;
+	fAudioMaxDistVolume  = 0.25f;
 	fAudioBloom          = 0.5f;
 
 	// OverlayPrivateWin

--- a/src/mumble/mumble_ar.ts
+++ b/src/mumble/mumble_ar.ts
@@ -1248,10 +1248,6 @@ This value allows you to set the maximum number of users allowed in the channel.
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Factor for sound volume decrease</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Bloom</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1430,6 +1426,10 @@ This value allows you to set the maximum number of users allowed in the channel.
     </message>
     <message>
         <source>Attenuation</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The minimum volume a player&apos;s audio will fade out to with increasing distance. Set to 0% for it to fade into complete silence for a realistic maximum hearing distance.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/mumble/mumble_bg.ts
+++ b/src/mumble/mumble_bg.ts
@@ -1249,10 +1249,6 @@ This value allows you to set the maximum number of users allowed in the channel.
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Factor for sound volume decrease</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Bloom</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1431,6 +1427,10 @@ This value allows you to set the maximum number of users allowed in the channel.
     </message>
     <message>
         <source>Attenuation</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The minimum volume a player&apos;s audio will fade out to with increasing distance. Set to 0% for it to fade into complete silence for a realistic maximum hearing distance.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/mumble/mumble_br.ts
+++ b/src/mumble/mumble_br.ts
@@ -1248,10 +1248,6 @@ This value allows you to set the maximum number of users allowed in the channel.
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Factor for sound volume decrease</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Bloom</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1430,6 +1426,10 @@ This value allows you to set the maximum number of users allowed in the channel.
     </message>
     <message>
         <source>Attenuation</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The minimum volume a player&apos;s audio will fade out to with increasing distance. Set to 0% for it to fade into complete silence for a realistic maximum hearing distance.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/mumble/mumble_ca.ts
+++ b/src/mumble/mumble_ca.ts
@@ -1254,10 +1254,6 @@ This value allows you to set the maximum number of users allowed in the channel.
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Factor for sound volume decrease</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Bloom</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1436,6 +1432,10 @@ This value allows you to set the maximum number of users allowed in the channel.
     </message>
     <message>
         <source>Attenuation</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The minimum volume a player&apos;s audio will fade out to with increasing distance. Set to 0% for it to fade into complete silence for a realistic maximum hearing distance.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/mumble/mumble_cs.ts
+++ b/src/mumble/mumble_cs.ts
@@ -1256,10 +1256,6 @@ Tato hodnota Vám umožňuje nastavit maximální počet povolených uživatelů
         <translation>Připojené &quot;reproduktory&quot; jsou vlastně sluchátka</translation>
     </message>
     <message>
-        <source>Factor for sound volume decrease</source>
-        <translation>Faktor pro snížení hlasitosti zvuku</translation>
-    </message>
-    <message>
         <source>Bloom</source>
         <translation>Bloom</translation>
     </message>
@@ -1438,6 +1434,10 @@ Tato hodnota Vám umožňuje nastavit maximální počet povolených uživatelů
     </message>
     <message>
         <source>Attenuation</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The minimum volume a player&apos;s audio will fade out to with increasing distance. Set to 0% for it to fade into complete silence for a realistic maximum hearing distance.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/mumble/mumble_cy.ts
+++ b/src/mumble/mumble_cy.ts
@@ -1249,10 +1249,6 @@ This value allows you to set the maximum number of users allowed in the channel.
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Factor for sound volume decrease</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Bloom</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1431,6 +1427,10 @@ This value allows you to set the maximum number of users allowed in the channel.
     </message>
     <message>
         <source>Attenuation</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The minimum volume a player&apos;s audio will fade out to with increasing distance. Set to 0% for it to fade into complete silence for a realistic maximum hearing distance.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/mumble/mumble_da.ts
+++ b/src/mumble/mumble_da.ts
@@ -1255,10 +1255,6 @@ This value allows you to set the maximum number of users allowed in the channel.
         <translation>De forbundne &quot;højtalere&quot; er rent faktisk et headset</translation>
     </message>
     <message>
-        <source>Factor for sound volume decrease</source>
-        <translation>Faktor for lydstyrke formindskelse</translation>
-    </message>
-    <message>
         <source>Bloom</source>
         <translation>Bloom</translation>
     </message>
@@ -1437,6 +1433,10 @@ This value allows you to set the maximum number of users allowed in the channel.
     </message>
     <message>
         <source>Attenuation</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The minimum volume a player&apos;s audio will fade out to with increasing distance. Set to 0% for it to fade into complete silence for a realistic maximum hearing distance.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/mumble/mumble_de.ts
+++ b/src/mumble/mumble_de.ts
@@ -1257,10 +1257,6 @@ Zum Beispiel wäre für die Audigy 2 ZS &apos;&lt;i&gt;Mic L&lt;/i&gt;&apos; ein
         <translation>Die angeschlossenen Audioausgabe-Geräte sind Kopfhörer</translation>
     </message>
     <message>
-        <source>Factor for sound volume decrease</source>
-        <translation>Faktor zur Lautstärkensenkung</translation>
-    </message>
-    <message>
         <source>Bloom</source>
         <translation>Bloom</translation>
     </message>
@@ -1443,6 +1439,10 @@ Mumble unterstützt das Herabsetzen der Lautstärke anderer Anwendungen während
     <message>
         <source>Attenuation</source>
         <translation>Dämpfung</translation>
+    </message>
+    <message>
+        <source>The minimum volume a player&apos;s audio will fade out to with increasing distance. Set to 0% for it to fade into complete silence for a realistic maximum hearing distance.</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/src/mumble/mumble_el.ts
+++ b/src/mumble/mumble_el.ts
@@ -1259,10 +1259,6 @@ This value allows you to set the maximum number of users allowed in the channel.
         <translation>Τα συνδεδεμένα &quot;ηχεία&quot; είναι στην πραγματικότητα ακουστικά</translation>
     </message>
     <message>
-        <source>Factor for sound volume decrease</source>
-        <translation>Παράγοντας για μείωση της έντασης του ήχου</translation>
-    </message>
-    <message>
         <source>Bloom</source>
         <translation>Ενίσχυση</translation>
     </message>
@@ -1441,6 +1437,10 @@ This value allows you to set the maximum number of users allowed in the channel.
     </message>
     <message>
         <source>Attenuation</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The minimum volume a player&apos;s audio will fade out to with increasing distance. Set to 0% for it to fade into complete silence for a realistic maximum hearing distance.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/mumble/mumble_en.ts
+++ b/src/mumble/mumble_en.ts
@@ -1248,10 +1248,6 @@ This value allows you to set the maximum number of users allowed in the channel.
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Factor for sound volume decrease</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Bloom</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1430,6 +1426,10 @@ This value allows you to set the maximum number of users allowed in the channel.
     </message>
     <message>
         <source>Attenuation</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The minimum volume a player&apos;s audio will fade out to with increasing distance. Set to 0% for it to fade into complete silence for a realistic maximum hearing distance.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/mumble/mumble_en_GB.ts
+++ b/src/mumble/mumble_en_GB.ts
@@ -1256,10 +1256,6 @@ This value allows you to set the maximum number of users allowed in the channel.
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Factor for sound volume decrease</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Bloom</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1438,6 +1434,10 @@ This value allows you to set the maximum number of users allowed in the channel.
     </message>
     <message>
         <source>Attenuation</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The minimum volume a player&apos;s audio will fade out to with increasing distance. Set to 0% for it to fade into complete silence for a realistic maximum hearing distance.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/mumble/mumble_eo.ts
+++ b/src/mumble/mumble_eo.ts
@@ -1253,10 +1253,6 @@ This value allows you to set the maximum number of users allowed in the channel.
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Factor for sound volume decrease</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Bloom</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1435,6 +1431,10 @@ This value allows you to set the maximum number of users allowed in the channel.
     </message>
     <message>
         <source>Attenuation</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The minimum volume a player&apos;s audio will fade out to with increasing distance. Set to 0% for it to fade into complete silence for a realistic maximum hearing distance.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/mumble/mumble_es.ts
+++ b/src/mumble/mumble_es.ts
@@ -1256,10 +1256,6 @@ Este valor permite fijar el número máximo de usuarios permitidos en el canal. 
         <translation>Los &quot;altavoces&quot; conectados son en realidad auriculares</translation>
     </message>
     <message>
-        <source>Factor for sound volume decrease</source>
-        <translation>Factor para la disminución del volumen del sonido</translation>
-    </message>
-    <message>
         <source>Bloom</source>
         <translation>Bloom</translation>
     </message>
@@ -1439,6 +1435,10 @@ Este valor permite fijar el número máximo de usuarios permitidos en el canal. 
     <message>
         <source>Attenuation</source>
         <translation>Atenuación</translation>
+    </message>
+    <message>
+        <source>The minimum volume a player&apos;s audio will fade out to with increasing distance. Set to 0% for it to fade into complete silence for a realistic maximum hearing distance.</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/src/mumble/mumble_et.ts
+++ b/src/mumble/mumble_et.ts
@@ -1249,10 +1249,6 @@ This value allows you to set the maximum number of users allowed in the channel.
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Factor for sound volume decrease</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Bloom</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1432,6 +1428,10 @@ This value allows you to set the maximum number of users allowed in the channel.
     <message>
         <source>Attenuation</source>
         <translation>Sumbuvus</translation>
+    </message>
+    <message>
+        <source>The minimum volume a player&apos;s audio will fade out to with increasing distance. Set to 0% for it to fade into complete silence for a realistic maximum hearing distance.</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/src/mumble/mumble_eu.ts
+++ b/src/mumble/mumble_eu.ts
@@ -1258,10 +1258,6 @@ This value allows you to set the maximum number of users allowed in the channel.
         <translation>Konektatutako &quot;bozgorailuak&quot; egia esan, aurikularrak dira</translation>
     </message>
     <message>
-        <source>Factor for sound volume decrease</source>
-        <translation>Soinu bolumena jaisteko faktorea</translation>
-    </message>
-    <message>
         <source>Bloom</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1440,6 +1436,10 @@ This value allows you to set the maximum number of users allowed in the channel.
     </message>
     <message>
         <source>Attenuation</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The minimum volume a player&apos;s audio will fade out to with increasing distance. Set to 0% for it to fade into complete silence for a realistic maximum hearing distance.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/mumble/mumble_fa_IR.ts
+++ b/src/mumble/mumble_fa_IR.ts
@@ -1248,10 +1248,6 @@ This value allows you to set the maximum number of users allowed in the channel.
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Factor for sound volume decrease</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Bloom</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1430,6 +1426,10 @@ This value allows you to set the maximum number of users allowed in the channel.
     </message>
     <message>
         <source>Attenuation</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The minimum volume a player&apos;s audio will fade out to with increasing distance. Set to 0% for it to fade into complete silence for a realistic maximum hearing distance.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/mumble/mumble_fi.ts
+++ b/src/mumble/mumble_fi.ts
@@ -1256,10 +1256,6 @@ Tämän numeron ollessa suurempi kuin nolla kanava sallii enintään numeron suu
         <translation>Yhdistetyt &quot;kaiuttimet&quot; ovat kuulokkeet</translation>
     </message>
     <message>
-        <source>Factor for sound volume decrease</source>
-        <translation>Prosentti jolla ääntä vähennetään</translation>
-    </message>
-    <message>
         <source>Bloom</source>
         <translation>Korostus</translation>
     </message>
@@ -1439,6 +1435,10 @@ Tämän numeron ollessa suurempi kuin nolla kanava sallii enintään numeron suu
     <message>
         <source>Attenuation</source>
         <translation>Vaimennus</translation>
+    </message>
+    <message>
+        <source>The minimum volume a player&apos;s audio will fade out to with increasing distance. Set to 0% for it to fade into complete silence for a realistic maximum hearing distance.</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/src/mumble/mumble_fr.ts
+++ b/src/mumble/mumble_fr.ts
@@ -1256,10 +1256,6 @@ Cette valeur vous permet de définir un nombre maximum d&apos;utilisateurs autor
         <translation>Les « haut-parleurs » actuellement connectés sont un casque</translation>
     </message>
     <message>
-        <source>Factor for sound volume decrease</source>
-        <translation>Facteur de diminution du volume sonore</translation>
-    </message>
-    <message>
         <source>Bloom</source>
         <translation>Boost sonore</translation>
     </message>
@@ -1439,6 +1435,10 @@ Cette valeur vous permet de définir un nombre maximum d&apos;utilisateurs autor
     <message>
         <source>Attenuation</source>
         <translation>Atténuation</translation>
+    </message>
+    <message>
+        <source>The minimum volume a player&apos;s audio will fade out to with increasing distance. Set to 0% for it to fade into complete silence for a realistic maximum hearing distance.</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/src/mumble/mumble_gl.ts
+++ b/src/mumble/mumble_gl.ts
@@ -1250,10 +1250,6 @@ This value allows you to set the maximum number of users allowed in the channel.
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Factor for sound volume decrease</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Bloom</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1432,6 +1428,10 @@ This value allows you to set the maximum number of users allowed in the channel.
     </message>
     <message>
         <source>Attenuation</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The minimum volume a player&apos;s audio will fade out to with increasing distance. Set to 0% for it to fade into complete silence for a realistic maximum hearing distance.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/mumble/mumble_he.ts
+++ b/src/mumble/mumble_he.ts
@@ -1257,10 +1257,6 @@ This value allows you to set the maximum number of users allowed in the channel.
         <translation>הרמקולים המחוברים הם למעשה אוזניות</translation>
     </message>
     <message>
-        <source>Factor for sound volume decrease</source>
-        <translation>הערך להפחתת עוצמת הקול</translation>
-    </message>
-    <message>
         <source>Bloom</source>
         <translation>הגברה</translation>
     </message>
@@ -1439,6 +1435,10 @@ This value allows you to set the maximum number of users allowed in the channel.
     </message>
     <message>
         <source>Attenuation</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The minimum volume a player&apos;s audio will fade out to with increasing distance. Set to 0% for it to fade into complete silence for a realistic maximum hearing distance.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/mumble/mumble_hu.ts
+++ b/src/mumble/mumble_hu.ts
@@ -1252,10 +1252,6 @@ This value allows you to set the maximum number of users allowed in the channel.
         <translation>A csatlakoztatott „hangszóró” valójában fejhallgató</translation>
     </message>
     <message>
-        <source>Factor for sound volume decrease</source>
-        <translation>Hangerőcsökkentés együtthatója</translation>
-    </message>
-    <message>
         <source>Bloom</source>
         <translation>Hangosítás</translation>
     </message>
@@ -1434,6 +1430,10 @@ This value allows you to set the maximum number of users allowed in the channel.
     </message>
     <message>
         <source>Attenuation</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The minimum volume a player&apos;s audio will fade out to with increasing distance. Set to 0% for it to fade into complete silence for a realistic maximum hearing distance.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/mumble/mumble_it.ts
+++ b/src/mumble/mumble_it.ts
@@ -1256,10 +1256,6 @@ Questo valore ti permette di impostare il numero massimo di utenti consentiti ne
         <translation>Gli altoparlanti attualmente connessi sono delle cuffie</translation>
     </message>
     <message>
-        <source>Factor for sound volume decrease</source>
-        <translation>Fattore di decremento del volume</translation>
-    </message>
-    <message>
         <source>Bloom</source>
         <translation>Volume massimo</translation>
     </message>
@@ -1439,6 +1435,10 @@ Questo valore ti permette di impostare il numero massimo di utenti consentiti ne
     <message>
         <source>Attenuation</source>
         <translation>Attenuazione</translation>
+    </message>
+    <message>
+        <source>The minimum volume a player&apos;s audio will fade out to with increasing distance. Set to 0% for it to fade into complete silence for a realistic maximum hearing distance.</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/src/mumble/mumble_ja.ts
+++ b/src/mumble/mumble_ja.ts
@@ -1256,10 +1256,6 @@ This value allows you to set the maximum number of users allowed in the channel.
         <translation>接続している &quot;出力機器&quot; はヘッドホンです</translation>
     </message>
     <message>
-        <source>Factor for sound volume decrease</source>
-        <translation>ボリューム減少の割合</translation>
-    </message>
-    <message>
         <source>Bloom</source>
         <translation>ブルーム</translation>
     </message>
@@ -1438,6 +1434,10 @@ This value allows you to set the maximum number of users allowed in the channel.
     </message>
     <message>
         <source>Attenuation</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The minimum volume a player&apos;s audio will fade out to with increasing distance. Set to 0% for it to fade into complete silence for a realistic maximum hearing distance.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/mumble/mumble_ko.ts
+++ b/src/mumble/mumble_ko.ts
@@ -1255,10 +1255,6 @@ This value allows you to set the maximum number of users allowed in the channel.
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Factor for sound volume decrease</source>
-        <translation>볼륨 감소 비율</translation>
-    </message>
-    <message>
         <source>Bloom</source>
         <translation>블룸</translation>
     </message>
@@ -1437,6 +1433,10 @@ This value allows you to set the maximum number of users allowed in the channel.
     </message>
     <message>
         <source>Attenuation</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The minimum volume a player&apos;s audio will fade out to with increasing distance. Set to 0% for it to fade into complete silence for a realistic maximum hearing distance.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/mumble/mumble_lt.ts
+++ b/src/mumble/mumble_lt.ts
@@ -1250,10 +1250,6 @@ This value allows you to set the maximum number of users allowed in the channel.
         <translation>Prijungti &quot;garsiakalbiai&quot;, iš tikrųjų, yra ausinės</translation>
     </message>
     <message>
-        <source>Factor for sound volume decrease</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Bloom</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1432,6 +1428,10 @@ This value allows you to set the maximum number of users allowed in the channel.
     </message>
     <message>
         <source>Attenuation</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The minimum volume a player&apos;s audio will fade out to with increasing distance. Set to 0% for it to fade into complete silence for a realistic maximum hearing distance.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/mumble/mumble_nl.ts
+++ b/src/mumble/mumble_nl.ts
@@ -1256,10 +1256,6 @@ Deze waarde laat je toe om een maximum aantal gebruikers in te stellen voor het 
         <translation>De aangesloten &quot;luidsprekers&quot; zijn eigenlijk een hoofdtelefoon</translation>
     </message>
     <message>
-        <source>Factor for sound volume decrease</source>
-        <translation>Geluidsvolumeverlagingsfactor</translation>
-    </message>
-    <message>
         <source>Bloom</source>
         <translation>Bloeien</translation>
     </message>
@@ -1439,6 +1435,10 @@ Deze waarde laat je toe om een maximum aantal gebruikers in te stellen voor het 
     <message>
         <source>Attenuation</source>
         <translation>Verafzwakking</translation>
+    </message>
+    <message>
+        <source>The minimum volume a player&apos;s audio will fade out to with increasing distance. Set to 0% for it to fade into complete silence for a realistic maximum hearing distance.</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/src/mumble/mumble_no.ts
+++ b/src/mumble/mumble_no.ts
@@ -1258,10 +1258,6 @@ Når du er lenger unna enn dette vil andres stemme ikke bli dempet ytterligere.<
         <translation>De tilkoblede &quot;høyttalerne&quot; er faktisk hodetelefoner</translation>
     </message>
     <message>
-        <source>Factor for sound volume decrease</source>
-        <translation>Faktor for lydstyrkesenkning</translation>
-    </message>
-    <message>
         <source>Bloom</source>
         <translation>Glød</translation>
     </message>
@@ -1441,6 +1437,10 @@ Når du er lenger unna enn dette vil andres stemme ikke bli dempet ytterligere.<
     <message>
         <source>Attenuation</source>
         <translation>Demping</translation>
+    </message>
+    <message>
+        <source>The minimum volume a player&apos;s audio will fade out to with increasing distance. Set to 0% for it to fade into complete silence for a realistic maximum hearing distance.</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/src/mumble/mumble_oc.ts
+++ b/src/mumble/mumble_oc.ts
@@ -1249,10 +1249,6 @@ This value allows you to set the maximum number of users allowed in the channel.
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Factor for sound volume decrease</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Bloom</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1431,6 +1427,10 @@ This value allows you to set the maximum number of users allowed in the channel.
     </message>
     <message>
         <source>Attenuation</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The minimum volume a player&apos;s audio will fade out to with increasing distance. Set to 0% for it to fade into complete silence for a realistic maximum hearing distance.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/mumble/mumble_pl.ts
+++ b/src/mumble/mumble_pl.ts
@@ -1256,10 +1256,6 @@ Określa maksymalną dozwoloną liczbę użytkowników na tym kanale. Jeżeli wa
         <translation>Podłączone &quot;głośniki&quot; to w rzeczywistości słuchawki</translation>
     </message>
     <message>
-        <source>Factor for sound volume decrease</source>
-        <translation>Jak szybko odbierany dźwięk ma zanikać</translation>
-    </message>
-    <message>
         <source>Bloom</source>
         <translation>Zmienna głośność</translation>
     </message>
@@ -1439,6 +1435,10 @@ Określa maksymalną dozwoloną liczbę użytkowników na tym kanale. Jeżeli wa
     <message>
         <source>Attenuation</source>
         <translation>Tłumienie</translation>
+    </message>
+    <message>
+        <source>The minimum volume a player&apos;s audio will fade out to with increasing distance. Set to 0% for it to fade into complete silence for a realistic maximum hearing distance.</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/src/mumble/mumble_pt_BR.ts
+++ b/src/mumble/mumble_pt_BR.ts
@@ -1256,10 +1256,6 @@ Este valor permite que você especifique o número máximo de usuárias permitid
         <translation>Os &quot;alto-falantes&quot; conectados são na realidade fones de ouvido</translation>
     </message>
     <message>
-        <source>Factor for sound volume decrease</source>
-        <translation>Fator para redução do volume</translation>
-    </message>
-    <message>
         <source>Bloom</source>
         <translation>Floração</translation>
     </message>
@@ -1439,6 +1435,10 @@ Este valor permite que você especifique o número máximo de usuárias permitid
     <message>
         <source>Attenuation</source>
         <translation>Atenuação</translation>
+    </message>
+    <message>
+        <source>The minimum volume a player&apos;s audio will fade out to with increasing distance. Set to 0% for it to fade into complete silence for a realistic maximum hearing distance.</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/src/mumble/mumble_pt_PT.ts
+++ b/src/mumble/mumble_pt_PT.ts
@@ -1255,10 +1255,6 @@ Este valor permite definir o número máximo de utilizadores permitido no canal.
         <translation>Os &quot;altifalantes&quot; conectados são na realidade auscultadores</translation>
     </message>
     <message>
-        <source>Factor for sound volume decrease</source>
-        <translation>Fator para redução do volume</translation>
-    </message>
-    <message>
         <source>Bloom</source>
         <translation>Bloom</translation>
     </message>
@@ -1437,6 +1433,10 @@ Este valor permite definir o número máximo de utilizadores permitido no canal.
     </message>
     <message>
         <source>Attenuation</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The minimum volume a player&apos;s audio will fade out to with increasing distance. Set to 0% for it to fade into complete silence for a realistic maximum hearing distance.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/mumble/mumble_ro.ts
+++ b/src/mumble/mumble_ro.ts
@@ -1252,10 +1252,6 @@ This value allows you to set the maximum number of users allowed in the channel.
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Factor for sound volume decrease</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Bloom</source>
         <translation>Bloom</translation>
     </message>
@@ -1434,6 +1430,10 @@ This value allows you to set the maximum number of users allowed in the channel.
     </message>
     <message>
         <source>Attenuation</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The minimum volume a player&apos;s audio will fade out to with increasing distance. Set to 0% for it to fade into complete silence for a realistic maximum hearing distance.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/mumble/mumble_ru.ts
+++ b/src/mumble/mumble_ru.ts
@@ -1251,10 +1251,6 @@ This value allows you to set the maximum number of users allowed in the channel.
         <translation>Подключенные &quot;динамики&quot; являются наушниками</translation>
     </message>
     <message>
-        <source>Factor for sound volume decrease</source>
-        <translation>Коэффициент уменьшения громкости звука</translation>
-    </message>
-    <message>
         <source>Bloom</source>
         <translation>Пик</translation>
     </message>
@@ -1434,6 +1430,10 @@ This value allows you to set the maximum number of users allowed in the channel.
     <message>
         <source>Attenuation</source>
         <translation>Приглушение</translation>
+    </message>
+    <message>
+        <source>The minimum volume a player&apos;s audio will fade out to with increasing distance. Set to 0% for it to fade into complete silence for a realistic maximum hearing distance.</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/src/mumble/mumble_si.ts
+++ b/src/mumble/mumble_si.ts
@@ -1367,10 +1367,6 @@ Contains the list of members inherited by the current channel. Uncheck &lt;i&gt;
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Factor for sound volume decrease</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>What should the volume be at the maximum distance?</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1424,6 +1420,10 @@ Contains the list of members inherited by the current channel. Uncheck &lt;i&gt;
     </message>
     <message>
         <source>&lt;b&gt;This enables one of the loopback test modes.&lt;/b&gt;&lt;br /&gt;&lt;i&gt;None&lt;/i&gt; - Loopback disabled&lt;br /&gt;&lt;i&gt;Local&lt;/i&gt; - Emulate a local server.&lt;br /&gt;&lt;i&gt;Server&lt;/i&gt; - Request loopback from server.&lt;br /&gt;Please note than when loopback is enabled, no other users will hear your voice. This setting is not saved on application exit.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The minimum volume a player&apos;s audio will fade out to with increasing distance. Set to 0% for it to fade into complete silence for a realistic maximum hearing distance.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/mumble/mumble_sv.ts
+++ b/src/mumble/mumble_sv.ts
@@ -1256,10 +1256,6 @@ Det värdet tillåter dig att ställa in ett maximalt antal av användare som ä
         <translation>De anslutna &quot;högtalarna&quot; är faktiskt hörlurar</translation>
     </message>
     <message>
-        <source>Factor for sound volume decrease</source>
-        <translation>Faktisk sänkning av volym</translation>
-    </message>
-    <message>
         <source>Bloom</source>
         <translation>Bloom</translation>
     </message>
@@ -1439,6 +1435,10 @@ Det värdet tillåter dig att ställa in ett maximalt antal av användare som ä
     <message>
         <source>Attenuation</source>
         <translation>Dämpning</translation>
+    </message>
+    <message>
+        <source>The minimum volume a player&apos;s audio will fade out to with increasing distance. Set to 0% for it to fade into complete silence for a realistic maximum hearing distance.</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/src/mumble/mumble_te.ts
+++ b/src/mumble/mumble_te.ts
@@ -1254,10 +1254,6 @@ This value allows you to set the maximum number of users allowed in the channel.
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Factor for sound volume decrease</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Bloom</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1436,6 +1432,10 @@ This value allows you to set the maximum number of users allowed in the channel.
     </message>
     <message>
         <source>Attenuation</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The minimum volume a player&apos;s audio will fade out to with increasing distance. Set to 0% for it to fade into complete silence for a realistic maximum hearing distance.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/mumble/mumble_th.ts
+++ b/src/mumble/mumble_th.ts
@@ -1248,10 +1248,6 @@ This value allows you to set the maximum number of users allowed in the channel.
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Factor for sound volume decrease</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Bloom</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1430,6 +1426,10 @@ This value allows you to set the maximum number of users allowed in the channel.
     </message>
     <message>
         <source>Attenuation</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The minimum volume a player&apos;s audio will fade out to with increasing distance. Set to 0% for it to fade into complete silence for a realistic maximum hearing distance.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/mumble/mumble_tr.ts
+++ b/src/mumble/mumble_tr.ts
@@ -1256,10 +1256,6 @@ Bu değer kanalda izin verilen azami kullanıcı sayısını ayarlamanıza izin 
         <translation>Bağlı &quot;hoparlörler&quot; aslında kulaklıktır</translation>
     </message>
     <message>
-        <source>Factor for sound volume decrease</source>
-        <translation>Ses hacmi düşürülmesi için katsayı</translation>
-    </message>
-    <message>
         <source>Bloom</source>
         <translation>Genişletme</translation>
     </message>
@@ -1438,6 +1434,10 @@ Bu değer kanalda izin verilen azami kullanıcı sayısını ayarlamanıza izin 
     </message>
     <message>
         <source>Attenuation</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The minimum volume a player&apos;s audio will fade out to with increasing distance. Set to 0% for it to fade into complete silence for a realistic maximum hearing distance.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/mumble/mumble_uk.ts
+++ b/src/mumble/mumble_uk.ts
@@ -1248,10 +1248,6 @@ This value allows you to set the maximum number of users allowed in the channel.
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Factor for sound volume decrease</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Bloom</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1430,6 +1426,10 @@ This value allows you to set the maximum number of users allowed in the channel.
     </message>
     <message>
         <source>Attenuation</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The minimum volume a player&apos;s audio will fade out to with increasing distance. Set to 0% for it to fade into complete silence for a realistic maximum hearing distance.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/mumble/mumble_zh_CN.ts
+++ b/src/mumble/mumble_zh_CN.ts
@@ -1256,10 +1256,6 @@ This value allows you to set the maximum number of users allowed in the channel.
         <translation>已连接的“扬声器”实际上是耳机</translation>
     </message>
     <message>
-        <source>Factor for sound volume decrease</source>
-        <translation>音量减小因子</translation>
-    </message>
-    <message>
         <source>Bloom</source>
         <translation>增幅</translation>
     </message>
@@ -1439,6 +1435,10 @@ This value allows you to set the maximum number of users allowed in the channel.
     <message>
         <source>Attenuation</source>
         <translation>衰减</translation>
+    </message>
+    <message>
+        <source>The minimum volume a player&apos;s audio will fade out to with increasing distance. Set to 0% for it to fade into complete silence for a realistic maximum hearing distance.</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/src/mumble/mumble_zh_HK.ts
+++ b/src/mumble/mumble_zh_HK.ts
@@ -1248,10 +1248,6 @@ This value allows you to set the maximum number of users allowed in the channel.
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Factor for sound volume decrease</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Bloom</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1430,6 +1426,10 @@ This value allows you to set the maximum number of users allowed in the channel.
     </message>
     <message>
         <source>Attenuation</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The minimum volume a player&apos;s audio will fade out to with increasing distance. Set to 0% for it to fade into complete silence for a realistic maximum hearing distance.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/mumble/mumble_zh_TW.ts
+++ b/src/mumble/mumble_zh_TW.ts
@@ -1251,10 +1251,6 @@ This value allows you to set the maximum number of users allowed in the channel.
         <translation>使用耳機</translation>
     </message>
     <message>
-        <source>Factor for sound volume decrease</source>
-        <translation>音量減弱因子</translation>
-    </message>
-    <message>
         <source>Bloom</source>
         <translation>音量增強</translation>
     </message>
@@ -1433,6 +1429,10 @@ This value allows you to set the maximum number of users allowed in the channel.
     </message>
     <message>
         <source>Attenuation</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The minimum volume a player&apos;s audio will fade out to with increasing distance. Set to 0% for it to fade into complete silence for a realistic maximum hearing distance.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>


### PR DESCRIPTION
The minimum volume setting determines how much a user's audio will fade
out with increasing in-game distance when positional audio is enabled.
Having this at 80% yields a basically non-noticeable effect leading to a
couple of reports of volume fading not working at all.

Thus this commit changes the default to 25% which should be an audible
difference. It is not set to 0% in order to not run into situations in
which users don't hear each other at all and then thinking that
positional audio is completely broken.

For anyone who wants a realistic audio experience though, this should be
set to 0%.

Furthermore the tooltip for this setting was changed as well.

### Checks

- [x] My commits follow the [commit guidelines](https://github.com/mumble-voip/mumble/blob/master/COMMIT_GUIDELINES.md)

