### PR TITLE
FIX(client,mac): Add support for input/output device switching on macOS

### DIFF
--- a/src/mumble/CoreAudio.h
+++ b/src/mumble/CoreAudio.h
@@ -45,6 +45,8 @@ protected:
 	AudioBufferList buflist{};
 	static void propertyChange(void *udata, AudioUnit au, AudioUnitPropertyID prop, AudioUnitScope scope,
 							   AudioUnitElement element);
+	static OSStatus deviceChange(AudioObjectID inObjectID, UInt32 inNumberAddresses,
+								 const AudioObjectPropertyAddress inAddresses[], void *udata);
 	static OSStatus inputCallback(void *udata, AudioUnitRenderActionFlags *flags, const AudioTimeStamp *ts,
 								  UInt32 busnum, UInt32 npackets, AudioBufferList *buflist);
 
@@ -64,6 +66,8 @@ protected:
 	AudioUnit auHAL{};
 	static void propertyChange(void *udata, AudioUnit au, AudioUnitPropertyID prop, AudioUnitScope scope,
 							   AudioUnitElement element);
+	static OSStatus deviceChange(AudioObjectID inObjectID, UInt32 inNumberAddresses,
+								 const AudioObjectPropertyAddress inAddresses[], void *udata);
 	static OSStatus outputCallback(void *udata, AudioUnitRenderActionFlags *flags, const AudioTimeStamp *ts,
 								   UInt32 busnum, UInt32 npackets, AudioBufferList *buflist);
 


### PR DESCRIPTION
Previously, when switching input/output devices at the system level, Mumble would ignore the switch and continue to use the previous device. This patch adds support for proper device switching, allowing Mumble to correctly follow the system input/output device.

Fixes #1013


### Checks

- [x] My commits follow the [commit guidelines](https://github.com/mumble-voip/mumble/blob/master/COMMIT_GUIDELINES.md)

