### PR TITLE
CI: Fix PR checks for backports

### DIFF
--- a/.github/workflows/check_commit_style.py
+++ b/.github/workflows/check_commit_style.py
@@ -19,6 +19,14 @@ def cmd(args):
 
 
 def main():
+    targetBranch = ""
+    if len(sys.argv) > 1:
+        targetBranch = sys.argv[1]
+    else:
+        raise RuntimeError("Target branch not specified!")
+
+    print("Checking commit styles - target branch: \"{}\"".format(targetBranch))
+
     try:
         # Set up remote 
         remoteName = "mumble-upstream"
@@ -28,7 +36,7 @@ def main():
         cmd(["git", "fetch", "--no-recurse-submodules", remoteName])
 
         # get new commits
-        commitHashes = [x for x in cmd(["git", "rev-list", "{}/master..HEAD".format(remoteName)]).split("\n") if x]
+        commitHashes = [x for x in cmd(["git", "rev-list", "{}/{}..HEAD".format(remoteName, targetBranch)]).split("\n") if x]
         # Reverse the order of the commits so that oldest comes first
         commitHashes.reverse()
 

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -21,7 +21,7 @@ jobs:
           ref: ${{ github.event.pull_request.head.sha }}
 
     - name: Check commit style
-      run: $GITHUB_WORKSPACE/.github/workflows/check_commit_style.py
+      run: $GITHUB_WORKSPACE/.github/workflows/check_commit_style.py ${{ github.base_ref }}
       shell: bash
 
     - name: Check line endings


### PR DESCRIPTION
The commit style checker had a hard-coded assumption that the changes
were made against the master branch. For backports that is not the case
though and that's why the script fails for backports as soon as the
master and the backport branch have diverged.


### Checks

- [x] My commits follow the [commit guidelines](https://github.com/mumble-voip/mumble/blob/master/COMMIT_GUIDELINES.md)

