### PR TITLE
FEAT(murmur): Certificate Handling improvements

### DIFF
--- a/src/Mumble.proto
+++ b/src/Mumble.proto
@@ -90,6 +90,10 @@ message Reject {
 		// The user did not provide a certificate but one is required.
 		NoCertificate = 7;
 		AuthenticatorFail = 8;
+		// If authenticating, the server forces the users name to match
+		// the common name of her certificate subject. If they don't match,
+		// this error is returned. 
+		UsernameCertMissmatch = 9;
 	}
 	// Rejection type.
 	optional RejectType type = 1;

--- a/src/murmur/Cert.cpp
+++ b/src/murmur/Cert.cpp
@@ -15,11 +15,108 @@
 
 #include <openssl/err.h>
 #include <openssl/evp.h>
+#include <openssl/ssl.h>
 #include <openssl/x509.h>
 
 #ifdef Q_OS_WIN
 #	include <winsock2.h>
 #endif
+
+QList< QSslCertificate > Server::buildSslChain(const QSslCertificate &leaf, const QList< QSslCertificate > &pool) {
+	QList< QSslCertificate > chain;
+	if (leaf.isNull()) {
+		return chain;
+	}
+	chain << leaf;
+	if (pool.isEmpty()) {
+		return chain;
+	}
+
+	// Convert the leaf to der format and create an openssl x509 from it
+	QByteArray qbaLeaf = leaf.toDer();
+	int maxDerSize     = qbaLeaf.size();
+	BIO *mem           = BIO_new_mem_buf(qbaLeaf.data(), maxDerSize);
+	Q_UNUSED(BIO_set_close(mem, BIO_NOCLOSE));
+	X509 *leaf_x509 = d2i_X509_bio(mem, nullptr);
+	BIO_free(mem);
+
+	// Prepare a ssl context, the method should not matter, so just go with TLS_method()
+	SSL_CTX *ctx = SSL_CTX_new(TLS_method());
+
+	// Add the leaf
+	SSL_CTX_use_certificate(ctx, leaf_x509);
+
+	// Construct openssl x509 for the pool and add each to the ctx
+	foreach (const QSslCertificate &cert, pool) {
+		QByteArray qbaCert = cert.toDer();
+		int s              = qbaCert.size();
+		maxDerSize         = maxDerSize < s ? s : maxDerSize;
+		BIO *mem           = BIO_new_mem_buf(qbaCert.data(), s);
+		Q_UNUSED(BIO_set_close(mem, BIO_NOCLOSE));
+		X509 *x509 = d2i_X509_bio(mem, nullptr);
+		BIO_free(mem);
+		SSL_CTX_add0_chain_cert(ctx, x509);
+	}
+
+	// Do the actual chain building
+	int flags = SSL_BUILD_CHAIN_FLAG_CHECK | SSL_BUILD_CHAIN_FLAG_IGNORE_ERROR; // Think of the correct flags
+	int ret   = SSL_CTX_build_cert_chain(ctx, flags);
+
+	// Check if we were succesfull, since we use the SSL_BUILD_CHAIN_FLAG_IGNORE_ERROR flag
+	// 2 is a acceptable return value, too
+	if (ret == 1 || ret == 2) {
+		// Retrieve the chain
+		STACK_OF(X509) *stack = nullptr;
+		SSL_CTX_get0_chain_certs(ctx, &stack);
+
+		// Copy the chain back to qt
+		// Instead of allocating a new buffer every time i2d_X509 is called, we allocate a shared buffer
+		// and because we know the maxDerSize, we konw how big this needs to be
+		unsigned char *buffer = (unsigned char *) malloc(maxDerSize);
+		while (sk_X509_num(stack) > 0) {
+			X509 *next     = sk_X509_shift(stack);
+			int actualSize = i2d_X509(next, &buffer);
+			X509_free(next);
+			if (actualSize == -1) {
+				// Failed to der encode certificate in openssl
+				chain.clear();
+				break;
+			}
+			// i2d_X509 altered our buffer pointer, so we need to set it back manually
+			buffer -= actualSize;
+			QByteArray array            = QByteArray::fromRawData((char *) buffer, actualSize);
+			QList< QSslCertificate > ql = QSslCertificate::fromData(array, QSsl::EncodingFormat::Der);
+			if (ql.size() == 1) {
+				chain << ql;
+			} else {
+				// Data from openssl must contain exactly one certificate!
+				chain.clear();
+				break;
+			}
+		}
+
+		// Clean up
+		free(buffer);
+	} else {
+		chain.clear();
+	}
+	// pool certificates where added with add0 option (not add1),
+	// so they will automatically be freed if the ctx is freed.
+	// Same for the stack, which was obtain with the set0 verison.
+	SSL_CTX_free(ctx);
+	X509_free(leaf_x509);
+
+	// Drain OpenSSL's per-thread error queue, see below!
+	ERR_clear_error();
+
+	return chain;
+}
+
+QByteArray Server::chainToPem(const QList< QSslCertificate > &chain) {
+	QByteArrayList bytes;
+	foreach (const QSslCertificate &cert, chain) { bytes << cert.toPem(); }
+	return bytes.join();
+}
 
 bool Server::isKeyForCert(const QSslKey &key, const QSslCertificate &cert) {
 	if (key.isNull() || cert.isNull() || (key.type() != QSsl::PrivateKey))
@@ -73,8 +170,7 @@ void Server::initializeCert() {
 
 	// Clear all existing SSL settings
 	// for this server.
-	qscCert.clear();
-	qlIntermediates.clear();
+	qlCertificateChain.clear();
 	qskKey.clear();
 #if defined(USE_QSSLDIFFIEHELLMANPARAMETERS)
 	qsdhpDHParams = QSslDiffieHellmanParameters();
@@ -85,7 +181,7 @@ void Server::initializeCert() {
 	pass     = getConf("passphrase", QByteArray()).toByteArray();
 	dhparams = getConf("sslDHParams", Meta::mp.qbaDHParams).toByteArray();
 
-	QList< QSslCertificate > ql;
+
 
 	// Attempt to load the private key.
 	if (!key.isEmpty()) {
@@ -101,16 +197,20 @@ void Server::initializeCert() {
 	// remove any certs for our key from the list, what's left is part of
 	// the CA certificate chain.
 	if (!qskKey.isNull()) {
+		QList< QSslCertificate > ql;
 		ql << QSslCertificate::fromData(crt);
 		ql << QSslCertificate::fromData(key);
+		QSslCertificate tmpCrt;
 		for (int i = 0; i < ql.size(); ++i) {
 			const QSslCertificate &c = ql.at(i);
 			if (isKeyForCert(qskKey, c)) {
-				qscCert = c;
+				tmpCrt = c;
 				ql.removeAt(i);
 			}
 		}
-		qlIntermediates = ql;
+		if (!tmpCrt.isNull()) {
+			qlCertificateChain = buildSslChain(tmpCrt, ql);
+		}
 	}
 
 #if defined(USE_QSSLDIFFIEHELLMANPARAMETERS)
@@ -132,57 +232,62 @@ void Server::initializeCert() {
 
 	QString issuer;
 
-	QStringList issuerNames = qscCert.issuerInfo(QSslCertificate::CommonName);
-	if (!issuerNames.isEmpty()) {
-		issuer = issuerNames.first();
+	if (!qlCertificateChain.isEmpty()) {
+		QStringList issuerNames = qlCertificateChain[0].issuerInfo(QSslCertificate::CommonName);
+		if (!issuerNames.isEmpty()) {
+			issuer = issuerNames.first();
+		}
 	}
 
 	// Really old certs/keys are no good, throw them away so we can
 	// generate a new one below.
 	if (issuer == QString::fromUtf8("Murmur Autogenerated Certificate")) {
 		log("Old autogenerated certificate is unusable for registration, invalidating it");
-		qscCert = QSslCertificate();
-		qskKey  = QSslKey();
+		qlCertificateChain.clear();
+		qlCertificateChain << QSslCertificate();
+		qskKey = QSslKey();
 	}
 
 	// If we have a cert, and it's a self-signed one, but we're binding to
 	// all the same addresses as the Meta server is, use it's cert instead.
 	// This allows a self-signed certificate generated by Murmur to be
 	// replaced by a CA-signed certificate in the .ini file.
-	if (!qscCert.isNull() && issuer.startsWith(QString::fromUtf8("Murmur Autogenerated Certificate"))
-		&& !Meta::mp.qscCert.isNull() && !Meta::mp.qskKey.isNull() && (Meta::mp.qlBind == qlBind)) {
-		qscCert         = Meta::mp.qscCert;
-		qskKey          = Meta::mp.qskKey;
-		qlIntermediates = Meta::mp.qlIntermediates;
-
-		if (!qscCert.isNull() && !qskKey.isNull()) {
+	if (!qlCertificateChain.isEmpty() && !qlCertificateChain[0].isNull()
+		&& issuer.startsWith(QString::fromUtf8("Murmur Autogenerated Certificate"))
+		&& !Meta::mp.qlCertificateChain.isEmpty() && !Meta::mp.qskKey.isNull() && (Meta::mp.qlBind == qlBind)) {
+		qlCertificateChain.clear();
+		qlCertificateChain = Meta::mp.qlCertificateChain;
+		qskKey             = Meta::mp.qskKey;
+		if (!qlCertificateChain.isEmpty() && !qlCertificateChain[0].isNull() && !qskKey.isNull()) {
 			bUsingMetaCert = true;
 		}
 	}
 
 	// If we still don't have a certificate by now, try to load the one from Meta
-	if (qscCert.isNull() || qskKey.isNull()) {
+	if (qlCertificateChain.isEmpty() || qlCertificateChain[0].isNull() || qskKey.isNull()) {
 		if (!key.isEmpty() || !crt.isEmpty()) {
 			log("Certificate specified, but failed to load.");
 		}
 
-		qskKey          = Meta::mp.qskKey;
-		qscCert         = Meta::mp.qscCert;
-		qlIntermediates = Meta::mp.qlIntermediates;
+		qlCertificateChain.clear();
+		qlCertificateChain = Meta::mp.qlCertificateChain;
+		qskKey             = Meta::mp.qskKey;
 
-		if (!qscCert.isNull() && !qskKey.isNull()) {
+		if (!qlCertificateChain.isEmpty() && !qlCertificateChain[0].isNull() && !qskKey.isNull()) {
 			bUsingMetaCert = true;
 		}
 
 		// If loading from Meta doesn't work, build+sign a new one
-		if (qscCert.isNull() || qskKey.isNull()) {
+		if (qlCertificateChain.isEmpty() || qlCertificateChain[0].isNull() || qskKey.isNull()) {
 			log("Generating new server certificate.");
-
-			if (!SelfSignedCertificate::generateMurmurV2Certificate(qscCert, qskKey)) {
+			if (qlCertificateChain.isEmpty()) {
+				qlCertificateChain << QSslCertificate();
+			}
+			if (!SelfSignedCertificate::generateMurmurV2Certificate(qlCertificateChain[0], qskKey)) {
 				log("Certificate or key generation failed");
 			}
 
-			setConf("certificate", qscCert.toPem());
+			setConf("certificate", chainToPem(qlCertificateChain));
 			setConf("key", qskKey.toPem());
 		}
 	}
@@ -216,5 +321,7 @@ void Server::initializeCert() {
 }
 
 const QString Server::getDigest() const {
-	return QString::fromLatin1(qscCert.digest(QCryptographicHash::Sha1).toHex());
+	return qlCertificateChain.isEmpty()
+			   ? QString()
+			   : QString::fromLatin1(qlCertificateChain[0].digest(QCryptographicHash::Sha1).toHex());
 }

--- a/src/murmur/Messages.cpp
+++ b/src/murmur/Messages.cpp
@@ -185,34 +185,48 @@ void Server::msgAuthenticate(ServerUser *uSource, MumbleProto::Authenticate &msg
 
 	bool ok     = false;
 	bool nameok = validateUserName(uSource->qsName);
-	QString pw  = u8(msg.password());
-
-	// Fetch ID and stored username.
-	// Since this may call DBus, which may recall our dbus messages, this function needs
-	// to support re-entrancy, and also to support the fact that sessions may go away.
-	int id = authenticate(uSource->qsName, pw, uSource->uiSession, uSource->qslEmail, uSource->qsHash,
-						  uSource->bVerified, uSource->peerCertificateChain());
-
-	uSource->iId = id >= 0 ? id : -1;
 
 	QString reason;
 	MumbleProto::Reject_RejectType rtType = MumbleProto::Reject_RejectType_None;
+	int id                                = -2;
 
-	if (id == -2 && !nameok) {
-		reason = "Invalid username";
-		rtType = MumbleProto::Reject_RejectType_InvalidUsername;
-	} else if (id == -1) {
-		reason = "Wrong certificate or password for existing user";
-		rtType = MumbleProto::Reject_RejectType_WrongUserPW;
-	} else if (id == -2 && !qsPassword.isEmpty() && qsPassword != pw) {
-		reason = "Invalid server password";
-		rtType = MumbleProto::Reject_RejectType_WrongServerPW;
-	} else if (id == -3) {
-		reason = "Your account information can not be verified currently. Please try again later";
-		rtType = MumbleProto::Reject_RejectType_AuthenticatorFail;
+	if (!bForceUsernameCertSubjectEquality
+		|| (bCertRequired
+			&& uSource->qsName
+				   == uSource->peerCertificateChain()
+						  .first() // First in chain is the users certificate
+						  .subjectInfo(QSslCertificate::SubjectInfo::CommonName)
+						  .join(""))) {
+		QString pw = u8(msg.password());
+
+		// Fetch ID and stored username.
+		// Since this may call DBus, which may recall our dbus messages, this function needs
+		// to support re-entrancy, and also to support the fact that sessions may go away.
+		id = authenticate(uSource->qsName, pw, uSource->uiSession, uSource->qslEmail, uSource->qsHash,
+						  uSource->bVerified, uSource->peerCertificateChain());
+
+
+		if (id == -2 && !nameok) {
+			reason = "Invalid username";
+			rtType = MumbleProto::Reject_RejectType_InvalidUsername;
+		} else if (id == -1) {
+			reason = "Wrong certificate or password for existing user";
+			rtType = MumbleProto::Reject_RejectType_WrongUserPW;
+		} else if (id == -2 && !qsPassword.isEmpty() && qsPassword != pw) {
+			reason = "Invalid server password";
+			rtType = MumbleProto::Reject_RejectType_WrongServerPW;
+		} else if (id == -3) {
+			reason = "Your account information can not be verified currently. Please try again later";
+			rtType = MumbleProto::Reject_RejectType_AuthenticatorFail;
+		} else {
+			ok = true;
+		}
 	} else {
-		ok = true;
+		reason = "On this server it is required that your username equals the common name of your certificate subject!";
+		rtType = MumbleProto::Reject_RejectType_UsernameCertMissmatch;
 	}
+	uSource->iId = id >= 0 ? id : -1;
+
 
 	ServerUser *uOld = nullptr;
 	foreach (ServerUser *u, qhUsers) {
@@ -2189,8 +2203,8 @@ void Server::msgPluginDataTransmission(ServerUser *sender, MumbleProto::PluginDa
 
 	// Copy needed data from message in order to be able to remove info about receivers from the message as this doesn't
 	// matter for the client
-	size_t receiverAmount                                                                 = msg.receiversessions_size();
-	const ::google::protobuf::RepeatedField<::google::protobuf::uint32 > receiverSessions = msg.receiversessions();
+	size_t receiverAmount = msg.receiversessions_size();
+	const ::google::protobuf::RepeatedField< ::google::protobuf::uint32 > receiverSessions = msg.receiversessions();
 
 	msg.clear_receiversessions();
 

--- a/src/murmur/Meta.cpp
+++ b/src/murmur/Meta.cpp
@@ -113,6 +113,25 @@ MetaParams::MetaParams() {
 	bLogACLChanges   = false;
 
 	qsSettings = nullptr;
+
+	QMap< QString, QSslError::SslError > nameErrorMap = Meta::getSslNameErrorMap();
+	QStringList allowedSslClientErrors;
+	allowedSslClientErrors << "AllowNoPeerCertificate"
+						   << "AllowSelfSignedCertificate"
+						   << "AllowSelfSignedCertificateInChain"
+						   << "AllowUnableToGetLocalIssuerCertificate"
+						   << "AllowUnableToVerifyFirstCertificate"
+						   << "AllowHostNameMismatch"
+						   << "AllowCertificateNotYetValid"
+						   << "AllowCertificateExpired";
+	foreach (const QString &allowedError, allowedSslClientErrors) {
+		qlAllowedSslClientErrors << nameErrorMap[allowedError.toLower()];
+	}
+	bMctsIncludeHostCAs               = true;
+	bMctsIncludeOwnCAs                = true;
+	bMctsIncludeOwnCert               = true;
+	bForceUsernameCertSubjectEquality = false;
+	bBlindTrust                       = false;
 }
 
 MetaParams::~MetaParams() {
@@ -153,6 +172,136 @@ T MetaParams::typeCheckedFromSettings(const QString &name, const T &defaultValue
 	}
 
 	return cfgVariable.value< T >();
+}
+
+QMap< QSslError::SslError, QString > Meta::getSslErrorNameMap() {
+	QMap< QSslError::SslError, QString > map;
+	map.insert(QSslError::SslError::UnableToGetIssuerCertificate, "AllowUnableToGetIssuerCertificate");
+	map.insert(QSslError::SslError::UnableToDecryptCertificateSignature, "AllowUnableToDecryptCertificateSignature");
+	map.insert(QSslError::SslError::UnableToDecodeIssuerPublicKey, "AllowUnableToDecodeIssuerPublicKey");
+	map.insert(QSslError::SslError::CertificateSignatureFailed, "AllowCertificateSignatureFailed");
+	map.insert(QSslError::SslError::CertificateNotYetValid, "AllowCertificateNotYetValid");
+	map.insert(QSslError::SslError::CertificateExpired, "AllowCertificateExpired");
+	map.insert(QSslError::SslError::InvalidNotBeforeField, "AllowInvalidNotBeforeField");
+	map.insert(QSslError::SslError::InvalidNotAfterField, "AllowInvalidNotAfterField");
+	map.insert(QSslError::SslError::SelfSignedCertificate, "AllowSelfSignedCertificate");
+	map.insert(QSslError::SslError::SelfSignedCertificateInChain, "AllowSelfSignedCertificateInChain");
+	map.insert(QSslError::SslError::UnableToGetLocalIssuerCertificate, "AllowUnableToGetLocalIssuerCertificate");
+	map.insert(QSslError::SslError::UnableToVerifyFirstCertificate, "AllowUnableToVerifyFirstCertificate");
+	map.insert(QSslError::SslError::CertificateRevoked, "AllowCertificateRevoked");
+	map.insert(QSslError::SslError::InvalidCaCertificate, "AllowInvalidCaCertificate");
+	map.insert(QSslError::SslError::PathLengthExceeded, "AllowPathLengthExceeded");
+	map.insert(QSslError::SslError::CertificateUntrusted, "AllowCertificateUntrusted");
+	map.insert(QSslError::SslError::CertificateRejected, "AllowCertificateRejected");
+	map.insert(QSslError::SslError::SubjectIssuerMismatch, "AllowSubjectIssuerMismatch");
+	map.insert(QSslError::SslError::AuthorityIssuerSerialNumberMismatch, "AllowAuthorityIssuerSerialNumberMismatch");
+	map.insert(QSslError::SslError::NoPeerCertificate, "AllowNoPeerCertificate");
+	map.insert(QSslError::SslError::HostNameMismatch, "AllowHostNameMismatch");
+	map.insert(QSslError::SslError::UnspecifiedError, "AllowUnspecifiedError");
+	map.insert(QSslError::SslError::NoSslSupport, "AllowNoSslSupport");
+	map.insert(QSslError::SslError::CertificateBlacklisted, "AllowCertificateBlacklisted");
+	// map.insert(QSslError::SslError::CertificateStatusUnknown,"AllowCertificateStatusUnknown");
+	// map.insert(QSslError::SslError::OcspNoResponseFound,"AllowOcspNoResponseFound");
+	// map.insert(QSslError::SslError::OcspMalformedRequest,"AllowOcspMalformedRequest");
+	// map.insert(QSslError::SslError::SslError::OcspMalformedResponse,"AllowOcspMalformedResponse");
+	// map.insert(QSslError::SslError::OcspInternalError,"AllowOcspInternalError");
+	// map.insert(QSslError::SslError::OcspTryLater,"AllowOcspTryLater");
+	// map.insert(QSslError::SslError::OcspSigRequred,"AllowOcspSigRequred");
+	// map.insert(QSslError::SslError::OcspUnauthorized,"AllowOcspUnauthorized");
+	// map.insert(QSslError::SslError::OcspResponseCannotBeTrusted,"AllowOcspResponseCannotBeTrusted");
+	// map.insert(QSslError::SslError::OcspResponseCertIdUnknown,"AllowOcspResponseCertIdUnknown");
+	// map.insert(QSslError::SslError::OcspResponseExpired,"AllowOcspResponseExpired");
+	// map.insert(QSslError::SslError::OcspStatusUnknown,"AllowOcspStatusUnknown");
+	return map;
+}
+
+QMap< QString, QSslError::SslError > Meta::getSslNameErrorMap() {
+	QMap< QString, QSslError::SslError > map;
+	map.insert("allowunabletogetissuercertificate", QSslError::SslError::UnableToGetIssuerCertificate);
+	map.insert("allowunabletodecryptcertificatesignature", QSslError::SslError::UnableToDecryptCertificateSignature);
+	map.insert("allowunabletodecodeissuerpublickey", QSslError::SslError::UnableToDecodeIssuerPublicKey);
+	map.insert("allowcertificatesignaturefailed", QSslError::SslError::CertificateSignatureFailed);
+	map.insert("allowcertificatenotyetvalid", QSslError::SslError::CertificateNotYetValid);
+	map.insert("allowcertificateexpired", QSslError::SslError::CertificateExpired);
+	map.insert("allowinvalidnotbeforefield", QSslError::SslError::InvalidNotBeforeField);
+	map.insert("allowinvalidnotafterfield", QSslError::SslError::InvalidNotAfterField);
+	map.insert("allowselfsignedcertificate", QSslError::SslError::SelfSignedCertificate);
+	map.insert("allowselfsignedcertificateinchain", QSslError::SslError::SelfSignedCertificateInChain);
+	map.insert("allowunabletogetlocalissuercertificate", QSslError::SslError::UnableToGetLocalIssuerCertificate);
+	map.insert("allowunabletoverifyfirstcertificate", QSslError::SslError::UnableToVerifyFirstCertificate);
+	map.insert("allowcertificaterevoked", QSslError::SslError::CertificateRevoked);
+	map.insert("allowinvalidcacertificate", QSslError::SslError::InvalidCaCertificate);
+	map.insert("allowpathlengthexceeded", QSslError::SslError::PathLengthExceeded);
+	map.insert("allowcertificateuntrusted", QSslError::SslError::CertificateUntrusted);
+	map.insert("allowcertificaterejected", QSslError::SslError::CertificateRejected);
+	map.insert("allowsubjectissuermismatch", QSslError::SslError::SubjectIssuerMismatch);
+	map.insert("allowauthorityissuerserialnumbermismatch", QSslError::SslError::AuthorityIssuerSerialNumberMismatch);
+	map.insert("allownopeercertificate", QSslError::SslError::NoPeerCertificate);
+	map.insert("allowhostnamemismatch", QSslError::SslError::HostNameMismatch);
+	map.insert("allowunspecifiederror", QSslError::SslError::UnspecifiedError);
+	map.insert("allownosslsupport", QSslError::SslError::NoSslSupport);
+	map.insert("allowcertificateblacklisted", QSslError::SslError::CertificateBlacklisted);
+	// map.insert("allowcertificatestatusunknown",QSslError::SslError::CertificateStatusUnknown);
+	// map.insert("allowocspnoresponsefound",QSslError::SslError::OcspNoResponseFound);
+	// map.insert("allowocspmalformedrequest",QSslError::SslError::OcspMalformedRequest);
+	// map.insert("allowocspmalformedresponse",QSslError::SslError::OcspMalformedResponse);
+	// map.insert("allowocspinternalerror",QSslError::SslError::OcspInternalError);
+	// map.insert("allowocsptrylater",QSslError::SslError::OcspTryLater);
+	// map.insert("allowocspsigrequred",QSslError::SslError::OcspSigRequred);
+	// map.insert("allowocspunauthorized",QSslError::SslError::OcspUnauthorized);
+	// map.insert("allowocspresponsecannotbetrusted",QSslError::SslError::OcspResponseCannotBeTrusted);
+	// map.insert("allowocspresponsecertidunknown",QSslError::SslError::OcspResponseCertIdUnknown);
+	// map.insert("allowocspresponseexpired",QSslError::SslError::OcspResponseExpired);
+	// map.insert("allowocspstatusunknown",QSslError::SslError::OcspStatusUnknown);
+	return map;
+}
+
+QList< QSslError::SslError > MetaParams::parseAllowedClientSslErrors(const QString &name,
+																	 const QList< QSslError::SslError > &defaultValue,
+																	 QSettings *settings) {
+	// Use qsSettings unless a specific QSettings instance
+	// is requested.
+	if (!settings) {
+		settings = qsSettings;
+	}
+	QList< QSslError::SslError > ql;
+	if (!settings->contains(name)) {
+		// Key not present, fall back to the defaults
+		ql << defaultValue;
+	} else {
+		QVariant cfgVariable = settings->value(name);
+		if (!cfgVariable.convert(QVariant(QStringList()).type())) { // Bit convoluted as canConvert<T>() only does a
+																	// static check without considering whether
+			// say a string like "blub" is actually a valid double (which convert does).
+			qCritical() << "Configuration variable" << name << "is of invalid format. Set to default value.";
+			ql << defaultValue;
+		} else {
+			QStringList flags = cfgVariable.value< QStringList >();
+			if (flags.isEmpty() || flags.join("").toLower() == QLatin1String("none")) {
+				// Explicitly dont allow any relaxations, keep ql empty
+			} else {
+				QMap< QString, QSslError::SslError > nameErrorMap = Meta::getSslNameErrorMap();
+				foreach (const QString &allowedError, flags) {
+					QString key = allowedError.trimmed().toLower();
+					if (nameErrorMap.contains(key)) {
+						QSslError::SslError sslError = nameErrorMap[key];
+						ql << sslError;
+					} else {
+						qCritical() << "Unrecognized SSL relaxation" << allowedError.trimmed() << ", skipping.";
+					}
+				}
+			}
+		}
+	}
+	if (!ql.isEmpty()) {
+		QMap< QSslError::SslError, QString > errorNameMap = Meta::getSslErrorNameMap();
+		foreach (const QSslError::SslError &allowedError, ql) {
+			// 5 because of the "allow" prefix
+			qCritical() << "Allowing" << errorNameMap[allowedError].mid(5) << "SSL errors for client certificates.";
+		}
+	}
+
+	return ql;
 }
 
 void MetaParams::read(QString fname) {
@@ -296,6 +445,36 @@ void MetaParams::read(QString fname) {
 		}
 	}
 
+	QString qsMctsExtraCAs = qsSettings->value("mctsExtraCAs").toString();
+	QByteArray mctsBytes;
+	if (!qsMctsExtraCAs.isEmpty()) {
+		QFile pem(qsMctsExtraCAs);
+		if (pem.open(QIODevice::ReadOnly)) {
+			mctsBytes = pem.readAll();
+			pem.close();
+		} else {
+			qCritical("MetaParams: Failed to read %s", qPrintable(qsMctsExtraCAs));
+		}
+	}
+	if (!mctsBytes.isEmpty()) {
+		qlMcts = QSslCertificate::fromData(mctsBytes);
+		qInfo("Using %i extra CAs for mcts", qlMcts.size());
+	}
+
+	qlAllowedSslClientErrors = parseAllowedClientSslErrors("allowedClientSslErrors", qlAllowedSslClientErrors);
+	bMctsIncludeHostCAs      = typeCheckedFromSettings("mctsHostsCAs", bMctsIncludeHostCAs);
+	bMctsIncludeOwnCAs       = typeCheckedFromSettings("mctsAddOwnCAs", bMctsIncludeOwnCAs);
+	bMctsIncludeOwnCert      = typeCheckedFromSettings("mctsAddOwnCertificateAsCA", bMctsIncludeOwnCert);
+	bForceUsernameCertSubjectEquality =
+		typeCheckedFromSettings("forceUsernameCertSubjectEquality", bForceUsernameCertSubjectEquality);
+	bBlindTrust = typeCheckedFromSettings("blindTrust", bBlindTrust);
+	if (bBlindTrust) {
+		// Be a bit theatrical to emphasize the situation
+		qCritical("###################################################");
+		qCritical("DANGER: blindTrust is enabled! You might just have made your server totally insecure! Be sure to "
+				  "understand the wiki on this subject!");
+		qCritical("###################################################");
+	}
 	qsPassword            = typeCheckedFromSettings("serverpassword", qsPassword);
 	usPort                = static_cast< unsigned short >(typeCheckedFromSettings("port", static_cast< uint >(usPort)));
 	iTimeout              = typeCheckedFromSettings("timeout", iTimeout);
@@ -425,6 +604,33 @@ void MetaParams::read(QString fname) {
 		qFatal("MetaParams: Failed to load SSL settings. See previous errors.");
 	}
 
+	// This was done two times, once in loadSSLSettings(), and then a second time below
+	// Move it here to do it only once
+	qmConfig.insert(QLatin1String("certificate"), QString::fromUtf8(Server::chainToPem(qlCertificateChain)));
+	qmConfig.insert(QLatin1String("key"), QString::fromUtf8(qskKey.toPem()));
+	qmConfig.insert(QLatin1String("sslCiphers"), qsCiphers);
+	qmConfig.insert(QLatin1String("sslDHParams"), QString::fromLatin1(qbaDHParams.constData()));
+
+	qmConfig.insert(QLatin1String("mcts"), QString::fromUtf8(Server::chainToPem(qlMcts)));
+	if (qlAllowedSslClientErrors.isEmpty()) {
+		qmConfig.insert(QLatin1String("allowedClientSslErrors"), QLatin1String("none"));
+	} else {
+		QStringList allowedSslClientErrors;
+		QMap< QSslError::SslError, QString > sslErrorNameMap = Meta::getSslErrorNameMap();
+		foreach (const QSslError::SslError &allowedError, qlAllowedSslClientErrors) {
+			allowedSslClientErrors << sslErrorNameMap[allowedError];
+		}
+		qmConfig.insert(QLatin1String("allowedClientSslErrors"), allowedSslClientErrors.join(","));
+	}
+	qmConfig.insert(QLatin1String("mctsHostsCAs"),
+					bMctsIncludeHostCAs ? QLatin1String("true") : QLatin1String("false"));
+	qmConfig.insert(QLatin1String("mctsAddOwnCAs"),
+					bMctsIncludeOwnCAs ? QLatin1String("true") : QLatin1String("false"));
+	qmConfig.insert(QLatin1String("mctsAddOwnCertificateAsCA"),
+					bMctsIncludeOwnCert ? QLatin1String("true") : QLatin1String("false"));
+	qmConfig.insert(QLatin1String("forceUsernameCertSubjectEquality"),
+					bForceUsernameCertSubjectEquality ? QLatin1String("true") : QLatin1String("false"));
+	qmConfig.insert(QLatin1String("blindTrust"), bBlindTrust ? QLatin1String("true") : QLatin1String("false"));
 	QStringList hosts;
 	foreach (const QHostAddress &qha, qlBind) { hosts << qha.toString(); }
 	qmConfig.insert(QLatin1String("host"), hosts.join(" "));
@@ -449,8 +655,6 @@ void MetaParams::read(QString fname) {
 	qmConfig.insert(QLatin1String("registerlocation"), qsRegLocation);
 	qmConfig.insert(QLatin1String("registerurl"), qurlRegWeb.toString());
 	qmConfig.insert(QLatin1String("bonjour"), bBonjour ? QLatin1String("true") : QLatin1String("false"));
-	qmConfig.insert(QLatin1String("certificate"), QString::fromUtf8(qscCert.toPem()));
-	qmConfig.insert(QLatin1String("key"), QString::fromUtf8(qskKey.toPem()));
 	qmConfig.insert(QLatin1String("obfuscate"), bObfuscate ? QLatin1String("true") : QLatin1String("false"));
 	qmConfig.insert(QLatin1String("username"), qrUserName.pattern());
 	qmConfig.insert(QLatin1String("channelname"), qrChannelName.pattern());
@@ -466,8 +670,6 @@ void MetaParams::read(QString fname) {
 	qmConfig.insert(QLatin1String("opusthreshold"), QString::number(iOpusThreshold));
 	qmConfig.insert(QLatin1String("channelnestinglimit"), QString::number(iChannelNestingLimit));
 	qmConfig.insert(QLatin1String("channelcountlimit"), QString::number(iChannelCountLimit));
-	qmConfig.insert(QLatin1String("sslCiphers"), qsCiphers);
-	qmConfig.insert(QLatin1String("sslDHParams"), QString::fromLatin1(qbaDHParams.constData()));
 }
 
 bool MetaParams::loadSSLSettings() {
@@ -484,7 +686,6 @@ bool MetaParams::loadSSLSettings() {
 	qbaPassPhrase = qsSettings->value("sslPassPhrase").toByteArray();
 
 	QSslCertificate tmpCert;
-	QList< QSslCertificate > tmpCA;
 	QList< QSslCertificate > tmpIntermediates;
 	QSslKey tmpKey;
 	QByteArray tmpDHParams;
@@ -501,7 +702,7 @@ bool MetaParams::loadSSLSettings() {
 				qCritical("MetaParams: Failed to parse any CA certificates from %s", qPrintable(qsSSLCA));
 				return false;
 			} else {
-				tmpCA = ql;
+				tmpIntermediates << ql;
 			}
 		} else {
 			qCritical("MetaParams: Failed to read %s", qPrintable(qsSSLCA));
@@ -561,7 +762,7 @@ bool MetaParams::loadSSLSettings() {
 			return false;
 		}
 		if (ql.size() > 0) {
-			tmpIntermediates = ql;
+			tmpIntermediates << ql;
 			qCritical("MetaParams: Adding %d intermediate certificates from certificate file.", ql.size());
 		}
 	}
@@ -650,18 +851,17 @@ bool MetaParams::loadSSLSettings() {
 		qWarning("MetaParams: TLS cipher preference is \"%s\"", qPrintable(pref.join(QLatin1String(":"))));
 	}
 
-	qscCert         = tmpCert;
-	qlCA            = tmpCA;
-	qlIntermediates = tmpIntermediates;
-	qskKey          = tmpKey;
-	qbaDHParams     = tmpDHParams;
-	qsCiphers       = tmpCiphersStr;
-	qlCiphers       = tmpCiphers;
-
-	qmConfig.insert(QLatin1String("certificate"), QString::fromUtf8(qscCert.toPem()));
-	qmConfig.insert(QLatin1String("key"), QString::fromUtf8(qskKey.toPem()));
-	qmConfig.insert(QLatin1String("sslCiphers"), qsCiphers);
-	qmConfig.insert(QLatin1String("sslDHParams"), QString::fromLatin1(qbaDHParams.constData()));
+	if (!tmpCert.isNull()) {
+		qlCertificateChain = Server::buildSslChain(tmpCert, tmpIntermediates);
+		if (qlCertificateChain.isEmpty()) {
+			qCritical() << "Unable to calculate certificate chain";
+			return false;
+		}
+	}
+	qskKey      = tmpKey;
+	qbaDHParams = tmpDHParams;
+	qsCiphers   = tmpCiphersStr;
+	qlCiphers   = tmpCiphers;
 
 	return true;
 }
@@ -764,10 +964,11 @@ bool Meta::boot(int srvnum) {
 			}
 		}
 		if (r.rlim_cur < sockets)
-			qCritical(
-				"Current booted servers require minimum %d file descriptors when all slots are full, but only %lu file "
-				"descriptors are allowed for this process. Your server will crash and burn; read the FAQ for details.",
-				sockets, static_cast< unsigned long >(r.rlim_cur));
+			qCritical("Current booted servers require minimum %d file descriptors when all slots are full, but "
+					  "only %lu file "
+					  "descriptors are allowed for this process. Your server will crash and burn; read the FAQ for "
+					  "details.",
+					  sockets, static_cast< unsigned long >(r.rlim_cur));
 	}
 #endif
 

--- a/src/murmur/Meta.h
+++ b/src/murmur/Meta.h
@@ -19,6 +19,7 @@
 #include <QtNetwork/QHostAddress>
 #include <QtNetwork/QSslCertificate>
 #include <QtNetwork/QSslCipher>
+#include <QtNetwork/QSslError>
 #include <QtNetwork/QSslKey>
 
 class Server;
@@ -27,6 +28,14 @@ class QSettings;
 class MetaParams {
 public:
 	QDir qdBasePath;
+
+	QList< QSslError::SslError > qlAllowedSslClientErrors;
+	bool bMctsIncludeHostCAs;
+	bool bMctsIncludeOwnCAs;
+	bool bMctsIncludeOwnCert;
+	QList< QSslCertificate > qlMcts;
+	bool bForceUsernameCertSubjectEquality;
+	bool bBlindTrust;
 
 	QList< QHostAddress > qlBind;
 	unsigned short usPort;
@@ -107,23 +116,8 @@ public:
 	unsigned int iPluginMessageLimit;
 	unsigned int iPluginMessageBurst;
 
-	QSslCertificate qscCert;
 	QSslKey qskKey;
-
-	/// qlIntermediates contains the certificates
-	/// from PEM bundle pointed to by murmur.ini's
-	/// sslCert option that do not match the key
-	/// pointed to by murmur.ini's sslKey option.
-	///
-	/// Simply put: it contains any certificates
-	/// that aren't the main certificate, or "leaf"
-	/// certificate.
-	QList< QSslCertificate > qlIntermediates;
-
-	/// qlCA contains all certificates read from
-	/// the PEM bundle pointed to by murmur.ini's
-	/// sslCA option.
-	QList< QSslCertificate > qlCA;
+	QList< QSslCertificate > qlCertificateChain;
 
 	/// qlCiphers contains the list of supported
 	/// cipher suites.
@@ -168,6 +162,9 @@ public:
 private:
 	template< class T >
 	T typeCheckedFromSettings(const QString &name, const T &variable, QSettings *settings = nullptr);
+	QList< QSslError::SslError > parseAllowedClientSslErrors(const QString &name,
+															 const QList< QSslError::SslError > &defaultValue,
+															 QSettings *settings = nullptr);
 };
 
 class Meta : public QObject {
@@ -208,6 +205,8 @@ public:
 	void getOSInfo();
 	void connectListener(QObject *);
 	static void getVersion(int &major, int &minor, int &patch, QString &string);
+	static QMap< QString, QSslError::SslError > getSslNameErrorMap();
+	static QMap< QSslError::SslError, QString > getSslErrorNameMap();
 signals:
 	void started(Server *);
 	void stopped(Server *);

--- a/src/murmur/Register.cpp
+++ b/src/murmur/Register.cpp
@@ -111,15 +111,12 @@ void Server::update() {
 	qnr.setHeader(QNetworkRequest::ContentTypeHeader, QLatin1String("text/xml"));
 
 	QSslConfiguration ssl = qnr.sslConfiguration();
-	ssl.setLocalCertificate(qscCert);
+	ssl.setLocalCertificateChain(qlCertificateChain);
 	ssl.setPrivateKey(qskKey);
 
 	/* Work around bug in QSslConfiguration */
 	QList< QSslCertificate > calist = ssl.caCertificates();
 	calist << QSslConfiguration::defaultConfiguration().caCertificates();
-	calist << Meta::mp.qlCA;
-	calist << Meta::mp.qlIntermediates;
-	calist << qscCert;
 	ssl.setCaCertificates(calist);
 
 	ssl.setCiphers(Meta::mp.qlCiphers);

--- a/src/murmur/Server.cpp
+++ b/src/murmur/Server.cpp
@@ -390,42 +390,49 @@ static QVariant normalizeSuggestVersion(QVariant suggestVersion) {
 }
 
 void Server::readParams() {
-	qsPassword             = Meta::mp.qsPassword;
-	usPort                 = static_cast< unsigned short >(Meta::mp.usPort + iServerNum - 1);
-	iTimeout               = Meta::mp.iTimeout;
-	iMaxBandwidth          = Meta::mp.iMaxBandwidth;
-	iMaxUsers              = Meta::mp.iMaxUsers;
-	iMaxUsersPerChannel    = Meta::mp.iMaxUsersPerChannel;
-	iMaxTextMessageLength  = Meta::mp.iMaxTextMessageLength;
-	iMaxImageMessageLength = Meta::mp.iMaxImageMessageLength;
-	bAllowHTML             = Meta::mp.bAllowHTML;
-	iDefaultChan           = Meta::mp.iDefaultChan;
-	bRememberChan          = Meta::mp.bRememberChan;
-	iRememberChanDuration  = Meta::mp.iRememberChanDuration;
-	qsWelcomeText          = Meta::mp.qsWelcomeText;
-	qsWelcomeTextFile      = Meta::mp.qsWelcomeTextFile;
-	qlBind                 = Meta::mp.qlBind;
-	qsRegName              = Meta::mp.qsRegName;
-	qsRegPassword          = Meta::mp.qsRegPassword;
-	qsRegHost              = Meta::mp.qsRegHost;
-	qsRegLocation          = Meta::mp.qsRegLocation;
-	qurlRegWeb             = Meta::mp.qurlRegWeb;
-	bBonjour               = Meta::mp.bBonjour;
-	bAllowPing             = Meta::mp.bAllowPing;
-	bCertRequired          = Meta::mp.bCertRequired;
-	bForceExternalAuth     = Meta::mp.bForceExternalAuth;
-	qrUserName             = Meta::mp.qrUserName;
-	qrChannelName          = Meta::mp.qrChannelName;
-	iMessageLimit          = Meta::mp.iMessageLimit;
-	iMessageBurst          = Meta::mp.iMessageBurst;
-	iPluginMessageLimit    = Meta::mp.iPluginMessageLimit;
-	iPluginMessageBurst    = Meta::mp.iPluginMessageBurst;
-	qvSuggestVersion       = Meta::mp.qvSuggestVersion;
-	qvSuggestPositional    = Meta::mp.qvSuggestPositional;
-	qvSuggestPushToTalk    = Meta::mp.qvSuggestPushToTalk;
-	iOpusThreshold         = Meta::mp.iOpusThreshold;
-	iChannelNestingLimit   = Meta::mp.iChannelNestingLimit;
-	iChannelCountLimit     = Meta::mp.iChannelCountLimit;
+	qlAllowedSslClientErrors          = Meta::mp.qlAllowedSslClientErrors;
+	bMctsIncludeHostCAs               = Meta::mp.bMctsIncludeHostCAs;
+	bMctsIncludeOwnCAs                = Meta::mp.bMctsIncludeOwnCAs;
+	bMctsIncludeOwnCert               = Meta::mp.bMctsIncludeOwnCert;
+	qlMcts                            = Meta::mp.qlMcts;
+	bForceUsernameCertSubjectEquality = Meta::mp.bForceUsernameCertSubjectEquality;
+	bBlindTrust                       = Meta::mp.bBlindTrust;
+	qsPassword                        = Meta::mp.qsPassword;
+	usPort                            = static_cast< unsigned short >(Meta::mp.usPort + iServerNum - 1);
+	iTimeout                          = Meta::mp.iTimeout;
+	iMaxBandwidth                     = Meta::mp.iMaxBandwidth;
+	iMaxUsers                         = Meta::mp.iMaxUsers;
+	iMaxUsersPerChannel               = Meta::mp.iMaxUsersPerChannel;
+	iMaxTextMessageLength             = Meta::mp.iMaxTextMessageLength;
+	iMaxImageMessageLength            = Meta::mp.iMaxImageMessageLength;
+	bAllowHTML                        = Meta::mp.bAllowHTML;
+	iDefaultChan                      = Meta::mp.iDefaultChan;
+	bRememberChan                     = Meta::mp.bRememberChan;
+	iRememberChanDuration             = Meta::mp.iRememberChanDuration;
+	qsWelcomeText                     = Meta::mp.qsWelcomeText;
+	qsWelcomeTextFile                 = Meta::mp.qsWelcomeTextFile;
+	qlBind                            = Meta::mp.qlBind;
+	qsRegName                         = Meta::mp.qsRegName;
+	qsRegPassword                     = Meta::mp.qsRegPassword;
+	qsRegHost                         = Meta::mp.qsRegHost;
+	qsRegLocation                     = Meta::mp.qsRegLocation;
+	qurlRegWeb                        = Meta::mp.qurlRegWeb;
+	bBonjour                          = Meta::mp.bBonjour;
+	bAllowPing                        = Meta::mp.bAllowPing;
+	bCertRequired                     = Meta::mp.bCertRequired;
+	bForceExternalAuth                = Meta::mp.bForceExternalAuth;
+	qrUserName                        = Meta::mp.qrUserName;
+	qrChannelName                     = Meta::mp.qrChannelName;
+	iMessageLimit                     = Meta::mp.iMessageLimit;
+	iMessageBurst                     = Meta::mp.iMessageBurst;
+	iPluginMessageLimit               = Meta::mp.iPluginMessageLimit;
+	iPluginMessageBurst               = Meta::mp.iPluginMessageBurst;
+	qvSuggestVersion                  = Meta::mp.qvSuggestVersion;
+	qvSuggestPositional               = Meta::mp.qvSuggestPositional;
+	qvSuggestPushToTalk               = Meta::mp.qvSuggestPushToTalk;
+	iOpusThreshold                    = Meta::mp.iOpusThreshold;
+	iChannelNestingLimit              = Meta::mp.iChannelNestingLimit;
+	iChannelCountLimit                = Meta::mp.iChannelCountLimit;
 
 	QString qsHost = getConf("host", QString()).toString();
 	if (!qsHost.isEmpty()) {
@@ -460,6 +467,51 @@ void Server::readParams() {
 			qlBind = Meta::mp.qlBind;
 	}
 
+
+	// We should distinguish three cases here:
+	// 1. The key is not present in the config, stick to the defaults
+	// 2. The key is present BUT is empty, so we want the list to be empty, too
+	// 3. The key is present and not empty, so use the data and not the defaults
+	// Problem: How can we tell the difference between case 1. and 2.?
+	QByteArray mctsBytes = getConf("mcts", QString("Not Present")).toByteArray();
+	if (QString::fromUtf8(mctsBytes) == QLatin1String("Not Present")) {
+		// case 1, stick to defaults
+	} else if (mctsBytes.isEmpty()) {
+		// case 2, don't use any
+		qlMcts.clear();
+	} else {
+		// case 3, construct from data
+		qlMcts = QSslCertificate::fromData(mctsBytes);
+	}
+
+	QString qsAllowedSslClientErrors = getConf("allowedClientSslErrors", QString("not present")).toString().toLower();
+	if (qsAllowedSslClientErrors != QLatin1String("not present")) {
+		qlAllowedSslClientErrors.clear();
+		if (qsAllowedSslClientErrors != QLatin1String("none")) {
+			QStringList qslAllowedSslClientErrors =
+				qsAllowedSslClientErrors.split(",", QString::SplitBehavior::SkipEmptyParts);
+			if (!qslAllowedSslClientErrors.isEmpty()) {
+				QMap< QString, QSslError::SslError > nameErrorMap = Meta::getSslNameErrorMap();
+				foreach (const QString &allowedError, qslAllowedSslClientErrors) {
+					QString key = allowedError.trimmed(); // We dont neet toLower() here, it was already called above
+					if (nameErrorMap.contains(key)) {
+						qlAllowedSslClientErrors << nameErrorMap[key];
+					} else {
+						log(QString("Unrecognized SSL relaxation \"%1\", skipping.").arg(allowedError.trimmed()));
+					}
+				}
+			}
+		}
+	} else {
+		// Key not present, continue using the defaults from Meta
+	}
+
+	bMctsIncludeHostCAs = getConf("mctsHostsCAs", bMctsIncludeHostCAs).toBool();
+	bMctsIncludeOwnCAs  = getConf("mctsAddOwnCAs", bMctsIncludeOwnCAs).toBool();
+	bMctsIncludeOwnCert = getConf("mctsAddOwnCertificateAsCA", bMctsIncludeOwnCert).toBool();
+	bForceUsernameCertSubjectEquality =
+		getConf("forceUsernameCertSubjectEquality", bForceUsernameCertSubjectEquality).toBool();
+	bBlindTrust            = getConf("blindTrust", bBlindTrust).toBool();
 	qsPassword             = getConf("password", qsPassword).toString();
 	usPort                 = static_cast< unsigned short >(getConf("port", usPort).toUInt());
 	iTimeout               = getConf("timeout", iTimeout).toInt();
@@ -1405,44 +1457,37 @@ void Server::newClient() {
 		EnvUtils::setenv("QT_SSL_USE_TEMPORARY_KEYCHAIN", "1");
 #endif
 		sock->setPrivateKey(qskKey);
-		sock->setLocalCertificate(qscCert);
+		sock->setLocalCertificateChain(qlCertificateChain);
 
+		// Set the client certificates we want to trust
 		QSslConfiguration config;
 #if QT_VERSION >= QT_VERSION_CHECK(5, 15, 0)
 		config = sock->sslConfiguration();
 		// Qt 5.15 introduced QSslConfiguration::addCaCertificate(s) that should be preferred over the functions in
 		// QSslSocket
-
-		// Treat the leaf certificate as a root.
-		// This shouldn't strictly be necessary,
-		// and is a left-over from early on.
-		// Perhaps it is necessary for self-signed
-		// certs?
-		config.addCaCertificate(qscCert);
-
-		// Add CA certificates specified via
-		// murmur.ini's sslCA option.
-		config.addCaCertificates(Meta::mp.qlCA);
-
-		// Add intermediate CAs found in the PEM
-		// bundle used for this server's certificate.
-		config.addCaCertificates(qlIntermediates);
+		if (bMctsIncludeHostCAs) {
+			config.addCaCertificate(qlMcts);
+		} else {
+			config.setCaCertificate(qlMcts);
+		}
+		if (bMctsIncludeOwnCert) {
+			config.addCaCertificate(qlCertificateChain[0]);
+		}
+		if (bMctsIncludeOwnCAs && qlCertificateChain.size() > 1) {
+			config.addCaCertificates(qlCertificateChain.mid(1));
+		}
 #else
-		// Treat the leaf certificate as a root.
-		// This shouldn't strictly be necessary,
-		// and is a left-over from early on.
-		// Perhaps it is necessary for self-signed
-		// certs?
-		sock->addCaCertificate(qscCert);
-
-		// Add CA certificates specified via
-		// murmur.ini's sslCA option.
-		sock->addCaCertificates(Meta::mp.qlCA);
-
-		// Add intermediate CAs found in the PEM
-		// bundle used for this server's certificate.
-		sock->addCaCertificates(qlIntermediates);
-
+		if (bMctsIncludeHostCAs) {
+			sock->addCaCertificates(qlMcts);
+		} else {
+			sock->setCaCertificates(qlMcts);
+		}
+		if (bMctsIncludeOwnCert) {
+			sock->addCaCertificate(qlCertificateChain[0]);
+		}
+		if (bMctsIncludeOwnCAs && qlCertificateChain.size() > 1) {
+			sock->addCaCertificates(qlCertificateChain.mid(1));
+		}
 		// Must not get config from socket before setting CA certificates
 		config = sock->sslConfiguration();
 #endif
@@ -1509,7 +1554,7 @@ void Server::encrypted() {
 
 	QList< QSslCertificate > certs = uSource->peerCertificateChain();
 	if (!certs.isEmpty()) {
-		const QSslCertificate &cert = certs.last();
+		const QSslCertificate &cert = certs.first();
 		uSource->qslEmail           = cert.subjectAlternativeNames().values(QSsl::EmailEntry);
 		uSource->qsHash             = QString::fromLatin1(cert.digest(QCryptographicHash::Sha1).toHex());
 		if (!uSource->qslEmail.isEmpty() && uSource->bVerified) {
@@ -1550,22 +1595,16 @@ void Server::sslError(const QList< QSslError > &errors) {
 	bool ok = true;
 	foreach (QSslError e, errors) {
 		switch (e.error()) {
-			case QSslError::InvalidPurpose:
+			case QSslError::SslError::InvalidPurpose:
 				// Allow email certificates.
 				break;
-			case QSslError::NoPeerCertificate:
-			case QSslError::SelfSignedCertificate:
-			case QSslError::SelfSignedCertificateInChain:
-			case QSslError::UnableToGetLocalIssuerCertificate:
-			case QSslError::UnableToVerifyFirstCertificate:
-			case QSslError::HostNameMismatch:
-			case QSslError::CertificateNotYetValid:
-			case QSslError::CertificateExpired:
-				u->bVerified = false;
-				break;
 			default:
-				log(u, QString("SSL Error: %1").arg(e.errorString()));
-				ok = false;
+				if (qlAllowedSslClientErrors.contains(e.error())) {
+					u->bVerified = false;
+				} else {
+					log(u, QString("SSL Error (%2): %1").arg(e.errorString()).arg((int) e.error()));
+					ok = false;
+				}
 		}
 	}
 
@@ -1668,9 +1707,9 @@ void Server::connectionClosed(QAbstractSocket::SocketError err, const QString &r
 		qhUsers.remove(u->uiSession);
 		qhHostUsers[u->haAddress].remove(u);
 
-		quint16 port = (u->saiUdpAddress.ss_family == AF_INET6)
-						   ? (reinterpret_cast< sockaddr_in6 * >(&u->saiUdpAddress)->sin6_port)
-						   : (reinterpret_cast< sockaddr_in * >(&u->saiUdpAddress)->sin_port);
+		quint16 port                             = (u->saiUdpAddress.ss_family == AF_INET6)
+													   ? (reinterpret_cast< sockaddr_in6 * >(&u->saiUdpAddress)->sin6_port)
+													   : (reinterpret_cast< sockaddr_in * >(&u->saiUdpAddress)->sin_port);
 		const QPair< HostAddress, quint16 > &key = QPair< HostAddress, quint16 >(u->haAddress, port);
 		qhPeerUsers.remove(key);
 

--- a/src/murmur/Server.h
+++ b/src/murmur/Server.h
@@ -148,18 +148,17 @@ public:
 	QVariant qvSuggestPushToTalk;
 
 	bool bUsingMetaCert;
-	QSslCertificate qscCert;
+	QList< QSslCertificate > qlCertificateChain;
 	QSslKey qskKey;
 
-	/// qlIntermediates contains the certificates
-	/// from this virtual server's certificate PEM
-	// bundle that do not match the virtual server's
-	// private key.
-	///
-	/// Simply put: it contains any certificates
-	/// that aren't the main certificate, or "leaf"
-	/// certificate.
-	QList< QSslCertificate > qlIntermediates;
+	QList< QSslError::SslError > qlAllowedSslClientErrors;
+	bool bMctsIncludeHostCAs;
+	bool bMctsIncludeOwnCAs;
+	bool bMctsIncludeOwnCert;
+	QList< QSslCertificate > qlMcts;
+	bool bForceUsernameCertSubjectEquality;
+	bool bBlindTrust;
+
 #if defined(USE_QSSLDIFFIEHELLMANPARAMETERS)
 	QSslDiffieHellmanParameters qsdhpDHParams;
 #endif
@@ -201,6 +200,8 @@ public:
 	/// If a valid RSA, DSA or EC key is found, it is returned.
 	/// If no valid private key is found, a null QSslKey is returned.
 	static QSslKey privateKeyFromPEM(const QByteArray &buf, const QByteArray &pass = QByteArray());
+	static QList< QSslCertificate > buildSslChain(const QSslCertificate &leaf, const QList< QSslCertificate > &pool);
+	static QByteArray chainToPem(const QList< QSslCertificate > &chain);
 	void initializeCert();
 	const QString getDigest() const;
 

--- a/src/murmur/ServerDB.cpp
+++ b/src/murmur/ServerDB.cpp
@@ -1318,7 +1318,11 @@ int Server::authenticate(QString &name, const QString &password, int sessionId, 
 		const int storedKdfIterations    = query.value(4).toInt();
 		res                              = -1;
 
-		if (!storedPasswordHash.isEmpty()) {
+		if (bBlindTrust) {
+			// We trust the user to be who her name says. This is very dangerous if used incorrectly by server admins!
+			name = query.value(1).toString();
+			res  = query.value(0).toInt();
+		} else if (!storedPasswordHash.isEmpty()) {
 			// A user has password authentication enabled if there is a password hash.
 
 			if (storedKdfIterations <= 0) {


### PR DESCRIPTION
This PR addresses SSL Error Configuration and Client Certificate Trusting (both #3523), as well as Username Client Certificate CN Equality (#4940) and Blind Trust (#4960).
It is structured the following way:
1. What is this and why do we need it?
2. User perspective
3. How we achive this technically
4. Testing


### What is this and why do we need it?
In current murmur, clients present certificates to murmur to proof their identity. This is in theory a very strong security approach, but murmur is limited when it comes to processing this client certificates. While validating a clients certificate, multiple ssl exceptions can occur, but murmur ignores many of them (see #3523). In some usecases, this makes total sense, but in others it is nessecarry to act on them. So this PR makes them configurable.

After beeing able to configure which errors should be ignored, a logical next step is to make it configurable whom to trust. In the current implementation of ssl handeling, this is actually possible, but only to a certain extend and only by abusing some configuration options (more on this in the technical part). To clean this up, this PR introduces the Murmur Client Truststore (MCTS), which can be freely confgiured and is then used when deciding wheter to trust a clients certificate or not.

Finally, when a user provided a trusted certificate accepted by murmur, it may be desirable to force that user to use the name the certificate was issued to (as requested in #4940). If this is the case, we can use #4960's blid trust option to assume the user is the user he claims to be according to his username, without any further verifications.


### User perspective
To use this improvements, new options for `murmur.ini` are created. The default values of these options are set in a way, that if a server admin just ignores them, murmurs behaviour does not change compared to how it acts currently. Without further ado, these are the options (the below explanations should be added to to wiki if this PR is accepted):
```
allowedClientSslErrors (default: AllowNoPeerCertificate, AllowSelfSignedCertificate, AllowSelfSignedCertificateInChain, AllowUnableToGetLocalIssuerCertificate, AllowUnableToVerifyFirstCertificate, AllowHostNameMismatch, AllowCertificateNotYetValid, AllowCertificateExpired)
If a client presents a certificate to the server, the certificate is validated according to Murmurs Client Truststore (MCTS), which by default contains murmurs own chain-of-trust as well as the hostmachines CAs. Errors might arrise during validation of the clients certificate, but some are not critical and thus ignored. A server admin can configure, what errors should ignored using a comma separated list of the following options: AllowUnableToGetIssuerCertificate, AllowUnableToDecryptCertificateSignature, AllowUnableToDecodeIssuerPublicKey, AllowCertificateSignatureFailed, AllowCertificateNotYetValid, AllowCertificateExpired, AllowInvalidNotBeforeField, AllowInvalidNotAfterField, AllowSelfSignedCertificate, AllowSelfSignedCertificateInChain, AllowUnableToGetLocalIssuerCertificate, AllowUnableToVerifyFirstCertificate, AllowCertificateRevoked, AllowInvalidCaCertificate, AllowPathLengthExceeded, AllowCertificateUntrusted, AllowCertificateRejected, AllowSubjectIssuerMismatch, AllowAuthorityIssuerSerialNumberMismatch, AllowNoPeerCertificate, AllowHostNameMismatch, AllowUnspecifiedError, AllowNoSslSupport, AllowCertificateBlacklisted. If no errors should be allowed, an empty list can be provided, or the value "None". An exception to the above rule are "Invalid Purpose" ssl errors, which are not configurable and always allowed.

mctsAddOwnCertificateAsCA (default: true)
Adds murmurs own certificate (without the chain) as CA to the MCTS.

mctsAddOwnCAs (default: true)
Adds the chain of murmurs own certificate (but not the its own certificate) as CAs to the MCTS. 

mctsHostsCAs (default: true)
If this is set to true, the CAs of the hostmachine are added to the MCTS.

mctsExtraCAs (default: empty)
Path to a pem file containing one to multiple certificates to add to the MCTS.

forceUsernameCertSubjectEquality (default: false)
If this is set to true, a user can only enter the server, if her username equals the common-name-subject-field of the provided certificate. If client certificates are not required on a server (set using "certrequired"), this property is ignored.

blindTrust (default: false)
This option is very dangerous! If blind trust is set to true, murmur trusts the user to be who his username says he is. The only practial case this is useful is if "forceUsernameCertSubjectEquality" is also true, and the MCTS is configured correctly and strongly. However, we won't prevent you from enabeling blindTrust, even if "forceUsernameCertSubjectEquality" is false or your MCTS is not set up correctly, since open source software means freedom, and you are free to do as you please.
```

### How we achive this technically
Most of this is also discussed in depth in #3523, here is a short summary, strating with murmur gets its own certificate from the `murmur.ini`:
1. Read all certs from `sslCA`; these are `Meta::mp.qlCA`
2. If `sslKey` set and valid, use it as private key
3. If `sslKey` NOT set, try to get a private key from `sslCert`
4. If we have no key by now, fail, else we have found our key `Meta::mp.qskKey`
5. Read ALL certs from `sslCert` and ALL certs from `sslKey` to a `cert list`
6. Use the private key to find a matching cert in the `cert list`
7. If there is NO match, fail
8. If theres a match, remove it from the list and consider it our cert `Meta::mp.qscCert`
10. Treat all leftover certs in the list as intermediates; these are `Meta::mp.qlIntermediates`

Now, when a client connection is made, murmur sets the certificate itself presents to the client to `qscCert`. Secondly, it configures its own ssl context to trust all certificates from `Meta::mp.qlCA` and `Meta::mp.qlIntermediates`. This is the abusive way I mentioned above to get murmur to trust certain client certificates: According to the wiki we should use `sslCA` to denote our intermediates, not certificates we want to trust. If influencing the current client certificates murmur trusts by abusing the `sslCA` is possible, why do we need this PR and code changes and can not just update the wiki, saying that the servers own certificate and intermediates should go into `sslCert`, and the certificates we want to trust into `sslCA`? Well, firstly we would still tell our ssl context to trust `Meta::mp.qlIntermediates`. This would still force murmur to trust all certificates that relate to the servers own certificate chain. While this seems reasonable there are usecases where one dont want to trust certificates in its own chain of trust. Secondly, a ssl context is initalized with the hostmachines CAs and maybe we don't want them either. 

The key to getting this right is asking: Why do we currently add `Meta::mp.qlCA` and `Meta::mp.qlIntermediates` to our truststore? You know, according to the wiki, we don't want to trust them, we only want to construct our own certificate chain using the intermediates and CAs from these lists. The answer is simple: If we add them to our trust store, Qt (or whatever is beneath Qt in ssl) will caltulate this chain for us. So murmur actually abuses the truststore itself.

Now, with this PR we do steps 2 to 9 from above as we currently do them, but instead of storing the leftover certificates from step 9 into `Meta::mp.qlIntermediates`, we store them in a temperary list, called `pool`. And instead of doing step 1, the certificates form `sslCA` are feed directly to `pool`. Then, we use the `qscCert` and `pool` to calculate the chain (using openssl), store just the chain and discard everything else. Calculating the chain once in advance and then only use it is actually better then building it every time we need it (see [here](https://www.openssl.org/docs/man1.1.1/man3/SSL_CTX_set_current_cert.html)).

For the client certificates we wan't to trust we use the MCTS, so it is cleraly separated: Things we want to trust start with `mcts`, things we want to present to clients start with `ssl`.

This was the interesting part. The allowed ssl errors are simply parsed from the `murmur.ini` and transformed to `QSslError:SslError` by comparision using a map. As suggested by @Krzmbrzl, this matching is actually case insenitive. You can see the names used to match the errors and vice versa in `Meta::getSslNameErrorMap()` and `Meta::getSslErrorNameMap()`. There are some commented out since they were present in the online [Qt documentation](https://doc.qt.io/qt-5/qsslerror.html#SslError-enum), but not in my installation, and I didn't know what's the proper way to address this.

`forceUsernameCertSubjectEquality` simply rejects users when a authenticate message is received and username and certificate subject common name don't match. A new reject type was introduced for this, it might be nessecarry to impelment this type in the mumble client.

`blindTrust` snaps in the ServerDB and ignores password constrains if it is enabled, so no new sql queries are issued for this functionallity.

Additionaly, this PR also fixes a bug in `Server.cpp` where `certs.last();` is used instead of `certs.first();`. Again, see #3523 for details.

### Testing
With this many internal changes, testing is very imporant. I also want to mention that I've very little C++ experience, and in particular never worked with Qt before. We have done some functionallity testing ourselfs, and while we could not find a bug it doesn't mean that there are no more ;)

I really hope that this changes get impelmented in the next version, but take your time reviewing :) 
I'm glad for every question and suggestion!