### PR TITLE
BUILD(client): Report correct/current release version in overlay

### DIFF
--- a/overlay/CMakeLists.txt
+++ b/overlay/CMakeLists.txt
@@ -10,10 +10,12 @@ option(BUILD_OVERLAY_XCOMPILE "Build an x86 overlay" OFF)
 if(BUILD_OVERLAY_XCOMPILE)
 	cmake_minimum_required(VERSION 3.15)
 
+	message(STATUS "again, CMAKE_PROJECT_VERSION is ${CMAKE_PROJECT_VERSION} whereas PROJECT_VERSION is ${PROJECT_VERSION}")
 	project(overlay_xcompile
 		VERSION ${CMAKE_PROJECT_VERSION}
 		LANGUAGES CXX
 	)
+	message(STATUS "after calling project(), CMAKE_PROJECT_VERSION is ${CMAKE_PROJECT_VERSION} whereas PROJECT_VERSION is ${PROJECT_VERSION}")
 
 	include("${PARENT_SOURCE_DIR}/cmake/compiler.cmake")
 endif()

--- a/overlay/CMakeLists.txt
+++ b/overlay/CMakeLists.txt
@@ -7,10 +7,8 @@ option(BUILD_OVERLAY_XCOMPILE "Build an x86 overlay" OFF)
 if(BUILD_OVERLAY_XCOMPILE)
 	cmake_minimum_required(VERSION 3.15)
 
-	set(version "1.4.0" CACHE STRING "Project version")
-
 	project(overlay_xcompile
-		VERSION ${version}
+		VERSION ${CMAKE_PROJECT_VERSION}
 		LANGUAGES CXX
 	)
 

--- a/overlay/CMakeLists.txt
+++ b/overlay/CMakeLists.txt
@@ -2,6 +2,9 @@
 # Use of this source code is governed by a BSD-style license
 # that can be found in the LICENSE file at the root of the
 # Mumble source tree or at <https://www.mumble.info/LICENSE>.
+
+message(STATUS "CMAKE_PROJECT_VERSION is ${CMAKE_PROJECT_VERSION} whereas PROJECT_VERSION is ${PROJECT_VERSION}")
+
 option(BUILD_OVERLAY_XCOMPILE "Build an x86 overlay" OFF)
 
 if(BUILD_OVERLAY_XCOMPILE)

--- a/src/mumble/CMakeLists.txt
+++ b/src/mumble/CMakeLists.txt
@@ -14,6 +14,8 @@ configure_file("${CMAKE_CURRENT_SOURCE_DIR}/mumble.rc.in" "${MUMBLE_RC}")
 configure_file("${CMAKE_CURRENT_SOURCE_DIR}/mumble_dll.rc.in" "${MUMBLE_DLL_RC}")
 configure_file("${CMAKE_CURRENT_SOURCE_DIR}/mumble.plist.in" "${MUMBLE_PLIST}")
 
+configure_file("${CMAKE_SOURCE_DIR}/themes/Default/overlay.mumblelay.in" "${CMAKE_SOURCE_DIR}/themes/Default/overlay.mumblelay")
+
 include(qt-utils)
 include(install-library)
 

--- a/themes/Default/overlay.mumblelay.in
+++ b/themes/Default/overlay.mumblelay.in
@@ -1,5 +1,5 @@
 [overlay]
-version=1.4.0
+version=${CMAKE_PROJECT_VERSION}
 alwaysself=false
 sort=1
 y=@Variant(\0\0\0\x87>j\xbcl)


### PR DESCRIPTION
Probably overlooked while cutting the release.
Reuse the main project's version number rather than hardcoding it.

Note 1.4.230 was released with an incorrect version number and therefore
builds as

```
-- ##################################################
-- Mumble version:          1.4.0
```

which is also visible in the final executable, e.g. prominently in the
window title (xprop(1) output):

```
WM_NAME(STRING) = "Mumble -- 1.4.0 | FOO"
_NET_WM_NAME(UTF8_STRING) = "Mumble -- 1.4.0 | FOO"
```

as well as the `Help > About... > About Mumble` menu.


### Checks

- [x] My commits follow the [commit guidelines](https://github.com/mumble-voip/mumble/blob/master/COMMIT_GUIDELINES.md)
