### PR TITLE
Backport "FIX(server): Value queried but not used in DB insertion (#5131)" to 1.4.x

### DIFF
--- a/src/murmur/ServerDB.cpp
+++ b/src/murmur/ServerDB.cpp
@@ -733,7 +733,7 @@ ServerDB::ServerDB() {
 			else
 				SQLDO("INSERT INTO `%1users` (`server_id`, `user_id`, `name`, `pw`, `lastchannel`, `texture`, "
 					  "`last_active`) SELECT `server_id`, `user_id`, `name`, `pw`, `lastchannel`, `texture`, "
-					  "`last_active`, `last_disconnect` FROM `%1users%2`");
+					  "`last_active` FROM `%1users%2`");
 
 			SQLDO("INSERT INTO `%1groups` (`group_id`, `server_id`, `name`, `channel_id`, `inherit`, `inheritable`) "
 				  "SELECT `group_id`, `server_id`, `name`, `channel_id`, `inherit`, `inheritable` FROM `%1groups%2`");


### PR DESCRIPTION
Backports the following commits to 1.4.x:
 - FIX(server): Value queried but not used in DB insertion (#5131)