### PR TITLE
DOCS(build): Clean up leftovers from RELEASE_ID concept

### DIFF
--- a/docs/dev/build-instructions/build_linux.md
+++ b/docs/dev/build-instructions/build_linux.md
@@ -88,10 +88,6 @@ following commands:
 2. `cd build` (Switches into the build directory)
 3. `cmake ..` (Actually runs cmake)
 
-Optionally you can use: `cmake -DRELEASE_ID=$(python "../scripts/mumble-version.py") ..`
-
-This will include the latest commit hash and date in the version info. This should be run in bash.
-
 This will cause cmake to create the necessary build files for you. If you want to customize your build, you can pass special flags to cmake in step 3.
 For all available build options, have a look [here](cmake_options.md).
 


### PR DESCRIPTION
The concept of RELEASE_ID was dropped with PR #5401 in commit 6caa808e6.
Thus, drop its leftovers from the documentation.

### Checks

- [x] My commits follow the [commit guidelines](https://github.com/mumble-voip/mumble/blob/master/COMMIT_GUIDELINES.md)

