### PR TITLE
FIX(client): Windows loading/saving shortcuts

### DIFF
--- a/src/mumble/GlobalShortcut_win.cpp
+++ b/src/mumble/GlobalShortcut_win.cpp
@@ -635,6 +635,11 @@ GlobalShortcutWin::ButtonInfo GlobalShortcutWin::buttonInfo(const QVariant &butt
 		wchar_t buffer[MAX_PATH];
 		if (GetKeyNameText((input.code << 16) | (input.e0 << 24), buffer, MAX_PATH)) {
 			info.name = QString::fromWCharArray(buffer);
+		} else {
+			// If GetKeyNameText() cannot find the name. Show a K prefix and the scan code instead of Unknown.
+			// For keys like F13 - F24
+			info.devicePrefix = QStringLiteral("K");
+			info.name         = QString::number(static_cast< uint >(input.code));
 		}
 	} else if (button.userType() == qMetaTypeId< InputMouse >()) {
 		info.device       = tr("Mouse");

--- a/src/mumble/GlobalShortcut_win.cpp
+++ b/src/mumble/GlobalShortcut_win.cpp
@@ -31,7 +31,7 @@ extern "C" {
 extern HWND mumble_mw_hwnd;
 
 struct InputHid {
-	uint32_t button;
+	uint32_t button = 0;
 	std::string deviceName;
 	std::string devicePrefix;
 
@@ -228,8 +228,8 @@ void GlobalShortcutWin::run() {
 		yieldCurrentThread();
 	}
 
-	constexpr uint8_t nRid = 5;
-	RAWINPUTDEVICE rid[nRid];
+	constexpr uint8_t nRid   = 5;
+	RAWINPUTDEVICE rid[nRid] = {};
 
 	rid[0].usUsagePage = HID_USAGE_PAGE_GENERIC;
 	rid[0].usUsage     = HID_USAGE_GENERIC_MOUSE;
@@ -268,7 +268,7 @@ void GlobalShortcutWin::run() {
 }
 
 void GlobalShortcutWin::injectRawInputMessage(HRAWINPUT handle) {
-	UINT size;
+	UINT size = 0;
 	if (GetRawInputData(handle, RID_INPUT, nullptr, &size, sizeof(RAWINPUTHEADER)) != 0) {
 		return;
 	}
@@ -367,9 +367,9 @@ void GlobalShortcutWin::on_keyboardMessage(const uint16_t flags, uint16_t scanCo
 		scanCode = virtualKey != VK_PAUSE ? MapVirtualKey(virtualKey, MAPVK_VK_TO_VSC) : 0x45;
 	}
 
-	InputKeyboard input;
-	input.code = scanCode;
-	input.e0   = flags & RI_KEY_E0;
+	InputKeyboard input = {};
+	input.code          = scanCode;
+	input.e0            = flags & RI_KEY_E0;
 
 	handleButton(QVariant::fromValue(input), !(flags & RI_KEY_BREAK));
 }
@@ -427,8 +427,8 @@ void GlobalShortcutWin::on_mouseMessage(const uint16_t flags, const uint16_t dat
 }
 
 GlobalShortcutWin::DeviceMap::iterator GlobalShortcutWin::addDevice(const HANDLE deviceHandle) {
-	RID_DEVICE_INFO deviceInfo;
-	UINT size = sizeof(deviceInfo);
+	RID_DEVICE_INFO deviceInfo = {};
+	UINT size                  = sizeof(deviceInfo);
 	if (GetRawInputDeviceInfo(deviceHandle, RIDI_DEVICEINFO, &deviceInfo, &size) <= 0) {
 		return m_devices.end();
 	}
@@ -582,8 +582,8 @@ void GlobalShortcutWin::timeTicked() {
 				continue;
 			}
 
-			InputXinput input;
-			input.device = i;
+			InputXinput input = {};
+			input.device      = i;
 
 			for (uint8_t j = 0; j < 18; ++j) {
 				input.code = j;
@@ -596,8 +596,8 @@ void GlobalShortcutWin::timeTicked() {
 #endif
 #ifdef USE_GKEY
 	if (m_gkey) {
-		InputGkey input;
-		input.keyboard = false;
+		InputGkey input = {};
+		input.keyboard  = false;
 
 		for (uint8_t button = GKEY_MIN_MOUSE_BUTTON; button <= GKEY_MAX_MOUSE_BUTTON; ++button) {
 			input.button = button;

--- a/src/mumble/GlobalShortcut_win.cpp
+++ b/src/mumble/GlobalShortcut_win.cpp
@@ -58,6 +58,15 @@ struct InputHid {
 
 		return stream;
 	}
+
+	bool operator==(const InputHid &rhs) const {
+		return this->button == rhs.button && this->deviceName == rhs.deviceName
+			   && this->devicePrefix == rhs.devicePrefix;
+	}
+
+	bool operator<(const InputHid &rhs) const {
+		return this->button < rhs.button && this->deviceName < rhs.deviceName && this->devicePrefix < rhs.devicePrefix;
+	}
 };
 Q_DECLARE_METATYPE(InputHid)
 
@@ -82,6 +91,10 @@ struct InputKeyboard {
 
 		return stream;
 	}
+
+	bool operator==(const InputKeyboard &rhs) const { return this->e0 == rhs.e0 && this->code == rhs.code; }
+
+	bool operator<(const InputKeyboard &rhs) const { return this->e0 < rhs.e0 && this->code < rhs.code; }
 };
 Q_DECLARE_METATYPE(InputKeyboard)
 
@@ -112,6 +125,10 @@ struct InputXinput {
 
 		return stream;
 	}
+
+	bool operator==(const InputXinput &rhs) const { return this->device == rhs.device && this->code == rhs.code; }
+
+	bool operator<(const InputXinput &rhs) const { return this->device < rhs.device && this->code < rhs.code; }
 };
 Q_DECLARE_METATYPE(InputXinput)
 #endif
@@ -142,6 +159,14 @@ struct InputGkey {
 
 		return stream;
 	}
+
+	bool operator==(const InputGkey &rhs) const {
+		return this->keyboard == rhs.keyboard && this->button == rhs.button && this->mode == rhs.mode;
+	}
+
+	bool operator<(const InputGkey &rhs) const {
+		return this->keyboard < rhs.keyboard && this->button < rhs.button && this->mode < rhs.mode;
+	}
 };
 Q_DECLARE_METATYPE(InputGkey)
 #endif
@@ -159,19 +184,24 @@ void GlobalShortcutWin::registerMetaTypes() {
 
 		qRegisterMetaType< InputHid >();
 		qRegisterMetaTypeStreamOperators< InputHid >();
+		QMetaType::registerComparators< InputHid >();
 
 		qRegisterMetaType< InputKeyboard >();
 		qRegisterMetaTypeStreamOperators< InputKeyboard >();
+		QMetaType::registerComparators< InputKeyboard >();
 
 		qRegisterMetaType< InputMouse >();
 		qRegisterMetaTypeStreamOperators< InputMouse >();
+		QMetaType::registerComparators< InputMouse >();
 #ifdef USE_XBOXINPUT
 		qRegisterMetaType< InputXinput >();
 		qRegisterMetaTypeStreamOperators< InputXinput >();
+		QMetaType::registerComparators< InputXinput >();
 #endif
 #ifdef USE_GKEY
 		qRegisterMetaType< InputGkey >();
 		qRegisterMetaTypeStreamOperators< InputGkey >();
+		QMetaType::registerComparators< InputGkey >();
 #endif
 	}
 }

--- a/src/mumble/GlobalShortcut_win.h
+++ b/src/mumble/GlobalShortcut_win.h
@@ -24,6 +24,8 @@ class GlobalShortcutWin : public GlobalShortcutEngine {
 	Q_DISABLE_COPY(GlobalShortcutWin)
 
 public:
+	static void registerMetaTypes();
+
 	/// Inject a native Windows raw input message into GlobalShortcutWin's
 	/// thread. This method is meant to be called from the main thread
 	/// to pass native Windows keyboard messages to GlobalShortcutWin.

--- a/src/mumble/PluginManager.cpp
+++ b/src/mumble/PluginManager.cpp
@@ -480,7 +480,7 @@ const QVector< const_plugin_ptr_t > PluginManager::getPlugins(bool sorted) const
 		std::sort(ids.begin(), ids.end(), [this](plugin_id_t first, plugin_id_t second) {
 			return QString::compare(m_pluginHashMap.value(first)->getName(), m_pluginHashMap.value(second)->getName(),
 									Qt::CaseInsensitive)
-				   <= 0;
+				   < 0;
 		});
 
 		foreach (plugin_id_t currentID, ids) { pluginList.append(m_pluginHashMap.value(currentID)); }

--- a/src/mumble/Settings.cpp
+++ b/src/mumble/Settings.cpp
@@ -11,6 +11,10 @@
 #include "SSL.h"
 #include "Global.h"
 
+#if defined(Q_OS_WIN)
+#	include "GlobalShortcut_win.h"
+#endif
+
 #include "../../overlay/overlay.h"
 
 #include <QtCore/QFileInfo>
@@ -288,6 +292,9 @@ void OverlaySettings::setPreset(const OverlayPresets preset) {
 }
 
 Settings::Settings() {
+#if defined(Q_OS_WIN)
+	GlobalShortcutWin::registerMetaTypes();
+#endif
 	qRegisterMetaType< ShortcutTarget >("ShortcutTarget");
 	qRegisterMetaTypeStreamOperators< ShortcutTarget >("ShortcutTarget");
 	qRegisterMetaType< QVariant >("QVariant");


### PR DESCRIPTION
### Checks

- [x] My commits follow the [commit guidelines](https://github.com/mumble-voip/mumble/blob/master/COMMIT_GUIDELINES.md)

### Issues

This pull request fixes the following issues:

The revamped raw inputs are not saving / loading shortcuts for the Windows client.

Keyboard shortcuts that are outside of the normal range show up as "Unknown"

Fix the shortcuts events not firing for input buttons when the structs were compared using the default memcmp.

### Tested

- [x] InputXinput (Xbox controller)
- [x] InputKeyboard (Normal and "Unknown" characters)
- [x] InputMouse
- [x] InputHid ( Turn off XInput per @davidebeatrici Thanks!)
- [ ] InputGKey

I don't believe InputGKey is compatible with my mouse under Logitech GHub.

![image](https://user-images.githubusercontent.com/1136966/117616679-acbfef00-b128-11eb-9bd5-9329b1af2c1a.png)

1. Is the Xinput Xbox controller's A.
2. Is the InputHid Xbox controller's A.
3. M3 is for Mouse3.
4. K118 is "F24" on the keyboard which is mapped from mouse using Logitech GHub.


### Notes

This could be considered a breaking change since the shortcut save format might not be backwards compatible. Though that format change had already been made, this fixes it so the change persists to disk.
It is also difficult to reload a previous version's shortcuts to be sure what would be backwards compatible.