### PR TITLE
DOCS: Mention BUILD_NUMBER for building installer

### DIFF
--- a/docs/dev/build-instructions/build_installer.md
+++ b/docs/dev/build-instructions/build_installer.md
@@ -8,6 +8,10 @@ For creating the installer, [WixSharp](https://github.com/oleg-shilo/wixsharp) h
 2. Extract into a folder
 3. Add that folder to the PATH environment variable
 
+When creating an installer, you _have to_ specify a build number using e.g. `-DBUILD_NUMBER=3` when invoking cmake. The build number is used to
+differentiate multiple builds for the same Mumble version and makes sure that always the latest build will upgrade any previous builds. If you are
+creating an installer for yourself, just use build number `0`.
+
 The cmake option `packaging`, off by default, specifies whether or not to build the installer. If being built it will be multi-lingual by default. 
 
 Use the cmake generate option `-Dpackaging=ON` to enable building the installer.
@@ -15,3 +19,4 @@ Use the cmake generate option `-Dpackaging=ON` to enable building the installer.
 Use the additional cmake generate option `-Dtranslations=OFF` to build a single-language installer instead.
 
 Note that the installers expect some components to be built. For example, the client installer expects the `g15` component to be built too. Without it packaging will fail on the missing expected file.
+


### PR DESCRIPTION
The requirement to set the BUILD_NUMBER variable was not mentioned in
the docs for how to build an installer.

Fixes #5060


### Checks

- [x] My commits follow the [commit guidelines](https://github.com/mumble-voip/mumble/blob/master/COMMIT_GUIDELINES.md)

