### PR TITLE
MAINT: Add config for backport CLI

### DIFF
--- a/.backportrc.json
+++ b/.backportrc.json
@@ -1,0 +1,11 @@
+{
+	"upstream": "mumble-voip/mumble",
+	"targetBranchChoices": [
+		{ "name": "1.4.x", "checked": true },
+		"1.3.x"
+	],
+	"targetPRLabels": ["backport"],
+	"fork": true,
+	"multipleCommits": true,
+	"prTitle": "Backport \"{commitMessages}\" to {targetBranch}"
+}


### PR DESCRIPTION
In order to use https://github.com/sqren/backport we need a bit of
configuration in our project but in the end this has the potential to
save use a lot of time when backporting commits to a stable release
series.


### Checks

- [x] My commits follow the [commit guidelines](https://github.com/mumble-voip/mumble/blob/master/COMMIT_GUIDELINES.md)

