### PR TITLE
MAINT(vcpkg): Restore profiledir variable in get_mumble_dependencies.ps1

### DIFF
--- a/scripts/vcpkg/get_mumble_dependencies.ps1
+++ b/scripts/vcpkg/get_mumble_dependencies.ps1
@@ -3,7 +3,7 @@
 # that can be found in the LICENSE file at the root of the
 # Mumble source tree or at <https://www.mumble.info/LICENSE>.
 
-﻿$profiledir = $Env:USERPROFILE 
+$profiledir = $Env:USERPROFILE 
 $vcpkgdir = $profiledir + "\vcpkg"
 
 $mumble_deps = "qt5-base",


### PR DESCRIPTION
Removes invalid characters (UTF-16 BOM) at the start of line 6.
The profiledir variable is set properly again. Fixing the vcpkg directory being created in the root of the system directory.

### Impact
Anyone that built the vcpkg using get_mumble_dependecies.ps1 should move their vcpkg folder to the userprofile directory before re-running it. If vcpkg doesn't exist under the userprofile directory it will be recreated by the script.

### Issue

Original error message below:
```
ï»¿$profiledir` : The term 'ï»¿$profiledir' is not recognized as the name of a cmdlet, function, script file, or
operable program. Check the spelling of the name, or if a path was included, verify that the path is correct and try
again.
At C:\Dev\Git\mumble\scripts\vcpkg\get_mumble_dependencies.ps1:6 char:1
+ ï»¿$profiledir = $Env:USERPROFILE
+ ~~~~~~~~~~~~~~
    + CategoryInfo          : ObjectNotFound: (ï»¿$profiledir:String) [], CommandNotFoundException
    + FullyQualifiedErrorId : CommandNotFoundException
```


### Checks

- [x] My commits follow the [commit guidelines](https://github.com/mumble-voip/mumble/blob/master/COMMIT_GUIDELINES.md)

