### PR TITLE
MAINT(docker): Update server executable name (backported)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -67,7 +67,7 @@ RUN apt-get update && apt-get install --no-install-recommends -y \
 	&& apt-get clean \
 	&& rm -rf /var/lib/apt/lists/*
 
-COPY --from=0 /root/mumble/build/murmurd /usr/bin/murmurd
+COPY --from=0 /root/mumble/build/mumble-server /usr/bin/mumble-server
 COPY --from=0 /root/mumble/scripts/murmur.ini /etc/murmur/murmur.ini
 
 RUN mkdir /var/lib/murmur && \
@@ -77,4 +77,4 @@ RUN mkdir /var/lib/murmur && \
 EXPOSE 64738/tcp 64738/udp 50051
 USER murmur
 
-CMD /usr/bin/murmurd -v -fg -ini /etc/murmur/murmur.ini
+CMD /usr/bin/mumble-server -v -fg -ini /etc/murmur/murmur.ini


### PR DESCRIPTION
The Dockerfile was still referencing the old name (Murmur)
for the server executable but this has changed to mumble-server
by now causing the Dockerfile to error.

Fixes #5171


### Checks

- [x] My commits follow the [commit guidelines](https://github.com/mumble-voip/mumble/blob/master/COMMIT_GUIDELINES.md)

