### PR TITLE
FEAT(client): Do not play the mute cue when push-to-muted

### DIFF
--- a/src/mumble/AudioInput.cpp
+++ b/src/mumble/AudioInput.cpp
@@ -1116,7 +1116,8 @@ void AudioInput::encodeAudioFrame(AudioChunk chunk) {
 				}
 			}
 
-			if (Global::get().s.bTxMuteCue && !Global::get().s.bDeaf && bTalkingWhenMuted) {
+			if (Global::get().s.bTxMuteCue && !Global::get().bPushToMute && !Global::get().s.bDeaf
+				&& bTalkingWhenMuted) {
 				if (!qetLastMuteCue.isValid() || qetLastMuteCue.elapsed() > iMuteCueDelay) {
 					qetLastMuteCue.start();
 					ao->playSample(Global::get().s.qsTxMuteCue);


### PR DESCRIPTION
Push-to-mute requires a constant button press (not togglable), so reminding them that they are muted is not really useful in that case.

The use case that targets is using push-to-mute to talk to another VOIP client (a game for example) with the same people as in the mumble channel. Without this change the user will get the muted cue each time they use push-to-mute.

### Checks

- [x] My commits follow the [commit guidelines](https://github.com/mumble-voip/mumble/blob/master/COMMIT_GUIDELINES.md)

