### PR TITLE
MAINT(github): List OpenBSD as supported OS

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -52,6 +52,7 @@ body:
         - Windows
         - macOS
         - FreeBSD
+        - OpenBSD
         - Other
     validations:
       required: true

--- a/.github/ISSUE_TEMPLATE/support.yml
+++ b/.github/ISSUE_TEMPLATE/support.yml
@@ -45,6 +45,7 @@ body:
         - Windows
         - macOS
         - FreeBSD
+        - OpenBSD
         - Other
     validations:
       required: true


### PR DESCRIPTION
Noticed while creating #5488.


### Checks

- [x] My commits follow the [commit guidelines](https://github.com/mumble-voip/mumble/blob/master/COMMIT_GUIDELINES.md)
