### PR TITLE
FIX(client, ui): Use proper name for fallback theme

### DIFF
--- a/src/mumble/Themes.cpp
+++ b/src/mumble/Themes.cpp
@@ -49,7 +49,7 @@ void Themes::applyFallback() {
 	qWarning() << "Applying fallback style sheet";
 
 	QStringList skinPaths;
-	skinPaths << QLatin1String(":/themes/Mumble");
+	skinPaths << QLatin1String(":/themes/Default");
 	QString defaultTheme = getDefaultStylesheet();
 	setTheme(defaultTheme, skinPaths);
 }


### PR DESCRIPTION
2cd4635e85ba8629e98a956d1f73d99f2a166728 has integrated the theme
submodule into the main repository and by doing so renamed the default
theme from "Mumble" to "Default".

When using no theme (The "None" theme) for the application's style, it
would fail to find the necessary icons though.
This is because the fallback theme that is used in this case was still
referring to the old "Mumble" theme that no longer exists.

This commit fixes the issue by changing the name referenced in the
fallback theme to "Default" again.

Fixes #5086


### Checks

- [x] My commits follow the [commit guidelines](https://github.com/mumble-voip/mumble/blob/master/COMMIT_GUIDELINES.md)

