### PR TITLE
BUILD(windows): Fix debug build

### DIFF
--- a/plugins/ProcessBase.cpp
+++ b/plugins/ProcessBase.cpp
@@ -3,19 +3,20 @@
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.
 
-#include "Process.h"
+#include "ProcessBase.h"
 
 #include "mumble_positional_audio_utils.h"
 
 #include <chrono>
 
-Process::Process(const procid_t id, const std::string &name) : Host(id), m_ok(false), m_name(name), m_pointerSize(0) {
+ProcessBase::ProcessBase(const procid_t id, const std::string &name)
+	: Host(id), m_ok(false), m_name(name), m_pointerSize(0) {
 }
 
-Process::~Process() {
+ProcessBase::~ProcessBase() {
 }
 
-procptr_t Process::peekPtr(const procptr_t address) const {
+procptr_t ProcessBase::peekPtr(const procptr_t address) const {
 	procptr_t v = 0;
 
 	if (!peek(address, &v, m_pointerSize)) {
@@ -25,7 +26,7 @@ procptr_t Process::peekPtr(const procptr_t address) const {
 	return v;
 }
 
-std::string Process::peekString(const procptr_t address, const size_t length) const {
+std::string ProcessBase::peekString(const procptr_t address, const size_t length) const {
 	std::string string;
 
 	if (length > 0) {
@@ -54,7 +55,7 @@ std::string Process::peekString(const procptr_t address, const size_t length) co
 	return string;
 }
 
-procptr_t Process::virtualFunction(const procptr_t classObject, const size_t index) const {
+procptr_t ProcessBase::virtualFunction(const procptr_t classObject, const size_t index) const {
 	const auto vTable = peekPtr(classObject);
 	if (!vTable) {
 		return 0;
@@ -63,7 +64,7 @@ procptr_t Process::virtualFunction(const procptr_t classObject, const size_t ind
 	return peekPtr(vTable + (index * m_pointerSize));
 }
 
-procptr_t Process::findPattern(const std::vector< uint8_t > &pattern, const Module &module) {
+procptr_t ProcessBase::findPattern(const std::vector< uint8_t > &pattern, const Module &module) {
 	for (const auto &region : module.regions()) {
 		if (!region.readable) {
 			continue;
@@ -78,7 +79,7 @@ procptr_t Process::findPattern(const std::vector< uint8_t > &pattern, const Modu
 	return 0;
 }
 
-procptr_t Process::findPattern(const std::vector< uint8_t > &pattern, procptr_t address, const size_t size) {
+procptr_t ProcessBase::findPattern(const std::vector< uint8_t > &pattern, procptr_t address, const size_t size) {
 	// 32 KiB appears to be a good balance
 	constexpr uint16_t bufferSize = 32768;
 	std::vector< uint8_t > buffer(bufferSize);
@@ -113,7 +114,7 @@ procptr_t Process::findPattern(const std::vector< uint8_t > &pattern, procptr_t 
 	return 0;
 }
 
-procid_t Process::find(const std::string &name, const std::multimap< std::wstring, unsigned long long int > &pids) {
+procid_t ProcessBase::find(const std::string &name, const std::multimap< std::wstring, unsigned long long int > &pids) {
 	if (pids.empty()) {
 		return 0;
 	}

--- a/plugins/ProcessBase.h
+++ b/plugins/ProcessBase.h
@@ -3,8 +3,8 @@
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.
 
-#ifndef PROCESS_H_
-#define PROCESS_H_
+#ifndef PROCESSBASE_H_
+#define PROCESSBASE_H_
 
 #ifdef OS_WINDOWS
 #	include "HostWindows.h"
@@ -19,7 +19,7 @@ using Host = HostLinux;
 
 /// Abstract class.
 /// Only defines stuff that can be used with both Linux and Windows processes.
-class Process : public Host {
+class ProcessBase : public Host {
 protected:
 	bool m_ok;
 	std::string m_name;
@@ -106,8 +106,8 @@ public:
 
 	static procid_t find(const std::string &name, const std::multimap< std::wstring, unsigned long long int > &pids);
 
-	Process(const procid_t id, const std::string &name);
-	virtual ~Process();
+	ProcessBase(const procid_t id, const std::string &name);
+	virtual ~ProcessBase();
 };
 
-#endif
+#endif // PROCESSBASE_H_

--- a/plugins/ProcessLinux.cpp
+++ b/plugins/ProcessLinux.cpp
@@ -17,7 +17,7 @@ struct GnuHash {
 	// uint32_t  chain[];
 };
 
-ProcessLinux::ProcessLinux(const procid_t id, const std::string &name) : Process(id, name) {
+ProcessLinux::ProcessLinux(const procid_t id, const std::string &name) : ProcessBase(id, name) {
 	const auto mods = modules();
 	const auto iter = mods.find(name);
 	if (iter == mods.cend()) {
@@ -47,7 +47,7 @@ ProcessLinux::~ProcessLinux() {
 }
 
 template< typename Elf_Ehdr, typename Elf_Phdr, typename Elf_Dyn, typename Elf_Sym >
-static procptr_t exportedSymbol(const Process &proc, const std::string &symbol, const procptr_t module) {
+static procptr_t exportedSymbol(const ProcessBase &proc, const std::string &symbol, const procptr_t module) {
 	procptr_t hashTable = 0;
 	procptr_t strTable  = 0;
 	procptr_t symTable  = 0;

--- a/plugins/ProcessLinux.h
+++ b/plugins/ProcessLinux.h
@@ -6,10 +6,10 @@
 #ifndef PROCESSLINUX_H_
 #define PROCESSLINUX_H_
 
-#include "Process.h"
+#include "ProcessBase.h"
 
 /// Meant to be used with Linux processes.
-class ProcessLinux : public Process {
+class ProcessLinux : public ProcessBase {
 public:
 	procptr_t exportedSymbol(const std::string &symbol, const procptr_t module) const override;
 

--- a/plugins/ProcessWindows.cpp
+++ b/plugins/ProcessWindows.cpp
@@ -7,7 +7,7 @@
 
 #include "mumble_positional_audio_win32_internals.h"
 
-ProcessWindows::ProcessWindows(const procid_t id, const std::string &name) : Process(id, name) {
+ProcessWindows::ProcessWindows(const procid_t id, const std::string &name) : ProcessBase(id, name) {
 	const auto mods = modules();
 	const auto iter = mods.find(name);
 	if (iter == mods.cend()) {
@@ -44,7 +44,7 @@ ProcessWindows::~ProcessWindows() {
 }
 
 template< typename ImageNtHeaders >
-static procptr_t exportedSymbol(const Process &proc, const std::string &symbol, const procptr_t module) {
+static procptr_t exportedSymbol(const ProcessBase &proc, const std::string &symbol, const procptr_t module) {
 	const auto dos = proc.peek< ImageDosHeader >(module);
 	if (!(dos.magic[0] == 'M' && dos.magic[1] == 'Z')) {
 		return 0;

--- a/plugins/ProcessWindows.h
+++ b/plugins/ProcessWindows.h
@@ -6,10 +6,10 @@
 #ifndef PROCESSWINDOWS_H_
 #define PROCESSWINDOWS_H_
 
-#include "Process.h"
+#include "ProcessBase.h"
 
 /// Meant to be used with Windows processes.
-class ProcessWindows : public Process {
+class ProcessWindows : public ProcessBase {
 public:
 	procptr_t exportedSymbol(const std::string &symbol, const procptr_t module) const override;
 

--- a/plugins/amongus/CMakeLists.txt
+++ b/plugins/amongus/CMakeLists.txt
@@ -8,7 +8,7 @@ add_library(amongus SHARED
 	"Game.cpp"
 
 	"../Module.cpp"
-	"../Process.cpp"
+	"../ProcessBase.cpp"
 	"../ProcessWindows.cpp"
 )
 

--- a/plugins/cod2/CMakeLists.txt
+++ b/plugins/cod2/CMakeLists.txt
@@ -7,7 +7,7 @@ add_library(cod2 SHARED
 	"cod2.cpp"
 
 	"../Module.cpp"
-	"../Process.cpp"
+	"../ProcessBase.cpp"
 	"../ProcessWindows.cpp"
 )
 

--- a/plugins/cod2/cod2.cpp
+++ b/plugins/cod2/cod2.cpp
@@ -75,7 +75,7 @@ static int fetch(float *avatarPos, float *avatarFront, float *avatarTop, float *
 static int tryLock(const std::multimap< std::wstring, unsigned long long int > &pids) {
 	const std::string name = "CoD2MP_s.exe";
 
-	const auto id = Process::find(name, pids);
+	const auto id = ProcessBase::find(name, pids);
 	if (!id) {
 		return false;
 	}

--- a/plugins/gtav/CMakeLists.txt
+++ b/plugins/gtav/CMakeLists.txt
@@ -8,7 +8,7 @@ add_library(gtav SHARED
 	"Game.cpp"
 
 	"../Module.cpp"
-	"../Process.cpp"
+	"../ProcessBase.cpp"
 	"../ProcessWindows.cpp"
 )
 

--- a/plugins/se/CMakeLists.txt
+++ b/plugins/se/CMakeLists.txt
@@ -7,7 +7,7 @@ add_library(se SHARED
 	"se.cpp"
 
 	"../Module.cpp"
-	"../Process.cpp"
+	"../ProcessBase.cpp"
 	"../ProcessWindows.cpp"
 )
 

--- a/plugins/se/se.cpp
+++ b/plugins/se/se.cpp
@@ -17,7 +17,7 @@
 #include <memory>
 #include <sstream>
 
-std::unique_ptr< Process > proc;
+std::unique_ptr< ProcessBase > proc;
 
 static bool isWin32 = false;
 
@@ -191,7 +191,7 @@ static bool tryInit(const std::multimap< std::wstring, unsigned long long int > 
 	};
 
 	for (const auto &name : names) {
-		const auto id = Process::find(name, pids);
+		const auto id = ProcessBase::find(name, pids);
 		if (!id) {
 			continue;
 		}


### PR DESCRIPTION
When performing a debug build, the "deadlock plugin" will be included
in the build, which uses the thread functionality of the std. However,
during compiling there would be an error about a symbol in thread.hpp
not being found (_beginthreadex). As it turns out, this was due to us
having a header file called Process.h, which would shadow the windows-
specific header file defining the mentioned symbol.

Therefore, in this commit we rename the Process base class to
AbstractProcess and rename the files accordingly, fixing that error.

See also: https://stackoverflow.com/q/27230258


### Checks

- [x] My commits follow the [commit guidelines](https://github.com/mumble-voip/mumble/blob/master/COMMIT_GUIDELINES.md)

