### PR TITLE
FIX(crypto): no such function empty for QByteArray

### DIFF
--- a/src/crypto/CryptographicHash.cpp
+++ b/src/crypto/CryptographicHash.cpp
@@ -105,7 +105,7 @@ QByteArray CryptographicHashPrivate::result() {
 
 	m_result = digest;
 
-	assert(!m_result.empty());
+	assert(!m_result.isEmpty());
 
 	return m_result;
 }


### PR DESCRIPTION
### Checks

- [X] My commits follow the [commit guidelines](https://github.com/mumble-voip/mumble/blob/master/COMMIT_GUIDELINES.md)

