### PR TITLE
FEAT(client): Add option to change background color in the TalkingUI

### DIFF
--- a/src/mumble/Settings.cpp
+++ b/src/mumble/Settings.cpp
@@ -520,6 +520,7 @@ Settings::Settings() {
 	iTalkingUI_PrefixCharCount          = 3;
 	iTalkingUI_PostfixCharCount         = 2;
 	qsTalkingUI_AbbreviationReplacement = QLatin1String("...");
+	qsTalkingUI_BackgroundColor         = QLatin1String("#000000")
 
 	qsHierarchyChannelSeparator = QLatin1String("/");
 
@@ -971,6 +972,7 @@ void Settings::load(QSettings *settings_ptr) {
 	LOAD(iTalkingUI_PrefixCharCount, "ui/talkingUI_PrefixCharCount");
 	LOAD(iTalkingUI_PostfixCharCount, "ui/talkingUI_PostfixCharCount");
 	LOAD(qsTalkingUI_AbbreviationReplacement, "ui/talkingUI_AbbreviationReplacement");
+	LOAD(qsTalkingUI_BackgroundColor, "ui/talkingUI_BackgroundColor")
 
 	// Load the old setting first in case it is set and then load the actual setting
 	LOAD(qsHierarchyChannelSeparator, "ui/talkingUI_ChannelSeparator");
@@ -1390,6 +1392,7 @@ void Settings::save() {
 	SAVE(iTalkingUI_PrefixCharCount, "ui/talkingUI_PrefixCharCount");
 	SAVE(iTalkingUI_PostfixCharCount, "ui/talkingUI_PostfixCharCount");
 	SAVE(qsTalkingUI_AbbreviationReplacement, "ui/talkingUI_AbbreviationReplacement");
+	SAVE(qsTalkingUI_BackgroundColor, "ui/talkingUI_BackgroundColor")
 
 	DEPRECATED("ui/talkingUI_ChannelSeparator");
 	SAVE(qsHierarchyChannelSeparator, "ui/hierarchy_channelSeparator");

--- a/src/mumble/Settings.h
+++ b/src/mumble/Settings.h
@@ -321,6 +321,7 @@ struct Settings {
 	int iTalkingUI_PrefixCharCount;
 	int iTalkingUI_PostfixCharCount;
 	QString qsTalkingUI_AbbreviationReplacement;
+	QString qsTalkingUI_BackgroundColor;
 
 	QString qsHierarchyChannelSeparator;
 

--- a/src/mumble/TalkingUI.cpp
+++ b/src/mumble/TalkingUI.cpp
@@ -752,6 +752,13 @@ void TalkingUI::on_settingsChanged() {
 		}
 	}
 
+	// Update Background Color
+	for (auto& currentContainer : m_containers) {
+		for (auto &currentEntry : currentContainer->getEntires()) {
+			currentEntry->setBackgroundColor(Global::get().s.qsTalkingUI_BackgroundColor);
+		}
+	}
+
 	const ClientUser *self = ClientUser::get(Global::get().uiSession);
 
 	// Whether or not the current user should always be displayed might also have changed,

--- a/src/mumble/TalkingUIEntry.cpp
+++ b/src/mumble/TalkingUIEntry.cpp
@@ -99,9 +99,6 @@ TalkingUIUser::TalkingUIUser(const ClientUser &user)
 										 USER_CONTAINER_HORIZONTAL_MARGIN, USER_CONTAINER_VERTICAL_MARGIN);
 	m_backgroundWidget->setLayout(backgroundLayout);
 	m_backgroundWidget->setAutoFillBackground(true);
-	QPalette myPal = QPalette();
-	pal.setColor(QPalette::Window, Qt::black);
-	m_backgroundWidget.setPalette(pal);
 
 
 	// Create the label we use to display the user's name
@@ -352,9 +349,6 @@ TalkingUIChannelListener::TalkingUIChannelListener(const ClientUser &user, const
 										 USER_CONTAINER_HORIZONTAL_MARGIN, USER_CONTAINER_VERTICAL_MARGIN);
 	m_backgroundWidget->setLayout(backgroundLayout);
 	m_backgroundWidget->setAutoFillBackground(true);
-	QPalette myPal = QPalette();
-	pal.setColor(QPalette::Window, Qt::black);
-	m_backgroundWidget.setPalette(pal);
 
 
 

--- a/src/mumble/TalkingUIEntry.cpp
+++ b/src/mumble/TalkingUIEntry.cpp
@@ -99,6 +99,10 @@ TalkingUIUser::TalkingUIUser(const ClientUser &user)
 										 USER_CONTAINER_HORIZONTAL_MARGIN, USER_CONTAINER_VERTICAL_MARGIN);
 	m_backgroundWidget->setLayout(backgroundLayout);
 	m_backgroundWidget->setAutoFillBackground(true);
+	QPalette myPal = QPalette();
+	pal.setColor(QPalette::Window, Qt::black);
+	m_backgroundWidget.setPalette(pal);
+
 
 	// Create the label we use to display the user's name
 	m_nameLabel                 = new QLabel(m_backgroundWidget);
@@ -262,6 +266,10 @@ void TalkingUIUser::setDisplayString(const QString &displayString) {
 	}
 }
 
+void TalkingUIUser::setBackgroundColor(const QString &color) {
+	m_backgroundWidgetStyleWrapper.setBackgroundColor(color);
+}
+
 void TalkingUIUser::setLifeTime(unsigned int time) {
 	m_timer.setInterval(time);
 }
@@ -344,6 +352,10 @@ TalkingUIChannelListener::TalkingUIChannelListener(const ClientUser &user, const
 										 USER_CONTAINER_HORIZONTAL_MARGIN, USER_CONTAINER_VERTICAL_MARGIN);
 	m_backgroundWidget->setLayout(backgroundLayout);
 	m_backgroundWidget->setAutoFillBackground(true);
+	QPalette myPal = QPalette();
+	pal.setColor(QPalette::Window, Qt::black);
+	m_backgroundWidget.setPalette(pal);
+
 
 
 	// Create the label we use to display the icon
@@ -394,6 +406,10 @@ void TalkingUIChannelListener::setIconSize(int size) {
 
 void TalkingUIChannelListener::setDisplayString(const QString &displayString) {
 	m_nameLabel->setText(QString::fromLatin1("<i>%1</i>").arg(displayString));
+}
+
+void TalkingUIChannelListener::setBackgroundColor(const QString &color) {
+	m_backgroundWidgetStyleWrapper.setBackgroundColor(color);
 }
 
 int TalkingUIChannelListener::getAssociatedChannelID() const {

--- a/src/mumble/TalkingUIEntry.h
+++ b/src/mumble/TalkingUIEntry.h
@@ -57,6 +57,8 @@ public:
 
 	virtual void setDisplayString(const QString &displayString) = 0;
 
+	virtual void setBackgroundColor(const QString &color) = 0;
+
 	virtual int compare(const TalkingUIEntry &other) const;
 
 	bool operator==(const TalkingUIEntry &other) const;
@@ -113,6 +115,8 @@ public:
 
 	virtual void setDisplayString(const QString &displayString) override;
 
+	virtual void setBackgroundColor(const QString &color) override;
+
 	virtual void setLifeTime(unsigned int time);
 	virtual void restrictLifetime(bool restrict);
 
@@ -144,6 +148,8 @@ public:
 	virtual void setIconSize(int size) override;
 
 	virtual void setDisplayString(const QString &displayString) override;
+
+	virtual void setBackgroundColor(const QString &color) override;
 
 	virtual int getAssociatedChannelID() const;
 };


### PR DESCRIPTION
FEAT(client): Add option to change background color in the TalkingUI

 As requested in #5411, this commit implements member functions of the TalkingUIEntry.cpp class, where the QWidget is modified to change the background color. A QString datatype was chosen as the parameter, though a QColor has been recommended, this is a small fix as QColor::name() can be called inside the talkingUIEntry function to change the QColor to a QString.

Implements (partially) #5411
Co-Authored-By: Michael Hayworth <mhayworth@ufl.edu>


- [x] My commits follow the [commit guidelines](https://github.com/mumble-voip/mumble/blob/master/COMMIT_GUIDELINES.md)

