### PR TITLE
Backport "FIX(server): Tray icon not shown on Windows (#5172)" to 1.4.x

### DIFF
--- a/src/murmur/CMakeLists.txt
+++ b/src/murmur/CMakeLists.txt
@@ -118,6 +118,11 @@ if(WIN32)
 			"${MURMUR_RC}"
 	)
 
+	set_target_properties(mumble-server
+		PROPERTIES
+			AUTORCC ON
+	)
+
 	find_pkg(Qt5 COMPONENTS Widgets REQUIRED)
 
 	target_link_libraries(mumble-server 


### PR DESCRIPTION
Backports the following commits to 1.4.x:
 - FIX(server): Tray icon not shown on Windows (#5172)