### PR TITLE
Backport "FIX(installer): Re-add URL protocol registration registry keys on install (#5521)" to 1.4.x

### DIFF
--- a/installer/ClientInstaller.cs
+++ b/installer/ClientInstaller.cs
@@ -155,7 +155,7 @@ public class ClientInstaller : MumbleInstall {
 
 		for (int i = 0; i < binaries.Count; i++) {
 			if (binaries[i] == "mumble.exe") {
-				binaryFiles[i] = new File(@"..\..\" + binaries[i], new FileAssociation("mumble_plugin", "application/mumble", "Open", "\"%1\""));
+				binaryFiles[i] = new File(new Id("mumble.exe"), @"..\..\" + binaries[i], new FileAssociation("mumble_plugin", "application/mumble", "Open", "\"%1\""));
 			} else {
 				binaryFiles[i] = new File(@"..\..\" + binaries[i]);
 			}
@@ -182,6 +182,12 @@ public class ClientInstaller : MumbleInstall {
 			progsDir,
 			menuDir,
 			desktopDir
+		};
+		this.RegValues = new RegValue[] {
+			new RegValue(RegistryHive.ClassesRoot, "mumble", "", "URL:Mumble"),
+			new RegValue(RegistryHive.ClassesRoot, "mumble", "URL Protocol", ""),
+			new RegValue(RegistryHive.ClassesRoot, @"mumble\DefaultIcon", "", "[#mumble.exe]"),
+			new RegValue(RegistryHive.ClassesRoot, @"mumble\shell\open\command", "", "[#mumble.exe] \"%1\"")
 		};
 	}
 }


### PR DESCRIPTION
Backports the following commits to 1.4.x:
 - FIX(installer): Re-add URL protocol registration registry keys on install (#5521)