### PR TITLE
Backport "FIX(positional-audio): Update Among Us plugin to work with v2021.12.15s (1421) (#5376)" to 1.4.x

### DIFF
--- a/plugins/amongus/structs.h
+++ b/plugins/amongus/structs.h
@@ -156,6 +156,7 @@ struct InnerNet_InnerNetClient_Fields : UnityEngine_Object_Fields {
 	int32_t msgNum;
 	ptr_t networkAddress;
 	int32_t networkPort;
+	bool useDTLS;
 	ptr_t connection;
 	Mode mode;
 	GameMode gameMode;


### PR DESCRIPTION
Backports the following commits to 1.4.x:
 - FIX(positional-audio): Update Among Us plugin to work with v2021.12.15s (1421) (#5376)