### PR TITLE
BUILD: Build tests in package builds by default

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -54,7 +54,6 @@ include(CheckIPOSupported)
 check_ipo_supported(RESULT LTO_DEFAULT)
 
 
-option(tests "Build tests" OFF)
 
 option(optimize "Build a heavily optimized version, specific to the machine it's being compiled on." OFF)
 option(static "Build static binaries." OFF)
@@ -63,6 +62,7 @@ option(warnings-as-errors "All warnings are treated as errors." ON)
 
 option(overlay "Build overlay." ON)
 option(packaging "Build package." OFF)
+option(tests "Build tests." ${packaging})
 option(plugins "Build plugins." ON)
 
 option(debug-dependency-search "Prints extended information during the search for the needed dependencies" OFF)

--- a/docs/dev/build-instructions/cmake_options.md
+++ b/docs/dev/build-instructions/cmake_options.md
@@ -231,8 +231,8 @@ Build binaries in a way that allows easier debugging.
 
 ### tests
 
-Build tests
-(Default: OFF)
+Build tests.
+(Default: ${packaging})
 
 ### tracy
 


### PR DESCRIPTION
Encourage OS package maintainers to run tests by `packaging=ON` implying
`tests=ON`.

Keep `online-tests=OFF` by default since it is common practise for
packages to be built in unprivileged environments, e.g. without network.


### Checks

- [x] My commits follow the [commit guidelines](https://github.com/mumble-voip/mumble/blob/master/COMMIT_GUIDELINES.md)
