### PR TITLE
CI(azure): Don't package AppImage

### DIFF
--- a/.ci/azure-pipelines/steps_linux.yml
+++ b/.ci/azure-pipelines/steps_linux.yml
@@ -14,8 +14,8 @@ steps:
     displayName: 'Build'
   - script: 'cd $BUILD_BINARIESDIRECTORY; ctest --verbose'
     displayName: 'Test'
-  - script: .ci/azure-pipelines/package_AppImage.bash
-    displayName: 'Release'
-  - template: task-publish-artifacts.yml
-    parameters:
-      name: "AppImage" 
+# - script: .ci/azure-pipelines/package_AppImage.bash
+#   displayName: 'Release'
+# - template: task-publish-artifacts.yml
+#   parameters:
+#     name: "AppImage" 


### PR DESCRIPTION
The packaging of the AppImage did not yield usable binaries for a long
time now but it does take up a significant amount of time in the Linux
CI and (more importantly) tends to fail every now and then causing the
entire build to fail with it.

For this reason, we will no longer bundle an AppImage at least until we
properly fixed the underlying issues and are able to produce working
AppImages again.


### Checks

- [x] My commits follow the [commit guidelines](https://github.com/mumble-voip/mumble/blob/master/COMMIT_GUIDELINES.md)

