### PR TITLE
DOCS: Link WixSharp to latest releases page

### DIFF
--- a/docs/dev/build-instructions/build_installer.md
+++ b/docs/dev/build-instructions/build_installer.md
@@ -2,7 +2,7 @@
 
 Currently, the installer creation has been tested on Windows only.
 
-For creating the installer, [WixSharp](https://github.com/oleg-shilo/wixsharp/releases/tag/v1.15.0.0) has to be present on your system. Please see the following [README](https://github.com/oleg-shilo/wixsharp/blob/master/README.md) for install information.
+For creating the installer, [WixSharp](https://github.com/oleg-shilo/wixsharp/releases) has to be present on your system. Please see the following [README](https://github.com/oleg-shilo/wixsharp/blob/master/README.md) for install information.
 
 An installer can be created after invoking cmake with the `-Dpackaging=ON` and `-Dtranslations=OFF` options, and building. This creates a *single-language* installer.
 


### PR DESCRIPTION
I assume we want to support and use the most recent version of WixSharp. The description does not mention a specific version.

This change changes the link to WixSharp from the v1.15.0.0 release to the releases page, which shows the most recent release first.

### Checks

- [x] My commits follow the [commit guidelines](https://github.com/mumble-voip/mumble/blob/master/COMMIT_GUIDELINES.md)

