### PR TITLE
BUILD(cmake): Use dedicated function to declare options

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -50,22 +50,56 @@ include(pkg-utils)
 include(project-utils)
 include(TargetArch)
 include(CheckIPOSupported)
+include(options-helper)
 
 check_ipo_supported(RESULT LTO_DEFAULT)
 
 
-
-option(optimize "Build a heavily optimized version, specific to the machine it's being compiled on." OFF)
-option(static "Build static binaries." OFF)
-option(symbols "Build binaries in a way that allows easier debugging." OFF)
-option(warnings-as-errors "All warnings are treated as errors." ON)
-
-option(overlay "Build overlay." ON)
-option(packaging "Build package." OFF)
-option(tests "Build tests." ${packaging})
-option(plugins "Build plugins." ON)
-
-option(debug-dependency-search "Prints extended information during the search for the needed dependencies" OFF)
+declare_option(
+	NAME optimize
+	DESCRIPTION "Build a heavily optimized version, specific to the machine it's being compiled on."
+	DEFAULT OFF
+)
+declare_option(
+	NAME static
+	DESCRIPTION "Build static binaries."
+	DEFAULT OFF
+)
+declare_option(
+	NAME symbols
+	DESCRIPTION "Build binaries in a way that allows easier debugging."
+	DEFAULT OFF
+)
+declare_option(
+	NAME warnings-as-errors
+	DESCRIPTION "All warnings are treated as errors."
+	DEFAULT ON
+)
+declare_option(
+	NAME overlay
+	DESCRIPTION "Build overlay."
+	DEFAULT ON
+)
+declare_option(
+	NAME packaging
+	DESCRIPTION "Build package."
+	DEFAULT OFF
+)
+declare_option(
+	NAME tests
+	DESCRIPTION "Build tests."
+	DEFAULT ${packaging}
+)
+declare_option(
+	NAME plugins
+	DESCRIPTION "Build plugins."
+	DEFAULT ON
+)
+declare_option(
+	NAME debug-dependency-search
+	DESCRIPTION "Prints extended information during the search for the needed dependencies"
+	DEFAULT OFF
+)
 
 if(NOT CMAKE_BUILD_TYPE)
 	set_property(CACHE CMAKE_BUILD_TYPE PROPERTY VALUE "Release")
@@ -79,7 +113,11 @@ elseif(CMAKE_BUILD_TYPE STREQUAL "Debug")
 	set(LTO_DEFAULT OFF)
 endif()
 
-option(lto "Enables link-time optimizations" ${LTO_DEFAULT})
+declare_option(
+	NAME lto
+	DESCRIPTION "Enables link-time optimizations"
+	DEFAULT ${LTO_DEFAULT}
+)
 
 include(compiler)
 include(os)
@@ -157,6 +195,19 @@ if(APPLE AND CMAKE_SYSTEM_PROCESSOR MATCHES "arm64")
 endif()
 
 if(overlay AND client)
+	if (${CMAKE_SYSTEM_PROCESSOR} STREQUAL "x86_64" OR ${CMAKE_SYSTEM_PROCESSOR} STREQUAL "amd64")
+		set(is_x64 TRUE)
+	else()
+		set(is_x64 FALSE)
+	endif()
+
+	declare_option(
+		NAME overlay-xcompile
+		DESCRIPTION "Build 32 bit overlay library, necessary for the overlay to work with 32 bit processes."
+		DEFAULT ${is_x64}
+		WINDOWS_DEFAULT OFF
+	)
+
 	if(WIN32)
 		add_subdirectory(overlay)
 	else()

--- a/cmake/options-helper.cmake
+++ b/cmake/options-helper.cmake
@@ -1,0 +1,106 @@
+# Copyright 2022 The Mumble Developers. All rights reserved.
+# Use of this source code is governed by a BSD-style license
+# that can be found in the LICENSE file at the root of the
+# Mumble source tree or at <https://www.mumble.info/LICENSE>.
+
+cmake_minimum_required(VERSION 3.15)
+
+# declare_option(
+#     NAME <option_name>
+#     DESCRIPTION <option_description>
+#     [DEFAULT <option_default>]
+#     [RESTRICT_TO ...]
+#     [EXCLUDE_ON ...]
+#     [<system>_DEFAULT <system-specific default value>]
+# )
+#
+# Declares an option with the given name and description. The default value for the declared option is either the value passed to
+# the DEFAULT argument, or to the system-specific default key (e.g. LINUX_DEFAULT or WINDOWS_DEFAULT). If given, the latter takes
+# precedence.
+# The RESTRICT_TO keyword can be used to restrict a given option to the list of specified systems. Defining the option on any other
+# system will result in an error.
+# The inverse logic is applied to the arguments given to the EXCLUDE_ON keyword. If the option is specified on one of the listed
+# systems, an error will be generated.
+function(declare_option)
+	set(MUMBLE_OPTIONS_SUPPORTED_OS "WINDOWS" "LINUX" "DARWIN" "FREEBSD" "OPENBSD")
+
+	string(TOUPPER "${CMAKE_SYSTEM_NAME}" UPPER_SYSTEM_NAME)
+
+	set(CURRENT_OS_DEFAULT_VAR MUMBLE_OPTIONS_${UPPER_SYSTEM_NAME}_DEFAULT)
+
+
+	# Declare known arguments
+	set(FLAGS "")
+	set(ONE_VALUE_KEYWORDS NAME DESCRIPTION DEFAULT)
+	set(MULTI_VALUE_KEYWORDS RESTRICT_TO EXCLUDE_ON)
+
+	# Build and append OS-specific function arguments
+	foreach(CURRENT_OS IN LISTS MUMBLE_OPTIONS_SUPPORTED_OS)
+		list(APPEND ONE_VALUE_KEYWORDS "${CURRENT_OS}_DEFAULT")
+	endforeach()
+
+	# Parse arguments
+	cmake_parse_arguments(MUMBLE_OPTIONS "${FLAGS}" "${ONE_VALUE_KEYWORDS}" "${MULTI_VALUE_KEYWORDS}" ${ARGN})
+
+	# Error handling
+	if (DEFINED MUMBLE_OPTIONS_UNPARSED_ARGUMENTS)
+		message(FATAL_ERROR "Unrecognized arguments to declare_option: \"${MUMBLE_OPTIONS_UNPARSED_ARGUMENTS}\"")
+	endif()
+	if (NOT DEFINED MUMBLE_OPTIONS_NAME)
+		message(FATAL_ERROR "Called declare_option without specifying a NAME")
+	endif()
+	if (NOT DEFINED MUMBLE_OPTIONS_DESCRIPTION)
+		message(FATAL_ERROR "declare_option: No DESCRIPTION provided")
+	endif()
+	if (NOT DEFINED MUMBLE_OPTIONS_DEFAULT AND NOT DEFINED ${CURRENT_OS_DEFAULT_VAR})
+		message(FATAL_ERROR "declare_option: No DEFAULT provided for option \"${MUMBLE_OPTIONS_NAME}\" and ${CURRENT_OS_DEFAULT_VAR} is not given either")
+	endif()
+	if (DEFINED MUMBLE_OPTIONS_RESTRICT_TO)
+		# Make sure the OS is given in uppercase
+		list(TRANSFORM MUMBLE_OPTIONS_RESTRICT_TO TOUPPER)
+
+		foreach (CURRENT_OS IN LISTS MUMBLE_OPTIONS_RESTRICT_TO)
+			if (NOT ${CURRENT_OS} IN_LIST MUMBLE_OPTIONS_SUPPORTED_OS)
+				message(FATAL_ERROR "declare_option: Trying to restrict option ${MUMBLE_OPTIONS_NAME} to unknown/unsupported OS ${CURRENT_OS}")
+			endif()
+		endforeach()
+	endif()
+	if (DEFINED MUMBLE_OPTIONS_EXCLUDE_ON)
+		# Make sure the OS is given in uppercase
+		list(TRANSFORM MUMBLE_OPTIONS_EXCLUDE_ON TOUPPER)
+
+		foreach (CURRENT_OS IN LISTS MUMBLE_OPTIONS_EXCLUDE_ON)
+			if (NOT ${CURRENT_OS} IN_LIST MUMBLE_OPTIONS_SUPPORTED_OS)
+				message(FATAL_ERROR "declare_option: Trying to exclude option ${MUMBLE_OPTIONS_NAME} on unknown/unsupported OS ${CURRENT_OS}")
+			endif()
+		endforeach()
+	endif()
+
+
+	# First check if the given option is supposed to be defined on the current OS
+	if ((DEFINED MUMBLE_OPTIONS_RESTRICT_TO AND NOT ${UPPER_SYSTEM_NAME} IN_LIST MUMBLE_OPTIONS_RESTRICT_TO)
+		OR (DEFINED MUMBLE_OPTIONS_EXCLUDE_ON AND ${UPPER_SYSTEM_NAME} IN_LIST MUMBLE_OPTIONS_EXCLUDE_ON))
+		# The specified option is not supposed to exist on the given system. Make sure it is not set by accident
+		if (DEFINED ${MUMBLE_OPTIONS_NAME})
+			# The option was set regardless -> error (avoid confused people wondering why setting option xy has no effect)
+			message(FATAL_ERROR "declare_option: Option \"${MUMBLE_OPTIONS_NAME}\" does not apply to system ${CMAKE_SYSTEM_NAME} but was set to"
+			" ${${MUMBLE_OPTIONS_NAME}}.")
+		endif()
+
+		# Nothing more to do in this case - just return from this function
+		return()
+	endif()
+
+	# Prepare to define the option
+	if (DEFINED ${CURRENT_OS_DEFAULT_VAR})
+		# Prefer the system-specific default value over the generic one
+		set(DEFAULT_VALUE ${${CURRENT_OS_DEFAULT_VAR}})
+	else()
+		set(DEFAULT_VALUE ${MUMBLE_OPTIONS_DEFAULT})
+	endif()
+
+	message(DEBUG "Declaring option ${MUMBLE_OPTIONS_NAME} with default value ${DEFAULT_VALUE} and description \"${MUMBLE_OPTIONS_DESCRIPTION}\"")
+
+	# Actually define the option with the provided default and description
+	option(${MUMBLE_OPTIONS_NAME} "${MUMBLE_OPTIONS_DESCRIPTION}" ${DEFAULT_VALUE})
+endfunction()

--- a/g15helper/CMakeLists.txt
+++ b/g15helper/CMakeLists.txt
@@ -3,7 +3,14 @@
 # that can be found in the LICENSE file at the root of the
 # Mumble source tree or at <https://www.mumble.info/LICENSE>.
 
-option(g15-emulator "Build the g15helper executable in emulator mode. This will cause an emulated G15 window to appear on screen. Allows the use of Mumble's G15 support without owning the physical hardware." OFF)
+include(options-helper)
+
+declare_option(
+	NAME g15-emulator
+	DESCRIPTION "Build the g15helper executable in emulator mode. This will cause an emulated G15 window to appear on screen. Allows the use of Mumble's G15 support without owning the physical hardware."
+	DEFAULT OFF
+	RESTRICT_TO Windows
+)
 
 set(G15HELPER_RC "${CMAKE_CURRENT_BINARY_DIR}/g15helper.rc")
 set(G15HELPER_ICON "${CMAKE_SOURCE_DIR}/icons/g15helper.ico")

--- a/overlay/CMakeLists.txt
+++ b/overlay/CMakeLists.txt
@@ -2,9 +2,7 @@
 # Use of this source code is governed by a BSD-style license
 # that can be found in the LICENSE file at the root of the
 # Mumble source tree or at <https://www.mumble.info/LICENSE>.
-option(BUILD_OVERLAY_XCOMPILE "Build an x86 overlay" OFF)
-
-if(BUILD_OVERLAY_XCOMPILE)
+if(overlay-xcompile)
 	cmake_minimum_required(VERSION 3.15)
 
 	set(version "1.4.0" CACHE STRING "Project version")
@@ -30,7 +28,7 @@ set(OVERLAY_RC "${CMAKE_CURRENT_BINARY_DIR}/mumble_ol.rc")
 configure_file("${CMAKE_CURRENT_SOURCE_DIR}/mumble_ol.rc.in" "${OVERLAY_RC}")
 
 # We save the output name in a variable because it's used by configure_file()
-if(64_BIT AND NOT BUILD_OVERLAY_XCOMPILE)
+if(64_BIT AND NOT overlay-xcompile)
 	set(OUTPUT_NAME "mumble_ol_x64")
 else()
 	set(OUTPUT_NAME "mumble_ol")
@@ -112,7 +110,7 @@ set_target_properties(overlay PROPERTIES OUTPUT_NAME ${OUTPUT_NAME})
 
 find_package(Boost REQUIRED)
 
-if(BUILD_OVERLAY_XCOMPILE)
+if(overlay-xcompile)
 	set_target_properties(overlay PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${MUMBLE_BINARY_DIR})
 
 	target_include_directories(overlay
@@ -134,7 +132,7 @@ else()
 	install(TARGETS overlay RUNTIME DESTINATION "${MUMBLE_INSTALL_EXECUTABLEDIR}" COMPONENT mumble_client)
 endif()
 
-if(64_BIT AND NOT BUILD_OVERLAY_XCOMPILE)
+if(64_BIT AND NOT overlay-xcompile)
 	add_subdirectory("${3RDPARTY_DIR}/minhook" "${CMAKE_CURRENT_BINARY_DIR}/minhook" EXCLUDE_FROM_ALL)
 	target_compile_definitions(overlay PRIVATE "USE_MINHOOK")
 	target_link_libraries(overlay PRIVATE minhook)

--- a/overlay_gl/CMakeLists.txt
+++ b/overlay_gl/CMakeLists.txt
@@ -5,10 +5,6 @@
 
 # Overlay payload for UNIX-like systems.
 
-if(${CMAKE_SYSTEM_PROCESSOR} STREQUAL "x86_64" OR ${CMAKE_SYSTEM_PROCESSOR} STREQUAL "amd64")
-	option(overlay-xcompile "Build 32 bit overlay library, necessary for the overlay to work with 32 bit processes." ON)
-endif()
-
 add_library(overlay_gl SHARED "overlay.c")
 
 set_target_properties(overlay_gl

--- a/plugins/CMakeLists.txt
+++ b/plugins/CMakeLists.txt
@@ -3,7 +3,13 @@
 # that can be found in the LICENSE file at the root of the
 # Mumble source tree or at <https://www.mumble.info/LICENSE>.
 
-option(retracted-plugins "Build redacted (outdated) plugins as well" OFF)
+include(options-helper)
+
+declare_option(
+	NAME retracted-plugins
+	DESCRIPTION "Build redacted (outdated) plugins as well"
+	DEFAULT OFF
+)
 
 if(retracted-plugins)
 	message(STATUS "Including retracted plugins")

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -3,18 +3,40 @@
 # that can be found in the LICENSE file at the root of the
 # Mumble source tree or at <https://www.mumble.info/LICENSE>.
 
+include(options-helper)
+
 set(PROTO_FILE "${CMAKE_CURRENT_SOURCE_DIR}/Mumble.proto")
 
-option(client "Build the client (Mumble)" ON)
-option(server "Build the server (Murmur)" ON)
-
-option(qssldiffiehellmanparameters "Build support for custom Diffie-Hellman parameters." ON)
-
-option(zeroconf "Build support for zeroconf (mDNS/DNS-SD)." ON)
-
-option(dbus "Build support for DBus." ON)
-
-option(tracy "Enable the tracy profiler." OFF)
+declare_option(
+	NAME client
+	DESCRIPTION "Build the client (Mumble)"
+	DEFAULT ON
+)
+declare_option(
+	NAME server
+	DESCRIPTION "Build the server (Murmur)"
+	DEFAULT ON
+)
+declare_option(
+	NAME qssldiffiehellmanparameters
+	DESCRIPTION "Build support for custom Diffie-Hellman parameters."
+	DEFAULT ON
+)
+declare_option(
+	NAME zeroconf
+	DESCRIPTION "Build support for zeroconf (mDNS/DNS-SD)."
+	DEFAULT ON
+)
+declare_option(
+	NAME dbus
+	DESCRIPTION "Build support for DBus."
+	DEFAULT OFF
+)
+declare_option(
+	NAME tracy
+	DESCRIPTION "Enable the tracy profiler."
+	DEFAULT OFF
+)
 
 find_pkg(Qt5
 	COMPONENTS

--- a/src/mumble/CMakeLists.txt
+++ b/src/mumble/CMakeLists.txt
@@ -16,65 +16,168 @@ configure_file("${CMAKE_CURRENT_SOURCE_DIR}/mumble.plist.in" "${MUMBLE_PLIST}")
 
 include(qt-utils)
 include(install-library)
+include(options-helper)
 
-option(update "Check for updates by default." ON)
+declare_option(
+	NAME update
+	DESCRIPTION "Check for updates by default."
+	DEFAULT ON
+)
+declare_option(
+	NAME translations
+	DESCRIPTION "Include languages other than English."
+	DEFAULT ON
+)
+declare_option(
+	NAME bundle-qt-translations
+	DESCRIPTION "Bundle Qt's translations as well"
+	DEFAULT ${static}
+)
 
-option(translations "Include languages other than English." ON)
-option(bundle-qt-translations "Bundle Qt's translations as well" ${static}) 
+declare_option(
+	NAME bundled-opus
+	DESCRIPTION "Build the included version of Opus instead of looking for one on the system."
+	DEFAULT ON
+)
+declare_option(
+	NAME bundled-celt
+	DESCRIPTION "Build the included version of CELT instead of looking for one on the system."
+	DEFAULT ON
+)
+declare_option(
+	NAME bundled-speex
+	DESCRIPTION "Build the included version of Speex instead of looking for one on the system."
+	DEFAULT ON
+)
+declare_option(
+	NAME rnnoise
+	DESCRIPTION "Use RNNoise for machine learning noise reduction."
+	DEFAULT ON
+)
+declare_option(
+	NAME bundled-rnnoise
+	DESCRIPTION "Build the included version of RNNoise instead of looking for one on the system."
+	DEFAULT ${rnnoise}
+)
 
-option(bundled-opus "Build the included version of Opus instead of looking for one on the system." ON)
-option(bundled-celt "Build the included version of CELT instead of looking for one on the system." ON)
-option(bundled-speex "Build the included version of Speex instead of looking for one on the system." ON)
-option(rnnoise "Use RNNoise for machine learning noise reduction." ON)
-option(bundled-rnnoise "Build the included version of RNNoise instead of looking for one on the system." ${rnnoise})
+declare_option(
+	NAME manual-plugin
+	DESCRIPTION "Include the built-in \"manual\" positional audio plugin."
+	DEFAULT ON
+)
+declare_option(
+	NAME qtspeech
+	DESCRIPTION "Use Qt's text-to-speech system (part of the Qt Speech module) instead of Mumble's own OS-specific text-to-speech implementations."
+	DEFAULT OFF
+)
 
-option(manual-plugin "Include the built-in \"manual\" positional audio plugin." ON)
+declare_option(
+	NAME plugin-debug
+	DESCRIPTION "Build Mumble with debug output for plugin developers."
+	DEFAULT OFF
+)
+declare_option(
+	NAME plugin-callback-debug
+	DESCRIPTION "Build Mumble with debug output for plugin callbacks inside of Mumble."
+	DEFAULT OFF
+)
 
-option(qtspeech "Use Qt's text-to-speech system (part of the Qt Speech module) instead of Mumble's own OS-specific text-to-speech implementations." OFF)
+declare_option(
+	NAME jackaudio
+	DESCRIPTION "Build support for JackAudio."
+	DEFAULT ON
+)
+declare_option(
+	NAME portaudio
+	DESCRIPTION "Build support for PortAudio."
+	DEFAULT ON
+)
+declare_option(
+	NAME asio
+	DESCRIPTION "Build support for ASIO audio input."
+	DEFAULT OFF
+	RESTRICT_TO Windows
+)
+declare_option(
+	NAME wasapi
+	DESCRIPTION "Build support for WASAPI."
+	DEFAULT ON
+	RESTRICT_TO Windows
+)
+declare_option(
+	NAME coreaudio
+	DESCRIPTION "Build support for CoreAudio."
+	DEFAULT ON
+	RESTRICT_TO Darwin
+)
+declare_option(
+	NAME oss
+	DESCRIPTION "Build support for OSS."
+	DEFAULT ON
+	RESTRICT_TO FreeBSD
+)
+declare_option(
+	NAME alsa
+	DESCRIPTION "Build support for ALSA."
+	DEFAULT ON
+	RESTRICT_TO Linux
+)
+declare_option(
+	NAME pipewire
+	DESCRIPTION "Build support for PipeWire."
+	DEFAULT ON
+	RESTRICT_TO Linux
+)
+declare_option(
+	NAME pulseaudio
+	DESCRIPTION "Build support for PulseAudio."
+	DEFAULT ON
+	RESTRICT_TO Linux
+)
 
-option(jackaudio "Build support for JackAudio." ON)
-option(portaudio "Build support for PortAudio" ON)
+declare_option(
+	NAME speechd
+	DESCRIPTION "Build support for Speech Dispatcher."
+	DEFAULT ON
+	RESTRICT_TO Linux
+)
+declare_option(
+	NAME xinput2
+	DESCRIPTION "Build support for XI2."
+	DEFAULT ON
+	RESTRICT_TO Linux OpenBSD
+)
+declare_option(
+	NAME xboxinput
+	DESCRIPTION "Build support for global shortcuts from Xbox controllers via the XInput DLL."
+	DEFAULT ON
+	RESTRICT_TO Windows
+)
+declare_option(
+	NAME gkey
+	DESCRIPTION "Build support for Logitech G-Keys. Note: This feature does not require any build-time dependencies, and requires Logitech Gaming Software to be installed to have any effect at runtime."
+	DEFAULT ON
+	RESTRICT_TO Windows
+)
+declare_option(
+	NAME g15
+	DESCRIPTION "Include support for the G15 keyboard (and compatible devices)."
+	DEFAULT OFF
+	EXCLUDE_ON Darwin
+)
+declare_option(
+	NAME crash-report
+	DESCRIPTION "Include support for reporting crashes to the Mumble developers."
+	DEFAULT ON
+	RESTRICT_TO Windows Darwin
+)
+declare_option(
+	NAME elevation
+	DESCRIPTION "Set \"uiAccess=true\", required for global shortcuts to work with privileged applications. Requires the client's executable to be signed with a trusted code signing certificate."
+	DEFAULT ON
+	RESTRICT_TO Windows
+)
 
-option(plugin-debug "Build Mumble with debug output for plugin developers." OFF)
-option(plugin-callback-debug "Build Mumble with debug output for plugin callbacks inside of Mumble." OFF)
-
-if(WIN32)
-	option(asio "Build support for ASIO audio input." OFF)
-	option(wasapi "Build support for WASAPI." ON)
-	option(xboxinput "Build support for global shortcuts from Xbox controllers via the XInput DLL." ON)
-	option(gkey "Build support for Logitech G-Keys. Note: This feature does not require any build-time dependencies, and requires Logitech Gaming Software to be installed to have any effect at runtime." ON)
-elseif(UNIX)
-	if(APPLE)
-		option(coreaudio "Build support for CoreAudio." ON)
-	elseif(${CMAKE_SYSTEM_NAME} STREQUAL "FreeBSD")
-		option(oss "Build support for OSS." ON)
-	elseif(${CMAKE_SYSTEM_NAME} STREQUAL "Linux")
-		option(alsa "Build support for ALSA." ON)
-		option(pipewire "Build support for PipeWire." ON)
-		option(pulseaudio "Build support for PulseAudio." ON)
-		option(speechd "Build support for Speech Dispatcher." ON)
-	endif()
-
-	# scripts/generate_cmake_options_docs.py does not cope with duplicate option() lines,
-	# so single out common options into combined conditions.
-	# https://github.com/mumble-voip/mumble/issues/5488
-	if(${CMAKE_SYSTEM_NAME} STREQUAL "Linux" OR
-	   ${CMAKE_SYSTEM_NAME} STREQUAL "OpenBSD")
-		option(xinput2 "Build support for XI2." ON)
-	endif()
-endif()
-
-if(NOT APPLE)
-	option(g15 "Include support for the G15 keyboard (and compatible devices)." OFF)
-endif()
-
-if(WIN32 OR APPLE)
-	option(crash-report "Include support for reporting crashes to the Mumble developers." ON)
-endif()
-
-if(MSVC)
-	option(elevation "Set \"uiAccess=true\", required for global shortcuts to work with privileged applications. Requires the client's executable to be signed with a trusted code signing certificate." OFF)
-endif()
 
 find_pkg(Qt5
 	COMPONENTS

--- a/src/murmur/CMakeLists.txt
+++ b/src/murmur/CMakeLists.txt
@@ -14,9 +14,18 @@ set(GRPC_FILE "${CMAKE_CURRENT_SOURCE_DIR}/MurmurRPC.proto")
 set(ICE_FILE "${CMAKE_CURRENT_SOURCE_DIR}/Murmur.ice")
 
 include(qt-utils)
+include(options-helper)
 
-option(grpc "Build support for gRPC." OFF)
-option(ice "Build support for Ice RPC." ON)
+declare_option(
+	NAME grpc
+	DESCRIPTION "Build support for gRPC."
+	DEFAULT OFF
+)
+declare_option(
+	NAME ice
+	DESCRIPTION "Build support for Ice RPC."
+	DEFAULT ON
+)
 
 find_pkg(Qt5 COMPONENTS Sql REQUIRED)
 

--- a/src/tests/CMakeLists.txt
+++ b/src/tests/CMakeLists.txt
@@ -3,9 +3,15 @@
 # that can be found in the LICENSE file at the root of the
 # Mumble source tree or at <https://www.mumble.info/LICENSE>.
 
+include(options-helper)
+
 find_pkg(Qt5 COMPONENTS Test REQUIRED)
 
-option(online-tests "Whether or not tests that need a working internet connection should be included" OFF)
+declare_option(
+	NAME online-tests
+	DESCRIPTION "Whether or not tests that need a working internet connection should be included"
+	DEFAULT OFF
+)
 
 set(TESTS "")
 


### PR DESCRIPTION
This functions allows a better markup of the cmake source code and also
allows us to restrict certain options to certain OS (or use different
defaults on different OS).


### Checks

- [x] My commits follow the [commit guidelines](https://github.com/mumble-voip/mumble/blob/master/COMMIT_GUIDELINES.md)

