### PR TITLE
MAINT: Update copyright to 2022

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,4 +1,4 @@
-# Copyright 2021 The Mumble Developers. All rights reserved.
+# Copyright 2021-2022 The Mumble Developers. All rights reserved.
 # Use of this source code is governed by a BSD-style license
 # that can be found in the LICENSE file at the root of the
 # Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/.ci/azure-pipelines/assertNoTranslationChanges.sh
+++ b/.ci/azure-pipelines/assertNoTranslationChanges.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# Copyright 2020-2021 The Mumble Developers. All rights reserved.
+# Copyright 2020-2022 The Mumble Developers. All rights reserved.
 # Use of this source code is governed by a BSD-style license
 # that can be found in the LICENSE file at the root of the
 # Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/.ci/azure-pipelines/build_linux.bash
+++ b/.ci/azure-pipelines/build_linux.bash
@@ -1,6 +1,6 @@
 #!/bin/bash -ex
 #
-# Copyright 2020-2021 The Mumble Developers. All rights reserved.
+# Copyright 2020-2022 The Mumble Developers. All rights reserved.
 # Use of this source code is governed by a BSD-style license
 # that can be found in the LICENSE file at the root of the
 # Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/.ci/azure-pipelines/build_macos.bash
+++ b/.ci/azure-pipelines/build_macos.bash
@@ -1,6 +1,6 @@
 #!/bin/bash -ex
 #
-# Copyright 2020-2021 The Mumble Developers. All rights reserved.
+# Copyright 2020-2022 The Mumble Developers. All rights reserved.
 # Use of this source code is governed by a BSD-style license
 # that can be found in the LICENSE file at the root of the
 # Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/.ci/azure-pipelines/checkDocs.bash
+++ b/.ci/azure-pipelines/checkDocs.bash
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# Copyright 2020-2021 The Mumble Developers. All rights reserved.
+# Copyright 2020-2022 The Mumble Developers. All rights reserved.
 # Use of this source code is governed by a BSD-style license
 # that can be found in the LICENSE file at the root of the
 # Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/.ci/azure-pipelines/extractWithProgress.bash
+++ b/.ci/azure-pipelines/extractWithProgress.bash
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# Copyright 2020-2021 The Mumble Developers. All rights reserved.
+# Copyright 2020-2022 The Mumble Developers. All rights reserved.
 # Use of this source code is governed by a BSD-style license
 # that can be found in the LICENSE file at the root of the
 # Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/.ci/azure-pipelines/install-environment_linux.bash
+++ b/.ci/azure-pipelines/install-environment_linux.bash
@@ -1,6 +1,6 @@
 #!/bin/bash -ex
 #
-# Copyright 2020-2021 The Mumble Developers. All rights reserved.
+# Copyright 2020-2022 The Mumble Developers. All rights reserved.
 # Use of this source code is governed by a BSD-style license
 # that can be found in the LICENSE file at the root of the
 # Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/.ci/azure-pipelines/install-environment_linux_translations.bash
+++ b/.ci/azure-pipelines/install-environment_linux_translations.bash
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# Copyright 2020-2021 The Mumble Developers. All rights reserved.
+# Copyright 2020-2022 The Mumble Developers. All rights reserved.
 # Use of this source code is governed by a BSD-style license
 # that can be found in the LICENSE file at the root of the
 # Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/.ci/azure-pipelines/install-environment_macos.bash
+++ b/.ci/azure-pipelines/install-environment_macos.bash
@@ -1,6 +1,6 @@
 #!/bin/bash -ex
 #
-# Copyright 2020-2021 The Mumble Developers. All rights reserved.
+# Copyright 2020-2022 The Mumble Developers. All rights reserved.
 # Use of this source code is governed by a BSD-style license
 # that can be found in the LICENSE file at the root of the
 # Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/.ci/azure-pipelines/main-pr.yml
+++ b/.ci/azure-pipelines/main-pr.yml
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 The Mumble Developers. All rights reserved.
+# Copyright 2020-2022 The Mumble Developers. All rights reserved.
 # Use of this source code is governed by a BSD-style license
 # that can be found in the LICENSE file at the root of the
 # Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/.ci/azure-pipelines/main.yml
+++ b/.ci/azure-pipelines/main.yml
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 The Mumble Developers. All rights reserved.
+# Copyright 2020-2022 The Mumble Developers. All rights reserved.
 # Use of this source code is governed by a BSD-style license
 # that can be found in the LICENSE file at the root of the
 # Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/.ci/azure-pipelines/package_AppImage.bash
+++ b/.ci/azure-pipelines/package_AppImage.bash
@@ -1,6 +1,6 @@
 #!/bin/bash -ex
 #
-# Copyright 2020-2021 The Mumble Developers. All rights reserved.
+# Copyright 2020-2022 The Mumble Developers. All rights reserved.
 # Use of this source code is governed by a BSD-style license
 # that can be found in the LICENSE file at the root of the
 # Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/.ci/azure-pipelines/release_macos.bash
+++ b/.ci/azure-pipelines/release_macos.bash
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash -ex
 #
-# Copyright 2021 The Mumble Developers. All rights reserved.
+# Copyright 2021-2022 The Mumble Developers. All rights reserved.
 # Use of this source code is governed by a BSD-style license
 # that can be found in the LICENSE file at the root of the
 # Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/.ci/azure-pipelines/release_windows.bat
+++ b/.ci/azure-pipelines/release_windows.bat
@@ -1,4 +1,4 @@
-:: Copyright 2021 The Mumble Developers. All rights reserved.
+:: Copyright 2021-2022 The Mumble Developers. All rights reserved.
 :: Use of this source code is governed by a BSD-style license
 :: that can be found in the LICENSE file at the root of the
 :: Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/.ci/azure-pipelines/steps_linux.yml
+++ b/.ci/azure-pipelines/steps_linux.yml
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 The Mumble Developers. All rights reserved.
+# Copyright 2020-2022 The Mumble Developers. All rights reserved.
 # Use of this source code is governed by a BSD-style license
 # that can be found in the LICENSE file at the root of the
 # Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/.ci/azure-pipelines/steps_macos.yml
+++ b/.ci/azure-pipelines/steps_macos.yml
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 The Mumble Developers. All rights reserved.
+# Copyright 2020-2022 The Mumble Developers. All rights reserved.
 # Use of this source code is governed by a BSD-style license
 # that can be found in the LICENSE file at the root of the
 # Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/.ci/azure-pipelines/steps_windows.yml
+++ b/.ci/azure-pipelines/steps_windows.yml
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 The Mumble Developers. All rights reserved.
+# Copyright 2020-2022 The Mumble Developers. All rights reserved.
 # Use of this source code is governed by a BSD-style license
 # that can be found in the LICENSE file at the root of the
 # Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/.ci/azure-pipelines/task-environment-cache.yml
+++ b/.ci/azure-pipelines/task-environment-cache.yml
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 The Mumble Developers. All rights reserved.
+# Copyright 2020-2022 The Mumble Developers. All rights reserved.
 # Use of this source code is governed by a BSD-style license
 # that can be found in the LICENSE file at the root of the
 # Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/.ci/azure-pipelines/task-publish-artifacts.yml
+++ b/.ci/azure-pipelines/task-publish-artifacts.yml
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 The Mumble Developers. All rights reserved.
+# Copyright 2020-2022 The Mumble Developers. All rights reserved.
 # Use of this source code is governed by a BSD-style license
 # that can be found in the LICENSE file at the root of the
 # Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/.ci/build_windows.bat
+++ b/.ci/build_windows.bat
@@ -1,4 +1,4 @@
-:: Copyright 2021 The Mumble Developers. All rights reserved.
+:: Copyright 2021-2022 The Mumble Developers. All rights reserved.
 :: Use of this source code is governed by a BSD-style license
 :: that can be found in the LICENSE file at the root of the
 :: Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/.ci/install-environment_windows.ps1
+++ b/.ci/install-environment_windows.ps1
@@ -1,4 +1,4 @@
-# Copyright 2021 The Mumble Developers. All rights reserved.
+# Copyright 2021-2022 The Mumble Developers. All rights reserved.
 # Use of this source code is governed by a BSD-style license
 # that can be found in the LICENSE file at the root of the
 # Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,4 +1,4 @@
-# Copyright 2019-2021 The Mumble Developers. All rights reserved.
+# Copyright 2019-2022 The Mumble Developers. All rights reserved.
 # Use of this source code is governed by a BSD-style license
 # that can be found in the LICENSE file at the root of the
 # Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 The Mumble Developers. All rights reserved.
+# Copyright 2020-2022 The Mumble Developers. All rights reserved.
 # Use of this source code is governed by a BSD-style license
 # that can be found in the LICENSE file at the root of the
 # Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/cmake/FindModules/FindGRPC.cmake
+++ b/cmake/FindModules/FindGRPC.cmake
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 The Mumble Developers. All rights reserved.
+# Copyright 2020-2022 The Mumble Developers. All rights reserved.
 # Use of this source code is governed by a BSD-style license
 # that can be found in the LICENSE file at the root of the
 # Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/cmake/TargetArch.cmake
+++ b/cmake/TargetArch.cmake
@@ -1,3 +1,8 @@
+# Copyright 2021-2022 The Mumble Developers. All rights reserved.
+# Use of this source code is governed by a BSD-style license
+# that can be found in the LICENSE file at the root of the
+# Mumble source tree or at <https://www.mumble.info/LICENSE>.
+
 # Taken from https://github.com/axr/solar-cmake/blob/master/TargetArch.cmake
 
 # Copyright (c) 2012 Petroules Corporation. All rights reserved.

--- a/cmake/compiler.cmake
+++ b/cmake/compiler.cmake
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 The Mumble Developers. All rights reserved.
+# Copyright 2020-2022 The Mumble Developers. All rights reserved.
 # Use of this source code is governed by a BSD-style license
 # that can be found in the LICENSE file at the root of the
 # Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/cmake/install-library.cmake
+++ b/cmake/install-library.cmake
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 The Mumble Developers. All rights reserved.
+# Copyright 2020-2022 The Mumble Developers. All rights reserved.
 # Use of this source code is governed by a BSD-style license
 # that can be found in the LICENSE file at the root of the
 # Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/cmake/install-paths.cmake
+++ b/cmake/install-paths.cmake
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 The Mumble Developers. All rights reserved.
+# Copyright 2020-2022 The Mumble Developers. All rights reserved.
 # Use of this source code is governed by a BSD-style license
 # that can be found in the LICENSE file at the root of the
 # Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/cmake/os.cmake
+++ b/cmake/os.cmake
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 The Mumble Developers. All rights reserved.
+# Copyright 2020-2022 The Mumble Developers. All rights reserved.
 # Use of this source code is governed by a BSD-style license
 # that can be found in the LICENSE file at the root of the
 # Mumble source tree or at <https://www.mumble.info/LICENSE>. 

--- a/cmake/pkg-utils.cmake
+++ b/cmake/pkg-utils.cmake
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 The Mumble Developers. All rights reserved.
+# Copyright 2020-2022 The Mumble Developers. All rights reserved.
 # Use of this source code is governed by a BSD-style license
 # that can be found in the LICENSE file at the root of the
 # Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/cmake/project-utils.cmake
+++ b/cmake/project-utils.cmake
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 The Mumble Developers. All rights reserved.
+# Copyright 2020-2022 The Mumble Developers. All rights reserved.
 # Use of this source code is governed by a BSD-style license
 # that can be found in the LICENSE file at the root of the
 # Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/cmake/qt-utils.cmake
+++ b/cmake/qt-utils.cmake
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 The Mumble Developers. All rights reserved.
+# Copyright 2020-2022 The Mumble Developers. All rights reserved.
 # Use of this source code is governed by a BSD-style license
 # that can be found in the LICENSE file at the root of the
 # Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/g15helper/CMakeLists.txt
+++ b/g15helper/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 The Mumble Developers. All rights reserved.
+# Copyright 2020-2022 The Mumble Developers. All rights reserved.
 # Use of this source code is governed by a BSD-style license
 # that can be found in the LICENSE file at the root of the
 # Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/g15helper/g15helper.c
+++ b/g15helper/g15helper.c
@@ -1,4 +1,4 @@
-// Copyright 2008-2021 The Mumble Developers. All rights reserved.
+// Copyright 2008-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/g15helper/g15helper.h
+++ b/g15helper/g15helper.h
@@ -1,4 +1,4 @@
-// Copyright 2008-2021 The Mumble Developers. All rights reserved.
+// Copyright 2008-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/g15helper/g15helper_emu.cpp
+++ b/g15helper/g15helper_emu.cpp
@@ -1,4 +1,4 @@
-// Copyright 2016-2021 The Mumble Developers. All rights reserved.
+// Copyright 2016-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/g15helper/g15helper_emu.h
+++ b/g15helper/g15helper_emu.h
@@ -1,4 +1,4 @@
-// Copyright 2016-2021 The Mumble Developers. All rights reserved.
+// Copyright 2016-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/g15helper/g15helper_macx.c
+++ b/g15helper/g15helper_macx.c
@@ -1,4 +1,4 @@
-// Copyright 2009-2021 The Mumble Developers. All rights reserved.
+// Copyright 2009-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/helpers/vcpkg/ports/zeroc-ice/portfile.cmake
+++ b/helpers/vcpkg/ports/zeroc-ice/portfile.cmake
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 The Mumble Developers. All rights reserved.
+# Copyright 2020-2022 The Mumble Developers. All rights reserved.
 # Use of this source code is governed by a BSD-style license
 # that can be found in the LICENSE file at the root of the
 # Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/installer/ClientInstaller.cs
+++ b/installer/ClientInstaller.cs
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 The Mumble Developers. All rights reserved.
+// Copyright 2020-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/installer/MumbleInstall.cs
+++ b/installer/MumbleInstall.cs
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 The Mumble Developers. All rights reserved.
+// Copyright 2020-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/installer/ServerInstaller.cs
+++ b/installer/ServerInstaller.cs
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 The Mumble Developers. All rights reserved.
+// Copyright 2020-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/macx/osax/CMakeLists.txt
+++ b/macx/osax/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 The Mumble Developers. All rights reserved.
+# Copyright 2020-2022 The Mumble Developers. All rights reserved.
 # Use of this source code is governed by a BSD-style license
 # that can be found in the LICENSE file at the root of the
 # Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/macx/osax/osax.m
+++ b/macx/osax/osax.m
@@ -1,4 +1,4 @@
-// Copyright 2010-2021 The Mumble Developers. All rights reserved.
+// Copyright 2010-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/macx/scripts/gendmg.pl
+++ b/macx/scripts/gendmg.pl
@@ -1,6 +1,6 @@
 #!/usr/bin/perl
 #
-# Copyright 2010-2021 The Mumble Developers. All rights reserved.
+# Copyright 2010-2022 The Mumble Developers. All rights reserved.
 # Use of this source code is governed by a BSD-style license
 # that can be found in the LICENSE file at the root of the
 # Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/macx/scripts/osxdist.py
+++ b/macx/scripts/osxdist.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 #
-# Copyright 2010-2021 The Mumble Developers. All rights reserved.
+# Copyright 2010-2022 The Mumble Developers. All rights reserved.
 # Use of this source code is governed by a BSD-style license
 # that can be found in the LICENSE file at the root of the
 # Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/overlay/CMakeLists.txt
+++ b/overlay/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 The Mumble Developers. All rights reserved.
+# Copyright 2020-2022 The Mumble Developers. All rights reserved.
 # Use of this source code is governed by a BSD-style license
 # that can be found in the LICENSE file at the root of the
 # Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/overlay/D11StateBlock.cpp
+++ b/overlay/D11StateBlock.cpp
@@ -1,4 +1,4 @@
-// Copyright 2014-2021 The Mumble Developers. All rights reserved.
+// Copyright 2014-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/overlay/D11StateBlock.h
+++ b/overlay/D11StateBlock.h
@@ -1,4 +1,4 @@
-// Copyright 2014-2021 The Mumble Developers. All rights reserved.
+// Copyright 2014-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/overlay/HardHook.cpp
+++ b/overlay/HardHook.cpp
@@ -1,4 +1,4 @@
-// Copyright 2010-2021 The Mumble Developers. All rights reserved.
+// Copyright 2010-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/overlay/HardHook.h
+++ b/overlay/HardHook.h
@@ -1,4 +1,4 @@
-// Copyright 2010-2021 The Mumble Developers. All rights reserved.
+// Copyright 2010-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/overlay/HardHook_minhook.cpp
+++ b/overlay/HardHook_minhook.cpp
@@ -1,4 +1,4 @@
-// Copyright 2015-2021 The Mumble Developers. All rights reserved.
+// Copyright 2015-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/overlay/HardHook_minhook.h
+++ b/overlay/HardHook_minhook.h
@@ -1,4 +1,4 @@
-// Copyright 2015-2021 The Mumble Developers. All rights reserved.
+// Copyright 2015-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/overlay/HardHook_x86.cpp
+++ b/overlay/HardHook_x86.cpp
@@ -1,4 +1,4 @@
-// Copyright 2015-2021 The Mumble Developers. All rights reserved.
+// Copyright 2015-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/overlay/HardHook_x86.h
+++ b/overlay/HardHook_x86.h
@@ -1,4 +1,4 @@
-// Copyright 2015-2021 The Mumble Developers. All rights reserved.
+// Copyright 2015-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/overlay/ancestor.cpp
+++ b/overlay/ancestor.cpp
@@ -1,4 +1,4 @@
-// Copyright 2017-2021 The Mumble Developers. All rights reserved.
+// Copyright 2017-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/overlay/ancestor.h
+++ b/overlay/ancestor.h
@@ -1,4 +1,4 @@
-// Copyright 2017-2021 The Mumble Developers. All rights reserved.
+// Copyright 2017-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/overlay/d3d10.cpp
+++ b/overlay/d3d10.cpp
@@ -1,4 +1,4 @@
-// Copyright 2009-2021 The Mumble Developers. All rights reserved.
+// Copyright 2009-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/overlay/d3d11.cpp
+++ b/overlay/d3d11.cpp
@@ -1,4 +1,4 @@
-// Copyright 2014-2021 The Mumble Developers. All rights reserved.
+// Copyright 2014-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/overlay/d3d9.cpp
+++ b/overlay/d3d9.cpp
@@ -1,4 +1,4 @@
-// Copyright 2007-2021 The Mumble Developers. All rights reserved.
+// Copyright 2007-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/overlay/dxgi.cpp
+++ b/overlay/dxgi.cpp
@@ -1,4 +1,4 @@
-// Copyright 2013-2021 The Mumble Developers. All rights reserved.
+// Copyright 2013-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/overlay/excludecheck.cpp
+++ b/overlay/excludecheck.cpp
@@ -1,4 +1,4 @@
-// Copyright 2017-2021 The Mumble Developers. All rights reserved.
+// Copyright 2017-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/overlay/excludecheck.h
+++ b/overlay/excludecheck.h
@@ -1,4 +1,4 @@
-// Copyright 2017-2021 The Mumble Developers. All rights reserved.
+// Copyright 2017-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/overlay/lib.cpp
+++ b/overlay/lib.cpp
@@ -1,4 +1,4 @@
-// Copyright 2005-2021 The Mumble Developers. All rights reserved.
+// Copyright 2005-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/overlay/lib.h
+++ b/overlay/lib.h
@@ -1,4 +1,4 @@
-// Copyright 2007-2021 The Mumble Developers. All rights reserved.
+// Copyright 2007-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/overlay/ods.cpp
+++ b/overlay/ods.cpp
@@ -1,4 +1,4 @@
-// Copyright 2011-2021 The Mumble Developers. All rights reserved.
+// Copyright 2011-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/overlay/ods.h
+++ b/overlay/ods.h
@@ -1,4 +1,4 @@
-// Copyright 2011-2021 The Mumble Developers. All rights reserved.
+// Copyright 2011-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/overlay/olsettings.cpp
+++ b/overlay/olsettings.cpp
@@ -1,4 +1,4 @@
-// Copyright 2017-2021 The Mumble Developers. All rights reserved.
+// Copyright 2017-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/overlay/olsettings.h
+++ b/overlay/olsettings.h
@@ -1,4 +1,4 @@
-// Copyright 2017-2021 The Mumble Developers. All rights reserved.
+// Copyright 2017-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/overlay/opengl.cpp
+++ b/overlay/opengl.cpp
@@ -1,4 +1,4 @@
-// Copyright 2007-2021 The Mumble Developers. All rights reserved.
+// Copyright 2007-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/overlay/overlay.fx
+++ b/overlay/overlay.fx
@@ -1,4 +1,4 @@
-// Copyright 2009-2021 The Mumble Developers. All rights reserved.
+// Copyright 2009-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/overlay/overlay.h
+++ b/overlay/overlay.h
@@ -1,4 +1,4 @@
-// Copyright 2005-2021 The Mumble Developers. All rights reserved.
+// Copyright 2005-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/overlay/overlay11-common.hlsl
+++ b/overlay/overlay11-common.hlsl
@@ -1,4 +1,4 @@
-// Copyright 2015-2021 The Mumble Developers. All rights reserved.
+// Copyright 2015-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/overlay/overlay11.ps
+++ b/overlay/overlay11.ps
@@ -1,4 +1,4 @@
-// Copyright 2015-2021 The Mumble Developers. All rights reserved.
+// Copyright 2015-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/overlay/overlay11.vs
+++ b/overlay/overlay11.vs
@@ -1,4 +1,4 @@
-// Copyright 2015-2021 The Mumble Developers. All rights reserved.
+// Copyright 2015-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/overlay/overlay_blacklist.h
+++ b/overlay/overlay_blacklist.h
@@ -1,4 +1,4 @@
-// Copyright 2011-2021 The Mumble Developers. All rights reserved.
+// Copyright 2011-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/overlay/overlay_exe/CMakeLists.txt
+++ b/overlay/overlay_exe/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 The Mumble Developers. All rights reserved.
+# Copyright 2020-2022 The Mumble Developers. All rights reserved.
 # Use of this source code is governed by a BSD-style license
 # that can be found in the LICENSE file at the root of the
 # Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/overlay/overlay_exe/overlay_exe.cpp
+++ b/overlay/overlay_exe/overlay_exe.cpp
@@ -1,4 +1,4 @@
-// Copyright 2015-2021 The Mumble Developers. All rights reserved.
+// Copyright 2015-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/overlay/overlay_exe/overlay_exe.h
+++ b/overlay/overlay_exe/overlay_exe.h
@@ -1,4 +1,4 @@
-// Copyright 2015-2021 The Mumble Developers. All rights reserved.
+// Copyright 2015-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/overlay/overlay_launchers.h
+++ b/overlay/overlay_launchers.h
@@ -1,4 +1,4 @@
-// Copyright 2017-2021 The Mumble Developers. All rights reserved.
+// Copyright 2017-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/overlay/overlay_whitelist.h
+++ b/overlay/overlay_whitelist.h
@@ -1,4 +1,4 @@
-// Copyright 2017-2021 The Mumble Developers. All rights reserved.
+// Copyright 2017-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/overlay/scripts/build_overlay_xcompile.cmd
+++ b/overlay/scripts/build_overlay_xcompile.cmd
@@ -1,4 +1,4 @@
-:: Copyright 2020-2021 The Mumble Developers. All rights reserved.
+:: Copyright 2020-2022 The Mumble Developers. All rights reserved.
 :: Use of this source code is governed by a BSD-style license
 :: that can be found in the LICENSE file at the root of the
 :: Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/overlay/util.h
+++ b/overlay/util.h
@@ -1,4 +1,4 @@
-// Copyright 2017-2021 The Mumble Developers. All rights reserved.
+// Copyright 2017-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/overlay_gl/CMakeLists.txt
+++ b/overlay_gl/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 The Mumble Developers. All rights reserved.
+# Copyright 2020-2022 The Mumble Developers. All rights reserved.
 # Use of this source code is governed by a BSD-style license
 # that can be found in the LICENSE file at the root of the
 # Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/overlay_gl/avail_mac.h
+++ b/overlay_gl/avail_mac.h
@@ -1,4 +1,4 @@
-// Copyright 2015-2021 The Mumble Developers. All rights reserved.
+// Copyright 2015-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/overlay_gl/avail_mac.pl
+++ b/overlay_gl/avail_mac.pl
@@ -1,6 +1,6 @@
 #!/usr/bin/perl
 
-# Copyright 2015-2021 The Mumble Developers. All rights reserved.
+# Copyright 2015-2022 The Mumble Developers. All rights reserved.
 # Use of this source code is governed by a BSD-style license
 # that can be found in the LICENSE file at the root of the
 # Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/overlay_gl/init_mac.c
+++ b/overlay_gl/init_mac.c
@@ -1,4 +1,4 @@
-// Copyright 2015-2021 The Mumble Developers. All rights reserved.
+// Copyright 2015-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/overlay_gl/init_unix.c
+++ b/overlay_gl/init_unix.c
@@ -1,4 +1,4 @@
-// Copyright 2015-2021 The Mumble Developers. All rights reserved.
+// Copyright 2015-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/overlay_gl/overlay.c
+++ b/overlay_gl/overlay.c
@@ -1,4 +1,4 @@
-// Copyright 2007-2021 The Mumble Developers. All rights reserved.
+// Copyright 2007-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/plugins/CMakeLists.txt
+++ b/plugins/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 The Mumble Developers. All rights reserved.
+# Copyright 2020-2022 The Mumble Developers. All rights reserved.
 # Use of this source code is governed by a BSD-style license
 # that can be found in the LICENSE file at the root of the
 # Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/plugins/HostLinux.cpp
+++ b/plugins/HostLinux.cpp
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 The Mumble Developers. All rights reserved.
+// Copyright 2020-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/plugins/HostLinux.h
+++ b/plugins/HostLinux.h
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 The Mumble Developers. All rights reserved.
+// Copyright 2020-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/plugins/HostWindows.cpp
+++ b/plugins/HostWindows.cpp
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 The Mumble Developers. All rights reserved.
+// Copyright 2020-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/plugins/HostWindows.h
+++ b/plugins/HostWindows.h
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 The Mumble Developers. All rights reserved.
+// Copyright 2020-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/plugins/Module.cpp
+++ b/plugins/Module.cpp
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 The Mumble Developers. All rights reserved.
+// Copyright 2020-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/plugins/Module.h
+++ b/plugins/Module.h
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 The Mumble Developers. All rights reserved.
+// Copyright 2020-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/plugins/MumbleAPI_v_1_0_x.h
+++ b/plugins/MumbleAPI_v_1_0_x.h
@@ -1,4 +1,4 @@
-// Copyright 2021 The Mumble Developers. All rights reserved.
+// Copyright 2021-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/plugins/MumblePlugin_v_1_0_x.h
+++ b/plugins/MumblePlugin_v_1_0_x.h
@@ -1,4 +1,4 @@
-// Copyright 2021 The Mumble Developers. All rights reserved.
+// Copyright 2021-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/plugins/MumblePlugin_v_1_1_x.h
+++ b/plugins/MumblePlugin_v_1_1_x.h
@@ -1,4 +1,4 @@
-// Copyright 2021 The Mumble Developers. All rights reserved.
+// Copyright 2021-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/plugins/PluginComponents_v_1_0_x.h
+++ b/plugins/PluginComponents_v_1_0_x.h
@@ -1,4 +1,4 @@
-// Copyright 2021 The Mumble Developers. All rights reserved.
+// Copyright 2021-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/plugins/ProcessBase.cpp
+++ b/plugins/ProcessBase.cpp
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 The Mumble Developers. All rights reserved.
+// Copyright 2021-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/plugins/ProcessBase.h
+++ b/plugins/ProcessBase.h
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 The Mumble Developers. All rights reserved.
+// Copyright 2021-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/plugins/ProcessLinux.cpp
+++ b/plugins/ProcessLinux.cpp
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 The Mumble Developers. All rights reserved.
+// Copyright 2020-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/plugins/ProcessLinux.h
+++ b/plugins/ProcessLinux.h
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 The Mumble Developers. All rights reserved.
+// Copyright 2020-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/plugins/ProcessWindows.cpp
+++ b/plugins/ProcessWindows.cpp
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 The Mumble Developers. All rights reserved.
+// Copyright 2020-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/plugins/ProcessWindows.h
+++ b/plugins/ProcessWindows.h
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 The Mumble Developers. All rights reserved.
+// Copyright 2020-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/plugins/amongus/CMakeLists.txt
+++ b/plugins/amongus/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 The Mumble Developers. All rights reserved.
+# Copyright 2020-2022 The Mumble Developers. All rights reserved.
 # Use of this source code is governed by a BSD-style license
 # that can be found in the LICENSE file at the root of the
 # Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/plugins/amongus/Game.cpp
+++ b/plugins/amongus/Game.cpp
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 The Mumble Developers. All rights reserved.
+// Copyright 2020-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/plugins/amongus/Game.h
+++ b/plugins/amongus/Game.h
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 The Mumble Developers. All rights reserved.
+// Copyright 2020-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/plugins/amongus/amongus.cpp
+++ b/plugins/amongus/amongus.cpp
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 The Mumble Developers. All rights reserved.
+// Copyright 2020-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/plugins/amongus/structs.h
+++ b/plugins/amongus/structs.h
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 The Mumble Developers. All rights reserved.
+// Copyright 2020-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/plugins/aoc/CMakeLists.txt
+++ b/plugins/aoc/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 The Mumble Developers. All rights reserved.
+# Copyright 2020-2022 The Mumble Developers. All rights reserved.
 # Use of this source code is governed by a BSD-style license
 # that can be found in the LICENSE file at the root of the
 # Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/plugins/aoc/aoc.cpp
+++ b/plugins/aoc/aoc.cpp
@@ -1,4 +1,4 @@
-// Copyright 2009-2021 The Mumble Developers. All rights reserved.
+// Copyright 2009-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/plugins/arma2/CMakeLists.txt
+++ b/plugins/arma2/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 The Mumble Developers. All rights reserved.
+# Copyright 2020-2022 The Mumble Developers. All rights reserved.
 # Use of this source code is governed by a BSD-style license
 # that can be found in the LICENSE file at the root of the
 # Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/plugins/arma2/arma2.cpp
+++ b/plugins/arma2/arma2.cpp
@@ -1,4 +1,4 @@
-// Copyright 2010-2021 The Mumble Developers. All rights reserved.
+// Copyright 2010-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/plugins/bf1/CMakeLists.txt
+++ b/plugins/bf1/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 The Mumble Developers. All rights reserved.
+# Copyright 2020-2022 The Mumble Developers. All rights reserved.
 # Use of this source code is governed by a BSD-style license
 # that can be found in the LICENSE file at the root of the
 # Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/plugins/bf1/bf1.cpp
+++ b/plugins/bf1/bf1.cpp
@@ -1,4 +1,4 @@
-// Copyright 2016-2021 The Mumble Developers. All rights reserved.
+// Copyright 2016-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/plugins/bf1942/CMakeLists.txt
+++ b/plugins/bf1942/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 The Mumble Developers. All rights reserved.
+# Copyright 2020-2022 The Mumble Developers. All rights reserved.
 # Use of this source code is governed by a BSD-style license
 # that can be found in the LICENSE file at the root of the
 # Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/plugins/bf1942/bf1942.cpp
+++ b/plugins/bf1942/bf1942.cpp
@@ -1,4 +1,4 @@
-// Copyright 2010-2021 The Mumble Developers. All rights reserved.
+// Copyright 2010-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/plugins/bf2/CMakeLists.txt
+++ b/plugins/bf2/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 The Mumble Developers. All rights reserved.
+# Copyright 2020-2022 The Mumble Developers. All rights reserved.
 # Use of this source code is governed by a BSD-style license
 # that can be found in the LICENSE file at the root of the
 # Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/plugins/bf2/bf2.cpp
+++ b/plugins/bf2/bf2.cpp
@@ -1,4 +1,4 @@
-// Copyright 2005-2021 The Mumble Developers. All rights reserved.
+// Copyright 2005-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/plugins/bf2142/CMakeLists.txt
+++ b/plugins/bf2142/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 The Mumble Developers. All rights reserved.
+# Copyright 2020-2022 The Mumble Developers. All rights reserved.
 # Use of this source code is governed by a BSD-style license
 # that can be found in the LICENSE file at the root of the
 # Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/plugins/bf2142/bf2142.cpp
+++ b/plugins/bf2142/bf2142.cpp
@@ -1,4 +1,4 @@
-// Copyright 2009-2021 The Mumble Developers. All rights reserved.
+// Copyright 2009-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/plugins/bf3/CMakeLists.txt
+++ b/plugins/bf3/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 The Mumble Developers. All rights reserved.
+# Copyright 2020-2022 The Mumble Developers. All rights reserved.
 # Use of this source code is governed by a BSD-style license
 # that can be found in the LICENSE file at the root of the
 # Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/plugins/bf3/bf3.cpp
+++ b/plugins/bf3/bf3.cpp
@@ -1,4 +1,4 @@
-// Copyright 2011-2021 The Mumble Developers. All rights reserved.
+// Copyright 2011-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/plugins/bf4/CMakeLists.txt
+++ b/plugins/bf4/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 The Mumble Developers. All rights reserved.
+# Copyright 2020-2022 The Mumble Developers. All rights reserved.
 # Use of this source code is governed by a BSD-style license
 # that can be found in the LICENSE file at the root of the
 # Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/plugins/bf4/bf4.cpp
+++ b/plugins/bf4/bf4.cpp
@@ -1,4 +1,4 @@
-// Copyright 2016-2021 The Mumble Developers. All rights reserved.
+// Copyright 2016-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/plugins/bf4_x86/CMakeLists.txt
+++ b/plugins/bf4_x86/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 The Mumble Developers. All rights reserved.
+# Copyright 2020-2022 The Mumble Developers. All rights reserved.
 # Use of this source code is governed by a BSD-style license
 # that can be found in the LICENSE file at the root of the
 # Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/plugins/bf4_x86/bf4_x86.cpp
+++ b/plugins/bf4_x86/bf4_x86.cpp
@@ -1,4 +1,4 @@
-// Copyright 2016-2021 The Mumble Developers. All rights reserved.
+// Copyright 2016-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/plugins/bfbc2/CMakeLists.txt
+++ b/plugins/bfbc2/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 The Mumble Developers. All rights reserved.
+# Copyright 2020-2022 The Mumble Developers. All rights reserved.
 # Use of this source code is governed by a BSD-style license
 # that can be found in the LICENSE file at the root of the
 # Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/plugins/bfbc2/bfbc2.cpp
+++ b/plugins/bfbc2/bfbc2.cpp
@@ -1,4 +1,4 @@
-// Copyright 2010-2021 The Mumble Developers. All rights reserved.
+// Copyright 2010-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/plugins/bfheroes/CMakeLists.txt
+++ b/plugins/bfheroes/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 The Mumble Developers. All rights reserved.
+# Copyright 2020-2022 The Mumble Developers. All rights reserved.
 # Use of this source code is governed by a BSD-style license
 # that can be found in the LICENSE file at the root of the
 # Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/plugins/bfheroes/bfheroes.cpp
+++ b/plugins/bfheroes/bfheroes.cpp
@@ -1,4 +1,4 @@
-// Copyright 2009-2021 The Mumble Developers. All rights reserved.
+// Copyright 2009-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/plugins/blacklight/CMakeLists.txt
+++ b/plugins/blacklight/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 The Mumble Developers. All rights reserved.
+# Copyright 2020-2022 The Mumble Developers. All rights reserved.
 # Use of this source code is governed by a BSD-style license
 # that can be found in the LICENSE file at the root of the
 # Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/plugins/blacklight/blacklight.cpp
+++ b/plugins/blacklight/blacklight.cpp
@@ -1,4 +1,4 @@
-// Copyright 2012-2021 The Mumble Developers. All rights reserved.
+// Copyright 2012-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/plugins/borderlands/CMakeLists.txt
+++ b/plugins/borderlands/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 The Mumble Developers. All rights reserved.
+# Copyright 2020-2022 The Mumble Developers. All rights reserved.
 # Use of this source code is governed by a BSD-style license
 # that can be found in the LICENSE file at the root of the
 # Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/plugins/borderlands/borderlands.cpp
+++ b/plugins/borderlands/borderlands.cpp
@@ -1,4 +1,4 @@
-// Copyright 2010-2021 The Mumble Developers. All rights reserved.
+// Copyright 2010-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/plugins/borderlands2/CMakeLists.txt
+++ b/plugins/borderlands2/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 The Mumble Developers. All rights reserved.
+# Copyright 2020-2022 The Mumble Developers. All rights reserved.
 # Use of this source code is governed by a BSD-style license
 # that can be found in the LICENSE file at the root of the
 # Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/plugins/borderlands2/borderlands2.cpp
+++ b/plugins/borderlands2/borderlands2.cpp
@@ -1,4 +1,4 @@
-// Copyright 2013-2021 The Mumble Developers. All rights reserved.
+// Copyright 2013-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/plugins/breach/CMakeLists.txt
+++ b/plugins/breach/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 The Mumble Developers. All rights reserved.
+# Copyright 2020-2022 The Mumble Developers. All rights reserved.
 # Use of this source code is governed by a BSD-style license
 # that can be found in the LICENSE file at the root of the
 # Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/plugins/breach/breach.cpp
+++ b/plugins/breach/breach.cpp
@@ -1,4 +1,4 @@
-// Copyright 2011-2021 The Mumble Developers. All rights reserved.
+// Copyright 2011-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/plugins/cod2/CMakeLists.txt
+++ b/plugins/cod2/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 The Mumble Developers. All rights reserved.
+# Copyright 2020-2022 The Mumble Developers. All rights reserved.
 # Use of this source code is governed by a BSD-style license
 # that can be found in the LICENSE file at the root of the
 # Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/plugins/cod2/cod2.cpp
+++ b/plugins/cod2/cod2.cpp
@@ -1,4 +1,4 @@
-// Copyright 2008-2021 The Mumble Developers. All rights reserved.
+// Copyright 2008-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/plugins/cod4/CMakeLists.txt
+++ b/plugins/cod4/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 The Mumble Developers. All rights reserved.
+# Copyright 2020-2022 The Mumble Developers. All rights reserved.
 # Use of this source code is governed by a BSD-style license
 # that can be found in the LICENSE file at the root of the
 # Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/plugins/cod4/cod4.cpp
+++ b/plugins/cod4/cod4.cpp
@@ -1,4 +1,4 @@
-// Copyright 2008-2021 The Mumble Developers. All rights reserved.
+// Copyright 2008-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/plugins/cod5/CMakeLists.txt
+++ b/plugins/cod5/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 The Mumble Developers. All rights reserved.
+# Copyright 2020-2022 The Mumble Developers. All rights reserved.
 # Use of this source code is governed by a BSD-style license
 # that can be found in the LICENSE file at the root of the
 # Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/plugins/cod5/cod5.cpp
+++ b/plugins/cod5/cod5.cpp
@@ -1,4 +1,4 @@
-// Copyright 2008-2021 The Mumble Developers. All rights reserved.
+// Copyright 2008-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/plugins/codmw2/CMakeLists.txt
+++ b/plugins/codmw2/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 The Mumble Developers. All rights reserved.
+# Copyright 2020-2022 The Mumble Developers. All rights reserved.
 # Use of this source code is governed by a BSD-style license
 # that can be found in the LICENSE file at the root of the
 # Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/plugins/codmw2/codmw2.cpp
+++ b/plugins/codmw2/codmw2.cpp
@@ -1,4 +1,4 @@
-// Copyright 2009-2021 The Mumble Developers. All rights reserved.
+// Copyright 2009-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/plugins/codmw2so/CMakeLists.txt
+++ b/plugins/codmw2so/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 The Mumble Developers. All rights reserved.
+# Copyright 2020-2022 The Mumble Developers. All rights reserved.
 # Use of this source code is governed by a BSD-style license
 # that can be found in the LICENSE file at the root of the
 # Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/plugins/codmw2so/codmw2so.cpp
+++ b/plugins/codmw2so/codmw2so.cpp
@@ -1,4 +1,4 @@
-// Copyright 2009-2021 The Mumble Developers. All rights reserved.
+// Copyright 2009-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/plugins/cs/CMakeLists.txt
+++ b/plugins/cs/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 The Mumble Developers. All rights reserved.
+# Copyright 2020-2022 The Mumble Developers. All rights reserved.
 # Use of this source code is governed by a BSD-style license
 # that can be found in the LICENSE file at the root of the
 # Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/plugins/cs/cs.cpp
+++ b/plugins/cs/cs.cpp
@@ -1,4 +1,4 @@
-// Copyright 2010-2021 The Mumble Developers. All rights reserved.
+// Copyright 2010-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/plugins/css/CMakeLists.txt
+++ b/plugins/css/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 The Mumble Developers. All rights reserved.
+# Copyright 2020-2022 The Mumble Developers. All rights reserved.
 # Use of this source code is governed by a BSD-style license
 # that can be found in the LICENSE file at the root of the
 # Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/plugins/deadLockPlugin/CMakeLists.txt
+++ b/plugins/deadLockPlugin/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright 2021 The Mumble Developers. All rights reserved.
+# Copyright 2021-2022 The Mumble Developers. All rights reserved.
 # Use of this source code is governed by a BSD-style license
 # that can be found in the LICENSE file at the root of the
 # Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/plugins/deadLockPlugin/deadLockPlugin.cpp
+++ b/plugins/deadLockPlugin/deadLockPlugin.cpp
@@ -1,4 +1,4 @@
-// Copyright 2021 The Mumble Developers. All rights reserved.
+// Copyright 2021-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/plugins/dods/CMakeLists.txt
+++ b/plugins/dods/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 The Mumble Developers. All rights reserved.
+# Copyright 2020-2022 The Mumble Developers. All rights reserved.
 # Use of this source code is governed by a BSD-style license
 # that can be found in the LICENSE file at the root of the
 # Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/plugins/dys/CMakeLists.txt
+++ b/plugins/dys/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 The Mumble Developers. All rights reserved.
+# Copyright 2020-2022 The Mumble Developers. All rights reserved.
 # Use of this source code is governed by a BSD-style license
 # that can be found in the LICENSE file at the root of the
 # Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/plugins/dys/dys.cpp
+++ b/plugins/dys/dys.cpp
@@ -1,4 +1,4 @@
-// Copyright 2009-2021 The Mumble Developers. All rights reserved.
+// Copyright 2009-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/plugins/etqw/CMakeLists.txt
+++ b/plugins/etqw/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 The Mumble Developers. All rights reserved.
+# Copyright 2020-2022 The Mumble Developers. All rights reserved.
 # Use of this source code is governed by a BSD-style license
 # that can be found in the LICENSE file at the root of the
 # Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/plugins/etqw/etqw.cpp
+++ b/plugins/etqw/etqw.cpp
@@ -1,4 +1,4 @@
-// Copyright 2009-2021 The Mumble Developers. All rights reserved.
+// Copyright 2009-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/plugins/ffxiv/CMakeLists.txt
+++ b/plugins/ffxiv/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 The Mumble Developers. All rights reserved.
+# Copyright 2020-2022 The Mumble Developers. All rights reserved.
 # Use of this source code is governed by a BSD-style license
 # that can be found in the LICENSE file at the root of the
 # Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/plugins/ffxiv/ffxiv.cpp
+++ b/plugins/ffxiv/ffxiv.cpp
@@ -1,4 +1,4 @@
-// Copyright 2016-2021 The Mumble Developers. All rights reserved.
+// Copyright 2016-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/plugins/ffxiv_x64/CMakeLists.txt
+++ b/plugins/ffxiv_x64/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 The Mumble Developers. All rights reserved.
+# Copyright 2020-2022 The Mumble Developers. All rights reserved.
 # Use of this source code is governed by a BSD-style license
 # that can be found in the LICENSE file at the root of the
 # Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/plugins/gmod/CMakeLists.txt
+++ b/plugins/gmod/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 The Mumble Developers. All rights reserved.
+# Copyright 2020-2022 The Mumble Developers. All rights reserved.
 # Use of this source code is governed by a BSD-style license
 # that can be found in the LICENSE file at the root of the
 # Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/plugins/gmod/gmod.cpp
+++ b/plugins/gmod/gmod.cpp
@@ -1,4 +1,4 @@
-// Copyright 2009-2021 The Mumble Developers. All rights reserved.
+// Copyright 2009-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/plugins/gtaiv/CMakeLists.txt
+++ b/plugins/gtaiv/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 The Mumble Developers. All rights reserved.
+# Copyright 2020-2022 The Mumble Developers. All rights reserved.
 # Use of this source code is governed by a BSD-style license
 # that can be found in the LICENSE file at the root of the
 # Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/plugins/gtaiv/gtaiv.cpp
+++ b/plugins/gtaiv/gtaiv.cpp
@@ -1,4 +1,4 @@
-// Copyright 2011-2021 The Mumble Developers. All rights reserved.
+// Copyright 2011-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/plugins/gtasa/CMakeLists.txt
+++ b/plugins/gtasa/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 The Mumble Developers. All rights reserved.
+# Copyright 2020-2022 The Mumble Developers. All rights reserved.
 # Use of this source code is governed by a BSD-style license
 # that can be found in the LICENSE file at the root of the
 # Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/plugins/gtasa/gtasa.cpp
+++ b/plugins/gtasa/gtasa.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2021 The Mumble Developers. All rights reserved.
+// Copyright 2019-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/plugins/gtav/CMakeLists.txt
+++ b/plugins/gtav/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 The Mumble Developers. All rights reserved.
+# Copyright 2020-2022 The Mumble Developers. All rights reserved.
 # Use of this source code is governed by a BSD-style license
 # that can be found in the LICENSE file at the root of the
 # Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/plugins/gtav/Game.cpp
+++ b/plugins/gtav/Game.cpp
@@ -1,4 +1,4 @@
-// Copyright 2021 The Mumble Developers. All rights reserved.
+// Copyright 2021-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/plugins/gtav/Game.h
+++ b/plugins/gtav/Game.h
@@ -1,4 +1,4 @@
-// Copyright 2021 The Mumble Developers. All rights reserved.
+// Copyright 2021-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/plugins/gtav/gtav.cpp
+++ b/plugins/gtav/gtav.cpp
@@ -1,4 +1,4 @@
-// Copyright 2016-2021 The Mumble Developers. All rights reserved.
+// Copyright 2016-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/plugins/gw/CMakeLists.txt
+++ b/plugins/gw/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 The Mumble Developers. All rights reserved.
+# Copyright 2020-2022 The Mumble Developers. All rights reserved.
 # Use of this source code is governed by a BSD-style license
 # that can be found in the LICENSE file at the root of the
 # Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/plugins/gw/gw.cpp
+++ b/plugins/gw/gw.cpp
@@ -1,4 +1,4 @@
-// Copyright 2012-2021 The Mumble Developers. All rights reserved.
+// Copyright 2012-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/plugins/hl2dm/CMakeLists.txt
+++ b/plugins/hl2dm/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 The Mumble Developers. All rights reserved.
+# Copyright 2020-2022 The Mumble Developers. All rights reserved.
 # Use of this source code is governed by a BSD-style license
 # that can be found in the LICENSE file at the root of the
 # Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/plugins/insurgency/CMakeLists.txt
+++ b/plugins/insurgency/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 The Mumble Developers. All rights reserved.
+# Copyright 2020-2022 The Mumble Developers. All rights reserved.
 # Use of this source code is governed by a BSD-style license
 # that can be found in the LICENSE file at the root of the
 # Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/plugins/insurgency/insurgency.cpp
+++ b/plugins/insurgency/insurgency.cpp
@@ -1,4 +1,4 @@
-// Copyright 2009-2021 The Mumble Developers. All rights reserved.
+// Copyright 2009-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/plugins/jc2/CMakeLists.txt
+++ b/plugins/jc2/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 The Mumble Developers. All rights reserved.
+# Copyright 2020-2022 The Mumble Developers. All rights reserved.
 # Use of this source code is governed by a BSD-style license
 # that can be found in the LICENSE file at the root of the
 # Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/plugins/jc2/jc2.cpp
+++ b/plugins/jc2/jc2.cpp
@@ -1,4 +1,4 @@
-// Copyright 2012-2021 The Mumble Developers. All rights reserved.
+// Copyright 2012-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/plugins/l4d/CMakeLists.txt
+++ b/plugins/l4d/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 The Mumble Developers. All rights reserved.
+# Copyright 2020-2022 The Mumble Developers. All rights reserved.
 # Use of this source code is governed by a BSD-style license
 # that can be found in the LICENSE file at the root of the
 # Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/plugins/l4d2/CMakeLists.txt
+++ b/plugins/l4d2/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 The Mumble Developers. All rights reserved.
+# Copyright 2020-2022 The Mumble Developers. All rights reserved.
 # Use of this source code is governed by a BSD-style license
 # that can be found in the LICENSE file at the root of the
 # Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/plugins/link/CMakeLists.txt
+++ b/plugins/link/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 The Mumble Developers. All rights reserved.
+# Copyright 2020-2022 The Mumble Developers. All rights reserved.
 # Use of this source code is governed by a BSD-style license
 # that can be found in the LICENSE file at the root of the
 # Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/plugins/link/LinkedMem.h
+++ b/plugins/link/LinkedMem.h
@@ -1,4 +1,4 @@
-// Copyright 2021 The Mumble Developers. All rights reserved.
+// Copyright 2021-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/plugins/link/SharedMemory.cpp
+++ b/plugins/link/SharedMemory.cpp
@@ -1,4 +1,4 @@
-// Copyright 2021 The Mumble Developers. All rights reserved.
+// Copyright 2021-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/plugins/link/SharedMemory.h
+++ b/plugins/link/SharedMemory.h
@@ -1,4 +1,4 @@
-// Copyright 2021 The Mumble Developers. All rights reserved.
+// Copyright 2021-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/plugins/link/link.cpp
+++ b/plugins/link/link.cpp
@@ -1,4 +1,4 @@
-// Copyright 2008-2021 The Mumble Developers. All rights reserved.
+// Copyright 2007-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/plugins/link/link_tester.cpp
+++ b/plugins/link/link_tester.cpp
@@ -1,4 +1,4 @@
-// Copyright 2021 The Mumble Developers. All rights reserved.
+// Copyright 2021-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/plugins/lol/CMakeLists.txt
+++ b/plugins/lol/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 The Mumble Developers. All rights reserved.
+# Copyright 2020-2022 The Mumble Developers. All rights reserved.
 # Use of this source code is governed by a BSD-style license
 # that can be found in the LICENSE file at the root of the
 # Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/plugins/lol/lol.cpp
+++ b/plugins/lol/lol.cpp
@@ -1,4 +1,4 @@
-// Copyright 2012-2021 The Mumble Developers. All rights reserved.
+// Copyright 2012-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/plugins/lotro/CMakeLists.txt
+++ b/plugins/lotro/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 The Mumble Developers. All rights reserved.
+# Copyright 2020-2022 The Mumble Developers. All rights reserved.
 # Use of this source code is governed by a BSD-style license
 # that can be found in the LICENSE file at the root of the
 # Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/plugins/lotro/lotro.cpp
+++ b/plugins/lotro/lotro.cpp
@@ -1,4 +1,4 @@
-// Copyright 2010-2021 The Mumble Developers. All rights reserved.
+// Copyright 2010-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/plugins/mumble_legacy_plugin.h
+++ b/plugins/mumble_legacy_plugin.h
@@ -1,4 +1,4 @@
-// Copyright 2021 The Mumble Developers. All rights reserved.
+// Copyright 2021-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/plugins/mumble_positional_audio_linux.h
+++ b/plugins/mumble_positional_audio_linux.h
@@ -1,4 +1,4 @@
-// Copyright 2021 The Mumble Developers. All rights reserved.
+// Copyright 2021-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/plugins/mumble_positional_audio_main.h
+++ b/plugins/mumble_positional_audio_main.h
@@ -1,4 +1,4 @@
-// Copyright 2021 The Mumble Developers. All rights reserved.
+// Copyright 2021-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/plugins/mumble_positional_audio_utils.h
+++ b/plugins/mumble_positional_audio_utils.h
@@ -1,4 +1,4 @@
-// Copyright 2021 The Mumble Developers. All rights reserved.
+// Copyright 2021-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/plugins/mumble_positional_audio_win32.h
+++ b/plugins/mumble_positional_audio_win32.h
@@ -1,4 +1,4 @@
-// Copyright 2021 The Mumble Developers. All rights reserved.
+// Copyright 2021-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/plugins/mumble_positional_audio_win32_internals.h
+++ b/plugins/mumble_positional_audio_win32_internals.h
@@ -1,4 +1,4 @@
-// Copyright 2021 The Mumble Developers. All rights reserved.
+// Copyright 2021-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/plugins/null_plugin.cpp
+++ b/plugins/null_plugin.cpp
@@ -1,4 +1,4 @@
-// Copyright 2013-2021 The Mumble Developers. All rights reserved.
+// Copyright 2013-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/plugins/ql/CMakeLists.txt
+++ b/plugins/ql/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 The Mumble Developers. All rights reserved.
+# Copyright 2020-2022 The Mumble Developers. All rights reserved.
 # Use of this source code is governed by a BSD-style license
 # that can be found in the LICENSE file at the root of the
 # Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/plugins/ql/ql.cpp
+++ b/plugins/ql/ql.cpp
@@ -1,4 +1,4 @@
-// Copyright 2016-2021 The Mumble Developers. All rights reserved.
+// Copyright 2016-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/plugins/rl/CMakeLists.txt
+++ b/plugins/rl/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 The Mumble Developers. All rights reserved.
+# Copyright 2020-2022 The Mumble Developers. All rights reserved.
 # Use of this source code is governed by a BSD-style license
 # that can be found in the LICENSE file at the root of the
 # Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/plugins/rl/rl.cpp
+++ b/plugins/rl/rl.cpp
@@ -1,4 +1,4 @@
-// Copyright 2018-2021 The Mumble Developers. All rights reserved.
+// Copyright 2018-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/plugins/se/CMakeLists.txt
+++ b/plugins/se/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 The Mumble Developers. All rights reserved.
+# Copyright 2020-2022 The Mumble Developers. All rights reserved.
 # Use of this source code is governed by a BSD-style license
 # that can be found in the LICENSE file at the root of the
 # Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/plugins/se/client.h
+++ b/plugins/se/client.h
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 The Mumble Developers. All rights reserved.
+// Copyright 2020-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/plugins/se/common.h
+++ b/plugins/se/common.h
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 The Mumble Developers. All rights reserved.
+// Copyright 2020-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/plugins/se/engine.h
+++ b/plugins/se/engine.h
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 The Mumble Developers. All rights reserved.
+// Copyright 2020-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/plugins/se/se.cpp
+++ b/plugins/se/se.cpp
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 The Mumble Developers. All rights reserved.
+// Copyright 2020-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/plugins/sr/CMakeLists.txt
+++ b/plugins/sr/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 The Mumble Developers. All rights reserved.
+# Copyright 2020-2022 The Mumble Developers. All rights reserved.
 # Use of this source code is governed by a BSD-style license
 # that can be found in the LICENSE file at the root of the
 # Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/plugins/sr/sr.cpp
+++ b/plugins/sr/sr.cpp
@@ -1,4 +1,4 @@
-// Copyright 2013-2021 The Mumble Developers. All rights reserved.
+// Copyright 2013-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/plugins/sto/CMakeLists.txt
+++ b/plugins/sto/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 The Mumble Developers. All rights reserved.
+# Copyright 2020-2022 The Mumble Developers. All rights reserved.
 # Use of this source code is governed by a BSD-style license
 # that can be found in the LICENSE file at the root of the
 # Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/plugins/testPlugin/CMakeLists.txt
+++ b/plugins/testPlugin/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright 2021 The Mumble Developers. All rights reserved.
+# Copyright 2021-2022 The Mumble Developers. All rights reserved.
 # Use of this source code is governed by a BSD-style license
 # that can be found in the LICENSE file at the root of the
 # Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/plugins/testPlugin/testPlugin.cpp
+++ b/plugins/testPlugin/testPlugin.cpp
@@ -1,4 +1,4 @@
-// Copyright 2021 The Mumble Developers. All rights reserved.
+// Copyright 2021-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/plugins/tf2/CMakeLists.txt
+++ b/plugins/tf2/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 The Mumble Developers. All rights reserved.
+# Copyright 2020-2022 The Mumble Developers. All rights reserved.
 # Use of this source code is governed by a BSD-style license
 # that can be found in the LICENSE file at the root of the
 # Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/plugins/ut2004/CMakeLists.txt
+++ b/plugins/ut2004/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 The Mumble Developers. All rights reserved.
+# Copyright 2020-2022 The Mumble Developers. All rights reserved.
 # Use of this source code is governed by a BSD-style license
 # that can be found in the LICENSE file at the root of the
 # Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/plugins/ut2004/ut2004.cpp
+++ b/plugins/ut2004/ut2004.cpp
@@ -1,4 +1,4 @@
-// Copyright 2010-2021 The Mumble Developers. All rights reserved.
+// Copyright 2010-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/plugins/ut3/CMakeLists.txt
+++ b/plugins/ut3/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 The Mumble Developers. All rights reserved.
+# Copyright 2020-2022 The Mumble Developers. All rights reserved.
 # Use of this source code is governed by a BSD-style license
 # that can be found in the LICENSE file at the root of the
 # Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/plugins/ut3/ut3.cpp
+++ b/plugins/ut3/ut3.cpp
@@ -1,4 +1,4 @@
-// Copyright 2010-2021 The Mumble Developers. All rights reserved.
+// Copyright 2010-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/plugins/ut99/CMakeLists.txt
+++ b/plugins/ut99/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 The Mumble Developers. All rights reserved.
+# Copyright 2020-2022 The Mumble Developers. All rights reserved.
 # Use of this source code is governed by a BSD-style license
 # that can be found in the LICENSE file at the root of the
 # Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/plugins/ut99/ut99.cpp
+++ b/plugins/ut99/ut99.cpp
@@ -1,4 +1,4 @@
-// Copyright 2012-2021 The Mumble Developers. All rights reserved.
+// Copyright 2012-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/plugins/wolfet/CMakeLists.txt
+++ b/plugins/wolfet/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 The Mumble Developers. All rights reserved.
+# Copyright 2020-2022 The Mumble Developers. All rights reserved.
 # Use of this source code is governed by a BSD-style license
 # that can be found in the LICENSE file at the root of the
 # Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/plugins/wolfet/wolfet.cpp
+++ b/plugins/wolfet/wolfet.cpp
@@ -1,4 +1,4 @@
-// Copyright 2008-2021 The Mumble Developers. All rights reserved.
+// Copyright 2008-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/plugins/wow/CMakeLists.txt
+++ b/plugins/wow/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 The Mumble Developers. All rights reserved.
+# Copyright 2020-2022 The Mumble Developers. All rights reserved.
 # Use of this source code is governed by a BSD-style license
 # that can be found in the LICENSE file at the root of the
 # Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/plugins/wow/wow.cpp
+++ b/plugins/wow/wow.cpp
@@ -1,4 +1,4 @@
-// Copyright 2009-2021 The Mumble Developers. All rights reserved.
+// Copyright 2009-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/plugins/wow_x64/CMakeLists.txt
+++ b/plugins/wow_x64/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 The Mumble Developers. All rights reserved.
+# Copyright 2020-2022 The Mumble Developers. All rights reserved.
 # Use of this source code is governed by a BSD-style license
 # that can be found in the LICENSE file at the root of the
 # Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/plugins/wow_x64/wow_x64.cpp
+++ b/plugins/wow_x64/wow_x64.cpp
@@ -1,4 +1,4 @@
-// Copyright 2016-2021 The Mumble Developers. All rights reserved.
+// Copyright 2016-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/scripts/backportTranslations.py
+++ b/scripts/backportTranslations.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 #
-# Copyright 2021 The Mumble Developers. All rights reserved.
+# Copyright 2021-2022 The Mumble Developers. All rights reserved.
 # Use of this source code is governed by a BSD-style license
 # that can be found in the LICENSE file at the root of the
 # Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/scripts/commitMessage/CommitMessage.py
+++ b/scripts/commitMessage/CommitMessage.py
@@ -1,4 +1,4 @@
-# Copyright 2021 The Mumble Developers. All rights reserved.
+# Copyright 2021-2022 The Mumble Developers. All rights reserved.
 # Use of this source code is governed by a BSD-style license
 # that can be found in the LICENSE file at the root of the
 # Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/scripts/development/IconSync.cpp
+++ b/scripts/development/IconSync.cpp
@@ -1,4 +1,4 @@
-// Copyright 2013-2021 The Mumble Developers. All rights reserved.
+// Copyright 2013-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/scripts/docker-compose.yml
+++ b/scripts/docker-compose.yml
@@ -1,3 +1,8 @@
+# Copyright 2021-2022 The Mumble Developers. All rights reserved.
+# Use of this source code is governed by a BSD-style license
+# that can be found in the LICENSE file at the root of the
+# Mumble source tree or at <https://www.mumble.info/LICENSE>.
+
 version: '3'
 services:
   mumble-server:

--- a/scripts/extract-emojione-flags.py
+++ b/scripts/extract-emojione-flags.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 #
-# Copyright 2015-2021 The Mumble Developers. All rights reserved.
+# Copyright 2015-2022 The Mumble Developers. All rights reserved.
 # Use of this source code is governed by a BSD-style license
 # that can be found in the LICENSE file at the root of the
 # Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/scripts/generate-AUTHORS.py
+++ b/scripts/generate-AUTHORS.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 #
-# Copyright 2016-2021 The Mumble Developers. All rights reserved.
+# Copyright 2016-2022 The Mumble Developers. All rights reserved.
 # Use of this source code is governed by a BSD-style license
 # that can be found in the LICENSE file at the root of the
 # Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/scripts/generate-ApplicationPalette-class.py
+++ b/scripts/generate-ApplicationPalette-class.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 #
-# Copyright 2014-2021 The Mumble Developers. All rights reserved.
+# Copyright 2014-2022 The Mumble Developers. All rights reserved.
 # Use of this source code is governed by a BSD-style license
 # that can be found in the LICENSE file at the root of the
 # Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/scripts/generate-CHANGES.py
+++ b/scripts/generate-CHANGES.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 #
-# Copyright 2016-2021 The Mumble Developers. All rights reserved.
+# Copyright 2016-2022 The Mumble Developers. All rights reserved.
 # Use of this source code is governed by a BSD-style license
 # that can be found in the LICENSE file at the root of the
 # Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/scripts/generate-cipherinfo.py
+++ b/scripts/generate-cipherinfo.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 #
-# Copyright 2015-2021 The Mumble Developers. All rights reserved.
+# Copyright 2015-2022 The Mumble Developers. All rights reserved.
 # Use of this source code is governed by a BSD-style license
 # that can be found in the LICENSE file at the root of the
 # Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/scripts/generate-ffdhe.py
+++ b/scripts/generate-ffdhe.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 #
-# Copyright 2017-2021 The Mumble Developers. All rights reserved.
+# Copyright 2017-2022 The Mumble Developers. All rights reserved.
 # Use of this source code is governed by a BSD-style license
 # that can be found in the LICENSE file at the root of the
 # Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/scripts/generate-mumble_qt-qrc.py
+++ b/scripts/generate-mumble_qt-qrc.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 #
-# Copyright 2015-2021 The Mumble Developers. All rights reserved.
+# Copyright 2015-2022 The Mumble Developers. All rights reserved.
 # Use of this source code is governed by a BSD-style license
 # that can be found in the LICENSE file at the root of the
 # Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/scripts/generate-qrc.py
+++ b/scripts/generate-qrc.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-# Copyright 2015-2021 The Mumble Developers. All rights reserved.
+# Copyright 2015-2022 The Mumble Developers. All rights reserved.
 # Use of this source code is governed by a BSD-style license
 # that can be found in the LICENSE file at the root of the
 # Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/scripts/generateChangelog.py
+++ b/scripts/generateChangelog.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 #
-# Copyright 2021 The Mumble Developers. All rights reserved.
+# Copyright 2021-2022 The Mumble Developers. All rights reserved.
 # Use of this source code is governed by a BSD-style license
 # that can be found in the LICENSE file at the root of the
 # Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/scripts/generateIceWrapper.py
+++ b/scripts/generateIceWrapper.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-# Copyright 2020-2021 The Mumble Developers. All rights reserved.
+# Copyright 2020-2022 The Mumble Developers. All rights reserved.
 # Use of this source code is governed by a BSD-style license
 # that can be found in the LICENSE file at the root of the
 # Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/scripts/generate_cmake_options_docs.py
+++ b/scripts/generate_cmake_options_docs.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 #
-# Copyright 2020-2021 The Mumble Developers. All rights reserved.
+# Copyright 2020-2022 The Mumble Developers. All rights reserved.
 # Use of this source code is governed by a BSD-style license
 # that can be found in the LICENSE file at the root of the
 # Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/scripts/git2cl.pl
+++ b/scripts/git2cl.pl
@@ -1,6 +1,6 @@
 #! /usr/bin/perl -w
 #
-# Copyright 2009-2021 The Mumble Developers. All rights reserved.
+# Copyright 2009-2022 The Mumble Developers. All rights reserved.
 # Use of this source code is governed by a BSD-style license
 # that can be found in the LICENSE file at the root of the
 # Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/scripts/mkflags.py
+++ b/scripts/mkflags.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 #
-# Copyright 2016-2021 The Mumble Developers. All rights reserved.
+# Copyright 2016-2022 The Mumble Developers. All rights reserved.
 # Use of this source code is governed by a BSD-style license
 # that can be found in the LICENSE file at the root of the
 # Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/scripts/mkini-win32.bat
+++ b/scripts/mkini-win32.bat
@@ -1,4 +1,4 @@
-:: Copyright 2012-2021 The Mumble Developers. All rights reserved.
+:: Copyright 2012-2022 The Mumble Developers. All rights reserved.
 :: Use of this source code is governed by a BSD-style license
 :: that can be found in the LICENSE file at the root of the
 :: Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/scripts/mkini.sh
+++ b/scripts/mkini.sh
@@ -1,6 +1,6 @@
 #! /bin/bash
 #
-# Copyright 2009-2021 The Mumble Developers. All rights reserved.
+# Copyright 2009-2022 The Mumble Developers. All rights reserved.
 # Use of this source code is governed by a BSD-style license
 # that can be found in the LICENSE file at the root of the
 # Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/scripts/mklic.pl
+++ b/scripts/mklic.pl
@@ -1,6 +1,6 @@
 #! /usr/bin/perl
 #
-# Copyright 2005-2021 The Mumble Developers. All rights reserved.
+# Copyright 2005-2022 The Mumble Developers. All rights reserved.
 # Use of this source code is governed by a BSD-style license
 # that can be found in the LICENSE file at the root of the
 # Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/scripts/mumble-version.py
+++ b/scripts/mumble-version.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 #
-# Copyright 2019-2021 The Mumble Developers. All rights reserved.
+# Copyright 2019-2022 The Mumble Developers. All rights reserved.
 # Use of this source code is governed by a BSD-style license
 # that can be found in the LICENSE file at the root of the
 # Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/scripts/murmur.init
+++ b/scripts/murmur.init
@@ -1,6 +1,6 @@
 #! /bin/sh
 
-# Copyright 2007-2021 The Mumble Developers. All rights reserved.
+# Copyright 2007-2022 The Mumble Developers. All rights reserved.
 # Use of this source code is governed by a BSD-style license
 # that can be found in the LICENSE file at the root of the
 # Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/scripts/rcc-depends.py
+++ b/scripts/rcc-depends.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 #
-# Copyright 2015-2021 The Mumble Developers. All rights reserved.
+# Copyright 2015-2022 The Mumble Developers. All rights reserved.
 # Use of this source code is governed by a BSD-style license
 # that can be found in the LICENSE file at the root of the
 # Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/scripts/release.pl
+++ b/scripts/release.pl
@@ -1,6 +1,6 @@
 #! /usr/bin/perl -w
 #
-# Copyright 2005-2021 The Mumble Developers. All rights reserved.
+# Copyright 2005-2022 The Mumble Developers. All rights reserved.
 # Use of this source code is governed by a BSD-style license
 # that can be found in the LICENSE file at the root of the
 # Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/scripts/runClangFormat.sh
+++ b/scripts/runClangFormat.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# Copyright 2020-2021 The Mumble Developers. All rights reserved.
+# Copyright 2020-2022 The Mumble Developers. All rights reserved.
 # Use of this source code is governed by a BSD-style license
 # that can be found in the LICENSE file at the root of the
 # Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/scripts/server/dbus/ListUsers.cs
+++ b/scripts/server/dbus/ListUsers.cs
@@ -1,4 +1,4 @@
-// Copyright 2013-2021 The Mumble Developers. All rights reserved.
+// Copyright 2013-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/scripts/server/dbus/dbusauth.pl
+++ b/scripts/server/dbus/dbusauth.pl
@@ -1,6 +1,6 @@
 #! /usr/bin/perl
 
-# Copyright 2013-2021 The Mumble Developers. All rights reserved.
+# Copyright 2013-2022 The Mumble Developers. All rights reserved.
 # Use of this source code is governed by a BSD-style license
 # that can be found in the LICENSE file at the root of the
 # Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/scripts/server/dbus/murmur.pl
+++ b/scripts/server/dbus/murmur.pl
@@ -1,6 +1,6 @@
 #! /usr/bin/perl
 
-# Copyright 2013-2021 The Mumble Developers. All rights reserved.
+# Copyright 2013-2022 The Mumble Developers. All rights reserved.
 # Use of this source code is governed by a BSD-style license
 # that can be found in the LICENSE file at the root of the
 # Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/scripts/server/dbus/weblist.pl
+++ b/scripts/server/dbus/weblist.pl
@@ -1,6 +1,6 @@
 #! /usr/bin/perl
 
-# Copyright 2013-2021 The Mumble Developers. All rights reserved.
+# Copyright 2013-2022 The Mumble Developers. All rights reserved.
 # Use of this source code is governed by a BSD-style license
 # that can be found in the LICENSE file at the root of the
 # Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/scripts/server/ice/mumble-auth.py
+++ b/scripts/server/ice/mumble-auth.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 
-# Copyright 2013-2021 The Mumble Developers. All rights reserved.
+# Copyright 2013-2022 The Mumble Developers. All rights reserved.
 # Use of this source code is governed by a BSD-style license
 # that can be found in the LICENSE file at the root of the
 # Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/scripts/server/ice/rubytest.rb
+++ b/scripts/server/ice/rubytest.rb
@@ -1,6 +1,6 @@
 #!/usr/bin/env ruby
 
-# Copyright 2013-2021 The Mumble Developers. All rights reserved.
+# Copyright 2013-2022 The Mumble Developers. All rights reserved.
 # Use of this source code is governed by a BSD-style license
 # that can be found in the LICENSE file at the root of the
 # Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/scripts/server/ice/testauth.py
+++ b/scripts/server/ice/testauth.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 
-# Copyright 2013-2021 The Mumble Developers. All rights reserved.
+# Copyright 2013-2022 The Mumble Developers. All rights reserved.
 # Use of this source code is governed by a BSD-style license
 # that can be found in the LICENSE file at the root of the
 # Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/scripts/server/ice/testcallback.py
+++ b/scripts/server/ice/testcallback.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 
-# Copyright 2013-2021 The Mumble Developers. All rights reserved.
+# Copyright 2013-2022 The Mumble Developers. All rights reserved.
 # Use of this source code is governed by a BSD-style license
 # that can be found in the LICENSE file at the root of the
 # Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/scripts/server/ice/testdynamic.py
+++ b/scripts/server/ice/testdynamic.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 
-# Copyright 2013-2021 The Mumble Developers. All rights reserved.
+# Copyright 2013-2022 The Mumble Developers. All rights reserved.
 # Use of this source code is governed by a BSD-style license
 # that can be found in the LICENSE file at the root of the
 # Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/scripts/transtate.py
+++ b/scripts/transtate.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 #
-# Copyright 2012-2021 The Mumble Developers. All rights reserved.
+# Copyright 2012-2022 The Mumble Developers. All rights reserved.
 # Use of this source code is governed by a BSD-style license
 # that can be found in the LICENSE file at the root of the
 # Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/scripts/updateLicenseHeaders.py
+++ b/scripts/updateLicenseHeaders.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-# Copyright 2021 The Mumble Developers. All rights reserved.
+# Copyright 2021-2022 The Mumble Developers. All rights reserved.
 # Use of this source code is governed by a BSD-style license
 # that can be found in the LICENSE file at the root of the
 # Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/scripts/updatetranslations.py
+++ b/scripts/updatetranslations.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 #
-# Copyright 2021 The Mumble Developers. All rights reserved.
+# Copyright 2021-2022 The Mumble Developers. All rights reserved.
 # Use of this source code is governed by a BSD-style license
 # that can be found in the LICENSE file at the root of the
 # Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/scripts/vcpkg/get_mumble_dependencies.ps1
+++ b/scripts/vcpkg/get_mumble_dependencies.ps1
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 The Mumble Developers. All rights reserved.
+# Copyright 2020-2022 The Mumble Developers. All rights reserved.
 # Use of this source code is governed by a BSD-style license
 # that can be found in the LICENSE file at the root of the
 # Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/scripts/vcpkg/get_mumble_dependencies.sh
+++ b/scripts/vcpkg/get_mumble_dependencies.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Copyright 2020-2021 The Mumble Developers. All rights reserved.
+# Copyright 2020-2022 The Mumble Developers. All rights reserved.
 # Use of this source code is governed by a BSD-style license
 # that can be found in the LICENSE file at the root of the
 # Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/ACL.cpp
+++ b/src/ACL.cpp
@@ -1,4 +1,4 @@
-// Copyright 2007-2021 The Mumble Developers. All rights reserved.
+// Copyright 2007-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/ACL.h
+++ b/src/ACL.h
@@ -1,4 +1,4 @@
-// Copyright 2007-2021 The Mumble Developers. All rights reserved.
+// Copyright 2007-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/Ban.cpp
+++ b/src/Ban.cpp
@@ -1,4 +1,4 @@
-// Copyright 2017-2021 The Mumble Developers. All rights reserved.
+// Copyright 2017-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/Ban.h
+++ b/src/Ban.h
@@ -1,4 +1,4 @@
-// Copyright 2017-2021 The Mumble Developers. All rights reserved.
+// Copyright 2017-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/ByteSwap.h
+++ b/src/ByteSwap.h
@@ -1,4 +1,4 @@
-// Copyright 2017-2021 The Mumble Developers. All rights reserved.
+// Copyright 2017-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 The Mumble Developers. All rights reserved.
+# Copyright 2020-2022 The Mumble Developers. All rights reserved.
 # Use of this source code is governed by a BSD-style license
 # that can be found in the LICENSE file at the root of the
 # Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/Channel.cpp
+++ b/src/Channel.cpp
@@ -1,4 +1,4 @@
-// Copyright 2007-2021 The Mumble Developers. All rights reserved.
+// Copyright 2007-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/Channel.h
+++ b/src/Channel.h
@@ -1,4 +1,4 @@
-// Copyright 2007-2021 The Mumble Developers. All rights reserved.
+// Copyright 2007-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/ChannelListenerManager.cpp
+++ b/src/ChannelListenerManager.cpp
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 The Mumble Developers. All rights reserved.
+// Copyright 2021-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/ChannelListenerManager.h
+++ b/src/ChannelListenerManager.h
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 The Mumble Developers. All rights reserved.
+// Copyright 2021-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/Connection.cpp
+++ b/src/Connection.cpp
@@ -1,4 +1,4 @@
-// Copyright 2007-2021 The Mumble Developers. All rights reserved.
+// Copyright 2007-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/Connection.h
+++ b/src/Connection.h
@@ -1,4 +1,4 @@
-// Copyright 2007-2021 The Mumble Developers. All rights reserved.
+// Copyright 2007-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/CryptState.h
+++ b/src/CryptState.h
@@ -1,4 +1,4 @@
-// Copyright 2007-2021 The Mumble Developers. All rights reserved.
+// Copyright 2007-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/EnvUtils.cpp
+++ b/src/EnvUtils.cpp
@@ -1,4 +1,4 @@
-// Copyright 2017-2021 The Mumble Developers. All rights reserved.
+// Copyright 2017-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/EnvUtils.h
+++ b/src/EnvUtils.h
@@ -1,4 +1,4 @@
-// Copyright 2017-2021 The Mumble Developers. All rights reserved.
+// Copyright 2017-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/FFDHE.cpp
+++ b/src/FFDHE.cpp
@@ -1,4 +1,4 @@
-// Copyright 2017-2021 The Mumble Developers. All rights reserved.
+// Copyright 2017-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/FFDHE.h
+++ b/src/FFDHE.h
@@ -1,4 +1,4 @@
-// Copyright 2017-2021 The Mumble Developers. All rights reserved.
+// Copyright 2017-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/FFDHETable.h
+++ b/src/FFDHETable.h
@@ -1,4 +1,4 @@
-// Copyright 2017-2021 The Mumble Developers. All rights reserved.
+// Copyright 2017-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/Group.cpp
+++ b/src/Group.cpp
@@ -1,4 +1,4 @@
-// Copyright 2007-2021 The Mumble Developers. All rights reserved.
+// Copyright 2007-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/Group.h
+++ b/src/Group.h
@@ -1,4 +1,4 @@
-// Copyright 2007-2021 The Mumble Developers. All rights reserved.
+// Copyright 2007-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/HTMLFilter.cpp
+++ b/src/HTMLFilter.cpp
@@ -1,4 +1,4 @@
-// Copyright 2016-2021 The Mumble Developers. All rights reserved.
+// Copyright 2016-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/HTMLFilter.h
+++ b/src/HTMLFilter.h
@@ -1,4 +1,4 @@
-// Copyright 2016-2021 The Mumble Developers. All rights reserved.
+// Copyright 2016-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/HostAddress.cpp
+++ b/src/HostAddress.cpp
@@ -1,4 +1,4 @@
-// Copyright 2017-2021 The Mumble Developers. All rights reserved.
+// Copyright 2017-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/HostAddress.h
+++ b/src/HostAddress.h
@@ -1,4 +1,4 @@
-// Copyright 2017-2021 The Mumble Developers. All rights reserved.
+// Copyright 2017-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/License.cpp
+++ b/src/License.cpp
@@ -1,4 +1,4 @@
-// Copyright 2016-2021 The Mumble Developers. All rights reserved.
+// Copyright 2016-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/License.h
+++ b/src/License.h
@@ -1,4 +1,4 @@
-// Copyright 2016-2021 The Mumble Developers. All rights reserved.
+// Copyright 2016-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/LogEmitter.cpp
+++ b/src/LogEmitter.cpp
@@ -1,4 +1,4 @@
-// Copyright 2016-2021 The Mumble Developers. All rights reserved.
+// Copyright 2016-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/LogEmitter.h
+++ b/src/LogEmitter.h
@@ -1,4 +1,4 @@
-// Copyright 2016-2021 The Mumble Developers. All rights reserved.
+// Copyright 2016-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/Message.h
+++ b/src/Message.h
@@ -1,4 +1,4 @@
-// Copyright 2007-2021 The Mumble Developers. All rights reserved.
+// Copyright 2007-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/Mumble.proto
+++ b/src/Mumble.proto
@@ -1,4 +1,4 @@
-// Copyright 2009-2021 The Mumble Developers. All rights reserved.
+// Copyright 2009-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/MumbleConstants.h
+++ b/src/MumbleConstants.h
@@ -1,4 +1,4 @@
-// Copyright 2021 The Mumble Developers. All rights reserved.
+// Copyright 2021-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/Net.cpp
+++ b/src/Net.cpp
@@ -1,4 +1,4 @@
-// Copyright 2009-2021 The Mumble Developers. All rights reserved.
+// Copyright 2009-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/Net.h
+++ b/src/Net.h
@@ -1,4 +1,4 @@
-// Copyright 2009-2021 The Mumble Developers. All rights reserved.
+// Copyright 2009-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/OSInfo.cpp
+++ b/src/OSInfo.cpp
@@ -1,4 +1,4 @@
-// Copyright 2009-2021 The Mumble Developers. All rights reserved.
+// Copyright 2009-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/OSInfo.h
+++ b/src/OSInfo.h
@@ -1,4 +1,4 @@
-// Copyright 2009-2021 The Mumble Developers. All rights reserved.
+// Copyright 2009-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/PacketDataStream.h
+++ b/src/PacketDataStream.h
@@ -1,4 +1,4 @@
-// Copyright 2009-2021 The Mumble Developers. All rights reserved.
+// Copyright 2009-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/PasswordGenerator.cpp
+++ b/src/PasswordGenerator.cpp
@@ -1,4 +1,4 @@
-// Copyright 2017-2021 The Mumble Developers. All rights reserved.
+// Copyright 2017-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/PasswordGenerator.h
+++ b/src/PasswordGenerator.h
@@ -1,4 +1,4 @@
-// Copyright 2017-2021 The Mumble Developers. All rights reserved.
+// Copyright 2017-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/PlatformCheck.cpp
+++ b/src/PlatformCheck.cpp
@@ -1,4 +1,4 @@
-// Copyright 2018-2021 The Mumble Developers. All rights reserved.
+// Copyright 2018-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/PlatformCheck.h
+++ b/src/PlatformCheck.h
@@ -1,4 +1,4 @@
-// Copyright 2018-2021 The Mumble Developers. All rights reserved.
+// Copyright 2018-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/ProcessResolver.cpp
+++ b/src/ProcessResolver.cpp
@@ -1,4 +1,4 @@
-// Copyright 2021 The Mumble Developers. All rights reserved.
+// Copyright 2021-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/ProcessResolver.h
+++ b/src/ProcessResolver.h
@@ -1,4 +1,4 @@
-// Copyright 2021 The Mumble Developers. All rights reserved.
+// Copyright 2021-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/QtUtils.cpp
+++ b/src/QtUtils.cpp
@@ -1,4 +1,4 @@
-// Copyright 2021 The Mumble Developers. All rights reserved.
+// Copyright 2021-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/QtUtils.h
+++ b/src/QtUtils.h
@@ -1,4 +1,4 @@
-// Copyright 2021 The Mumble Developers. All rights reserved.
+// Copyright 2021-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/SSL.cpp
+++ b/src/SSL.cpp
@@ -1,4 +1,4 @@
-// Copyright 2009-2021 The Mumble Developers. All rights reserved.
+// Copyright 2009-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/SSL.h
+++ b/src/SSL.h
@@ -1,4 +1,4 @@
-// Copyright 2009-2021 The Mumble Developers. All rights reserved.
+// Copyright 2009-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/SSLCipherInfo.cpp
+++ b/src/SSLCipherInfo.cpp
@@ -1,4 +1,4 @@
-// Copyright 2015-2021 The Mumble Developers. All rights reserved.
+// Copyright 2015-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/SSLCipherInfo.h
+++ b/src/SSLCipherInfo.h
@@ -1,4 +1,4 @@
-// Copyright 2015-2021 The Mumble Developers. All rights reserved.
+// Copyright 2015-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/SSLCipherInfoTable.h
+++ b/src/SSLCipherInfoTable.h
@@ -1,4 +1,4 @@
-// Copyright 2015-2021 The Mumble Developers. All rights reserved.
+// Copyright 2015-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/SSLLocks.cpp
+++ b/src/SSLLocks.cpp
@@ -1,4 +1,4 @@
-// Copyright 2017-2021 The Mumble Developers. All rights reserved.
+// Copyright 2017-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/SSLLocks.h
+++ b/src/SSLLocks.h
@@ -1,4 +1,4 @@
-// Copyright 2017-2021 The Mumble Developers. All rights reserved.
+// Copyright 2017-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/SelfSignedCertificate.cpp
+++ b/src/SelfSignedCertificate.cpp
@@ -1,4 +1,4 @@
-// Copyright 2017-2021 The Mumble Developers. All rights reserved.
+// Copyright 2017-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/SelfSignedCertificate.h
+++ b/src/SelfSignedCertificate.h
@@ -1,4 +1,4 @@
-// Copyright 2017-2021 The Mumble Developers. All rights reserved.
+// Copyright 2017-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/ServerAddress.cpp
+++ b/src/ServerAddress.cpp
@@ -1,4 +1,4 @@
-// Copyright 2017-2021 The Mumble Developers. All rights reserved.
+// Copyright 2017-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/ServerAddress.h
+++ b/src/ServerAddress.h
@@ -1,4 +1,4 @@
-// Copyright 2017-2021 The Mumble Developers. All rights reserved.
+// Copyright 2017-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/ServerResolver.cpp
+++ b/src/ServerResolver.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2021 The Mumble Developers. All rights reserved.
+// Copyright 2019-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/ServerResolver.h
+++ b/src/ServerResolver.h
@@ -1,4 +1,4 @@
-// Copyright 2017-2021 The Mumble Developers. All rights reserved.
+// Copyright 2017-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/ServerResolverRecord.cpp
+++ b/src/ServerResolverRecord.cpp
@@ -1,4 +1,4 @@
-// Copyright 2017-2021 The Mumble Developers. All rights reserved.
+// Copyright 2017-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/ServerResolverRecord.h
+++ b/src/ServerResolverRecord.h
@@ -1,4 +1,4 @@
-// Copyright 2017-2021 The Mumble Developers. All rights reserved.
+// Copyright 2017-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/SignalCurry.h
+++ b/src/SignalCurry.h
@@ -1,4 +1,4 @@
-// Copyright 2012-2021 The Mumble Developers. All rights reserved.
+// Copyright 2012-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/SpeechFlags.h
+++ b/src/SpeechFlags.h
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 The Mumble Developers. All rights reserved.
+// Copyright 2020-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/Timer.cpp
+++ b/src/Timer.cpp
@@ -1,4 +1,4 @@
-// Copyright 2007-2021 The Mumble Developers. All rights reserved.
+// Copyright 2007-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/Timer.h
+++ b/src/Timer.h
@@ -1,4 +1,4 @@
-// Copyright 2007-2021 The Mumble Developers. All rights reserved.
+// Copyright 2007-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/UnresolvedServerAddress.cpp
+++ b/src/UnresolvedServerAddress.cpp
@@ -1,4 +1,4 @@
-// Copyright 2017-2021 The Mumble Developers. All rights reserved.
+// Copyright 2017-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/UnresolvedServerAddress.h
+++ b/src/UnresolvedServerAddress.h
@@ -1,4 +1,4 @@
-// Copyright 2017-2021 The Mumble Developers. All rights reserved.
+// Copyright 2017-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/User.cpp
+++ b/src/User.cpp
@@ -1,4 +1,4 @@
-// Copyright 2009-2021 The Mumble Developers. All rights reserved.
+// Copyright 2009-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/User.h
+++ b/src/User.h
@@ -1,4 +1,4 @@
-// Copyright 2009-2021 The Mumble Developers. All rights reserved.
+// Copyright 2009-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/Utils.h
+++ b/src/Utils.h
@@ -1,4 +1,4 @@
-// Copyright 2019-2021 The Mumble Developers. All rights reserved.
+// Copyright 2019-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/Version.cpp
+++ b/src/Version.cpp
@@ -1,4 +1,4 @@
-// Copyright 2010-2021 The Mumble Developers. All rights reserved.
+// Copyright 2010-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/Version.h
+++ b/src/Version.h
@@ -1,4 +1,4 @@
-// Copyright 2008-2021 The Mumble Developers. All rights reserved.
+// Copyright 2008-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/crypto/CryptState.h
+++ b/src/crypto/CryptState.h
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 The Mumble Developers. All rights reserved.
+// Copyright 2020-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/crypto/CryptStateOCB2.cpp
+++ b/src/crypto/CryptStateOCB2.cpp
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 The Mumble Developers. All rights reserved.
+// Copyright 2020-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/crypto/CryptStateOCB2.h
+++ b/src/crypto/CryptStateOCB2.h
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 The Mumble Developers. All rights reserved.
+// Copyright 2020-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/crypto/CryptographicHash.cpp
+++ b/src/crypto/CryptographicHash.cpp
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 The Mumble Developers. All rights reserved.
+// Copyright 2020-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/crypto/CryptographicHash.h
+++ b/src/crypto/CryptographicHash.h
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 The Mumble Developers. All rights reserved.
+// Copyright 2020-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/crypto/CryptographicRandom.cpp
+++ b/src/crypto/CryptographicRandom.cpp
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 The Mumble Developers. All rights reserved.
+// Copyright 2020-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/crypto/CryptographicRandom.h
+++ b/src/crypto/CryptographicRandom.h
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 The Mumble Developers. All rights reserved.
+// Copyright 2020-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/licenses.h
+++ b/src/licenses.h
@@ -1,4 +1,4 @@
-// Copyright 2016-2021 The Mumble Developers. All rights reserved.
+// Copyright 2016-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/mumble/ACLEditor.cpp
+++ b/src/mumble/ACLEditor.cpp
@@ -1,4 +1,4 @@
-// Copyright 2007-2021 The Mumble Developers. All rights reserved.
+// Copyright 2007-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/mumble/ACLEditor.h
+++ b/src/mumble/ACLEditor.h
@@ -1,4 +1,4 @@
-// Copyright 2007-2021 The Mumble Developers. All rights reserved.
+// Copyright 2007-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/mumble/ALSAAudio.cpp
+++ b/src/mumble/ALSAAudio.cpp
@@ -1,4 +1,4 @@
-// Copyright 2007-2021 The Mumble Developers. All rights reserved.
+// Copyright 2007-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/mumble/ALSAAudio.h
+++ b/src/mumble/ALSAAudio.h
@@ -1,4 +1,4 @@
-// Copyright 2007-2021 The Mumble Developers. All rights reserved.
+// Copyright 2007-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/mumble/API.h
+++ b/src/mumble/API.h
@@ -1,4 +1,4 @@
-// Copyright 2021 The Mumble Developers. All rights reserved.
+// Copyright 2021-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/mumble/API_v_1_0_x.cpp
+++ b/src/mumble/API_v_1_0_x.cpp
@@ -1,4 +1,4 @@
-// Copyright 2021 The Mumble Developers. All rights reserved.
+// Copyright 2021-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/mumble/ASIOInput.cpp
+++ b/src/mumble/ASIOInput.cpp
@@ -1,4 +1,4 @@
-// Copyright 2007-2021 The Mumble Developers. All rights reserved.
+// Copyright 2007-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/mumble/ASIOInput.h
+++ b/src/mumble/ASIOInput.h
@@ -1,4 +1,4 @@
-// Copyright 2007-2021 The Mumble Developers. All rights reserved.
+// Copyright 2007-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/mumble/About.cpp
+++ b/src/mumble/About.cpp
@@ -1,4 +1,4 @@
-// Copyright 2007-2021 The Mumble Developers. All rights reserved.
+// Copyright 2007-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/mumble/About.h
+++ b/src/mumble/About.h
@@ -1,4 +1,4 @@
-// Copyright 2007-2021 The Mumble Developers. All rights reserved.
+// Copyright 2007-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/mumble/AppNap.h
+++ b/src/mumble/AppNap.h
@@ -1,4 +1,4 @@
-// Copyright 2015-2021 The Mumble Developers. All rights reserved.
+// Copyright 2015-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/mumble/AppNap.mm
+++ b/src/mumble/AppNap.mm
@@ -1,4 +1,4 @@
-// Copyright 2015-2021 The Mumble Developers. All rights reserved.
+// Copyright 2015-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/mumble/ApplicationPalette.h
+++ b/src/mumble/ApplicationPalette.h
@@ -1,4 +1,4 @@
-// Copyright 2014-2021 The Mumble Developers. All rights reserved.
+// Copyright 2014-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/mumble/ApplicationPaletteTemplate.h
+++ b/src/mumble/ApplicationPaletteTemplate.h
@@ -1,4 +1,4 @@
-// Copyright 2014-2021 The Mumble Developers. All rights reserved.
+// Copyright 2014-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/mumble/Audio.cpp
+++ b/src/mumble/Audio.cpp
@@ -1,4 +1,4 @@
-// Copyright 2007-2021 The Mumble Developers. All rights reserved.
+// Copyright 2007-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/mumble/Audio.h
+++ b/src/mumble/Audio.h
@@ -1,4 +1,4 @@
-// Copyright 2007-2021 The Mumble Developers. All rights reserved.
+// Copyright 2007-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/mumble/AudioConfigDialog.cpp
+++ b/src/mumble/AudioConfigDialog.cpp
@@ -1,4 +1,4 @@
-// Copyright 2007-2021 The Mumble Developers. All rights reserved.
+// Copyright 2007-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/mumble/AudioConfigDialog.h
+++ b/src/mumble/AudioConfigDialog.h
@@ -1,4 +1,4 @@
-// Copyright 2007-2021 The Mumble Developers. All rights reserved.
+// Copyright 2007-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/mumble/AudioInput.cpp
+++ b/src/mumble/AudioInput.cpp
@@ -1,4 +1,4 @@
-// Copyright 2007-2021 The Mumble Developers. All rights reserved.
+// Copyright 2007-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/mumble/AudioInput.h
+++ b/src/mumble/AudioInput.h
@@ -1,4 +1,4 @@
-// Copyright 2007-2021 The Mumble Developers. All rights reserved.
+// Copyright 2007-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/mumble/AudioOutput.cpp
+++ b/src/mumble/AudioOutput.cpp
@@ -1,4 +1,4 @@
-// Copyright 2007-2021 The Mumble Developers. All rights reserved.
+// Copyright 2007-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/mumble/AudioOutput.h
+++ b/src/mumble/AudioOutput.h
@@ -1,4 +1,4 @@
-// Copyright 2007-2021 The Mumble Developers. All rights reserved.
+// Copyright 2007-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/mumble/AudioOutputSample.cpp
+++ b/src/mumble/AudioOutputSample.cpp
@@ -1,4 +1,4 @@
-// Copyright 2011-2021 The Mumble Developers. All rights reserved.
+// Copyright 2011-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/mumble/AudioOutputSample.h
+++ b/src/mumble/AudioOutputSample.h
@@ -1,4 +1,4 @@
-// Copyright 2011-2021 The Mumble Developers. All rights reserved.
+// Copyright 2011-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/mumble/AudioOutputSpeech.cpp
+++ b/src/mumble/AudioOutputSpeech.cpp
@@ -1,4 +1,4 @@
-// Copyright 2011-2021 The Mumble Developers. All rights reserved.
+// Copyright 2011-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/mumble/AudioOutputSpeech.h
+++ b/src/mumble/AudioOutputSpeech.h
@@ -1,4 +1,4 @@
-// Copyright 2011-2021 The Mumble Developers. All rights reserved.
+// Copyright 2011-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/mumble/AudioOutputUser.cpp
+++ b/src/mumble/AudioOutputUser.cpp
@@ -1,4 +1,4 @@
-// Copyright 2011-2021 The Mumble Developers. All rights reserved.
+// Copyright 2011-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/mumble/AudioOutputUser.h
+++ b/src/mumble/AudioOutputUser.h
@@ -1,4 +1,4 @@
-// Copyright 2011-2021 The Mumble Developers. All rights reserved.
+// Copyright 2011-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/mumble/AudioStats.cpp
+++ b/src/mumble/AudioStats.cpp
@@ -1,4 +1,4 @@
-// Copyright 2007-2021 The Mumble Developers. All rights reserved.
+// Copyright 2007-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/mumble/AudioStats.h
+++ b/src/mumble/AudioStats.h
@@ -1,4 +1,4 @@
-// Copyright 2007-2021 The Mumble Developers. All rights reserved.
+// Copyright 2007-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/mumble/AudioWizard.cpp
+++ b/src/mumble/AudioWizard.cpp
@@ -1,4 +1,4 @@
-// Copyright 2007-2021 The Mumble Developers. All rights reserved.
+// Copyright 2007-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/mumble/AudioWizard.h
+++ b/src/mumble/AudioWizard.h
@@ -1,4 +1,4 @@
-// Copyright 2007-2021 The Mumble Developers. All rights reserved.
+// Copyright 2007-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/mumble/BanEditor.cpp
+++ b/src/mumble/BanEditor.cpp
@@ -1,4 +1,4 @@
-// Copyright 2007-2021 The Mumble Developers. All rights reserved.
+// Copyright 2007-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/mumble/BanEditor.h
+++ b/src/mumble/BanEditor.h
@@ -1,4 +1,4 @@
-// Copyright 2007-2021 The Mumble Developers. All rights reserved.
+// Copyright 2007-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/mumble/CELTCodec.cpp
+++ b/src/mumble/CELTCodec.cpp
@@ -1,4 +1,4 @@
-// Copyright 2012-2021 The Mumble Developers. All rights reserved.
+// Copyright 2012-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/mumble/CELTCodec.h
+++ b/src/mumble/CELTCodec.h
@@ -1,4 +1,4 @@
-// Copyright 2012-2021 The Mumble Developers. All rights reserved.
+// Copyright 2012-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/mumble/CELTCodec_sbcelt.cpp
+++ b/src/mumble/CELTCodec_sbcelt.cpp
@@ -1,4 +1,4 @@
-// Copyright 2012-2021 The Mumble Developers. All rights reserved.
+// Copyright 2012-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/mumble/CMakeLists.txt
+++ b/src/mumble/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 The Mumble Developers. All rights reserved.
+# Copyright 2020-2022 The Mumble Developers. All rights reserved.
 # Use of this source code is governed by a BSD-style license
 # that can be found in the LICENSE file at the root of the
 # Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/mumble/Cert.cpp
+++ b/src/mumble/Cert.cpp
@@ -1,4 +1,4 @@
-// Copyright 2009-2021 The Mumble Developers. All rights reserved.
+// Copyright 2009-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/mumble/Cert.h
+++ b/src/mumble/Cert.h
@@ -1,4 +1,4 @@
-// Copyright 2009-2021 The Mumble Developers. All rights reserved.
+// Copyright 2009-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/mumble/ClientUser.cpp
+++ b/src/mumble/ClientUser.cpp
@@ -1,4 +1,4 @@
-// Copyright 2009-2021 The Mumble Developers. All rights reserved.
+// Copyright 2009-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/mumble/ClientUser.h
+++ b/src/mumble/ClientUser.h
@@ -1,4 +1,4 @@
-// Copyright 2009-2021 The Mumble Developers. All rights reserved.
+// Copyright 2009-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/mumble/ConfigDialog.cpp
+++ b/src/mumble/ConfigDialog.cpp
@@ -1,4 +1,4 @@
-// Copyright 2007-2021 The Mumble Developers. All rights reserved.
+// Copyright 2007-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/mumble/ConfigDialog.h
+++ b/src/mumble/ConfigDialog.h
@@ -1,4 +1,4 @@
-// Copyright 2007-2021 The Mumble Developers. All rights reserved.
+// Copyright 2007-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/mumble/ConfigWidget.cpp
+++ b/src/mumble/ConfigWidget.cpp
@@ -1,4 +1,4 @@
-// Copyright 2009-2021 The Mumble Developers. All rights reserved.
+// Copyright 2009-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/mumble/ConfigWidget.h
+++ b/src/mumble/ConfigWidget.h
@@ -1,4 +1,4 @@
-// Copyright 2009-2021 The Mumble Developers. All rights reserved.
+// Copyright 2009-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/mumble/ConnectDialog.cpp
+++ b/src/mumble/ConnectDialog.cpp
@@ -1,4 +1,4 @@
-// Copyright 2007-2021 The Mumble Developers. All rights reserved.
+// Copyright 2007-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/mumble/ConnectDialog.h
+++ b/src/mumble/ConnectDialog.h
@@ -1,4 +1,4 @@
-// Copyright 2007-2021 The Mumble Developers. All rights reserved.
+// Copyright 2007-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/mumble/CoreAudio.h
+++ b/src/mumble/CoreAudio.h
@@ -1,4 +1,4 @@
-// Copyright 2009-2021 The Mumble Developers. All rights reserved.
+// Copyright 2009-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/mumble/CoreAudio.mm
+++ b/src/mumble/CoreAudio.mm
@@ -1,4 +1,4 @@
-// Copyright 2021 The Mumble Developers. All rights reserved.
+// Copyright 2021-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/mumble/CrashReporter.cpp
+++ b/src/mumble/CrashReporter.cpp
@@ -1,4 +1,4 @@
-// Copyright 2009-2021 The Mumble Developers. All rights reserved.
+// Copyright 2009-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/mumble/CrashReporter.h
+++ b/src/mumble/CrashReporter.h
@@ -1,4 +1,4 @@
-// Copyright 2009-2021 The Mumble Developers. All rights reserved.
+// Copyright 2009-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/mumble/CustomElements.cpp
+++ b/src/mumble/CustomElements.cpp
@@ -1,4 +1,4 @@
-// Copyright 2009-2021 The Mumble Developers. All rights reserved.
+// Copyright 2009-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/mumble/CustomElements.h
+++ b/src/mumble/CustomElements.h
@@ -1,4 +1,4 @@
-// Copyright 2009-2021 The Mumble Developers. All rights reserved.
+// Copyright 2009-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/mumble/DBus.cpp
+++ b/src/mumble/DBus.cpp
@@ -1,4 +1,4 @@
-// Copyright 2007-2021 The Mumble Developers. All rights reserved.
+// Copyright 2007-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/mumble/DBus.h
+++ b/src/mumble/DBus.h
@@ -1,4 +1,4 @@
-// Copyright 2007-2021 The Mumble Developers. All rights reserved.
+// Copyright 2007-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/mumble/Database.cpp
+++ b/src/mumble/Database.cpp
@@ -1,4 +1,4 @@
-// Copyright 2007-2021 The Mumble Developers. All rights reserved.
+// Copyright 2007-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/mumble/Database.h
+++ b/src/mumble/Database.h
@@ -1,4 +1,4 @@
-// Copyright 2007-2021 The Mumble Developers. All rights reserved.
+// Copyright 2007-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/mumble/DeveloperConsole.cpp
+++ b/src/mumble/DeveloperConsole.cpp
@@ -1,4 +1,4 @@
-// Copyright 2016-2021 The Mumble Developers. All rights reserved.
+// Copyright 2016-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/mumble/DeveloperConsole.h
+++ b/src/mumble/DeveloperConsole.h
@@ -1,4 +1,4 @@
-// Copyright 2016-2021 The Mumble Developers. All rights reserved.
+// Copyright 2016-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/mumble/EchoCancelOption.cpp
+++ b/src/mumble/EchoCancelOption.cpp
@@ -1,4 +1,4 @@
-// Copyright 2021 The Mumble Developers. All rights reserved.
+// Copyright 2021-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/mumble/EchoCancelOption.h
+++ b/src/mumble/EchoCancelOption.h
@@ -1,4 +1,4 @@
-// Copyright 2021 The Mumble Developers. All rights reserved.
+// Copyright 2021-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/mumble/G15LCDEngine_helper.cpp
+++ b/src/mumble/G15LCDEngine_helper.cpp
@@ -1,4 +1,4 @@
-// Copyright 2010-2021 The Mumble Developers. All rights reserved.
+// Copyright 2010-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/mumble/G15LCDEngine_helper.h
+++ b/src/mumble/G15LCDEngine_helper.h
@@ -1,4 +1,4 @@
-// Copyright 2010-2021 The Mumble Developers. All rights reserved.
+// Copyright 2010-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/mumble/G15LCDEngine_lglcd.cpp
+++ b/src/mumble/G15LCDEngine_lglcd.cpp
@@ -1,4 +1,4 @@
-// Copyright 2009-2021 The Mumble Developers. All rights reserved.
+// Copyright 2009-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/mumble/G15LCDEngine_lglcd.h
+++ b/src/mumble/G15LCDEngine_lglcd.h
@@ -1,4 +1,4 @@
-// Copyright 2009-2021 The Mumble Developers. All rights reserved.
+// Copyright 2009-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/mumble/G15LCDEngine_unix.cpp
+++ b/src/mumble/G15LCDEngine_unix.cpp
@@ -1,4 +1,4 @@
-// Copyright 2008-2021 The Mumble Developers. All rights reserved.
+// Copyright 2008-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/mumble/G15LCDEngine_unix.h
+++ b/src/mumble/G15LCDEngine_unix.h
@@ -1,4 +1,4 @@
-// Copyright 2008-2021 The Mumble Developers. All rights reserved.
+// Copyright 2008-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/mumble/GKey.cpp
+++ b/src/mumble/GKey.cpp
@@ -1,4 +1,4 @@
-// Copyright 2015-2021 The Mumble Developers. All rights reserved.
+// Copyright 2015-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/mumble/GKey.h
+++ b/src/mumble/GKey.h
@@ -1,4 +1,4 @@
-// Copyright 2015-2021 The Mumble Developers. All rights reserved.
+// Copyright 2015-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/mumble/Global.cpp
+++ b/src/mumble/Global.cpp
@@ -1,4 +1,4 @@
-// Copyright 2007-2021 The Mumble Developers. All rights reserved.
+// Copyright 2007-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/mumble/Global.h
+++ b/src/mumble/Global.h
@@ -1,4 +1,4 @@
-// Copyright 2007-2021 The Mumble Developers. All rights reserved.
+// Copyright 2007-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/mumble/GlobalShortcut.cpp
+++ b/src/mumble/GlobalShortcut.cpp
@@ -1,4 +1,4 @@
-// Copyright 2007-2021 The Mumble Developers. All rights reserved.
+// Copyright 2007-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/mumble/GlobalShortcut.h
+++ b/src/mumble/GlobalShortcut.h
@@ -1,4 +1,4 @@
-// Copyright 2007-2021 The Mumble Developers. All rights reserved.
+// Copyright 2007-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/mumble/GlobalShortcutButtons.cpp
+++ b/src/mumble/GlobalShortcutButtons.cpp
@@ -1,4 +1,4 @@
-// Copyright 2021 The Mumble Developers. All rights reserved.
+// Copyright 2021-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/mumble/GlobalShortcutButtons.h
+++ b/src/mumble/GlobalShortcutButtons.h
@@ -1,4 +1,4 @@
-// Copyright 2021 The Mumble Developers. All rights reserved.
+// Copyright 2021-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/mumble/GlobalShortcut_macx.h
+++ b/src/mumble/GlobalShortcut_macx.h
@@ -1,4 +1,4 @@
-// Copyright 2007-2021 The Mumble Developers. All rights reserved.
+// Copyright 2007-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/mumble/GlobalShortcut_macx.mm
+++ b/src/mumble/GlobalShortcut_macx.mm
@@ -1,4 +1,4 @@
-// Copyright 2010-2021 The Mumble Developers. All rights reserved.
+// Copyright 2010-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/mumble/GlobalShortcut_unix.cpp
+++ b/src/mumble/GlobalShortcut_unix.cpp
@@ -1,4 +1,4 @@
-// Copyright 2007-2021 The Mumble Developers. All rights reserved.
+// Copyright 2007-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/mumble/GlobalShortcut_unix.h
+++ b/src/mumble/GlobalShortcut_unix.h
@@ -1,4 +1,4 @@
-// Copyright 2007-2021 The Mumble Developers. All rights reserved.
+// Copyright 2007-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/mumble/GlobalShortcut_win.cpp
+++ b/src/mumble/GlobalShortcut_win.cpp
@@ -1,4 +1,4 @@
-// Copyright 2007-2021 The Mumble Developers. All rights reserved.
+// Copyright 2007-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/mumble/GlobalShortcut_win.h
+++ b/src/mumble/GlobalShortcut_win.h
@@ -1,4 +1,4 @@
-// Copyright 2007-2021 The Mumble Developers. All rights reserved.
+// Copyright 2007-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/mumble/JackAudio.cpp
+++ b/src/mumble/JackAudio.cpp
@@ -1,4 +1,4 @@
-// Copyright 2018-2021 The Mumble Developers. All rights reserved.
+// Copyright 2018-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/mumble/JackAudio.h
+++ b/src/mumble/JackAudio.h
@@ -1,4 +1,4 @@
-// Copyright 2018-2021 The Mumble Developers. All rights reserved.
+// Copyright 2018-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/mumble/LCD.cpp
+++ b/src/mumble/LCD.cpp
@@ -1,4 +1,4 @@
-// Copyright 2008-2021 The Mumble Developers. All rights reserved.
+// Copyright 2008-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/mumble/LCD.h
+++ b/src/mumble/LCD.h
@@ -1,4 +1,4 @@
-// Copyright 2008-2021 The Mumble Developers. All rights reserved.
+// Copyright 2008-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/mumble/LegacyPlugin.cpp
+++ b/src/mumble/LegacyPlugin.cpp
@@ -1,4 +1,4 @@
-// Copyright 2021 The Mumble Developers. All rights reserved.
+// Copyright 2021-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/mumble/LegacyPlugin.h
+++ b/src/mumble/LegacyPlugin.h
@@ -1,4 +1,4 @@
-// Copyright 2021 The Mumble Developers. All rights reserved.
+// Copyright 2021-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/mumble/ListenerLocalVolumeDialog.cpp
+++ b/src/mumble/ListenerLocalVolumeDialog.cpp
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 The Mumble Developers. All rights reserved.
+// Copyright 2020-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/mumble/ListenerLocalVolumeDialog.h
+++ b/src/mumble/ListenerLocalVolumeDialog.h
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 The Mumble Developers. All rights reserved.
+// Copyright 2020-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/mumble/Log.cpp
+++ b/src/mumble/Log.cpp
@@ -1,4 +1,4 @@
-// Copyright 2007-2021 The Mumble Developers. All rights reserved.
+// Copyright 2007-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/mumble/Log.h
+++ b/src/mumble/Log.h
@@ -1,4 +1,4 @@
-// Copyright 2007-2021 The Mumble Developers. All rights reserved.
+// Copyright 2007-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/mumble/Log_macx.mm
+++ b/src/mumble/Log_macx.mm
@@ -1,4 +1,4 @@
-// Copyright 2012-2021 The Mumble Developers. All rights reserved.
+// Copyright 2012-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/mumble/Log_unix.cpp
+++ b/src/mumble/Log_unix.cpp
@@ -1,4 +1,4 @@
-// Copyright 2012-2021 The Mumble Developers. All rights reserved.
+// Copyright 2012-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/mumble/Log_win.cpp
+++ b/src/mumble/Log_win.cpp
@@ -1,4 +1,4 @@
-// Copyright 2012-2021 The Mumble Developers. All rights reserved.
+// Copyright 2012-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/mumble/LookConfig.cpp
+++ b/src/mumble/LookConfig.cpp
@@ -1,4 +1,4 @@
-// Copyright 2007-2021 The Mumble Developers. All rights reserved.
+// Copyright 2007-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/mumble/LookConfig.h
+++ b/src/mumble/LookConfig.h
@@ -1,4 +1,4 @@
-// Copyright 2007-2021 The Mumble Developers. All rights reserved.
+// Copyright 2007-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/mumble/MainWindow.cpp
+++ b/src/mumble/MainWindow.cpp
@@ -1,4 +1,4 @@
-// Copyright 2007-2021 The Mumble Developers. All rights reserved.
+// Copyright 2007-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/mumble/MainWindow.h
+++ b/src/mumble/MainWindow.h
@@ -1,4 +1,4 @@
-// Copyright 2007-2021 The Mumble Developers. All rights reserved.
+// Copyright 2007-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/mumble/ManualPlugin.cpp
+++ b/src/mumble/ManualPlugin.cpp
@@ -1,4 +1,4 @@
-// Copyright 2016-2021 The Mumble Developers. All rights reserved.
+// Copyright 2016-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/mumble/ManualPlugin.h
+++ b/src/mumble/ManualPlugin.h
@@ -1,4 +1,4 @@
-// Copyright 2016-2021 The Mumble Developers. All rights reserved.
+// Copyright 2016-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/mumble/Markdown.cpp
+++ b/src/mumble/Markdown.cpp
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 The Mumble Developers. All rights reserved.
+// Copyright 2020-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/mumble/Markdown.h
+++ b/src/mumble/Markdown.h
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 The Mumble Developers. All rights reserved.
+// Copyright 2020-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/mumble/Messages.cpp
+++ b/src/mumble/Messages.cpp
@@ -1,4 +1,4 @@
-// Copyright 2007-2021 The Mumble Developers. All rights reserved.
+// Copyright 2007-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/mumble/MumbleApplication.cpp
+++ b/src/mumble/MumbleApplication.cpp
@@ -1,4 +1,4 @@
-// Copyright 2014-2021 The Mumble Developers. All rights reserved.
+// Copyright 2014-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/mumble/MumbleApplication.h
+++ b/src/mumble/MumbleApplication.h
@@ -1,4 +1,4 @@
-// Copyright 2014-2021 The Mumble Developers. All rights reserved.
+// Copyright 2014-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/mumble/NetworkConfig.cpp
+++ b/src/mumble/NetworkConfig.cpp
@@ -1,4 +1,4 @@
-// Copyright 2008-2021 The Mumble Developers. All rights reserved.
+// Copyright 2008-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/mumble/NetworkConfig.h
+++ b/src/mumble/NetworkConfig.h
@@ -1,4 +1,4 @@
-// Copyright 2008-2021 The Mumble Developers. All rights reserved.
+// Copyright 2008-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/mumble/OSS.cpp
+++ b/src/mumble/OSS.cpp
@@ -1,4 +1,4 @@
-// Copyright 2007-2021 The Mumble Developers. All rights reserved.
+// Copyright 2007-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/mumble/OSS.h
+++ b/src/mumble/OSS.h
@@ -1,4 +1,4 @@
-// Copyright 2007-2021 The Mumble Developers. All rights reserved.
+// Copyright 2007-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/mumble/OpusCodec.cpp
+++ b/src/mumble/OpusCodec.cpp
@@ -1,4 +1,4 @@
-// Copyright 2018-2021 The Mumble Developers. All rights reserved.
+// Copyright 2018-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/mumble/OpusCodec.h
+++ b/src/mumble/OpusCodec.h
@@ -1,4 +1,4 @@
-// Copyright 2018-2021 The Mumble Developers. All rights reserved.
+// Copyright 2018-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/mumble/Overlay.cpp
+++ b/src/mumble/Overlay.cpp
@@ -1,4 +1,4 @@
-// Copyright 2007-2021 The Mumble Developers. All rights reserved.
+// Copyright 2007-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/mumble/Overlay.h
+++ b/src/mumble/Overlay.h
@@ -1,4 +1,4 @@
-// Copyright 2007-2021 The Mumble Developers. All rights reserved.
+// Copyright 2007-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/mumble/OverlayClient.cpp
+++ b/src/mumble/OverlayClient.cpp
@@ -1,4 +1,4 @@
-// Copyright 2010-2021 The Mumble Developers. All rights reserved.
+// Copyright 2010-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/mumble/OverlayClient.h
+++ b/src/mumble/OverlayClient.h
@@ -1,4 +1,4 @@
-// Copyright 2014-2021 The Mumble Developers. All rights reserved.
+// Copyright 2014-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/mumble/OverlayConfig.cpp
+++ b/src/mumble/OverlayConfig.cpp
@@ -1,4 +1,4 @@
-// Copyright 2010-2021 The Mumble Developers. All rights reserved.
+// Copyright 2010-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/mumble/OverlayConfig.h
+++ b/src/mumble/OverlayConfig.h
@@ -1,4 +1,4 @@
-// Copyright 2014-2021 The Mumble Developers. All rights reserved.
+// Copyright 2014-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/mumble/OverlayEditor.cpp
+++ b/src/mumble/OverlayEditor.cpp
@@ -1,4 +1,4 @@
-// Copyright 2010-2021 The Mumble Developers. All rights reserved.
+// Copyright 2010-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/mumble/OverlayEditor.h
+++ b/src/mumble/OverlayEditor.h
@@ -1,4 +1,4 @@
-// Copyright 2014-2021 The Mumble Developers. All rights reserved.
+// Copyright 2014-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/mumble/OverlayEditorScene.cpp
+++ b/src/mumble/OverlayEditorScene.cpp
@@ -1,4 +1,4 @@
-// Copyright 2010-2021 The Mumble Developers. All rights reserved.
+// Copyright 2010-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/mumble/OverlayEditorScene.h
+++ b/src/mumble/OverlayEditorScene.h
@@ -1,4 +1,4 @@
-// Copyright 2014-2021 The Mumble Developers. All rights reserved.
+// Copyright 2014-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/mumble/OverlayPositionableItem.cpp
+++ b/src/mumble/OverlayPositionableItem.cpp
@@ -1,4 +1,4 @@
-// Copyright 2015-2021 The Mumble Developers. All rights reserved.
+// Copyright 2015-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/mumble/OverlayPositionableItem.h
+++ b/src/mumble/OverlayPositionableItem.h
@@ -1,4 +1,4 @@
-// Copyright 2015-2021 The Mumble Developers. All rights reserved.
+// Copyright 2015-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/mumble/OverlayText.cpp
+++ b/src/mumble/OverlayText.cpp
@@ -1,4 +1,4 @@
-// Copyright 2010-2021 The Mumble Developers. All rights reserved.
+// Copyright 2010-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/mumble/OverlayText.h
+++ b/src/mumble/OverlayText.h
@@ -1,4 +1,4 @@
-// Copyright 2010-2021 The Mumble Developers. All rights reserved.
+// Copyright 2010-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/mumble/OverlayUser.cpp
+++ b/src/mumble/OverlayUser.cpp
@@ -1,4 +1,4 @@
-// Copyright 2010-2021 The Mumble Developers. All rights reserved.
+// Copyright 2010-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/mumble/OverlayUser.h
+++ b/src/mumble/OverlayUser.h
@@ -1,4 +1,4 @@
-// Copyright 2014-2021 The Mumble Developers. All rights reserved.
+// Copyright 2014-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/mumble/OverlayUserGroup.cpp
+++ b/src/mumble/OverlayUserGroup.cpp
@@ -1,4 +1,4 @@
-// Copyright 2010-2021 The Mumble Developers. All rights reserved.
+// Copyright 2010-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/mumble/OverlayUserGroup.h
+++ b/src/mumble/OverlayUserGroup.h
@@ -1,4 +1,4 @@
-// Copyright 2014-2021 The Mumble Developers. All rights reserved.
+// Copyright 2014-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/mumble/Overlay_macx.mm
+++ b/src/mumble/Overlay_macx.mm
@@ -1,4 +1,4 @@
-// Copyright 2010-2021 The Mumble Developers. All rights reserved.
+// Copyright 2010-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/mumble/Overlay_unix.cpp
+++ b/src/mumble/Overlay_unix.cpp
@@ -1,4 +1,4 @@
-// Copyright 2007-2021 The Mumble Developers. All rights reserved.
+// Copyright 2007-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/mumble/Overlay_win.cpp
+++ b/src/mumble/Overlay_win.cpp
@@ -1,4 +1,4 @@
-// Copyright 2007-2021 The Mumble Developers. All rights reserved.
+// Copyright 2007-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/mumble/Overlay_win.h
+++ b/src/mumble/Overlay_win.h
@@ -1,4 +1,4 @@
-// Copyright 2015-2021 The Mumble Developers. All rights reserved.
+// Copyright 2015-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/mumble/PAAudio.cpp
+++ b/src/mumble/PAAudio.cpp
@@ -1,4 +1,4 @@
-// Copyright 2007-2021 The Mumble Developers. All rights reserved.
+// Copyright 2007-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/mumble/PAAudio.h
+++ b/src/mumble/PAAudio.h
@@ -1,4 +1,4 @@
-// Copyright 2007-2021 The Mumble Developers. All rights reserved.
+// Copyright 2007-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/mumble/PTTButtonWidget.cpp
+++ b/src/mumble/PTTButtonWidget.cpp
@@ -1,4 +1,4 @@
-// Copyright 2011-2021 The Mumble Developers. All rights reserved.
+// Copyright 2011-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/mumble/PTTButtonWidget.h
+++ b/src/mumble/PTTButtonWidget.h
@@ -1,4 +1,4 @@
-// Copyright 2011-2021 The Mumble Developers. All rights reserved.
+// Copyright 2011-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/mumble/PathListWidget.cpp
+++ b/src/mumble/PathListWidget.cpp
@@ -1,4 +1,4 @@
-// Copyright 2017-2021 The Mumble Developers. All rights reserved.
+// Copyright 2017-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/mumble/PathListWidget.h
+++ b/src/mumble/PathListWidget.h
@@ -1,4 +1,4 @@
-// Copyright 2017-2021 The Mumble Developers. All rights reserved.
+// Copyright 2017-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/mumble/PipeWire.cpp
+++ b/src/mumble/PipeWire.cpp
@@ -1,4 +1,4 @@
-// Copyright 2021 The Mumble Developers. All rights reserved.
+// Copyright 2021-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/mumble/PipeWire.h
+++ b/src/mumble/PipeWire.h
@@ -1,4 +1,4 @@
-// Copyright 2021 The Mumble Developers. All rights reserved.
+// Copyright 2021-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/mumble/Plugin.cpp
+++ b/src/mumble/Plugin.cpp
@@ -1,4 +1,4 @@
-// Copyright 2021 The Mumble Developers. All rights reserved.
+// Copyright 2021-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/mumble/Plugin.h
+++ b/src/mumble/Plugin.h
@@ -1,4 +1,4 @@
-// Copyright 2021 The Mumble Developers. All rights reserved.
+// Copyright 2021-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/mumble/PluginConfig.cpp
+++ b/src/mumble/PluginConfig.cpp
@@ -1,4 +1,4 @@
-// Copyright 2021 The Mumble Developers. All rights reserved.
+// Copyright 2021-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/mumble/PluginConfig.h
+++ b/src/mumble/PluginConfig.h
@@ -1,4 +1,4 @@
-// Copyright 2021 The Mumble Developers. All rights reserved.
+// Copyright 2021-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/mumble/PluginInstaller.cpp
+++ b/src/mumble/PluginInstaller.cpp
@@ -1,4 +1,4 @@
-// Copyright 2021 The Mumble Developers. All rights reserved.
+// Copyright 2021-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/mumble/PluginInstaller.h
+++ b/src/mumble/PluginInstaller.h
@@ -1,4 +1,4 @@
-// Copyright 2021 The Mumble Developers. All rights reserved.
+// Copyright 2021-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/mumble/PluginManager.cpp
+++ b/src/mumble/PluginManager.cpp
@@ -1,4 +1,4 @@
-// Copyright 2021 The Mumble Developers. All rights reserved.
+// Copyright 2021-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/mumble/PluginManager.h
+++ b/src/mumble/PluginManager.h
@@ -1,4 +1,4 @@
-// Copyright 2021 The Mumble Developers. All rights reserved.
+// Copyright 2021-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/mumble/PluginManifest.cpp
+++ b/src/mumble/PluginManifest.cpp
@@ -1,4 +1,4 @@
-// Copyright 2021 The Mumble Developers. All rights reserved.
+// Copyright 2021-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/mumble/PluginManifest.h
+++ b/src/mumble/PluginManifest.h
@@ -1,4 +1,4 @@
-// Copyright 2021 The Mumble Developers. All rights reserved.
+// Copyright 2021-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/mumble/PluginUpdater.cpp
+++ b/src/mumble/PluginUpdater.cpp
@@ -1,4 +1,4 @@
-// Copyright 2021 The Mumble Developers. All rights reserved.
+// Copyright 2021-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/mumble/PluginUpdater.h
+++ b/src/mumble/PluginUpdater.h
@@ -1,4 +1,4 @@
-// Copyright 2021 The Mumble Developers. All rights reserved.
+// Copyright 2021-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/mumble/PositionalAudioViewer.cpp
+++ b/src/mumble/PositionalAudioViewer.cpp
@@ -1,4 +1,4 @@
-// Copyright 2021 The Mumble Developers. All rights reserved.
+// Copyright 2021-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/mumble/PositionalAudioViewer.h
+++ b/src/mumble/PositionalAudioViewer.h
@@ -1,4 +1,4 @@
-// Copyright 2021 The Mumble Developers. All rights reserved.
+// Copyright 2021-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/mumble/PositionalData.cpp
+++ b/src/mumble/PositionalData.cpp
@@ -1,4 +1,4 @@
-// Copyright 2021 The Mumble Developers. All rights reserved.
+// Copyright 2021-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/mumble/PositionalData.h
+++ b/src/mumble/PositionalData.h
@@ -1,4 +1,4 @@
-// Copyright 2021 The Mumble Developers. All rights reserved.
+// Copyright 2021-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/mumble/PulseAudio.cpp
+++ b/src/mumble/PulseAudio.cpp
@@ -1,4 +1,4 @@
-// Copyright 2007-2021 The Mumble Developers. All rights reserved.
+// Copyright 2007-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/mumble/PulseAudio.h
+++ b/src/mumble/PulseAudio.h
@@ -1,4 +1,4 @@
-// Copyright 2007-2021 The Mumble Developers. All rights reserved.
+// Copyright 2007-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/mumble/QtWidgetUtils.cpp
+++ b/src/mumble/QtWidgetUtils.cpp
@@ -1,4 +1,4 @@
-// Copyright 2021 The Mumble Developers. All rights reserved.
+// Copyright 2021-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/mumble/QtWidgetUtils.h
+++ b/src/mumble/QtWidgetUtils.h
@@ -1,4 +1,4 @@
-// Copyright 2021 The Mumble Developers. All rights reserved.
+// Copyright 2021-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/mumble/RichTextEditor.cpp
+++ b/src/mumble/RichTextEditor.cpp
@@ -1,4 +1,4 @@
-// Copyright 2009-2021 The Mumble Developers. All rights reserved.
+// Copyright 2009-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/mumble/RichTextEditor.h
+++ b/src/mumble/RichTextEditor.h
@@ -1,4 +1,4 @@
-// Copyright 2009-2021 The Mumble Developers. All rights reserved.
+// Copyright 2009-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/mumble/Screen.cpp
+++ b/src/mumble/Screen.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2021 The Mumble Developers. All rights reserved.
+// Copyright 2019-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/mumble/Screen.h
+++ b/src/mumble/Screen.h
@@ -1,4 +1,4 @@
-// Copyright 2019-2021 The Mumble Developers. All rights reserved.
+// Copyright 2019-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/mumble/SearchDialog.cpp
+++ b/src/mumble/SearchDialog.cpp
@@ -1,4 +1,4 @@
-// Copyright 2021 The Mumble Developers. All rights reserved.
+// Copyright 2021-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/mumble/SearchDialog.h
+++ b/src/mumble/SearchDialog.h
@@ -1,4 +1,4 @@
-// Copyright 2021 The Mumble Developers. All rights reserved.
+// Copyright 2021-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/mumble/ServerHandler.cpp
+++ b/src/mumble/ServerHandler.cpp
@@ -1,4 +1,4 @@
-// Copyright 2007-2021 The Mumble Developers. All rights reserved.
+// Copyright 2007-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/mumble/ServerHandler.h
+++ b/src/mumble/ServerHandler.h
@@ -1,4 +1,4 @@
-// Copyright 2007-2021 The Mumble Developers. All rights reserved.
+// Copyright 2007-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/mumble/ServerInformation.cpp
+++ b/src/mumble/ServerInformation.cpp
@@ -1,4 +1,4 @@
-// Copyright 2021 The Mumble Developers. All rights reserved.
+// Copyright 2021-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/mumble/ServerInformation.h
+++ b/src/mumble/ServerInformation.h
@@ -1,4 +1,4 @@
-// Copyright 2021 The Mumble Developers. All rights reserved.
+// Copyright 2021-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/mumble/Settings.cpp
+++ b/src/mumble/Settings.cpp
@@ -1,4 +1,4 @@
-// Copyright 2007-2021 The Mumble Developers. All rights reserved.
+// Copyright 2007-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/mumble/Settings.h
+++ b/src/mumble/Settings.h
@@ -1,4 +1,4 @@
-// Copyright 2007-2021 The Mumble Developers. All rights reserved.
+// Copyright 2007-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/mumble/SharedMemory.cpp
+++ b/src/mumble/SharedMemory.cpp
@@ -1,4 +1,4 @@
-// Copyright 2010-2021 The Mumble Developers. All rights reserved.
+// Copyright 2010-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/mumble/SharedMemory.h
+++ b/src/mumble/SharedMemory.h
@@ -1,4 +1,4 @@
-// Copyright 2010-2021 The Mumble Developers. All rights reserved.
+// Copyright 2010-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/mumble/SharedMemory_unix.cpp
+++ b/src/mumble/SharedMemory_unix.cpp
@@ -1,4 +1,4 @@
-// Copyright 2010-2021 The Mumble Developers. All rights reserved.
+// Copyright 2010-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/mumble/SharedMemory_win.cpp
+++ b/src/mumble/SharedMemory_win.cpp
@@ -1,4 +1,4 @@
-// Copyright 2010-2021 The Mumble Developers. All rights reserved.
+// Copyright 2010-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/mumble/SocketRPC.cpp
+++ b/src/mumble/SocketRPC.cpp
@@ -1,4 +1,4 @@
-// Copyright 2010-2021 The Mumble Developers. All rights reserved.
+// Copyright 2010-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/mumble/SocketRPC.h
+++ b/src/mumble/SocketRPC.h
@@ -1,4 +1,4 @@
-// Copyright 2010-2021 The Mumble Developers. All rights reserved.
+// Copyright 2010-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/mumble/SvgIcon.cpp
+++ b/src/mumble/SvgIcon.cpp
@@ -1,4 +1,4 @@
-// Copyright 2018-2021 The Mumble Developers. All rights reserved.
+// Copyright 2018-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/mumble/SvgIcon.h
+++ b/src/mumble/SvgIcon.h
@@ -1,4 +1,4 @@
-// Copyright 2018-2021 The Mumble Developers. All rights reserved.
+// Copyright 2018-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/mumble/TalkingUI.cpp
+++ b/src/mumble/TalkingUI.cpp
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 The Mumble Developers. All rights reserved.
+// Copyright 2020-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/mumble/TalkingUI.h
+++ b/src/mumble/TalkingUI.h
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 The Mumble Developers. All rights reserved.
+// Copyright 2020-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/mumble/TalkingUIComponent.h
+++ b/src/mumble/TalkingUIComponent.h
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 The Mumble Developers. All rights reserved.
+// Copyright 2020-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/mumble/TalkingUIContainer.cpp
+++ b/src/mumble/TalkingUIContainer.cpp
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 The Mumble Developers. All rights reserved.
+// Copyright 2020-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/mumble/TalkingUIContainer.h
+++ b/src/mumble/TalkingUIContainer.h
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 The Mumble Developers. All rights reserved.
+// Copyright 2020-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/mumble/TalkingUIEntry.cpp
+++ b/src/mumble/TalkingUIEntry.cpp
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 The Mumble Developers. All rights reserved.
+// Copyright 2020-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/mumble/TalkingUIEntry.h
+++ b/src/mumble/TalkingUIEntry.h
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 The Mumble Developers. All rights reserved.
+// Copyright 2020-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/mumble/TalkingUISelection.cpp
+++ b/src/mumble/TalkingUISelection.cpp
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 The Mumble Developers. All rights reserved.
+// Copyright 2020-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/mumble/TalkingUISelection.h
+++ b/src/mumble/TalkingUISelection.h
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 The Mumble Developers. All rights reserved.
+// Copyright 2020-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/mumble/TaskList.cpp
+++ b/src/mumble/TaskList.cpp
@@ -1,4 +1,4 @@
-// Copyright 2009-2021 The Mumble Developers. All rights reserved.
+// Copyright 2009-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/mumble/TaskList.h
+++ b/src/mumble/TaskList.h
@@ -1,4 +1,4 @@
-// Copyright 2009-2021 The Mumble Developers. All rights reserved.
+// Copyright 2009-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/mumble/TextMessage.cpp
+++ b/src/mumble/TextMessage.cpp
@@ -1,4 +1,4 @@
-// Copyright 2007-2021 The Mumble Developers. All rights reserved.
+// Copyright 2007-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/mumble/TextMessage.h
+++ b/src/mumble/TextMessage.h
@@ -1,4 +1,4 @@
-// Copyright 2007-2021 The Mumble Developers. All rights reserved.
+// Copyright 2007-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/mumble/TextToSpeech.cpp
+++ b/src/mumble/TextToSpeech.cpp
@@ -1,4 +1,4 @@
-// Copyright 2017-2021 The Mumble Developers. All rights reserved.
+// Copyright 2017-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/mumble/TextToSpeech.h
+++ b/src/mumble/TextToSpeech.h
@@ -1,4 +1,4 @@
-// Copyright 2007-2021 The Mumble Developers. All rights reserved.
+// Copyright 2007-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/mumble/TextToSpeech_macx.mm
+++ b/src/mumble/TextToSpeech_macx.mm
@@ -1,4 +1,4 @@
-// Copyright 2014-2021 The Mumble Developers. All rights reserved.
+// Copyright 2014-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/mumble/TextToSpeech_unix.cpp
+++ b/src/mumble/TextToSpeech_unix.cpp
@@ -1,4 +1,4 @@
-// Copyright 2007-2021 The Mumble Developers. All rights reserved.
+// Copyright 2007-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/mumble/TextToSpeech_win.cpp
+++ b/src/mumble/TextToSpeech_win.cpp
@@ -1,4 +1,4 @@
-// Copyright 2007-2021 The Mumble Developers. All rights reserved.
+// Copyright 2007-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/mumble/ThemeInfo.cpp
+++ b/src/mumble/ThemeInfo.cpp
@@ -1,4 +1,4 @@
-// Copyright 2015-2021 The Mumble Developers. All rights reserved.
+// Copyright 2015-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/mumble/ThemeInfo.h
+++ b/src/mumble/ThemeInfo.h
@@ -1,4 +1,4 @@
-// Copyright 2015-2021 The Mumble Developers. All rights reserved.
+// Copyright 2015-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/mumble/Themes.cpp
+++ b/src/mumble/Themes.cpp
@@ -1,4 +1,4 @@
-// Copyright 2015-2021 The Mumble Developers. All rights reserved.
+// Copyright 2015-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/mumble/Themes.h
+++ b/src/mumble/Themes.h
@@ -1,4 +1,4 @@
-// Copyright 2015-2021 The Mumble Developers. All rights reserved.
+// Copyright 2015-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/mumble/Tokens.cpp
+++ b/src/mumble/Tokens.cpp
@@ -1,4 +1,4 @@
-// Copyright 2009-2021 The Mumble Developers. All rights reserved.
+// Copyright 2009-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/mumble/Tokens.h
+++ b/src/mumble/Tokens.h
@@ -1,4 +1,4 @@
-// Copyright 2009-2021 The Mumble Developers. All rights reserved.
+// Copyright 2009-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/mumble/Translations.cpp
+++ b/src/mumble/Translations.cpp
@@ -1,4 +1,4 @@
-// Copyright 2021 The Mumble Developers. All rights reserved.
+// Copyright 2021-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/mumble/Translations.h
+++ b/src/mumble/Translations.h
@@ -1,4 +1,4 @@
-// Copyright 2021 The Mumble Developers. All rights reserved.
+// Copyright 2021-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/mumble/Usage.cpp
+++ b/src/mumble/Usage.cpp
@@ -1,4 +1,4 @@
-// Copyright 2009-2021 The Mumble Developers. All rights reserved.
+// Copyright 2009-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/mumble/Usage.h
+++ b/src/mumble/Usage.h
@@ -1,4 +1,4 @@
-// Copyright 2009-2021 The Mumble Developers. All rights reserved.
+// Copyright 2009-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/mumble/UserEdit.cpp
+++ b/src/mumble/UserEdit.cpp
@@ -1,4 +1,4 @@
-// Copyright 2009-2021 The Mumble Developers. All rights reserved.
+// Copyright 2009-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/mumble/UserEdit.h
+++ b/src/mumble/UserEdit.h
@@ -1,4 +1,4 @@
-// Copyright 2009-2021 The Mumble Developers. All rights reserved.
+// Copyright 2009-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/mumble/UserInformation.cpp
+++ b/src/mumble/UserInformation.cpp
@@ -1,4 +1,4 @@
-// Copyright 2010-2021 The Mumble Developers. All rights reserved.
+// Copyright 2010-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/mumble/UserInformation.h
+++ b/src/mumble/UserInformation.h
@@ -1,4 +1,4 @@
-// Copyright 2010-2021 The Mumble Developers. All rights reserved.
+// Copyright 2010-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/mumble/UserListModel.cpp
+++ b/src/mumble/UserListModel.cpp
@@ -1,4 +1,4 @@
-// Copyright 2013-2021 The Mumble Developers. All rights reserved.
+// Copyright 2013-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/mumble/UserListModel.h
+++ b/src/mumble/UserListModel.h
@@ -1,4 +1,4 @@
-// Copyright 2013-2021 The Mumble Developers. All rights reserved.
+// Copyright 2013-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/mumble/UserLocalNicknameDialog.cpp
+++ b/src/mumble/UserLocalNicknameDialog.cpp
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 The Mumble Developers. All rights reserved.
+// Copyright 2020-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/mumble/UserLocalNicknameDialog.h
+++ b/src/mumble/UserLocalNicknameDialog.h
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 The Mumble Developers. All rights reserved.
+// Copyright 2020-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/mumble/UserLocalVolumeDialog.cpp
+++ b/src/mumble/UserLocalVolumeDialog.cpp
@@ -1,4 +1,4 @@
-// Copyright 2015-2021 The Mumble Developers. All rights reserved.
+// Copyright 2015-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/mumble/UserLocalVolumeDialog.h
+++ b/src/mumble/UserLocalVolumeDialog.h
@@ -1,4 +1,4 @@
-// Copyright 2015-2021 The Mumble Developers. All rights reserved.
+// Copyright 2015-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/mumble/UserLockFile.h
+++ b/src/mumble/UserLockFile.h
@@ -1,4 +1,4 @@
-// Copyright 2015-2021 The Mumble Developers. All rights reserved.
+// Copyright 2015-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/mumble/UserLockFile_win.cpp
+++ b/src/mumble/UserLockFile_win.cpp
@@ -1,4 +1,4 @@
-// Copyright 2015-2021 The Mumble Developers. All rights reserved.
+// Copyright 2015-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/mumble/UserModel.cpp
+++ b/src/mumble/UserModel.cpp
@@ -1,4 +1,4 @@
-// Copyright 2009-2021 The Mumble Developers. All rights reserved.
+// Copyright 2009-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/mumble/UserModel.h
+++ b/src/mumble/UserModel.h
@@ -1,4 +1,4 @@
-// Copyright 2009-2021 The Mumble Developers. All rights reserved.
+// Copyright 2009-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/mumble/UserView.cpp
+++ b/src/mumble/UserView.cpp
@@ -1,4 +1,4 @@
-// Copyright 2009-2021 The Mumble Developers. All rights reserved.
+// Copyright 2009-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/mumble/UserView.h
+++ b/src/mumble/UserView.h
@@ -1,4 +1,4 @@
-// Copyright 2009-2021 The Mumble Developers. All rights reserved.
+// Copyright 2009-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/mumble/VersionCheck.cpp
+++ b/src/mumble/VersionCheck.cpp
@@ -1,4 +1,4 @@
-// Copyright 2007-2021 The Mumble Developers. All rights reserved.
+// Copyright 2007-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/mumble/VersionCheck.h
+++ b/src/mumble/VersionCheck.h
@@ -1,4 +1,4 @@
-// Copyright 2007-2021 The Mumble Developers. All rights reserved.
+// Copyright 2007-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/mumble/ViewCert.cpp
+++ b/src/mumble/ViewCert.cpp
@@ -1,4 +1,4 @@
-// Copyright 2007-2021 The Mumble Developers. All rights reserved.
+// Copyright 2007-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/mumble/ViewCert.h
+++ b/src/mumble/ViewCert.h
@@ -1,4 +1,4 @@
-// Copyright 2007-2021 The Mumble Developers. All rights reserved.
+// Copyright 2007-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/mumble/VoiceRecorder.cpp
+++ b/src/mumble/VoiceRecorder.cpp
@@ -1,4 +1,4 @@
-// Copyright 2010-2021 The Mumble Developers. All rights reserved.
+// Copyright 2010-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/mumble/VoiceRecorder.h
+++ b/src/mumble/VoiceRecorder.h
@@ -1,4 +1,4 @@
-// Copyright 2010-2021 The Mumble Developers. All rights reserved.
+// Copyright 2010-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/mumble/VoiceRecorderDialog.cpp
+++ b/src/mumble/VoiceRecorderDialog.cpp
@@ -1,4 +1,4 @@
-// Copyright 2010-2021 The Mumble Developers. All rights reserved.
+// Copyright 2010-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/mumble/VoiceRecorderDialog.h
+++ b/src/mumble/VoiceRecorderDialog.h
@@ -1,4 +1,4 @@
-// Copyright 2010-2021 The Mumble Developers. All rights reserved.
+// Copyright 2010-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/mumble/WASAPI.cpp
+++ b/src/mumble/WASAPI.cpp
@@ -1,4 +1,4 @@
-// Copyright 2008-2021 The Mumble Developers. All rights reserved.
+// Copyright 2008-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/mumble/WASAPI.h
+++ b/src/mumble/WASAPI.h
@@ -1,4 +1,4 @@
-// Copyright 2008-2021 The Mumble Developers. All rights reserved.
+// Copyright 2008-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/mumble/WASAPINotificationClient.cpp
+++ b/src/mumble/WASAPINotificationClient.cpp
@@ -1,4 +1,4 @@
-// Copyright 2012-2021 The Mumble Developers. All rights reserved.
+// Copyright 2012-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/mumble/WASAPINotificationClient.h
+++ b/src/mumble/WASAPINotificationClient.h
@@ -1,4 +1,4 @@
-// Copyright 2012-2021 The Mumble Developers. All rights reserved.
+// Copyright 2012-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/mumble/WebFetch.cpp
+++ b/src/mumble/WebFetch.cpp
@@ -1,4 +1,4 @@
-// Copyright 2011-2021 The Mumble Developers. All rights reserved.
+// Copyright 2011-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/mumble/WebFetch.h
+++ b/src/mumble/WebFetch.h
@@ -1,4 +1,4 @@
-// Copyright 2011-2021 The Mumble Developers. All rights reserved.
+// Copyright 2011-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/mumble/WinGUIDs.cpp
+++ b/src/mumble/WinGUIDs.cpp
@@ -1,4 +1,4 @@
-// Copyright 2017-2021 The Mumble Developers. All rights reserved.
+// Copyright 2017-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/mumble/XMLTools.cpp
+++ b/src/mumble/XMLTools.cpp
@@ -1,4 +1,4 @@
-// Copyright 2017-2021 The Mumble Developers. All rights reserved.
+// Copyright 2017-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/mumble/XMLTools.h
+++ b/src/mumble/XMLTools.h
@@ -1,4 +1,4 @@
-// Copyright 2017-2021 The Mumble Developers. All rights reserved.
+// Copyright 2017-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/mumble/XboxInput.cpp
+++ b/src/mumble/XboxInput.cpp
@@ -1,4 +1,4 @@
-// Copyright 2015-2021 The Mumble Developers. All rights reserved.
+// Copyright 2015-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/mumble/XboxInput.h
+++ b/src/mumble/XboxInput.h
@@ -1,4 +1,4 @@
-// Copyright 2015-2021 The Mumble Developers. All rights reserved.
+// Copyright 2015-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/mumble/Zeroconf.cpp
+++ b/src/mumble/Zeroconf.cpp
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 The Mumble Developers. All rights reserved.
+// Copyright 2020-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/mumble/Zeroconf.h
+++ b/src/mumble/Zeroconf.h
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 The Mumble Developers. All rights reserved.
+// Copyright 2020-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/mumble/main.cpp
+++ b/src/mumble/main.cpp
@@ -1,4 +1,4 @@
-// Copyright 2007-2021 The Mumble Developers. All rights reserved.
+// Copyright 2007-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/mumble/mumble_pch.hpp
+++ b/src/mumble/mumble_pch.hpp
@@ -1,4 +1,4 @@
-// Copyright 2008-2021 The Mumble Developers. All rights reserved.
+// Copyright 2008-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/mumble/os_early_win.cpp
+++ b/src/mumble/os_early_win.cpp
@@ -1,4 +1,4 @@
-// Copyright 2017-2021 The Mumble Developers. All rights reserved.
+// Copyright 2017-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/mumble/os_macx.mm
+++ b/src/mumble/os_macx.mm
@@ -1,4 +1,4 @@
-// Copyright 2010-2021 The Mumble Developers. All rights reserved.
+// Copyright 2010-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/mumble/os_unix.cpp
+++ b/src/mumble/os_unix.cpp
@@ -1,4 +1,4 @@
-// Copyright 2016-2021 The Mumble Developers. All rights reserved.
+// Copyright 2016-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/mumble/os_win.cpp
+++ b/src/mumble/os_win.cpp
@@ -1,4 +1,4 @@
-// Copyright 2007-2021 The Mumble Developers. All rights reserved.
+// Copyright 2007-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/mumble/widgets/CompletablePage.cpp
+++ b/src/mumble/widgets/CompletablePage.cpp
@@ -1,4 +1,4 @@
-// Copyright 2021 The Mumble Developers. All rights reserved.
+// Copyright 2021-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/mumble/widgets/CompletablePage.h
+++ b/src/mumble/widgets/CompletablePage.h
@@ -1,4 +1,4 @@
-// Copyright 2021 The Mumble Developers. All rights reserved.
+// Copyright 2021-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/mumble/widgets/MUComboBox.cpp
+++ b/src/mumble/widgets/MUComboBox.cpp
@@ -1,4 +1,4 @@
-// Copyright 2016-2021 The Mumble Developers. All rights reserved.
+// Copyright 2016-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/mumble/widgets/MUComboBox.h
+++ b/src/mumble/widgets/MUComboBox.h
@@ -1,4 +1,4 @@
-// Copyright 2016-2021 The Mumble Developers. All rights reserved.
+// Copyright 2016-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/mumble/widgets/MultiStyleWidgetWrapper.cpp
+++ b/src/mumble/widgets/MultiStyleWidgetWrapper.cpp
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 The Mumble Developers. All rights reserved.
+// Copyright 2020-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/mumble/widgets/MultiStyleWidgetWrapper.h
+++ b/src/mumble/widgets/MultiStyleWidgetWrapper.h
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 The Mumble Developers. All rights reserved.
+// Copyright 2020-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/mumble/widgets/RichTextItemDelegate.cpp
+++ b/src/mumble/widgets/RichTextItemDelegate.cpp
@@ -1,4 +1,4 @@
-// Copyright 2021 The Mumble Developers. All rights reserved.
+// Copyright 2021-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/mumble/widgets/RichTextItemDelegate.h
+++ b/src/mumble/widgets/RichTextItemDelegate.h
@@ -1,4 +1,4 @@
-// Copyright 2021 The Mumble Developers. All rights reserved.
+// Copyright 2021-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/mumble/widgets/SearchDialogItemDelegate.cpp
+++ b/src/mumble/widgets/SearchDialogItemDelegate.cpp
@@ -1,4 +1,4 @@
-// Copyright 2021 The Mumble Developers. All rights reserved.
+// Copyright 2021-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/mumble/widgets/SearchDialogItemDelegate.h
+++ b/src/mumble/widgets/SearchDialogItemDelegate.h
@@ -1,4 +1,4 @@
-// Copyright 2021 The Mumble Developers. All rights reserved.
+// Copyright 2021-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/mumble/widgets/SearchDialogTree.cpp
+++ b/src/mumble/widgets/SearchDialogTree.cpp
@@ -1,4 +1,4 @@
-// Copyright 2021 The Mumble Developers. All rights reserved.
+// Copyright 2021-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/mumble/widgets/SearchDialogTree.h
+++ b/src/mumble/widgets/SearchDialogTree.h
@@ -1,4 +1,4 @@
-// Copyright 2021 The Mumble Developers. All rights reserved.
+// Copyright 2021-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/mumble_exe/CMakeLists.txt
+++ b/src/mumble_exe/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 The Mumble Developers. All rights reserved.
+# Copyright 2020-2022 The Mumble Developers. All rights reserved.
 # Use of this source code is governed by a BSD-style license
 # that can be found in the LICENSE file at the root of the
 # Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/mumble_exe/Overlay.cpp
+++ b/src/mumble_exe/Overlay.cpp
@@ -1,4 +1,4 @@
-// Copyright 2013-2021 The Mumble Developers. All rights reserved.
+// Copyright 2013-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/mumble_exe/mumble_exe.cpp
+++ b/src/mumble_exe/mumble_exe.cpp
@@ -1,4 +1,4 @@
-// Copyright 2013-2021 The Mumble Developers. All rights reserved.
+// Copyright 2013-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/murmur/About.cpp
+++ b/src/murmur/About.cpp
@@ -1,4 +1,4 @@
-// Copyright 2016-2021 The Mumble Developers. All rights reserved.
+// Copyright 2016-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/murmur/About.h
+++ b/src/murmur/About.h
@@ -1,4 +1,4 @@
-// Copyright 2016-2021 The Mumble Developers. All rights reserved.
+// Copyright 2016-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/murmur/CMakeLists.txt
+++ b/src/murmur/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 The Mumble Developers. All rights reserved.
+# Copyright 2020-2022 The Mumble Developers. All rights reserved.
 # Use of this source code is governed by a BSD-style license
 # that can be found in the LICENSE file at the root of the
 # Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/murmur/Cert.cpp
+++ b/src/murmur/Cert.cpp
@@ -1,4 +1,4 @@
-// Copyright 2007-2021 The Mumble Developers. All rights reserved.
+// Copyright 2007-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/murmur/DBus.cpp
+++ b/src/murmur/DBus.cpp
@@ -1,4 +1,4 @@
-// Copyright 2007-2021 The Mumble Developers. All rights reserved.
+// Copyright 2007-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/murmur/DBus.h
+++ b/src/murmur/DBus.h
@@ -1,4 +1,4 @@
-// Copyright 2007-2021 The Mumble Developers. All rights reserved.
+// Copyright 2007-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/murmur/Messages.cpp
+++ b/src/murmur/Messages.cpp
@@ -1,4 +1,4 @@
-// Copyright 2007-2021 The Mumble Developers. All rights reserved.
+// Copyright 2007-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/murmur/Meta.cpp
+++ b/src/murmur/Meta.cpp
@@ -1,4 +1,4 @@
-// Copyright 2007-2021 The Mumble Developers. All rights reserved.
+// Copyright 2007-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/murmur/Meta.h
+++ b/src/murmur/Meta.h
@@ -1,4 +1,4 @@
-// Copyright 2007-2021 The Mumble Developers. All rights reserved.
+// Copyright 2007-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/murmur/Murmur.ice
+++ b/src/murmur/Murmur.ice
@@ -1,4 +1,4 @@
-// Copyright 2008-2021 The Mumble Developers. All rights reserved.
+// Copyright 2008-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/murmur/MurmurGRPCImpl.cpp
+++ b/src/murmur/MurmurGRPCImpl.cpp
@@ -1,4 +1,4 @@
-// Copyright 2016-2021 The Mumble Developers. All rights reserved.
+// Copyright 2016-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/murmur/MurmurGRPCImpl.h
+++ b/src/murmur/MurmurGRPCImpl.h
@@ -1,4 +1,4 @@
-// Copyright 2016-2021 The Mumble Developers. All rights reserved.
+// Copyright 2016-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/murmur/MurmurI.h
+++ b/src/murmur/MurmurI.h
@@ -1,4 +1,4 @@
-// Copyright 2008-2021 The Mumble Developers. All rights reserved.
+// Copyright 2008-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/murmur/MurmurIce.cpp
+++ b/src/murmur/MurmurIce.cpp
@@ -1,4 +1,4 @@
-// Copyright 2008-2021 The Mumble Developers. All rights reserved.
+// Copyright 2008-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/murmur/MurmurIce.h
+++ b/src/murmur/MurmurIce.h
@@ -1,4 +1,4 @@
-// Copyright 2008-2021 The Mumble Developers. All rights reserved.
+// Copyright 2008-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/murmur/MurmurIceWrapper.cpp
+++ b/src/murmur/MurmurIceWrapper.cpp
@@ -1,4 +1,4 @@
-// Copyright 2008-2021 The Mumble Developers. All rights reserved.
+// Copyright 2008-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/murmur/MurmurRPC.proto
+++ b/src/murmur/MurmurRPC.proto
@@ -1,4 +1,4 @@
-// Copyright 2016-2021 The Mumble Developers. All rights reserved.
+// Copyright 2016-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/murmur/PBKDF2.cpp
+++ b/src/murmur/PBKDF2.cpp
@@ -1,4 +1,4 @@
-// Copyright 2014-2021 The Mumble Developers. All rights reserved.
+// Copyright 2014-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/murmur/PBKDF2.h
+++ b/src/murmur/PBKDF2.h
@@ -1,4 +1,4 @@
-// Copyright 2014-2021 The Mumble Developers. All rights reserved.
+// Copyright 2014-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/murmur/RPC.cpp
+++ b/src/murmur/RPC.cpp
@@ -1,4 +1,4 @@
-// Copyright 2008-2021 The Mumble Developers. All rights reserved.
+// Copyright 2008-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/murmur/Register.cpp
+++ b/src/murmur/Register.cpp
@@ -1,4 +1,4 @@
-// Copyright 2007-2021 The Mumble Developers. All rights reserved.
+// Copyright 2007-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/murmur/Server.cpp
+++ b/src/murmur/Server.cpp
@@ -1,4 +1,4 @@
-// Copyright 2007-2021 The Mumble Developers. All rights reserved.
+// Copyright 2007-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/murmur/Server.h
+++ b/src/murmur/Server.h
@@ -1,4 +1,4 @@
-// Copyright 2007-2021 The Mumble Developers. All rights reserved.
+// Copyright 2007-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/murmur/ServerDB.cpp
+++ b/src/murmur/ServerDB.cpp
@@ -1,4 +1,4 @@
-// Copyright 2007-2021 The Mumble Developers. All rights reserved.
+// Copyright 2007-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/murmur/ServerDB.h
+++ b/src/murmur/ServerDB.h
@@ -1,4 +1,4 @@
-// Copyright 2007-2021 The Mumble Developers. All rights reserved.
+// Copyright 2007-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/murmur/ServerUser.cpp
+++ b/src/murmur/ServerUser.cpp
@@ -1,4 +1,4 @@
-// Copyright 2010-2021 The Mumble Developers. All rights reserved.
+// Copyright 2010-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/murmur/ServerUser.h
+++ b/src/murmur/ServerUser.h
@@ -1,4 +1,4 @@
-// Copyright 2010-2021 The Mumble Developers. All rights reserved.
+// Copyright 2010-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/murmur/TracyConstants.h
+++ b/src/murmur/TracyConstants.h
@@ -1,4 +1,4 @@
-// Copyright 2021 The Mumble Developers. All rights reserved.
+// Copyright 2021-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/murmur/Tray.cpp
+++ b/src/murmur/Tray.cpp
@@ -1,4 +1,4 @@
-// Copyright 2007-2021 The Mumble Developers. All rights reserved.
+// Copyright 2007-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/murmur/Tray.h
+++ b/src/murmur/Tray.h
@@ -1,4 +1,4 @@
-// Copyright 2007-2021 The Mumble Developers. All rights reserved.
+// Copyright 2007-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/murmur/UnixMurmur.cpp
+++ b/src/murmur/UnixMurmur.cpp
@@ -1,4 +1,4 @@
-// Copyright 2007-2021 The Mumble Developers. All rights reserved.
+// Copyright 2007-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/murmur/UnixMurmur.h
+++ b/src/murmur/UnixMurmur.h
@@ -1,4 +1,4 @@
-// Copyright 2007-2021 The Mumble Developers. All rights reserved.
+// Copyright 2007-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/murmur/Zeroconf.cpp
+++ b/src/murmur/Zeroconf.cpp
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 The Mumble Developers. All rights reserved.
+// Copyright 2020-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/murmur/Zeroconf.h
+++ b/src/murmur/Zeroconf.h
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 The Mumble Developers. All rights reserved.
+// Copyright 2020-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/murmur/main.cpp
+++ b/src/murmur/main.cpp
@@ -1,4 +1,4 @@
-// Copyright 2008-2021 The Mumble Developers. All rights reserved.
+// Copyright 2008-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/murmur/murmur_pch.h
+++ b/src/murmur/murmur_pch.h
@@ -1,4 +1,4 @@
-// Copyright 2007-2021 The Mumble Developers. All rights reserved.
+// Copyright 2007-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/murmur_grpcwrapper_protoc_plugin/CMakeLists.txt
+++ b/src/murmur_grpcwrapper_protoc_plugin/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 The Mumble Developers. All rights reserved.
+# Copyright 2020-2022 The Mumble Developers. All rights reserved.
 # Use of this source code is governed by a BSD-style license
 # that can be found in the LICENSE file at the root of the
 # Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/murmur_grpcwrapper_protoc_plugin/main.cpp
+++ b/src/murmur_grpcwrapper_protoc_plugin/main.cpp
@@ -1,4 +1,4 @@
-// Copyright 2016-2021 The Mumble Developers. All rights reserved.
+// Copyright 2016-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/tests/Benchmark.cpp
+++ b/src/tests/Benchmark.cpp
@@ -1,4 +1,4 @@
-// Copyright 2007-2021 The Mumble Developers. All rights reserved.
+// Copyright 2007-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/tests/CMakeLists.txt
+++ b/src/tests/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 The Mumble Developers. All rights reserved.
+# Copyright 2020-2022 The Mumble Developers. All rights reserved.
 # Use of this source code is governed by a BSD-style license
 # that can be found in the LICENSE file at the root of the
 # Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/tests/Collections.cpp
+++ b/src/tests/Collections.cpp
@@ -1,4 +1,4 @@
-// Copyright 2009-2021 The Mumble Developers. All rights reserved.
+// Copyright 2009-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/tests/Emit.cpp
+++ b/src/tests/Emit.cpp
@@ -1,4 +1,4 @@
-// Copyright 2009-2021 The Mumble Developers. All rights reserved.
+// Copyright 2009-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/tests/Hash.cpp
+++ b/src/tests/Hash.cpp
@@ -1,4 +1,4 @@
-// Copyright 2009-2021 The Mumble Developers. All rights reserved.
+// Copyright 2009-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/tests/Lock.cpp
+++ b/src/tests/Lock.cpp
@@ -1,4 +1,4 @@
-// Copyright 2009-2021 The Mumble Developers. All rights reserved.
+// Copyright 2009-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/tests/OverlayTest.cpp
+++ b/src/tests/OverlayTest.cpp
@@ -1,4 +1,4 @@
-// Copyright 2010-2021 The Mumble Developers. All rights reserved.
+// Copyright 2010-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/tests/ProtoBuf.cpp
+++ b/src/tests/ProtoBuf.cpp
@@ -1,4 +1,4 @@
-// Copyright 2009-2021 The Mumble Developers. All rights reserved.
+// Copyright 2009-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/tests/ProtoBuf.proto
+++ b/src/tests/ProtoBuf.proto
@@ -1,4 +1,4 @@
-// Copyright 2009-2021 The Mumble Developers. All rights reserved.
+// Copyright 2009-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/tests/Resample.cpp
+++ b/src/tests/Resample.cpp
@@ -1,4 +1,4 @@
-// Copyright 2009-2021 The Mumble Developers. All rights reserved.
+// Copyright 2009-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/tests/TestCrypt/CMakeLists.txt
+++ b/src/tests/TestCrypt/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 The Mumble Developers. All rights reserved.
+# Copyright 2020-2022 The Mumble Developers. All rights reserved.
 # Use of this source code is governed by a BSD-style license
 # that can be found in the LICENSE file at the root of the
 # Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/tests/TestCrypt/TestCrypt.cpp
+++ b/src/tests/TestCrypt/TestCrypt.cpp
@@ -1,4 +1,4 @@
-// Copyright 2017-2021 The Mumble Developers. All rights reserved.
+// Copyright 2017-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/tests/TestCryptographicHash/CMakeLists.txt
+++ b/src/tests/TestCryptographicHash/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 The Mumble Developers. All rights reserved.
+# Copyright 2020-2022 The Mumble Developers. All rights reserved.
 # Use of this source code is governed by a BSD-style license
 # that can be found in the LICENSE file at the root of the
 # Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/tests/TestCryptographicHash/TestCryptographicHash.cpp
+++ b/src/tests/TestCryptographicHash/TestCryptographicHash.cpp
@@ -1,4 +1,4 @@
-// Copyright 2017-2021 The Mumble Developers. All rights reserved.
+// Copyright 2017-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/tests/TestCryptographicRandom/CMakeLists.txt
+++ b/src/tests/TestCryptographicRandom/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 The Mumble Developers. All rights reserved.
+# Copyright 2020-2022 The Mumble Developers. All rights reserved.
 # Use of this source code is governed by a BSD-style license
 # that can be found in the LICENSE file at the root of the
 # Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/tests/TestCryptographicRandom/TestCryptographicRandom.cpp
+++ b/src/tests/TestCryptographicRandom/TestCryptographicRandom.cpp
@@ -1,4 +1,4 @@
-// Copyright 2017-2021 The Mumble Developers. All rights reserved.
+// Copyright 2017-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/tests/TestFFDHE/CMakeLists.txt
+++ b/src/tests/TestFFDHE/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 The Mumble Developers. All rights reserved.
+# Copyright 2020-2022 The Mumble Developers. All rights reserved.
 # Use of this source code is governed by a BSD-style license
 # that can be found in the LICENSE file at the root of the
 # Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/tests/TestFFDHE/TestFFDHE.cpp
+++ b/src/tests/TestFFDHE/TestFFDHE.cpp
@@ -1,4 +1,4 @@
-// Copyright 2017-2021 The Mumble Developers. All rights reserved.
+// Copyright 2017-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/tests/TestLink.cpp
+++ b/src/tests/TestLink.cpp
@@ -1,4 +1,4 @@
-// Copyright 2008-2021 The Mumble Developers. All rights reserved.
+// Copyright 2008-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/tests/TestPacketDataStream/CMakeLists.txt
+++ b/src/tests/TestPacketDataStream/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 The Mumble Developers. All rights reserved.
+# Copyright 2020-2022 The Mumble Developers. All rights reserved.
 # Use of this source code is governed by a BSD-style license
 # that can be found in the LICENSE file at the root of the
 # Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/tests/TestPacketDataStream/TestPacketDataStream.cpp
+++ b/src/tests/TestPacketDataStream/TestPacketDataStream.cpp
@@ -1,4 +1,4 @@
-// Copyright 2017-2021 The Mumble Developers. All rights reserved.
+// Copyright 2017-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/tests/TestPasswordGenerator/CMakeLists.txt
+++ b/src/tests/TestPasswordGenerator/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 The Mumble Developers. All rights reserved.
+# Copyright 2020-2022 The Mumble Developers. All rights reserved.
 # Use of this source code is governed by a BSD-style license
 # that can be found in the LICENSE file at the root of the
 # Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/tests/TestPasswordGenerator/TestPasswordGenerator.cpp
+++ b/src/tests/TestPasswordGenerator/TestPasswordGenerator.cpp
@@ -1,4 +1,4 @@
-// Copyright 2017-2021 The Mumble Developers. All rights reserved.
+// Copyright 2017-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/tests/TestSSLLocks/CMakeLists.txt
+++ b/src/tests/TestSSLLocks/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 The Mumble Developers. All rights reserved.
+# Copyright 2020-2022 The Mumble Developers. All rights reserved.
 # Use of this source code is governed by a BSD-style license
 # that can be found in the LICENSE file at the root of the
 # Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/tests/TestSSLLocks/TestSSLLocks.cpp
+++ b/src/tests/TestSSLLocks/TestSSLLocks.cpp
@@ -1,4 +1,4 @@
-// Copyright 2017-2021 The Mumble Developers. All rights reserved.
+// Copyright 2017-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/tests/TestSelfSignedCertificate/CMakeLists.txt
+++ b/src/tests/TestSelfSignedCertificate/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 The Mumble Developers. All rights reserved.
+# Copyright 2020-2022 The Mumble Developers. All rights reserved.
 # Use of this source code is governed by a BSD-style license
 # that can be found in the LICENSE file at the root of the
 # Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/tests/TestSelfSignedCertificate/TestSelfSignedCertificate.cpp
+++ b/src/tests/TestSelfSignedCertificate/TestSelfSignedCertificate.cpp
@@ -1,4 +1,4 @@
-// Copyright 2017-2021 The Mumble Developers. All rights reserved.
+// Copyright 2017-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/tests/TestServerAddress/CMakeLists.txt
+++ b/src/tests/TestServerAddress/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 The Mumble Developers. All rights reserved.
+# Copyright 2020-2022 The Mumble Developers. All rights reserved.
 # Use of this source code is governed by a BSD-style license
 # that can be found in the LICENSE file at the root of the
 # Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/tests/TestServerAddress/TestServerAddress.cpp
+++ b/src/tests/TestServerAddress/TestServerAddress.cpp
@@ -1,4 +1,4 @@
-// Copyright 2017-2021 The Mumble Developers. All rights reserved.
+// Copyright 2017-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/tests/TestServerResolver/CMakeLists.txt
+++ b/src/tests/TestServerResolver/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 The Mumble Developers. All rights reserved.
+# Copyright 2020-2022 The Mumble Developers. All rights reserved.
 # Use of this source code is governed by a BSD-style license
 # that can be found in the LICENSE file at the root of the
 # Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/tests/TestServerResolver/TestServerResolver.cpp
+++ b/src/tests/TestServerResolver/TestServerResolver.cpp
@@ -1,4 +1,4 @@
-// Copyright 2017-2021 The Mumble Developers. All rights reserved.
+// Copyright 2017-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/tests/TestStdAbs/CMakeLists.txt
+++ b/src/tests/TestStdAbs/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 The Mumble Developers. All rights reserved.
+# Copyright 2020-2022 The Mumble Developers. All rights reserved.
 # Use of this source code is governed by a BSD-style license
 # that can be found in the LICENSE file at the root of the
 # Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/tests/TestStdAbs/TestStdAbs.cpp
+++ b/src/tests/TestStdAbs/TestStdAbs.cpp
@@ -1,4 +1,4 @@
-// Copyright 2017-2021 The Mumble Developers. All rights reserved.
+// Copyright 2017-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/tests/TestTimer/CMakeLists.txt
+++ b/src/tests/TestTimer/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 The Mumble Developers. All rights reserved.
+# Copyright 2020-2022 The Mumble Developers. All rights reserved.
 # Use of this source code is governed by a BSD-style license
 # that can be found in the LICENSE file at the root of the
 # Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/tests/TestTimer/TestTimer.cpp
+++ b/src/tests/TestTimer/TestTimer.cpp
@@ -1,4 +1,4 @@
-// Copyright 2017-2021 The Mumble Developers. All rights reserved.
+// Copyright 2017-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/tests/TestUnresolvedServerAddress/CMakeLists.txt
+++ b/src/tests/TestUnresolvedServerAddress/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 The Mumble Developers. All rights reserved.
+# Copyright 2020-2022 The Mumble Developers. All rights reserved.
 # Use of this source code is governed by a BSD-style license
 # that can be found in the LICENSE file at the root of the
 # Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/tests/TestUnresolvedServerAddress/TestUnresolvedServerAddress.cpp
+++ b/src/tests/TestUnresolvedServerAddress/TestUnresolvedServerAddress.cpp
@@ -1,4 +1,4 @@
-// Copyright 2017-2021 The Mumble Developers. All rights reserved.
+// Copyright 2017-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/tests/TestXMLTools/CMakeLists.txt
+++ b/src/tests/TestXMLTools/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 The Mumble Developers. All rights reserved.
+# Copyright 2020-2022 The Mumble Developers. All rights reserved.
 # Use of this source code is governed by a BSD-style license
 # that can be found in the LICENSE file at the root of the
 # Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/tests/TestXMLTools/TestXMLTools.cpp
+++ b/src/tests/TestXMLTools/TestXMLTools.cpp
@@ -1,4 +1,4 @@
-// Copyright 2017-2021 The Mumble Developers. All rights reserved.
+// Copyright 2017-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.

--- a/src/win.h
+++ b/src/win.h
@@ -1,4 +1,4 @@
-// Copyright 2019-2021 The Mumble Developers. All rights reserved.
+// Copyright 2019-2022 The Mumble Developers. All rights reserved.
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file at the root of the
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.


### PR DESCRIPTION
### Checks

- [x] My commits follow the [commit guidelines](https://github.com/mumble-voip/mumble/blob/master/COMMIT_GUIDELINES.md)

