### PR TITLE
FIX(installer): Generate output filename from release ID

### DIFF
--- a/.ci/azure-pipelines/release_windows.bat
+++ b/.ci/azure-pipelines/release_windows.bat
@@ -17,9 +17,8 @@ if errorlevel 1 (
 	exit /b %errorlevel%
 )
 
-copy installer\client\mumble_client*.msi %BUILD_ARTIFACTSTAGINGDIRECTORY%
-
-copy installer\server\mumble_server*.msi %BUILD_ARTIFACTSTAGINGDIRECTORY%
+copy installer\client\mumble*.msi %BUILD_ARTIFACTSTAGINGDIRECTORY%
+copy installer\server\mumble*.msi %BUILD_ARTIFACTSTAGINGDIRECTORY%
 
 7z a PDBs.7z *.pdb plugins\*.pdb
 copy PDBs.7z %BUILD_ARTIFACTSTAGINGDIRECTORY%

--- a/installer/ClientInstaller.cs
+++ b/installer/ClientInstaller.cs
@@ -21,7 +21,7 @@ public struct Features {
 }
 
 public class ClientInstaller : MumbleInstall {
-	public ClientInstaller(string version, string arch, Features features) {
+	public ClientInstaller(string version, string releaseID, string arch, Features features) {
 		string upgradeGuid = "D269FC55-4F2C-4285-9AA9-4D034AF305C4";
 		List<string> binaries = new List<string>();
 		string[] plugins = {
@@ -129,7 +129,7 @@ public class ClientInstaller : MumbleInstall {
 		this.Name = "Mumble (client)";
 		this.UpgradeCode = Guid.Parse(upgradeGuid);
 		this.Version = new Version(version);
-		this.OutFileName = "mumble_client-" + this.Version + "-" + arch;
+		this.OutFileName = "mumble-client_" + releaseID + '.' + arch;
 		this.Media.First().Cabinet = "Mumble.cab";
 
 		var progsDir = new Dir(@"%ProgramFiles%");
@@ -190,6 +190,7 @@ class BuildInstaller
 {
 	public static void Main(string[] args) {
 		string version = "";
+		string releaseID = "";
 		string arch = "";
 		bool isAllLangs = false;
 		Features features = new Features();
@@ -197,6 +198,10 @@ class BuildInstaller
 		for (int i = 0; i < args.Length; i++) {
 			if (args[i] == "--version" && Regex.IsMatch(args[i + 1], @"^([0-9]+\.){3}[0-9]+$")) {
 				version = args[i + 1];
+			}
+
+			if (args[i] == "--release-id") {
+				releaseID = args[i + 1];
 			}
 
 			if (args[i] == "--arch" && (args[i + 1] == "x64" || args[i + 1] == "x86")) {
@@ -217,8 +222,7 @@ class BuildInstaller
 		}
 
 		if (version != null && arch != null) {
-			var clInstaller = new ClientInstaller(version, arch, features);
-			clInstaller.Version = new Version(version);
+			var clInstaller = new ClientInstaller(version, releaseID, arch, features);
 
 			if (isAllLangs) {
 				clInstaller.BuildMultilanguageMsi();

--- a/installer/ServerInstaller.cs
+++ b/installer/ServerInstaller.cs
@@ -14,7 +14,7 @@ using WixSharp;
 using WixSharp.CommonTasks;
 
 public class ServerInstaller : MumbleInstall {
-	public ServerInstaller(string version, string arch) {
+	public ServerInstaller(string version, string releaseID, string arch) {
 		string upgradeGuid = "03E9476F-0F75-4661-BFC9-A9DAEB23D3A0";
 		string[] binaries = {
 			"mumble-server.exe",
@@ -38,10 +38,10 @@ public class ServerInstaller : MumbleInstall {
 			this.Platform = WixSharp.Platform.x86;
 		}
 
-		this.Name = "Mumble Server";
+		this.Name = "Mumble (server)";
 		this.UpgradeCode = Guid.Parse(upgradeGuid);
 		this.Version = new Version(version);
-		this.OutFileName = "mumble_server-" + this.Version + "-" + arch;
+		this.OutFileName = "mumble-server_" + releaseID + '.' + arch;
 		this.Media.First().Cabinet = "Mumble.cab";
 
 		var progsDir = new Dir(@"%ProgramFiles%");
@@ -84,12 +84,17 @@ class BuildInstaller
 {
 	public static void Main(string[] args) {
 		string version = "";
+		string releaseID = "";
 		string arch = "";
 		bool isAllLangs = false;
 
 		for (int i = 0; i < args.Length; i++) {
 			if (args[i] == "--version" && Regex.IsMatch(args[i + 1], @"^([0-9]+\.){3}[0-9]+$")) {
 				version = args[i + 1];
+			}
+
+			if (args[i] == "--release-id") {
+				releaseID = args[i + 1];
 			}
 
 			if (args[i] == "--arch" && (args[i + 1] == "x64" || args[i + 1] == "x86")) {
@@ -102,8 +107,7 @@ class BuildInstaller
 		}
 
 		if (version != null && arch != null) {
-			var srvInstaller = new ServerInstaller(version, arch);
-			srvInstaller.Version = new Version(version);
+			var srvInstaller = new ServerInstaller(version, releaseID, arch);
 
 			if (isAllLangs) {
 				srvInstaller.BuildMultilanguageMsi();

--- a/src/mumble_exe/CMakeLists.txt
+++ b/src/mumble_exe/CMakeLists.txt
@@ -57,6 +57,7 @@ if(packaging)
 
 	list(APPEND installer_vars
 		"--version" ${PROJECT_VERSION}
+		"--release-id" ${RELEASE_ID}
 		"--arch" "${MUMBLE_TARGET_ARCH}"
 	)
 

--- a/src/murmur/CMakeLists.txt
+++ b/src/murmur/CMakeLists.txt
@@ -350,6 +350,7 @@ if(packaging)
 
 		list(APPEND installer_vars
 			"--version" ${PROJECT_VERSION}
+			"--release-id" ${RELEASE_ID}
 			"--arch" ${MUMBLE_TARGET_ARCH}
 		)
 


### PR DESCRIPTION
Right now the output filename looks like this:

- `mumble_client-1.4.0.224-x64.msi`
- `mumble_server-1.4.0.224-x64.msi`

We had always been renaming the binaries manually before signing and uploading them on our server.

Now that we use an automatic signing workflow with AppVeyor + SignPath, the undesired initial filename is an issue.
The package is identified as `{FILENAME} by github.com/mumble-voip/mumble`, meaning that the final result would be:

- `mumble_client-1.4.0.224-x64.msi by github.com/mumble-voip/mumble`
- `mumble_server-1.4.0.224-x64.msi by github.com/mumble-voip/mumble`

This commit fixes the installer builder so that it generates the filename based on the release ID:

- `mumble-client_1.4.0-rc1.x64.msi`
- `mumble-server_1.4.0-rc1.x64.msi`

Extra changes:

- The server's product name was `Mumble Server`. It's now `Mumble (server)`, consistent with `Mumble (client)`.
- Redundant version assignments removed from `Main()`. `ClientInstaller()` and `ServerInstaller()` take care of that.