### PR TITLE
FIX(server): Also INSERT queried value 

### DIFF
--- a/src/murmur/ServerDB.cpp
+++ b/src/murmur/ServerDB.cpp
@@ -733,7 +733,7 @@ ServerDB::ServerDB() {
 			else
 				SQLDO("INSERT INTO `%1users` (`server_id`, `user_id`, `name`, `pw`, `lastchannel`, `texture`, "
 					  "`last_active`) SELECT `server_id`, `user_id`, `name`, `pw`, `lastchannel`, `texture`, "
-					  "`last_active` FROM `%1users%2`");
+					  "`last_active`, `last_disconnect` FROM `%1users%2`");
 
 			SQLDO("INSERT INTO `%1groups` (`group_id`, `server_id`, `name`, `channel_id`, `inherit`, `inheritable`) "
 				  "SELECT `group_id`, `server_id`, `name`, `channel_id`, `inherit`, `inheritable` FROM `%1groups%2`");

--- a/src/murmur/ServerDB.cpp
+++ b/src/murmur/ServerDB.cpp
@@ -732,8 +732,8 @@ ServerDB::ServerDB() {
 					  "`last_active` FROM `%1users%2`");
 			else
 				SQLDO("INSERT INTO `%1users` (`server_id`, `user_id`, `name`, `pw`, `lastchannel`, `texture`, "
-					  "`last_active`) SELECT `server_id`, `user_id`, `name`, `pw`, `lastchannel`, `texture`, "
-					  "`last_active`, `last_disconnect` FROM `%1users%2`");
+					  "`last_active`, `last_disconnect`) SELECT `server_id`, `user_id`, `name`, `pw`, `lastchannel`, "
+					  "`texture`, `last_active`, `last_disconnect` FROM `%1users%2`");
 
 			SQLDO("INSERT INTO `%1groups` (`group_id`, `server_id`, `name`, `channel_id`, `inherit`, `inheritable`) "
 				  "SELECT `group_id`, `server_id`, `name`, `channel_id`, `inherit`, `inheritable` FROM `%1groups%2`");


### PR DESCRIPTION
13b85a3 introduced a new feature for
which it is required to remember when the last user disconnected from a
channel. However in the upgrade path that variable was part of the query
but not of the insert statement.

Note this reverts the changes of #5131 as it seems the approach taken there was wrong.

### Checks

- [x] My commits follow the [commit guidelines](https://github.com/mumble-voip/mumble/blob/master/COMMIT_GUIDELINES.md)

