### PR TITLE
Backport "BUILD(windows): Fix missing include (#5077)" to 1.4.x

### DIFF
--- a/plugins/amongus/amongus.cpp
+++ b/plugins/amongus/amongus.cpp
@@ -10,6 +10,7 @@
 
 #include "../mumble_positional_audio_utils.h"
 
+#include <memory>
 #include <sstream>
 
 std::unique_ptr< Game > game;

--- a/plugins/cod2/cod2.cpp
+++ b/plugins/cod2/cod2.cpp
@@ -10,6 +10,8 @@
 
 #include "../mumble_positional_audio_utils.h"
 
+#include <memory>
+
 std::unique_ptr< ProcessWindows > process;
 
 static inline bool inGame() {

--- a/plugins/se/se.cpp
+++ b/plugins/se/se.cpp
@@ -14,6 +14,7 @@
 #include "ProcessWindows.h"
 
 #include <cstring>
+#include <memory>
 #include <sstream>
 
 std::unique_ptr< Process > proc;


### PR DESCRIPTION
Backports the following commits to 1.4.x:
 - BUILD(windows): Fix missing include (#5077)