### PR TITLE
REFAC(plugin): Rename plugin ID parameter

### DIFF
--- a/plugins/MumblePlugin_v_1_0_x.h
+++ b/plugins/MumblePlugin_v_1_0_x.h
@@ -39,7 +39,7 @@ extern "C" {
 /// @param id The ID for this plugin. This is the ID Mumble will reference this plugin with
 /// and by which this plugin can identify itself when communicating with Mumble.
 /// @returns The status of the initialization. If everything went fine, return STATUS_OK
-PLUGIN_EXPORT mumble_error_t PLUGIN_CALLING_CONVENTION mumble_init(uint32_t id);
+PLUGIN_EXPORT mumble_error_t PLUGIN_CALLING_CONVENTION mumble_init(mumble_plugin_id_t id);
 
 /// Gets called when unloading the plugin in order to allow it to clean up after itself.
 /// Note that it is still safe to call API functions from within this callback.


### PR DESCRIPTION
Instead of passing the type name directly we pass the alias instead in
order to make code more easily portable between API versions.


### Checks

- [x] My commits follow the [commit guidelines](https://github.com/mumble-voip/mumble/blob/master/COMMIT_GUIDELINES.md)

