### PR TITLE
FIX(client): Remove unnecessary wait for mutex

### DIFF
--- a/src/mumble/JackAudio.cpp
+++ b/src/mumble/JackAudio.cpp
@@ -173,10 +173,6 @@ bool JackAudioOutputRegistrar::usesOutputDelay() const {
 void JackAudioInit::initialize() {
 	jas.reset(new JackAudioSystem());
 
-	jas->qmWait.lock();
-	jas->qwcWait.wait(&jas->qmWait, 1000);
-	jas->qmWait.unlock();
-
 	if (jas->bAvailable) {
 		airJackAudio.reset(new JackAudioInputRegistrar());
 		aorJackAudio.reset(new JackAudioOutputRegistrar());

--- a/src/mumble/JackAudio.h
+++ b/src/mumble/JackAudio.h
@@ -44,7 +44,6 @@ protected:
 	uint8_t users;
 	QMutex qmWait;
 	QLibrary qlJack;
-	QWaitCondition qwcWait;
 	jack_client_t *client;
 
 	static int processCallback(jack_nframes_t frames, void *);

--- a/src/mumble/PAAudio.cpp
+++ b/src/mumble/PAAudio.cpp
@@ -101,10 +101,6 @@ void PortAudioOutputRegistrar::setDeviceChoice(const QVariant &choice, Settings 
 void PortAudioInit::initialize() {
 	pas.reset(new PortAudioSystem());
 
-	pas->qmWait.lock();
-	pas->qwcWait.wait(&pas->qmWait, 1000);
-	pas->qmWait.unlock();
-
 	if (pas->bOk) {
 		airPortAudio.reset(new PortAudioInputRegistrar());
 		aorPortAudio.reset(new PortAudioOutputRegistrar());

--- a/src/mumble/PAAudio.h
+++ b/src/mumble/PAAudio.h
@@ -26,7 +26,6 @@ protected:
 	bool bOk;
 	QMutex qmWait;
 	QLibrary qlPortAudio;
-	QWaitCondition qwcWait;
 
 	static int streamCallback(const void *input, void *output, unsigned long frames, const PaStreamCallbackTimeInfo *,
 							  PaStreamCallbackFlags statusFlags, void *isInput);

--- a/src/mumble/PipeWire.cpp
+++ b/src/mumble/PipeWire.cpp
@@ -111,11 +111,6 @@ bool PipeWireOutputRegistrar::usesOutputDelay() const {
 void PipeWireInit::initialize() {
 	pws = std::make_unique< PipeWireSystem >();
 
-	// Wait for initialization process to complete.
-	pws->m_lock.lock();
-	pws->m_waiter.wait(&pws->m_lock, 1000);
-	pws->m_lock.unlock();
-
 	if (pws->m_ok) {
 		inputRegistrar  = std::make_unique< PipeWireInputRegistrar >();
 		outputRegistrar = std::make_unique< PipeWireOutputRegistrar >();

--- a/src/mumble/PipeWire.h
+++ b/src/mumble/PipeWire.h
@@ -65,8 +65,6 @@ protected:
 	bool m_ok;
 	uint8_t m_users;
 	QLibrary m_lib;
-	QMutex m_lock;
-	QWaitCondition m_waiter;
 
 	const char *(*pw_get_library_version)();
 

--- a/src/mumble/PulseAudio.h
+++ b/src/mumble/PulseAudio.h
@@ -177,8 +177,6 @@ public:
 	QHash< QString, QString > qhInput;
 	QHash< QString, QString > qhOutput;
 	bool bPulseIsGood;
-	QMutex qmWait;
-	QWaitCondition qwcWait;
 
 	void wakeup_lock();
 


### PR DESCRIPTION
It looks like some Backends were unnecessarily waiting for another thread, that didn't exist.

I tested all affected backends, they all still work for me (though obviously this should be tested by at least someone else).

Mumble starts up instantly now.

Fixes #5157
Fixes #5022