### PR TITLE
FEAT(client): Industry standard for hold time

### DIFF
--- a/src/mumble/AudioInput.cpp
+++ b/src/mumble/AudioInput.cpp
@@ -1068,6 +1068,7 @@ void AudioInput::encodeAudioFrame(AudioChunk chunk) {
 	if (!bIsSpeech) {
 		iHoldFrames++;
 		if (iHoldFrames < Global::get().s.iVoiceHold)
+			// Hold mic open until iVoiceHold threshold is reached
 			bIsSpeech = true;
 	} else {
 		iHoldFrames = 0;

--- a/src/mumble/AudioInput.h
+++ b/src/mumble/AudioInput.h
@@ -210,8 +210,12 @@ protected:
 
 	bool bEchoMulti;
 	Settings::NoiseCancel noiseCancel;
+	// Standard microphone sample rate (samples/s)
 	static const unsigned int iSampleRate = SAMPLE_RATE;
-	static const int iFrameSize           = SAMPLE_RATE / 100;
+	/// Based the sample rate, 48,000 samples/s = 48 samples/ms.
+	/// For each 10 ms, this yields 480 samples. This corresponds numerically with the calculation:
+	/// iFrameSize = 48000 / 100 = 480 samples, allowing a consistent 10ms of audio data per frame.
+	static const int iFrameSize = SAMPLE_RATE / 100;
 
 	QMutex qmSpeex;
 	SpeexPreprocessState *sppPreprocess;

--- a/src/mumble/Settings.cpp
+++ b/src/mumble/Settings.cpp
@@ -323,9 +323,11 @@ Settings::Settings() {
 	bOnlyAttenuateSameOutput       = false;
 	bAttenuateLoopbacks            = false;
 	iMinLoudness                   = 1000;
-	iVoiceHold                     = 50;
-	iJitterBufferSize              = 1;
-	iFramesPerPacket               = 2;
+	/// Actual mic hold time is (iVoiceHold / 100) seconds, where iVoiceHold is specified in 'frames',
+	/// each of which is has a size of iFrameSize (see AudioInput.h)
+	iVoiceHold        = 20;
+	iJitterBufferSize = 1;
+	iFramesPerPacket  = 2;
 #ifdef USE_RNNOISE
 	noiseCancelMode = NoiseCancelRNN;
 #else


### PR DESCRIPTION
As request in #2453, this commit implements the industry standard
for microphone hold time for voice activation detection. The calculation
that yields hold time (s) from the iVoiceHold setting is described and
comments are added to describe the function of related fields.

Implements #2453.


### Checks

- [X] My commits follow the [commit guidelines](https://github.com/mumble-voip/mumble/blob/master/COMMIT_GUIDELINES.md)

