### PR TITLE
FEAT(server): Add option to disallow recording

### DIFF
--- a/scripts/murmur.ini
+++ b/scripts/murmur.ini
@@ -405,6 +405,14 @@ allowping=true
 ;
 ;logaclchanges=false
 
+; A flag dictating whether clients may use the built-in recording function. Newer
+; clients will respect this option in the UI (e.g. disable the recording feature
+; in the UI). Additionally any client that tries to start a recording is kicked
+; from the server with a corresponding message, if recording is disabled.
+; Default is true. This option was introduced with Murmur 1.5.0.
+;
+; allowRecording=true
+
 ; You can configure any of the configuration options for Ice here. We recommend
 ; leave the defaults as they are.
 ; Please note that this section has to be last in the configuration file.

--- a/src/Mumble.proto
+++ b/src/Mumble.proto
@@ -574,6 +574,8 @@ message ServerConfig {
 	optional uint32 image_message_length = 5;
 	// The maximum number of users allowed on the server.
 	optional uint32 max_users = 6;
+	// Whether using Mumble's recording feature is allowed on the server
+	optional bool recording_allowed = 7;
 }
 
 // Sent by the server to inform the clients of suggested client configuration

--- a/src/mumble/Global.cpp
+++ b/src/mumble/Global.cpp
@@ -102,10 +102,11 @@ Global::Global(const QString &qsConfigPath) {
 	bAttenuateOthers              = false;
 	prioritySpeakerActiveOverride = false;
 
-	bAllowHTML      = true;
-	uiMessageLength = 5000;
-	uiImageLength   = 131072;
-	uiMaxUsers      = 0;
+	bAllowHTML       = true;
+	uiMessageLength  = 5000;
+	uiImageLength    = 131072;
+	uiMaxUsers       = 0;
+	recordingAllowed = true;
 
 	qs = nullptr;
 

--- a/src/mumble/Global.h
+++ b/src/mumble/Global.h
@@ -106,6 +106,7 @@ public:
 	unsigned int uiMessageLength;
 	unsigned int uiImageLength;
 	unsigned int uiMaxUsers;
+	bool recordingAllowed;
 	bool bQuit;
 	QString windowTitlePostfix;
 	bool bDebugDumpInput;

--- a/src/mumble/MainWindow.cpp
+++ b/src/mumble/MainWindow.cpp
@@ -967,6 +967,16 @@ void MainWindow::toggleSearchDialogVisibility() {
 	m_searchDialog->setVisible(!m_searchDialog->isVisible());
 }
 
+void MainWindow::enableRecording(bool recordingAllowed) {
+	qaRecording->setEnabled(recordingAllowed);
+
+	Global::get().recordingAllowed = recordingAllowed;
+
+	if (!recordingAllowed && voiceRecorderDialog) {
+		voiceRecorderDialog->reject();
+	}
+}
+
 static void recreateServerHandler() {
 	// New server connection, so the sync has not happened yet
 	Global::get().channelListenerManager->setInitialServerSyncDone(false);
@@ -2658,6 +2668,7 @@ void MainWindow::on_qaRecording_triggered() {
 	} else {
 		voiceRecorderDialog = new VoiceRecorderDialog(this);
 		connect(voiceRecorderDialog, SIGNAL(finished(int)), this, SLOT(voiceRecorderDialog_finished(int)));
+		QObject::connect(Global::get().sh.get(), &ServerHandler::disconnected, voiceRecorderDialog, &QDialog::reject);
 		voiceRecorderDialog->show();
 	}
 }
@@ -3208,6 +3219,8 @@ void MainWindow::serverConnected() {
 	Global::get().uiMessageLength = 5000;
 	Global::get().uiImageLength   = 131072;
 	Global::get().uiMaxUsers      = 0;
+
+	enableRecording(true);
 
 	if (Global::get().s.bMute || Global::get().s.bDeaf) {
 		Global::get().sh->setSelfMuteDeafState(Global::get().s.bMute, Global::get().s.bDeaf);

--- a/src/mumble/MainWindow.cpp
+++ b/src/mumble/MainWindow.cpp
@@ -3329,6 +3329,9 @@ void MainWindow::serverDisconnected(QAbstractSocket::SocketError err, QString re
 	qmUser_aboutToShow();
 	on_qmConfig_aboutToShow();
 
+	// We can't record without a server anyway, so we disable the functionality here
+	enableRecording(false);
+
 	if (!Global::get().sh->qlErrors.isEmpty()) {
 		foreach (QSslError e, Global::get().sh->qlErrors)
 			Global::get().l->log(Log::Warning, tr("SSL Verification failed: %1").arg(e.errorString().toHtmlEscaped()));

--- a/src/mumble/MainWindow.h
+++ b/src/mumble/MainWindow.h
@@ -339,6 +339,8 @@ public slots:
 	// Callback the search action being triggered
 	void on_qaSearch_triggered();
 	void toggleSearchDialogVisibility();
+	/// Enables or disables the recording feature
+	void enableRecording(bool recordingAllowed);
 signals:
 	/// Signal emitted when the server and the client have finished
 	/// synchronizing (after a new connection).

--- a/src/mumble/MainWindow.ui
+++ b/src/mumble/MainWindow.ui
@@ -916,6 +916,9 @@ the channel's context menu.</string>
    </property>
   </action>
   <action name="qaRecording">
+   <property name="enabled">
+    <bool>false</bool>
+   </property>
    <property name="icon">
     <iconset>
      <normaloff>skin:actions/media-record.svg</normaloff>skin:actions/media-record.svg</iconset>

--- a/src/mumble/Messages.cpp
+++ b/src/mumble/Messages.cpp
@@ -240,6 +240,9 @@ void MainWindow::msgServerConfig(const MumbleProto::ServerConfig &msg) {
 		Global::get().uiImageLength = msg.image_message_length();
 	if (msg.has_max_users())
 		Global::get().uiMaxUsers = msg.max_users();
+	if (msg.has_recording_allowed()) {
+		Global::get().mw->enableRecording(msg.recording_allowed());
+	}
 }
 
 /// This message is being received when the server denied the permission to perform a requested action. This function

--- a/src/mumble/mumble_ar.ts
+++ b/src/mumble/mumble_ar.ts
@@ -8812,6 +8812,10 @@ Please contact your server administrator for further information.</source>
         <source>Downmix</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Unable to start recording - the audio output is miconfigured (0Hz sample rate)</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>WASAPIInput</name>

--- a/src/mumble/mumble_bg.ts
+++ b/src/mumble/mumble_bg.ts
@@ -8805,6 +8805,10 @@ Please contact your server administrator for further information.</source>
         <source>Downmix</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Unable to start recording - the audio output is miconfigured (0Hz sample rate)</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>WASAPIInput</name>

--- a/src/mumble/mumble_br.ts
+++ b/src/mumble/mumble_br.ts
@@ -8804,6 +8804,10 @@ Please contact your server administrator for further information.</source>
         <source>Downmix</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Unable to start recording - the audio output is miconfigured (0Hz sample rate)</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>WASAPIInput</name>

--- a/src/mumble/mumble_ca.ts
+++ b/src/mumble/mumble_ca.ts
@@ -8810,6 +8810,10 @@ Please contact your server administrator for further information.</source>
         <source>Downmix</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Unable to start recording - the audio output is miconfigured (0Hz sample rate)</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>WASAPIInput</name>

--- a/src/mumble/mumble_cs.ts
+++ b/src/mumble/mumble_cs.ts
@@ -8873,6 +8873,10 @@ Prosím kontaktujte Vašeho administrátora serveru pro další informace.</tran
         <source>Downmix</source>
         <translation>Smíšení Kanálů</translation>
     </message>
+    <message>
+        <source>Unable to start recording - the audio output is miconfigured (0Hz sample rate)</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>WASAPIInput</name>

--- a/src/mumble/mumble_cy.ts
+++ b/src/mumble/mumble_cy.ts
@@ -8812,6 +8812,10 @@ Cysylltwch â gweinyddwr y gweinydd ar gyfer gwybodaeth bellach.</translation>
         <source>Downmix</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Unable to start recording - the audio output is miconfigured (0Hz sample rate)</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>WASAPIInput</name>

--- a/src/mumble/mumble_da.ts
+++ b/src/mumble/mumble_da.ts
@@ -8867,6 +8867,10 @@ Kontakt venligst din serveradministrator for yderligere information.</translatio
         <source>Downmix</source>
         <translation>Nedmixet</translation>
     </message>
+    <message>
+        <source>Unable to start recording - the audio output is miconfigured (0Hz sample rate)</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>WASAPIInput</name>

--- a/src/mumble/mumble_de.ts
+++ b/src/mumble/mumble_de.ts
@@ -8965,6 +8965,10 @@ Bitte kontaktieren Sie den Server-Administrator für weitere Informationen.</tra
         <source>Downmix</source>
         <translation>Gemischt</translation>
     </message>
+    <message>
+        <source>Unable to start recording - the audio output is miconfigured (0Hz sample rate)</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>WASAPIInput</name>

--- a/src/mumble/mumble_el.ts
+++ b/src/mumble/mumble_el.ts
@@ -8969,6 +8969,10 @@ Please contact your server administrator for further information.</source>
         <source>Downmix</source>
         <translation>Downmix</translation>
     </message>
+    <message>
+        <source>Unable to start recording - the audio output is miconfigured (0Hz sample rate)</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>WASAPIInput</name>

--- a/src/mumble/mumble_en.ts
+++ b/src/mumble/mumble_en.ts
@@ -8802,6 +8802,10 @@ Please contact your server administrator for further information.</source>
         <source>Downmix</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Unable to start recording - the audio output is miconfigured (0Hz sample rate)</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>WASAPIInput</name>

--- a/src/mumble/mumble_en_GB.ts
+++ b/src/mumble/mumble_en_GB.ts
@@ -8843,6 +8843,10 @@ Please contact your server administrator for further information.</source>
         <source>Downmix</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Unable to start recording - the audio output is miconfigured (0Hz sample rate)</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>WASAPIInput</name>

--- a/src/mumble/mumble_eo.ts
+++ b/src/mumble/mumble_eo.ts
@@ -8815,6 +8815,10 @@ Please contact your server administrator for further information.</source>
         <source>Downmix</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Unable to start recording - the audio output is miconfigured (0Hz sample rate)</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>WASAPIInput</name>

--- a/src/mumble/mumble_es.ts
+++ b/src/mumble/mumble_es.ts
@@ -8884,6 +8884,10 @@ Por favor, contacte con el administrador de su servidor para más información.<
         <source>Downmix</source>
         <translation>Mezclar</translation>
     </message>
+    <message>
+        <source>Unable to start recording - the audio output is miconfigured (0Hz sample rate)</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>WASAPIInput</name>

--- a/src/mumble/mumble_et.ts
+++ b/src/mumble/mumble_et.ts
@@ -8805,6 +8805,10 @@ Please contact your server administrator for further information.</source>
         <source>Downmix</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Unable to start recording - the audio output is miconfigured (0Hz sample rate)</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>WASAPIInput</name>

--- a/src/mumble/mumble_eu.ts
+++ b/src/mumble/mumble_eu.ts
@@ -8824,6 +8824,10 @@ Please contact your server administrator for further information.</source>
         <source>Downmix</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Unable to start recording - the audio output is miconfigured (0Hz sample rate)</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>WASAPIInput</name>

--- a/src/mumble/mumble_fa_IR.ts
+++ b/src/mumble/mumble_fa_IR.ts
@@ -8802,6 +8802,10 @@ Please contact your server administrator for further information.</source>
         <source>Downmix</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Unable to start recording - the audio output is miconfigured (0Hz sample rate)</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>WASAPIInput</name>

--- a/src/mumble/mumble_fi.ts
+++ b/src/mumble/mumble_fi.ts
@@ -8928,6 +8928,10 @@ Ota yhteyttä palvelintarjoajaan jos haluat lisätietoja.</translation>
         <source>Downmix</source>
         <translation>Alasmiksaus</translation>
     </message>
+    <message>
+        <source>Unable to start recording - the audio output is miconfigured (0Hz sample rate)</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>WASAPIInput</name>

--- a/src/mumble/mumble_fr.ts
+++ b/src/mumble/mumble_fr.ts
@@ -8884,6 +8884,10 @@ Contactez l&apos;administrateur de votre serveur pour de plus amples information
         <source>Downmix</source>
         <translation>Downmixage</translation>
     </message>
+    <message>
+        <source>Unable to start recording - the audio output is miconfigured (0Hz sample rate)</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>WASAPIInput</name>

--- a/src/mumble/mumble_gl.ts
+++ b/src/mumble/mumble_gl.ts
@@ -8806,6 +8806,10 @@ Please contact your server administrator for further information.</source>
         <source>Downmix</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Unable to start recording - the audio output is miconfigured (0Hz sample rate)</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>WASAPIInput</name>

--- a/src/mumble/mumble_he.ts
+++ b/src/mumble/mumble_he.ts
@@ -8863,6 +8863,10 @@ Please contact your server administrator for further information.</source>
         <source>Downmix</source>
         <translation>ערבול</translation>
     </message>
+    <message>
+        <source>Unable to start recording - the audio output is miconfigured (0Hz sample rate)</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>WASAPIInput</name>

--- a/src/mumble/mumble_hu.ts
+++ b/src/mumble/mumble_hu.ts
@@ -8859,6 +8859,10 @@ Please contact your server administrator for further information.</source>
         <source>Downmix</source>
         <translation>Lekeverés</translation>
     </message>
+    <message>
+        <source>Unable to start recording - the audio output is miconfigured (0Hz sample rate)</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>WASAPIInput</name>

--- a/src/mumble/mumble_it.ts
+++ b/src/mumble/mumble_it.ts
@@ -8968,6 +8968,10 @@ Per favore contatta l&apos;amministratore del server per maggiori informazioni.<
         <source>Downmix</source>
         <translation>Downmix</translation>
     </message>
+    <message>
+        <source>Unable to start recording - the audio output is miconfigured (0Hz sample rate)</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>WASAPIInput</name>

--- a/src/mumble/mumble_ja.ts
+++ b/src/mumble/mumble_ja.ts
@@ -8860,6 +8860,10 @@ Please contact your server administrator for further information.</source>
         <source>Downmix</source>
         <translation>ダウンミックス</translation>
     </message>
+    <message>
+        <source>Unable to start recording - the audio output is miconfigured (0Hz sample rate)</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>WASAPIInput</name>

--- a/src/mumble/mumble_ko.ts
+++ b/src/mumble/mumble_ko.ts
@@ -8966,6 +8966,10 @@ Please contact your server administrator for further information.</source>
         <source>Downmix</source>
         <translation>다운 믹스</translation>
     </message>
+    <message>
+        <source>Unable to start recording - the audio output is miconfigured (0Hz sample rate)</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>WASAPIInput</name>

--- a/src/mumble/mumble_lt.ts
+++ b/src/mumble/mumble_lt.ts
@@ -8905,6 +8905,10 @@ Please contact your server administrator for further information.</source>
         <source>Downmix</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Unable to start recording - the audio output is miconfigured (0Hz sample rate)</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>WASAPIInput</name>

--- a/src/mumble/mumble_nl.ts
+++ b/src/mumble/mumble_nl.ts
@@ -8969,6 +8969,10 @@ Contacteer je serverbeheerder voor meer informatie.</translation>
         <source>Downmix</source>
         <translation>Downmix</translation>
     </message>
+    <message>
+        <source>Unable to start recording - the audio output is miconfigured (0Hz sample rate)</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>WASAPIInput</name>

--- a/src/mumble/mumble_no.ts
+++ b/src/mumble/mumble_no.ts
@@ -8897,6 +8897,10 @@ Please contact your server administrator for further information.</source>
         <source>Downmix</source>
         <translation>Nedmikset</translation>
     </message>
+    <message>
+        <source>Unable to start recording - the audio output is miconfigured (0Hz sample rate)</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>WASAPIInput</name>

--- a/src/mumble/mumble_oc.ts
+++ b/src/mumble/mumble_oc.ts
@@ -8805,6 +8805,10 @@ Please contact your server administrator for further information.</source>
         <source>Downmix</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Unable to start recording - the audio output is miconfigured (0Hz sample rate)</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>WASAPIInput</name>

--- a/src/mumble/mumble_pl.ts
+++ b/src/mumble/mumble_pl.ts
@@ -8971,6 +8971,10 @@ Skontaktuj się z administratorem serwera po dalsze informacje.</translation>
         <source>Downmix</source>
         <translation>Scalaj ścieżki</translation>
     </message>
+    <message>
+        <source>Unable to start recording - the audio output is miconfigured (0Hz sample rate)</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>WASAPIInput</name>

--- a/src/mumble/mumble_pt_BR.ts
+++ b/src/mumble/mumble_pt_BR.ts
@@ -8886,6 +8886,10 @@ Por favor contate seu administrador de servidor para mais informações.</transl
         <source>Downmix</source>
         <translation>Remixagem</translation>
     </message>
+    <message>
+        <source>Unable to start recording - the audio output is miconfigured (0Hz sample rate)</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>WASAPIInput</name>

--- a/src/mumble/mumble_pt_PT.ts
+++ b/src/mumble/mumble_pt_PT.ts
@@ -8886,6 +8886,10 @@ Por favor contate seu administrador de servidor para mais informações.</transl
         <source>Downmix</source>
         <translation>Remistura</translation>
     </message>
+    <message>
+        <source>Unable to start recording - the audio output is miconfigured (0Hz sample rate)</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>WASAPIInput</name>

--- a/src/mumble/mumble_ro.ts
+++ b/src/mumble/mumble_ro.ts
@@ -8810,6 +8810,10 @@ Please contact your server administrator for further information.</source>
         <source>Downmix</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Unable to start recording - the audio output is miconfigured (0Hz sample rate)</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>WASAPIInput</name>

--- a/src/mumble/mumble_ru.ts
+++ b/src/mumble/mumble_ru.ts
@@ -8921,6 +8921,10 @@ Please contact your server administrator for further information.</source>
         <source>Downmix</source>
         <translation>Микшированный</translation>
     </message>
+    <message>
+        <source>Unable to start recording - the audio output is miconfigured (0Hz sample rate)</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>WASAPIInput</name>

--- a/src/mumble/mumble_si.ts
+++ b/src/mumble/mumble_si.ts
@@ -8759,6 +8759,10 @@ Please contact your server administrator for further information.</source>
         <source>Select target directory</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Unable to start recording - the audio output is miconfigured (0Hz sample rate)</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>WASAPIInput</name>

--- a/src/mumble/mumble_sq.ts
+++ b/src/mumble/mumble_sq.ts
@@ -8759,6 +8759,10 @@ Please contact your server administrator for further information.</source>
         <source>Select target directory</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Unable to start recording - the audio output is miconfigured (0Hz sample rate)</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>WASAPIInput</name>

--- a/src/mumble/mumble_sv.ts
+++ b/src/mumble/mumble_sv.ts
@@ -8909,6 +8909,10 @@ Kontakta din serveradministratör för mer information.</translation>
         <source>Downmix</source>
         <translation>Nedmixning</translation>
     </message>
+    <message>
+        <source>Unable to start recording - the audio output is miconfigured (0Hz sample rate)</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>WASAPIInput</name>

--- a/src/mumble/mumble_te.ts
+++ b/src/mumble/mumble_te.ts
@@ -8822,6 +8822,10 @@ Please contact your server administrator for further information.</source>
         <source>Downmix</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Unable to start recording - the audio output is miconfigured (0Hz sample rate)</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>WASAPIInput</name>

--- a/src/mumble/mumble_th.ts
+++ b/src/mumble/mumble_th.ts
@@ -8802,6 +8802,10 @@ Please contact your server administrator for further information.</source>
         <source>Downmix</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Unable to start recording - the audio output is miconfigured (0Hz sample rate)</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>WASAPIInput</name>

--- a/src/mumble/mumble_tr.ts
+++ b/src/mumble/mumble_tr.ts
@@ -8967,6 +8967,10 @@ Daha fazla bilgi için sunucu yöneticisi ile irtibata geçiniz.</translation>
         <source>Downmix</source>
         <translation>Kanalları azalt</translation>
     </message>
+    <message>
+        <source>Unable to start recording - the audio output is miconfigured (0Hz sample rate)</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>WASAPIInput</name>

--- a/src/mumble/mumble_uk.ts
+++ b/src/mumble/mumble_uk.ts
@@ -8806,6 +8806,10 @@ Please contact your server administrator for further information.</source>
         <source>Downmix</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Unable to start recording - the audio output is miconfigured (0Hz sample rate)</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>WASAPIInput</name>

--- a/src/mumble/mumble_zh_CN.ts
+++ b/src/mumble/mumble_zh_CN.ts
@@ -8958,6 +8958,10 @@ Please contact your server administrator for further information.</source>
         <source>Downmix</source>
         <translation>缩混</translation>
     </message>
+    <message>
+        <source>Unable to start recording - the audio output is miconfigured (0Hz sample rate)</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>WASAPIInput</name>

--- a/src/mumble/mumble_zh_HK.ts
+++ b/src/mumble/mumble_zh_HK.ts
@@ -8814,6 +8814,10 @@ Please contact your server administrator for further information.</source>
         <source>Downmix</source>
         <translation>降混</translation>
     </message>
+    <message>
+        <source>Unable to start recording - the audio output is miconfigured (0Hz sample rate)</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>WASAPIInput</name>

--- a/src/mumble/mumble_zh_TW.ts
+++ b/src/mumble/mumble_zh_TW.ts
@@ -8834,6 +8834,10 @@ Please contact your server administrator for further information.</source>
         <source>Downmix</source>
         <translation>立體聲轉單聲道</translation>
     </message>
+    <message>
+        <source>Unable to start recording - the audio output is miconfigured (0Hz sample rate)</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>WASAPIInput</name>

--- a/src/murmur/Meta.cpp
+++ b/src/murmur/Meta.cpp
@@ -111,6 +111,8 @@ MetaParams::MetaParams() {
 	bLogGroupChanges = false;
 	bLogACLChanges   = false;
 
+	allowRecording = true;
+
 	qsSettings = nullptr;
 }
 
@@ -319,6 +321,8 @@ void MetaParams::read(QString fname) {
 
 	bLogGroupChanges = typeCheckedFromSettings("loggroupchanges", bLogGroupChanges);
 	bLogACLChanges   = typeCheckedFromSettings("logaclchanges", bLogACLChanges);
+
+	allowRecording = typeCheckedFromSettings("allowRecording", allowRecording);
 
 	iOpusThreshold = typeCheckedFromSettings("opusthreshold", iOpusThreshold);
 

--- a/src/murmur/Meta.h
+++ b/src/murmur/Meta.h
@@ -150,6 +150,9 @@ public:
 	/// A flag indicating whether changes in ACLs should be logged
 	bool bLogACLChanges;
 
+	/// A flag indicating whether recording is allowed on this server
+	bool allowRecording;
+
 	/// qsAbsSettingsFilePath is the absolute path to
 	/// the murmur.ini used by this Meta instance.
 	QString qsAbsSettingsFilePath;

--- a/src/murmur/Server.cpp
+++ b/src/murmur/Server.cpp
@@ -373,6 +373,7 @@ void Server::readParams() {
 	qurlRegWeb             = Meta::mp.qurlRegWeb;
 	bBonjour               = Meta::mp.bBonjour;
 	bAllowPing             = Meta::mp.bAllowPing;
+	allowRecording         = Meta::mp.allowRecording;
 	bCertRequired          = Meta::mp.bCertRequired;
 	bForceExternalAuth     = Meta::mp.bForceExternalAuth;
 	qrUserName             = Meta::mp.qrUserName;
@@ -603,6 +604,8 @@ void Server::setLiveConf(const QString &key, const QString &value) {
 #endif
 	} else if (key == "allowping")
 		bAllowPing = !v.isNull() ? QVariant(v).toBool() : Meta::mp.bAllowPing;
+	else if (key == "allowrecording")
+		allowRecording = !v.isNull() ? QVariant(v).toBool() : Meta::mp.allowRecording;
 	else if (key == "username")
 		qrUserName = !v.isNull() ? QRegExp(v) : Meta::mp.qrUserName;
 	else if (key == "channelname")

--- a/src/murmur/Server.h
+++ b/src/murmur/Server.h
@@ -131,6 +131,7 @@ public:
 	QUrl qurlRegWeb;
 	bool bBonjour;
 	bool bAllowPing;
+	bool allowRecording;
 
 	QRegExp qrUserName;
 	QRegExp qrChannelName;


### PR DESCRIPTION
This commit adds a new server-configuration that can be used in the
murmur.ini file. It can be used to forbid anyone on the server from
using Mumble's built-in recording functionality.

Any client trying to start a recording nonetheless, will be kicked from
the server.

From Mumble 1.5.0 clients will know about this configuration and will
disable the recording action in the UI, if recording is not allowed on
the server.

Additionally this PR also fixes/revamps two other small issues related to the recording feature. See the respective commit messages or details.

### Checks

- [x] My commits follow the [commit guidelines](https://github.com/mumble-voip/mumble/blob/master/COMMIT_GUIDELINES.md)

