### PR TITLE
MAINT: Use release cert on SignPath

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -46,6 +46,6 @@ artifacts:
 
 deploy:
   - provider: Webhook
-    url: https://app.signpath.io/API/v1/79916aba-7a9f-448d-91c6-fb83593b59d3/Integrations/AppVeyor?ProjectSlug=mumble&SigningPolicySlug=test-signing
+    url: https://app.signpath.io/API/v1/79916aba-7a9f-448d-91c6-fb83593b59d3/Integrations/AppVeyor?ProjectSlug=mumble&SigningPolicySlug=release-signing
     authorization:
       secure: WKbGSfFSHTtODf6eHRSHPAobctJli48O/VoMpCYTuIlITl2piOpCH6igCRDX4EuJTzgDX45H34tVfPuNzSMdLA==


### PR DESCRIPTION
Previously we were using the test certificate but since we now have a
release cert, we should use that instead.


### Checks

- [x] My commits follow the [commit guidelines](https://github.com/mumble-voip/mumble/blob/master/COMMIT_GUIDELINES.md)

