### PR TITLE
FIX(client): Specify description for entitlements in plist file

### DIFF
--- a/src/mumble/mumble.plist.in
+++ b/src/mumble/mumble.plist.in
@@ -35,5 +35,14 @@
 	<true/>
 	<key>NSMicrophoneUsageDescription</key>
 	<string>Mumble uses your microphone to allow you to talk to other people</string>
+
+	<key>com.apple.security.device.audio-input</key>
+	<string>Mumble uses your microphone to allow you to talk to other people</string>
+	<key>com.apple.security.cs.disable-library-validation</key>
+	<string>Mumble needs library validation to be disabled in order to load plugins</string>
+	<key>com.apple.security.network.client</key>
+	<string>Mumble needs network access to allow you to connect to a server</string>
+	<key>com.apple.security.network.server</key>
+	<string>Mumble needs network access to allow you to connect to a server</string>
 </dict>
 </plist>


### PR DESCRIPTION
Looks like macOS now requires a description filled in, otherwise it just terminates the application.

We already had one for `NSMicrophoneUsageDescription`, but evidently that's not enough anymore.

https://www.mail-archive.com/interest@qt-project.org/msg36457.html