### PR TITLE
BUILD(client): overlay_gl: Detect OpenBSD

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -61,7 +61,9 @@ option(static "Build static binaries." OFF)
 option(symbols "Build binaries in a way that allows easier debugging." OFF)
 option(warnings-as-errors "All warnings are treated as errors." ON)
 
-option(overlay "Build overlay." ON)
+if(NOT ${CMAKE_SYSTEM_NAME} STREQUAL "OpenBSD")
+	option(overlay "Build overlay." ON)
+endif()
 option(packaging "Build package." OFF)
 option(plugins "Build plugins." ON)
 

--- a/overlay_gl/CMakeLists.txt
+++ b/overlay_gl/CMakeLists.txt
@@ -6,7 +6,9 @@
 # Overlay payload for UNIX-like systems.
 
 if(${CMAKE_SYSTEM_PROCESSOR} STREQUAL "x86_64" OR ${CMAKE_SYSTEM_PROCESSOR} STREQUAL "amd64")
-	option(overlay-xcompile "Build 32 bit overlay library, necessary for the overlay to work with 32 bit processes." ON)
+	if(NOT ${CMAKE_SYSTEM_NAME} STREQUAL "OpenBSD")
+		option(overlay-xcompile "Build 32 bit overlay library, necessary for the overlay to work with 32 bit processes." ON)
+	endif()
 endif()
 
 add_library(overlay_gl SHARED "overlay.c")

--- a/overlay_gl/CMakeLists.txt
+++ b/overlay_gl/CMakeLists.txt
@@ -21,6 +21,9 @@ set_target_properties(overlay_gl
 )
 
 if(NOT APPLE)
+	find_pkg(gl REQUIRED)
+	target_include_directories(overlay_gl PRIVATE ${gl_INCLUDE_DIRS})
+
 	target_link_options(overlay_gl BEFORE
 		PRIVATE
 			"-Wl,-z,lazy"


### PR DESCRIPTION
Get sane default configuration and prepare the build for future fixes.

- BUILD(client): overlay_gl: Do not build overlay-xcompile on OpenBSD
- BUILD(client): overlay_gl: Require libGL includes on OpenBSD
- BUILD(client): overlay_gl: Do not build by default on OpenBSD (for now)


### Checks

- [x] My commits follow the [commit guidelines](https://github.com/mumble-voip/mumble/blob/master/COMMIT_GUIDELINES.md)

