### PR TITLE
BUILD(windows): Fix missing include

### DIFF
--- a/src/mumble/GlobalShortcut_win.cpp
+++ b/src/mumble/GlobalShortcut_win.cpp
@@ -19,6 +19,8 @@
 
 #include <QTimer>
 
+#include <sstream>
+
 extern "C" {
 // clang-format off
 // Do NOT change the order of the includes below or compile errors will occur!


### PR DESCRIPTION
GlobalShortcut_win was using stringstream objects but did not include
the sstream header for it.


### Checks

- [x] My commits follow the [commit guidelines](https://github.com/mumble-voip/mumble/blob/master/COMMIT_GUIDELINES.md)

