### PR TITLE
FIX(server): Tray icon not shown on Windows

### DIFF
--- a/src/murmur/CMakeLists.txt
+++ b/src/murmur/CMakeLists.txt
@@ -118,6 +118,11 @@ if(WIN32)
 			"${MURMUR_RC}"
 	)
 
+	set_target_properties(mumble-server
+		PROPERTIES
+			AUTORCC ON
+	)
+
 	find_pkg(Qt5 COMPONENTS Widgets REQUIRED)
 
 	target_link_libraries(mumble-server 


### PR DESCRIPTION
The code that was used to create the tray icon was perfectly fine. The
issue was that the icon that was set was invalid because Qt did not find
the respective resource (which for some reason leads to the tray entry
not being shown at all).

The issue was that auto-RCC was not enabled for the server. This is
probably because usually the server doesn't need it, except on Windows
where we have that tray icon. While the respective resource files were
present and added as needed, the lack of this property caused Qt to
never process the resource file and thus thew icon was always missing.

Fixes #4930


### Checks

- [x] My commits follow the [commit guidelines](https://github.com/mumble-voip/mumble/blob/master/COMMIT_GUIDELINES.md)

