### PR TITLE
BUILD: Fix -Wunused-function when compiling without rnnoise

### DIFF
--- a/src/mumble/AudioInput.cpp
+++ b/src/mumble/AudioInput.cpp
@@ -32,11 +32,13 @@ extern "C" {
 #include <algorithm>
 #include <limits>
 
+#ifdef USE_RNNOISE
 /// Clip the given float value to a range that can be safely converted into a short (without causing integer overflow)
 static short clampFloatSample(float v) {
 	return static_cast< short >(std::min(std::max(v, static_cast< float >(std::numeric_limits< short >::min())),
 										 static_cast< float >(std::numeric_limits< short >::max())));
 }
+#endif
 
 void Resynchronizer::addMic(short *mic) {
 	bool drop = false;


### PR DESCRIPTION
The clampFloatSample function is only used when rnnoise support is enabled, when it isn't this the presence of the function (since it is static) causes a `-Wunused-function` warning which ultimately ends up causing a build error due to `-Werror`.


### Checks

- [x] My commits follow the [commit guidelines](https://github.com/mumble-voip/mumble/blob/master/COMMIT_GUIDELINES.md)

