### PR TITLE
BUILD(windows): Fix missing include

### DIFF
--- a/plugins/amongus/amongus.cpp
+++ b/plugins/amongus/amongus.cpp
@@ -10,6 +10,7 @@
 
 #include "../mumble_positional_audio_utils.h"
 
+#include <memory>
 #include <sstream>
 
 std::unique_ptr< Game > game;

--- a/plugins/cod2/cod2.cpp
+++ b/plugins/cod2/cod2.cpp
@@ -10,6 +10,8 @@
 
 #include "../mumble_positional_audio_utils.h"
 
+#include <memory>
+
 std::unique_ptr< ProcessWindows > process;
 
 static inline bool inGame() {

--- a/plugins/se/se.cpp
+++ b/plugins/se/se.cpp
@@ -14,6 +14,7 @@
 #include "ProcessWindows.h"
 
 #include <cstring>
+#include <memory>
 #include <sstream>
 
 std::unique_ptr< Process > proc;


### PR DESCRIPTION
some of overlay source files such as: amongus, cod2 and se uses
std::unique_ptr
which requires include `<memory>`


### Checks

- [x] My commits follow the [commit guidelines](https://github.com/mumble-voip/mumble/blob/master/COMMIT_GUIDELINES.md)

