### PR TITLE
DOCS: Updated build instructions to remove duplicated step

### DIFF
--- a/docs/dev/build-instructions/README.md
+++ b/docs/dev/build-instructions/README.md
@@ -10,8 +10,6 @@ directory and run `git submodule update --init --recursive` in order to also clo
 
 _Tip:_ You can also [build a specific version or commit](faq.md#build-a-specific-version-or-commit) of Mumble.
 
-Then go into the cloned repository and run `git submodule update --init --recursive` in order to also clone all submodules.
-
 In order to actually build Mumble, you can follow one of the following instruction sets:
 - [Build on Windows](build_windows.md)
 - [Build on Linux](build_linux.md)


### PR DESCRIPTION
DOCS: Updated build instructions to remove duplicated step

There's a duplicated step in the build instructions, which is already covered on line 8.  This change removes the unneeded duplicate step.