### PR TITLE
CHANGE(client): Remove channel listener persistence

### DIFF
--- a/src/ChannelListenerManager.h
+++ b/src/ChannelListenerManager.h
@@ -37,9 +37,6 @@ protected:
 	/// A map between channel IDs and local volume adjustments to be made for ChannelListeners
 	/// in that channel
 	QHash< int, float > m_listenerVolumeAdjustments;
-
-	/// A flag indicating whether the initial synchronization with the server has finished yet
-	std::atomic< bool > m_initialSyncDone;
 #endif
 
 public:
@@ -102,13 +99,6 @@ public:
 	/// @param filter Whether to filter out adjustments of 1 (which have no effect)
 	/// @returns A map between channel IDs and the currently set volume adjustment
 	QHash< int, float > getAllListenerLocalVolumeAdjustments(bool filter = false) const;
-
-	/// @done Whether the initial synchronization with the server is done yet
-	void setInitialServerSyncDone(bool done);
-
-	/// Saves the current ChannelListener state to the database.
-	/// NOTE: This function may only be called from the main thread!
-	void saveToDB() const;
 #endif
 
 	/// Clears all ChannelListeners and volume adjustments

--- a/src/mumble/Database.cpp
+++ b/src/mumble/Database.cpp
@@ -225,13 +225,6 @@ Database::Database(const QString &dbname) {
 		query,
 		QLatin1String("CREATE UNIQUE INDEX IF NOT EXISTS `pingcache_host_port` ON `pingcache`(`hostname`,`port`)"));
 
-	execQueryAndLogFailure(query,
-						   QLatin1String("CREATE TABLE IF NOT EXISTS `listener_volume` (`id` INTEGER PRIMARY KEY "
-										 "AUTOINCREMENT, `digest` BLOB, `channel_id` INTEGER, `volume` FLOAT)"));
-
-	execQueryAndLogFailure(query, QLatin1String("CREATE TABLE IF NOT EXISTS `channel_listeners` (`id` INTEGER PRIMARY "
-												"KEY AUTOINCREMENT, `digest` BLOB, `channel_id` INTEGER)"));
-
 	execQueryAndLogFailure(query, QLatin1String("DELETE FROM `comments` WHERE `seen` < datetime('now', '-1 years')"));
 	execQueryAndLogFailure(query, QLatin1String("DELETE FROM `blobs` WHERE `seen` < datetime('now', '-1 months')"));
 
@@ -717,75 +710,6 @@ void Database::setUdp(const QByteArray &digest, bool udp) {
 	execQueryAndLogFailure(query);
 }
 
-
-QList< int > Database::getChannelListeners(const QByteArray &digest) {
-	QList< int > channelIDs;
-
-	QSqlQuery query(db);
-	query.prepare(QLatin1String("SELECT `channel_id` FROM `channel_listeners` where `digest` = ?"));
-	query.addBindValue(digest);
-
-	execQueryAndLogFailure(query);
-
-	while (query.next()) {
-		channelIDs << query.value(0).toInt();
-	}
-
-	return channelIDs;
-}
-
-void Database::setChannelListeners(const QByteArray &digest, const QSet< int > &channelIDs) {
-	QSqlQuery query(db);
-
-	// Delete old set of ChannelListeners for this server
-	query.prepare(QLatin1String("DELETE FROM `channel_listeners` WHERE `digest` = ?"));
-	query.addBindValue(digest);
-	execQueryAndLogFailure(query);
-
-	query.prepare(QLatin1String("INSERT INTO `channel_listeners` (`digest`, `channel_id`) VALUES (?,?)"));
-	QSetIterator< int > it(channelIDs);
-	while (it.hasNext()) {
-		query.addBindValue(digest);
-		query.addBindValue(it.next());
-		execQueryAndLogFailure(query);
-	}
-}
-
-QHash< int, float > Database::getChannelListenerLocalVolumeAdjustments(const QByteArray &digest) {
-	QHash< int, float > volumeMap;
-
-	QSqlQuery query(db);
-	query.prepare(QLatin1String("SELECT `channel_id`, `volume`  FROM `listener_volume` where `digest` = ?"));
-	query.addBindValue(digest);
-
-	execQueryAndLogFailure(query);
-
-	while (query.next()) {
-		volumeMap.insert(query.value(0).toInt(), query.value(1).toFloat());
-	}
-
-	return volumeMap;
-}
-
-void Database::setChannelListenerLocalVolumeAdjustments(const QByteArray &digest,
-														const QHash< int, float > &volumeMap) {
-	QSqlQuery query(db);
-
-	// Delete old set of volume adjustments for this server
-	query.prepare(QLatin1String("DELETE FROM `listener_volume` WHERE `digest` = ?"));
-	query.addBindValue(digest);
-	execQueryAndLogFailure(query);
-
-	query.prepare(QLatin1String("INSERT INTO `listener_volume` (`digest`, `channel_id`, `volume`) VALUES (?,?,?)"));
-	QHashIterator< int, float > it(volumeMap);
-	while (it.hasNext()) {
-		it.next();
-		query.addBindValue(digest);
-		query.addBindValue(it.key());
-		query.addBindValue(it.value());
-		execQueryAndLogFailure(query);
-	}
-}
 
 bool Database::fuzzyMatch(QString &name, QString &user, QString &pw, QString &hostname, unsigned short port) {
 	QSqlQuery query(db);

--- a/src/mumble/Database.h
+++ b/src/mumble/Database.h
@@ -82,12 +82,6 @@ public:
 
 	bool getUdp(const QByteArray &digest);
 	void setUdp(const QByteArray &digest, bool udp);
-
-	QList< int > getChannelListeners(const QByteArray &digest);
-	void setChannelListeners(const QByteArray &digest, const QSet< int > &channelIDs);
-
-	QHash< int, float > getChannelListenerLocalVolumeAdjustments(const QByteArray &digest);
-	void setChannelListenerLocalVolumeAdjustments(const QByteArray &digest, const QHash< int, float > &volumeMap);
 };
 
 #endif

--- a/src/mumble/MainWindow.cpp
+++ b/src/mumble/MainWindow.cpp
@@ -978,9 +978,6 @@ void MainWindow::enableRecording(bool recordingAllowed) {
 }
 
 static void recreateServerHandler() {
-	// New server connection, so the sync has not happened yet
-	Global::get().channelListenerManager->setInitialServerSyncDone(false);
-
 	ServerHandlerPtr sh = Global::get().sh;
 	if (sh && sh->isRunning()) {
 		Global::get().mw->on_qaServerDisconnect_triggered();
@@ -3238,12 +3235,6 @@ void MainWindow::serverConnected() {
 }
 
 void MainWindow::serverDisconnected(QAbstractSocket::SocketError err, QString reason) {
-	if (Global::get().sh->hasSynchronized()) {
-		// Note that the saving of the ChannelListeners has to be done, before resetting Global::get().uiSession
-		// Save ChannelListeners
-		Global::get().channelListenerManager->saveToDB();
-	}
-
 	// clear ChannelListener
 	Global::get().channelListenerManager->clear();
 

--- a/src/mumble/Messages.cpp
+++ b/src/mumble/Messages.cpp
@@ -184,34 +184,6 @@ void MainWindow::msgServerSync(const MumbleProto::ServerSync &msg) {
 
 	updateTrayIcon();
 
-	// Set-up all ChannelListeners and their volume adjustments as before for this server
-	QList< int > localListeners = Global::get().db->getChannelListeners(Global::get().sh->qbaDigest);
-
-	if (!localListeners.isEmpty()) {
-		Global::get().channelListenerManager->setInitialServerSyncDone(false);
-		Global::get().sh->startListeningToChannels(localListeners);
-	} else {
-		// If there are no listeners, then no synchronization is needed in the first place
-		Global::get().channelListenerManager->setInitialServerSyncDone(true);
-	}
-
-	{
-		// Since we are only loading the adjustments from the database, we don't really want to consider the adjustments
-		// to have "changed" by this action. Furthermore we are setting the volume adjustments before the listeners
-		// officially exist. Therefore some code that would receive the change-event would try to get the respective
-		// listener and fail due to it not existing yet. Therefore we block all signals while setting the volume
-		// adjustments.
-		const QSignalBlocker blocker(Global::get().channelListenerManager.get());
-
-		QHash< int, float > volumeMap =
-			Global::get().db->getChannelListenerLocalVolumeAdjustments(Global::get().sh->qbaDigest);
-		QHashIterator< int, float > it(volumeMap);
-		while (it.hasNext()) {
-			it.next();
-			Global::get().channelListenerManager->setListenerLocalVolumeAdjustment(it.key(), it.value());
-		}
-	}
-
 
 	Global::get().sh->setServerSynchronized(true);
 
@@ -496,13 +468,6 @@ void MainWindow::msgUserState(const MumbleProto::UserState &msg) {
 		QString logMsg;
 		if (pDst == pSelf) {
 			logMsg = tr("You started listening to %1").arg(Log::formatChannel(c));
-
-			// Since ChannelListeners are sent out in bulks (all in a single message), the fact that we received
-			// a message that contains information about a ChannelListener of the local user means that we have
-			// succecssfully told the server that we are listening to the respective channels. Even if this message
-			// here has nothing to do with the actual initial synchronization, this means that we have been connected
-			// to the server long enough for the synchronization to be done.
-			Global::get().channelListenerManager->setInitialServerSyncDone(true);
 		} else if (pSelf && pSelf->cChannel == c) {
 			logMsg = tr("%1 started listening to your channel").arg(Log::formatClientUser(pDst, Log::Target));
 		}

--- a/src/mumble/Messages.cpp
+++ b/src/mumble/Messages.cpp
@@ -462,6 +462,11 @@ void MainWindow::msgUserState(const MumbleProto::UserState &msg) {
 			continue;
 		}
 
+		if (Global::get().channelListenerManager->isListening(pDst->uiSession, c->iId)) {
+			// We are already listening to this channel
+			continue;
+		}
+
 		Global::get().channelListenerManager->addListener(pDst->uiSession, c->iId);
 		emit userAddedChannelListener(pDst, c);
 


### PR DESCRIPTION
This is done, since the underlying framework for how channel listeners
are handled (more specifically: where they are stored) will be changed
in an upcoming PR. This upcoming change will cause listener persistence
to only apply to registered users. Thus, if the current persistence
feature was to be retained, that would mean that when introducing this
change, we'd remove a feature from Mumble.

As that is not a great thing to do, we'll remove the feature now that it
is still unreleased and then the upcoming change will _introduce_
persistence for some users instead of taking it away from others.

Furthermore, this PR fixes a little bug that made it possible for channel listeners
to be shown multiple times in the UI.

### Checks

- [x] My commits follow the [commit guidelines](https://github.com/mumble-voip/mumble/blob/master/COMMIT_GUIDELINES.md)

