### PR TITLE
CHANGE: Make joining root channel explicit

### DIFF
--- a/src/mumble/Messages.cpp
+++ b/src/mumble/Messages.cpp
@@ -387,7 +387,7 @@ void MainWindow::msgUserState(const MumbleProto::UserState &msg) {
 		connect(pDst, &ClientUser::talkingStateChanged, Global::get().talkingUI, &TalkingUI::on_talkingStateChanged);
 		connect(pDst, &ClientUser::muteDeafStateChanged, Global::get().talkingUI, &TalkingUI::on_muteDeafStateChanged);
 
-		if (channel) {
+		if (channel && channel != pDst->cChannel) {
 			pmModel->moveUser(pDst, channel);
 		}
 

--- a/src/murmur/Messages.cpp
+++ b/src/murmur/Messages.cpp
@@ -416,8 +416,8 @@ void Server::msgAuthenticate(ServerUser *uSource, MumbleProto::Authenticate &msg
 	}
 	if (!uSource->qsHash.isEmpty())
 		mpus.set_hash(u8(uSource->qsHash));
-	if (uSource->cChannel->iId != 0)
-		mpus.set_channel_id(uSource->cChannel->iId);
+
+	mpus.set_channel_id(uSource->cChannel->iId);
 
 	sendAll(mpus, 0x010202);
 


### PR DESCRIPTION
When joining a server, a client is placed in the root channel by
default. However, this placement was implicit as the server would
explicitly exclude this information to be broadcast with the sent
UserState message.

In order to facilitate external applications to get this all right, this
commit now makes sure that this information is shared explicitly (just
as if the user would be placed in a different channel because the server
remembered their last channel).

Note: This commit also adapts the client code to only move the user if
the specified channel is not its current channel already, but even
without this change, the client code will handle the additional
information gracefully.

Fixes #5270


### Checks

- [x] My commits follow the [commit guidelines](https://github.com/mumble-voip/mumble/blob/master/COMMIT_GUIDELINES.md)

