### PR TITLE
FIX(client, ui): TalkingUI font not scaling properly

### DIFF
--- a/src/mumble/widgets/MultiStyleWidgetWrapper.cpp
+++ b/src/mumble/widgets/MultiStyleWidgetWrapper.cpp
@@ -17,16 +17,9 @@ MultiStyleWidgetWrapper::MultiStyleWidgetWrapper(QWidget *widget) : m_widget(wid
 }
 
 void MultiStyleWidgetWrapper::setFontSize(uint32_t fontSize, bool isPixels) {
-	if (!isPixels) {
-		// Convert the font size to pixels
-		QFont font;
-		font.setPixelSize(fontSize);
-
-		fontSize = QFontMetrics(font).height();
-	}
-
-	if (fontSize != m_fontSize) {
-		m_fontSize = fontSize;
+	if (fontSize != m_fontSize || m_fontSizeInPixels != isPixels) {
+		m_fontSize         = fontSize;
+		m_fontSizeInPixels = isPixels;
 
 		updateStyleSheet();
 	}
@@ -76,7 +69,10 @@ void MultiStyleWidgetWrapper::updateStyleSheet() {
 	QString styleSheet;
 
 	if (m_fontSize != UNSET_FONTSIZE) {
-		styleSheet += QString(" %1 { font-size: %2px; }").arg(m_fontSizeSelector).arg(m_fontSize);
+		styleSheet += QString(" %1 { font-size: %2%3; }")
+						  .arg(m_fontSizeSelector)
+						  .arg(m_fontSize)
+						  .arg(m_fontSizeInPixels ? QStringLiteral("px") : QStringLiteral("pt"));
 	}
 	if (m_backgroundColor != UNSET_COLOR) {
 		styleSheet += QString(" %1 { background-color: %2; }").arg(m_backgroundColorSelector).arg(m_backgroundColor);

--- a/src/mumble/widgets/MultiStyleWidgetWrapper.h
+++ b/src/mumble/widgets/MultiStyleWidgetWrapper.h
@@ -37,8 +37,11 @@ protected:
 	static const QString UNSET_SELECTOR;
 	/// The wrapped widget
 	QWidget *m_widget;
-	/// The current font size in pixels
+	/// The current font size
 	uint32_t m_fontSize = UNSET_FONTSIZE;
+	/// Whether the font size is currently set in pixels (as opposed
+	/// to points)
+	bool m_fontSizeInPixels = true;
 	/// The CSS selector to be applied to the font size
 	QString m_fontSizeSelector = UNSET_SELECTOR;
 	/// The current background color


### PR DESCRIPTION
When scaling the font size system-wide (e.g. set to 150%), the TalkingUI
might not adapt to this properly.

This started happening with the introduction of the
MultiStyleWidgetWrapper class (commit
ff040fb23c407ee34e6d8796a3f058a455f40cb1). As it turns out the
conversion from pixel to point size performed in its setFontSize did not
work properly, causing an incorrect font size to be used. And as the
font size also determines the icons size, these were not scaled properly
either.

The fix is to simply skip on the pixel to point conversion entirely and
instead use the appropriate unit when setting the respective StyleSheet
property. That way Qt can figure the conversion out as needed.


### Checks

- [x] My commits follow the [commit guidelines](https://github.com/mumble-voip/mumble/blob/master/COMMIT_GUIDELINES.md)

