### PR TITLE
FIX(client): Wrong entry in plugin search path

### DIFF
--- a/src/mumble/PluginManager.cpp
+++ b/src/mumble/PluginManager.cpp
@@ -77,7 +77,11 @@ PluginManager::PluginManager(QSet< QString > *additionalSearchPaths, QObject *p)
 	for (const QString &currentPath : pluginPaths) {
 		// Transform currentPath to an absolute, canonical path and only then add it to m_pluginSearchPaths in order
 		// to ensure that each path is contained only once.
-		m_pluginSearchPaths.insert(QDir(currentPath).canonicalPath());
+		QDir dir(currentPath);
+
+		if (dir.exists()) {
+			m_pluginSearchPaths.insert(dir.canonicalPath());
+		}
 	}
 
 #ifdef Q_OS_WIN


### PR DESCRIPTION
ff8be8b80eae32311345f90ee5d184076c023017 introduced a fix that prevented
duplicate entries from showing up in the plugin search path by ensuring
that only canonical, absolute paths are used.

However, the function to canonicalize a path will return an empty
string, if the given path doesn't exist. Thus by adding a non-existing
path to the search path, an empty string was added instead, which means
that the current working directory is considered part of the plugin
search path. This could lead to misleading errors about "non-plugins"
being found in a "plugin directory".

This commit fixes this by first checking whether the specified directory
actually exists and only then adding it to the search path (in
canonicalized form).


### Checks

- [x] My commits follow the [commit guidelines](https://github.com/mumble-voip/mumble/blob/master/COMMIT_GUIDELINES.md)

