### PR TITLE
MAINT: Update copyright notice to 2022

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright (C) 2005-2021 The Mumble Developers
+Copyright (C) 2005-2022 The Mumble Developers
 
 A list of The Mumble Developers can be found in the
 AUTHORS file at the root of the Mumble source tree


### PR DESCRIPTION
Varioues files were bumped but not this one.  Spotted by following the
https://www.mumble.info/LICENSE link in another file.


### Checks

- [x] My commits follow the [commit guidelines](https://github.com/mumble-voip/mumble/blob/master/COMMIT_GUIDELINES.md)

