### PR TITLE
BUILD(macos): Fix package script failing 

### DIFF
--- a/COMMIT_GUIDELINES.md
+++ b/COMMIT_GUIDELINES.md
@@ -52,6 +52,7 @@ The `TYPE` is one of the following:
 | BUILD    | Changes related to the build process / buildsystem | Fix cmake script |
 | TRANSLATION | Translation updates and changes | Update translation files |
 | CHANGE   | Something was changed without falling into existing categories | Changed the default of a setting |
+| REVERT   | A previous commit had to be reverted because e.g. it was buggy | - |
 
 The `TYPE` has to be in **all-uppercase** in order for it to stand out.
 

--- a/macx/scripts/osxdist.py
+++ b/macx/scripts/osxdist.py
@@ -248,32 +248,14 @@ class DiskImage(FolderObject):
 			Create the disk image itself.
 		'''
 		print ' * Creating diskimage. Please wait...'
-		if not self.filename.endswith(".dmg"):
-			self.filename += ".dmg"
 		if os.path.exists(self.filename):
 			os.remove(self.filename)
-		# First create an intermediate, uncompressed image. We do this as otherwise it often happens that
-		# hdiutils fails with the message "no space left on device" which doesn't seem to appear without compression
-                intermediateName = self.filename.replace(".dmg", "_intermediate.dmg")
 		p = Popen(['hdiutil', 'create',
 		           '-srcfolder', self.tmp,
-		           '-format', 'UDRW',
-		           '-volname', self.volname,
-                           '-verbose',
-		           intermediateName])
-		retval = p.wait()
-		if retval != 0:
-			raise Exception("Creating intermediate dmg file failed")
-
-		# Now take that intermediate and compress it
-		p = Popen(['hdiutil', 'convert',
-		           intermediateName,
 		           '-format', 'UDBZ',
-                           '-verbose', '-o',
+		           '-volname', self.volname,
 		           self.filename])
 		retval = p.wait()
-		if retval != 0:
-			raise Exception("Compressing dmg file failed")
 		print ' * Removing temporary directory.'
 		shutil.rmtree(self.tmp)
 		print ' * Done!'

--- a/macx/scripts/osxdist.py
+++ b/macx/scripts/osxdist.py
@@ -254,6 +254,7 @@ class DiskImage(FolderObject):
 		           '-srcfolder', self.tmp,
 		           '-format', 'UDBZ',
 		           '-volname', self.volname,
+		           '-megabytes', '130',
 		           self.filename])
 		retval = p.wait()
 		print ' * Removing temporary directory.'

--- a/scripts/commitMessage/CommitMessage.py
+++ b/scripts/commitMessage/CommitMessage.py
@@ -11,7 +11,7 @@ class CommitFormatError(Exception):
         Exception(msg)
 
 class CommitMessage:
-    knownTypes = ["BREAK", "FEAT", "FIX", "FORMAT", "DOCS", "TEST", "MAINT", "CI", "REFAC", "BUILD", "TRANSLATION", "CHANGE"]
+    knownTypes = ["BREAK", "FEAT", "FIX", "FORMAT", "DOCS", "TEST", "MAINT", "CI", "REFAC", "BUILD", "TRANSLATION", "CHANGE", "REVERT"]
 
     def __init__(self, commitString):
         lines = commitString.strip().split("\n")

--- a/scripts/generateChangelog.py
+++ b/scripts/generateChangelog.py
@@ -94,6 +94,8 @@ def main():
                 prefix = "Fixed: "
             elif "CHANGE" in commit.m_types:
                 prefix = "Changed: "
+            elif "REVERT" in commit.m_types:
+                prefix = "Reverted: "
             else:
                 prefix = "Unknown: "
 


### PR DESCRIPTION
We were seeing errors like
```
could not access /Volumes/Mumble 1.4.0~2021-05-16~g789f2d79e~snapshot/Mumble.app/Contents/MacOS/Mumble - No space left on device
hdiutil: create failed - No space left on device
```
every now and then when attempting to package the DMG package for macOS.

Following the trick described at
www.apple.stackexchange.com/a/177071/417917, we now add the
-megabytes option to the call which seems to fix the issue somehow.

This PR also reverts 0b75cd6f8a25f015857525392e746949b680c99c which failed to solve the issue.

### Checks

- [x] My commits follow the [commit guidelines](https://github.com/mumble-voip/mumble/blob/master/COMMIT_GUIDELINES.md)

