### PR TITLE
BUILD(client): Add missing ifdef guards

### DIFF
--- a/src/mumble/GlobalShortcut_win.cpp
+++ b/src/mumble/GlobalShortcut_win.cpp
@@ -229,8 +229,14 @@ QList< Shortcut > GlobalShortcutWin::migrateSettings(const QList< Shortcut > &ol
 			}
 
 			if (button.userType() == qMetaTypeId< InputHid >() || button.userType() == qMetaTypeId< InputKeyboard >()
-				|| button.userType() == qMetaTypeId< InputMouse >() || button.userType() == qMetaTypeId< InputXinput >()
-				|| button.userType() == qMetaTypeId< InputGkey >()) {
+				|| button.userType() == qMetaTypeId< InputMouse >()
+#ifdef USE_XBOXINPUT
+				|| button.userType() == qMetaTypeId< InputXinput >()
+#endif
+#ifdef USE_GKEY
+				|| button.userType() == qMetaTypeId< InputGkey >()
+#endif
+			) {
 				// Already in the new format.
 				continue;
 			}


### PR DESCRIPTION
0e17c5394c5597b746c6076d16c732e2a4a04e7f introduced a migration system
from migrating from the old shortcut format to the newer one (on
Windows) but it seems in this new function it was forgotten to check
whether support for GKey and/or XBox-Input was actually included or not.

This could lead to compile errors when e.g. using -Dgkey=OFF when
invoking cmake.

This PR fixes that by adding the mentioned include-guards.

Fixes #5322


### Checks

- [x] My commits follow the [commit guidelines](https://github.com/mumble-voip/mumble/blob/master/COMMIT_GUIDELINES.md)

