### PR TITLE
Backport "MAINT(macOS): Add client entitlements plist, for hardened runtime to work (#5093)" to 1.4.x

### DIFF
--- a/src/mumble/mumble.entitlements.plist
+++ b/src/mumble/mumble.entitlements.plist
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>com.apple.security.device.audio-input</key>
+	<true/>
+	<key>com.apple.security.cs.disable-library-validation</key>
+	<true/>
+	<key>com.apple.security.network.client</key>
+	<true/>
+	<key>com.apple.security.network.server</key>
+	<true/>
+</dict>
+</plist>


### PR DESCRIPTION
Backports the following commits to 1.4.x:
 - MAINT(macOS): Add client entitlements plist, for hardened runtime to work (#5093)