### PR TITLE
FEAT(server): Add support for the tracy profiler

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -22,3 +22,6 @@
 [submodule "3rdparty/FindPythonInterpreter"]
 	path = 3rdparty/FindPythonInterpreter
 	url = https://github.com/Krzmbrzl/FindPythonInterpreter.git
+[submodule "3rdparty/tracy"]
+	path = 3rdparty/tracy
+	url = https://github.com/wolfpld/tracy.git

--- a/docs/dev/Profiling.md
+++ b/docs/dev/Profiling.md
@@ -1,0 +1,33 @@
+# Profiling
+
+Mumble comes with built-in support for the [Tracy](https://github.com/wolfpld/tracy) profiler. In order to activate the baked-in instrumentation, use
+`-Dtracy=ON` when compiling Mumble. When using that option, you should see a line in the cmake output that says `TRACY_ENABLE: ON`.
+
+
+## Instrumented parts
+
+Currently only the Mumble server is instrumented (can be profiled using Tracy).
+
+
+## Instructions
+
+Once you have built Mumble with `-Dtracy=ON`, Mumble will act as a Tracy _client_ (in Tracy terms) which means that you can connect any Tracy _server_
+to it. Most commonly, you'll want to use either the `profiler` or the `capture`. Both of these programs live in the tracy submodule
+(`3rdparty/tracy/`) and can be built from there. For build instructions, see the
+[Tracy Manual](https://github.com/wolfpld/tracy/releases/latest/download/tracy.pdf).
+
+The `profiler` is an interactive GUI that can be attached to a currently running Mumble instance to see the profiling data (more or less) in realtime
+or you can open a previously recorded trace for analysis. Note that it is also possible to connect to a Mumble instance on a remote machine using this
+tool. All that is required is that it is able to establish a TCP connection to the target machine.
+
+The `capture` tool has to be run on the same machine as the Mumble instance that shall be profiled. It is a command-line tool that will attach to a
+running Tracy _client_ as soon as it is started. It will dump the captured data directly into a file, that can later on be opened in `profiler` for
+further analysis. This tool is recommended when you want to profile over a longer period of time or you don't want to add the burden of sending all
+profiling data out through the network, while Mumble is running.
+
+
+## Notes
+
+- Profiling should generally be done in `Release` mode in order to obtain reasonable data
+- If you are having issues connecting your Tracy _server_ to the Mumble server, you should not let it fork. The default behavior in release
+  mode is to fork, but you can change that by using the `-fg` parameter when starting the server.

--- a/docs/dev/build-instructions/cmake_options.md
+++ b/docs/dev/build-instructions/cmake_options.md
@@ -224,6 +224,11 @@ Build binaries in a way that allows easier debugging.
 Build tests
 (Default: OFF)
 
+### tracy
+
+Enable the tracy profiler.
+(Default: OFF)
+
 ### translations
 
 Include languages other than English.

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -14,6 +14,8 @@ option(zeroconf "Build support for zeroconf (mDNS/DNS-SD)." ON)
 
 option(dbus "Build support for DBus." ON)
 
+option(tracy "Enable the tracy profiler." OFF)
+
 find_pkg(Qt5
 	COMPONENTS
 		Core
@@ -165,6 +167,16 @@ endif()
 if(qssldiffiehellmanparameters)
 	target_compile_definitions(shared PUBLIC "USE_QSSLDIFFIEHELLMANPARAMETERS")
 endif()
+
+# Note: We always include and link against Tracy but it is only enabled, if we set the TRACY_ENABLE cmake option
+# to ON, before including the respective subdirectory
+set(TRACY_ENABLE ${tracy} CACHE BOOL "" FORCE)
+set(TRACY_ON_DEMAND ON CACHE BOOL "" FORCE)
+add_subdirectory("${3RDPARTY_DIR}/tracy" "tracy")
+disable_warnings_for_all_targets_in("${3RDPARTY_DIR}/tracy")
+message(STATUS "Tracy: ${TRACY_ENABLE}")
+
+target_link_libraries(shared PUBLIC Tracy::TracyClient)
 
 if(client)
 	add_subdirectory(mumble)

--- a/src/murmur/Messages.cpp
+++ b/src/murmur/Messages.cpp
@@ -22,6 +22,8 @@
 
 #include <cassert>
 
+#include <Tracy.hpp>
+
 #define RATELIMIT(user)                   \
 	if (user->leakyBucket.ratelimit(1)) { \
 		return;                           \
@@ -157,6 +159,8 @@ bool isChannelEnterRestricted(Channel *c) {
 }
 
 void Server::msgAuthenticate(ServerUser *uSource, MumbleProto::Authenticate &msg) {
+	ZoneScoped;
+
 	if ((msg.tokens_size() > 0) || (uSource->sState == ServerUser::Authenticated)) {
 		QStringList qsl;
 		for (int i = 0; i < msg.tokens_size(); ++i)
@@ -556,6 +560,8 @@ void Server::msgAuthenticate(ServerUser *uSource, MumbleProto::Authenticate &msg
 }
 
 void Server::msgBanList(ServerUser *uSource, MumbleProto::BanList &msg) {
+	ZoneScoped;
+
 	MSG_SETUP(ServerUser::Authenticated);
 
 	QSet< Ban > previousBans, newBans;
@@ -630,6 +636,8 @@ void Server::msgPermissionDenied(ServerUser *, MumbleProto::PermissionDenied &) 
 }
 
 void Server::msgUDPTunnel(ServerUser *uSource, MumbleProto::UDPTunnel &msg) {
+	ZoneScoped;
+
 	MSG_SETUP_NO_UNIDLE(ServerUser::Authenticated);
 
 	const std::string &str = msg.packet();
@@ -641,6 +649,8 @@ void Server::msgUDPTunnel(ServerUser *uSource, MumbleProto::UDPTunnel &msg) {
 }
 
 void Server::msgUserState(ServerUser *uSource, MumbleProto::UserState &msg) {
+	ZoneScoped;
+
 	MSG_SETUP(ServerUser::Authenticated);
 	VICTIM_SETUP;
 
@@ -1043,6 +1053,8 @@ void Server::msgUserState(ServerUser *uSource, MumbleProto::UserState &msg) {
 }
 
 void Server::msgUserRemove(ServerUser *uSource, MumbleProto::UserRemove &msg) {
+	ZoneScoped;
+
 	MSG_SETUP(ServerUser::Authenticated);
 	VICTIM_SETUP;
 
@@ -1080,6 +1092,8 @@ void Server::msgUserRemove(ServerUser *uSource, MumbleProto::UserRemove &msg) {
 }
 
 void Server::msgChannelState(ServerUser *uSource, MumbleProto::ChannelState &msg) {
+	ZoneScoped;
+
 	MSG_SETUP(ServerUser::Authenticated);
 
 	Channel *c = nullptr;
@@ -1360,6 +1374,8 @@ void Server::msgChannelState(ServerUser *uSource, MumbleProto::ChannelState &msg
 }
 
 void Server::msgChannelRemove(ServerUser *uSource, MumbleProto::ChannelRemove &msg) {
+	ZoneScoped;
+
 	MSG_SETUP(ServerUser::Authenticated);
 
 	Channel *c = qhChannels.value(msg.channel_id());
@@ -1377,6 +1393,8 @@ void Server::msgChannelRemove(ServerUser *uSource, MumbleProto::ChannelRemove &m
 }
 
 void Server::msgTextMessage(ServerUser *uSource, MumbleProto::TextMessage &msg) {
+	ZoneScoped;
+
 	MSG_SETUP(ServerUser::Authenticated);
 	QMutexLocker qml(&qmCache);
 
@@ -1586,6 +1604,8 @@ void logACLs(Server *server, const Channel *c, QString prefix = QString()) {
 
 
 void Server::msgACL(ServerUser *uSource, MumbleProto::ACL &msg) {
+	ZoneScoped;
+
 	MSG_SETUP(ServerUser::Authenticated);
 
 	Channel *c = qhChannels.value(msg.channel_id());
@@ -1796,6 +1816,8 @@ void Server::msgACL(ServerUser *uSource, MumbleProto::ACL &msg) {
 }
 
 void Server::msgQueryUsers(ServerUser *uSource, MumbleProto::QueryUsers &msg) {
+	ZoneScoped;
+
 	MSG_SETUP(ServerUser::Authenticated);
 
 	MumbleProto::QueryUsers reply;
@@ -1825,6 +1847,8 @@ void Server::msgQueryUsers(ServerUser *uSource, MumbleProto::QueryUsers &msg) {
 }
 
 void Server::msgPing(ServerUser *uSource, MumbleProto::Ping &msg) {
+	ZoneScoped;
+
 	MSG_SETUP_NO_UNIDLE(ServerUser::Authenticated);
 
 	QMutexLocker l(&uSource->qmCrypt);
@@ -1854,6 +1878,8 @@ void Server::msgPing(ServerUser *uSource, MumbleProto::Ping &msg) {
 }
 
 void Server::msgCryptSetup(ServerUser *uSource, MumbleProto::CryptSetup &msg) {
+	ZoneScoped;
+
 	MSG_SETUP_NO_UNIDLE(ServerUser::Authenticated);
 
 	QMutexLocker l(&uSource->qmCrypt);
@@ -1875,6 +1901,8 @@ void Server::msgContextActionModify(ServerUser *, MumbleProto::ContextActionModi
 }
 
 void Server::msgContextAction(ServerUser *uSource, MumbleProto::ContextAction &msg) {
+	ZoneScoped;
+
 	MSG_SETUP(ServerUser::Authenticated);
 
 	unsigned int session = msg.has_session() ? msg.session() : 0;
@@ -1901,6 +1929,8 @@ QString convertWithSizeRestriction(const std::string &str, size_t maxSize) {
 }
 
 void Server::msgVersion(ServerUser *uSource, MumbleProto::Version &msg) {
+	ZoneScoped;
+
 	RATELIMIT(uSource);
 
 	if (msg.has_version()) {
@@ -1925,6 +1955,8 @@ void Server::msgVersion(ServerUser *uSource, MumbleProto::Version &msg) {
 }
 
 void Server::msgUserList(ServerUser *uSource, MumbleProto::UserList &msg) {
+	ZoneScoped;
+
 	MSG_SETUP(ServerUser::Authenticated);
 
 	// The register permission is required on the root channel to be allowed to
@@ -2000,6 +2032,8 @@ void Server::msgUserList(ServerUser *uSource, MumbleProto::UserList &msg) {
 }
 
 void Server::msgVoiceTarget(ServerUser *uSource, MumbleProto::VoiceTarget &msg) {
+	ZoneScoped;
+
 	MSG_SETUP_NO_UNIDLE(ServerUser::Authenticated);
 
 	int target = msg.id();
@@ -2043,6 +2077,8 @@ void Server::msgVoiceTarget(ServerUser *uSource, MumbleProto::VoiceTarget &msg) 
 }
 
 void Server::msgPermissionQuery(ServerUser *uSource, MumbleProto::PermissionQuery &msg) {
+	ZoneScoped;
+
 	MSG_SETUP_NO_UNIDLE(ServerUser::Authenticated);
 
 	Channel *c = qhChannels.value(msg.channel_id());
@@ -2056,6 +2092,8 @@ void Server::msgCodecVersion(ServerUser *, MumbleProto::CodecVersion &) {
 }
 
 void Server::msgUserStats(ServerUser *uSource, MumbleProto::UserStats &msg) {
+	ZoneScoped;
+
 	MSG_SETUP_NO_UNIDLE(ServerUser::Authenticated);
 	VICTIM_SETUP;
 	const BandwidthRecord &bwr            = pDstServerUser->bwr;
@@ -2141,6 +2179,8 @@ void Server::msgUserStats(ServerUser *uSource, MumbleProto::UserStats &msg) {
 }
 
 void Server::msgRequestBlob(ServerUser *uSource, MumbleProto::RequestBlob &msg) {
+	ZoneScoped;
+
 	MSG_SETUP_NO_UNIDLE(ServerUser::Authenticated);
 
 	int ntextures     = msg.session_texture_size();
@@ -2191,6 +2231,8 @@ void Server::msgSuggestConfig(ServerUser *, MumbleProto::SuggestConfig &) {
 }
 
 void Server::msgPluginDataTransmission(ServerUser *sender, MumbleProto::PluginDataTransmission &msg) {
+	ZoneScoped;
+
 	// A client's plugin has sent us a message that we shall delegate to its receivers
 
 	if (sender->m_pluginMessageBucket.ratelimit(1)) {

--- a/src/murmur/TracyConstants.h
+++ b/src/murmur/TracyConstants.h
@@ -1,0 +1,19 @@
+// Copyright 2021 The Mumble Developers. All rights reserved.
+// Use of this source code is governed by a BSD-style license
+// that can be found in the LICENSE file at the root of the
+// Mumble source tree or at <https://www.mumble.info/LICENSE>.
+
+#ifndef MUMBLE_MURMUR_TRACYCONSTANTS_H_
+#define MUMBLE_MURMUR_TRACYCONSTANTS_H_
+
+namespace TracyConstants {
+static constexpr const char *udp_packet_processing_zone = "udp_packet_processing";
+static constexpr const char *tcp_packet_processing_zone = "tcp_packet_processing";
+static constexpr const char *ping_processing_zone       = "tcp_ping";
+static constexpr const char *udp_ping_processing_zone   = "udp_ping";
+static constexpr const char *decrypt_unknown_peer_zone  = "decrypt_unknown_peer";
+
+static constexpr const char *udp_frame = "udp_frame";
+}; // namespace TracyConstants
+
+#endif // MUMBLE_MURMUR_TRACYCONSTANTS_H_


### PR DESCRIPTION
Tracy (https://github.com/wolfpld/tracy) is a profiler that is aimed at
having a very low impact on the runtime performance and is thus suitable
to be used in production systems to figure out what is going on and how
the code is performing.

For the time being, this commit instruments only the server code.
Furthermore, the instrumentation is performed in a rather minimalistic
way that should suffice to start profiling audio and control message
processing but is definitely far from being complete. Further
instrumentation will be added on-demand.


### Checks

- [x] My commits follow the [commit guidelines](https://github.com/mumble-voip/mumble/blob/master/COMMIT_GUIDELINES.md)

