### PR TITLE
BUILD(audiowizard): Fix build with -Dspeechd=OFF -Dwarnings-as-errors=ON

### DIFF
--- a/src/mumble/AudioWizard.cpp
+++ b/src/mumble/AudioWizard.cpp
@@ -92,11 +92,6 @@ AudioWizard::AudioWizard(QWidget *p) : QWizard(p) {
 	else
 		qrbQualityCustom->setChecked(true);
 
-	quint32 iMessage = Settings::LogNone;
-	for (int i = Log::firstMsgType; i <= Log::lastMsgType; ++i) {
-		iMessage |= (Global::get().s.qmMessages[i] & (Settings::LogSoundfile | Settings::LogTTS));
-	}
-
 #ifdef USE_NO_TTS
 	qrbNotificationCustom->setChecked(false);
 	qrbNotificationCustom->setDisabled(true);
@@ -104,6 +99,11 @@ AudioWizard::AudioWizard(QWidget *p) : QWizard(p) {
 	qrbNotificationTTS->setDisabled(true);
 	qrbNotificationSounds->setChecked(true);
 #else
+	quint32 iMessage = Settings::LogNone;
+	for (int i = Log::firstMsgType; i <= Log::lastMsgType; ++i) {
+		iMessage |= (Global::get().s.qmMessages[i] & (Settings::LogSoundfile | Settings::LogTTS));
+	}
+
 	if (iMessage == Settings::LogTTS && Global::get().s.bTTS)
 		qrbNotificationTTS->setChecked(true);
 	else if (iMessage == Settings::LogSoundfile)


### PR DESCRIPTION
Move the declaration/definition of `iMessage` to where it is used,
otherwise the build fails with

```
src/mumble/AudioWizard.cpp:95:10: error: variable 'iMessage' set but not used [-Werror,-Wunused-but-set-variable]
        quint32 iMessage = Settings::LogNone;
                        ^
1 error generated.
```

Build-tested on OpenBSD 7.0-CURRENT using
```
$ cc --version
OpenBSD clang version 13.0.0
Target: amd64-unknown-openbsd7.0
Thread model: posix
InstalledDir: /usr/bin
```


### Checks

- [x] My commits follow the [commit guidelines](https://github.com/mumble-voip/mumble/blob/master/COMMIT_GUIDELINES.md)

