### PR TITLE
MAINT: Make changelog script work with backports

### DIFF
--- a/scripts/generateChangelog.py
+++ b/scripts/generateChangelog.py
@@ -38,6 +38,7 @@ def main():
     args = parser.parse_args()
 
     mergeCommitPattern = re.compile("^([0-9a-f]+)\s*[Mm]erge\s.+?#(\d+):?\s*(.+)$", re.MULTILINE)
+    backportCommitPattern = re.compile("^[Bb]ackport\s*\"(.*)\".*$")
 
     commits = cmd(["git", "log" ,"--format=oneline",  "--date=short", "{}..{}".format(args.FROM_TAG, args.TO_TAG)]).split("\n")
 
@@ -59,6 +60,11 @@ def main():
         commitHash = match.group(1)
         prNumber = match.group(2)
         commitTitle = match.group(3)
+
+        backportMatch = re.match(backportCommitPattern, commitTitle)
+        if backportMatch:
+            # This commit is a backport commit where the actual commit title is the bit in the quotes
+            commitTitle = backportMatch.group(1)
 
         try:
             commit = CommitMessage(commitTitle)


### PR DESCRIPTION
Merge commits of backports follow a little different pattern than
regular merge commits. This has to be accounted for in the script
generating the changelog.


### Checks

- [x] My commits follow the [commit guidelines](https://github.com/mumble-voip/mumble/blob/master/COMMIT_GUIDELINES.md)

