### PR TITLE
BUILD: Enable LTO, if supported 

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -17,7 +17,7 @@ freebsd_task:
   - cmake --build .
   test_script:
   - cd build
-  - ctest
+  - ctest --output-on-failure
   install_script:
   - cd build
   - cmake --install .

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,10 +3,12 @@
 # that can be found in the LICENSE file at the root of the
 # Mumble source tree or at <https://www.mumble.info/LICENSE>.
 
+
 cmake_minimum_required(VERSION 3.15)
 
 cmake_policy(SET CMP0079 NEW)
 cmake_policy(SET CMP0091 NEW)
+cmake_policy(SET CMP0069 NEW)
 if(${CMAKE_VERSION} VERSION_GREATER_EQUAL "3.20.0")
 	cmake_policy(SET CMP0118 NEW)
 endif()
@@ -48,6 +50,9 @@ list(APPEND CMAKE_MODULE_PATH
 include(pkg-utils)
 include(project-utils)
 include(TargetArch)
+include(CheckIPOSupported)
+
+check_ipo_supported(RESULT LTO_DEFAULT)
 
 
 option(tests "Build tests" OFF)
@@ -70,7 +75,12 @@ elseif(CMAKE_BUILD_TYPE STREQUAL "Debug")
         "-DDEBUG"
         "-DSNAPSHOT_BUILD"
     )
+
+	# Disable LTO in Debug builds in order to reduce time required for linking
+	set(LTO_DEFAULT OFF)
 endif()
+
+option(lto "Enables link-time optimizations" ${LTO_DEFAULT})
 
 include(compiler)
 include(os)
@@ -87,6 +97,7 @@ if(NOT IS_MULTI_CONFIG)
 else()
     message(STATUS "Using multi-config generator that will determine build type on-the-fly")
 endif()
+message(STATUS "Using LTO:               ${lto}")
 message(STATUS "##################################################")
 
 include(install-paths)

--- a/docs/dev/build-instructions/cmake_options.md
+++ b/docs/dev/build-instructions/cmake_options.md
@@ -104,6 +104,11 @@ Build support for Ice RPC.
 Build support for JackAudio.
 (Default: ON)
 
+### lto
+
+Enables link-time optimizations
+(Default: ${LTO_DEFAULT})
+
 ### manual-plugin
 
 Include the built-in \"manual\

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -33,6 +33,8 @@ find_pkg(Protobuf REQUIRED)
 
 add_library(shared STATIC)
 
+set_property(TARGET shared PROPERTY INTERPROCEDURAL_OPTIMIZATION ${lto})
+
 protobuf_generate(LANGUAGE cpp TARGET shared PROTOS ${PROTO_FILE} OUT_VAR BUILT_PROTO_FILES)
 
 # Disable warnings for the generated source files

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -72,7 +72,6 @@ set(SHARED_SOURCES
 	"SSLLocks.cpp"
 	"Timer.cpp"
 	"UnresolvedServerAddress.cpp"
-	"User.cpp"
 	"Version.cpp"
 
 	"crypto/CryptographicHash.cpp"
@@ -108,7 +107,6 @@ set(SHARED_HEADERS
 	"SSLLocks.h"
 	"Timer.h"
 	"UnresolvedServerAddress.h"
-	"User.h"
 	"Version.h"
 
 	"crypto/CryptographicHash.h"

--- a/src/crypto/CryptographicHash.cpp
+++ b/src/crypto/CryptographicHash.cpp
@@ -9,6 +9,8 @@
 
 #include <openssl/evp.h>
 
+#include <cassert>
+
 class CryptographicHashPrivate {
 public:
 	CryptographicHashPrivate(const EVP_MD *type);
@@ -71,7 +73,7 @@ void CryptographicHashPrivate::addData(const QByteArray &buf) {
 	// In that case, transition into an error state by cleaning
 	// up the mdctx -- that way, subsequent calls to result()
 	// will return an empty QByteArray.
-	if (!m_result.isNull()) {
+	if (!m_result.isEmpty()) {
 		cleanupMdctx();
 		return;
 	}
@@ -90,7 +92,7 @@ QByteArray CryptographicHashPrivate::result() {
 	// If we have a result already, that means our m_mdctx
 	// object has been finalized, and can't be used anymore.
 	// In that case, just return the already computed result.
-	if (!m_result.isNull()) {
+	if (!m_result.isEmpty()) {
 		return m_result;
 	}
 
@@ -102,6 +104,8 @@ QByteArray CryptographicHashPrivate::result() {
 	}
 
 	m_result = digest;
+
+	assert(!m_result.empty());
 
 	return m_result;
 }

--- a/src/crypto/CryptographicHash.cpp
+++ b/src/crypto/CryptographicHash.cpp
@@ -34,7 +34,7 @@ private:
 	void cleanupMdctx();
 };
 
-CryptographicHashPrivate::CryptographicHashPrivate() : m_mdctx(nullptr) {
+CryptographicHashPrivate::CryptographicHashPrivate() : m_mdctx(nullptr), m_result() {
 }
 
 void CryptographicHashPrivate::cleanupMdctx() {
@@ -44,7 +44,7 @@ void CryptographicHashPrivate::cleanupMdctx() {
 	}
 }
 
-CryptographicHashPrivate::CryptographicHashPrivate(const EVP_MD *type) : m_mdctx(nullptr) {
+CryptographicHashPrivate::CryptographicHashPrivate(const EVP_MD *type) : CryptographicHashPrivate() {
 	m_mdctx = EVP_MD_CTX_create();
 	if (!m_mdctx) {
 		return;

--- a/src/mumble/CMakeLists.txt
+++ b/src/mumble/CMakeLists.txt
@@ -345,6 +345,8 @@ else()
 	endif()
 endif()
 
+set_property(TARGET mumble PROPERTY INTERPROCEDURAL_OPTIMIZATION ${lto})
+
 target_compile_definitions(mumble
 	PRIVATE
 		"MUMBLE_LIBRARY_PATH=${MUMBLE_INSTALL_LIBDIR}"

--- a/src/mumble/CMakeLists.txt
+++ b/src/mumble/CMakeLists.txt
@@ -297,6 +297,8 @@ set(MUMBLE_SOURCES
 	"${SHARED_SOURCE_DIR}/Group.cpp"
 	"${SHARED_SOURCE_DIR}/Group.h"
 	"${SHARED_SOURCE_DIR}/SignalCurry.h"
+	"${SHARED_SOURCE_DIR}/User.cpp"
+	"${SHARED_SOURCE_DIR}/User.h"
 
 	"${3RDPARTY_DIR}/smallft/smallft.cpp"
 

--- a/src/murmur/CMakeLists.txt
+++ b/src/murmur/CMakeLists.txt
@@ -57,6 +57,8 @@ else()
 	add_executable(mumble-server ${MURMUR_SOURCES})
 endif()
 
+set_property(TARGET mumble-server PROPERTY INTERPROCEDURAL_OPTIMIZATION ${lto})
+
 set_target_properties(mumble-server
 	PROPERTIES
 		AUTOMOC ON

--- a/src/murmur/CMakeLists.txt
+++ b/src/murmur/CMakeLists.txt
@@ -47,6 +47,8 @@ set(MURMUR_SOURCES
 	"${SHARED_SOURCE_DIR}/Connection.h"
 	"${SHARED_SOURCE_DIR}/Group.cpp"
 	"${SHARED_SOURCE_DIR}/Group.h"
+	"${SHARED_SOURCE_DIR}/User.cpp"
+	"${SHARED_SOURCE_DIR}/User.h"
 )
 
 if(WIN32)


### PR DESCRIPTION
In theory LTO could give us a bit more performance than what we are
currently seeing. Client-side this will probably not be very noticeably
but on the server-side a few drops of extra performance can't hurt.

LTO will be enabled by default in all non-Debug builds. It remains
disabled for Debug builds as this is expected to be the kind of build
that a developer will use when they perform their work and there it is
useful to be able to go through multiple iterations of the program,
without waiting long times on the linker each time.

### Checks

- [x] My commits follow the [commit guidelines](https://github.com/mumble-voip/mumble/blob/master/COMMIT_GUIDELINES.md)

