### PR TITLE
BUILD(client): Remove USE_OPUS define, make Opus a hard requirement

### DIFF
--- a/src/mumble/Audio.cpp
+++ b/src/mumble/Audio.cpp
@@ -8,10 +8,8 @@
 #include "AudioInput.h"
 #include "AudioOutput.h"
 #include "CELTCodec.h"
-#ifdef USE_OPUS
-#	include "OpusCodec.h"
-#endif
 #include "Log.h"
+#include "OpusCodec.h"
 #include "PacketDataStream.h"
 #include "PluginManager.h"
 #include "Global.h"
@@ -31,7 +29,6 @@ LoopUser LoopUser::lpLoopy;
 CodecInit ciInit;
 
 void CodecInit::initialize() {
-#ifdef USE_OPUS
 	OpusCodec *oCodec = new OpusCodec();
 	if (oCodec->isValid()) {
 		oCodec->report();
@@ -42,7 +39,6 @@ void CodecInit::initialize() {
 			QObject::tr("CodecInit: Failed to load Opus, it will not be available for encoding/decoding audio."));
 		delete oCodec;
 	}
-#endif
 
 	if (Global::get().s.bDisableCELT) {
 		// Kill switch for CELT activated. Do not initialize it.
@@ -78,9 +74,7 @@ void CodecInit::initialize() {
 }
 
 void CodecInit::destroy() {
-#ifdef USE_OPUS
 	delete Global::get().oCodec;
-#endif
 
 	foreach (CELTCodec *codec, Global::get().qmCodecs)
 		delete codec;

--- a/src/mumble/CMakeLists.txt
+++ b/src/mumble/CMakeLists.txt
@@ -385,7 +385,6 @@ endif()
 target_compile_definitions(mumble
 	PRIVATE
 		"MUMBLE"
-		"USE_OPUS"
 		"QT_RESTRICTED_CAST_FROM_ASCII"
 )
 

--- a/src/mumble/Global.cpp
+++ b/src/mumble/Global.cpp
@@ -93,11 +93,7 @@ Global::Global(const QString &qsConfigPath) {
 	iCodecAlpha  = 0;
 	iCodecBeta   = 0;
 	bPreferAlpha = true;
-#ifdef USE_OPUS
-	bOpus = true;
-#else
-	bOpus = false;
-#endif
+	bOpus        = true;
 
 	bAttenuateOthers              = false;
 	prioritySpeakerActiveOverride = false;

--- a/src/mumble/MainWindow.cpp
+++ b/src/mumble/MainWindow.cpp
@@ -13,9 +13,6 @@
 #include "AudioWizard.h"
 #include "BanEditor.h"
 #include "CELTCodec.h"
-#ifdef USE_OPUS
-#	include "OpusCodec.h"
-#endif
 #include "Cert.h"
 #include "Channel.h"
 #include "ConnectDialog.h"
@@ -25,6 +22,7 @@
 #include "Log.h"
 #include "Net.h"
 #include "NetworkConfig.h"
+#include "OpusCodec.h"
 #include "GlobalShortcut.h"
 #ifdef USE_OVERLAY
 #	include "OverlayClient.h"
@@ -3181,12 +3179,8 @@ void MainWindow::serverConnected() {
 	Global::get().pPermissions = ChanACL::None;
 	Global::get().iCodecAlpha  = 0x8000000b;
 	Global::get().bPreferAlpha = true;
-#ifdef USE_OPUS
-	Global::get().bOpus = true;
-#else
-	Global::get().bOpus = false;
-#endif
-	Global::get().iCodecBeta = 0;
+	Global::get().bOpus        = true;
+	Global::get().iCodecBeta   = 0;
 
 #ifdef Q_OS_MAC
 	// Suppress AppNap while we're connected to a server.

--- a/src/mumble/Messages.cpp
+++ b/src/mumble/Messages.cpp
@@ -1223,7 +1223,6 @@ void MainWindow::msgCodecVersion(const MumbleProto::CodecVersion &msg) {
 	int beta  = msg.has_beta() ? msg.beta() : -1;
 	bool pref = msg.prefer_alpha();
 
-#ifdef USE_OPUS
 	static bool warnedOpus = false;
 	Global::get().bOpus    = msg.opus();
 
@@ -1232,7 +1231,6 @@ void MainWindow::msgCodecVersion(const MumbleProto::CodecVersion &msg) {
 							 tr("Failed to load Opus, it will not be available for audio encoding/decoding."));
 		warnedOpus = true;
 	}
-#endif
 
 	// Workaround for broken 1.2.2 servers
 	if (Global::get().sh && Global::get().sh->uiVersion == 0x010202 && alpha != -1 && alpha == beta) {

--- a/src/mumble/ServerHandler.cpp
+++ b/src/mumble/ServerHandler.cpp
@@ -783,11 +783,7 @@ void ServerHandler::serverConnectionConnected() {
 	QMap< int, CELTCodec * >::const_iterator i;
 	for (i = Global::get().qmCodecs.constBegin(); i != Global::get().qmCodecs.constEnd(); ++i)
 		mpa.add_celt_versions(i.key());
-#ifdef USE_OPUS
 	mpa.set_opus(true);
-#else
-	mpa.set_opus(false);
-#endif
 	sendMessage(mpa);
 
 	{
@@ -839,8 +835,8 @@ void ServerHandler::serverConnectionConnected() {
 			if (hQoS) {
 				struct sockaddr_in addr;
 				memset(&addr, 0, sizeof(addr));
-				addr.sin_family = AF_INET;
-				addr.sin_port = htons(usPort);
+				addr.sin_family      = AF_INET;
+				addr.sin_port        = htons(usPort);
 				addr.sin_addr.s_addr = htonl(qhaRemote.toIPv4Address());
 
 				dwFlowUDP = 0;


### PR DESCRIPTION
CELT support will be removed, so Opus will not be optional any longer.

Remove all code outside of `USE_OPUS` scope with
```
$ git grep -w -l USE_OPUS -- '**/*'.{h,hpp,cpp} |
	xargs unifdef -B -D USE_OPUS -M ''
```

This is a no-op since it has already been defined unconditionally.

Supersedes #5505.


### Checks

- [x] My commits follow the [commit guidelines](https://github.com/mumble-voip/mumble/blob/master/COMMIT_GUIDELINES.md)

