### PR TITLE
FIX(client): Properly show currently selected audio device in settings dialog

### DIFF
--- a/src/mumble/ALSAAudio.cpp
+++ b/src/mumble/ALSAAudio.cpp
@@ -30,6 +30,7 @@ class ALSAAudioInputRegistrar : public AudioInputRegistrar {
 public:
 	ALSAAudioInputRegistrar();
 	virtual AudioInput *create();
+	virtual const QVariant getDeviceChoice();
 	virtual const QList< audioDevice > getDeviceChoices();
 	virtual void setDeviceChoice(const QVariant &, Settings &);
 	virtual bool canEcho(EchoCancelOptionID echoCancelID, const QString &outputSystem) const;
@@ -41,6 +42,7 @@ class ALSAAudioOutputRegistrar : public AudioOutputRegistrar {
 public:
 	ALSAAudioOutputRegistrar();
 	virtual AudioOutput *create();
+	virtual const QVariant getDeviceChoice();
 	virtual const QList< audioDevice > getDeviceChoices();
 	virtual void setDeviceChoice(const QVariant &, Settings &);
 };
@@ -88,23 +90,22 @@ AudioInput *ALSAAudioInputRegistrar::create() {
 	return new ALSAAudioInput();
 }
 
+const QVariant ALSAAudioInputRegistrar::getDeviceChoice() {
+	return Global::get().s.qsALSAInput;
+}
+
 const QList< audioDevice > ALSAAudioInputRegistrar::getDeviceChoices() {
-	QList< audioDevice > qlReturn;
+	QList< audioDevice > choices;
 
-	QStringList qlInputDevs = cards->qhInput.keys();
-	std::sort(qlInputDevs.begin(), qlInputDevs.end());
+	QStringList keys = cards->qhInput.keys();
+	std::sort(keys.begin(), keys.end());
 
-	if (qlInputDevs.contains(Global::get().s.qsALSAInput)) {
-		qlInputDevs.removeAll(Global::get().s.qsALSAInput);
-		qlInputDevs.prepend(Global::get().s.qsALSAInput);
+	for (const auto &key : keys) {
+		const auto name = QString::fromLatin1("[%1] %2").arg(key, cards->qhInput.value(key));
+		choices << audioDevice(name, key);
 	}
 
-	foreach (const QString &dev, qlInputDevs) {
-		QString t = QString::fromLatin1("[%1] %2").arg(dev, cards->qhInput.value(dev));
-		qlReturn << audioDevice(t, dev);
-	}
-
-	return qlReturn;
+	return choices;
 }
 
 void ALSAAudioInputRegistrar::setDeviceChoice(const QVariant &choice, Settings &s) {
@@ -122,23 +123,22 @@ AudioOutput *ALSAAudioOutputRegistrar::create() {
 	return new ALSAAudioOutput();
 }
 
+const QVariant ALSAAudioOutputRegistrar::getDeviceChoice() {
+	return Global::get().s.qsALSAOutput;
+}
+
 const QList< audioDevice > ALSAAudioOutputRegistrar::getDeviceChoices() {
-	QList< audioDevice > qlReturn;
+	QList< audioDevice > choices;
 
-	QStringList qlOutputDevs = cards->qhOutput.keys();
-	std::sort(qlOutputDevs.begin(), qlOutputDevs.end());
+	QStringList keys = cards->qhOutput.keys();
+	std::sort(keys.begin(), keys.end());
 
-	if (qlOutputDevs.contains(Global::get().s.qsALSAOutput)) {
-		qlOutputDevs.removeAll(Global::get().s.qsALSAOutput);
-		qlOutputDevs.prepend(Global::get().s.qsALSAOutput);
+	for (const auto &key : keys) {
+		const auto name = QString::fromLatin1("[%1] %2").arg(key, cards->qhOutput.value(key));
+		choices << audioDevice(name, key);
 	}
 
-	foreach (const QString &dev, qlOutputDevs) {
-		QString t = QString::fromLatin1("[%1] %2").arg(dev, cards->qhOutput.value(dev));
-		qlReturn << audioDevice(t, dev);
-	}
-
-	return qlReturn;
+	return choices;
 }
 
 void ALSAAudioOutputRegistrar::setDeviceChoice(const QVariant &choice, Settings &s) {

--- a/src/mumble/ASIOInput.cpp
+++ b/src/mumble/ASIOInput.cpp
@@ -23,6 +23,7 @@ class ASIOAudioInputRegistrar : public AudioInputRegistrar {
 public:
 	ASIOAudioInputRegistrar();
 	virtual AudioInput *create();
+	virtual const QVariant getDeviceChoice();
 	virtual const QList< audioDevice > getDeviceChoices();
 	virtual void setDeviceChoice(const QVariant &, Settings &);
 	virtual bool canEcho(EchoCancelOptionID echoCancelID, const QString &outputSystem) const;
@@ -37,16 +38,20 @@ ASIOAudioInputRegistrar::ASIOAudioInputRegistrar() : AudioInputRegistrar(QLatin1
 AudioInput *ASIOAudioInputRegistrar::create() {
 	return new ASIOInput();
 }
+
+const QVariant ASIOAudioInputRegistrar::getDeviceChoice() {
+	return {};
+}
+
 const QList< audioDevice > ASIOAudioInputRegistrar::getDeviceChoices() {
-	QList< audioDevice > qlReturn;
-	return qlReturn;
+	return {};
+}
+
+void ASIOAudioInputRegistrar::setDeviceChoice(const QVariant &, Settings &) {
 }
 
 bool ASIOAudioInputRegistrar::canEcho(EchoCancelOptionID echoOption, const QString &) const {
 	return (echoOption == EchoCancelOptionID::SPEEX_MIXED || echoOption == EchoCancelOptionID::SPEEX_MULTICHANNEL);
-}
-
-void ASIOAudioInputRegistrar::setDeviceChoice(const QVariant &, Settings &) {
 }
 
 static ConfigWidget *ASIOConfigDialogNew(Settings &st) {

--- a/src/mumble/AudioConfigDialog.cpp
+++ b/src/mumble/AudioConfigDialog.cpp
@@ -497,18 +497,21 @@ void AudioInputDialog::on_qcbTransmit_currentIndexChanged(int v) {
 void AudioInputDialog::on_qcbSystem_currentIndexChanged(int) {
 	qcbDevice->clear();
 
-	QList< audioDevice > ql;
+	QList< audioDevice > choices;
 
 	if (AudioInputRegistrar::qmNew) {
-		AudioInputRegistrar *air = AudioInputRegistrar::qmNew->value(qcbSystem->currentText());
-		ql                       = air->getDeviceChoices();
+		auto air         = AudioInputRegistrar::qmNew->value(qcbSystem->currentText());
+		QVariant current = air->getDeviceChoice();
+		choices          = air->getDeviceChoices();
 
-		int idx = 0;
+		for (int i = 0; i < choices.size(); ++i) {
+			auto &choice = choices.at(i);
+			qcbDevice->addItem(choice.first, choice.second);
+			qcbDevice->setItemData(i, choice.first.toHtmlEscaped(), Qt::ToolTipRole);
 
-		foreach (audioDevice d, ql) {
-			qcbDevice->addItem(d.first, d.second);
-			qcbDevice->setItemData(idx, d.first.toHtmlEscaped(), Qt::ToolTipRole);
-			++idx;
+			if (choice.second == current) {
+				qcbDevice->setCurrentIndex(i);
+			}
 		}
 
 		updateEchoEnableState();
@@ -516,7 +519,7 @@ void AudioInputDialog::on_qcbSystem_currentIndexChanged(int) {
 		qcbExclusive->setEnabled(air->canExclusive());
 	}
 
-	qcbDevice->setEnabled(ql.count() > 1);
+	qcbDevice->setEnabled(!choices.isEmpty());
 	verifyMicrophonePermission();
 }
 
@@ -750,19 +753,23 @@ void AudioOutputDialog::save() const {
 void AudioOutputDialog::on_qcbSystem_currentIndexChanged(int) {
 	qcbDevice->clear();
 
-	QList< audioDevice > ql;
+	QList< audioDevice > choices;
 
 	if (AudioOutputRegistrar::qmNew) {
-		AudioOutputRegistrar *aor = AudioOutputRegistrar::qmNew->value(qcbSystem->currentText());
-		ql                        = aor->getDeviceChoices();
+		auto aor         = AudioOutputRegistrar::qmNew->value(qcbSystem->currentText());
+		QVariant current = aor->getDeviceChoice();
+		choices          = aor->getDeviceChoices();
 
-		int idx = 0;
+		for (int i = 0; i < choices.size(); ++i) {
+			auto &choice = choices.at(i);
+			qcbDevice->addItem(choice.first, choice.second);
+			qcbDevice->setItemData(i, choice.first.toHtmlEscaped(), Qt::ToolTipRole);
 
-		foreach (audioDevice d, ql) {
-			qcbDevice->addItem(d.first, d.second);
-			qcbDevice->setItemData(idx, d.first.toHtmlEscaped(), Qt::ToolTipRole);
-			++idx;
+			if (choice.second == current) {
+				qcbDevice->setCurrentIndex(i);
+			}
 		}
+
 		bool canmute = aor->canMuteOthers();
 		qsOtherVolume->setEnabled(canmute);
 		qcbAttenuateOthersOnTalk->setEnabled(canmute);
@@ -779,7 +786,7 @@ void AudioOutputDialog::on_qcbSystem_currentIndexChanged(int) {
 		qcbExclusive->setEnabled(aor->canExclusive());
 	}
 
-	qcbDevice->setEnabled(ql.count() > 1);
+	qcbDevice->setEnabled(!choices.isEmpty());
 }
 
 void AudioOutputDialog::on_qsJitter_valueChanged(int v) {

--- a/src/mumble/AudioInput.h
+++ b/src/mumble/AudioInput.h
@@ -138,6 +138,7 @@ public:
 	AudioInputRegistrar(const QString &n, int priority = 0);
 	virtual ~AudioInputRegistrar();
 	virtual AudioInput *create()                               = 0;
+	virtual const QVariant getDeviceChoice()                   = 0;
 	virtual const QList< audioDevice > getDeviceChoices()      = 0;
 	virtual void setDeviceChoice(const QVariant &, Settings &) = 0;
 

--- a/src/mumble/AudioOutput.h
+++ b/src/mumble/AudioOutput.h
@@ -65,6 +65,7 @@ public:
 	AudioOutputRegistrar(const QString &n, int priority = 0);
 	virtual ~AudioOutputRegistrar();
 	virtual AudioOutput *create()                              = 0;
+	virtual const QVariant getDeviceChoice()                   = 0;
 	virtual const QList< audioDevice > getDeviceChoices()      = 0;
 	virtual void setDeviceChoice(const QVariant &, Settings &) = 0;
 	virtual bool canMuteOthers() const;

--- a/src/mumble/CoreAudio.h
+++ b/src/mumble/CoreAudio.h
@@ -78,6 +78,7 @@ class CoreAudioInputRegistrar : public AudioInputRegistrar {
 public:
 	CoreAudioInputRegistrar();
 	virtual AudioInput *create();
+	virtual const QVariant getDeviceChoice();
 	virtual const QList< audioDevice > getDeviceChoices();
 	virtual void setDeviceChoice(const QVariant &, Settings &);
 	virtual bool canEcho(EchoCancelOptionID echoCancelID, const QString &outputSystem) const;
@@ -88,6 +89,7 @@ class CoreAudioOutputRegistrar : public AudioOutputRegistrar {
 public:
 	CoreAudioOutputRegistrar() : AudioOutputRegistrar(QLatin1String("CoreAudio"), 10) {}
 	virtual AudioOutput *create();
+	virtual const QVariant getDeviceChoice();
 	virtual const QList< audioDevice > getDeviceChoices();
 	virtual void setDeviceChoice(const QVariant &, Settings &);
 	bool canMuteOthers() const;

--- a/src/mumble/CoreAudio.mm
+++ b/src/mumble/CoreAudio.mm
@@ -417,25 +417,18 @@ void CoreAudioInit::destroy() {
 }
 
 const QList< audioDevice > CoreAudioSystem::getDeviceChoices(bool input) {
-	bool doEcho = (Global::get().s.echoOption == EchoCancelOptionID::APPLE_AEC);
-	QHash< QString, QString > qhDevices = CoreAudioSystem::getDevices(input, doEcho);
-	QList< audioDevice > qlReturn;
-	QStringList qlDevices;
+	const bool doEcho = (Global::get().s.echoOption == EchoCancelOptionID::APPLE_AEC);
+	const QHash< QString, QString > devices = CoreAudioSystem::getDevices(input, doEcho);
 
-	qhDevices.insert(QString(), QObject::tr("Default Device"));
-	qlDevices = qhDevices.keys();
+	QList< audioDevice > choices = {
+		audioDevice(QObject::tr("Default Device"), QString())
+	};
 
-	const QString &qsDev = input ? Global::get().s.qsCoreAudioInput : Global::get().s.qsCoreAudioOutput;
-	if (qlDevices.contains(qsDev)) {
-		qlDevices.removeAll(qsDev);
-		qlDevices.prepend(qsDev);
+	for (auto &key : devices.keys()) {
+		choices << audioDevice(devices.value(key), key);
 	}
 
-	foreach (const QString &qsIdentifier, qlDevices) {
-		qlReturn << audioDevice(qhDevices.value(qsIdentifier), qsIdentifier);
-	}
-
-	return qlReturn;
+	return choices;
 }
 
 const QHash< QString, QString > CoreAudioSystem::getDevices(bool input, bool echo) {
@@ -477,6 +470,10 @@ AudioInput *CoreAudioInputRegistrar::create() {
 	} else {
 		return nullptr;
 	}
+}
+
+const QVariant CoreAudioInputRegistrar::getDeviceChoice() {
+	return Global::get().s.qsCoreAudioInput;
 }
 
 const QList< audioDevice > CoreAudioInputRegistrar::getDeviceChoices() {
@@ -549,6 +546,10 @@ bool CoreAudioInputRegistrar::isMicrophoneAccessDeniedByOS() {
 
 AudioOutput *CoreAudioOutputRegistrar::create() {
 	return new CoreAudioOutput();
+}
+
+const QVariant CoreAudioOutputRegistrar::getDeviceChoice() {
+	return Global::get().s.qsCoreAudioOutput;
 }
 
 const QList< audioDevice > CoreAudioOutputRegistrar::getDeviceChoices() {

--- a/src/mumble/OSS.cpp
+++ b/src/mumble/OSS.cpp
@@ -40,6 +40,7 @@ class OSSInputRegistrar : public AudioInputRegistrar {
 public:
 	OSSInputRegistrar();
 	virtual AudioInput *create();
+	virtual const QVariant getDeviceChoice();
 	virtual const QList< audioDevice > getDeviceChoices();
 	virtual void setDeviceChoice(const QVariant &, Settings &);
 	virtual bool canEcho(EchoCancelOptionID echoCancelID, const QString &outputSystem) const;
@@ -51,6 +52,7 @@ class OSSOutputRegistrar : public AudioOutputRegistrar {
 public:
 	OSSOutputRegistrar();
 	virtual AudioOutput *create();
+	virtual const QVariant getDeviceChoice();
 	virtual const QList< audioDevice > getDeviceChoices();
 	virtual void setDeviceChoice(const QVariant &, Settings &);
 };
@@ -65,20 +67,21 @@ AudioInput *OSSInputRegistrar::create() {
 	return new OSSInput();
 }
 
+const QVariant OSSInputRegistrar::getDeviceChoice() {
+	return Global::get().s.qsOSSInput;
+}
+
 const QList< audioDevice > OSSInputRegistrar::getDeviceChoices() {
-	QList< audioDevice > qlReturn;
+	QList< audioDevice > choices;
 
-	QStringList qlInputDevs = cards->qhInput.keys();
-	std::sort(qlInputDevs.begin(), qlInputDevs.end());
+	QStringList keys = cards->qhInput.keys();
+	std::sort(keys.begin(), keys.end());
 
-	if (qlInputDevs.contains(Global::get().s.qsOSSInput)) {
-		qlInputDevs.removeAll(Global::get().s.qsOSSInput);
-		qlInputDevs.prepend(Global::get().s.qsOSSInput);
+	for (const auto &key : keys) {
+		choices << audioDevice(cards->qhInput.value(key), key);
 	}
 
-	foreach (const QString &dev, qlInputDevs) { qlReturn << audioDevice(cards->qhInput.value(dev), dev); }
-
-	return qlReturn;
+	return choices;
 }
 
 void OSSInputRegistrar::setDeviceChoice(const QVariant &choice, Settings &s) {
@@ -96,20 +99,21 @@ AudioOutput *OSSOutputRegistrar::create() {
 	return new OSSOutput();
 }
 
+const QVariant OSSOutputRegistrar::getDeviceChoice() {
+	return Global::get().s.qsOSSOutput;
+}
+
 const QList< audioDevice > OSSOutputRegistrar::getDeviceChoices() {
-	QList< audioDevice > qlReturn;
+	QList< audioDevice > choices;
 
-	QStringList qlOutputDevs = cards->qhOutput.keys();
-	std::sort(qlOutputDevs.begin(), qlOutputDevs.end());
+	QStringList keys = cards->qhOutput.keys();
+	std::sort(keys.begin(), keys.end());
 
-	if (qlOutputDevs.contains(Global::get().s.qsOSSOutput)) {
-		qlOutputDevs.removeAll(Global::get().s.qsOSSOutput);
-		qlOutputDevs.prepend(Global::get().s.qsOSSOutput);
+	for (const auto &key : keys) {
+		choices << audioDevice(cards->qhOutput.value(key), key);
 	}
 
-	foreach (const QString &dev, qlOutputDevs) { qlReturn << audioDevice(cards->qhOutput.value(dev), dev); }
-
-	return qlReturn;
+	return choices;
 }
 
 void OSSOutputRegistrar::setDeviceChoice(const QVariant &choice, Settings &s) {

--- a/src/mumble/PAAudio.cpp
+++ b/src/mumble/PAAudio.cpp
@@ -27,6 +27,7 @@ static std::unique_ptr< PortAudioSystem > pas;
 class PortAudioInputRegistrar : public AudioInputRegistrar {
 private:
 	AudioInput *create() Q_DECL_OVERRIDE;
+	const QVariant getDeviceChoice() Q_DECL_OVERRIDE;
 	const QList< audioDevice > getDeviceChoices() Q_DECL_OVERRIDE;
 	void setDeviceChoice(const QVariant &, Settings &) Q_DECL_OVERRIDE;
 	bool canEcho(EchoCancelOptionID echoCancelID, const QString &outputSystem) const Q_DECL_OVERRIDE;
@@ -39,6 +40,7 @@ public:
 class PortAudioOutputRegistrar : public AudioOutputRegistrar {
 private:
 	AudioOutput *create() Q_DECL_OVERRIDE;
+	const QVariant getDeviceChoice() Q_DECL_OVERRIDE;
 	const QList< audioDevice > getDeviceChoices() Q_DECL_OVERRIDE;
 	void setDeviceChoice(const QVariant &, Settings &) Q_DECL_OVERRIDE;
 
@@ -61,8 +63,12 @@ AudioInput *PortAudioInputRegistrar::create() {
 	return new PortAudioInput();
 }
 
+const QVariant PortAudioInputRegistrar::getDeviceChoice() {
+	return Global::get().s.iPortAudioInput;
+}
+
 const QList< audioDevice > PortAudioInputRegistrar::getDeviceChoices() {
-	return pas->enumerateDevices(true, Global::get().s.iPortAudioInput);
+	return pas->enumerateDevices(true);
 }
 
 void PortAudioInputRegistrar::setDeviceChoice(const QVariant &choice, Settings &s) {
@@ -80,8 +86,12 @@ AudioOutput *PortAudioOutputRegistrar::create() {
 	return new PortAudioOutput();
 }
 
+const QVariant PortAudioOutputRegistrar::getDeviceChoice() {
+	return Global::get().s.iPortAudioOutput;
+}
+
 const QList< audioDevice > PortAudioOutputRegistrar::getDeviceChoices() {
-	return pas->enumerateDevices(false, Global::get().s.iPortAudioOutput);
+	return pas->enumerateDevices(false);
 }
 
 void PortAudioOutputRegistrar::setDeviceChoice(const QVariant &choice, Settings &s) {
@@ -172,7 +182,7 @@ PortAudioSystem::~PortAudioSystem() {
 	}
 }
 
-const QList< audioDevice > PortAudioSystem::enumerateDevices(const bool input, const PaDeviceIndex current) {
+const QList< audioDevice > PortAudioSystem::enumerateDevices(const bool input) {
 	QList< audioDevice > audioDevices;
 
 	if (!bOk) {
@@ -198,15 +208,6 @@ const QList< audioDevice > PortAudioSystem::enumerateDevices(const bool input, c
 				audioDevices << audioDevice(
 					QLatin1String(apiInfo->name) + QLatin1String(": ") + QLatin1String(deviceInfo->name), deviceIndex);
 			}
-		}
-	}
-
-	for (auto i = 0; i < audioDevices.count(); ++i) {
-		if (audioDevices.at(i).second == current) {
-			// We want the current device to appear at the top of the list
-			audioDevice audioDevice = audioDevices.takeAt(i);
-			audioDevices.prepend(audioDevice);
-			break;
 		}
 	}
 

--- a/src/mumble/PAAudio.h
+++ b/src/mumble/PAAudio.h
@@ -51,7 +51,7 @@ protected:
 	const PaDeviceInfo *(*Pa_GetDeviceInfo)(PaDeviceIndex device);
 
 public:
-	const QList< audioDevice > enumerateDevices(const bool input, const PaDeviceIndex current);
+	const QList< audioDevice > enumerateDevices(const bool input);
 
 	bool isStreamRunning(PaStream *stream);
 

--- a/src/mumble/PulseAudio.cpp
+++ b/src/mumble/PulseAudio.cpp
@@ -37,6 +37,7 @@ class PulseAudioInputRegistrar : public AudioInputRegistrar {
 public:
 	PulseAudioInputRegistrar();
 	virtual AudioInput *create();
+	virtual const QVariant getDeviceChoice();
 	virtual const QList< audioDevice > getDeviceChoices();
 	virtual void setDeviceChoice(const QVariant &, Settings &);
 	virtual bool canEcho(EchoCancelOptionID echoCancelID, const QString &outputSystem) const;
@@ -48,6 +49,7 @@ class PulseAudioOutputRegistrar : public AudioOutputRegistrar {
 public:
 	PulseAudioOutputRegistrar();
 	virtual AudioOutput *create();
+	virtual const QVariant getDeviceChoice();
 	virtual const QList< audioDevice > getDeviceChoices();
 	virtual void setDeviceChoice(const QVariant &, Settings &);
 	bool canMuteOthers() const;
@@ -898,20 +900,21 @@ AudioInput *PulseAudioInputRegistrar::create() {
 	return new PulseAudioInput();
 }
 
+const QVariant PulseAudioInputRegistrar::getDeviceChoice() {
+	return Global::get().s.qsPulseAudioInput;
+}
+
 const QList< audioDevice > PulseAudioInputRegistrar::getDeviceChoices() {
-	QList< audioDevice > qlReturn;
+	QList< audioDevice > choices;
 
-	QStringList qlInputDevs = pasys->qhInput.keys();
-	std::sort(qlInputDevs.begin(), qlInputDevs.end());
+	QStringList keys = pasys->qhInput.keys();
+	std::sort(keys.begin(), keys.end());
 
-	if (qlInputDevs.contains(Global::get().s.qsPulseAudioInput)) {
-		qlInputDevs.removeAll(Global::get().s.qsPulseAudioInput);
-		qlInputDevs.prepend(Global::get().s.qsPulseAudioInput);
+	for (const auto &key : keys) {
+		choices << audioDevice(pasys->qhInput.value(key), key);
 	}
 
-	foreach (const QString &dev, qlInputDevs) { qlReturn << audioDevice(pasys->qhInput.value(dev), dev); }
-
-	return qlReturn;
+	return choices;
 }
 
 void PulseAudioInputRegistrar::setDeviceChoice(const QVariant &choice, Settings &s) {
@@ -930,20 +933,21 @@ AudioOutput *PulseAudioOutputRegistrar::create() {
 	return new PulseAudioOutput();
 }
 
+const QVariant PulseAudioOutputRegistrar::getDeviceChoice() {
+	return Global::get().s.qsPulseAudioOutput;
+}
+
 const QList< audioDevice > PulseAudioOutputRegistrar::getDeviceChoices() {
-	QList< audioDevice > qlReturn;
+	QList< audioDevice > choices;
 
-	QStringList qlOutputDevs = pasys->qhOutput.keys();
-	std::sort(qlOutputDevs.begin(), qlOutputDevs.end());
+	QStringList keys = pasys->qhOutput.keys();
+	std::sort(keys.begin(), keys.end());
 
-	if (qlOutputDevs.contains(Global::get().s.qsPulseAudioOutput)) {
-		qlOutputDevs.removeAll(Global::get().s.qsPulseAudioOutput);
-		qlOutputDevs.prepend(Global::get().s.qsPulseAudioOutput);
+	for (const auto &key : keys) {
+		choices << audioDevice(pasys->qhOutput.value(key), key);
 	}
 
-	foreach (const QString &dev, qlOutputDevs) { qlReturn << audioDevice(pasys->qhOutput.value(dev), dev); }
-
-	return qlReturn;
+	return choices;
 }
 
 void PulseAudioOutputRegistrar::setDeviceChoice(const QVariant &choice, Settings &s) {

--- a/src/mumble/WASAPI.h
+++ b/src/mumble/WASAPI.h
@@ -36,7 +36,6 @@ public:
 	static const QHash< QString, QString > getDevices(EDataFlow dataflow);
 	static const QHash< QString, QString > getInputDevices();
 	static const QHash< QString, QString > getOutputDevices();
-	static const QList< audioDevice > mapToDevice(const QHash< QString, QString > &, const QString &);
 };
 
 class WASAPIInput : public AudioInput {


### PR DESCRIPTION
Every audio backend implementation was moving the current device at the top.

This commit replaces that logic by selecting the current device in the combobox.

---

## Before

![Before](https://user-images.githubusercontent.com/5897523/117562662-ed742580-b0a0-11eb-8eec-b6afef090a0c.png)

# After

![After](https://user-images.githubusercontent.com/5897523/117562663-f2d17000-b0a0-11eb-813c-f7813bcac676.png)