### PR TITLE
FIX(musl): Explicitly use POSIX basename

### DIFF
--- a/plugins/HostLinux.cpp
+++ b/plugins/HostLinux.cpp
@@ -8,6 +8,7 @@
 #include "mumble_positional_audio_utils.h"
 
 #include <cstring>
+#include <libgen.h>
 #include <sstream>
 
 #include <sys/uio.h>

--- a/plugins/mumble_positional_audio_linux.h
+++ b/plugins/mumble_positional_audio_linux.h
@@ -15,6 +15,7 @@
 #include <cstring>
 #include <elf.h>
 #include <iostream>
+#include <libgen.h>
 #include <sstream>
 #include <stdio.h>
 #include <stdlib.h>


### PR DESCRIPTION
Explicitly use POSIX basename. Otherwise, Mumble will not build against
musl libc. This is done by simply explicitly including <libgen.h>


### Checks

- [x] My commits follow the [commit guidelines](https://github.com/mumble-voip/mumble/blob/master/COMMIT_GUIDELINES.md)

