### PR TITLE
BUILD: use FindPython3 available since CMake >= 3.12

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -19,9 +19,6 @@
 [submodule "3rdparty/rnnoise-src"]
 	path = 3rdparty/rnnoise-src
 	url = https://github.com/mumble-voip/rnnoise.git
-[submodule "3rdparty/FindPythonInterpreter"]
-	path = 3rdparty/FindPythonInterpreter
-	url = https://github.com/Krzmbrzl/FindPythonInterpreter.git
 [submodule "3rdparty/tracy"]
 	path = 3rdparty/tracy
 	url = https://github.com/wolfpld/tracy.git

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -42,7 +42,6 @@ set(CMAKE_OSX_DEPLOYMENT_TARGET 10.13)
 list(APPEND CMAKE_MODULE_PATH
 	"${CMAKE_SOURCE_DIR}/cmake"
 	"${CMAKE_SOURCE_DIR}/cmake/FindModules"
-	"${3RDPARTY_DIR}/FindPythonInterpreter"
 )
 
 

--- a/cmake/qt-utils.cmake
+++ b/cmake/qt-utils.cmake
@@ -3,7 +3,7 @@
 # that can be found in the LICENSE file at the root of the
 # Mumble source tree or at <https://www.mumble.info/LICENSE>.
 
-include(FindPythonInterpreter)
+find_package(Python3 COMPONENTS Interpreter REQUIRED)
 
 function(include_qt_plugin TARGET SCOPE PLUGIN)
 	set(PATH "${CMAKE_CURRENT_BINARY_DIR}/${TARGET}_plugin_import.cpp")
@@ -102,17 +102,6 @@ function(bundle_qt_translations TARGET)
 	file(GLOB TS_FILES "${QT_TRANSLATION_OVERWRITE_SOURCE_DIR}/*.ts")
 	compile_translations(QM_FILES "${QT_TRANSLATION_OVERWRITE_DIR}" "${TS_FILES}")
 
-	set(PYTHON_HINTS
-		"C:/Python39-x64" # Path on the AppVeyor CI server
-	)
-
-	find_python_interpreter(
-		VERSION 3
-		INTERPRETER_OUT_VAR PYTHON_INTERPRETER
-		HINTS ${PYTHON_HINTS}
-		REQUIRED
-	)
-
 	set(GENERATED_QRC_FILE "${CMAKE_CURRENT_BINARY_DIR}/mumble_qt_translations.qrc")
 
 	# Copy conf file to build dir for the Python script to find it
@@ -121,7 +110,7 @@ function(bundle_qt_translations TARGET)
 
 	# Generate the QRC file that contains the Qt translations and potentially our overwrites of them
 	execute_process(
-		COMMAND "${PYTHON_INTERPRETER}" "${CMAKE_SOURCE_DIR}/scripts/generate-mumble_qt-qrc.py"
+		COMMAND "${Python3_EXECUTABLE}" "${CMAKE_SOURCE_DIR}/scripts/generate-mumble_qt-qrc.py"
 			"${GENERATED_QRC_FILE}" "${QT_TRANSLATIONS_DIRECTORY}" "${QT_TRANSLATION_OVERWRITE_DIR}"
 		RESULT_VARIABLE GENERATOR_EXIT_CODE
 	)


### PR DESCRIPTION
Project already sets cmake_minimum_required to 3.15 so FindPython3 is
available. AppVeyor CI server should probably just pass the CMake option
-DPython3_EXECUTABLE for build if needed.

Obsoletes `3rdparty/FindPythonInterpreter`.

### Checks

- [x] My commits follow the [commit guidelines](https://github.com/mumble-voip/mumble/blob/master/COMMIT_GUIDELINES.md)

