### PR TITLE
FEAT(client): Add opus as output format for recording

### DIFF
--- a/src/mumble/CMakeLists.txt
+++ b/src/mumble/CMakeLists.txt
@@ -451,6 +451,13 @@ endif()
 
 find_pkg("SndFile;LibSndFile;sndfile" REQUIRED)
 
+# Check if sndfile version supports opus
+if("${sndfile_VERSION}" VERSION_GREATER_EQUAL "1.0.29")
+	target_compile_definitions(mumble PRIVATE USE_SNDFILE_OPUS)
+else()
+	message(WARNING "libsnfile is missing Opus-support -> No Opus-format recording")
+endif()
+
 # Look for various targets as they are named differently on different platforms
 if(static AND TARGET sndfile-static)
 	target_link_libraries(mumble PRIVATE sndfile-static)

--- a/src/mumble/VoiceRecorder.cpp
+++ b/src/mumble/VoiceRecorder.cpp
@@ -212,6 +212,18 @@ SF_INFO VoiceRecorder::createSoundFileInfo() const {
 			qWarning() << "VoiceRecorder: recording started to" << m_config.fileName << "@" << m_config.sampleRate
 					   << "hz in FLAC format";
 			break;
+#ifdef USE_SNDFILE_OPUS
+		case VoiceRecorderFormat::OPUS:
+			sfinfo.frames     = 0;
+			sfinfo.samplerate = m_config.sampleRate;
+			sfinfo.channels   = 1;
+			sfinfo.format     = SF_FORMAT_OGG | SF_FORMAT_OPUS;
+			sfinfo.sections   = 0;
+			sfinfo.seekable   = 0;
+			qWarning() << "VoiceRecorder: recording started to" << m_config.fileName << "@" << m_config.sampleRate
+					   << "hz in OPUS format";
+			break;
+#endif
 	}
 
 	Q_ASSERT(sf_format_check(&sfinfo));
@@ -429,6 +441,10 @@ QString VoiceRecorderFormat::getFormatDescription(VoiceRecorderFormat::Format fm
 			return VoiceRecorder::tr(".au - Uncompressed");
 		case VoiceRecorderFormat::FLAC:
 			return VoiceRecorder::tr(".flac - Lossless compressed");
+#ifdef USE_SNDFILE_OPUS
+		case VoiceRecorderFormat::OPUS:
+			return VoiceRecorder::tr(".opus - Lossy compressed");
+#endif
 		default:
 			return QString();
 	}
@@ -446,6 +462,10 @@ QString VoiceRecorderFormat::getFormatDefaultExtension(VoiceRecorderFormat::Form
 			return QLatin1String("au");
 		case VoiceRecorderFormat::FLAC:
 			return QLatin1String("flac");
+#ifdef USE_SNDFILE_OPUS
+		case VoiceRecorderFormat::OPUS:
+			return QLatin1String("opus");
+#endif
 		default:
 			return QString();
 	}

--- a/src/mumble/VoiceRecorder.h
+++ b/src/mumble/VoiceRecorder.h
@@ -51,6 +51,10 @@ enum Format {
 	AU,
 	/// FLAC Format
 	FLAC,
+#ifdef USE_SNDFILE_OPUS
+	// OPUS Format
+	OPUS,
+#endif
 	kEnd
 };
 

--- a/src/mumble/mumble_ar.ts
+++ b/src/mumble/mumble_ar.ts
@@ -8700,6 +8700,10 @@ An access token is a text string, which can be used as a password for very simpl
         <source>.flac - Lossless compressed</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>.opus - Lossy compressed</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>VoiceRecorderDialog</name>

--- a/src/mumble/mumble_bg.ts
+++ b/src/mumble/mumble_bg.ts
@@ -8693,6 +8693,10 @@ An access token is a text string, which can be used as a password for very simpl
         <source>.flac - Lossless compressed</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>.opus - Lossy compressed</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>VoiceRecorderDialog</name>

--- a/src/mumble/mumble_br.ts
+++ b/src/mumble/mumble_br.ts
@@ -8692,6 +8692,10 @@ An access token is a text string, which can be used as a password for very simpl
         <source>.flac - Lossless compressed</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>.opus - Lossy compressed</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>VoiceRecorderDialog</name>

--- a/src/mumble/mumble_ca.ts
+++ b/src/mumble/mumble_ca.ts
@@ -8698,6 +8698,10 @@ An access token is a text string, which can be used as a password for very simpl
         <source>.flac - Lossless compressed</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>.opus - Lossy compressed</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>VoiceRecorderDialog</name>

--- a/src/mumble/mumble_cs.ts
+++ b/src/mumble/mumble_cs.ts
@@ -8760,6 +8760,10 @@ Znak přístupu je textový řetězec, který může být použit jako heslo pro
         <source>.flac - Lossless compressed</source>
         <translation>.flac - Komprimováno bezeztrátově</translation>
     </message>
+    <message>
+        <source>.opus - Lossy compressed</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>VoiceRecorderDialog</name>

--- a/src/mumble/mumble_cy.ts
+++ b/src/mumble/mumble_cy.ts
@@ -8699,6 +8699,10 @@ An access token is a text string, which can be used as a password for very simpl
         <source>.flac - Lossless compressed</source>
         <translation>.flac - Cywasgu heb golled</translation>
     </message>
+    <message>
+        <source>.opus - Lossy compressed</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>VoiceRecorderDialog</name>

--- a/src/mumble/mumble_da.ts
+++ b/src/mumble/mumble_da.ts
@@ -8754,6 +8754,10 @@ Et adgangsudtryk er en tekststreng, der kan bruges som en adgangskode for meget 
         <source>.flac - Lossless compressed</source>
         <translation>.flac - Tabsfri komprimeret</translation>
     </message>
+    <message>
+        <source>.opus - Lossy compressed</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>VoiceRecorderDialog</name>

--- a/src/mumble/mumble_de.ts
+++ b/src/mumble/mumble_de.ts
@@ -8852,6 +8852,10 @@ Ein Zugriffscode ist eine Zeichenfolge, die als Passwort für ein sehr einfaches
         <source>.flac - Lossless compressed</source>
         <translation>.flac - Verlustfrei komprimiert</translation>
     </message>
+    <message>
+        <source>.opus - Lossy compressed</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>VoiceRecorderDialog</name>

--- a/src/mumble/mumble_el.ts
+++ b/src/mumble/mumble_el.ts
@@ -8766,6 +8766,10 @@ An access token is a text string, which can be used as a password for very simpl
         <source>.flac - Lossless compressed</source>
         <translation>.flac - Συμπιεσμένο χωρίς απώλειες</translation>
     </message>
+    <message>
+        <source>.opus - Lossy compressed</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>VoiceRecorderDialog</name>

--- a/src/mumble/mumble_en.ts
+++ b/src/mumble/mumble_en.ts
@@ -8690,6 +8690,10 @@ An access token is a text string, which can be used as a password for very simpl
         <source>.flac - Lossless compressed</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>.opus - Lossy compressed</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>VoiceRecorderDialog</name>

--- a/src/mumble/mumble_en_GB.ts
+++ b/src/mumble/mumble_en_GB.ts
@@ -8731,6 +8731,10 @@ An access token is a text string, which can be used as a password for very simpl
         <source>.flac - Lossless compressed</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>.opus - Lossy compressed</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>VoiceRecorderDialog</name>

--- a/src/mumble/mumble_eo.ts
+++ b/src/mumble/mumble_eo.ts
@@ -1120,15 +1120,15 @@ This value allows you to set the maximum number of users allowed in the channel.
     </message>
     <message>
         <source>Audio per packet</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">Sono en paketo</translation>
     </message>
     <message>
         <source>Quality of compression (peak bandwidth)</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">Kvalito de densigo (maksimuma kapacito)</translation>
     </message>
     <message>
         <source>Noise suppression</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">Forigo de bruo</translation>
     </message>
     <message>
         <source>Maximum amplification</source>
@@ -1731,7 +1731,7 @@ This value allows you to set the maximum number of users allowed in the channel.
     </message>
     <message>
         <source>Input method for audio</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">Eniga metodo por sono</translation>
     </message>
     <message>
         <source>Device</source>
@@ -8701,6 +8701,10 @@ An access token is a text string, which can be used as a password for very simpl
     </message>
     <message>
         <source>.flac - Lossless compressed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>.opus - Lossy compressed</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/mumble/mumble_es.ts
+++ b/src/mumble/mumble_es.ts
@@ -8771,6 +8771,10 @@ Una credencial de acceso es una cadena de texto que puede ser usada como contras
         <source>.flac - Lossless compressed</source>
         <translation>.flac - Comprimido sin pérdidas</translation>
     </message>
+    <message>
+        <source>.opus - Lossy compressed</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>VoiceRecorderDialog</name>

--- a/src/mumble/mumble_et.ts
+++ b/src/mumble/mumble_et.ts
@@ -8693,6 +8693,10 @@ An access token is a text string, which can be used as a password for very simpl
         <source>.flac - Lossless compressed</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>.opus - Lossy compressed</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>VoiceRecorderDialog</name>

--- a/src/mumble/mumble_eu.ts
+++ b/src/mumble/mumble_eu.ts
@@ -8712,6 +8712,10 @@ An access token is a text string, which can be used as a password for very simpl
         <source>.flac - Lossless compressed</source>
         <translation>.flac - Galera gabe konprimitua</translation>
     </message>
+    <message>
+        <source>.opus - Lossy compressed</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>VoiceRecorderDialog</name>

--- a/src/mumble/mumble_fa_IR.ts
+++ b/src/mumble/mumble_fa_IR.ts
@@ -8690,6 +8690,10 @@ An access token is a text string, which can be used as a password for very simpl
         <source>.flac - Lossless compressed</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>.opus - Lossy compressed</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>VoiceRecorderDialog</name>

--- a/src/mumble/mumble_fi.ts
+++ b/src/mumble/mumble_fi.ts
@@ -8814,6 +8814,10 @@ Pääsypoletti on merkkijonoketju, jota voidaan käyttää salasanana yksinkerta
         <source>.flac - Lossless compressed</source>
         <translation>.flac - Häviöttömästi pakattu</translation>
     </message>
+    <message>
+        <source>.opus - Lossy compressed</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>VoiceRecorderDialog</name>

--- a/src/mumble/mumble_fr.ts
+++ b/src/mumble/mumble_fr.ts
@@ -8771,6 +8771,10 @@ Un jeton d&apos;accès est une chaîne de caractères qui peut être utilisée c
         <source>.flac - Lossless compressed</source>
         <translation>.flac - Compressé sans perte</translation>
     </message>
+    <message>
+        <source>.opus - Lossy compressed</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>VoiceRecorderDialog</name>

--- a/src/mumble/mumble_gl.ts
+++ b/src/mumble/mumble_gl.ts
@@ -8694,6 +8694,10 @@ An access token is a text string, which can be used as a password for very simpl
         <source>.flac - Lossless compressed</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>.opus - Lossy compressed</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>VoiceRecorderDialog</name>

--- a/src/mumble/mumble_he.ts
+++ b/src/mumble/mumble_he.ts
@@ -8751,6 +8751,10 @@ An access token is a text string, which can be used as a password for very simpl
         <source>.flac - Lossless compressed</source>
         <translation>.flac - דחיסה משמרת איכות</translation>
     </message>
+    <message>
+        <source>.opus - Lossy compressed</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>VoiceRecorderDialog</name>

--- a/src/mumble/mumble_hu.ts
+++ b/src/mumble/mumble_hu.ts
@@ -8747,6 +8747,10 @@ A kulcs egy szöveges karaktersorozat, amely jelszóként használható a csator
         <source>.flac - Lossless compressed</source>
         <translation>.flac - veszteségmentes</translation>
     </message>
+    <message>
+        <source>.opus - Lossy compressed</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>VoiceRecorderDialog</name>

--- a/src/mumble/mumble_it.ts
+++ b/src/mumble/mumble_it.ts
@@ -8855,6 +8855,10 @@ Un token di accesso è una stringa di testo, che può essere usata come password
         <source>.flac - Lossless compressed</source>
         <translation>.flac - Compresso senza perdite</translation>
     </message>
+    <message>
+        <source>.opus - Lossy compressed</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>VoiceRecorderDialog</name>

--- a/src/mumble/mumble_ja.ts
+++ b/src/mumble/mumble_ja.ts
@@ -8747,6 +8747,10 @@ An access token is a text string, which can be used as a password for very simpl
         <source>.flac - Lossless compressed</source>
         <translation>.flac - ロスレス圧縮</translation>
     </message>
+    <message>
+        <source>.opus - Lossy compressed</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>VoiceRecorderDialog</name>

--- a/src/mumble/mumble_ko.ts
+++ b/src/mumble/mumble_ko.ts
@@ -8853,6 +8853,10 @@ An access token is a text string, which can be used as a password for very simpl
         <source>.flac - Lossless compressed</source>
         <translation>.flac - 무손실 압축</translation>
     </message>
+    <message>
+        <source>.opus - Lossy compressed</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>VoiceRecorderDialog</name>

--- a/src/mumble/mumble_lt.ts
+++ b/src/mumble/mumble_lt.ts
@@ -8793,6 +8793,10 @@ Prieigos raktas yra tekstinė eilutė, kuri gali būti naudojama kaip slaptažod
         <source>.flac - Lossless compressed</source>
         <translation>.flac - Nenuostolingasis suglaudintas</translation>
     </message>
+    <message>
+        <source>.opus - Lossy compressed</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>VoiceRecorderDialog</name>

--- a/src/mumble/mumble_nl.ts
+++ b/src/mumble/mumble_nl.ts
@@ -8856,6 +8856,10 @@ Een toegangssleutel is een tekenreeks die gebruikt kan worden als wachtwoord om 
         <source>.flac - Lossless compressed</source>
         <translation>.flac - Zonder verlies gecomprimeerd</translation>
     </message>
+    <message>
+        <source>.opus - Lossy compressed</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>VoiceRecorderDialog</name>

--- a/src/mumble/mumble_no.ts
+++ b/src/mumble/mumble_no.ts
@@ -8785,6 +8785,10 @@ Et tilgangssymbol er en tekststring, som kan brukes som et passord for veldig en
         <source>.flac - Lossless compressed</source>
         <translation>.flac - Tapsfritt komprimert</translation>
     </message>
+    <message>
+        <source>.opus - Lossy compressed</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>VoiceRecorderDialog</name>

--- a/src/mumble/mumble_oc.ts
+++ b/src/mumble/mumble_oc.ts
@@ -8693,6 +8693,10 @@ An access token is a text string, which can be used as a password for very simpl
         <source>.flac - Lossless compressed</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>.opus - Lossy compressed</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>VoiceRecorderDialog</name>

--- a/src/mumble/mumble_pl.ts
+++ b/src/mumble/mumble_pl.ts
@@ -8858,6 +8858,10 @@ Token dostępu to ciąg tekstowy, który może służyć jako hasło do bardzo p
         <source>.flac - Lossless compressed</source>
         <translation>.flac - Bezstratna kompresja</translation>
     </message>
+    <message>
+        <source>.opus - Lossy compressed</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>VoiceRecorderDialog</name>

--- a/src/mumble/mumble_pt_BR.ts
+++ b/src/mumble/mumble_pt_BR.ts
@@ -8773,6 +8773,10 @@ Uma credencial de acesso é uma cadeia de caracteres de texto, que podem ser usa
         <source>.flac - Lossless compressed</source>
         <translation>.flac - Comprimido sem perdas</translation>
     </message>
+    <message>
+        <source>.opus - Lossy compressed</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>VoiceRecorderDialog</name>

--- a/src/mumble/mumble_pt_PT.ts
+++ b/src/mumble/mumble_pt_PT.ts
@@ -8773,6 +8773,10 @@ Uma credencial de acesso é uma sequência de texto, que pode ser usada como uma
         <source>.flac - Lossless compressed</source>
         <translation>.flac - Comprimido sem perdas</translation>
     </message>
+    <message>
+        <source>.opus - Lossy compressed</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>VoiceRecorderDialog</name>

--- a/src/mumble/mumble_ro.ts
+++ b/src/mumble/mumble_ro.ts
@@ -8698,6 +8698,10 @@ An access token is a text string, which can be used as a password for very simpl
         <source>.flac - Lossless compressed</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>.opus - Lossy compressed</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>VoiceRecorderDialog</name>

--- a/src/mumble/mumble_ru.ts
+++ b/src/mumble/mumble_ru.ts
@@ -8809,6 +8809,10 @@ An access token is a text string, which can be used as a password for very simpl
         <source>.flac - Lossless compressed</source>
         <translation>.flac - Сжатый без потерь</translation>
     </message>
+    <message>
+        <source>.opus - Lossy compressed</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>VoiceRecorderDialog</name>

--- a/src/mumble/mumble_si.ts
+++ b/src/mumble/mumble_si.ts
@@ -8647,6 +8647,10 @@ An access token is a text string, which can be used as a password for very simpl
         <source>.flac - Lossless compressed</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>.opus - Lossy compressed</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>VoiceRecorderDialog</name>

--- a/src/mumble/mumble_sq.ts
+++ b/src/mumble/mumble_sq.ts
@@ -8647,6 +8647,10 @@ An access token is a text string, which can be used as a password for very simpl
         <source>.flac - Lossless compressed</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>.opus - Lossy compressed</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>VoiceRecorderDialog</name>

--- a/src/mumble/mumble_sv.ts
+++ b/src/mumble/mumble_sv.ts
@@ -8796,6 +8796,10 @@ En token är en textsträng, som kan användas som ett lösenord för enkel till
         <source>.flac - Lossless compressed</source>
         <translation>.flac - Förlustfritt komprimerad</translation>
     </message>
+    <message>
+        <source>.opus - Lossy compressed</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>VoiceRecorderDialog</name>

--- a/src/mumble/mumble_te.ts
+++ b/src/mumble/mumble_te.ts
@@ -8710,6 +8710,10 @@ An access token is a text string, which can be used as a password for very simpl
         <source>.flac - Lossless compressed</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>.opus - Lossy compressed</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>VoiceRecorderDialog</name>

--- a/src/mumble/mumble_th.ts
+++ b/src/mumble/mumble_th.ts
@@ -8690,6 +8690,10 @@ An access token is a text string, which can be used as a password for very simpl
         <source>.flac - Lossless compressed</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>.opus - Lossy compressed</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>VoiceRecorderDialog</name>

--- a/src/mumble/mumble_tr.ts
+++ b/src/mumble/mumble_tr.ts
@@ -8854,6 +8854,10 @@ Erişim jetonu bir metindir ve kanallara erişimin çok basit bir şekilde yöne
         <source>.flac - Lossless compressed</source>
         <translation>.flac - Kayıpsız olarak sıkıştırılmış</translation>
     </message>
+    <message>
+        <source>.opus - Lossy compressed</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>VoiceRecorderDialog</name>

--- a/src/mumble/mumble_uk.ts
+++ b/src/mumble/mumble_uk.ts
@@ -8694,6 +8694,10 @@ An access token is a text string, which can be used as a password for very simpl
         <source>.flac - Lossless compressed</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>.opus - Lossy compressed</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>VoiceRecorderDialog</name>

--- a/src/mumble/mumble_zh_CN.ts
+++ b/src/mumble/mumble_zh_CN.ts
@@ -8845,6 +8845,10 @@ An access token is a text string, which can be used as a password for very simpl
         <source>.flac - Lossless compressed</source>
         <translation>.flac - 无损压缩</translation>
     </message>
+    <message>
+        <source>.opus - Lossy compressed</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>VoiceRecorderDialog</name>

--- a/src/mumble/mumble_zh_HK.ts
+++ b/src/mumble/mumble_zh_HK.ts
@@ -8701,6 +8701,10 @@ An access token is a text string, which can be used as a password for very simpl
         <source>.flac - Lossless compressed</source>
         <translation>.flac - 無損壓縮</translation>
     </message>
+    <message>
+        <source>.opus - Lossy compressed</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>VoiceRecorderDialog</name>

--- a/src/mumble/mumble_zh_TW.ts
+++ b/src/mumble/mumble_zh_TW.ts
@@ -8721,6 +8721,10 @@ An access token is a text string, which can be used as a password for very simpl
         <source>.flac - Lossless compressed</source>
         <translation>.flac - 無損壓縮</translation>
     </message>
+    <message>
+        <source>.opus - Lossy compressed</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>VoiceRecorderDialog</name>


### PR DESCRIPTION
This commits adds opus as an output format for voice recordings as requested in #5065. It uses an OGG container like the already implemented Vorbis codec but has much better compression. For clarity the .opus file extension is used.

Implements #5065

### Checks

- [x] My commits follow the [commit guidelines](https://github.com/mumble-voip/mumble/blob/master/COMMIT_GUIDELINES.md)

