### PR TITLE
BUILD: Fixes for Ubuntu 20.04 ppa build

### DIFF
--- a/3rdparty/celt-0.7.0-build/CMakeLists.txt
+++ b/3rdparty/celt-0.7.0-build/CMakeLists.txt
@@ -68,3 +68,13 @@ target_sources(celt PRIVATE
 )
 
 target_disable_warnings(celt)
+
+# We have to explicitly link to the "m" (math) library.
+# See https://stackoverflow.com/q/1033898/3907364 for why
+find_library(MATH_LIBRARY m)
+
+# If -lm exists
+if(MATH_LIBRARY)
+	# Link it to prevent "contains an unresolvable reference to symbol sin: it's probably a plugin"
+	target_link_libraries(celt PUBLIC ${MATH_LIBRARY})
+endif()

--- a/plugins/PluginComponents_v_1_0_x.h
+++ b/plugins/PluginComponents_v_1_0_x.h
@@ -16,7 +16,7 @@
 #	include <string>
 #endif
 
-#ifdef QT_VERSION
+#if defined(QT_CORE_LIB) || defined(QT_VERSION)
 #	include <QString>
 #endif
 
@@ -298,7 +298,7 @@ struct Version {
 			   + std::string(".") + std::to_string(this->patch);
 	}
 
-#	ifdef QT_VERSION
+#	if defined(QT_CORE_LIB) || defined(QT_VERSION)
 	operator QString() const {
 		return QString::fromLatin1("v%0.%1.%2").arg(this->major).arg(this->minor).arg(this->patch);
 	}

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -120,9 +120,8 @@ set(SHARED_HEADERS
 )
 
 target_sources(shared
-	PUBLIC
-		${SHARED_HEADERS}
 	PRIVATE
+		${SHARED_HEADERS}
 		${SHARED_SOURCES}
 )
 

--- a/src/mumble/GlobalShortcut_unix.h
+++ b/src/mumble/GlobalShortcut_unix.h
@@ -46,5 +46,7 @@ public slots:
 // These are macros that X11/X.h defines and that are causing problems in unity builds
 // if left defined
 #undef None
+#undef KeyPress
+#undef FontChange
 
 #endif


### PR DESCRIPTION
While working on the Ubuntu ppa build I ran into a few build issues on my local 20.04 VM.
To finish up prepping for the mumble-ubuntu-ppa PR it would help if these were merged.

### Checks

- [x] My commits follow the [commit guidelines](https://github.com/mumble-voip/mumble/blob/master/COMMIT_GUIDELINES.md)

### Note

The fix for PRIVATE keyword in target_sources could apply to the macOS mach 3rd party build's CMakeLists.txt it appears to have a comment about the unity build not working.
