### PR TITLE
BUILD(cmake): Reorganize how plugins are handled

### DIFF
--- a/plugins/CMakeLists.txt
+++ b/plugins/CMakeLists.txt
@@ -9,59 +9,118 @@ if(retracted-plugins)
 	message(STATUS "Including retracted plugins")
 endif()
 
-set(CMAKE_INCLUDE_CURRENT_DIR ON)
 
-if(NOT WIN32 AND NOT (${CMAKE_SYSTEM_NAME} STREQUAL "Linux"))
-	add_subdirectory(link)
+set(AVAILABLE_PLUGINS "")
 
-	# Shared library on UNIX (e.g. ".so")
-	set_target_properties(link PROPERTIES LIBRARY_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/plugins")
+# Plugins available on all platforms
+list(APPEND AVAILABLE_PLUGINS
+	"link"
+)
 
-	return()
+if(${CMAKE_BUILD_TYPE} MATCHES Debug)
+	message("Including TestPlugin in debug mode")
+	list(APPEND AVAILABLE_PLUGINS
+		"testPlugin"
+	)
 endif()
 
-file(GLOB ITEMS RELATIVE ${CMAKE_CURRENT_SOURCE_DIR} "${CMAKE_CURRENT_SOURCE_DIR}/*")
+if(WIN32 OR (UNIX AND CMAKE_SYSTEM_NAME STREQUAL "Linux"))
+	# Plugins available on Windows and Linux
+	list(APPEND AVAILABLE_PLUGINS
+		"amongus"
+		"aoc"
+		"arma2"
+		"bf1"
+		"bf1942"
+		"bf2"
+		"bf2142"
+		"bf3"
+		"bf4"
+		"bf4_x86"
+		"bfbc2"
+		"bfheroes"
+		"blacklight"
+		"borderlands"
+		"borderlands2"
+		"breach"
+		"cod2"
+		"cod4"
+		"cod5"
+		"codmw2"
+		"codmw2so"
+		"cs"
+		"css"
+		"dods"
+		"dys"
+		"etqw"
+		"ffxiv"
+		"ffxiv_x64"
+		"gmod"
+		"gtaiv"
+		"gtasa"
+		"gtav"
+		"gw"
+		"hl2dm"
+		"insurgency"
+		"jc2"
+		"l4d"
+		"l4d2"
+		"lol"
+		"lotro"
+		"ql"
+		"rl"
+		"se"
+		"sr"
+		"sto"
+		"tf2"
+		"ut2004"
+		"ut3"
+		"ut99"
+		"wolfet"
+		"wow"
+		"wow_x64"
+	)
+endif()
 
-foreach(ITEM ${ITEMS})
-	if(IS_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/${ITEM}")
-		set(PLUGIN_RETRACTED OFF)
+list(REMOVE_DUPLICATES AVAILABLE_PLUGINS)
 
-		# If the plugin is retracted the corresponding CMakeLists.txt is supposed to set the
-		# PLUGIN_RETRACTED variable in the parent scope so that we can access it here
-		add_subdirectory(${ITEM})
 
-		if(${ITEM} STREQUAL "testPlugin" AND NOT ${CMAKE_BUILD_TYPE} MATCHES Debug)
-			# The testPlugin is only included in Debug builds
-			continue()
-		endif()
+# Note: We are assuming that all plugins follow the convention of naming their sub-directory the same as the
+# plugin cmake target. Therefore we can use the CURRENT_PLUGIN variable to reference the dir as well as the
+# target.
+foreach(CURRENT_PLUGIN IN LISTS AVAILABLE_PLUGINS)
+	set(PLUGIN_RETRACTED OFF)
 
-		if(PLUGIN_RETRACTED AND NOT retracted-plugins)
-			# The included subdir didn't actually add a target since the associated plugin is retracted
-			# and therefore it should not be built.
-			continue()
-		endif()
+	# If the plugin is retracted the corresponding CMakeLists.txt is supposed to set the
+	# PLUGIN_RETRACTED variable in the parent scope so that we can access it here
+	add_subdirectory(${CURRENT_PLUGIN})
 
-		target_include_directories(${ITEM} PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
-
-		if(WIN32)
-			target_compile_definitions(${ITEM} PRIVATE "OS_WINDOWS")
-			target_link_libraries(${ITEM} user32.lib)
-
-			# Shared library on Windows (e.g. ".dll")
-			set_target_properties(${ITEM} PROPERTIES RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/plugins")
-			install(TARGETS ${ITEM} RUNTIME DESTINATION "${MUMBLE_INSTALL_PLUGINDIR}" COMPONENT mumble_client)
-		else()
-			if(${CMAKE_SYSTEM_NAME} STREQUAL "Linux")
-				target_compile_definitions(${ITEM} PRIVATE "OS_LINUX")
-			endif()
-
-			# Shared library on UNIX (e.g. ".so")
-			set_target_properties(${ITEM} PROPERTIES LIBRARY_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/plugins")
-			install(TARGETS ${ITEM} LIBRARY DESTINATION "${MUMBLE_INSTALL_PLUGINDIR}" COMPONENT mumble_client)
-		endif()
-
-		if(packaging)
-			add_dependencies(mumble ${ITEM})
-		endif()
+	if(PLUGIN_RETRACTED AND NOT retracted-plugins)
+		# The included subdir didn't actually add a target since the associated plugin is retracted
+		# and therefore it should not be built.
+		continue()
 	endif()
+
+	target_include_directories(${CURRENT_PLUGIN} PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
+
+	if(WIN32)
+		target_compile_definitions(${CURRENT_PLUGIN} PRIVATE "OS_WINDOWS")
+		target_link_libraries(${CURRENT_PLUGIN} user32.lib)
+
+		# Shared library on Windows (e.g. ".dll")
+		set_target_properties(${CURRENT_PLUGIN} PROPERTIES RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/plugins")
+		install(TARGETS ${CURRENT_PLUGIN} RUNTIME DESTINATION "${MUMBLE_INSTALL_PLUGINDIR}" COMPONENT mumble_client)
+	elseif(UNIX)
+		if(${CMAKE_SYSTEM_NAME} STREQUAL "Linux")
+			target_compile_definitions(${CURRENT_PLUGIN} PRIVATE "OS_LINUX")
+		elseif(APPLE)
+			target_compile_definitions(${CURRENT_PLUGIN} PRIVATE "OS_MACOS")
+		endif()
+
+		# Shared library on UNIX (e.g. ".so")
+		set_target_properties(${CURRENT_PLUGIN} PROPERTIES LIBRARY_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/plugins")
+		install(TARGETS ${CURRENT_PLUGIN} LIBRARY DESTINATION "${MUMBLE_INSTALL_PLUGINDIR}" COMPONENT mumble_client)
+	endif()
+
+	add_dependencies(mumble ${CURRENT_PLUGIN})
 endforeach()

--- a/plugins/amongus/Game.cpp
+++ b/plugins/amongus/Game.cpp
@@ -5,7 +5,7 @@
 
 #include "Game.h"
 
-#include "../mumble_positional_audio_utils.h"
+#include "mumble_positional_audio_utils.h"
 
 Game::Game(const uint64_t id, const std::string name) : m_proc(static_cast< procid_t >(id), name) {
 }

--- a/plugins/aoc/aoc.cpp
+++ b/plugins/aoc/aoc.cpp
@@ -4,9 +4,9 @@
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.
 
 #define MUMBLE_ALLOW_DEPRECATED_LEGACY_PLUGIN_API
-#include "../mumble_legacy_plugin.h"
+#include "mumble_legacy_plugin.h"
 
-#include "../mumble_positional_audio_main.h"
+#include "mumble_positional_audio_main.h"
 
 using namespace std;
 

--- a/plugins/arma2/arma2.cpp
+++ b/plugins/arma2/arma2.cpp
@@ -4,9 +4,9 @@
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.
 
 #define MUMBLE_ALLOW_DEPRECATED_LEGACY_PLUGIN_API
-#include "../mumble_legacy_plugin.h"
+#include "mumble_legacy_plugin.h"
 
-#include "../mumble_positional_audio_main.h"
+#include "mumble_positional_audio_main.h"
 
 procptr_t posptr, frontptr, topptr;
 

--- a/plugins/bf1/bf1.cpp
+++ b/plugins/bf1/bf1.cpp
@@ -4,10 +4,10 @@
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.
 
 #define MUMBLE_ALLOW_DEPRECATED_LEGACY_PLUGIN_API
-#include "../mumble_legacy_plugin.h"
+#include "mumble_legacy_plugin.h"
 
-#include "../mumble_positional_audio_main.h"  // Include standard positional audio header
-#include "../mumble_positional_audio_utils.h" // Include positional audio header for special functions, like "escape".
+#include "mumble_positional_audio_main.h"  // Include standard positional audio header
+#include "mumble_positional_audio_utils.h" // Include positional audio header for special functions, like "escape".
 
 static int fetch(float *avatar_pos, float *avatar_front, float *avatar_top, float *camera_pos, float *camera_front,
 				 float *camera_top, std::string &context, std::wstring &identity) {

--- a/plugins/bf1942/bf1942.cpp
+++ b/plugins/bf1942/bf1942.cpp
@@ -4,9 +4,9 @@
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.
 
 #define MUMBLE_ALLOW_DEPRECATED_LEGACY_PLUGIN_API
-#include "../mumble_legacy_plugin.h"
+#include "mumble_legacy_plugin.h"
 
-#include "../mumble_positional_audio_main.h"
+#include "mumble_positional_audio_main.h"
 
 procptr_t faceptr, topptr;
 // BYTE *stateptr;

--- a/plugins/bf2/bf2.cpp
+++ b/plugins/bf2/bf2.cpp
@@ -4,9 +4,9 @@
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.
 
 #define MUMBLE_ALLOW_DEPRECATED_LEGACY_PLUGIN_API
-#include "../mumble_legacy_plugin.h"
+#include "mumble_legacy_plugin.h"
 
-#include "../mumble_positional_audio_main.h"
+#include "mumble_positional_audio_main.h"
 
 using namespace std;
 

--- a/plugins/bf2142/bf2142.cpp
+++ b/plugins/bf2142/bf2142.cpp
@@ -4,10 +4,10 @@
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.
 
 #define MUMBLE_ALLOW_DEPRECATED_LEGACY_PLUGIN_API
-#include "../mumble_legacy_plugin.h"
+#include "mumble_legacy_plugin.h"
 
-#include "../mumble_positional_audio_main.h"  // Include standard positional audio header.
-#include "../mumble_positional_audio_utils.h" // Include positional audio header for special functions, like "escape".
+#include "mumble_positional_audio_main.h"  // Include standard positional audio header.
+#include "mumble_positional_audio_utils.h" // Include positional audio header for special functions, like "escape".
 
 // Variable to contain module's addresses
 procptr_t RendDX9 = 0;

--- a/plugins/bf3/bf3.cpp
+++ b/plugins/bf3/bf3.cpp
@@ -37,9 +37,9 @@
 */
 
 #define MUMBLE_ALLOW_DEPRECATED_LEGACY_PLUGIN_API
-#include "../mumble_legacy_plugin.h"
+#include "mumble_legacy_plugin.h"
 
-#include "../mumble_positional_audio_main.h"
+#include "mumble_positional_audio_main.h"
 
 static bool ptr_chain_valid = false;
 

--- a/plugins/bf4/bf4.cpp
+++ b/plugins/bf4/bf4.cpp
@@ -4,10 +4,10 @@
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.
 
 #define MUMBLE_ALLOW_DEPRECATED_LEGACY_PLUGIN_API
-#include "../mumble_legacy_plugin.h"
+#include "mumble_legacy_plugin.h"
 
-#include "../mumble_positional_audio_main.h"  // Include standard positional audio header.
-#include "../mumble_positional_audio_utils.h" // Include positional audio header for special functions, like "escape".
+#include "mumble_positional_audio_main.h"  // Include standard positional audio header.
+#include "mumble_positional_audio_utils.h" // Include positional audio header for special functions, like "escape".
 
 static int fetch(float *avatar_pos, float *avatar_front, float *avatar_top, float *camera_pos, float *camera_front,
 				 float *camera_top, std::string &context, std::wstring &identity) {

--- a/plugins/bf4_x86/bf4_x86.cpp
+++ b/plugins/bf4_x86/bf4_x86.cpp
@@ -4,10 +4,10 @@
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.
 
 #define MUMBLE_ALLOW_DEPRECATED_LEGACY_PLUGIN_API
-#include "../mumble_legacy_plugin.h"
+#include "mumble_legacy_plugin.h"
 
-#include "../mumble_positional_audio_main.h"  // Include standard positional audio header.
-#include "../mumble_positional_audio_utils.h" // Include positional audio header for special functions, like "escape".
+#include "mumble_positional_audio_main.h"  // Include standard positional audio header.
+#include "mumble_positional_audio_utils.h" // Include positional audio header for special functions, like "escape".
 
 static int fetch(float *avatar_pos, float *avatar_front, float *avatar_top, float *camera_pos, float *camera_front,
 				 float *camera_top, std::string &context, std::wstring &identity) {

--- a/plugins/bfbc2/bfbc2.cpp
+++ b/plugins/bfbc2/bfbc2.cpp
@@ -4,9 +4,9 @@
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.
 
 #define MUMBLE_ALLOW_DEPRECATED_LEGACY_PLUGIN_API
-#include "../mumble_legacy_plugin.h"
+#include "mumble_legacy_plugin.h"
 
-#include "../mumble_positional_audio_main.h"
+#include "mumble_positional_audio_main.h"
 
 bool is_steam = false;
 

--- a/plugins/bfheroes/bfheroes.cpp
+++ b/plugins/bfheroes/bfheroes.cpp
@@ -4,9 +4,9 @@
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.
 
 #define MUMBLE_ALLOW_DEPRECATED_LEGACY_PLUGIN_API
-#include "../mumble_legacy_plugin.h"
+#include "mumble_legacy_plugin.h"
 
-#include "../mumble_positional_audio_main.h"
+#include "mumble_positional_audio_main.h"
 
 procptr_t posptr, faceptr, topptr, stateptr;
 

--- a/plugins/blacklight/blacklight.cpp
+++ b/plugins/blacklight/blacklight.cpp
@@ -35,9 +35,9 @@
 */
 
 #define MUMBLE_ALLOW_DEPRECATED_LEGACY_PLUGIN_API
-#include "../mumble_legacy_plugin.h"
+#include "mumble_legacy_plugin.h"
 
-#include "../mumble_positional_audio_main.h"
+#include "mumble_positional_audio_main.h"
 
 /*
 	Arrays of bytes to find addresses accessed by respective functions so we don't have to blindly search for addresses

--- a/plugins/borderlands/borderlands.cpp
+++ b/plugins/borderlands/borderlands.cpp
@@ -35,9 +35,9 @@
 */
 
 #define MUMBLE_ALLOW_DEPRECATED_LEGACY_PLUGIN_API
-#include "../mumble_legacy_plugin.h"
+#include "mumble_legacy_plugin.h"
 
-#include "../mumble_positional_audio_main.h"
+#include "mumble_positional_audio_main.h"
 
 procptr_t posptr, frontptr, topptr, contextptraddress, stateaddress, loginaddress;
 

--- a/plugins/borderlands2/borderlands2.cpp
+++ b/plugins/borderlands2/borderlands2.cpp
@@ -36,9 +36,9 @@
 */
 
 #define MUMBLE_ALLOW_DEPRECATED_LEGACY_PLUGIN_API
-#include "../mumble_legacy_plugin.h"
+#include "mumble_legacy_plugin.h"
 
-#include "../mumble_positional_audio_main.h"
+#include "mumble_positional_audio_main.h"
 
 #include <algorithm>
 

--- a/plugins/breach/breach.cpp
+++ b/plugins/breach/breach.cpp
@@ -35,9 +35,9 @@
 */
 
 #define MUMBLE_ALLOW_DEPRECATED_LEGACY_PLUGIN_API
-#include "../mumble_legacy_plugin.h"
+#include "mumble_legacy_plugin.h"
 
-#include "../mumble_positional_audio_main.h"
+#include "mumble_positional_audio_main.h"
 
 procptr_t posptr, frontptr, topptr;
 

--- a/plugins/cod2/cod2.cpp
+++ b/plugins/cod2/cod2.cpp
@@ -6,9 +6,9 @@
 #include "ProcessWindows.h"
 
 #define MUMBLE_ALLOW_DEPRECATED_LEGACY_PLUGIN_API
-#include "../mumble_legacy_plugin.h"
+#include "mumble_legacy_plugin.h"
 
-#include "../mumble_positional_audio_utils.h"
+#include "mumble_positional_audio_utils.h"
 
 #include <memory>
 

--- a/plugins/cod4/cod4.cpp
+++ b/plugins/cod4/cod4.cpp
@@ -4,9 +4,9 @@
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.
 
 #define MUMBLE_ALLOW_DEPRECATED_LEGACY_PLUGIN_API
-#include "../mumble_legacy_plugin.h"
+#include "mumble_legacy_plugin.h"
 
-#include "../mumble_positional_audio_main.h"
+#include "mumble_positional_audio_main.h"
 
 using namespace std;
 

--- a/plugins/cod5/cod5.cpp
+++ b/plugins/cod5/cod5.cpp
@@ -4,9 +4,9 @@
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.
 
 #define MUMBLE_ALLOW_DEPRECATED_LEGACY_PLUGIN_API
-#include "../mumble_legacy_plugin.h"
+#include "mumble_legacy_plugin.h"
 
-#include "../mumble_positional_audio_main.h"
+#include "mumble_positional_audio_main.h"
 
 static int fetch(float *avatar_pos, float *avatar_front, float *avatar_top, float *camera_pos, float *camera_front,
 				 float *camera_top, std::string &, std::wstring &) {

--- a/plugins/codmw2/codmw2.cpp
+++ b/plugins/codmw2/codmw2.cpp
@@ -4,9 +4,9 @@
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.
 
 #define MUMBLE_ALLOW_DEPRECATED_LEGACY_PLUGIN_API
-#include "../mumble_legacy_plugin.h"
+#include "mumble_legacy_plugin.h"
 
-#include "../mumble_positional_audio_main.h"
+#include "mumble_positional_audio_main.h"
 
 static int fetch(float *avatar_pos, float *avatar_front, float *avatar_top, float *camera_pos, float *camera_front,
 				 float *camera_top, std::string &, std::wstring &) {

--- a/plugins/codmw2so/codmw2so.cpp
+++ b/plugins/codmw2so/codmw2so.cpp
@@ -36,9 +36,9 @@
 */
 
 #define MUMBLE_ALLOW_DEPRECATED_LEGACY_PLUGIN_API
-#include "../mumble_legacy_plugin.h"
+#include "mumble_legacy_plugin.h"
 
-#include "../mumble_positional_audio_main.h"
+#include "mumble_positional_audio_main.h"
 
 static int fetch(float *avatar_pos, float *avatar_front, float *avatar_top, float *camera_pos, float *camera_front,
 				 float *camera_top, std::string &, std::wstring &) {

--- a/plugins/cs/cs.cpp
+++ b/plugins/cs/cs.cpp
@@ -36,9 +36,9 @@
 */
 
 #define MUMBLE_ALLOW_DEPRECATED_LEGACY_PLUGIN_API
-#include "../mumble_legacy_plugin.h"
+#include "mumble_legacy_plugin.h"
 
-#include "../mumble_positional_audio_main.h"
+#include "mumble_positional_audio_main.h"
 
 using namespace std;
 

--- a/plugins/dys/dys.cpp
+++ b/plugins/dys/dys.cpp
@@ -4,9 +4,9 @@
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.
 
 #define MUMBLE_ALLOW_DEPRECATED_LEGACY_PLUGIN_API
-#include "../mumble_legacy_plugin.h"
+#include "mumble_legacy_plugin.h"
 
-#include "../mumble_positional_audio_main.h"
+#include "mumble_positional_audio_main.h"
 
 using namespace std;
 

--- a/plugins/etqw/etqw.cpp
+++ b/plugins/etqw/etqw.cpp
@@ -4,9 +4,9 @@
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.
 
 #define MUMBLE_ALLOW_DEPRECATED_LEGACY_PLUGIN_API
-#include "../mumble_legacy_plugin.h"
+#include "mumble_legacy_plugin.h"
 
-#include "../mumble_positional_audio_main.h"
+#include "mumble_positional_audio_main.h"
 
 using namespace std;
 

--- a/plugins/ffxiv/ffxiv.cpp
+++ b/plugins/ffxiv/ffxiv.cpp
@@ -4,10 +4,10 @@
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.
 
 #define MUMBLE_ALLOW_DEPRECATED_LEGACY_PLUGIN_API
-#include "../mumble_legacy_plugin.h"
+#include "mumble_legacy_plugin.h"
 
-#include "../mumble_positional_audio_main.h"  // Include standard positional audio header.
-#include "../mumble_positional_audio_utils.h" // Include positional audio header for special functions, like "escape".
+#include "mumble_positional_audio_main.h"  // Include standard positional audio header.
+#include "mumble_positional_audio_utils.h" // Include positional audio header for special functions, like "escape".
 
 #include <cmath>
 

--- a/plugins/gmod/gmod.cpp
+++ b/plugins/gmod/gmod.cpp
@@ -4,9 +4,9 @@
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.
 
 #define MUMBLE_ALLOW_DEPRECATED_LEGACY_PLUGIN_API
-#include "../mumble_legacy_plugin.h"
+#include "mumble_legacy_plugin.h"
 
-#include "../mumble_positional_audio_main.h"
+#include "mumble_positional_audio_main.h"
 
 using namespace std;
 

--- a/plugins/gtaiv/gtaiv.cpp
+++ b/plugins/gtaiv/gtaiv.cpp
@@ -35,9 +35,9 @@
 */
 
 #define MUMBLE_ALLOW_DEPRECATED_LEGACY_PLUGIN_API
-#include "../mumble_legacy_plugin.h"
+#include "mumble_legacy_plugin.h"
 
-#include "../mumble_positional_audio_main.h"
+#include "mumble_positional_audio_main.h"
 
 static unsigned int playerid;
 static procptr_t base_address;

--- a/plugins/gtasa/gtasa.cpp
+++ b/plugins/gtasa/gtasa.cpp
@@ -4,9 +4,9 @@
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.
 
 #define MUMBLE_ALLOW_DEPRECATED_LEGACY_PLUGIN_API
-#include "../mumble_legacy_plugin.h"
+#include "mumble_legacy_plugin.h"
 
-#include "../mumble_positional_audio_main.h"
+#include "mumble_positional_audio_main.h"
 
 struct Matrix {
 	float right[4];

--- a/plugins/gtav/gtav.cpp
+++ b/plugins/gtav/gtav.cpp
@@ -4,10 +4,10 @@
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.
 
 #define MUMBLE_ALLOW_DEPRECATED_LEGACY_PLUGIN_API
-#include "../mumble_legacy_plugin.h"
+#include "mumble_legacy_plugin.h"
 
-#include "../mumble_positional_audio_main.h"  // Include standard positional audio header.
-#include "../mumble_positional_audio_utils.h" // Include positional audio header for special functions, like "escape".
+#include "mumble_positional_audio_main.h"  // Include standard positional audio header.
+#include "mumble_positional_audio_utils.h" // Include positional audio header for special functions, like "escape".
 
 #include <algorithm> // Include algorithm header for the game version detector
 

--- a/plugins/gw/gw.cpp
+++ b/plugins/gw/gw.cpp
@@ -35,9 +35,9 @@
 */
 
 #define MUMBLE_ALLOW_DEPRECATED_LEGACY_PLUGIN_API
-#include "../mumble_legacy_plugin.h"
+#include "mumble_legacy_plugin.h"
 
-#include "../mumble_positional_audio_main.h"
+#include "mumble_positional_audio_main.h"
 
 /*
 	Arrays of bytes to find addresses accessed by respective functions so we don't have to blindly search for addresses

--- a/plugins/insurgency/insurgency.cpp
+++ b/plugins/insurgency/insurgency.cpp
@@ -4,9 +4,9 @@
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.
 
 #define MUMBLE_ALLOW_DEPRECATED_LEGACY_PLUGIN_API
-#include "../mumble_legacy_plugin.h"
+#include "mumble_legacy_plugin.h"
 
-#include "../mumble_positional_audio_main.h"
+#include "mumble_positional_audio_main.h"
 
 using namespace std;
 

--- a/plugins/jc2/jc2.cpp
+++ b/plugins/jc2/jc2.cpp
@@ -36,9 +36,9 @@
 */
 
 #define MUMBLE_ALLOW_DEPRECATED_LEGACY_PLUGIN_API
-#include "../mumble_legacy_plugin.h"
+#include "mumble_legacy_plugin.h"
 
-#include "../mumble_positional_audio_main.h"
+#include "mumble_positional_audio_main.h"
 
 const unsigned int off_character_manager = 0xD8FB24;
 const unsigned int off_local_player      = 0x3570;

--- a/plugins/link/link-posix.cpp
+++ b/plugins/link/link-posix.cpp
@@ -4,7 +4,7 @@
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.
 
 #define MUMBLE_ALLOW_DEPRECATED_LEGACY_PLUGIN_API
-#include "../mumble_legacy_plugin.h"
+#include "mumble_legacy_plugin.h"
 
 #include <stdint.h>
 #include <stdio.h>

--- a/plugins/link/link.cpp
+++ b/plugins/link/link.cpp
@@ -11,7 +11,7 @@
 #include <math.h>
 
 #define MUMBLE_ALLOW_DEPRECATED_LEGACY_PLUGIN_API
-#include "../mumble_legacy_plugin.h"
+#include "mumble_legacy_plugin.h"
 
 static std::wstring wsPluginName;
 static std::wstring wsDescription;

--- a/plugins/lol/lol.cpp
+++ b/plugins/lol/lol.cpp
@@ -35,9 +35,9 @@
 */
 
 #define MUMBLE_ALLOW_DEPRECATED_LEGACY_PLUGIN_API
-#include "../mumble_legacy_plugin.h"
+#include "mumble_legacy_plugin.h"
 
-#include "../mumble_positional_audio_main.h"
+#include "mumble_positional_audio_main.h"
 
 /*
 	Arrays of bytes to find addresses accessed by respective functions so we don't have to blindly search for addresses

--- a/plugins/lotro/lotro.cpp
+++ b/plugins/lotro/lotro.cpp
@@ -35,9 +35,9 @@
 */
 
 #define MUMBLE_ALLOW_DEPRECATED_LEGACY_PLUGIN_API
-#include "../mumble_legacy_plugin.h"
+#include "mumble_legacy_plugin.h"
 
-#include "../mumble_positional_audio_main.h"
+#include "mumble_positional_audio_main.h"
 
 static int fetch(float *avatar_pos, float *avatar_front, float *avatar_top, float *camera_pos, float *camera_front,
 				 float *camera_top, std::string &context, std::wstring &) {

--- a/plugins/mumble_positional_audio_main.h
+++ b/plugins/mumble_positional_audio_main.h
@@ -228,9 +228,9 @@ static inline int8_t isWin32Process64Bit(const procptr_t &baseAddress) {
 }
 
 #ifdef WIN32
-#	include "../mumble_positional_audio_win32.h"
+#	include "mumble_positional_audio_win32.h"
 #else
-#	include "../mumble_positional_audio_linux.h"
+#	include "mumble_positional_audio_linux.h"
 #endif
 
 #endif

--- a/plugins/ql/ql.cpp
+++ b/plugins/ql/ql.cpp
@@ -4,10 +4,10 @@
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.
 
 #define MUMBLE_ALLOW_DEPRECATED_LEGACY_PLUGIN_API
-#include "../mumble_legacy_plugin.h"
+#include "mumble_legacy_plugin.h"
 
-#include "../mumble_positional_audio_main.h"  // Include standard positional audio header.
-#include "../mumble_positional_audio_utils.h" // Include positional audio header for special functions, like "escape".
+#include "mumble_positional_audio_main.h"  // Include standard positional audio header.
+#include "mumble_positional_audio_utils.h" // Include positional audio header for special functions, like "escape".
 
 static int fetch(float *avatar_pos, float *avatar_front, float *avatar_top, float *camera_pos, float *camera_front,
 				 float *camera_top, std::string &context, std::wstring &identity) {

--- a/plugins/rl/rl.cpp
+++ b/plugins/rl/rl.cpp
@@ -4,9 +4,9 @@
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.
 
 #define MUMBLE_ALLOW_DEPRECATED_LEGACY_PLUGIN_API
-#include "../mumble_legacy_plugin.h"
+#include "mumble_legacy_plugin.h"
 
-#include "../mumble_positional_audio_main.h"
+#include "mumble_positional_audio_main.h"
 
 #ifdef WIN32
 // Memory offsets

--- a/plugins/se/se.cpp
+++ b/plugins/se/se.cpp
@@ -4,9 +4,9 @@
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.
 
 #define MUMBLE_ALLOW_DEPRECATED_LEGACY_PLUGIN_API
-#include "../mumble_legacy_plugin.h"
+#include "mumble_legacy_plugin.h"
 
-#include "../mumble_positional_audio_utils.h"
+#include "mumble_positional_audio_utils.h"
 
 #ifdef OS_LINUX
 #	include "ProcessLinux.h"

--- a/plugins/sr/sr.cpp
+++ b/plugins/sr/sr.cpp
@@ -36,9 +36,9 @@
 */
 
 #define MUMBLE_ALLOW_DEPRECATED_LEGACY_PLUGIN_API
-#include "../mumble_legacy_plugin.h"
+#include "mumble_legacy_plugin.h"
 
-#include "../mumble_positional_audio_main.h"
+#include "mumble_positional_audio_main.h"
 
 static int fetch(float *avatar_pos, float *avatar_front, float *avatar_top, float *camera_pos, float *camera_front,
 				 float *camera_top, std::string & /*context*/, std::wstring & /*identity*/) {

--- a/plugins/testPlugin/CMakeLists.txt
+++ b/plugins/testPlugin/CMakeLists.txt
@@ -3,7 +3,4 @@
 # that can be found in the LICENSE file at the root of the
 # Mumble source tree or at <https://www.mumble.info/LICENSE>.
 
-if(${CMAKE_BUILD_TYPE} MATCHES Debug)
-	message("Including TestPlugin in debug mode")
-	add_library(testPlugin SHARED "testPlugin.cpp")
-endif()
+add_library(testPlugin SHARED "testPlugin.cpp")

--- a/plugins/ut2004/ut2004.cpp
+++ b/plugins/ut2004/ut2004.cpp
@@ -4,9 +4,9 @@
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.
 
 #define MUMBLE_ALLOW_DEPRECATED_LEGACY_PLUGIN_API
-#include "../mumble_legacy_plugin.h"
+#include "mumble_legacy_plugin.h"
 
-#include "../mumble_positional_audio_main.h"
+#include "mumble_positional_audio_main.h"
 
 using namespace std;
 

--- a/plugins/ut3/ut3.cpp
+++ b/plugins/ut3/ut3.cpp
@@ -4,9 +4,9 @@
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.
 
 #define MUMBLE_ALLOW_DEPRECATED_LEGACY_PLUGIN_API
-#include "../mumble_legacy_plugin.h"
+#include "mumble_legacy_plugin.h"
 
-#include "../mumble_positional_audio_main.h"
+#include "mumble_positional_audio_main.h"
 
 using namespace std;
 

--- a/plugins/ut99/ut99.cpp
+++ b/plugins/ut99/ut99.cpp
@@ -35,10 +35,10 @@
 */
 
 #define MUMBLE_ALLOW_DEPRECATED_LEGACY_PLUGIN_API
-#include "../mumble_legacy_plugin.h"
+#include "mumble_legacy_plugin.h"
 
-#include "../mumble_positional_audio_main.h"
-#include "../mumble_positional_audio_utils.h"
+#include "mumble_positional_audio_main.h"
+#include "mumble_positional_audio_utils.h"
 
 procptr_t posptr;
 procptr_t frtptr;

--- a/plugins/wolfet/wolfet.cpp
+++ b/plugins/wolfet/wolfet.cpp
@@ -48,9 +48,9 @@
 */
 
 #define MUMBLE_ALLOW_DEPRECATED_LEGACY_PLUGIN_API
-#include "../mumble_legacy_plugin.h"
+#include "mumble_legacy_plugin.h"
 
-#include "../mumble_positional_audio_main.h"
+#include "mumble_positional_audio_main.h"
 
 static int fetch(float *avatar_pos, float *avatar_front, float *avatar_top, float *camera_pos, float *camera_front,
 				 float *camera_top, std::string &context, std::wstring &) {

--- a/plugins/wow/wow.cpp
+++ b/plugins/wow/wow.cpp
@@ -4,10 +4,10 @@
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.
 
 #define MUMBLE_ALLOW_DEPRECATED_LEGACY_PLUGIN_API
-#include "../mumble_legacy_plugin.h"
+#include "mumble_legacy_plugin.h"
 
-#include "../mumble_positional_audio_main.h"  // Include standard positional audio header.
-#include "../mumble_positional_audio_utils.h" // Include positional audio header for special functions, like "escape".
+#include "mumble_positional_audio_main.h"  // Include standard positional audio header.
+#include "mumble_positional_audio_utils.h" // Include positional audio header for special functions, like "escape".
 
 static int fetch(float *avatar_pos, float *avatar_front, float *avatar_top, float *camera_pos, float *camera_front,
 				 float *camera_top, std::string &context, std::wstring &identity) {

--- a/plugins/wow_x64/wow_x64.cpp
+++ b/plugins/wow_x64/wow_x64.cpp
@@ -4,10 +4,10 @@
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.
 
 #define MUMBLE_ALLOW_DEPRECATED_LEGACY_PLUGIN_API
-#include "../mumble_legacy_plugin.h"
+#include "mumble_legacy_plugin.h"
 
-#include "../mumble_positional_audio_main.h"  // Include standard positional audio header.
-#include "../mumble_positional_audio_utils.h" // Include positional audio header for special functions, like "escape".
+#include "mumble_positional_audio_main.h"  // Include standard positional audio header.
+#include "mumble_positional_audio_utils.h" // Include positional audio header for special functions, like "escape".
 
 static int fetch(float *avatar_pos, float *avatar_front, float *avatar_top, float *camera_pos, float *camera_front,
 				 float *camera_top, std::string &context, std::wstring &identity) {


### PR DESCRIPTION
Instead of excluding all plugins but the link one on OSes other than
Windows and Linux, the new approach allows for a more granular control
by introducing a list of plugins that is supported on the different
platforms.

This replaces the globbing approach which means that new plugins have
now to be included in this list explicitly.

The advantage of this is that this allows for a much greater flexibility
for handling plugins on different OS.

Furthermore the plugin's own directory is no longer added to the
include-path by default. If a plugin wishes to do this, it should do so
explicitly. This should help make the plugins easier to move around in
the future.


### Checks

- [x] My commits follow the [commit guidelines](https://github.com/mumble-voip/mumble/blob/master/COMMIT_GUIDELINES.md)

