### PR TITLE
Backport "BUILD(client): Add missing ifdef guards (#5323)" to 1.4.x

### DIFF
--- a/src/mumble/GlobalShortcut_win.cpp
+++ b/src/mumble/GlobalShortcut_win.cpp
@@ -229,8 +229,14 @@ QList< Shortcut > GlobalShortcutWin::migrateSettings(const QList< Shortcut > &ol
 			}
 
 			if (button.userType() == qMetaTypeId< InputHid >() || button.userType() == qMetaTypeId< InputKeyboard >()
-				|| button.userType() == qMetaTypeId< InputMouse >() || button.userType() == qMetaTypeId< InputXinput >()
-				|| button.userType() == qMetaTypeId< InputGkey >()) {
+				|| button.userType() == qMetaTypeId< InputMouse >()
+#ifdef USE_XBOXINPUT
+				|| button.userType() == qMetaTypeId< InputXinput >()
+#endif
+#ifdef USE_GKEY
+				|| button.userType() == qMetaTypeId< InputGkey >()
+#endif
+			) {
 				// Already in the new format.
 				continue;
 			}


### PR DESCRIPTION
Backports the following commits to 1.4.x:
 - BUILD(client): Add missing ifdef guards (#5323)