### PR TITLE
Backport "FIX(client): Sort users case-insensitively (#5294)" to 1.4.x

### DIFF
--- a/src/User.cpp
+++ b/src/User.cpp
@@ -21,5 +21,17 @@ bool User::lessThan(const User *first, const User *second) {
 	// We explicitly don't use localeAwareCompare as this would result in a different
 	// ordering of users on clients with different locales. This is not what one would
 	// expect and thus we don't take the locale into account for comparing users.
-	return QString::compare(first->qsName, second->qsName) < 0;
+	// First we compare case-insensitively, in order to sort users with different names
+	// in a case-insensitive (intuitive) way. However, if some users have the same name
+	// that only differs in casing (theoretically possible), a case-insensitive comparison
+	// would not yield a (guaranteed) stable order of such users, which is why we compare
+	// such cases in a case-sensitive way.
+	int result = QString::compare(first->qsName, second->qsName, Qt::CaseInsensitive);
+
+	if (result == 0) {
+		// Names are equal (except for casing)
+		result = QString::compare(first->qsName, second->qsName, Qt::CaseSensitive);
+	}
+
+	return result < 0;
 }


### PR DESCRIPTION
Backports the following commits to 1.4.x:
 - FIX(client): Sort users case-insensitively (#5294)