### PR TITLE
MAINT: Change app ID in plist files

### DIFF
--- a/src/mumble/mumble.plist.in
+++ b/src/mumble/mumble.plist.in
@@ -5,7 +5,7 @@
 	<key>CFBundleExecutable</key>
 	<string>Mumble</string>
 	<key>CFBundleGetInfoString</key>
-	<string>An open source, low-latency, high quality voice chat software.</string>
+	<string>@PROJECT_DESCRIPTION@</string>
 	<key>CFBundleIconFile</key>
 	<string>mumble.icns</string>
 	<key>CFBundleIdentifier</key>

--- a/src/mumble/mumble.plist.in
+++ b/src/mumble/mumble.plist.in
@@ -5,11 +5,11 @@
 	<key>CFBundleExecutable</key>
 	<string>Mumble</string>
 	<key>CFBundleGetInfoString</key>
-	<string>An open source, low-latency, high quality voice chat software primarily intended for use while gaming.</string>
+	<string>An open source, low-latency, high quality voice chat software.</string>
 	<key>CFBundleIconFile</key>
 	<string>mumble.icns</string>
 	<key>CFBundleIdentifier</key>
-	<string>net.sourceforge.mumble.Mumble</string>
+	<string>mumble-client</string>
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleSignature</key>

--- a/src/murmur/murmur.plist.in
+++ b/src/murmur/murmur.plist.in
@@ -5,7 +5,7 @@
 	<key>CFBundleExecutable</key>
 	<string>murmurd</string>
 	<key>CFBundleGetInfoString</key>
-	<string>An open source, low-latency, high quality voice chat software.</string>
+	<string>@PROJECT_DESCRIPTION@</string>
 	<key>CFBundleIdentifier</key>
 	<string>mumble-server</string>
 	<key>CFBundlePackageType</key>

--- a/src/murmur/murmur.plist.in
+++ b/src/murmur/murmur.plist.in
@@ -5,9 +5,9 @@
 	<key>CFBundleExecutable</key>
 	<string>murmurd</string>
 	<key>CFBundleGetInfoString</key>
-	<string>An open source, low-latency, high quality voice chat software primarily intended for use while gaming.</string>
+	<string>An open source, low-latency, high quality voice chat software.</string>
 	<key>CFBundleIdentifier</key>
-	<string>net.sourceforge.mumble.Murmur</string>
+	<string>mumble-server</string>
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleSignature</key>


### PR DESCRIPTION
The previously used sourceforge-related IDs were really outdated and
were therefore changed.

And while we were touching these already, the description was also
adapted to remove the "intended for gamers" touch from it.


### Checks

- [x] My commits follow the [commit guidelines](https://github.com/mumble-voip/mumble/blob/master/COMMIT_GUIDELINES.md)

