### PR TITLE
FIX(client): Positional audio not working properly after canceling audio wizard

### DIFF
--- a/src/mumble/AudioWizard.cpp
+++ b/src/mumble/AudioWizard.cpp
@@ -393,6 +393,7 @@ void AudioWizard::reject() {
 		ao->wipe();
 	}
 
+	Global::get().bPosTest = false;
 	restartAudio();
 	Global::get().bInAudioWizard = false;
 

--- a/src/mumble/AudioWizard.cpp
+++ b/src/mumble/AudioWizard.cpp
@@ -385,12 +385,15 @@ void AudioWizard::reject() {
 	Global::get().s = sOldSettings;
 
 	Global::get().s.lmLoopMode = Settings::None;
-	restartAudio();
+
+	aosSource = nullptr;
 
 	AudioOutputPtr ao = Global::get().ao;
-	if (ao)
+	if (ao) {
 		ao->wipe();
-	aosSource                    = nullptr;
+	}
+
+	restartAudio();
 	Global::get().bInAudioWizard = false;
 
 	QWizard::reject();


### PR DESCRIPTION
The `bPosTest` variable indicates whether we're in the middle of a test.

It causes the user's direction vector to freeze so that it always "looks" straight ahead.

When completing the wizard, `accept()` is called and thus the variable is set to false again.

However, when the wizard is closed prematurely, `reject()` is called instead.