### PR TITLE
BUILD: include poll.h for poll(3) (instead of sys/poll.h)

### DIFF
--- a/src/mumble/ALSAAudio.cpp
+++ b/src/mumble/ALSAAudio.cpp
@@ -10,7 +10,7 @@
 #include "Utils.h"
 
 #include <alsa/asoundlib.h>
-#include <sys/poll.h>
+#include <poll.h>
 
 #include "Global.h"
 


### PR DESCRIPTION
As per POSIX.1-2008, the correct header to include for poll(3) is
poll.h. Including sys/poll.h instead of poll.h causes the following
warning message on Alpine Linux:

	/usr/include/sys/poll.h:1:2: warning: #warning redirecting incorrect #include <sys/poll.h> to <poll.h> [-Wcpp]
	    1 | #warning redirecting incorrect #include <sys/poll.h> to <poll.h>

Due to `-Werror`, this ultimately causes the build to fail.

### Checks

- [x] My commits follow the [commit guidelines](https://github.com/mumble-voip/mumble/blob/master/COMMIT_GUIDELINES.md)

