### PR TITLE
FIX(server,client): Validate/use the correct certifiacte from a chain

### DIFF
--- a/src/Connection.cpp
+++ b/src/Connection.cpp
@@ -228,11 +228,13 @@ quint16 Connection::localPort() const {
 }
 
 QList< QSslCertificate > Connection::peerCertificateChain() const {
-	const QSslCertificate cert = qtsSocket->peerCertificate();
-	if (cert.isNull())
-		return QList< QSslCertificate >();
-	else
-		return qtsSocket->peerCertificateChain() << cert;
+	// The documentation of QSslSocket::peerCertificateChain() actually says nothing
+	// about the order of the certificates in the chain. The sentence in this functions
+	// documentation is taken from QSslConfiguration::peerCertificateChain().
+	// Through tests and by looking into Qt's source code it was validated,
+	// that these two functions do the same thing.
+	// See mumble-voip/mumble#5280 for more information.
+	return qtsSocket->peerCertificateChain();
 }
 
 QSslCipher Connection::sessionCipher() const {

--- a/src/Connection.h
+++ b/src/Connection.h
@@ -74,7 +74,8 @@ public:
 	QMutex qmCrypt;
 #endif
 	std::unique_ptr< CryptState > csCrypt;
-
+	/// Returns the peer's chain of digital certificates, starting with the peer's immediate certificate
+	/// and ending with the CA's certificate.
 	QList< QSslCertificate > peerCertificateChain() const;
 	QSslCipher sessionCipher() const;
 	QSsl::SslProtocol sessionProtocol() const;

--- a/src/mumble/ServerHandler.cpp
+++ b/src/mumble/ServerHandler.cpp
@@ -745,7 +745,8 @@ void ServerHandler::serverConnectionConnected() {
 	qscCipher = connection->sessionCipher();
 
 	if (!qscCert.isEmpty()) {
-		const QSslCertificate &qsc = qscCert.last();
+		// Get the server's immediate SSL certificate
+		const QSslCertificate &qsc = qscCert.first();
 		qbaDigest                  = sha1(qsc.publicKey().toDer());
 		bUdp                       = database->getUdp(qbaDigest);
 	} else {

--- a/src/murmur/Server.cpp
+++ b/src/murmur/Server.cpp
@@ -1473,7 +1473,8 @@ void Server::encrypted() {
 
 	QList< QSslCertificate > certs = uSource->peerCertificateChain();
 	if (!certs.isEmpty()) {
-		const QSslCertificate &cert = certs.last();
+		// Get the client's immediate SSL certificate
+		const QSslCertificate &cert = certs.first();
 		uSource->qslEmail           = cert.subjectAlternativeNames().values(QSsl::EmailEntry);
 		uSource->qsHash             = QString::fromLatin1(cert.digest(QCryptographicHash::Sha1).toHex());
 		if (!uSource->qslEmail.isEmpty() && uSource->bVerified) {


### PR DESCRIPTION
The commit in this PR is an exceed from #5119 and part of the ssl overhault; for an in deep discussion, see there. For more information about this commit itself, see the commit's message.

Quick additional note: According to the TLS standard, the CA's certificate may be ommitted. If there are now no intermediates, the only remaning (and therefor the first and simultaneously last) certificate is the users certificate. Since most likely no mumble user ever sended multiple certificates with intermediates (and the ssl system even ignores some errors), this bug was not noticed before.