### PR TITLE
Backport "FIX(positional-audio): Update Among Us plugin to work with v2021.6.30s (#5185)" to 1.4.x

### DIFF
--- a/plugins/amongus/structs.h
+++ b/plugins/amongus/structs.h
@@ -102,8 +102,8 @@ struct InnerNet_InnerNetClient_Fields : UnityEngine_Object_Fields {
 	ptr_t destroyedObjects;
 	ptr_t allObjects;
 	ptr_t allObjectsFast;
-	ptr_t messageWriterArray;
-	int32_t unknown;
+	ptr_t streams;
+	int32_t msgNum;
 	ptr_t networkAddress;
 	int32_t networkPort;
 	ptr_t connection;
@@ -113,6 +113,7 @@ struct InnerNet_InnerNetClient_Fields : UnityEngine_Object_Fields {
 	int32_t hostId;
 	int32_t clientId;
 	ptr_t allClients;
+	ptr_t recentClients;
 	DisconnectReason lastDisconnectReason;
 	ptr_t lastCustomDisconnect;
 	ptr_t preSpawnDispatcher;
@@ -240,7 +241,7 @@ struct PlayerControl_o {
 struct GameData_PlayerInfo_Fields {
 	uint8_t playerId;
 	ptr_t playerName;
-	bool unknown;
+	bool dontCensorName;
 	int32_t colorId;
 	uint32_t hatId;
 	uint32_t petId;


### PR DESCRIPTION
Backports the following commits to 1.4.x:
 - FIX(positional-audio): Update Among Us plugin to work with v2021.6.30s (#5185)