### PR TITLE
FIX(client, audio): PulseAudio not initializing

### DIFF
--- a/src/mumble/PulseAudio.h
+++ b/src/mumble/PulseAudio.h
@@ -24,6 +24,9 @@
 #include <pulse/thread-mainloop.h>
 #include <pulse/volume.h>
 
+#include <condition_variable>
+#include <mutex>
+
 struct PulseAttenuation {
 	uint32_t index;
 	QString name;
@@ -119,6 +122,10 @@ private:
 	Q_OBJECT
 	Q_DISABLE_COPY(PulseAudioSystem)
 protected:
+	bool m_initialized = false;
+	std::mutex m_initLock;
+	std::condition_variable m_initWaiter;
+
 	void wakeup();
 
 	PulseAudio m_pulseAudio;


### PR DESCRIPTION
PR #5159 removed a few seemingly unneeded waits on audio system
initialization which drastically sped up Mumble's startup. However as it
turns out for PulseAudio some waiting is actually required as the system
initializes asynchronously but we require the knowledge about the init
result.

Instead of adding an arbitrary wait time again though, this commit adds
a mechanism that waits exactly as long as necessary for the init to be
completed and then continues. That still cuts down the waiting time
tremendously when comparing with the previous (arbitrary) wait time of 1
second.

Fixes #5181


### Checks

- [x] My commits follow the [commit guidelines](https://github.com/mumble-voip/mumble/blob/master/COMMIT_GUIDELINES.md)

