### PR TITLE
FIX(client): Fix PipeWire not being usable in Flatpaks

### DIFF
--- a/src/mumble/PipeWire.cpp
+++ b/src/mumble/PipeWire.cpp
@@ -128,7 +128,15 @@ void PipeWireInit::destroy() {
 static PipeWireInit pwi;
 
 PipeWireSystem::PipeWireSystem() : m_ok(false), m_users(0) {
-	const QStringList names{ "libpipewire.so", "libpipewire-0.3.so" };
+	// clang-format off
+	const QStringList names {
+		// Common names used by Linux distributions.
+		"libpipewire.so",
+		"libpipewire-0.3.so",
+		// Name used by the Flatpak FreeDesktop runtime.
+		"libpipewire-0.3.so.0"
+	};
+	// clang-format on
 
 	for (const auto &name : names) {
 		m_lib.setFileName(name);


### PR DESCRIPTION
PipeWire is correctly built and enabled in a Flatpak runtime, but does not properly intialize because the .so filename of the library is named slightly differently there.

See also https://github.com/flathub/info.mumble.Mumble/issues/19#issuecomment-1023001248

After this, I can select PipeWire as back end [in the Flatpak build](https://github.com/flathub/info.mumble.Mumble). As mentioned in the above issue, it doesn't actually _work_ yet after selecting it (no input or output is generated), but it's a first step. I'll do some digging to see if I can fix the second issue as well in a separate PR.

### Checks

- [x] My commits follow the [commit guidelines](https://github.com/mumble-voip/mumble/blob/master/COMMIT_GUIDELINES.md)

