### PR TITLE
CHANGE(client): Max. value for silent user setting

### DIFF
--- a/src/mumble/LookConfig.ui
+++ b/src/mumble/LookConfig.ui
@@ -607,6 +607,9 @@
         <property name="toolTip">
          <string>A user that is silent for the given amount of seconds will be removed from the Talkin UI.</string>
         </property>
+        <property name="maximum">
+         <number>999</number>
+        </property>
        </widget>
       </item>
       <item row="2" column="0" colspan="2">


### PR DESCRIPTION
Previously the maximum allowed value for the "silent user lifetime"
setting (affecting the TalkingUI) was 99 (apparently Qt's default for
spin boxes). However, this prevented users from keeping recent speakers
visible for a couple of minutes, which might be desirable (especially in
a situation in which Mumble is only running in the background while one
is doing other stuff).


### Checks

- [x] My commits follow the [commit guidelines](https://github.com/mumble-voip/mumble/blob/master/COMMIT_GUIDELINES.md)

