### PR TITLE
FIX(client): Use ReadProcessMemory() instead of Toolhelp32ReadProcessMemory()

### DIFF
--- a/plugins/HostWindows.cpp
+++ b/plugins/HostWindows.cpp
@@ -11,14 +11,18 @@
 #include <tlhelp32.h>
 
 HostWindows::HostWindows(const procid_t pid) : m_pid(pid) {
+	m_handle = OpenProcess(PROCESS_VM_READ, false, m_pid);
 }
 
 HostWindows::~HostWindows() {
+	if (m_handle) {
+		CloseHandle(m_handle);
+	}
 }
 
 bool HostWindows::peek(const procptr_t address, void *dst, const size_t size) const {
 	SIZE_T read;
-	const auto ok = Toolhelp32ReadProcessMemory(m_pid, reinterpret_cast< void * >(address), dst, size, &read);
+	const auto ok = ReadProcessMemory(m_handle, reinterpret_cast< void * >(address), dst, size, &read);
 	return (ok && read == size);
 }
 

--- a/plugins/HostWindows.h
+++ b/plugins/HostWindows.h
@@ -13,6 +13,7 @@ typedef uint32_t procid_t;
 class HostWindows {
 protected:
 	procid_t m_pid;
+	void *m_handle;
 
 public:
 	bool peek(const procptr_t address, void *dst, const size_t size) const;


### PR DESCRIPTION
I was wrong in #4566.

Turns out `Toolhelp32ReadProcessMemory()` is simply a wrapper for `ReadProcessMemory()` that takes care of opening an handle to the process and closing it.

For reference: MicrosoftDocs/sdk-api#793