### PR TITLE
BUILD(client): Fix compile errors without manual plugin

### DIFF
--- a/src/mumble/PluginConfig.cpp
+++ b/src/mumble/PluginConfig.cpp
@@ -7,7 +7,6 @@
 
 #include "Log.h"
 #include "MainWindow.h"
-#include "ManualPlugin.h"
 #include "Message.h"
 #include "MumbleApplication.h"
 #include "PluginInstaller.h"

--- a/src/mumble/PluginManager.cpp
+++ b/src/mumble/PluginManager.cpp
@@ -22,12 +22,15 @@
 
 #include "API.h"
 #include "Log.h"
-#include "ManualPlugin.h"
 #include "PluginInstaller.h"
 #include "PluginUpdater.h"
 #include "ProcessResolver.h"
 #include "ServerHandler.h"
 #include "Global.h"
+
+#ifdef USE_MANUAL_PLUGIN
+#	include "ManualPlugin.h"
+#endif
 
 #include <cstdint>
 #include <memory>

--- a/src/mumble/ServerHandler.cpp
+++ b/src/mumble/ServerHandler.cpp
@@ -31,6 +31,7 @@
 #include "Utils.h"
 #include "Global.h"
 
+#include <QPainter>
 #include <QtCore/QtEndian>
 #include <QtGui/QImageReader>
 #include <QtNetwork/QSslConfiguration>


### PR DESCRIPTION
This fixes the compile errors encountered when building without the
manual plugin (`-Dmanual-plugin=OFF`).

Fixes #5304

### Checks

- [x] My commits follow the [commit guidelines](https://github.com/mumble-voip/mumble/blob/master/COMMIT_GUIDELINES.md)

