### PR TITLE
FIX(installer): Re-add URL protocol registration registry keys on install

### DIFF
--- a/installer/ClientInstaller.cs
+++ b/installer/ClientInstaller.cs
@@ -155,7 +155,7 @@ public class ClientInstaller : MumbleInstall {
 
 		for (int i = 0; i < binaries.Count; i++) {
 			if (binaries[i] == "mumble.exe") {
-				binaryFiles[i] = new File(@"..\..\" + binaries[i], new FileAssociation("mumble_plugin", "application/mumble", "Open", "\"%1\""));
+				binaryFiles[i] = new File(new Id("mumble.exe"), @"..\..\" + binaries[i], new FileAssociation("mumble_plugin", "application/mumble", "Open", "\"%1\""));
 			} else {
 				binaryFiles[i] = new File(@"..\..\" + binaries[i]);
 			}
@@ -182,6 +182,12 @@ public class ClientInstaller : MumbleInstall {
 			progsDir,
 			menuDir,
 			desktopDir
+		};
+		this.RegValues = new RegValue[] {
+			new RegValue(RegistryHive.ClassesRoot, "mumble", "", "URL:Mumble"),
+			new RegValue(RegistryHive.ClassesRoot, "mumble", "URL Protocol", ""),
+			new RegValue(RegistryHive.ClassesRoot, @"mumble\DefaultIcon", "", "[#mumble.exe]"),
+			new RegValue(RegistryHive.ClassesRoot, @"mumble\shell\open\command", "", "[#mumble.exe] \"%1\"")
 		};
 	}
 }


### PR DESCRIPTION
In the installer refactor (88e17868493b7e08fe3339069c11cbc5c39e62e5) these registry keys were removed, so new installs did not register a URL protocol and users weren't able to use `mumble://` links.
This is a direct translation of `Files.wxs` to equivalent WixSharp code.

Closes #5473

### Checks

- [x] My commits follow the [commit guidelines](https://github.com/mumble-voip/mumble/blob/master/COMMIT_GUIDELINES.md)

