### PR TITLE
BUILD: include libgen.h for files which use basename(3)

### DIFF
--- a/plugins/HostLinux.cpp
+++ b/plugins/HostLinux.cpp
@@ -8,6 +8,7 @@
 #include "mumble_positional_audio_utils.h"
 
 #include <cstring>
+#include <libgen.h>
 #include <sstream>
 
 #include <sys/uio.h>

--- a/plugins/mumble_positional_audio_linux.h
+++ b/plugins/mumble_positional_audio_linux.h
@@ -15,6 +15,7 @@
 #include <cstring>
 #include <elf.h>
 #include <iostream>
+#include <libgen.h>
 #include <sstream>
 #include <stdio.h>
 #include <stdlib.h>


### PR DESCRIPTION
As per POSIX, basename(3) is defined in libgen.h. Without including this header file the code presently does not compile (on musl) due to `-Werror` and a `-Wimplicit-function-declaration` warning.


### Checks

- [x] My commits follow the [commit guidelines](https://github.com/mumble-voip/mumble/blob/master/COMMIT_GUIDELINES.md)

