### PR TITLE
Backport "FIX: Markdown parsing messing up links (#5351)" to 1.4.x

### DIFF
--- a/src/mumble/MainWindow.cpp
+++ b/src/mumble/MainWindow.cpp
@@ -2039,7 +2039,6 @@ void MainWindow::on_qaQuit_triggered() {
 }
 
 void MainWindow::sendChatbarText(QString qsText) {
-	qsText = qsText.toHtmlEscaped();
 	// Markdown::markdownToHTML also takes care of replacing line breaks (\n) with the respective
 	// HTML code <br/>. Therefore if Markdown support is ever going to be removed from this
 	// function, this job has to be done explicitly as otherwise line breaks won't be shown on

--- a/src/mumble/Markdown.cpp
+++ b/src/mumble/Markdown.cpp
@@ -26,7 +26,7 @@ bool processEscapedChar(QString &str, int &offset) {
 		s_regex.match(str, offset, QRegularExpression::NormalMatch, QRegularExpression::AnchoredMatchOption);
 
 	if (match.hasMatch()) {
-		QString replacement = QString::fromLatin1("%1").arg(match.captured(1));
+		QString replacement = QString::fromLatin1("%1").arg(match.captured(1)).toHtmlEscaped();
 
 		str.replace(match.capturedStart(), match.capturedEnd() - match.capturedStart(), replacement);
 
@@ -54,7 +54,7 @@ bool processMarkdownHeader(QString &str, int &offset) {
 
 	if (match.hasMatch()) {
 		int sectionLevel    = match.captured(1).size();
-		QString sectionName = match.captured(2);
+		QString sectionName = match.captured(2).trimmed().toHtmlEscaped();
 
 		QString replacement = QString::fromLatin1("<h%1>%2</h%1>").arg(sectionLevel).arg(sectionName);
 
@@ -104,7 +104,8 @@ bool processMarkdownLink(QString &str, int &offset) {
 			url = QLatin1String("http://") + url;
 		}
 
-		QString replacement = QString::fromLatin1("<a href=\"%1\">%2</a>").arg(unescapeURL(url)).arg(match.captured(1));
+		QString replacement =
+			QString::fromLatin1("<a href=\"%1\">%2</a>").arg(unescapeURL(url)).arg(match.captured(1).toHtmlEscaped());
 		str.replace(match.capturedStart(), match.capturedEnd() - match.capturedStart(), replacement);
 
 		offset += replacement.size();
@@ -129,7 +130,7 @@ bool processMarkdownBold(QString &str, int &offset) {
 		s_regex.match(str, offset, QRegularExpression::NormalMatch, QRegularExpression::AnchoredMatchOption);
 
 	if (match.hasMatch()) {
-		QString replacement = QString::fromLatin1("<b>%1</b>").arg(match.captured(1));
+		QString replacement = QString::fromLatin1("<b>%1</b>").arg(match.captured(1).toHtmlEscaped());
 		str.replace(match.capturedStart(), match.capturedEnd() - match.capturedStart(), replacement);
 
 		offset += replacement.size();
@@ -154,7 +155,7 @@ bool processMarkdownItalic(QString &str, int &offset) {
 		s_regex.match(str, offset, QRegularExpression::NormalMatch, QRegularExpression::AnchoredMatchOption);
 
 	if (match.hasMatch()) {
-		QString replacement = QString::fromLatin1("<i>%1</i>").arg(match.captured(1));
+		QString replacement = QString::fromLatin1("<i>%1</i>").arg(match.captured(1).toHtmlEscaped());
 		str.replace(match.capturedStart(), match.capturedEnd() - match.capturedStart(), replacement);
 
 		offset += replacement.size();
@@ -179,7 +180,7 @@ bool processMarkdownStrikethrough(QString &str, int &offset) {
 		s_regex.match(str, offset, QRegularExpression::NormalMatch, QRegularExpression::AnchoredMatchOption);
 
 	if (match.hasMatch()) {
-		QString replacement = QString::fromLatin1("<s>%1</s>").arg(match.captured(1));
+		QString replacement = QString::fromLatin1("<s>%1</s>").arg(match.captured(1).toHtmlEscaped());
 		str.replace(match.capturedStart(), match.capturedEnd() - match.capturedStart(), replacement);
 
 		offset += replacement.size();
@@ -220,8 +221,8 @@ bool processMarkdownBlockQuote(QString &str, int &offset) {
 			}
 		}
 
-		QString replacement =
-			QString::fromLatin1("<div><i>%1</i></div>").arg(quote.replace(QLatin1String("\n"), QLatin1String("<br/>")));
+		QString replacement = QString::fromLatin1("<div><i>%1</i></div>")
+								  .arg(quote.toHtmlEscaped().replace(QLatin1String("\n"), QLatin1String("<br/>")));
 		str.replace(match.capturedStart(), match.capturedEnd() - match.capturedStart(), replacement);
 
 		offset += replacement.size();
@@ -246,7 +247,7 @@ bool processMarkdownInlineCode(QString &str, int &offset) {
 		s_regex.match(str, offset, QRegularExpression::NormalMatch, QRegularExpression::AnchoredMatchOption);
 
 	if (match.hasMatch()) {
-		QString replacement = QString::fromLatin1("<code>%1</code>").arg(match.captured(1));
+		QString replacement = QString::fromLatin1("<code>%1</code>").arg(match.captured(1).toHtmlEscaped());
 		str.replace(match.capturedStart(), match.capturedEnd() - match.capturedStart(), replacement);
 
 		offset += replacement.size();
@@ -272,7 +273,7 @@ bool processMarkdownCodeBlock(QString &str, int &offset) {
 		s_regex.match(str, offset, QRegularExpression::NormalMatch, QRegularExpression::AnchoredMatchOption);
 
 	if (match.hasMatch()) {
-		QString code = match.captured(1);
+		QString code = match.captured(1).toHtmlEscaped();
 
 		// Trim away leading linebreaks
 		while (code.size() >= 1 && (code[0] == QLatin1Char('\n') || code[0] == QLatin1Char('\r'))) {
@@ -309,7 +310,9 @@ bool processMarkdownCodeBlock(QString &str, int &offset) {
 /// @returns Whether a replacement has been made
 bool processPlainLink(QString &str, int &offset) {
 	// We support links with prefixed protocol (e.g. https://bla.com) and prefixed with www (e.g. www.bla.com)
-	static const QRegularExpression s_regex(QLatin1String("([a-zA-Z]+://|[wW][wW][wW]\\.)[^ \\t\\n<]+"));
+	// See also https://stackoverflow.com/a/1547940/3907364
+	static const QRegularExpression s_regex(
+		QLatin1String("([a-zA-Z]+://|[wW][wW][wW]\\.)[A-Za-z0-9-._~:/?#\\[\\]@!$&'()*+,;=]+"));
 
 	QRegularExpressionMatch match =
 		s_regex.match(str, offset, QRegularExpression::NormalMatch, QRegularExpression::AnchoredMatchOption);
@@ -323,7 +326,8 @@ bool processPlainLink(QString &str, int &offset) {
 			url = QStringLiteral("http://") + url;
 		}
 
-		QString replacement = QString::fromLatin1("<a href=\"%1\">%2</a>").arg(unescapeURL(url)).arg(url);
+		QString replacement =
+			QString::fromLatin1("<a href=\"%1\">%2</a>").arg(unescapeURL(url)).arg(url.toHtmlEscaped());
 		str.replace(match.capturedStart(), match.capturedEnd() - match.capturedStart(), replacement);
 
 		offset += replacement.size();
@@ -332,6 +336,32 @@ bool processPlainLink(QString &str, int &offset) {
 	}
 
 	return false;
+}
+
+void escapeCharacter(QString &str, int &offset) {
+	QString tmp(str[offset]);
+
+	tmp = tmp.toHtmlEscaped();
+
+	if (tmp.size() == 1 && tmp == str[offset]) {
+		// Nothing to escape
+		return;
+	}
+
+	// Perform the replacement
+	QString first;
+	QString second;
+
+	if (offset > 0) {
+		first = str.left(offset);
+	}
+	if (offset < str.size() - 1) {
+		second = str.right(str.size() - offset - 1);
+	}
+
+	str = first + tmp + second;
+
+	offset += tmp.size() - 1;
 }
 
 QString markdownToHTML(const QString &markdownInput) {
@@ -356,16 +386,21 @@ QString markdownToHTML(const QString &markdownInput) {
 			  || processMarkdownStrikethrough(htmlString, offset) || processMarkdownBlockQuote(htmlString, offset)
 			  || processMarkdownCodeBlock(htmlString, offset) || processMarkdownInlineCode(htmlString, offset)
 			  || processPlainLink(htmlString, offset) || processEscapedChar(htmlString, offset))) {
+			escapeCharacter(htmlString, offset);
 			offset++;
 		}
 	}
 
 	// Replace linebreaks afterwards in order to not mess up the RegEx used by the
 	// different functions.
-	static const QRegularExpression s_lineBreakRegEx(QLatin1String("\r\n|\n|\r"));
-	htmlString.replace(s_lineBreakRegEx, QLatin1String("<br/>"));
+	static const QRegularExpression s_doubleLineBreakRegEx(QLatin1String("(\r\n|\n|\r)(\r\n|\n|\r)"));
+	htmlString.replace(s_doubleLineBreakRegEx, QLatin1String("<br/>"));
 
-	// Resore linebreaks in <pre> blocks
+	// Remove single newlines
+	static const QRegularExpression s_singleLineBreak("\r\n|\n|\r");
+	htmlString.replace(s_singleLineBreak, "");
+
+	// Restore linebreaks in <pre> blocks
 	htmlString.replace(regularLineBreakPlaceholder, QLatin1String("\n"));
 
 	return htmlString;


### PR DESCRIPTION
Backports the following commits to 1.4.x:
 - FIX: Markdown parsing messing up links (#5351)