### PR TITLE
Backport "FEAT(client): Do not play the mute cue when push-to-muted"

### DIFF
--- a/src/mumble/AudioInput.cpp
+++ b/src/mumble/AudioInput.cpp
@@ -1116,7 +1116,8 @@ void AudioInput::encodeAudioFrame(AudioChunk chunk) {
 				}
 			}
 
-			if (Global::get().s.bTxMuteCue && !Global::get().s.bDeaf && bTalkingWhenMuted) {
+			if (Global::get().s.bTxMuteCue && !Global::get().bPushToMute && !Global::get().s.bDeaf
+				&& bTalkingWhenMuted) {
 				if (!qetLastMuteCue.isValid() || qetLastMuteCue.elapsed() > iMuteCueDelay) {
 					qetLastMuteCue.start();
 					ao->playSample(Global::get().s.qsTxMuteCue);


### PR DESCRIPTION
Backport of #5038

### Checks

- [x] My commits follow the [commit guidelines](https://github.com/mumble-voip/mumble/blob/master/COMMIT_GUIDELINES.md)

