### PR TITLE
DOCS: Add FindPythonInterpreter error to common build errors

### DIFF
--- a/docs/dev/build-instructions/common_build_errors.md
+++ b/docs/dev/build-instructions/common_build_errors.md
@@ -5,3 +5,4 @@ This page is supposed to give a summary of the most common build errors that are
 | Error message | Description and fix |
 | ------------- | ------------------- |
 | inlining failed in call to always_inline ‘vdupq_n_f32’: target specific option mismatch | This error message occurs when attempting to build Opus. It seems to be an issue specific to the Raspberry Pi (4) (or maybe to ARM in general). This is a [known problem in Opus](https://github.com/xiph/opus/issues/203).<br><br>It can be fixed relatively easy by specifying `-DOPUS_DISABLE_INTRINSICS=ON` when invoking CMake. |
+|CMake Error at cmake/qt-utils.cmake:6 (include):<br>  include could not find requested file:<br><br>    FindPythonInterpreter<br>Call Stack (most recent call first):<br> <br>src/murmur/CMakeLists.txt:16 (include) | Submodules are outdated<br> Run the command 'git submodule update --init' |


### PR DESCRIPTION
TYPE(Scope): DOCS

Found this extremely helpful and I had difficulty finding this error.
https://githubmemory.com/repo/mumble-voip/mumble/issues/5120

Adds a line to FAQ for updating submodules



### Checks

- [x] My commits follow the [commit guidelines](https://github.com/mumble-voip/mumble/blob/master/COMMIT_GUIDELINES.md)

