### PR TITLE
MAINT(Dockerfile): Make 'git submodule update' to be recursive.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,8 @@ FROM ubuntu:latest
 ENV DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update && apt-get install --no-install-recommends -y \
+	ca-certificates \
+	git \
 	build-essential \
 	cmake \
 	pkg-config \
@@ -30,6 +32,7 @@ RUN apt-get update && apt-get install --no-install-recommends -y \
 COPY . /root/mumble
 WORKDIR /root/mumble/build
 
+RUN git submodule update --init
 RUN cmake -Dclient=OFF -DCMAKE_BUILD_TYPE=Release -Dgrpc=ON ..
 RUN make -j $(nproc)
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -32,7 +32,7 @@ RUN apt-get update && apt-get install --no-install-recommends -y \
 COPY . /root/mumble
 WORKDIR /root/mumble/build
 
-RUN git submodule update --init
+RUN git submodule update --init --recursive
 RUN cmake -Dclient=OFF -DCMAKE_BUILD_TYPE=Release -Dgrpc=ON ..
 RUN make -j $(nproc)
 


### PR DESCRIPTION
Docker builds was failing on my local due to #5120.
Just adding CA certs and git to perform `git submodule update --init`.
Fixes build if not done. If not needed (already done), build just continues.

-------

### Checks

- [x] My commits follow the [commit guidelines](https://github.com/mumble-voip/mumble/blob/master/COMMIT_GUIDELINES.md)