### PR TITLE
FIX(client): Echo cancellation options not translated

### DIFF
--- a/cmake/os.cmake
+++ b/cmake/os.cmake
@@ -32,6 +32,8 @@ if(WIN32)
 	add_definitions(
 		"-DUNICODE"
 		"-DWIN32_LEAN_AND_MEAN"
+		# Prevent Windows headers from defining the macros "min" and "max" that mess up e.g. std::min usage
+		"-DNOMINMAX"
 	)
 else()
 	if(${CMAKE_SYSTEM_NAME} STREQUAL "FreeBSD")

--- a/src/mumble/AudioConfigDialog.cpp
+++ b/src/mumble/AudioConfigDialog.cpp
@@ -550,7 +550,7 @@ void AudioInputDialog::updateEchoEnableState() {
 		if (air->canEcho(ecoid, outputInterface)) {
 			++i;
 			hasUsableEchoOption                = true;
-			const EchoCancelOption &echoOption = echoCancelOptions[static_cast< int >(ecoid)];
+			const EchoCancelOption &echoOption = EchoCancelOption::getOptions()[static_cast< int >(ecoid)];
 			qcbEcho->insertItem(i, echoOption.description, static_cast< int >(ecoid));
 			qcbEcho->setItemData(i, echoOption.explanation, Qt::ToolTipRole);
 			if (s.echoOption == ecoid) {

--- a/src/mumble/CMakeLists.txt
+++ b/src/mumble/CMakeLists.txt
@@ -133,6 +133,7 @@ set(MUMBLE_SOURCES
 	"Database.h"
 	"DeveloperConsole.cpp"
 	"DeveloperConsole.h"
+	"EchoCancelOption.cpp"
 	"EchoCancelOption.h"
 	"Global.cpp"
 	"Global.h"

--- a/src/mumble/EchoCancelOption.cpp
+++ b/src/mumble/EchoCancelOption.cpp
@@ -1,0 +1,34 @@
+// Copyright 2021 The Mumble Developers. All rights reserved.
+// Use of this source code is governed by a BSD-style license
+// that can be found in the LICENSE file at the root of the
+// Mumble source tree or at <https://www.mumble.info/LICENSE>.
+
+#include "EchoCancelOption.h"
+
+#include <QObject>
+
+const std::vector< EchoCancelOption > &EchoCancelOption::getOptions() {
+	// Note that we have to create this list lazily (at the time it is needed for the first time) in order
+	// to make sure that there actually is a translator installed that can translate these Strings. If we
+	// create these objects too early (e.g. by making them a static variable in global namespace), the Strings
+	// will not get translated.
+
+	// The item order MUST follow the order in the EchoCancelOptionID enum
+	static const std::vector< EchoCancelOption > echoCancelOptions = {
+		{ EchoCancelOptionID::DISABLED, QObject::tr("Disabled"), QObject::tr("Echo cancellation is disabled.") },
+		{ EchoCancelOptionID::SPEEX_MIXED, QObject::tr("Mixed echo cancellation (speex)"),
+		  QObject::tr("Mixed has low CPU impact, but only works well if your "
+					  "speakers are equally loud and equidistant from the microphone.") },
+		{ EchoCancelOptionID::SPEEX_MULTICHANNEL, QObject::tr("Multichannel echo cancellation (speex)"),
+		  QObject::tr("Multichannel echo cancellation provides much better echo "
+					  "cancellation, but at a higher CPU cost. "
+					  "Multichannel echo cancellation requires more CPU, so "
+					  "you should try mixed first.") },
+		// Available only on Apple devices
+		{ EchoCancelOptionID::APPLE_AEC, QObject::tr("EXPERIMENTAL: Acoustic echo cancellation (Apple)."),
+		  QObject::tr("The support for this option is experimental only! This option works best when using built-in "
+					  "microphone and speaker.") }
+	};
+
+	return echoCancelOptions;
+}

--- a/src/mumble/EchoCancelOption.h
+++ b/src/mumble/EchoCancelOption.h
@@ -7,6 +7,7 @@
 #define MUMBLE_MUMBLE_ECHOCANCELLATIONOPTION_H
 
 #include <QtCore/QObject>
+#include <vector>
 
 
 /// This enum lists a series of echo cancellation options
@@ -23,23 +24,10 @@ struct EchoCancelOption {
 	EchoCancelOptionID id;
 	QString description;
 	QString explanation;
-};
 
-// Please strictly follow the order of the EchoCancelOptionID when adding items to this array.
-static const EchoCancelOption echoCancelOptions[] = {
-	{ EchoCancelOptionID::DISABLED, QObject::tr("Disabled"), QObject::tr("Echo cancellation is disabled.") },
-	{ EchoCancelOptionID::SPEEX_MIXED, QObject::tr("Mixed echo cancellation (speex)"),
-	  QObject::tr("Mixed has low CPU impact, but only works well if your "
-				  "speakers are equally loud and equidistant from the microphone.") },
-	{ EchoCancelOptionID::SPEEX_MULTICHANNEL, QObject::tr("Multichannel echo cancellation (speex)"),
-	  QObject::tr("Multichannel echo cancellation provides much better echo "
-				  "cancellation, but at a higher CPU cost. "
-				  "Multichannel echo cancellation requires more CPU, so "
-				  "you should try mixed first.") },
-	// Available only on Apple devices
-	{ EchoCancelOptionID::APPLE_AEC, QObject::tr("EXPERIMENTAL: Acoustic echo cancellation (Apple)."),
-	  QObject::tr("The support for this option is experimental only! This option works best when using built-in "
-				  "microphone and speaker.") }
+	/// @returns A vector of EchoCancelOption objects in the same order as specified in the
+	/// EchoCancelOptionID enum. Thus the enums can be used as an index for the returned vector.
+	static const std::vector< EchoCancelOption > &getOptions();
 };
 
 #endif // MUMBLE_ECHOCANCELLATIONOPTION_H


### PR DESCRIPTION
These Strings were not translated because as global static variables
they were created before the necessary translators are installed.

This commit fixes this by making sure the containing EchoCancelOption
objects are created lazily (at the time they are needed for the first
time), thus causing a delaying instantiation.

Fixes #4993


### Checks

- [x] My commits follow the [commit guidelines](https://github.com/mumble-voip/mumble/blob/master/COMMIT_GUIDELINES.md)

