### PR TITLE
BUILD(client): Enable XInput2 support on OpenBSD by default

### DIFF
--- a/docs/dev/build-instructions/cmake_options.md
+++ b/docs/dev/build-instructions/cmake_options.md
@@ -266,7 +266,7 @@ Build support for global shortcuts from Xbox controllers via the XInput DLL.
 
 ### xinput2
 
-Build support for XI2
+Build support for XI2.
 (Default: ON)
 
 ### zeroconf

--- a/src/mumble/CMakeLists.txt
+++ b/src/mumble/CMakeLists.txt
@@ -53,7 +53,14 @@ elseif(UNIX)
 		option(pipewire "Build support for PipeWire." ON)
 		option(pulseaudio "Build support for PulseAudio." ON)
 		option(speechd "Build support for Speech Dispatcher." ON)
-		option(xinput2 "Build support for XI2" ON)
+	endif()
+
+	# scripts/generate_cmake_options_docs.py does not cope with duplicate option() lines,
+	# so single out common options into combined conditions.
+	# https://github.com/mumble-voip/mumble/issues/5488
+	if(${CMAKE_SYSTEM_NAME} STREQUAL "Linux" OR
+	   ${CMAKE_SYSTEM_NAME} STREQUAL "OpenBSD")
+		option(xinput2 "Build support for XI2." ON)
 	endif()
 endif()
 


### PR DESCRIPTION
The library is readily available in OpenBSD's version of X[0].
Follow suit with Linux in enabling.

Noticed by the warning upon startup:

```
-<W>2022-01-21 02:30:40.548 GlobalShortcutX: No XInput support, falling back to polled input. This wastes a lot of CPU resources, so please enable one of the other methods.
+<W>2022-01-21 02:34:00.159 GlobalShortcutX: Using XI2 2.4
```

0: https://xenocara.org/


### Checks

- [x] My commits follow the [commit guidelines](https://github.com/mumble-voip/mumble/blob/master/COMMIT_GUIDELINES.md)
