### PR TITLE
Backport "CI(azure): Don't package AppImage (#5191)" to 1.4.x

### DIFF
--- a/.ci/azure-pipelines/steps_linux.yml
+++ b/.ci/azure-pipelines/steps_linux.yml
@@ -14,8 +14,8 @@ steps:
     displayName: 'Build'
   - script: 'cd $BUILD_BINARIESDIRECTORY; ctest --verbose'
     displayName: 'Test'
-  - script: .ci/azure-pipelines/package_AppImage.bash
-    displayName: 'Release'
-  - template: task-publish-artifacts.yml
-    parameters:
-      name: "AppImage" 
+# - script: .ci/azure-pipelines/package_AppImage.bash
+#   displayName: 'Release'
+# - template: task-publish-artifacts.yml
+#   parameters:
+#     name: "AppImage" 


### PR DESCRIPTION
Backports the following commits to 1.4.x:
 - CI(azure): Don't package AppImage (#5191)