### PR TITLE
MAINT(desktop-file): Add StartupWMClass

### DIFF
--- a/scripts/org.mumble_voip.mumble.desktop
+++ b/scripts/org.mumble_voip.mumble.desktop
@@ -11,6 +11,7 @@ Icon=mumble
 Terminal=false
 Type=Application
 StartupNotify=false
+StartupWMClass=mumble
 MimeType=x-scheme-handler/mumble;
 Categories=Network;Chat;Qt;
 Keywords=VoIP;Messaging;Voice Chat;Secure Communication;


### PR DESCRIPTION
This adds the StartupWMClass to the .desktop file which allows pinning Mumble to the dash/dock/whatever in all major desktop environments. Since most package maintainers ship their own .desktop file where this is fixed this fixes it for everyone who compiles Mumble from source.


### Checks

- [x] My commits follow the [commit guidelines](https://github.com/mumble-voip/mumble/blob/master/COMMIT_GUIDELINES.md)

