### PR TITLE
Backport "FIX(client, plugin-api): onAudioOutputAboutToPlay (#5114)" to 1.4.x

### DIFF
--- a/src/mumble/PluginManager.cpp
+++ b/src/mumble/PluginManager.cpp
@@ -770,7 +770,7 @@ void PluginManager::on_audioOutputAboutToPlay(float *outputPCM, unsigned int sam
 #endif
 	foreachPlugin([outputPCM, sampleCount, channelCount, sampleRate, modifiedAudio](Plugin &plugin) {
 		if (plugin.isLoaded()) {
-			if (plugin.onAudioOutputAboutToPlay(outputPCM, sampleCount, sampleRate, channelCount)) {
+			if (plugin.onAudioOutputAboutToPlay(outputPCM, sampleCount, channelCount, sampleRate)) {
 				*modifiedAudio = true;
 			}
 		}


### PR DESCRIPTION
Backports the following commits to 1.4.x:
 - FIX(client, plugin-api): onAudioOutputAboutToPlay (#5114)