### PR TITLE
REFAC(client): Don't use deprecated mutex ctor

### DIFF
--- a/src/mumble/Plugin.cpp
+++ b/src/mumble/Plugin.cpp
@@ -15,7 +15,7 @@
 
 // initialize the static ID counter
 plugin_id_t Plugin::s_nextID = 1;
-QMutex Plugin::s_idLock(QMutex::NonRecursive);
+QMutex Plugin::s_idLock;
 
 void assertPluginLoaded(const Plugin *plugin) {
 	// don't throw and exception in release build

--- a/src/mumble/ServerHandler.cpp
+++ b/src/mumble/ServerHandler.cpp
@@ -59,7 +59,7 @@
 
 // Init ServerHandler::nextConnectionID
 int ServerHandler::nextConnectionID = -1;
-QMutex ServerHandler::nextConnectionIDMutex(QMutex::Recursive);
+QMutex ServerHandler::nextConnectionIDMutex;
 
 ServerHandlerMessageEvent::ServerHandlerMessageEvent(const QByteArray &msg, unsigned int mtype, bool flush)
 	: QEvent(static_cast< QEvent::Type >(SERVERSEND_EVENT)) {


### PR DESCRIPTION
In the latest Qt version, specifying a recrsion mode when creating a
mutex was deprecated in favor of QRecursiveMutex being used for the
cases where recursion is needed.

Given that we only ever needed non-recursive mutexes, all we had to do
was to remove the argument to the ctor.

Ref.: Upstream commit deprecating that ctor:
https://github.com/qt/qtbase/commit/d4b206b246caf9b49110526585693ab629609d99

Fixes #4973


### Checks

- [x] My commits follow the [commit guidelines](https://github.com/mumble-voip/mumble/blob/master/COMMIT_GUIDELINES.md)

