### PR TITLE
BUILD(client): CELT: Require version 0.7.x when using the system library

### DIFF
--- a/src/mumble/CMakeLists.txt
+++ b/src/mumble/CMakeLists.txt
@@ -693,6 +693,10 @@ if(bundled-celt)
 	install_library(celt mumble_client)
 else()
 	find_pkg(celt REQUIRED)
+	if(${celt_VERSION} VERSION_LESS          0.7 OR
+	   ${celt_VERSION} VERSION_GREATER_EQUAL 0.8)
+		message(FATAL_ERROR "CELT 0.7.x is required, found ${celt_VERSION}!")
+	endif()
 	target_include_directories(mumble PRIVATE ${celt_INCLUDE_DIRS})
 endif()
 


### PR DESCRIPTION
The bundled version is 0.7.0 and versions >0.7.x are NOT supported.

At least on OpenBSD (only packaging 0.11.x), the built would fail.
Yield and error at configure time with this fix.

CMake's `find_package()` function accepts an optional `version` argument
but Mumble's `find_pkg()` wrapper does not (treating it as package), so
roll our own check/error:

```
-- celt found | Version: 0.11.1
CMake Error at src/mumble/CMakeLists.txt:677 (message):
  CELT 0.7.x is required, found 0.11.1!
```

Relates to #4476.


### Checks

- [x] My commits follow the [commit guidelines](https://github.com/mumble-voip/mumble/blob/master/COMMIT_GUIDELINES.md)

