### PR TITLE
BUILD(opus): Fetch submodule from upstream repository

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -6,7 +6,7 @@
 	url = https://github.com/mumble-voip/celt-0.7.0.git
 [submodule "opus"]
 	path = 3rdparty/opus
-	url = https://github.com/mumble-voip/opus.git
+	url = https://gitlab.xiph.org/xiph/opus.git
 [submodule "3rdparty/minhook"]
 	path = 3rdparty/minhook
 	url = https://github.com/mumble-voip/minhook.git

--- a/src/mumble/CMakeLists.txt
+++ b/src/mumble/CMakeLists.txt
@@ -639,10 +639,6 @@ if(bundled-opus)
 
 	target_include_directories(mumble PRIVATE "${3RDPARTY_DIR}/opus/include")
 
-	if(tests)
-		set_target_properties(test_opus_decode test_opus_padding PROPERTIES RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/tests")
-	endif()
-
 	if(WIN32)
 		# Shared library on Windows (e.g. ".dll")
 		set_target_properties(opus PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR})


### PR DESCRIPTION
Upon switching to CMake, we kept using our own fork for the repository because a few fixes for the build were needed.

Now that the upstream repository works correctly as submodule, we can fetch from it directly.

Please note that tests provided in the Opus repository are not built anymore.