### PR TITLE
Backport "MAINT: Change build-number token for AppVeyor (#5418)" to 1.4.x

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -11,7 +11,7 @@ skip_branch_with_pr: true
 environment:
   global:
     MUMBLE_BUILD_NUMBER_TOKEN:
-      secure: PbzXN7ToXOY4tCdLi8S8qkQ6AsbUfxvQJUW8DLbbVj6jpf4n3h6owM0BeqLaR3e8lqkmlZHwNi0nwdWTwzFOj3ZRb/ozMC39Np6eaQ3g4dk=
+      secure: scRizsdwbTWjY7M9RHPT9EXDBxtWvXTsyVq1xXTWF1A=
     MUMBLE_ENVIRONMENT_SOURCE: 'https://dl.mumble.info/build/vcpkg'
     MUMBLE_ENVIRONMENT_STORE: 'C:/MumbleBuild'
     MUMBLE_ENVIRONMENT_PATH: '%MUMBLE_ENVIRONMENT_STORE%/%MUMBLE_ENVIRONMENT_VERSION%'


### PR DESCRIPTION
Backports the following commits to 1.4.x:
 - MAINT: Change build-number token for AppVeyor (#5418)