### PR TITLE
Backport "FIX(client): very distorted RNNoise output (#5363)" to 1.4.x

### DIFF
--- a/src/mumble/AudioInput.cpp
+++ b/src/mumble/AudioInput.cpp
@@ -29,6 +29,15 @@ extern "C" {
 }
 #endif
 
+#include <algorithm>
+#include <limits>
+
+/// Clip the given float value to a range that can be safely converted into a short (without causing integer overflow)
+static short clampFloatSample(float v) {
+	return static_cast< short >(std::min(std::max(v, static_cast< float >(std::numeric_limits< short >::min())),
+										 static_cast< float >(std::numeric_limits< short >::max())));
+}
+
 void Resynchronizer::addMic(short *mic) {
 	bool drop = false;
 	{
@@ -1017,7 +1026,7 @@ void AudioInput::encodeAudioFrame(AudioChunk chunk) {
 		rnnoise_process_frame(denoiseState, denoiseFrames, denoiseFrames);
 
 		for (int i = 0; i < 480; i++) {
-			psSource[i] = denoiseFrames[i];
+			psSource[i] = clampFloatSample(denoiseFrames[i]);
 		}
 	}
 #endif


### PR DESCRIPTION
Backports the following commits to 1.4.x:
 - FIX(client): very distorted RNNoise output (#5363)