### PR TITLE
CHANGE(client): Rezise chat images to 600x400 instead of 800x600

### DIFF
--- a/src/mumble/Log.cpp
+++ b/src/mumble/Log.cpp
@@ -549,8 +549,8 @@ QString Log::imageToImg(const QByteArray &format, const QByteArray &image) {
 }
 
 QString Log::imageToImg(QImage img, int maxSize) {
-	constexpr int maxWidth  = 800;
-	constexpr int maxHeight = 600;
+	constexpr int maxWidth  = 600;
+	constexpr int maxHeight = 400;
 
 	if ((img.width() > maxWidth) || (img.height() > maxHeight)) {
 		img = img.scaled(maxWidth, maxHeight, Qt::KeepAspectRatio, Qt::SmoothTransformation);


### PR DESCRIPTION
While beta testing 1.4.x the patrons of my server at first adored the new larger images but soon grew to dislike them as they were always larger than what they wanted to keep their Mumble windows. Having to scroll around their chat windows to see the entire image soon turned the larger images into an anti-feature.

A compromize between the 1.3 size of 480x270 and the currently in beta 1.4 size of 800x600 is what this commit suggests.

It should be noted that the aspect ratio of the original image is kept in the transform. This means that for the original 1.3 max sizes the much smaller vertical limit of 270px was most often the limiting factor among the two in 1.3.

480/270=1.78
600/400=1.5
800/600=1.33

These new limits of 600x400 also strikes a balance between the original Mumble 1.3 aspect ratio of 1.78 and the Beta 1.4 ratio of 1.33.

My guess as to why the original maximum height was as small as it was would be that it prevents one image from completely burying all old messages in the chat.


### Checks

- [x] My commits follow the [commit guidelines](https://github.com/mumble-voip/mumble/blob/master/COMMIT_GUIDELINES.md)
