### PR TITLE
FIX(client): Plugin updater keeping plugin locked

### DIFF
--- a/src/mumble/PluginUpdater.cpp
+++ b/src/mumble/PluginUpdater.cpp
@@ -352,11 +352,16 @@ void PluginUpdater::on_updateDownloaded(QNetworkReply *reply) {
 		file.close();
 
 		try {
+			const QString pluginName = plugin->getName();
+			// We have to release the plugin handle here by resetting the smart-pointer in order to make sure the
+			// installer can really unload the plugin in order to overwrite it.
+			plugin.reset();
+
 			// Launch installer
 			PluginInstaller installer(QFileInfo(file.fileName()));
 			installer.install();
 
-			Log::logOrDefer(Log::Information, tr("Successfully updated plugin \"%1\"").arg(plugin->getName()));
+			Log::logOrDefer(Log::Information, tr("Successfully updated plugin \"%1\"").arg(pluginName));
 
 			// Make sure Mumble won't use the old version of the plugin
 			Global::get().pluginManager->rescanPlugins();


### PR DESCRIPTION
PR #5152 overhauled the code for the plugin installer such that it
can completely unload a plugin before attempting to overwrite it.

However when the installer is called from the updater, that doesn't work
since the installer itself was still holding a handle to that plugin,
preventing it from unloading. Therefore this commit makes sure that the
installer releases its handle before calling the installer.

Fixes #4946


### Checks

- [x] My commits follow the [commit guidelines](https://github.com/mumble-voip/mumble/blob/master/COMMIT_GUIDELINES.md)

