### PR TITLE
Backport "DOCS(plugins): Fix missing pointer star in example (#5105)" to 1.4.x

### DIFF
--- a/docs/dev/plugins/PositionalAudioPlugin.md
+++ b/docs/dev/plugins/PositionalAudioPlugin.md
@@ -15,7 +15,7 @@ uint32_t mumble_getFeatures() {
     return MUMBLE_FEATURE_POSITIONAL;
 }
 
-uint8_t mumble_initPositionalData(const char *const programNames, const uint64_t programPIDs, size_t programCount) {
+uint8_t mumble_initPositionalData(const char *const *programNames, const uint64_t *programPIDs, size_t programCount) {
     // Check if the supported game is in the list of programs and if yes
 	// check if the position can be obtained from the program
 


### PR DESCRIPTION
Backports the following commits to 1.4.x:
 - DOCS(plugins): Fix missing pointer star in example (#5105)