### PR TITLE
FIX(pipewire): Do not initialize stream with 0 channels

### DIFF
--- a/src/mumble/Settings.cpp
+++ b/src/mumble/Settings.cpp
@@ -413,6 +413,9 @@ Settings::Settings() {
 	qsALSAInput  = QLatin1String("default");
 	qsALSAOutput = QLatin1String("default");
 
+	pipeWireInput  = 1;
+	pipeWireOutput = 2;
+
 	qsJackClientName  = QLatin1String("mumble");
 	qsJackAudioOutput = QLatin1String("1");
 	bJackStartServer  = false;


### PR DESCRIPTION
### Checks

- [x] My commits follow the [commit guidelines](https://github.com/mumble-voip/mumble/blob/master/COMMIT_GUIDELINES.md)

