### PR TITLE
FIX(server): Value queried but not used in DB insertion

### DIFF
--- a/src/murmur/ServerDB.cpp
+++ b/src/murmur/ServerDB.cpp
@@ -733,7 +733,7 @@ ServerDB::ServerDB() {
 			else
 				SQLDO("INSERT INTO `%1users` (`server_id`, `user_id`, `name`, `pw`, `lastchannel`, `texture`, "
 					  "`last_active`) SELECT `server_id`, `user_id`, `name`, `pw`, `lastchannel`, `texture`, "
-					  "`last_active`, `last_disconnect` FROM `%1users%2`");
+					  "`last_active` FROM `%1users%2`");
 
 			SQLDO("INSERT INTO `%1groups` (`group_id`, `server_id`, `name`, `channel_id`, `inherit`, `inheritable`) "
 				  "SELECT `group_id`, `server_id`, `name`, `channel_id`, `inherit`, `inheritable` FROM `%1groups%2`");


### PR DESCRIPTION
Inside ServerDB there was one SQL statement that reads values off from
one table and writes them into another one. However while doing so, it
(in contrast to the other statements doing the same for other DB
versions) also queries the `last_disconnect` value. This values is
unused in the INSERT statement though and therefore reading it in the
first place seems to be pointless.


### Checks

- [x] My commits follow the [commit guidelines](https://github.com/mumble-voip/mumble/blob/master/COMMIT_GUIDELINES.md)

