### PR TITLE
Backport "FIX(server): Add missing line breaks to --help output (#5443)" to 1.4.x

### DIFF
--- a/src/murmur/main.cpp
+++ b/src/murmur/main.cpp
@@ -404,8 +404,8 @@ int main(int argc, char **argv) {
 #endif
 				  "  -wipessl               Remove SSL certificates from database.\n"
 				  "  -wipelogs              Remove all log entries from database.\n"
-				  "  -loggroups             Turns on logging for group changes for all servers."
-				  "  -logacls               Turns on logging for ACL changes for all servers."
+				  "  -loggroups             Turns on logging for group changes for all servers.\n"
+				  "  -logacls               Turns on logging for ACL changes for all servers.\n"
 				  "  -version               Show version information.\n"
 				  "\n"
 				  "  -license               Show Murmur's license.\n"


### PR DESCRIPTION
Backports the following commits to 1.4.x:
 - FIX(server): Add missing line breaks to --help output (#5443)