### PR TITLE
Backport "BUILD(installer): Add file assoc. for plugin-files (#5169)" to 1.4.x

### DIFF
--- a/installer/ClientInstaller.cs
+++ b/installer/ClientInstaller.cs
@@ -154,7 +154,11 @@ public class ClientInstaller : MumbleInstall {
 		var pluginFiles = new File[plugins.Length];
 
 		for (int i = 0; i < binaries.Count; i++) {
-			binaryFiles[i] = new File(@"..\..\" + binaries[i]);
+			if (binaries[i] == "mumble.exe") {
+				binaryFiles[i] = new File(@"..\..\" + binaries[i], new FileAssociation("mumble_plugin", "application/mumble", "Open", "\"%1\""));
+			} else {
+				binaryFiles[i] = new File(@"..\..\" + binaries[i]);
+			}
 		}
 
 		for (int i = 0; i < licenses.Length; i++) {


### PR DESCRIPTION
Backports the following commits to 1.4.x:
 - BUILD(installer): Add file assoc. for plugin-files (#5169)