### PR TITLE
REFAC(client): Remove unnecessary include

### DIFF
--- a/plugins/mumble_positional_audio_utils.h
+++ b/plugins/mumble_positional_audio_utils.h
@@ -17,11 +17,6 @@
 #	include <fenv.h>
 #endif
 
-#ifdef _MSC_VER
-#	include <corecrt_math_defines.h>
-#	include <intrin.h>
-#endif
-
 /// This union is used by isBigEndian() to determine the endianness.
 union SingleSplit4Bytes {
 	uint32_t single;


### PR DESCRIPTION
The windows header was included for the definition of M_PI. However
given that we define _USE_MATH_DEFINES globally for all source files and
cmath is included already, this symbol is defined by cmath, making the
windows-specific header superfluous.


### Checks

- [x] My commits follow the [commit guidelines](https://github.com/mumble-voip/mumble/blob/master/COMMIT_GUIDELINES.md)

