### PR TITLE
Backport "FIX(server): Always bind to both IPv6 and IPv4 by default (#5209)" to 1.4.x

### DIFF
--- a/src/murmur/Meta.cpp
+++ b/src/murmur/Meta.cpp
@@ -23,7 +23,6 @@
 #endif
 
 #include <QtNetwork/QHostInfo>
-#include <QtNetwork/QNetworkInterface>
 
 #if defined(USE_QSSLDIFFIEHELLMANPARAMETERS)
 #	include <QtNetwork/QSslDiffieHellmanParameters>
@@ -242,58 +241,7 @@ void MetaParams::read(QString fname) {
 	}
 
 	if (qlBind.isEmpty()) {
-		bool hasipv6 = false;
-		bool hasipv4 = false;
-		int nif      = 0;
-
-		QList< QNetworkInterface > interfaces = QNetworkInterface::allInterfaces();
-		if (interfaces.isEmpty()) {
-			qWarning("Meta: Unable to acquire list of network interfaces.");
-		} else {
-			foreach (const QNetworkInterface &qni, interfaces) {
-				if (!(qni.flags() & QNetworkInterface::IsUp))
-					continue;
-				if (!(qni.flags() & QNetworkInterface::IsRunning))
-					continue;
-				if (qni.flags() & QNetworkInterface::IsLoopBack)
-					continue;
-
-				foreach (const QNetworkAddressEntry &qna, qni.addressEntries()) {
-					const QHostAddress &qha = qna.ip();
-					switch (qha.protocol()) {
-						case QAbstractSocket::IPv4Protocol:
-							hasipv4 = true;
-							break;
-						case QAbstractSocket::IPv6Protocol:
-							hasipv6 = true;
-							break;
-						default:
-							break;
-					}
-				}
-
-				++nif;
-			}
-		}
-
-		if (nif == 0) {
-			qWarning("Meta: Could not determine IPv4/IPv6 support via network interfaces, assuming support for both.");
-			hasipv6 = true;
-			hasipv4 = true;
-		}
-
-		if (hasipv6) {
-			if (SslServer::hasDualStackSupport() && hasipv4) {
-				qlBind << QHostAddress(QHostAddress::Any);
-				hasipv4 = false; // No need to add a separate ipv4 socket
-			} else {
-				qlBind << QHostAddress(QHostAddress::AnyIPv6);
-			}
-		}
-
-		if (hasipv4) {
-			qlBind << QHostAddress(QHostAddress::AnyIPv4);
-		}
+		qlBind << QHostAddress(QHostAddress::Any);
 	}
 
 	qsPassword            = typeCheckedFromSettings("serverpassword", qsPassword);

--- a/src/murmur/Server.cpp
+++ b/src/murmur/Server.cpp
@@ -61,44 +61,6 @@ void ExecEvent::execute() {
 SslServer::SslServer(QObject *p) : QTcpServer(p) {
 }
 
-bool SslServer::hasDualStackSupport() {
-	// Create a AF_INET6 socket and try to switch off IPV6_V6ONLY. This
-	// should only fail if the system does not support dual-stack mode
-	// for this socket type.
-
-	bool result = false;
-#ifdef Q_OS_UNIX
-	int s = ::socket(AF_INET6, SOCK_STREAM, 0);
-	if (s != -1) {
-		const int ipv6only = 0;
-		if (setsockopt(s, IPPROTO_IPV6, IPV6_V6ONLY, reinterpret_cast< const char * >(&ipv6only), sizeof(ipv6only))
-			== 0) {
-			result = true;
-		}
-		::close(s);
-	}
-#else
-	WSADATA wsaData;
-	WORD wVersionRequested = MAKEWORD(2, 2);
-	if (WSAStartup(wVersionRequested, &wsaData) != 0) {
-		// Seems like we won't be doing any network stuff anyways
-		return false;
-	}
-
-	SOCKET s = ::WSASocket(AF_INET6, SOCK_STREAM, IPPROTO_TCP, nullptr, 0, WSA_FLAG_OVERLAPPED);
-	if (s != INVALID_SOCKET) {
-		const int ipv6only = 0;
-		if (setsockopt(s, IPPROTO_IPV6, IPV6_V6ONLY, reinterpret_cast< const char * >(&ipv6only), sizeof(ipv6only))
-			== 0) {
-			result = true;
-		}
-		closesocket(s);
-	}
-	WSACleanup();
-#endif
-	return result;
-}
-
 void SslServer::incomingConnection(qintptr v) {
 	QSslSocket *s = new QSslSocket(this);
 	s->setSocketDescriptor(v);

--- a/src/murmur/Server.h
+++ b/src/murmur/Server.h
@@ -71,9 +71,6 @@ protected:
 public:
 	QSslSocket *nextPendingSSLConnection();
 	SslServer(QObject *parent = nullptr);
-
-	/// Checks whether the AF_INET6 socket on this system has dual-stack support.
-	static bool hasDualStackSupport();
 };
 
 #define EXEC_QEVENT (QEvent::User + 959)


### PR DESCRIPTION
Backports the following commits to 1.4.x:
 - FIX(server): Always bind to both IPv6 and IPv4 by default (#5209)