### PR TITLE
Backport "MAINT(docker): added frequently used sql drivers (#5175)" to 1.4.x

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -47,6 +47,8 @@ RUN apt-get update && apt-get install --no-install-recommends -y \
 	libqt5core5a \
 	libqt5network5 \
 	libqt5sql5 \
+	libqt5sql5-mysql \
+	libqt5sql5-psql \
 	libqt5sql5-sqlite \
 	libqt5xml5 \
 	libqt5dbus5 \


### PR DESCRIPTION
Backports the following commits to 1.4.x:
 - MAINT(docker): added frequently used sql drivers (#5175)