### PR TITLE
FIX(client): Don't prepend plugin name to context

### DIFF
--- a/src/mumble/PluginManager.cpp
+++ b/src/mumble/PluginManager.cpp
@@ -414,11 +414,6 @@ bool PluginManager::fetchPositionalData() {
 		m_positionalData.m_cameraPos, m_positionalData.m_cameraDir, m_positionalData.m_cameraAxis,
 		m_positionalData.m_context, m_positionalData.m_identity);
 
-	// Add the plugin's name to the context as well to prevent name-clashes between plugins
-	if (!m_positionalData.m_context.isEmpty()) {
-		m_positionalData.m_context = m_activePositionalDataPlugin->getName() + QChar::Null + m_positionalData.m_context;
-	}
-
 	if (!retStatus) {
 		// Shut the currently active plugin down and set a new one (if available)
 		m_activePositionalDataPlugin->shutdownPositionalData();


### PR DESCRIPTION
With the change to the new plugin system a change was introduced that
would prepend the current plugin's name to its context in order to
avoid context clashes between plugins.

As it turns out though, this breaks intercompatibility between the 1.4.x
series and all previous versions.

Therefore this commit removes this logic again.

Fixes #5217


### Checks

- [x] My commits follow the [commit guidelines](https://github.com/mumble-voip/mumble/blob/master/COMMIT_GUIDELINES.md)

