### PR TITLE
CI: Update clang-format action

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -40,7 +40,7 @@ jobs:
       shell: bash
 
     - name: Check code formatting
-      uses: jidicula/clang-format-action@v3.3.0
+      uses: jidicula/clang-format-action@3.5
       with:
           clang-format-version: '10'
           check-path: '.'


### PR DESCRIPTION
The old version was using Ubuntu Groovy as a base, which went EOL in
July, 2020 and apparently now the package repositories (required to run
this action) have been shut down.

The newer release uses Ubuntu focal (20.04) which is an LTS and will
remain supported for a while.


### Checks

- [x] My commits follow the [commit guidelines](https://github.com/mumble-voip/mumble/blob/master/COMMIT_GUIDELINES.md)

