### PR TITLE
MAINT: Fix password use in build-number script

### DIFF
--- a/scripts/mumble-build-number.py
+++ b/scripts/mumble-build-number.py
@@ -38,11 +38,11 @@ def main():
             always succeed.", type=int)
     args = parser.parse_args()
 
-    if not args.password is None and args.password.strip():
+    if not args.password is None and args.password.strip() == "":
         # An empty password is considered to be no password at all
         args.password = None
 
-    buildNumber = fetch_build_number(commit = args.commit, version = args.version, password = args.version)
+    buildNumber = fetch_build_number(commit = args.commit, version = args.version, password = args.password)
 
     if buildNumber is None and not args.default is None:
         buildNumber = args.default


### PR DESCRIPTION
There were a few typos in the program's logic regarding the handling of
a provided password which rendered its use invalid.


### Checks

- [x] My commits follow the [commit guidelines](https://github.com/mumble-voip/mumble/blob/master/COMMIT_GUIDELINES.md)

