### PR TITLE
Backport "FIX(audiowizard): Reset AudioOutput ownership before restartAudio() (#5082)" to 1.4.x

### DIFF
--- a/src/mumble/AudioWizard.cpp
+++ b/src/mumble/AudioWizard.cpp
@@ -392,6 +392,7 @@ void AudioWizard::reject() {
 	if (ao) {
 		ao->wipe();
 	}
+	ao.reset();
 
 	Global::get().bPosTest = false;
 	restartAudio();


### PR DESCRIPTION
Backports the following commits to 1.4.x:
 - FIX(audiowizard): Reset AudioOutput ownership before restartAudio() (#5082)