### PR TITLE
Backport "FIX(client, audio): PulseAudio not initializing (#5183)" to 1.4.x

### DIFF
--- a/src/mumble/PulseAudio.h
+++ b/src/mumble/PulseAudio.h
@@ -24,6 +24,9 @@
 #include <pulse/thread-mainloop.h>
 #include <pulse/volume.h>
 
+#include <condition_variable>
+#include <mutex>
+
 struct PulseAttenuation {
 	uint32_t index;
 	QString name;
@@ -119,6 +122,10 @@ private:
 	Q_OBJECT
 	Q_DISABLE_COPY(PulseAudioSystem)
 protected:
+	bool m_initialized = false;
+	std::mutex m_initLock;
+	std::condition_variable m_initWaiter;
+
 	void wakeup();
 
 	PulseAudio m_pulseAudio;


### PR DESCRIPTION
Backports the following commits to 1.4.x:
 - FIX(client, audio): PulseAudio not initializing (#5183)