### PR TITLE
FIX(client, plugin-api): onAudioOutputAboutToPlay

### DIFF
--- a/src/mumble/PluginManager.cpp
+++ b/src/mumble/PluginManager.cpp
@@ -770,7 +770,7 @@ void PluginManager::on_audioOutputAboutToPlay(float *outputPCM, unsigned int sam
 #endif
 	foreachPlugin([outputPCM, sampleCount, channelCount, sampleRate, modifiedAudio](Plugin &plugin) {
 		if (plugin.isLoaded()) {
-			if (plugin.onAudioOutputAboutToPlay(outputPCM, sampleCount, sampleRate, channelCount)) {
+			if (plugin.onAudioOutputAboutToPlay(outputPCM, sampleCount, channelCount, sampleRate)) {
 				*modifiedAudio = true;
 			}
 		}


### PR DESCRIPTION
The channel count and sample rate parameters for this function were
passed in reverse order (compared to the API spec). This would cause
plugins using this callback to calculate buffer sizes (sampleCount *
channelCount) to be vastly too high and therefore they most likely tried
accessing the output buffer at indices outside its actual range.


### Checks

- [x] My commits follow the [commit guidelines](https://github.com/mumble-voip/mumble/blob/master/COMMIT_GUIDELINES.md)

