### PR TITLE
Fix deadlock when cancelling AudioWizard

### DIFF
--- a/src/mumble/AudioWizard.cpp
+++ b/src/mumble/AudioWizard.cpp
@@ -386,8 +386,6 @@ void AudioWizard::reject() {
 
 	Global::get().s.lmLoopMode = Settings::None;
 
-	aosSource = nullptr;
-
 	AudioOutputPtr ao = Global::get().ao;
 	if (ao) {
 		ao->wipe();

--- a/src/mumble/AudioWizard.cpp
+++ b/src/mumble/AudioWizard.cpp
@@ -392,6 +392,7 @@ void AudioWizard::reject() {
 	if (ao) {
 		ao->wipe();
 	}
+	ao.reset();
 
 	Global::get().bPosTest = false;
 	restartAudio();


### PR DESCRIPTION
See #5081 

The PR is separated in two commits, the first one is the actual fix (should probably be cherry-picked to 1.4.x), the second one is just a minor code refactor, as we are doing `aosSource = nullptr;` in `restartAudio()` already.
