### PR TITLE
Backport "FIX(client): Positional audio not working properly after canceling audio wizard"

### DIFF
--- a/src/mumble/AudioWizard.cpp
+++ b/src/mumble/AudioWizard.cpp
@@ -393,6 +393,7 @@ void AudioWizard::reject() {
 		ao->wipe();
 	}
 
+	Global::get().bPosTest = false;
 	restartAudio();
 	Global::get().bInAudioWizard = false;
 

--- a/src/mumble/AudioWizard.cpp
+++ b/src/mumble/AudioWizard.cpp
@@ -385,12 +385,15 @@ void AudioWizard::reject() {
 	Global::get().s = sOldSettings;
 
 	Global::get().s.lmLoopMode = Settings::None;
-	restartAudio();
+
+	aosSource = nullptr;
 
 	AudioOutputPtr ao = Global::get().ao;
-	if (ao)
+	if (ao) {
 		ao->wipe();
-	aosSource                    = nullptr;
+	}
+
+	restartAudio();
 	Global::get().bInAudioWizard = false;
 
 	QWizard::reject();


### PR DESCRIPTION
Backport of #5035

### Checks

- [x] My commits follow the [commit guidelines](https://github.com/mumble-voip/mumble/blob/master/COMMIT_GUIDELINES.md)

