### PR TITLE
FIX(client): Sort users case-insensitively

### DIFF
--- a/src/User.cpp
+++ b/src/User.cpp
@@ -21,5 +21,17 @@ bool User::lessThan(const User *first, const User *second) {
 	// We explicitly don't use localeAwareCompare as this would result in a different
 	// ordering of users on clients with different locales. This is not what one would
 	// expect and thus we don't take the locale into account for comparing users.
-	return QString::compare(first->qsName, second->qsName) < 0;
+	// First we compare case-insensitively, in order to sort users with different names
+	// in a case-insensitive (intuitive) way. However, if some users have the same name
+	// that only differs in casing (theoretically possible), a case-insensitive comparison
+	// would not yield a (guaranteed) stable order of such users, which is why we compare
+	// such cases in a case-sensitive way.
+	int result = QString::compare(first->qsName, second->qsName, Qt::CaseInsensitive);
+
+	if (result == 0) {
+		// Names are equal (except for casing)
+		result = QString::compare(first->qsName, second->qsName, Qt::CaseSensitive);
+	}
+
+	return result < 0;
 }


### PR DESCRIPTION
In #4875 we changed the comparing between users to be locale-unaware.
During this change, the sorting was made case-sensitive, whereas before
it (potentially) was not.

However, intuitively a user will expect a case-insensitive ordering of
users in the UI. The only problem with that is that a case-insensitive
comparison will not yield a strong ordering between users that use
usernames that only differ in casing (e.g. "tom" and "Tom").

In order to avoid this problem, we now first perform a case-insensitive
comparison and fall back to a case-sensitive one, should the first
comparison yield "equal".

Fixes #5293


### Checks

- [x] My commits follow the [commit guidelines](https://github.com/mumble-voip/mumble/blob/master/COMMIT_GUIDELINES.md)

