### PR TITLE
DOCS(build): Add a missing dependency to static build instructions.

### DIFF
--- a/docs/dev/build-instructions/build_static.md
+++ b/docs/dev/build-instructions/build_static.md
@@ -45,6 +45,7 @@ Once vcpkg is installed on your system, you have to switch into the directory vc
 qt5-base
 qt5-svg
 qt5-tools
+qt5-translations
 grpc
 boost-accumulators
 opus


### PR DESCRIPTION
### Checks

- [x] My commits follow the [commit guidelines](https://github.com/mumble-voip/mumble/blob/master/COMMIT_GUIDELINES.md)

