### PR TITLE
DOCS: Add note to Mumble.proto

### DIFF
--- a/src/Mumble.proto
+++ b/src/Mumble.proto
@@ -107,6 +107,9 @@ message ServerSync {
 	// Server welcome text.
 	optional string welcome_text = 3;
 	// Current user permissions in the root channel.
+	// Note: The permissions data type usually is uin32 (e.g. in PermissionQuery and PermissionDenied messages). Here
+	// it is uint64 because of an oversight in the past. Nonetheless it should never exceed the uin32 range.
+	// See also: https://github.com/mumble-voip/mumble/issues/5139
 	optional uint64 permissions = 4;
 }
 


### PR DESCRIPTION
The datatype used for permissions in proto messages is inconsistent. In
2 of 3 message types it is uint32 but in erverSync it is uint64.

We can't change that anymore but this commit adds a note about it into
the proto file.

Ref: #5139


### Checks

- [x] My commits follow the [commit guidelines](https://github.com/mumble-voip/mumble/blob/master/COMMIT_GUIDELINES.md)

