### PR TITLE
Backport "BUILD(opus): Fetch submodule from upstream repository (#5229)" to 1.4.x

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -6,7 +6,7 @@
 	url = https://github.com/mumble-voip/celt-0.7.0.git
 [submodule "opus"]
 	path = 3rdparty/opus
-	url = https://github.com/mumble-voip/opus.git
+	url = https://gitlab.xiph.org/xiph/opus.git
 [submodule "3rdparty/minhook"]
 	path = 3rdparty/minhook
 	url = https://github.com/mumble-voip/minhook.git

--- a/src/mumble/CMakeLists.txt
+++ b/src/mumble/CMakeLists.txt
@@ -636,10 +636,6 @@ if(bundled-opus)
 
 	target_include_directories(mumble PRIVATE "${3RDPARTY_DIR}/opus/include")
 
-	if(tests)
-		set_target_properties(test_opus_decode test_opus_padding PROPERTIES RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/tests")
-	endif()
-
 	if(WIN32)
 		# Shared library on Windows (e.g. ".dll")
 		set_target_properties(opus PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR})


### PR DESCRIPTION
Backports the following commits to 1.4.x:
 - BUILD(opus): Fetch submodule from upstream repository (#5229)