### PR TITLE
FIX(client): very distorted RNNoise output

### DIFF
--- a/src/mumble/AudioInput.cpp
+++ b/src/mumble/AudioInput.cpp
@@ -29,6 +29,15 @@ extern "C" {
 }
 #endif
 
+#include <algorithm>
+#include <limits>
+
+/// Clip the given float value to a range that can be safely converted into a short (without causing integer overflow)
+static short clampFloatSample(float v) {
+	return static_cast< short >(std::min(std::max(v, static_cast< float >(std::numeric_limits< short >::min())),
+										 static_cast< float >(std::numeric_limits< short >::max())));
+}
+
 void Resynchronizer::addMic(short *mic) {
 	bool drop = false;
 	{
@@ -1017,7 +1026,7 @@ void AudioInput::encodeAudioFrame(AudioChunk chunk) {
 		rnnoise_process_frame(denoiseState, denoiseFrames, denoiseFrames);
 
 		for (int i = 0; i < 480; i++) {
-			psSource[i] = denoiseFrames[i];
+			psSource[i] = clampFloatSample(denoiseFrames[i]);
 		}
 	}
 #endif


### PR DESCRIPTION
When the input signal is very loud and clipping, the output of RNNoise
is very distorted, way more than the input signal.

This is because RNNoise outputs a signal that is unbounded and sometimes
goes over the limits of the signed 16-bit signal that Mumble uses
internally. When Mumble converts RNNoise output signal to 16-bit,
integer overflow occurs and creates a very loud distortion.

Mumble now clamps the output of RNNoise which results in a signal that
is not more distorted than the input signal.

Fixes #4391


### Checks

- [x] My commits follow the [commit guidelines](https://github.com/mumble-voip/mumble/blob/master/COMMIT_GUIDELINES.md)

