### PR TITLE
MAINT(macOS): Add client entitlements plist, for hardened runtime to work

### DIFF
--- a/src/mumble/mumble.entitlements.plist
+++ b/src/mumble/mumble.entitlements.plist
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>com.apple.security.device.audio-input</key>
+	<true/>
+	<key>com.apple.security.cs.disable-library-validation</key>
+	<true/>
+	<key>com.apple.security.network.client</key>
+	<true/>
+	<key>com.apple.security.network.server</key>
+	<true/>
+</dict>
+</plist>


### PR DESCRIPTION
The file is used by `codesign`.

The following entitlements are enabled:

- `com.apple.security.device.audio-input`: To capture audio.
- `com.apple.security.cs.disable-library-validation`: To load plugins.
- `com.apple.security.network.client`: To start TCP connection and to send UDP packets.
- `com.apple.security.network.server`: To receive UDP packets.