### PR TITLE
FEAT(client): Add opus as output format for recording

### DIFF
--- a/CODING_GUIDELINES.md
+++ b/CODING_GUIDELINES.md
@@ -1,0 +1,50 @@
+# Mumble coding guidelines
+
+## Formatting
+
+We use [clang-format](https://clang.llvm.org/docs/ClangFormat.html) to format our source code. The details of the formatting are fixed in the
+`.clang-format` file at the root of this repository.
+
+When making changes to the source code, please always reformat the changed files using this tool in order to ensure a consistent formatting across the
+code base.
+
+
+## Use of `auto`
+
+Since we are using a more modern C++ standard, the usage of the `auto` keyword is in principle possible. However we have decided that for the sake of
+readability of the code we want to restrict its usage to the following cases:
+1. Usage of STL-iterators
+2. If the expression of the assignment already contains the type explicitly (e.g. because of a cast or by usage of e.g. `make_unique`)
+
+An example of the first scenario would be
+```cpp
+auto it = myVector.begin();
+```
+And examples for the second case are
+```cpp
+auto myObj   = new MyObject();
+auto myOther = std::make_unique< MyOther >();
+auto number  = static_cast< int >(1.5);
+```
+
+
+## Smart pointers
+
+You should always prefer smart-pointers over raw pointers. The general rule is: Never use `new` and `delete` explicitly.
+
+Also prefer `std::unique_ptr` over `std::shared_ptr`, unless you are really intending for the object to have shared ownership.
+
+When it comes to passing pointers into functions, always pass as raw-pointer, unless you want to transfer ownership of the pointer to the function.
+
+
+## Pointer vs. Reference
+
+Use pointers only if `nullptr` is a valid option (and is therefore explicitly checked for). Whenever you are expecting that a passed value is set,
+pass that value by reference instead in order to make sure that the semantics forbid passing `nullptr` to the function.
+
+
+## Qt vs. STL
+
+Wherever feasible, you should prefer using types from the standard library (STL) instead of Qt-specific ones. Note that this only applies if you don't
+have to pass that type (indirectly) into Qt functions that only accept Qt-specific types. In these cases, prefer Qt-types.
+

--- a/src/mumble/VoiceRecorder.cpp
+++ b/src/mumble/VoiceRecorder.cpp
@@ -212,6 +212,16 @@ SF_INFO VoiceRecorder::createSoundFileInfo() const {
 			qWarning() << "VoiceRecorder: recording started to" << m_config.fileName << "@" << m_config.sampleRate
 					   << "hz in FLAC format";
 			break;
+		case VoiceRecorderFormat::OPUS:
+			sfinfo.frames     = 0;
+			sfinfo.samplerate = m_config.sampleRate;
+			sfinfo.channels   = 1;
+			sfinfo.format     = SF_FORMAT_OGG | SF_FORMAT_OPUS;
+			sfinfo.sections   = 0;
+			sfinfo.seekable   = 0;
+			qWarning() << "VoiceRecorder: recording started to" << m_config.fileName << "@" << m_config.sampleRate
+					   << "hz in OPUS format";
+			break;
 	}
 
 	Q_ASSERT(sf_format_check(&sfinfo));
@@ -429,6 +439,8 @@ QString VoiceRecorderFormat::getFormatDescription(VoiceRecorderFormat::Format fm
 			return VoiceRecorder::tr(".au - Uncompressed");
 		case VoiceRecorderFormat::FLAC:
 			return VoiceRecorder::tr(".flac - Lossless compressed");
+        case VoiceRecorderFormat::OPUS:
+            return VoiceRecorder::tr(".opus - Lossy compressed");
 		default:
 			return QString();
 	}
@@ -446,6 +458,8 @@ QString VoiceRecorderFormat::getFormatDefaultExtension(VoiceRecorderFormat::Form
 			return QLatin1String("au");
 		case VoiceRecorderFormat::FLAC:
 			return QLatin1String("flac");
+		case VoiceRecorderFormat::OPUS:
+			return QLatin1String("opus");
 		default:
 			return QString();
 	}

--- a/src/mumble/VoiceRecorder.h
+++ b/src/mumble/VoiceRecorder.h
@@ -51,6 +51,8 @@ enum Format {
 	AU,
 	/// FLAC Format
 	FLAC,
+    // OPUS Format
+    OPUS,
 	kEnd
 };
 


### PR DESCRIPTION
This commits adds opus as an output format for voice recordings as requested in #5065. It uses an OGG container like the already implemented Vorbis codec but has much better compression. For clarity the .opus file extension is used.

Implements #5065 

### Checks

- [x] My commits follow the [commit guidelines](https://github.com/mumble-voip/mumble/blob/master/COMMIT_GUIDELINES.md)

