### PR TITLE
Backport "CI: Update clang-format action (#5431)" to 1.4.x

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -40,7 +40,7 @@ jobs:
       shell: bash
 
     - name: Check code formatting
-      uses: jidicula/clang-format-action@3.5
+      uses: jidicula/clang-format-action@v3.5.2
       with:
           clang-format-version: '10'
           check-path: '.'


### PR DESCRIPTION
Backports the following commits to 1.4.x:
 - CI: Update clang-format action (#5431)