### PR TITLE
BUILD(installer): Add file assoc. for plugin-files

### DIFF
--- a/installer/ClientInstaller.cs
+++ b/installer/ClientInstaller.cs
@@ -154,7 +154,11 @@ public class ClientInstaller : MumbleInstall {
 		var pluginFiles = new File[plugins.Length];
 
 		for (int i = 0; i < binaries.Count; i++) {
-			binaryFiles[i] = new File(@"..\..\" + binaries[i]);
+			if (binaries[i] == "mumble.exe") {
+				binaryFiles[i] = new File(@"..\..\" + binaries[i], new FileAssociation("mumble_plugin", "application/mumble", "Open", "\"%1\""));
+			} else {
+				binaryFiles[i] = new File(@"..\..\" + binaries[i]);
+			}
 		}
 
 		for (int i = 0; i < licenses.Length; i++) {


### PR DESCRIPTION
This allows to install .mumble_plugin bundles simply by double-
clicking on them in the explorer.


### Checks

- [x] My commits follow the [commit guidelines](https://github.com/mumble-voip/mumble/blob/master/COMMIT_GUIDELINES.md)

