### PR TITLE
DOCS(client): Mention OpenBSD support

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Mumble is an Open Source, low-latency and high-quality voice-chat program
 written on top of Qt and Opus.
 
 There are two modules in Mumble; the client (mumble) and the server (murmur).
-The client works on Windows, Linux, FreeBSD and macOS,
+The client works on Windows, Linux, FreeBSD, OpenBSD and macOS,
 while the server should work on anything Qt can be installed on.
 
 Please note that with "Windows" we mean 7 and newer.


### PR DESCRIPTION
OpenBSD has provided binary packages for years,
both `mumble` and `murmurd` work.
(I happen to currently maintain the audio/mumble port.)


### Checks

- [x] My commits follow the [commit guidelines](https://github.com/mumble-voip/mumble/blob/master/COMMIT_GUIDELINES.md)

