### PR TITLE
FEAT(client): Improve handling of IP masks in BanEditor

### DIFF
--- a/src/mumble/BanEditor.cpp
+++ b/src/mumble/BanEditor.cpp
@@ -208,10 +208,56 @@ void BanEditor::on_qleSearch_textChanged(const QString &match) {
 	}
 }
 
-void BanEditor::on_qleIP_textChanged(QString) {
-	qpbAdd->setEnabled(qleIP->isModified());
-	if (qlwBans->currentRow() >= 0)
-		qpbUpdate->setEnabled(qleIP->isModified());
+void BanEditor::on_qleIP_textChanged(QString address) {
+	bool valid  = false;
+	int maxMask = 0;
+
+	switch (QHostAddress(address).protocol()) {
+		case QAbstractSocket::IPv4Protocol:
+			valid = true;
+			// IPv4: 8 <= mask <= 32
+			maxMask = 32;
+			break;
+		case QAbstractSocket::IPv6Protocol:
+			valid = true;
+			// IPv6: 8 <= mask <= 128
+			maxMask = 128;
+			break;
+		default:
+			valid = false;
+			break;
+	}
+
+	if (!valid) {
+		// Set red-ish background to indicate an invalid IP address
+		qleIP->setStyleSheet("background-color: #F08080;");
+	} else {
+		qleIP->setStyleSheet("");
+	}
+
+	if (qlwBans->currentRow() >= 0) {
+		qpbUpdate->setEnabled(valid && qleIP->isModified());
+	}
+
+	qpbAdd->setEnabled(valid && qleIP->isModified());
+
+	// Only display the controls for setting the mask, if a valid IP address has been entered (so we know what kind of
+	// masks are valid)
+	qsbMask->setVisible(valid);
+	qlMask->setVisible(valid);
+
+	if (valid) {
+		int prevMask     = qsbMask->value();
+		bool wasSetToMax = qsbMask->maximum() == prevMask;
+		qsbMask->setMaximum(maxMask);
+
+		if (wasSetToMax) {
+			// If the mask value was at its maximum value and we change from IPv4 to IPv6, we still want to set the mask
+			// to the max. value as we have to assume the user didn't explicitly modify the value (and thus we want the
+			// default, which always is the max. value).
+			qsbMask->setValue(maxMask);
+		}
+	}
 }
 
 void BanEditor::on_qleReason_textChanged(QString) {


### PR DESCRIPTION
When using the BanEditor to manually create a new Ban entry, it was
really easy to get the "mask" property wrong, which had the effect of
apparently not performing any action at all, when clicking on the "Add"
button.

The underlying problem was most likely that the "mask" field defaults to
128, which is only valid for IPv6 addresses. When entering an IPv4
address, the mask would be considered invalid (through some internal
wizardry) and thus the Ban would not be added.
However, the user was not presented with any kind of error message that
would have hinted at the problem.

This commit tackles this issue by first of all validating that the
entered IP address is valid. If it is not, then the respective input
field will be colored red. If it is, the mask spin box's maximum value
will automatically be set to the correct maximum value for the used IP
address flavor (32 for IPv4 and 128 for IPv6).

That way the user can only ever press "Add", if they entered a valid IP
address alongside a valid mask. Thus, pressing "Add" should now always
add the respective ban.

Fixes #3986


### Checks

- [x] My commits follow the [commit guidelines](https://github.com/mumble-voip/mumble/blob/master/COMMIT_GUIDELINES.md)

