### PR TITLE
MAINT(Dockerfile): Dockerfile improvements.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM ubuntu:latest
 
-# needed to install tzdata in disco
-ENV DEBIAN_FRONTEND=noninteractive
+# needed to install tzdata
+ARG DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update && apt-get install --no-install-recommends -y \
 	ca-certificates \
@@ -27,17 +27,25 @@ RUN apt-get update && apt-get install --no-install-recommends -y \
 	libgrpc++-dev \
 	libxi-dev \
 	libbz2-dev \
+	&& apt-get clean \
 	&& rm -rf /var/lib/apt/lists/*
 
 COPY . /root/mumble
 WORKDIR /root/mumble/build
 
 RUN git submodule update --init --recursive
-RUN cmake -Dclient=OFF -DCMAKE_BUILD_TYPE=Release -Dgrpc=ON ..
+RUN cmake -Dclient=OFF -DCMAKE_BUILD_TYPE=Release -Dgrpc=ON .. || \
+    ( cat \
+    /root/mumble/build/CMakeFiles/CMakeOutput.log \
+    /root/mumble/build/CMakeFiles/CMakeError.log \
+    && false \
+    )
 RUN make -j $(nproc)
 
 # Clean distribution stage
 FROM ubuntu:latest
+
+ARG DEBIAN_FRONTEND=noninteractive
 
 RUN adduser murmur
 RUN apt-get update && apt-get install --no-install-recommends -y \
@@ -56,13 +64,14 @@ RUN apt-get update && apt-get install --no-install-recommends -y \
 	libqt5xml5 \
 	libqt5dbus5 \
 	ca-certificates \
-	&& rm -rf /var/lib/apt/lists/* 
+	&& apt-get clean \
+	&& rm -rf /var/lib/apt/lists/*
 
 COPY --from=0 /root/mumble/build/mumble-server /usr/bin/mumble-server
 COPY --from=0 /root/mumble/scripts/murmur.ini /etc/murmur/murmur.ini
 
 RUN mkdir /var/lib/murmur && \
-	chown murmur:murmur /var/lib/murmur && \
+	chown --verbose murmur:murmur /var/lib/murmur && \
 	sed -i 's/^database=$/database=\/var\/lib\/murmur\/murmur.sqlite/' /etc/murmur/murmur.ini
 
 EXPOSE 64738/tcp 64738/udp 50051


### PR DESCRIPTION
* Dump CMake logs on failure.
* Set `DEBIAN_FRONTEND=noninteractive` for `apt-get` on final image.
* Use `ARG` instead of `ENV` to prevent variable persisting after build (it can't be assumed that `apt-get` won't be invoked interactively from a running container).
* Add verbosity to `chown`. Might come handy in diagnosing failures.
* A bit of cleanup after package install (`apt-get clean`).
* Remove reference to 'disco' distribution (no longer true) from comments.

I've tested log dumping on failure by just commenting out the `git submodule update` line on a fresh checkout.

Also, using `:latest` as base image is against Dockerfile best practices. Ideally, it should be pinned to a specific distro. I would suggest using latest LTS (Focal, as of now). I can send a PR, if it's OK.

### Checks

- [x] My commits follow the [commit guidelines](https://github.com/mumble-voip/mumble/blob/master/COMMIT_GUIDELINES.md)