### PR TITLE
Make posted images slightly larger to improve legibility

### DIFF
--- a/src/mumble/Log.cpp
+++ b/src/mumble/Log.cpp
@@ -525,8 +525,8 @@ QString Log::imageToImg(const QByteArray &format, const QByteArray &image) {
 }
 
 QString Log::imageToImg(QImage img, int maxSize) {
-	if ((img.width() > 480) || (img.height() > 270)) {
-		img = img.scaled(480, 270, Qt::KeepAspectRatio, Qt::SmoothTransformation);
+	if ((img.width() > 800) || (img.height() > 600)) {
+		img = img.scaled(800, 600, Qt::KeepAspectRatio, Qt::SmoothTransformation);
 	}
 
 	int quality       = 100;

--- a/src/mumble/Log.cpp
+++ b/src/mumble/Log.cpp
@@ -525,8 +525,11 @@ QString Log::imageToImg(const QByteArray &format, const QByteArray &image) {
 }
 
 QString Log::imageToImg(QImage img, int maxSize) {
-	if ((img.width() > 800) || (img.height() > 600)) {
-		img = img.scaled(800, 600, Qt::KeepAspectRatio, Qt::SmoothTransformation);
+	constexpr int maxWidth  = 800;
+	constexpr int maxHeight = 600;
+
+	if ((img.width() > maxWidth) || (img.height() > maxHeight)) {
+		img = img.scaled(maxWidth, maxHeight, Qt::KeepAspectRatio, Qt::SmoothTransformation);
 	}
 
 	int quality       = 100;


### PR DESCRIPTION
The commit message describes it:

```
For most images, this results in far better legibility, especially if they contain text, such as memes or web comics - you currently need to squint at the screen often, because it's always sized down to 480x270.

People with windows smaller than that will get a horizontal scroll. Scrolling is still better than having an image that's illegible because it's too small, and small images will never be scaled up this way.

800x600 should be okay since 1920x1080 is a very common desktop resolution by now.

This is a stopgap measure until images can be sized per client.
```

As mentioned, I don't know if this is an acceptable change, but I thought I'd propose it anyway as a stopgap. For our user group, this already significantly improves the use of images to the point where they are actually usable for us :-).

See also #4830.

A before and after screenshot, posting the example image from Mumble's GitHub page:

Before:

![Before](https://user-images.githubusercontent.com/24809863/119261223-006d1680-bbc6-11eb-923e-a0f3bc8bae57.png)

After:

![After](https://user-images.githubusercontent.com/24809863/119261230-0531ca80-bbc6-11eb-899c-a0fe0662f3e3.png)

### Checks

- [X] My commits follow the [commit guidelines](https://github.com/mumble-voip/mumble/blob/master/COMMIT_GUIDELINES.md)