### PR TITLE
CI: scripts/runClangFormat.sh: Use git-ls-files(1)

### DIFF
--- a/scripts/runClangFormat.sh
+++ b/scripts/runClangFormat.sh
@@ -1,16 +1,10 @@
-#!/usr/bin/env bash
+#!/bin/sh
 #
 # Copyright 2020-2022 The Mumble Developers. All rights reserved.
 # Use of this source code is governed by a BSD-style license
 # that can be found in the LICENSE file at the root of the
 # Mumble source tree or at <https://www.mumble.info/LICENSE>.
 
-currentDir=$(dirname $0)
-
-mainDir="$currentDir/.."
-
-cd "$mainDir"
-
-find -type f \( -iname "*.cpp" -o -iname "*.c" -o -iname "*.hpp" -o -iname "*.h" -o -iname "*.cxx" -o -iname "*.cc" \) \
-	-a -not -ipath "./3rdparty/*" -a -not -path "./.git/*" -a -not -ipath "./build/*" \
-	| xargs clang-format --style=file -i
+git ls-files --cached --modified --others -z -- \
+    :^3rdparty/ '**/*'.cpp '**/*'.c '**/*'.hpp '**/*'.h '**/*'.cxx '**/*'.cc  |
+	xargs -0 -r -- clang-format --style=file -i


### PR DESCRIPTION
Current problems:
- bash(1) is not always installed (by default), /bin/sh is
- (Open)BSD find(1) requires at least one path argument, i.e. `.` which GNU
  find(1) implies
- (Open)BSD find(1) does not support `-ipath`

git-ls-files(1) benefits:
- gitignore(5) files are honored
- simpler/more powerful patterns (see gitglossary(7) wrt. `pathspec`)
- `runClangFormat.sh` can be run from git subdirectories to only format
  selected files (explicitl passing files could be easil implemented)
- works on every system with git(1), no portability issues (see above)

The one "drawback" with git-ls-files(1) is requiring git(1) working tree
rather than a release tarball, but active development requries git
anyway, so that does not seem like a blocker.

Only run xargs(1) if files were listed (`-r`), since we can now run the
script from subdirectories without source code.
### Checks

- [x] My commits follow the [commit guidelines](https://github.com/mumble-voip/mumble/blob/master/COMMIT_GUIDELINES.md)

