### PR TITLE
CHANGE(client): Use JSON file for storing settings

### DIFF
--- a/.ci/azure-pipelines/steps_linux.yml
+++ b/.ci/azure-pipelines/steps_linux.yml
@@ -12,7 +12,7 @@ steps:
     env:
       MUMBLE_BUILD_NUMBER_TOKEN: $(BUILD_NUMBER_TOKEN)
     displayName: 'Build'
-  - script: 'cd $BUILD_BINARIESDIRECTORY; QT_QPA_PLATFORM=offscreen ctest --verbose'
+  - script: 'cd $BUILD_BINARIESDIRECTORY; QT_QPA_PLATFORM=offscreen ctest --output-on-failure'
     displayName: 'Test'
 # - script: .ci/azure-pipelines/package_AppImage.bash
 #   displayName: 'Release'

--- a/.ci/azure-pipelines/steps_linux.yml
+++ b/.ci/azure-pipelines/steps_linux.yml
@@ -12,7 +12,7 @@ steps:
     env:
       MUMBLE_BUILD_NUMBER_TOKEN: $(BUILD_NUMBER_TOKEN)
     displayName: 'Build'
-  - script: 'cd $BUILD_BINARIESDIRECTORY; ctest --verbose'
+  - script: 'cd $BUILD_BINARIESDIRECTORY; QT_QPA_PLATFORM=offscreen ctest --verbose'
     displayName: 'Test'
 # - script: .ci/azure-pipelines/package_AppImage.bash
 #   displayName: 'Release'

--- a/.ci/azure-pipelines/steps_macos.yml
+++ b/.ci/azure-pipelines/steps_macos.yml
@@ -18,7 +18,7 @@ steps:
     env:
       MUMBLE_BUILD_NUMBER_TOKEN: $(BUILD_NUMBER_TOKEN)
     displayName: 'Build'
-  - script: 'cd $BUILD_BINARIESDIRECTORY; ctest --verbose'
+  - script: 'cd $BUILD_BINARIESDIRECTORY; ctest --output-on-failure'
     displayName: 'Test'
   - script: .ci/azure-pipelines/release_macos.bash
     displayName: 'Release'

--- a/.ci/azure-pipelines/steps_windows.yml
+++ b/.ci/azure-pipelines/steps_windows.yml
@@ -12,7 +12,7 @@ steps:
     env:
       MUMBLE_BUILD_NUMBER_TOKEN: $(BUILD_NUMBER_TOKEN)
     displayName: 'Build'
-  - script: 'cd /d %BUILD_BINARIESDIRECTORY% & ctest --verbose'
+  - script: 'cd /d %BUILD_BINARIESDIRECTORY% & ctest --output-on-failure'
     env:
       # Set timeout for tests to 15min
       QTEST_FUNCTION_TIMEOUT: 900000

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -67,5 +67,5 @@ jobs:
     - name: Test
       working-directory: ${{runner.workspace}}/build
       shell: bash
-      run: QT_QPA_PLATFORM=offscreen ctest -v -C $BUILD_TYPE
+      run: QT_QPA_PLATFORM=offscreen ctest -output-on-failure -C $BUILD_TYPE
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -67,5 +67,5 @@ jobs:
     - name: Test
       working-directory: ${{runner.workspace}}/build
       shell: bash
-      run: ctest -v -C $BUILD_TYPE
+      run: QT_QPA_PLATFORM=offscreen ctest -v -C $BUILD_TYPE
 

--- a/.gitmodules
+++ b/.gitmodules
@@ -25,3 +25,6 @@
 [submodule "3rdparty/tracy"]
 	path = 3rdparty/tracy
 	url = https://github.com/wolfpld/tracy.git
+[submodule "3rdparty/nlohmann_json"]
+	path = 3rdparty/nlohmann_json
+	url = https://github.com/ArthurSonzogni/nlohmann_json_cmake_fetchcontent

--- a/src/mumble/CMakeLists.txt
+++ b/src/mumble/CMakeLists.txt
@@ -86,7 +86,6 @@ find_pkg(Qt5
 )
 
 set(MUMBLE_SOURCES
-	"main.cpp"
 	"About.cpp"
 	"About.h"
 	"ACLEditor.cpp"
@@ -321,10 +320,12 @@ set(MUMBLE_SOURCES
 	"${CMAKE_SOURCE_DIR}/themes/DefaultTheme.qrc"
 )
 
+add_library(mumble_client_object_lib OBJECT ${MUMBLE_SOURCES})
+
 if(static AND WIN32)
 	# On Windows, building a static client means building the main app into a DLL.
-	add_library(mumble SHARED ${MUMBLE_SOURCES})
-	target_compile_definitions(mumble PRIVATE "MUMBLEAPP_DLL")
+	add_library(mumble SHARED "main.cpp")
+	target_compile_definitions(mumble_client_object_lib PUBLIC "MUMBLEAPP_DLL")
 
 	set_target_properties(mumble PROPERTIES OUTPUT_NAME "mumble_app")
 	if(MINGW)
@@ -332,14 +333,14 @@ if(static AND WIN32)
 		set_target_properties(mumble PROPERTIES PREFIX "")
 	endif()
 
-	target_sources(mumble PRIVATE "${MUMBLE_DLL_RC}")
+	target_sources(mumble_client_object_lib PRIVATE "${MUMBLE_DLL_RC}")
 
 	add_subdirectory("${SHARED_SOURCE_DIR}/mumble_exe" "${CMAKE_BINARY_DIR}/mumble_exe")
 else()
-	add_executable(mumble ${MUMBLE_SOURCES})
+	add_executable(mumble "main.cpp")
 
 	if(WIN32)
-		target_sources(mumble
+		target_sources(mumble_client_object_lib
 			PRIVATE
 				"mumble.appcompat.manifest"
 				"${MUMBLE_RC}"
@@ -359,20 +360,24 @@ else()
 	endif()
 endif()
 
+set_property(TARGET mumble_client_object_lib PROPERTY INTERPROCEDURAL_OPTIMIZATION ${lto})
 set_property(TARGET mumble PROPERTY INTERPROCEDURAL_OPTIMIZATION ${lto})
 
-target_compile_definitions(mumble
-	PRIVATE
+target_link_libraries(mumble mumble_client_object_lib)
+
+target_compile_definitions(mumble_client_object_lib
+	PUBLIC
 		"MUMBLE_LIBRARY_PATH=${MUMBLE_INSTALL_LIBDIR}"
 		"MUMBLE_PLUGIN_PATH=${MUMBLE_INSTALL_PLUGINDIR}"
 )
 
-set_target_properties(mumble
+set_target_properties(mumble PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR})
+
+set_target_properties(mumble_client_object_lib
 	PROPERTIES
 		AUTOMOC ON
 		AUTORCC ON
 		AUTOUIC ON
-		RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}
 )
 
 if(WIN32)
@@ -388,15 +393,15 @@ else()
 	install(FILES "${CMAKE_SOURCE_DIR}/man/mumble.1" DESTINATION "${MUMBLE_INSTALL_MANDIR}" COMPONENT doc)
 endif()
 
-target_compile_definitions(mumble
-	PRIVATE
+target_compile_definitions(mumble_client_object_lib
+	PUBLIC
 		"MUMBLE"
 		"USE_OPUS"
 		"QT_RESTRICTED_CAST_FROM_ASCII"
 )
 
-target_include_directories(mumble
-	PRIVATE
+target_include_directories(mumble_client_object_lib
+	PUBLIC
 		${CMAKE_CURRENT_SOURCE_DIR} # This is required for includes in current folder to be found by files from the shared directory.
 		"widgets"
 		${SHARED_SOURCE_DIR}
@@ -407,8 +412,8 @@ target_include_directories(mumble
 find_pkg(Poco COMPONENTS Zip)
 
 if(TARGET Poco::Zip)
-	target_link_libraries(mumble
-		PRIVATE
+	target_link_libraries(mumble_client_object_lib
+		PUBLIC
 			Poco::Zip
 	)
 else()
@@ -446,13 +451,13 @@ else()
 
 
 	# Now use the found include dir and libraries by linking it to the target
-	target_include_directories(mumble
-		PRIVATE
+	target_include_directories(mumble_client_object_lib
+		PUBLIC
 			${POCO_INCLUDE_DIR}
 	)
 
-	target_link_libraries(mumble
-		PRIVATE
+	target_link_libraries(mumble_client_object_lib
+		PUBLIC
 			${POCO_LIB_ZIP}
 			${POCO_LIB_XML}
 			${POCO_LIB_UTIL}
@@ -460,7 +465,7 @@ else()
 	)
 
 	if(static)
-		target_compile_definitions(mumble
+		target_compile_definitions(mumble_client_object_lib
 			PUBLIC
 				POCO_STATIC
 		)
@@ -472,30 +477,30 @@ set(JSON_BuildTests OFF CACHE INTERNAL "")
 set(JSON_ImplicitConversions OFF CACHE INTERNAL "")
 add_subdirectory("${3RDPARTY_DIR}/nlohmann_json/" "${CMAKE_CURRENT_BINARY_DIR}/nlohmann_json/")
 
-target_link_libraries(mumble PRIVATE nlohmann_json::nlohmann_json)
+target_link_libraries(mumble_client_object_lib PUBLIC nlohmann_json::nlohmann_json)
 
 find_pkg("SndFile;LibSndFile;sndfile" REQUIRED)
 
 # Check if sndfile version supports opus
 if("${sndfile_VERSION}" VERSION_GREATER_EQUAL "1.0.29")
-	target_compile_definitions(mumble PRIVATE USE_SNDFILE_OPUS)
+	target_compile_definitions(mumble_client_object_lib PUBLIC USE_SNDFILE_OPUS)
 else()
 	message(WARNING "libsnfile is missing Opus-support -> No Opus-format recording")
 endif()
 
 # Look for various targets as they are named differently on different platforms
 if(static AND TARGET sndfile-static)
-	target_link_libraries(mumble PRIVATE sndfile-static)
+	target_link_libraries(mumble_client_object_lib PUBLIC sndfile-static)
 elseif(TARGET SndFile::sndfile)
-	target_link_libraries(mumble PRIVATE SndFile::sndfile)
+	target_link_libraries(mumble_client_object_lib PUBLIC SndFile::sndfile)
 elseif(TARGET sndfile)
-	target_link_libraries(mumble PRIVATE sndfile)
+	target_link_libraries(mumble_client_object_lib PUBLIC sndfile)
 else()
-	target_link_libraries(mumble PRIVATE ${sndfile_LIBRARIES})
+	target_link_libraries(mumble_client_object_lib PUBLIC ${sndfile_LIBRARIES})
 endif()
 
-target_link_libraries(mumble
-	PRIVATE
+target_link_libraries(mumble_client_object_lib
+	PUBLIC
 		shared
 		Qt5::Concurrent
 		Qt5::Sql
@@ -505,27 +510,27 @@ target_link_libraries(mumble
 
 if(static)
 	if(TARGET Qt5::QSQLiteDriverPlugin)
-		include_qt_plugin(mumble PRIVATE "QSQLiteDriverPlugin")
-		target_link_libraries(mumble PRIVATE Qt5::QSQLiteDriverPlugin)
+		include_qt_plugin(mumble_client_object_lib PRIVATE "QSQLiteDriverPlugin")
+		target_link_libraries(mumble_client_object_lib PUBLIC Qt5::QSQLiteDriverPlugin)
 	endif()
 	if(TARGET Qt5::QSvgIconPlugin)
-		include_qt_plugin(mumble PRIVATE "QSvgIconPlugin")
-		target_link_libraries(mumble PRIVATE Qt5::QSvgIconPlugin)
+		include_qt_plugin(mumble_client_object_lib PRIVATE "QSvgIconPlugin")
+		target_link_libraries(mumble_client_object_lib PUBLIC Qt5::QSvgIconPlugin)
 	endif()
 	if(TARGET Qt5::QSvgPlugin)
-		include_qt_plugin(mumble PRIVATE "QSvgPlugin")
-		target_link_libraries(mumble PRIVATE Qt5::QSvgPlugin)
+		include_qt_plugin(mumble_client_object_lib PRIVATE "QSvgPlugin")
+		target_link_libraries(mumble_client_object_lib PUBLIC Qt5::QSvgPlugin)
 	endif()
 endif()
 
 if(MSVC)
-	target_compile_definitions(mumble PRIVATE "RESTRICT=")
+	target_compile_definitions(mumble_client_object_lib PUBLIC "RESTRICT=")
 else()
-	target_compile_definitions(mumble PRIVATE "RESTRICT=__restrict__")
+	target_compile_definitions(mumble_client_object_lib PUBLIC "RESTRICT=__restrict__")
 endif()
 
 if(WIN32)
-	target_sources(mumble PRIVATE
+	target_sources(mumble_client_object_lib PRIVATE
 		"GlobalShortcut_win.cpp"
 		"GlobalShortcut_win.h"
 		"Log_win.cpp"
@@ -553,8 +558,8 @@ if(WIN32)
 	)
 
 	if(static AND TARGET Qt5::QWindowsIntegrationPlugin)
-		include_qt_plugin(mumble PRIVATE QWindowsIntegrationPlugin)
-		target_link_libraries(mumble PRIVATE Qt5::QWindowsIntegrationPlugin)
+		include_qt_plugin(mumble_client_object_lib PRIVATE QWindowsIntegrationPlugin)
+		target_link_libraries(mumble_client_object_lib PUBLIC Qt5::QWindowsIntegrationPlugin)
 	endif()
 
 	add_subdirectory("${3RDPARTY_DIR}/xinputcheck-build" "${CMAKE_CURRENT_BINARY_DIR}/xinputcheck")
@@ -562,49 +567,49 @@ if(WIN32)
 	# Disable all warnings that the xinputcheck code may emit
 	disable_warnings_for_all_targets_in("${3RDPARTY_DIR}/xinputcheck-build")
 
-	target_link_libraries(mumble PRIVATE xinputcheck)
+	target_link_libraries(mumble_client_object_lib PUBLIC xinputcheck)
 
 	if(MSVC)
-		target_link_libraries(mumble
-			PRIVATE
+		target_link_libraries(mumble_client_object_lib
+			PUBLIC
 				Boost::dynamic_linking
 				Delayimp.lib
 			)
-		set_property(TARGET mumble APPEND_STRING PROPERTY LINK_FLAGS " /DELAYLOAD:user32.dll /DELAYLOAD:qwave.dll")
+		set_property(TARGET mumble_client_object_lib APPEND_STRING PROPERTY LINK_FLAGS " /DELAYLOAD:user32.dll /DELAYLOAD:qwave.dll")
 	endif()
 
-	target_link_libraries(mumble
-		PRIVATE
+	target_link_libraries(mumble_client_object_lib
+		PUBLIC
 			Boost::system
 			Boost::thread
 	)
 
-	target_link_libraries(mumble
-		PRIVATE
+	target_link_libraries(mumble_client_object_lib
+		PUBLIC
 			dbghelp.lib
 			dxguid.lib
 			hid.lib
 			wintrust.lib
 	)
 else()
-	target_sources(mumble PRIVATE "SharedMemory_unix.cpp")
+	target_sources(mumble_client_object_lib PRIVATE "SharedMemory_unix.cpp")
 
 	if(NOT APPLE)
 		find_pkg(X11 COMPONENTS Xext REQUIRED)
 
 		if(xinput2)
 			find_pkg(X11 COMPONENTS Xi REQUIRED)
-			target_link_libraries(mumble PRIVATE X11::Xi)
+			target_link_libraries(mumble_client_object_lib PUBLIC X11::Xi)
 		else()
-			target_compile_definitions(mumble PRIVATE "NO_XINPUT2")
+			target_compile_definitions(mumble_client_object_lib PUBLIC "NO_XINPUT2")
 		endif()
 
 		if(static AND TARGET Qt5::QXcbIntegrationPlugin)
-			include_qt_plugin(mumble PRIVATE QXcbIntegrationPlugin)
-			target_link_libraries(mumble PRIVATE Qt5::QXcbIntegrationPlugin)
+			include_qt_plugin(mumble_client_object_lib PRIVATE QXcbIntegrationPlugin)
+			target_link_libraries(mumble_client_object_lib PUBLIC Qt5::QXcbIntegrationPlugin)
 		endif()
 
-		target_sources(mumble
+		target_sources(mumble_client_object_lib
 			PRIVATE
 				"GlobalShortcut_unix.cpp"
 				"GlobalShortcut_unix.h"
@@ -614,10 +619,10 @@ else()
 
 		if(${CMAKE_SYSTEM_NAME} STREQUAL "Linux")
 			find_library(LIB_RT rt)
-			target_link_libraries(mumble PRIVATE ${LIB_RT})
+			target_link_libraries(mumble_client_object_lib PUBLIC ${LIB_RT})
 		endif()
 
-		target_link_libraries(mumble PRIVATE X11::Xext)
+		target_link_libraries(mumble_client_object_lib PUBLIC X11::Xext)
 	else()
 		find_library(LIB_APPKIT "AppKit")
 		find_library(LIB_APPLICATIONSERVICES "ApplicationServices")
@@ -626,7 +631,7 @@ else()
 		find_library(LIB_SECURITY "Security")
 		find_library(LIB_XAR "xar")
 
-		target_sources(mumble
+		target_sources(mumble_client_object_lib
 			PRIVATE
 				"AppNap.h"
 				"AppNap.mm"
@@ -637,12 +642,12 @@ else()
 		)
 
 		if(static AND TARGET Qt5::QCocoaIntegrationPlugin)
-			include_qt_plugin(mumble PRIVATE QCocoaIntegrationPlugin)
-			target_link_libraries(mumble PRIVATE Qt5::QCocoaIntegrationPlugin)
+			include_qt_plugin(mumble_client_object_lib PRIVATE QCocoaIntegrationPlugin)
+			target_link_libraries(mumble_client_object_lib PUBLIC Qt5::QCocoaIntegrationPlugin)
 		endif()
 
-		target_link_libraries(mumble
-			PRIVATE
+		target_link_libraries(mumble_client_object_lib
+			PUBLIC
 				${LIB_APPKIT}
 				${LIB_APPLICATIONSERVICES}
 				${LIB_CARBON}
@@ -667,9 +672,9 @@ if(bundled-opus)
 	# Opus doesn't work in unity builds
 	set_target_properties(opus PROPERTIES UNITY_BUILD FALSE)
 
-	add_dependencies(mumble opus)
+	add_dependencies(mumble_client_object_lib opus)
 
-	target_include_directories(mumble PRIVATE "${3RDPARTY_DIR}/opus/include")
+	target_include_directories(mumble_client_object_lib PUBLIC "${3RDPARTY_DIR}/opus/include")
 
 	if(WIN32)
 		# Shared library on Windows (e.g. ".dll")
@@ -682,7 +687,7 @@ if(bundled-opus)
 	install_library(opus mumble_client)
 else()
 	find_pkg(opus REQUIRED)
-	target_include_directories(mumble PRIVATE ${opus_INCLUDE_DIRS})
+	target_include_directories(mumble_client_object_lib PUBLIC ${opus_INCLUDE_DIRS})
 endif()
 
 if(bundled-celt)
@@ -691,9 +696,9 @@ if(bundled-celt)
 	# Disable all warnings that the Celt code may emit
 	disable_warnings_for_all_targets_in("${3RDPARTY_DIR}/celt-0.7.0-build")
 
-	add_dependencies(mumble celt)
+	add_dependencies(mumble_client_object_lib celt)
 
-	target_include_directories(mumble PRIVATE "${3RDPARTY_DIR}/celt-0.7.0-src/libcelt")
+	target_include_directories(mumble_client_object_lib PUBLIC "${3RDPARTY_DIR}/celt-0.7.0-src/libcelt")
 
 	if(WIN32)
 		# Shared library on Windows (e.g. ".dll")
@@ -710,7 +715,7 @@ else()
 	   ${celt_VERSION} VERSION_GREATER_EQUAL 0.8)
 		message(FATAL_ERROR "CELT 0.7.x is required, found ${celt_VERSION}!")
 	endif()
-	target_include_directories(mumble PRIVATE ${celt_INCLUDE_DIRS})
+	target_include_directories(mumble_client_object_lib PUBLIC ${celt_INCLUDE_DIRS})
 endif()
 
 if(bundled-speex)
@@ -719,7 +724,7 @@ if(bundled-speex)
 	# Disable all warnings that the speex code may emit
 	disable_warnings_for_all_targets_in("${3RDPARTY_DIR}/speex-build")
 
-	target_link_libraries(mumble PRIVATE speex)
+	target_link_libraries(mumble_client_object_lib PUBLIC speex)
 
 	if(WIN32)
 		# Shared library on Windows (e.g. ".dll")
@@ -734,15 +739,15 @@ else()
 	find_pkg(speex REQUIRED)
 	find_pkg(speexdsp REQUIRED)
 
-	target_link_libraries(mumble
-		PRIVATE
+	target_link_libraries(mumble_client_object_lib
+		PUBLIC
 			${speex_LIBRARIES}
 			${speexdsp_LIBRARIES}
 	)
 endif()
 
 if(rnnoise)
-	target_compile_definitions(mumble PRIVATE "USE_RNNOISE")
+	target_compile_definitions(mumble_client_object_lib PRIVATE "USE_RNNOISE")
 
 	if(bundled-rnnoise)
 		add_subdirectory("${3RDPARTY_DIR}/rnnoise-build" "${CMAKE_CURRENT_BINARY_DIR}/rnnoise")
@@ -750,7 +755,7 @@ if(rnnoise)
 		# Disable all warnings that the RNNoise code may emit
 		disable_warnings_for_all_targets_in("${3RDPARTY_DIR}/rnnoise-build")
 
-		target_link_libraries(mumble PRIVATE rnnoise)
+		target_link_libraries(mumble_client_object_lib PRIVATE rnnoise)
 
 		if(WIN32)
 			# Shared library on Windows (e.g. ".dll")
@@ -764,74 +769,74 @@ if(rnnoise)
 	else()
 		find_pkg(rnnoise REQUIRED)
 
-		target_link_libraries(mumble PRIVATE ${rnnoise_LIBRARIES})
+		target_link_libraries(mumble_client_object_lib PRIVATE ${rnnoise_LIBRARIES})
 	endif()
 endif()
 
 if(qtspeech)
 	find_pkg(Qt5 COMPONENTS TextToSpeech REQUIRED)
-	target_sources(mumble PRIVATE "TextToSpeech.cpp")
-	target_link_libraries(mumble PRIVATE Qt5::TextToSpeech)
+	target_sources(mumble_client_object_lib PRIVATE "TextToSpeech.cpp")
+	target_link_libraries(mumble_client_object_lib PUBLIC Qt5::TextToSpeech)
 elseif(WIN32)
-	target_sources(mumble PRIVATE "TextToSpeech_win.cpp")
+	target_sources(mumble_client_object_lib PRIVATE "TextToSpeech_win.cpp")
 	if(MINGW)
-		target_link_libraries(mumble PRIVATE sapi.lib)
+		target_link_libraries(mumble_client_object_lib PUBLIC sapi.lib)
 	endif()
 elseif(APPLE)
-	target_sources(mumble PRIVATE "TextToSpeech_macx.mm")
+	target_sources(mumble_client_object_lib PRIVATE "TextToSpeech_macx.mm")
 else()
-	target_sources(mumble PRIVATE "TextToSpeech_unix.cpp")
+	target_sources(mumble_client_object_lib PRIVATE "TextToSpeech_unix.cpp")
 
 	if(speechd)
 		find_pkg("speech-dispatcher" REQUIRED)
 
-		target_compile_definitions(mumble
-			PRIVATE
+		target_compile_definitions(mumble_client_object_lib
+			PUBLIC
 				"USE_SPEECHD"
 				"USE_SPEECHD_PKGCONFIG"
 		)
-		target_link_libraries(mumble PRIVATE ${speech-dispatcher_LIBRARIES})
+		target_link_libraries(mumble_client_object_lib PUBLIC ${speech-dispatcher_LIBRARIES})
 	else()
-		target_compile_definitions(mumble PRIVATE "USE_NO_TTS")
+		target_compile_definitions(mumble_client_object_lib PUBLIC "USE_NO_TTS")
 	endif()
 endif()
 
 if(crash-report)
-	target_sources(mumble
+	target_sources(mumble_client_object_lib
 		PRIVATE
 			"CrashReporter.cpp"
 			"CrashReporter.h"
 	)
 else()
-	target_compile_definitions(mumble PRIVATE "NO_CRASH_REPORT")
+	target_compile_definitions(mumble_client_object_lib PUBLIC "NO_CRASH_REPORT")
 endif()
 
 if(manual-plugin)
-	target_sources(mumble
+	target_sources(mumble_client_object_lib
 		PRIVATE
 			"ManualPlugin.cpp"
 			"ManualPlugin.h"
 			"ManualPlugin.ui"
 	)
 
-	target_compile_definitions(mumble PRIVATE "USE_MANUAL_PLUGIN")
+target_compile_definitions(mumble_client_object_lib PUBLIC "USE_MANUAL_PLUGIN")
 endif()
 
 if(NOT update)
-	target_compile_definitions(mumble PRIVATE "NO_UPDATE_CHECK")
+	target_compile_definitions(mumble_client_object_lib PUBLIC "NO_UPDATE_CHECK")
 endif()
 
 if(dbus AND NOT WIN32 AND NOT APPLE)
 	find_pkg(Qt5 COMPONENTS DBus REQUIRED)
 
-	target_sources(mumble
+	target_sources(mumble_client_object_lib
 		PRIVATE
 			"DBus.cpp"
 			"DBus.h"
 	)
 
-	target_compile_definitions(mumble PRIVATE "USE_DBUS")
-	target_link_libraries(mumble PRIVATE Qt5::DBus)
+	target_compile_definitions(mumble_client_object_lib PUBLIC "USE_DBUS")
+	target_link_libraries(mumble_client_object_lib PUBLIC Qt5::DBus)
 endif()
 
 if(translations)
@@ -839,17 +844,17 @@ if(translations)
 	file(GLOB TS_FILES "${CMAKE_CURRENT_SOURCE_DIR}/*.ts")
 
 	include_translations(QRC_FILE ${CMAKE_CURRENT_BINARY_DIR} "${TS_FILES}")
-	target_sources(mumble PRIVATE "${QRC_FILE}")
+	target_sources(mumble_client_object_lib PRIVATE "${QRC_FILE}")
 
 	if(bundle-qt-translations)
-		bundle_qt_translations(mumble)
+		bundle_qt_translations(mumble_client_object_lib)
 	endif()
 elseif(bundle-qt-translations)
 	message(WARNING "Can't bundle Qt translations if translations are disabled!")
 endif()
 
 if(overlay)
-	target_sources(mumble
+	target_sources(mumble_client_object_lib
 		PRIVATE
 			"Overlay.cpp"
 			"Overlay.h"
@@ -876,45 +881,45 @@ if(overlay)
 	)
 
 	if(WIN32)
-		target_sources(mumble
+		target_sources(mumble_client_object_lib
 			PRIVATE
 				"Overlay_win.cpp"
 				"Overlay_win.h"
 		)
 	else()
 		if(APPLE)
-			target_sources(mumble PRIVATE "Overlay_macx.mm")
+			target_sources(mumble_client_object_lib PRIVATE "Overlay_macx.mm")
 		else()
-			target_sources(mumble PRIVATE "Overlay_unix.cpp")
+			target_sources(mumble_client_object_lib PRIVATE "Overlay_unix.cpp")
 		endif()
 	endif()
 
-	target_compile_definitions(mumble PRIVATE "USE_OVERLAY")
+	target_compile_definitions(mumble_client_object_lib PUBLIC "USE_OVERLAY")
 endif()
 
 if(xboxinput)
-	target_sources(mumble
+	target_sources(mumble_client_object_lib
 		PRIVATE
 			"XboxInput.cpp"
 			"XboxInput.h"
 	)
 
-	target_compile_definitions(mumble PRIVATE "USE_XBOXINPUT")
+	target_compile_definitions(mumble_client_object_lib PUBLIC "USE_XBOXINPUT")
 endif()
 
 if(gkey)
-	target_sources(mumble
+	target_sources(mumble_client_object_lib
 		PRIVATE
 			"GKey.cpp"
 			"GKey.h"
 	)
 
-	target_compile_definitions(mumble PRIVATE "USE_GKEY")
+	target_compile_definitions(mumble_client_object_lib PUBLIC "USE_GKEY")
 endif()
 
 if(g15)
 	if(WIN32 OR APPLE)
-		target_sources(mumble
+		target_sources(mumble_client_object_lib
 			PRIVATE
 				"G15LCDEngine_helper.cpp"
 				"G15LCDEngine_helper.h"
@@ -925,14 +930,14 @@ if(g15)
 			message(FATAL_ERROR "G15 library not found!")
 		endif()
 
-		target_sources(mumble
+		target_sources(mumble_client_object_lib
 			PRIVATE
 				"G15LCDEngine_unix.cpp"
 				"G15LCDEngine_unix.h"
 		)
 
-		target_compile_definitions(mumble PRIVATE "USE_G15")
-		target_link_libraries(mumble PRIVATE ${LIB_G15DAEMON_CLIENT})
+		target_compile_definitions(mumble_client_object_lib PUBLIC "USE_G15")
+		target_link_libraries(mumble_client_object_lib PUBLIC ${LIB_G15DAEMON_CLIENT})
 	endif()
 endif()
 
@@ -940,18 +945,18 @@ if(zeroconf)
 	if(NOT APPLE)
 		find_pkg(avahi-compat-libdns_sd QUIET)
 		if(avahi-compat-libdns_sd_FOUND)
-			target_include_directories(mumble PRIVATE ${avahi-compat-libdns_sd_INCLUDE_DIRS})
-			target_link_libraries(mumble PRIVATE ${avahi-compat-libdns_sd_LIBRARIES})
+			target_include_directories(mumble_client_object_lib PUBLIC ${avahi-compat-libdns_sd_INCLUDE_DIRS})
+			target_link_libraries(mumble_client_object_lib PUBLIC ${avahi-compat-libdns_sd_LIBRARIES})
 		else()
 			find_library(LIB_DNSSD "dnssd")
 			if(${LIB_DNSSD} STREQUAL "LIB_DNSSD-NOTFOUND")
 				message(FATAL_ERROR "DNS-SD library not found!")
 			endif()
-			target_link_libraries(mumble PRIVATE ${LIB_DNSSD})
+			target_link_libraries(mumble_client_object_lib PUBLIC ${LIB_DNSSD})
 		endif()
 	endif()
 
-	target_sources(mumble
+	target_sources(mumble_client_object_lib
 		PRIVATE
 			"Zeroconf.cpp"
 			"Zeroconf.h"
@@ -964,20 +969,20 @@ if(zeroconf)
 			"${3RDPARTY_DIR}/qqbonjour/BonjourServiceResolver.h"
 	)
 
-	target_compile_definitions(mumble PRIVATE "USE_ZEROCONF")
-	target_include_directories(mumble PRIVATE "${3RDPARTY_DIR}/qqbonjour")
+	target_compile_definitions(mumble_client_object_lib PUBLIC "USE_ZEROCONF")
+	target_include_directories(mumble_client_object_lib PUBLIC "${3RDPARTY_DIR}/qqbonjour")
 endif()
 
 if(alsa)
 	find_pkg(ALSA REQUIRED)
-	target_sources(mumble
+	target_sources(mumble_client_object_lib
 		PRIVATE
 			"ALSAAudio.cpp"
 			"ALSAAudio.h"
 	)
 
-	target_compile_definitions(mumble PRIVATE "USE_ALSA")
-	target_link_libraries(mumble PRIVATE ALSA::ALSA)
+	target_compile_definitions(mumble_client_object_lib PUBLIC "USE_ALSA")
+	target_link_libraries(mumble_client_object_lib PUBLIC ALSA::ALSA)
 endif()
 
 if(asio)
@@ -985,16 +990,16 @@ if(asio)
 		set(ASIO_DIR "${3RDPARTY_DIR}/asio")
 	endif()
 
-	target_sources(mumble
+	target_sources(mumble_client_object_lib
 		PRIVATE
 			"ASIOInput.cpp"
 			"ASIOInput.h"
 			"ASIOInput.ui"
 	)
 
-	target_compile_definitions(mumble PRIVATE "USE_ASIO")
-	target_include_directories(mumble
-		PRIVATE SYSTEM
+	target_compile_definitions(mumble_client_object_lib PUBLIC "USE_ASIO")
+	target_include_directories(mumble_client_object_lib
+		SYSTEM PUBLIC
 			"${ASIO_DIR}/common"
 			"${ASIO_DIR}/host"
 			"${ASIO_DIR}/host/pc"
@@ -1005,14 +1010,14 @@ if(coreaudio)
 	find_library(LIB_AUDIOUNIT "AudioUnit")
 	find_library(LIB_COREAUDIO "CoreAudio")
 
-	target_sources(mumble
+	target_sources(mumble_client_object_lib
 		PRIVATE
 			"CoreAudio.mm"
 			"CoreAudio.h"
 	)
 
-	target_link_libraries(mumble
-		PRIVATE
+	target_link_libraries(mumble_client_object_lib
+		PUBLIC
 			${LIB_AUDIOUNIT}
 			${LIB_COREAUDIO}
 			"-framework AVFoundation"
@@ -1020,62 +1025,62 @@ if(coreaudio)
 endif()
 
 if(jackaudio)
-	target_sources(mumble
+	target_sources(mumble_client_object_lib
 		PRIVATE
 			"JackAudio.cpp"
 			"JackAudio.h"
 	)
 
-	target_compile_definitions(mumble PRIVATE "USE_JACKAUDIO")
-	target_include_directories(mumble PRIVATE SYSTEM "${3RDPARTY_DIR}/jack")
+	target_compile_definitions(mumble_client_object_lib PUBLIC "USE_JACKAUDIO")
+	target_include_directories(mumble_client_object_lib SYSTEM PUBLIC "${3RDPARTY_DIR}/jack")
 endif()
 
 if(oss)
-	target_sources(mumble
+	target_sources(mumble_client_object_lib
 		PRIVATE
 			"OSS.cpp"
 			"OSS.h"
 	)
 
-	target_compile_definitions(mumble PRIVATE "USE_OSS")
-	target_include_directories(mumble PRIVATE SYSTEM "/usr/lib/oss/include")
+	target_compile_definitions(mumble_client_object_lib PUBLIC "USE_OSS")
+	target_include_directories(mumble_client_object_lib SYSTEM PUBLIC "/usr/lib/oss/include")
 endif()
 
 if(pipewire)
-	target_sources(mumble
+	target_sources(mumble_client_object_lib
 		PRIVATE
 			"PipeWire.cpp"
 			"PipeWire.h"
 	)
 
-	target_compile_definitions(mumble PRIVATE "USE_PIPEWIRE")
-	target_include_directories(mumble PRIVATE SYSTEM "${3RDPARTY_DIR}/pipewire")
+	target_compile_definitions(mumble_client_object_lib PUBLIC "USE_PIPEWIRE")
+	target_include_directories(mumble_client_object_lib SYSTEM PUBLIC "${3RDPARTY_DIR}/pipewire")
 endif()
 
 if(portaudio)
-	target_sources(mumble
+	target_sources(mumble_client_object_lib
 		PRIVATE
 			"PAAudio.cpp"
 			"PAAudio.h"
 	)
 
-	target_compile_definitions(mumble PRIVATE "USE_PORTAUDIO")
-	target_include_directories(mumble PRIVATE SYSTEM "${3RDPARTY_DIR}/portaudio")
+	target_compile_definitions(mumble_client_object_lib PUBLIC "USE_PORTAUDIO")
+	target_include_directories(mumble_client_object_lib SYSTEM PUBLIC "${3RDPARTY_DIR}/portaudio")
 endif()
 
 if(pulseaudio)
-	target_sources(mumble
+	target_sources(mumble_client_object_lib
 		PRIVATE
 			"PulseAudio.cpp"
 			"PulseAudio.h"
 	)
 
-	target_compile_definitions(mumble PRIVATE "USE_PULSEAUDIO")
-	target_include_directories(mumble PRIVATE SYSTEM "${3RDPARTY_DIR}/pulseaudio")
+	target_compile_definitions(mumble_client_object_lib PUBLIC "USE_PULSEAUDIO")
+	target_include_directories(mumble_client_object_lib SYSTEM PUBLIC "${3RDPARTY_DIR}/pulseaudio")
 endif()
 
 if(wasapi)
-	target_sources(mumble
+	target_sources(mumble_client_object_lib
 		PRIVATE
 			"WASAPI.cpp"
 			"WASAPI.h"
@@ -1083,14 +1088,14 @@ if(wasapi)
 			"WASAPINotificationClient.h"
 	)
 
-	target_compile_definitions(mumble PRIVATE "USE_WASAPI")
-	target_link_libraries(mumble PRIVATE avrt.lib)
+	target_compile_definitions(mumble_client_object_lib PUBLIC "USE_WASAPI")
+	target_link_libraries(mumble_client_object_lib PUBLIC avrt.lib)
 	if(MINGW)
-		target_link_libraries(mumble PRIVATE ksuser.lib)
+		target_link_libraries(mumble_client_object_lib PUBLIC ksuser.lib)
 	endif()
 
 	if(MSVC)
-		set_property(TARGET mumble APPEND_STRING PROPERTY LINK_FLAGS " /DELAYLOAD:avrt.dll")
+		set_property(TARGET mumble_client_object_lib APPEND_STRING PROPERTY LINK_FLAGS " /DELAYLOAD:avrt.dll")
 	endif()
 endif()
 
@@ -1120,19 +1125,36 @@ if(${CMAKE_VERSION} VERSION_GREATER_EQUAL "3.16.0")
 endif()
 
 if(plugin-debug)
-	target_compile_definitions(mumble PRIVATE "MUMBLE_PLUGIN_DEBUG")
+	target_compile_definitions(mumble_client_object_lib PUBLIC "MUMBLE_PLUGIN_DEBUG")
 endif()
 
 if(plugin-callback-debug)
-	target_compile_definitions(mumble PRIVATE "MUMBLE_PLUGIN_CALLBACK_DEBUG")
+	target_compile_definitions(mumble_client_object_lib PUBLIC "MUMBLE_PLUGIN_CALLBACK_DEBUG")
 endif()
 
 if(UNIX)
 	if(${CMAKE_SYSTEM_NAME} STREQUAL "FreeBSD")
 		# On FreeBSD we need the util library for src/ProcessResolver.cpp to work
-		target_link_libraries(mumble PRIVATE util)
+		target_link_libraries(mumble_client_object_lib PUBLIC util)
 	elseif(${CMAKE_SYSTEM_NAME} MATCHES ".*BSD")
 		# On any other BSD we need the kvm library for src/ProcessResolver.cpp to work
-		target_link_libraries(mumble PRIVATE kvm)
+		target_link_libraries(mumble_client_object_lib PUBLIC kvm)
 	endif()
 endif()
+
+
+# Workaround for a cmake bug that causes the auto-generated UI files (AutoUIC) to not be added
+# to the target's interface include directories. This can cause missing include errors in targets
+# linking to mumble_client_object_lib.
+# cmake bug report: https://gitlab.kitware.com/cmake/cmake/-/issues/17456
+set(TARGET_NAME "mumble_client_object_lib")
+get_property(_isMultiConfig GLOBAL PROPERTY GENERATOR_IS_MULTI_CONFIG)
+if(_isMultiConfig)
+  set(AUTOGEN_INCLUDE_DIR ${CMAKE_CURRENT_BINARY_DIR}/${TARGET_NAME}_autogen/include_$<CONFIG>)
+else()
+  set(AUTOGEN_INCLUDE_DIR ${CMAKE_CURRENT_BINARY_DIR}/${TARGET_NAME}_autogen/include)
+endif()
+
+target_include_directories(${TARGET_NAME} INTERFACE
+  $<BUILD_INTERFACE:${AUTOGEN_INCLUDE_DIR}>
+)

--- a/src/mumble/CMakeLists.txt
+++ b/src/mumble/CMakeLists.txt
@@ -144,6 +144,8 @@ set(MUMBLE_SOURCES
 	"DeveloperConsole.h"
 	"EchoCancelOption.cpp"
 	"EchoCancelOption.h"
+	"EnumStringConversions.cpp"
+	"EnumStringConversions.h"
 	"Global.cpp"
 	"Global.h"
 	"GlobalShortcut.cpp"
@@ -153,6 +155,8 @@ set(MUMBLE_SOURCES
 	"GlobalShortcutButtons.h"
 	"GlobalShortcutButtons.ui"
 	"GlobalShortcutTarget.ui"
+	"JSONSerialization.cpp"
+	"JSONSerialization.h"
 	"LCD.cpp"
 	"LCD.h"
 	"LCD.ui"
@@ -217,6 +221,8 @@ set(MUMBLE_SOURCES
 	"ServerInformation.cpp"
 	"ServerInformation.h"
 	"ServerInformation.ui"
+	"SettingsKeys.cpp"
+	"SettingsKeys.h"
 	"Settings.cpp"
 	"Settings.h"
 	"SharedMemory.cpp"
@@ -460,6 +466,13 @@ else()
 		)
 	endif()
 endif()
+
+
+set(JSON_BuildTests OFF CACHE INTERNAL "")
+set(JSON_ImplicitConversions OFF CACHE INTERNAL "")
+add_subdirectory("${3RDPARTY_DIR}/nlohmann_json/" "${CMAKE_CURRENT_BINARY_DIR}/nlohmann_json/")
+
+target_link_libraries(mumble PRIVATE nlohmann_json::nlohmann_json)
 
 find_pkg("SndFile;LibSndFile;sndfile" REQUIRED)
 

--- a/src/mumble/ConfigDialog.cpp
+++ b/src/mumble/ConfigDialog.cpp
@@ -268,5 +268,8 @@ void ConfigDialog::accept() {
 #endif
 		Global::get().s.qbaConfigGeometry = saveGeometry();
 
+	// Save settings to disk
+	Global::get().s.save();
+
 	QDialog::accept();
 }

--- a/src/mumble/ConnectDialog.cpp
+++ b/src/mumble/ConnectDialog.cpp
@@ -17,6 +17,7 @@
 #include "WebFetch.h"
 #include "Global.h"
 
+#include <QSettings>
 #include <QtCore/QMimeData>
 #include <QtCore/QUrlQuery>
 #include <QtCore/QtEndian>

--- a/src/mumble/CrashReporter.cpp
+++ b/src/mumble/CrashReporter.cpp
@@ -32,7 +32,7 @@ CrashReporter::CrashReporter(QWidget *p) : QDialog(p) {
 
 	QHBoxLayout *hbl = new QHBoxLayout();
 
-	qleEmail = new QLineEdit(Global::get().qs->value(QLatin1String("crashemail")).toString());
+	qleEmail = new QLineEdit(Global::get().s.crashReportEmail);
 	l        = new QLabel(tr("Email address (optional)"));
 	l->setBuddy(qleEmail);
 
@@ -66,7 +66,7 @@ CrashReporter::CrashReporter(QWidget *p) : QDialog(p) {
 }
 
 CrashReporter::~CrashReporter() {
-	Global::get().qs->setValue(QLatin1String("crashemail"), qleEmail->text());
+	Global::get().s.crashReportEmail = qleEmail->text();
 	delete qnrReply;
 }
 

--- a/src/mumble/Database.cpp
+++ b/src/mumble/Database.cpp
@@ -277,7 +277,7 @@ QList< FavoriteServer > Database::getFavorites() {
 
 void Database::setFavorites(const QList< FavoriteServer > &servers) {
 	QSqlQuery query(db);
-	QSqlDatabase::database().transaction();
+	db.transaction();
 
 	query.prepare(QLatin1String("DELETE FROM `servers`"));
 	execQueryAndLogFailure(query);
@@ -294,7 +294,7 @@ void Database::setFavorites(const QList< FavoriteServer > &servers) {
 		execQueryAndLogFailure(query);
 	}
 
-	QSqlDatabase::database().commit();
+	db.commit();
 }
 
 bool Database::isLocalIgnored(const QString &hash) {
@@ -445,7 +445,7 @@ void Database::setPingCache(const QMap< UnresolvedServerAddress, unsigned int > 
 	QSqlQuery query(db);
 	QMap< UnresolvedServerAddress, unsigned int >::const_iterator i;
 
-	QSqlDatabase::database().transaction();
+	db.transaction();
 
 	query.prepare(QLatin1String("DELETE FROM `pingcache`"));
 	execQueryAndLogFailure(query);
@@ -458,7 +458,7 @@ void Database::setPingCache(const QMap< UnresolvedServerAddress, unsigned int > 
 		execQueryAndLogFailure(query);
 	}
 
-	QSqlDatabase::database().commit();
+	db.commit();
 }
 
 bool Database::seenComment(const QString &hash, const QByteArray &commenthash) {

--- a/src/mumble/Database.cpp
+++ b/src/mumble/Database.cpp
@@ -580,23 +580,17 @@ QList< Shortcut > Database::getShortcuts(const QByteArray &digest) {
 	return ql;
 }
 
-bool Database::setShortcuts(const QByteArray &digest, QList< Shortcut > &shortcuts) {
+void Database::setShortcuts(const QByteArray &digest, const QList< Shortcut > &shortcuts) {
 	QSqlQuery query(db);
-	bool updated = false;
 
 	query.prepare(QLatin1String("DELETE FROM `shortcut` WHERE `digest` = ?"));
 	query.addBindValue(digest);
 	execQueryAndLogFailure(query);
 
-	const QList< Shortcut > scs = shortcuts;
-
 	query.prepare(
 		QLatin1String("INSERT INTO `shortcut` (`digest`, `shortcut`, `target`, `suppress`) VALUES (?,?,?,?)"));
-	foreach (const Shortcut &sc, scs) {
+	for (const Shortcut &sc : shortcuts) {
 		if (sc.isServerSpecific()) {
-			shortcuts.removeAll(sc);
-			updated = true;
-
 			query.addBindValue(digest);
 
 			QByteArray a;
@@ -619,7 +613,6 @@ bool Database::setShortcuts(const QByteArray &digest, QList< Shortcut > &shortcu
 			execQueryAndLogFailure(query);
 		}
 	}
-	return updated;
 }
 
 const QMap< QString, QString > Database::getFriends() {

--- a/src/mumble/Database.cpp
+++ b/src/mumble/Database.cpp
@@ -12,6 +12,7 @@
 #include "Version.h"
 #include "Global.h"
 
+#include <QSettings>
 #include <QtCore/QStandardPaths>
 #include <QtSql/QSqlError>
 #include <QtSql/QSqlQuery>
@@ -38,7 +39,6 @@ static bool execQueryAndLogFailure(QSqlQuery &query, const QString &queryString)
 	}
 	return true;
 }
-
 
 bool Database::findOrCreateDatabase() {
 	QSettings qs;
@@ -95,6 +95,11 @@ Database::Database(const QString &dbname) {
 		if (configuredLocation.exists()) {
 			db.setDatabaseName(Global::get().s.qsDatabaseLocation);
 			db.open();
+		} else if (!Global::get().migratedDBPath.isEmpty()) {
+			// Assume that we don't find the DB, because we have migrated it
+			db.setDatabaseName(Global::get().migratedDBPath);
+			db.open();
+			qWarning("Using migrated DB at %s", qUtf8Printable(Global::get().migratedDBPath));
 		} else {
 			int result = QMessageBox::critical(nullptr, QLatin1String("Mumble"),
 											   tr("The database file '%1' set in the configuration file does not "

--- a/src/mumble/Database.h
+++ b/src/mumble/Database.h
@@ -70,7 +70,7 @@ public:
 	void setTokens(const QByteArray &digest, QStringList &tokens);
 
 	QList< Shortcut > getShortcuts(const QByteArray &digest);
-	bool setShortcuts(const QByteArray &digest, QList< Shortcut > &shortcuts);
+	void setShortcuts(const QByteArray &digest, const QList< Shortcut > &shortcuts);
 
 	void addFriend(const QString &name, const QString &hash);
 	void removeFriend(const QString &hash);

--- a/src/mumble/EnumStringConversions.cpp
+++ b/src/mumble/EnumStringConversions.cpp
@@ -1,0 +1,266 @@
+// Copyright 2021 The Mumble Developers. All rights reserved.
+// Use of this source code is governed by a BSD-style license
+// that can be found in the LICENSE file at the root of the
+// Mumble source tree or at <https://www.mumble.info/LICENSE>.
+
+#include "EnumStringConversions.h"
+
+#define AUDIO_TRANSMIT_VALUES                                  \
+	PROCESS(Settings::AudioTransmit, Continuous, "Continuous") \
+	PROCESS(Settings::AudioTransmit, VAD, "VAD")               \
+	PROCESS(Settings::AudioTransmit, PushToTalk, "PTT")
+
+#define VAD_SOURCE_VALUES                                \
+	PROCESS(Settings::VADSource, Amplitude, "Amplitude") \
+	PROCESS(Settings::VADSource, SignalToNoise, "SignalToNoise")
+
+#define LOOP_MODE_VALUES                        \
+	PROCESS(Settings::LoopMode, None, "None")   \
+	PROCESS(Settings::LoopMode, Local, "Local") \
+	PROCESS(Settings::LoopMode, Server, "Server")
+
+#define CHANNEL_EXPAND_VALUES                                                \
+	PROCESS(Settings::ChannelExpand, NoChannels, "NoChannels")               \
+	PROCESS(Settings::ChannelExpand, ChannelsWithUsers, "ChannelsWithUsers") \
+	PROCESS(Settings::ChannelExpand, AllChannels, "AllChannels")
+
+#define CHANNEL_DRAG_VALUES                                \
+	PROCESS(Settings::ChannelDrag, Ask, "Ask")             \
+	PROCESS(Settings::ChannelDrag, DoNothing, "DoNothing") \
+	PROCESS(Settings::ChannelDrag, Move, "Move")
+
+#define SERVER_SHOW_VALUES                                        \
+	PROCESS(Settings::ServerShow, ShowPopulated, "ShowPopulated") \
+	PROCESS(Settings::ServerShow, ShowReachable, "ShowReachable") \
+	PROCESS(Settings::ServerShow, ShowAll, "ShowAll")
+
+#define TALK_STATE_VALUES                                  \
+	PROCESS(Settings::TalkState, Passive, "Passive")       \
+	PROCESS(Settings::TalkState, Talking, "Talking")       \
+	PROCESS(Settings::TalkState, Whispering, "Whispering") \
+	PROCESS(Settings::TalkState, Shouting, "Shouting")     \
+	PROCESS(Settings::TalkState, MutedTalking, "MutedTalking")
+
+#define IDLE_ACTION_VALUES                            \
+	PROCESS(Settings::IdleAction, Nothing, "Nothing") \
+	PROCESS(Settings::IdleAction, Deafen, "Deafen")   \
+	PROCESS(Settings::IdleAction, Mute, "Mute")
+
+#define NOISE_CANCEL_VALUES                                   \
+	PROCESS(Settings::NoiseCancel, NoiseCancelOff, "Off")     \
+	PROCESS(Settings::NoiseCancel, NoiseCancelSpeex, "Speex") \
+	PROCESS(Settings::NoiseCancel, NoiseCancelRNN, "RNN")     \
+	PROCESS(Settings::NoiseCancel, NoiseCancelBoth, "Speex&RNN")
+
+#define ECHO_CANCEL_VALUES                                                \
+	PROCESS(EchoCancelOptionID, DISABLED, "Disabled")                     \
+	PROCESS(EchoCancelOptionID, SPEEX_MIXED, "Speex_MixedChannel")        \
+	PROCESS(EchoCancelOptionID, SPEEX_MULTICHANNEL, "Speex_Multichannel") \
+	PROCESS(EchoCancelOptionID, APPLE_AEC, "Apple_AEC")
+
+#define PROXY_TYPE_VALUES                           \
+	PROCESS(Settings::ProxyType, NoProxy, "None")   \
+	PROCESS(Settings::ProxyType, HttpProxy, "Http") \
+	PROCESS(Settings::ProxyType, Socks5Proxy, "Socks5")
+
+#define ALWAYS_ON_TOP_VALUES                                             \
+	PROCESS(Settings::AlwaysOnTopBehaviour, OnTopNever, "Never")         \
+	PROCESS(Settings::AlwaysOnTopBehaviour, OnTopAlways, "Always")       \
+	PROCESS(Settings::AlwaysOnTopBehaviour, OnTopInMinimal, "InMinimal") \
+	PROCESS(Settings::AlwaysOnTopBehaviour, OnTopInNormal, "InNormal")
+
+#define WINDOW_LAYOUT_VALUES                                  \
+	PROCESS(Settings::WindowLayout, LayoutClassic, "Classic") \
+	PROCESS(Settings::WindowLayout, LayoutStacked, "Stacked") \
+	PROCESS(Settings::WindowLayout, LayoutHybrid, "Hybrid")   \
+	PROCESS(Settings::WindowLayout, LayoutCustom, "Custom")
+
+#define RECORDING_MODE_VALUES                                     \
+	PROCESS(Settings::RecordingMode, RecordingMixdown, "Mixdown") \
+	PROCESS(Settings::RecordingMode, RecordingMultichannel, "Multichannel")
+
+#define SEARCH_USER_ACTION_VALUES                           \
+	PROCESS(Search::SearchDialog::UserAction, NONE, "None") \
+	PROCESS(Search::SearchDialog::UserAction, JOIN, "Join")
+
+#define SEARCH_CHANNEL_ACTION_VALUES                           \
+	PROCESS(Search::SearchDialog::ChannelAction, NONE, "None") \
+	PROCESS(Search::SearchDialog::ChannelAction, JOIN, "Join")
+
+#define LOG_MSG_TYPE_VALUES                                                 \
+	PROCESS(Log::MsgType, DebugInfo, "DebugInfo")                           \
+	PROCESS(Log::MsgType, CriticalError, "CriticalError")                   \
+	PROCESS(Log::MsgType, Warning, "Warning")                               \
+	PROCESS(Log::MsgType, Information, "Information")                       \
+	PROCESS(Log::MsgType, ServerConnected, "ServerConnected")               \
+	PROCESS(Log::MsgType, ServerDisconnected, "ServerDisconnected")         \
+	PROCESS(Log::MsgType, UserJoin, "UserJoin")                             \
+	PROCESS(Log::MsgType, UserLeave, "UserLeave")                           \
+	PROCESS(Log::MsgType, Recording, "Recording")                           \
+	PROCESS(Log::MsgType, YouKicked, "YouKicked")                           \
+	PROCESS(Log::MsgType, UserKicked, "UserKicked")                         \
+	PROCESS(Log::MsgType, SelfMute, "SelfMute")                             \
+	PROCESS(Log::MsgType, OtherSelfMute, "OtherSelfMute")                   \
+	PROCESS(Log::MsgType, YouMuted, "YouMuted")                             \
+	PROCESS(Log::MsgType, YouMutedOther, "YouMutedOther")                   \
+	PROCESS(Log::MsgType, OtherMutedOther, "OtherMutedOther")               \
+	PROCESS(Log::MsgType, ChannelJoin, "ChannelJoin")                       \
+	PROCESS(Log::MsgType, ChannelLeave, "ChannelLeave")                     \
+	PROCESS(Log::MsgType, PermissionDenied, "PermissionDenied")             \
+	PROCESS(Log::MsgType, TextMessage, "TextMessage")                       \
+	PROCESS(Log::MsgType, SelfUnmute, "SelfUnmute")                         \
+	PROCESS(Log::MsgType, SelfDeaf, "SelfDeaf")                             \
+	PROCESS(Log::MsgType, SelfUndeaf, "SelfUndeaf")                         \
+	PROCESS(Log::MsgType, UserRenamed, "UserRenamed")                       \
+	PROCESS(Log::MsgType, SelfChannelJoin, "SelfChannelJoin")               \
+	PROCESS(Log::MsgType, SelfChannelJoinOther, "SelfChannelJoinOther")     \
+	PROCESS(Log::MsgType, ChannelJoinConnect, "ChannelJoinConnect")         \
+	PROCESS(Log::MsgType, ChannelLeaveDisconnect, "ChannelLeaveDisconnect") \
+	PROCESS(Log::MsgType, PrivateTextMessage, "PrivateTextMessage")         \
+	PROCESS(Log::MsgType, ChannelListeningAdd, "ChannelListeningAdd")       \
+	PROCESS(Log::MsgType, ChannelListeningRemove, "ChannelListeningRemove") \
+	PROCESS(Log::MsgType, PluginMessage, "PluginMessage")
+
+#define OVERLAY_PRESETS_VALUES                                               \
+	PROCESS(OverlaySettings::OverlayPresets, AvatarAndName, "AvatarAndName") \
+	PROCESS(OverlaySettings::OverlayPresets, LargeSquareAvatar, "LargeSquareAvatar")
+
+#define OVERLAY_SHOW_VALUES                                           \
+	PROCESS(OverlaySettings::OverlayShow, Talking, "Talking")         \
+	PROCESS(OverlaySettings::OverlayShow, Active, "Active")           \
+	PROCESS(OverlaySettings::OverlayShow, HomeChannel, "HomeChannel") \
+	PROCESS(OverlaySettings::OverlayShow, LinkedChannels, "LinkedChannels")
+
+#define OVERLAY_SORT_VALUES                                             \
+	PROCESS(OverlaySettings::OverlaySort, Alphabetical, "Alphabetical") \
+	PROCESS(OverlaySettings::OverlaySort, LastStateChange, "LastStateChange")
+
+#define OVERLAY_EXCLUSION_MODE_VALUES                                                             \
+	PROCESS(OverlaySettings::OverlayExclusionMode, LauncherFilterExclusionMode, "LauncherFilter") \
+	PROCESS(OverlaySettings::OverlayExclusionMode, WhitelistExclusionMode, "Whitelist")           \
+	PROCESS(OverlaySettings::OverlayExclusionMode, BlacklistExclusionMode, "Blacklist")
+
+
+#define PROCESS_ALL_ENUMS                              \
+	BEFORE_CODE(Settings::AudioTransmit)               \
+	AUDIO_TRANSMIT_VALUES                              \
+	AFTER_CODE                                         \
+	BEFORE_CODE(Settings::VADSource)                   \
+	VAD_SOURCE_VALUES                                  \
+	AFTER_CODE                                         \
+	BEFORE_CODE(Settings::LoopMode)                    \
+	LOOP_MODE_VALUES                                   \
+	AFTER_CODE                                         \
+	BEFORE_CODE(Settings::ChannelExpand)               \
+	CHANNEL_EXPAND_VALUES                              \
+	AFTER_CODE                                         \
+	BEFORE_CODE(Settings::ChannelDrag)                 \
+	CHANNEL_DRAG_VALUES                                \
+	AFTER_CODE                                         \
+	BEFORE_CODE(Settings::ServerShow)                  \
+	SERVER_SHOW_VALUES                                 \
+	AFTER_CODE                                         \
+	BEFORE_CODE(Settings::TalkState)                   \
+	TALK_STATE_VALUES                                  \
+	AFTER_CODE                                         \
+	BEFORE_CODE(Settings::IdleAction)                  \
+	IDLE_ACTION_VALUES                                 \
+	AFTER_CODE                                         \
+	BEFORE_CODE(Settings::NoiseCancel)                 \
+	NOISE_CANCEL_VALUES                                \
+	AFTER_CODE                                         \
+	BEFORE_CODE(EchoCancelOptionID)                    \
+	ECHO_CANCEL_VALUES                                 \
+	AFTER_CODE                                         \
+	BEFORE_CODE(Settings::ProxyType)                   \
+	PROXY_TYPE_VALUES                                  \
+	AFTER_CODE                                         \
+	BEFORE_CODE(Settings::AlwaysOnTopBehaviour)        \
+	ALWAYS_ON_TOP_VALUES                               \
+	AFTER_CODE                                         \
+	BEFORE_CODE(Settings::WindowLayout)                \
+	WINDOW_LAYOUT_VALUES                               \
+	AFTER_CODE                                         \
+	BEFORE_CODE(Settings::RecordingMode)               \
+	RECORDING_MODE_VALUES                              \
+	AFTER_CODE                                         \
+	BEFORE_CODE(Search::SearchDialog::UserAction)      \
+	SEARCH_USER_ACTION_VALUES                          \
+	AFTER_CODE                                         \
+	BEFORE_CODE(Search::SearchDialog::ChannelAction)   \
+	SEARCH_CHANNEL_ACTION_VALUES                       \
+	AFTER_CODE                                         \
+	BEFORE_CODE(Log::MsgType)                          \
+	LOG_MSG_TYPE_VALUES                                \
+	AFTER_CODE                                         \
+	BEFORE_CODE(OverlaySettings::OverlayPresets)       \
+	OVERLAY_PRESETS_VALUES                             \
+	AFTER_CODE                                         \
+	BEFORE_CODE(OverlaySettings::OverlayShow)          \
+	OVERLAY_SHOW_VALUES                                \
+	AFTER_CODE                                         \
+	BEFORE_CODE(OverlaySettings::OverlaySort)          \
+	OVERLAY_SORT_VALUES                                \
+	AFTER_CODE                                         \
+	BEFORE_CODE(OverlaySettings::OverlayExclusionMode) \
+	OVERLAY_EXCLUSION_MODE_VALUES                      \
+	AFTER_CODE
+
+
+#define BEFORE_CODE(enumType)              \
+	const char *enumToString(enumType e) { \
+		switch (e) {
+#define AFTER_CODE                                \
+	}                                             \
+	throw "This code part should be unreachable"; \
+	}
+#define PROCESS(enumType, enumValue, stringValue) \
+	case enumType::enumValue:                     \
+		return stringValue;
+
+PROCESS_ALL_ENUMS
+
+#undef BEFORE_CODE
+#undef AFTER_CODE
+#undef PROCESS
+
+#define BEFORE_CODE(enumType) void stringToEnum(const std::string &str, enumType &e) {
+#define AFTER_CODE                                           \
+	{ throw "Unable to convert given string to enum type"; } \
+	}
+#define PROCESS(enumType, enumValue, stringValue) \
+	if (str == stringValue) {                     \
+		e = enumType::enumValue;                  \
+	} else
+
+namespace details {
+
+PROCESS_ALL_ENUMS
+
+};
+
+#undef PROCESS
+#undef AFTER_CODE
+#undef BEFORE_CODE
+#undef PROCESS_ALL_ENUMS
+#undef OVERLAY_EXCLUSION_MODE_VALUES
+#undef OVERLAY_SORT_VALUES
+#undef OVERLAY_SHOW_VALUES
+#undef OVERLAY_PRESETS_VALUES
+#undef LOG_MSG_TYPE_VALUES
+#undef SEARCH_CHANNEL_ACTION_VALUES
+#undef SEARCH_USER_ACTION_VALUES
+#undef RECORDING_MODE_VALUES
+#undef WINDOW_LAYOUT_VALUES
+#undef ALWAYS_ON_TOP_VALUES
+#undef PROXY_TYPE_VALUES
+#undef ECHO_CANCEL_VALUES
+#undef NOISE_CANCEL_VALUES
+#undef IDLE_ACTION_VALUES
+#undef TALK_STATE_VALUES
+#undef SERVER_SHOW_VALUES
+#undef CHANNEL_DRAG_VALUES
+#undef CHANNEL_EXPAND_VALUES
+#undef LOOP_MODE_VALUES
+#undef VAD_SOURCE_VALUES
+#undef AUDIO_TRANSMIT_VALUES

--- a/src/mumble/EnumStringConversions.h
+++ b/src/mumble/EnumStringConversions.h
@@ -1,0 +1,74 @@
+// Copyright 2021 The Mumble Developers. All rights reserved.
+// Use of this source code is governed by a BSD-style license
+// that can be found in the LICENSE file at the root of the
+// Mumble source tree or at <https://www.mumble.info/LICENSE>.
+
+#ifndef MUMBLE_MUMBLE_ENUMSTRINGCONVERSIONS_H_
+#define MUMBLE_MUMBLE_ENUMSTRINGCONVERSIONS_H_
+
+
+#include "EchoCancelOption.h"
+#include "Log.h"
+#include "SearchDialog.h"
+#include "Settings.h"
+
+#include <type_traits>
+
+const char *enumToString(Settings::AudioTransmit e);
+const char *enumToString(Settings::VADSource e);
+const char *enumToString(Settings::LoopMode e);
+const char *enumToString(Settings::ChannelExpand e);
+const char *enumToString(Settings::ChannelDrag e);
+const char *enumToString(Settings::ServerShow e);
+const char *enumToString(Settings::TalkState e);
+const char *enumToString(Settings::IdleAction e);
+const char *enumToString(Settings::NoiseCancel e);
+const char *enumToString(EchoCancelOptionID e);
+const char *enumToString(Settings::ProxyType e);
+const char *enumToString(Settings::AlwaysOnTopBehaviour e);
+const char *enumToString(Settings::WindowLayout e);
+const char *enumToString(Settings::RecordingMode e);
+const char *enumToString(Search::SearchDialog::UserAction e);
+const char *enumToString(Search::SearchDialog::ChannelAction e);
+const char *enumToString(Log::MsgType e);
+const char *enumToString(OverlaySettings::OverlayPresets e);
+const char *enumToString(OverlaySettings::OverlayShow e);
+const char *enumToString(OverlaySettings::OverlaySort e);
+const char *enumToString(OverlaySettings::OverlayExclusionMode e);
+
+namespace details {
+
+void stringToEnum(const std::string &str, Settings::AudioTransmit &e);
+void stringToEnum(const std::string &str, Settings::VADSource &e);
+void stringToEnum(const std::string &str, Settings::LoopMode &e);
+void stringToEnum(const std::string &str, Settings::ChannelExpand &e);
+void stringToEnum(const std::string &str, Settings::ChannelDrag &e);
+void stringToEnum(const std::string &str, Settings::ServerShow &e);
+void stringToEnum(const std::string &str, Settings::TalkState &e);
+void stringToEnum(const std::string &str, Settings::IdleAction &e);
+void stringToEnum(const std::string &str, Settings::NoiseCancel &e);
+void stringToEnum(const std::string &str, EchoCancelOptionID &e);
+void stringToEnum(const std::string &str, Settings::ProxyType &e);
+void stringToEnum(const std::string &str, Settings::AlwaysOnTopBehaviour &e);
+void stringToEnum(const std::string &str, Settings::WindowLayout &e);
+void stringToEnum(const std::string &str, Settings::RecordingMode &e);
+void stringToEnum(const std::string &str, Search::SearchDialog::UserAction &e);
+void stringToEnum(const std::string &str, Search::SearchDialog::ChannelAction &e);
+void stringToEnum(const std::string &str, Log::MsgType &e);
+void stringToEnum(const std::string &str, OverlaySettings::OverlayPresets &e);
+void stringToEnum(const std::string &str, OverlaySettings::OverlayShow &e);
+void stringToEnum(const std::string &str, OverlaySettings::OverlaySort &e);
+void stringToEnum(const std::string &str, OverlaySettings::OverlayExclusionMode &e);
+
+}; // namespace details
+
+template< typename T > T stringToEnum(const std::string &str) {
+	static_assert(std::is_enum< T >::value, "Only enums can be converted to strings with this function");
+
+	T enumVal;
+	details::stringToEnum(str, enumVal);
+
+	return enumVal;
+}
+
+#endif // MUMBLE_MUMBLE_ENUMSTRINGCONVERSIONS_H_

--- a/src/mumble/Global.cpp
+++ b/src/mumble/Global.cpp
@@ -8,6 +8,9 @@
 #include <QtCore/QStandardPaths>
 
 #ifdef Q_OS_WIN
+#	ifndef NOMINMAX
+#		define NOMINMAX
+#	endif
 #	include <shlobj.h>
 #endif
 
@@ -21,54 +24,69 @@ Global &Global::get() {
 	return *g_global_struct;
 }
 
-#ifndef Q_OS_WIN
-static void migrateDataDir() {
-#	ifdef Q_OS_MAC
-	QString olddir  = QDir::homePath() + QLatin1String("/Library/Preferences/Mumble");
-	QString newdir  = QStandardPaths::writableLocation(QStandardPaths::DataLocation);
-	QString linksTo = QFile::symLinkTarget(olddir);
-	if (!QFile::exists(newdir) && QFile::exists(olddir) && linksTo.isEmpty()) {
-		QDir d;
-		d.mkpath(newdir + QLatin1String("/.."));
-		if (d.rename(olddir, newdir)) {
-			if (d.cd(QDir::homePath() + QLatin1String("/Library/Preferences"))) {
-				if (QFile::link(d.relativeFilePath(newdir), olddir)) {
-					qWarning("Migrated application data directory from '%s' to '%s'", qPrintable(olddir),
-							 qPrintable(newdir));
-					return;
-				}
-			}
-		}
-	} else {
-		/* Data dir has already been migrated. */
+void Global::migrateDataDir(const QDir &toDir) {
+	if (toDir.exists()) {
+		qWarning("No migration to be performed");
+		// The new directory already exists -> don't perform any migration
 		return;
 	}
 
-	qWarning("Application data migration failed.");
-#	endif // Q_OS_MAC
+	QStringList oldPaths;
+
+#ifdef Q_OS_MAC
+	oldPaths << QDir::homePath() + "/Library/Preferences/Mumble";
+#endif
 
 // Qt4 used another data directory on Unix-like systems, to ensure a seamless
 // transition we must first move the users data to the new directory.
-#	if defined(Q_OS_UNIX) && !defined(Q_OS_MAC)
-	QString olddir =
-		QStandardPaths::writableLocation(QStandardPaths::GenericDataLocation) + QLatin1String("/data/Mumble");
-	QString newdir = QStandardPaths::writableLocation(QStandardPaths::GenericDataLocation) + QLatin1String("/Mumble");
+#if defined(Q_OS_UNIX) && !defined(Q_OS_MAC)
+	oldPaths << QStandardPaths::writableLocation(QStandardPaths::GenericDataLocation) + "/data/Mumble";
+#endif
 
-	if (!QFile::exists(newdir) && QFile::exists(olddir)) {
-		QDir d;
-		if (d.rename(olddir, newdir)) {
-			qWarning("Migrated application data directory from '%s' to '%s'", qPrintable(olddir), qPrintable(newdir));
-			return;
+#ifdef Q_OS_WIN
+	// Get AppData dir
+	QString appdata;
+	wchar_t appData[MAX_PATH];
+	if (SUCCEEDED(SHGetFolderPath(nullptr, CSIDL_APPDATA, nullptr, SHGFP_TYPE_CURRENT, appData))) {
+		appdata = QDir::fromNativeSeparators(QString::fromWCharArray(appData));
+
+		if (!appdata.isEmpty()) {
+			appdata.append(QLatin1String("/Mumble"));
+			oldPaths << appdata;
 		}
-	} else {
-		/* Data dir has already been migrated. */
-		return;
+	}
+#endif
+
+	for (const QString &current : oldPaths) {
+		QDir currentDir(current);
+
+		if (currentDir.exists()) {
+			QDir dummy;
+
+			dummy.mkpath(toDir.absolutePath());
+
+			for (const QFileInfo &currentInfo : currentDir.entryInfoList()) {
+				if (currentInfo.fileName() == "." || currentInfo.fileName() == ".."
+					|| currentInfo.canonicalFilePath() == toDir.canonicalPath()) {
+					continue;
+				}
+				if (!dummy.rename(currentInfo.absoluteFilePath(), toDir.absoluteFilePath(currentInfo.fileName()))) {
+					qWarning("Failed at migrating %s", qUtf8Printable(currentInfo.fileName()));
+				}
+				if (currentInfo.fileName() == "mumble.sqlite") {
+					migratedDBPath = QDir(toDir.absoluteFilePath(currentInfo.fileName())).canonicalPath();
+				}
+			}
+
+			// Only consider the first path in the list (which is expected to be the most recent one)
+			break;
+		}
+
+		qWarning("Dir didn't exist: %s", qUtf8Printable(current));
 	}
 
-	qWarning("Application data migration failed.");
-#	endif // defined(Q_OS_UNIX) && ! defined(Q_OS_MAC)
+	qInfo("Successfully migrated data directory");
 }
-#endif // Q_OS_WIN
 
 Global::Global(const QString &qsConfigPath) {
 	mw              = 0;
@@ -108,8 +126,6 @@ Global::Global(const QString &qsConfigPath) {
 	uiMaxUsers       = 0;
 	recordingAllowed = true;
 
-	qs = nullptr;
-
 	zeroconf = nullptr;
 	lcd      = nullptr;
 	l        = nullptr;
@@ -132,49 +148,18 @@ Global::Global(const QString &qsConfigPath) {
 	wchar_t appData[MAX_PATH];
 #endif
 
-	if (!qsConfigPath.isEmpty()) {
-		QFile inifile(qsConfigPath);
-		qs = new QSettings(inifile.fileName(), QSettings::IniFormat);
-	} else {
-		QStringList qsl;
-		qsl << QCoreApplication::instance()->applicationDirPath();
-		qsl << QStandardPaths::writableLocation(QStandardPaths::DataLocation);
+	if (qsConfigPath.isEmpty()) {
+		qdBasePath.setPath(QStandardPaths::writableLocation(QStandardPaths::AppDataLocation));
 
-#if defined(Q_OS_WIN)
-		if (SUCCEEDED(SHGetFolderPath(nullptr, CSIDL_APPDATA, nullptr, SHGFP_TYPE_CURRENT, appData))) {
-			appdata = QDir::fromNativeSeparators(QString::fromWCharArray(appData));
+		migrateDataDir(qdBasePath);
 
-			if (!appdata.isEmpty()) {
-				appdata.append(QLatin1String("/Mumble"));
-				qsl << appdata;
-			}
-		}
-#endif
-
-		foreach (const QString &dir, qsl) {
-			QFile inifile(QString::fromLatin1("%1/mumble.ini").arg(dir));
-			if (inifile.exists() && inifile.permissions().testFlag(QFile::WriteUser)) {
-				qdBasePath.setPath(dir);
-				qs = new QSettings(inifile.fileName(), QSettings::IniFormat);
-				break;
-			}
-		}
-	}
-
-	if (!qs) {
-		qs = new QSettings();
-#if defined(Q_OS_WIN)
-		if (!appdata.isEmpty())
-			qdBasePath.setPath(appdata);
-#else
-		migrateDataDir();
-		qdBasePath.setPath(QStandardPaths::writableLocation(QStandardPaths::DataLocation));
-#endif
 		if (!qdBasePath.exists()) {
 			QDir::root().mkpath(qdBasePath.absolutePath());
 			if (!qdBasePath.exists())
 				qdBasePath = QDir::home();
 		}
+	} else {
+		qdBasePath = QFileInfo(qsConfigPath).absoluteDir();
 	}
 
 	if (!qdBasePath.exists(QLatin1String("Plugins")))
@@ -183,12 +168,6 @@ Global::Global(const QString &qsConfigPath) {
 		qdBasePath.mkpath(QLatin1String("Overlay"));
 	if (!qdBasePath.exists(QLatin1String("Themes")))
 		qdBasePath.mkpath(QLatin1String("Themes"));
-
-	qs->setIniCodec("UTF-8");
-}
-
-Global::~Global() {
-	delete qs;
 }
 
 const char Global::ccHappyEaster[] = {

--- a/src/mumble/Global.h
+++ b/src/mumble/Global.h
@@ -58,7 +58,6 @@ public:
 	Log *l;
 	/// A pointer to the PluginManager that is used in this session
 	PluginManager *pluginManager;
-	QSettings *qs;
 #ifdef USE_OVERLAY
 	Overlay *o;
 #endif
@@ -116,8 +115,13 @@ public:
 	bool bHappyEaster;
 	static const char ccHappyEaster[];
 
+	QString migratedDBPath;
+
 	Global(const QString &qsConfigPath = QString());
-	~Global();
+	~Global() = default;
+
+private:
+	void migrateDataDir(const QDir &toDir);
 };
 
 // Class to handle ordered initialization of globals.

--- a/src/mumble/GlobalShortcut.cpp
+++ b/src/mumble/GlobalShortcut.cpp
@@ -11,6 +11,7 @@
 #include "Database.h"
 #include "EnvUtils.h"
 #include "MainWindow.h"
+#include "ServerHandler.h"
 #include "Global.h"
 #include "GlobalShortcutButtons.h"
 
@@ -720,6 +721,16 @@ void GlobalShortcutConfig::save() const {
 
 	if (s.bEnableUIAccess != oldUIAccess || s.bEnableGKey != oldGKey || s.bEnableXboxInput != oldXboxInput) {
 		s.requireRestartToApply = true;
+	}
+
+	if (Global::get().sh && Global::get().sh->hasSynchronized()) {
+		// If we are connected to a server (that has finished synchronizing) there is the change, the user has
+		// configured server-specific shortcuts, which we save in the DB instead of in the regular settings. Thus we
+		// have to explicitly save them here.
+		// Note that the server needs to have finished synchronizing, since only then did we load any previously
+		// configured shortcuts from the DB in the first place. Otherwise, "saving" the shortcuts (which are not
+		// loaded yet) would effectively delete them.
+		Global::get().db->setShortcuts(Global::get().sh->qbaDigest, s.qlShortcuts);
 	}
 }
 

--- a/src/mumble/JSONSerialization.cpp
+++ b/src/mumble/JSONSerialization.cpp
@@ -1,0 +1,415 @@
+// Copyright 2021 The Mumble Developers. All rights reserved.
+// Use of this source code is governed by a BSD-style license
+// that can be found in the LICENSE file at the root of the
+// Mumble source tree or at <https://www.mumble.info/LICENSE>.
+
+#include "JSONSerialization.h"
+#include "Cert.h"
+#include "SettingsMacros.h"
+
+
+template< typename T, bool isEnum > struct SaveValueConverter {
+	static const T &getValue(const T &value) { return value; }
+
+	static void loadValue(const nlohmann::json &json, T &variable) { json.get_to(variable); }
+};
+
+template< typename T > using has_enum_conversion_function = decltype(enumToString(std::declval< T >()));
+
+template< typename T > struct SaveValueConverter< T, true > {
+	static const char *getValue(const T &enumeration) {
+#if BOOST_VERSION >= 106700
+		// Use the "detection idiom" to provide a proper error message in case there is no conversion function for the
+		// given enum.
+		// boost::is_detected is only available since Boost 1.67 and since we only use it to create a better error
+		// message, we can simply not make use of it, if earlier versions are used.
+		static_assert(boost::is_detected< has_enum_conversion_function, T >::value,
+					  "No viable enum-to-name function found");
+#endif
+
+		return enumToString(enumeration);
+	}
+
+	static void loadValue(const nlohmann::json &json, T &variable) {
+		variable = stringToEnum< T >(json.get< std::string >());
+	}
+};
+
+template< typename T > void save(nlohmann::json &json, const SettingsKey &key, const T &value) {
+	json[key] = SaveValueConverter< T, std::is_enum< T >::value >::getValue(value);
+}
+
+template< typename T > void save(nlohmann::json &json, const char *category, const SettingsKey &key, const T &value) {
+	if (!json.contains(category)) {
+		json[category] = nlohmann::json::object();
+	}
+
+	save(json[category], key, value);
+}
+
+template< typename T, bool isArray > struct CopyHelper {
+	static void copy(T &dest, const T &source) { dest = source; }
+};
+
+template< typename T > struct CopyHelper< T, true > {
+	template< size_t N > static constexpr std::size_t size(const T (&)[N]) { return N; }
+
+	static constexpr std::size_t size(const T &array) { return sizeof(array) / sizeof(*array); }
+
+	static void copy(T &dest, const T &source) {
+		static_assert(size(dest) == size(dest), "Can only copy arrays of equal size");
+
+		std::copy(source, source + size(source), dest);
+	}
+};
+
+template< typename T >
+void load(const nlohmann::json &json, const SettingsKey &key, T &variable, const T &defaultValue,
+		  bool useDefault = true) {
+	nlohmann::json valueEntry = key.selectFrom(json);
+
+	if (!valueEntry.is_null()) {
+		SaveValueConverter< T, std::is_enum< T >::value >::loadValue(valueEntry, variable);
+	} else if (useDefault) {
+		CopyHelper< T, std::is_array< T >::value >::copy(variable, defaultValue);
+	}
+}
+
+template< typename T >
+void load(const nlohmann::json &json, const char *category, const SettingsKey &key, T &variable, const T &defaultValue,
+		  bool useDefault = true) {
+	if (!json.contains(category)) {
+		if (useDefault) {
+			CopyHelper< T, std::is_array< T >::value >::copy(variable, defaultValue);
+		}
+
+		return;
+	}
+
+	const nlohmann::json &categoryJSON = json.at(category);
+
+	load(categoryJSON, key, variable, defaultValue, useDefault);
+}
+
+
+
+void to_json(nlohmann::json &j, const Settings &settings) {
+	j[SettingsKeys::SETTINGS_VERSION_KEY] = 1;
+
+	const Settings defaultValues;
+
+#define PROCESS(category, key, variable)                          \
+	if (settings.variable != defaultValues.variable) {            \
+		save(j, #category, SettingsKeys::key, settings.variable); \
+	}
+
+	PROCESS_ALL_SETTINGS
+
+#undef PROCESS
+
+	if (settings.qlShortcuts != defaultValues.qlShortcuts) {
+		// We only remove server specific shortcuts since they are saved in the DB.
+		// We should consider moving those out of the DB into the JSON settings.
+		QList< Shortcut > genericShortcuts;
+		for (const Shortcut &shortcut : settings.qlShortcuts) {
+			if (!shortcut.isServerSpecific()) {
+				genericShortcuts.push_back(shortcut);
+			}
+		}
+
+		j["shortcuts"]["defined"] = genericShortcuts;
+	}
+
+	if (settings.qmMessages != defaultValues.qmMessages) {
+		j["messages"]["traits"] = settings.qmMessages;
+	}
+	if (settings.qmMessageSounds != defaultValues.qmMessageSounds) {
+		j["messages"]["sounds"] = settings.qmMessageSounds;
+	}
+
+	if (settings.qmLCDDevices != defaultValues.qmLCDDevices) {
+		j["lcd"]["devices"] = settings.qmLCDDevices;
+	}
+
+	if (settings.qhPluginSettings != defaultValues.qhPluginSettings) {
+		j["plugins"] = settings.qhPluginSettings;
+	}
+
+	if (settings.os != defaultValues.os) {
+		j["overlay"] = settings.os;
+	}
+
+	j[SettingsKeys::CERTIFICATE_KEY] = CertWizard::exportCert(settings.kpCertificate);
+}
+
+void migrateSettings(nlohmann::json json, int settingsVersion) {
+	// Perform conversions required to transform the given JSON into the format applicable to be read out by the most
+	// recent standards
+
+	(void) json;
+	(void) settingsVersion;
+}
+
+void from_json(const nlohmann::json &j, Settings &settings) {
+	int settingsVersion = j.at(SettingsKeys::SETTINGS_VERSION_KEY).get< int >();
+
+	// Copy since we might have to make modifications
+	nlohmann::json json = j;
+
+	migrateSettings(json, settingsVersion);
+
+#define PROCESS(category, key, variable) \
+	load(json, #category, SettingsKeys::key, settings.variable, settings.variable, true);
+
+	PROCESS_ALL_SETTINGS
+
+#undef PROCESS
+
+	if (json.contains("shortcuts") && json.at("shortcuts").contains("defined")) {
+		settings.qlShortcuts = json.at("shortcuts").at("defined");
+	}
+
+	if (json.contains("messages") && json.at("messages").contains("traits")) {
+		settings.qmMessages = json.at("messages").at("traits");
+	}
+	if (json.contains("messages") && json.at("messages").contains("sounds")) {
+		settings.qmMessageSounds = json.at("messages").at("sounds");
+	}
+
+	if (json.contains("lcd") && json.at("lcd").contains("devices")) {
+		settings.qmLCDDevices = json.at("lcd").at("devices");
+	}
+
+	if (json.contains("plugins")) {
+		settings.qhPluginSettings = json.at("plugins");
+	}
+
+	if (json.contains("overlay")) {
+		settings.os = json.at("overlay");
+	}
+
+	if (json.contains(static_cast< const char * >(SettingsKeys::CERTIFICATE_KEY))) {
+		settings.kpCertificate = CertWizard::importCert(json.at(SettingsKeys::CERTIFICATE_KEY));
+	}
+
+	settings.kpCertificate = CertWizard::importCert(json.at(SettingsKeys::CERTIFICATE_KEY));
+
+#ifndef USE_RNNOISE
+	if (settings.noiseCancelMode == NoiseCancelRNN || settings.noiseCancelMode == NoiseCancelBoth) {
+		// Use Speex instead as this Mumble build was built without support for RNNoise
+		settings.noiseCancelMode = NoiseCancelSpeex;
+	}
+#endif
+}
+
+void to_json(nlohmann::json &j, const OverlaySettings &settings) {
+#define PROCESS(category, key, variable) save(j, SettingsKeys::key, settings.variable);
+
+	PROCESS_ALL_OVERLAY_SETTINGS
+
+#undef PROCESS
+}
+
+void from_json(const nlohmann::json &j, OverlaySettings &settings) {
+#define PROCESS(category, key, variable) load(j, SettingsKeys::key, settings.variable, settings.variable, true);
+
+	PROCESS_ALL_OVERLAY_SETTINGS
+
+#undef PROCESS
+}
+
+
+
+void to_json(nlohmann::json &j, const QString &string) {
+	j = string.toStdString();
+}
+
+void from_json(const nlohmann::json &j, QString &string) {
+	string = QString::fromStdString(j.get< std::string >());
+}
+
+void to_json(nlohmann::json &j, const QVariant &variant) {
+	QByteArray data;
+	QDataStream stream(&data, QIODevice::WriteOnly);
+	stream.setVersion(QDataStream::Qt_5_0);
+
+	stream << variant;
+	j = data.toBase64().toStdString();
+}
+
+void from_json(const nlohmann::json &j, QVariant &variant) {
+	QByteArray data = QByteArray::fromBase64(QByteArray::fromStdString(j.get< std::string >()));
+	QDataStream stream(&data, QIODevice::ReadOnly);
+	stream.setVersion(QDataStream::Qt_5_0);
+
+	stream >> variant;
+}
+
+void to_json(nlohmann::json &j, const QPoint &point) {
+	j = nlohmann::json::object({
+		{ "x", point.x() },
+		{ "y", point.y() },
+	});
+}
+
+void from_json(const nlohmann::json &j, QPoint &point) {
+	point.setX(j.at("x").get< int >());
+	point.setY(j.at("y").get< int >());
+}
+
+void to_json(nlohmann::json &j, const ShortcutTarget &target) {
+	bool link       = false;
+	bool subchannel = false;
+
+	if (target.bCurrentSelection) {
+		j["current_selection"] = target.bCurrentSelection;
+		link                   = true;
+		subchannel             = true;
+	} else if (target.bUsers) {
+		j["users"] = target.qlUsers;
+	} else {
+		j["channel_id"] = target.iChannel;
+		j["group"]      = target.qsGroup;
+		link            = true;
+		subchannel      = true;
+	}
+
+	if (link) {
+		j["include_links"] = target.bLinks;
+	}
+	if (subchannel) {
+		j["include_subchannel"] = target.bChildren;
+	}
+}
+
+void from_json(const nlohmann::json &j, ShortcutTarget &target) {
+	bool link       = false;
+	bool subchannel = false;
+
+	if (j.contains("current_selection")) {
+		j.at("current_selection").get_to(target.bCurrentSelection);
+		link       = true;
+		subchannel = true;
+	} else if (j.contains("users")) {
+		j.at("users").get_to(target.qlUsers);
+		target.bUsers = true;
+	} else {
+		j.at("channel_id").get_to(target.iChannel);
+		j.at("group").get_to(target.qsGroup);
+		link       = true;
+		subchannel = true;
+	}
+
+	if (link) {
+		j.at("link").get_to(target.bLinks);
+	}
+	if (subchannel) {
+		j.at("include_subchannel").get_to(target.bChildren);
+	}
+}
+
+void to_json(nlohmann::json &j, const Shortcut &shortcut) {
+	j["suppress"] = shortcut.bSuppress;
+	j["index"]    = shortcut.iIndex;
+	j["buttons"]  = shortcut.qlButtons;
+	j["data"]     = shortcut.qvData;
+}
+
+void from_json(const nlohmann::json &j, Shortcut &shortcut) {
+	j.at("suppress").get_to(shortcut.bSuppress);
+	j.at("index").get_to(shortcut.iIndex);
+	j.at("buttons").get_to(shortcut.qlButtons);
+	j.at("data").get_to(shortcut.qvData);
+}
+
+void to_json(nlohmann::json &j, const PluginSetting &setting) {
+	j["path"]                        = setting.path;
+	j["enabled"]                     = setting.enabled;
+	j["positional_data_enabled"]     = setting.positionalDataEnabled;
+	j["keyboard_monitoring_allowed"] = setting.allowKeyboardMonitoring;
+}
+
+void from_json(const nlohmann::json &j, PluginSetting &setting) {
+	j.at("path").get_to(setting.path);
+	j.at("enabled").get_to(setting.enabled);
+	j.at("positional_data_enabled").get_to(setting.positionalDataEnabled);
+	j.at("keyboard_monitoring_allowed").get_to(setting.allowKeyboardMonitoring);
+}
+
+void to_json(nlohmann::json &j, const QByteArray &byteArray) {
+	j = byteArray.toBase64().toStdString();
+}
+
+void from_json(const nlohmann::json &j, QByteArray &byteArray) {
+	byteArray = QByteArray::fromBase64(QByteArray::fromStdString(j.get< std::string >()));
+}
+
+void to_json(nlohmann::json &j, const QColor &color) {
+	j["red"]   = color.red();
+	j["green"] = color.green();
+	j["blue"]  = color.blue();
+	j["alpha"] = color.alpha();
+}
+
+void from_json(const nlohmann::json &j, QColor &color) {
+	color.setRed(j.at("red").get< decltype(color.red()) >());
+	color.setGreen(j.at("green").get< decltype(color.green()) >());
+	color.setBlue(j.at("blue").get< decltype(color.blue()) >());
+	color.setAlpha(j.at("alpha").get< decltype(color.alpha()) >());
+}
+
+void to_json(nlohmann::json &j, const QFont &font) {
+	j = font.toString();
+}
+
+void from_json(const nlohmann::json &j, QFont &font) {
+	font.fromString(j.get< QString >());
+}
+
+void to_json(nlohmann::json &j, const QRect &rect) {
+	j["x"]      = rect.x();
+	j["y"]      = rect.y();
+	j["width"]  = rect.width();
+	j["height"] = rect.height();
+}
+
+void from_json(const nlohmann::json &j, QRect &rect) {
+	rect.setX(j.at("x").get< int >());
+	rect.setY(j.at("y").get< int >());
+	rect.setWidth(j.at("width").get< int >());
+	rect.setHeight(j.at("height").get< int >());
+}
+
+void to_json(nlohmann::json &j, const QRectF &rect) {
+	j["x"]      = rect.x();
+	j["y"]      = rect.y();
+	j["width"]  = rect.width();
+	j["height"] = rect.height();
+}
+
+void from_json(const nlohmann::json &j, QRectF &rect) {
+	rect.setX(j.at("x").get< qreal >());
+	rect.setY(j.at("y").get< qreal >());
+	rect.setWidth(j.at("width").get< qreal >());
+	rect.setHeight(j.at("height").get< qreal >());
+}
+
+void to_json(nlohmann::json &j, const QSize &size) {
+	j["width"]  = size.width();
+	j["height"] = size.height();
+}
+
+void from_json(const nlohmann::json &j, QSize &size) {
+	size.setWidth(j.at("width").get< int >());
+	size.setHeight(j.at("height").get< int >());
+}
+
+void to_json(nlohmann::json &j, const QSizeF &size) {
+	j["width"]  = size.width();
+	j["height"] = size.height();
+}
+
+void from_json(const nlohmann::json &j, QSizeF &size) {
+	size.setWidth(j.at("width").get< qreal >());
+	size.setHeight(j.at("height").get< qreal >());
+}

--- a/src/mumble/JSONSerialization.cpp
+++ b/src/mumble/JSONSerialization.cpp
@@ -140,6 +140,13 @@ void to_json(nlohmann::json &j, const Settings &settings) {
 	}
 
 	j[SettingsKeys::CERTIFICATE_KEY] = CertWizard::exportCert(settings.kpCertificate);
+
+	// Save whether Mumble has quit regularly (in contrast to having crashed). This flag is set right before saving the
+	// settings because Mumble is shut down (regularly). In contrast, when saving the settings because the user has made
+	// changes in the UI, this will be false. Thus when loading the settings again and seeing this flag is false, it
+	// means Mumble never got to perform its regular shutdown routine, meaning that it is likely that it has crashed
+	// before.
+	j[SettingsKeys::MUMBLE_QUIT_NORMALLY_KEY] = settings.mumbleQuitNormally;
 }
 
 void migrateSettings(nlohmann::json json, int settingsVersion) {
@@ -192,7 +199,9 @@ void from_json(const nlohmann::json &j, Settings &settings) {
 		settings.kpCertificate = CertWizard::importCert(json.at(SettingsKeys::CERTIFICATE_KEY));
 	}
 
-	settings.kpCertificate = CertWizard::importCert(json.at(SettingsKeys::CERTIFICATE_KEY));
+	if (json.contains(static_cast< const char * >(SettingsKeys::MUMBLE_QUIT_NORMALLY_KEY))) {
+		settings.mumbleQuitNormally = json.at(SettingsKeys::MUMBLE_QUIT_NORMALLY_KEY);
+	}
 
 #ifndef USE_RNNOISE
 	if (settings.noiseCancelMode == NoiseCancelRNN || settings.noiseCancelMode == NoiseCancelBoth) {

--- a/src/mumble/JSONSerialization.h
+++ b/src/mumble/JSONSerialization.h
@@ -1,0 +1,200 @@
+// Copyright 2021 The Mumble Developers. All rights reserved.
+// Use of this source code is governed by a BSD-style license
+// that can be found in the LICENSE file at the root of the
+// Mumble source tree or at <https://www.mumble.info/LICENSE>.
+
+#ifndef MUMBLE_MUMBLE_JSONSERIALIZATION_H_
+#define MUMBLE_MUMBLE_JSONSERIALIZATION_H_
+
+#include "EnumStringConversions.h"
+#include "Settings.h"
+
+#include <sstream>
+#include <type_traits>
+
+#include <boost/version.hpp>
+#if BOOST_VERSION >= 106700
+// The is_detected type-trait was only included in Boost 1.67
+#	include <boost/type_traits/is_detected.hpp>
+#endif
+
+#include <nlohmann/json.hpp>
+
+#include <QByteArray>
+#include <QColor>
+#include <QDataStream>
+#include <QFlags>
+#include <QFont>
+#include <QHash>
+#include <QList>
+#include <QMap>
+#include <QObject>
+#include <QRect>
+#include <QRectF>
+#include <QSize>
+#include <QSizeF>
+#include <QString>
+
+namespace details {
+template< typename T > using has_enum_to_string_function = decltype(enumToString(std::declval< T >()));
+
+template< typename T, bool isEnum, bool isQObject > struct StringConverter {
+	static std::string to_string(const T &value) {
+		std::stringstream stream;
+
+		stream << value;
+
+		return stream.str();
+	}
+
+	static T from_string(const std::string &str) {
+		std::stringstream stream(str);
+
+		T value;
+
+		stream >> value;
+
+		return value;
+	}
+};
+
+template< typename T > struct StringConverter< T, true, false > {
+	static std::string to_string(const T value) {
+#if BOOST_VERSION >= 106700
+		// boost::is_detected is only available since Boost 1.67 and since we only use it to create a better error
+		// message, we can simply not make use of it, if earlier versions are used.
+		static_assert(boost::is_detected< has_enum_to_string_function, T >::value,
+					  "Template specialization requires corresponding enumToString function");
+#endif
+		return enumToString(value);
+	}
+
+	static T from_string(const std::string &str) { return ::stringToEnum< T >(str); }
+};
+
+template< typename T > struct StringConverter< T, false, true > {
+	static std::string to_string(const T &value) {
+		static_assert(std::is_base_of< QObject, T >::value, "Template specialization only applies to QObjects");
+
+		QByteArray data;
+		QDataStream stream(&data, QIODevice::WriteOnly);
+		stream.setVersion(QDataStream::Qt_5_0);
+
+		stream << value;
+
+		return data.toStdString();
+	}
+
+	static T from_string(const std::string &str) {
+		QByteArray data = QByteArray::fromStdString(str);
+		QDataStream stream(&data, QIODevice::WriteOnly);
+		stream.setVersion(QDataStream::Qt_5_0);
+
+		T value;
+		value << stream;
+
+		return value;
+	}
+};
+
+template< typename T > std::string to_string(const T &value) {
+	return StringConverter< T, std::is_enum< T >::value, std::is_base_of< QObject, T >::value >::to_string(value);
+}
+
+template<> inline std::string to_string< QString >(const QString &str) {
+	return str.toStdString();
+}
+
+template< typename T > T from_string(const std::string &str) {
+	return StringConverter< T, std::is_enum< T >::value, std::is_base_of< QObject, T >::value >::from_string(str);
+}
+
+template<> inline QString from_string< QString >(const std::string &str) {
+	return QString::fromStdString(str);
+}
+
+}; // namespace details
+
+
+
+void to_json(nlohmann::json &j, const Settings &settings);
+void from_json(const nlohmann::json &j, Settings &settings);
+void to_json(nlohmann::json &j, const OverlaySettings &settings);
+void from_json(const nlohmann::json &j, OverlaySettings &settings);
+
+void to_json(nlohmann::json &j, const QString &string);
+void from_json(const nlohmann::json &j, QString &string);
+void to_json(nlohmann::json &j, const QVariant &variant);
+void from_json(const nlohmann::json &j, QVariant &variant);
+void to_json(nlohmann::json &j, const QPoint &point);
+void from_json(const nlohmann::json &j, QPoint &point);
+void to_json(nlohmann::json &j, const Shortcut &shortcut);
+void from_json(const nlohmann::json &j, Shortcut &shortcut);
+void to_json(nlohmann::json &j, const ShortcutTarget &target);
+void from_json(const nlohmann::json &j, ShortcutTarget &target);
+void to_json(nlohmann::json &j, const PluginSetting &setting);
+void from_json(const nlohmann::json &j, PluginSetting &setting);
+void to_json(nlohmann::json &j, const QByteArray &byteArray);
+void from_json(const nlohmann::json &j, QByteArray &byteArray);
+void to_json(nlohmann::json &j, const QColor &color);
+void from_json(const nlohmann::json &j, QColor &color);
+void to_json(nlohmann::json &j, const QFont &font);
+void from_json(const nlohmann::json &j, QFont &font);
+void to_json(nlohmann::json &j, const QRect &rect);
+void from_json(const nlohmann::json &j, QRect &rect);
+void to_json(nlohmann::json &j, const QRectF &rect);
+void from_json(const nlohmann::json &j, QRectF &rect);
+void to_json(nlohmann::json &j, const QSize &size);
+void from_json(const nlohmann::json &j, QSize &size);
+void to_json(nlohmann::json &j, const QSizeF &size);
+void from_json(const nlohmann::json &j, QSizeF &size);
+
+template< typename T > void to_json(nlohmann::json &j, const QList< T > &list) {
+	j = nlohmann::json::array();
+	for (const T &current : list) {
+		j.push_back(current);
+	}
+}
+template< typename T > void from_json(const nlohmann::json &j, QList< T > &list) {
+	for (auto it = j.begin(); it != j.end(); ++it) {
+		list.push_back(it->get< T >());
+	}
+}
+
+template< typename Key, typename Value > void to_json(nlohmann::json &j, const QMap< Key, Value > &map) {
+	j = nlohmann::json::object();
+
+	for (auto it = map.constBegin(); it != map.constEnd(); ++it) {
+		j[details::to_string(it.key())] = it.value();
+	}
+}
+
+template< typename Key, typename Value > void from_json(const nlohmann::json &j, QMap< Key, Value > &map) {
+	for (auto it = j.cbegin(); it != j.cend(); ++it) {
+		map[details::from_string< Key >(it.key())] = it.value().get< Value >();
+	}
+}
+
+template< typename Key, typename Value > void to_json(nlohmann::json &j, const QHash< Key, Value > &map) {
+	j = nlohmann::json::object();
+
+	for (auto it = map.constBegin(); it != map.constEnd(); ++it) {
+		j[details::to_string(it.key())] = it.value();
+	}
+}
+
+template< typename Key, typename Value > void from_json(const nlohmann::json &j, QHash< Key, Value > &map) {
+	for (auto it = j.cbegin(); it != j.cend(); ++it) {
+		map[details::from_string< Key >(it.key())] = it.value().get< Value >();
+	}
+}
+
+template< typename T > void to_json(nlohmann::json &j, const QFlags< T > &flags) {
+	j = static_cast< typename QFlags< T >::Int >(flags);
+}
+
+template< typename T > void from_json(const nlohmann::json &j, QFlags< T > &flags) {
+	flags = QFlag(j.get< typename QFlags< T >::Int >());
+}
+
+#endif // MUMBLE_MUMBLE_JSONSERIALIZATION_H_

--- a/src/mumble/Log.cpp
+++ b/src/mumble/Log.cpp
@@ -581,7 +581,7 @@ QString Log::imageToImg(QImage img, int maxSize) {
 QString Log::validHtml(const QString &html, QTextCursor *tc) {
 	LogDocument qtd;
 
-	QRectF qr = Screen::screenFromWidget(*Global::get().mw)->availableGeometry();
+	QRectF qr = Mumble::Screen::screenFromWidget(*Global::get().mw)->availableGeometry();
 	qtd.setTextWidth(qr.width() / 2);
 	qtd.setDefaultStyleSheet(qApp->styleSheet());
 

--- a/src/mumble/MainWindow.cpp
+++ b/src/mumble/MainWindow.cpp
@@ -87,6 +87,8 @@
 #	include <dbt.h>
 #endif
 
+#include <algorithm>
+
 MessageBoxEvent::MessageBoxEvent(QString m) : QEvent(static_cast< QEvent::Type >(MB_QEVENT)) {
 	msg = m;
 }
@@ -3258,10 +3260,19 @@ void MainWindow::serverDisconnected(QAbstractSocket::SocketError err, QString re
 	Global::get().sh->getConnectionInfo(host, port, uname, pw);
 
 	if (Global::get().sh->hasSynchronized()) {
+		QList< Shortcut > &shortcuts = Global::get().s.qlShortcuts;
 		// Only save server-specific shortcuts if the client and server have been synchronized before as only then
 		// did the client actually load them from the DB. If we store them without having loaded them, we will
 		// effectively clear the server-specific shortcuts for this server.
-		if (Global::get().db->setShortcuts(Global::get().sh->qbaDigest, Global::get().s.qlShortcuts)) {
+		Global::get().db->setShortcuts(Global::get().sh->qbaDigest, shortcuts);
+
+		// Clear server-specific shortcuts from the list of known shortcuts
+		auto it = std::remove_if(shortcuts.begin(), shortcuts.end(),
+								 [](const Shortcut &shortcut) { return shortcut.isServerSpecific(); });
+		if (it != shortcuts.end()) {
+			// Some shortcuts have to be removed
+			shortcuts.erase(it, shortcuts.end());
+
 			GlobalShortcutEngine::engine->bNeedRemap = true;
 		}
 	}

--- a/src/mumble/MainWindow.cpp
+++ b/src/mumble/MainWindow.cpp
@@ -3478,7 +3478,7 @@ void MainWindow::trayAboutToShow() {
 		p = QCursor::pos();
 	}
 
-	QScreen *screen = Screen::screenAt(p);
+	QScreen *screen = Mumble::Screen::screenAt(p);
 	if (screen) {
 		QRect qr = screen->geometry();
 

--- a/src/mumble/MainWindow.cpp
+++ b/src/mumble/MainWindow.cpp
@@ -1025,20 +1025,20 @@ void MainWindow::openUrl(const QUrl &url) {
 		}
 		f.close();
 
-		QSettings *qs = new QSettings(f.fileName(), QSettings::IniFormat);
-		qs->setIniCodec("UTF-8");
-		if (qs->status() != QSettings::NoError) {
-			Global::get().l->log(Log::Warning, tr("File is not a configuration file."));
-		} else {
-			qSwap(qs, Global::get().qs);
-			Global::get().s.load();
-			qSwap(qs, Global::get().qs);
+		try {
+			Settings newSettings;
+			newSettings.load(f.fileName());
+
+			std::swap(newSettings, Global::get().s);
 
 			Global::get().l->log(Log::Warning, tr("Settings merged from file."));
+		} catch (const std::exception &e) {
+			Global::get().l->log(Log::Warning, tr("Invalid settings file encountered."));
 		}
-		delete qs;
+
 		return;
 	}
+
 	if (url.scheme() != QLatin1String("mumble")) {
 		Global::get().l->log(Log::Warning, tr("URL scheme is not 'mumble'"));
 		return;

--- a/src/mumble/MumbleApplication.cpp
+++ b/src/mumble/MumbleApplication.cpp
@@ -34,8 +34,9 @@ QString MumbleApplication::applicationVersionRootPath() {
 }
 
 void MumbleApplication::onCommitDataRequest(QSessionManager &) {
-	// Make sure the config is saved and supress the ask on quit message
+	// Make sure the config is saved and suppress the ask on quit message
 	if (Global::get().mw) {
+		Global::get().s.mumbleQuitNormally = true;
 		Global::get().s.save();
 		Global::get().mw->bSuppressAskOnQuit = true;
 		qWarning() << "Session likely ending. Suppressing ask on quit";

--- a/src/mumble/Screen.cpp
+++ b/src/mumble/Screen.cpp
@@ -11,51 +11,57 @@
 #include <QWidget>
 #include <QWindow>
 
-QWindow *Screen::windowFromWidget(const QWidget &widget) {
-	QWindow *window = widget.windowHandle();
-	if (window) {
-		return window;
-	}
+namespace Mumble {
+namespace Screen {
 
-	const QWidget *parent = widget.nativeParentWidget();
-	if (parent) {
-		return parent->windowHandle();
-	}
-
-	return nullptr;
-}
-
-QScreen *Screen::screenFromWidget(const QWidget &widget) {
-	const QWindow *window = windowFromWidget(widget);
-	if (window && window->screen()) {
-		return window->screen();
-	}
-
-	return qApp->primaryScreen();
-}
-
-QScreen *Screen::screenAt(const QPoint &point) {
-#if QT_VERSION >= QT_VERSION_CHECK(5, 10, 0)
-	return qApp->screenAt(point);
-#else
-	// Adapted from qguiapplication.cpp (Qt)
-	QVarLengthArray< const QScreen *, 8 > visitedScreens;
-
-	for (const QScreen *screen : qApp->screens()) {
-		if (visitedScreens.contains(screen)) {
-			continue;
+	QWindow *windowFromWidget(const QWidget &widget) {
+		QWindow *window = widget.windowHandle();
+		if (window) {
+			return window;
 		}
 
-		// The virtual siblings include the screen itself, so iterate directly
-		for (QScreen *sibling : screen->virtualSiblings()) {
-			if (sibling->geometry().contains(point)) {
-				return sibling;
+		const QWidget *parent = widget.nativeParentWidget();
+		if (parent) {
+			return parent->windowHandle();
+		}
+
+		return nullptr;
+	}
+
+	QScreen *screenFromWidget(const QWidget &widget) {
+		const QWindow *window = windowFromWidget(widget);
+		if (window && window->screen()) {
+			return window->screen();
+		}
+
+		return qApp->primaryScreen();
+	}
+
+	QScreen *screenAt(const QPoint &point) {
+#if QT_VERSION >= QT_VERSION_CHECK(5, 10, 0)
+		return qApp->screenAt(point);
+#else
+		// Adapted from qguiapplication.cpp (Qt)
+		QVarLengthArray< const QScreen *, 8 > visitedScreens;
+
+		for (const QScreen *screen : qApp->screens()) {
+			if (visitedScreens.contains(screen)) {
+				continue;
 			}
 
-			visitedScreens.append(sibling);
+			// The virtual siblings include the screen itself, so iterate directly
+			for (QScreen *sibling : screen->virtualSiblings()) {
+				if (sibling->geometry().contains(point)) {
+					return sibling;
+				}
+
+				visitedScreens.append(sibling);
+			}
 		}
+
+		return nullptr;
+#endif
 	}
 
-	return nullptr;
-#endif
-}
+}; // namespace Screen
+}; // namespace Mumble

--- a/src/mumble/Screen.h
+++ b/src/mumble/Screen.h
@@ -11,12 +11,15 @@ class QScreen;
 class QWidget;
 class QWindow;
 
-class Screen {
-public:
+namespace Mumble {
+
+namespace Screen {
 	/// Inspired by https://phabricator.kde.org/D22379
-	static QWindow *windowFromWidget(const QWidget &widget);
-	static QScreen *screenFromWidget(const QWidget &widget);
-	static QScreen *screenAt(const QPoint &point);
-};
+	QWindow *windowFromWidget(const QWidget &widget);
+	QScreen *screenFromWidget(const QWidget &widget);
+	QScreen *screenAt(const QPoint &point);
+}; // namespace Screen
+
+}; // namespace Mumble
 
 #endif

--- a/src/mumble/Settings.cpp
+++ b/src/mumble/Settings.cpp
@@ -71,13 +71,6 @@ bool Shortcut::operator==(const Shortcut &other) const {
 		   && (bSuppress == other.bSuppress);
 }
 
-ShortcutTarget::ShortcutTarget() {
-	bUsers            = true;
-	bCurrentSelection = false;
-	iChannel          = -3;
-	bLinks = bChildren = bForceCenter = false;
-}
-
 bool ShortcutTarget::isServerSpecific() const {
 	return !bCurrentSelection && !bUsers && iChannel >= 0;
 }
@@ -391,42 +384,18 @@ const QString Settings::cqsDefaultPushClickOff = QLatin1String(":/off.ogg");
 const QString Settings::cqsDefaultMuteCue = QLatin1String(":/off.ogg");
 
 OverlaySettings::OverlaySettings() {
-	bEnable = false;
-
-	fX    = 1.0f;
-	fY    = 0.0f;
-	fZoom = 0.875f;
-
 #ifdef Q_OS_MACOS
 	qsStyle = QLatin1String("Cleanlooks");
 #endif
-
-	osShow       = LinkedChannels;
-	bAlwaysSelf  = true;
-	uiActiveTime = 5;
-	osSort       = Alphabetical;
 
 	qcUserName[Settings::Passive]      = QColor(170, 170, 170);
 	qcUserName[Settings::MutedTalking] = QColor(170, 170, 170);
 	qcUserName[Settings::Talking]      = QColor(255, 255, 255);
 	qcUserName[Settings::Whispering]   = QColor(128, 255, 128);
 	qcUserName[Settings::Shouting]     = QColor(255, 128, 255);
-	qcChannel                          = QColor(255, 255, 128);
-	qcBoxPen                           = QColor(0, 0, 0, 224);
-	qcBoxFill                          = QColor(0, 0, 0);
 
 	setPreset();
-
-	// FPS and Time display settings
-	qcFps   = Qt::white;
-	fFps    = 0.75f;
-	qfFps   = qfUserName;
-	qrfFps  = QRectF(0.0f, 0.05, -1, 0.023438f);
-	bFps    = false;
-	qrfTime = QRectF(0.0f, 0.0, -1, 0.023438f);
-	bTime   = false;
-
-	oemOverlayExcludeMode = OverlaySettings::LauncherFilterExclusionMode;
+	qfFps = qfUserName;
 }
 
 void OverlaySettings::setPreset(const OverlayPresets preset) {
@@ -529,83 +498,16 @@ Settings::Settings() {
 	qRegisterMetaType< Search::SearchDialog::UserAction >("SearchDialog::UserAction");
 	qRegisterMetaType< Search::SearchDialog::ChannelAction >("SearchDialog::ChannelAction");
 
-	atTransmit        = VAD;
-	bTransmitPosition = false;
-	bMute = bDeaf                  = false;
-	bTTS                           = false;
-	bTTSMessageReadBack            = false;
-	bTTSNoScope                    = false;
-	bTTSNoAuthor                   = false;
-	iTTSVolume                     = 75;
-	iTTSThreshold                  = 250;
-	qsTTSLanguage                  = QString();
-	iQuality                       = 40000;
-	fVolume                        = 1.0f;
-	fOtherVolume                   = 0.5f;
-	bAttenuateOthersOnTalk         = false;
-	bAttenuateOthers               = false;
-	bAttenuateUsersOnPrioritySpeak = false;
-	bOnlyAttenuateSameOutput       = false;
-	bAttenuateLoopbacks            = false;
-	iMinLoudness                   = 1000;
-	/// Actual mic hold time is (iVoiceHold / 100) seconds, where iVoiceHold is specified in 'frames',
-	/// each of which is has a size of iFrameSize (see AudioInput.h)
-	iVoiceHold        = 20;
-	iJitterBufferSize = 1;
-	iFramesPerPacket  = 2;
+
 #ifdef USE_RNNOISE
 	noiseCancelMode = NoiseCancelRNN;
-#else
-	noiseCancelMode = NoiseCancelSpeex;
 #endif
-	iSpeexNoiseCancelStrength = -30;
-	bAllowLowDelay            = true;
-	uiAudioInputChannelMask   = 0xffffffffffffffffULL;
-
-	// Idle auto actions
-	iIdleTime                   = 5 * 60;
-	iaeIdleAction               = Nothing;
-	bUndoIdleActionUponActivity = false;
-
-	vsVAD   = Amplitude;
-	fVADmin = 0.80f;
-	fVADmax = 0.98f;
-
-	bTxAudioCue     = false;
-	qsTxAudioCueOn  = cqsDefaultPushClickOn;
-	qsTxAudioCueOff = cqsDefaultPushClickOff;
-
-	bTxMuteCue  = true;
-	qsTxMuteCue = cqsDefaultMuteCue;
-
-	bUserTop = true;
-
-	bWhisperFriends            = false;
-	iMessageLimitUserThreshold = 20;
-
-	uiDoublePush = 0;
-	pttHold      = 0;
-
-#ifdef NO_UPDATE_CHECK
-	bUpdateCheck = false;
-	bPluginCheck = false;
-#else
-	bUpdateCheck = true;
-	bPluginCheck = true;
+#ifdef Q_OS_MACOS
+	// The echo cancellation feature on macOS is experimental and known to be able to cause problems
+	// (e.g. muting the user instead of only cancelling echo - https://github.com/mumble-voip/mumble/issues/4912)
+	// Therefore we disable it by default until the issues are fixed.
+	echoOption = EchoCancelOptionID::DISABLED;
 #endif
-	bPluginAutoUpdate = false;
-
-	qsImagePath = QStandardPaths::writableLocation(QStandardPaths::PicturesLocation);
-
-	ceExpand             = ChannelsWithUsers;
-	ceChannelDrag        = Ask;
-	ceUserDrag           = Move;
-	bMinimalView         = false;
-	bHideFrame           = false;
-	aotbAlwaysOnTop      = OnTopNever;
-	bAskOnQuit           = true;
-	bEnableDeveloperMenu = false;
-	bLockLayout          = false;
 #ifdef Q_OS_WIN
 	// Don't enable minimize to tray by default on Windows >= 7
 #	if QT_VERSION >= QT_VERSION_CHECK(5, 9, 0)
@@ -620,142 +522,14 @@ Settings::Settings() {
 		QProcessEnvironment::systemEnvironment().value(QLatin1String("XDG_CURRENT_DESKTOP")) == QLatin1String("Unity");
 	bHideInTray = !isUnityDesktop && QSystemTrayIcon::isSystemTrayAvailable();
 #endif
-	bStateInTray              = true;
-	bUsage                    = true;
-	bShowUserCount            = false;
-	bShowVolumeAdjustments    = true;
-	bShowNicknamesOnly        = false;
-	bChatBarUseSelection      = false;
-	bFilterHidesEmptyChannels = true;
-	bFilterActive             = false;
-
-	wlWindowLayout            = LayoutClassic;
-	bShowContextMenuInMenuBar = false;
-
-	ssFilter = ShowReachable;
-
-	iOutputDelay = 5;
-
-	bASIOEnable = true;
-
-	qsALSAInput  = QLatin1String("default");
-	qsALSAOutput = QLatin1String("default");
-
-	pipeWireInput  = 1;
-	pipeWireOutput = 2;
-
-	qsJackClientName  = QLatin1String("mumble");
-	qsJackAudioOutput = QLatin1String("1");
-	bJackStartServer  = false;
-	bJackAutoConnect  = true;
-
-#ifdef Q_OS_MACOS
-	// The echo cancellation feature on macOS is experimental and known to be able to cause problems
-	// (e.g. muting the user instead of only cancelling echo - https://github.com/mumble-voip/mumble/issues/4912)
-	// Therefore we disable it by default until the issues are fixed.
-	echoOption = EchoCancelOptionID::DISABLED;
-#else
-	// Everywhere else Speex works and thus we default to using that
-	echoOption = EchoCancelOptionID::SPEEX_MIXED;
+#ifdef NO_UPDATE_CHECK
+	bUpdateCheck = false;
+	bPluginCheck = false;
 #endif
-
-	bExclusiveInput  = false;
-	bExclusiveOutput = false;
-
-	iPortAudioInput  = -1; // default device
-	iPortAudioOutput = -1; // default device
-
-	bPositionalAudio     = true;
-	bPositionalHeadphone = false;
-	fAudioMinDistance    = 1.0f;
-	fAudioMaxDistance    = 15.0f;
-	fAudioMaxDistVolume  = 0.25f;
-	fAudioBloom          = 0.5f;
-
-	// OverlayPrivateWin
-	iOverlayWinHelperRestartCooldownMsec = 10000;
-	bOverlayWinHelperX86Enable           = true;
-	bOverlayWinHelperX64Enable           = true;
-
-	iLCDUserViewMinColWidth   = 50;
-	iLCDUserViewSplitterWidth = 2;
-
-	// PTT Button window
-	bShowPTTButtonWindow = false;
-
-	// Network settings
-	bTCPCompat                     = false;
-	bQoS                           = true;
-	bReconnect                     = true;
-	bAutoConnect                   = false;
-	bDisablePublicList             = false;
-	ptProxyType                    = NoProxy;
-	usProxyPort                    = 0;
-	iMaxInFlightTCPPings           = 4;
-	bUdpForceTcpAddr               = true;
-	iPingIntervalMsec              = 5000;
-	iConnectionTimeoutDurationMsec = 30000;
-	iMaxImageWidth                 = 1024; // Allow 1024x1024 resolution
-	iMaxImageHeight                = 1024;
-	bSuppressIdentity              = false;
-	qsSslCiphers                   = MumbleSSL::defaultOpenSSLCipherString();
-	bHideOS                        = false;
-
-	bShowTransmitModeComboBox = false;
-
-	// Accessibility
-	bHighContrast = false;
-
-	// Recording
-	qsRecordingPath  = QStandardPaths::writableLocation(QStandardPaths::DocumentsLocation);
-	qsRecordingFile  = QLatin1String("Mumble-%date-%time-%host-%user");
-	rmRecordingMode  = RecordingMixdown;
-	iRecordingFormat = 0;
-
-	// Special configuration options not exposed to UI
-	bDisableCELT                = false;
-	disableConnectDialogEditing = false;
-	bPingServersDialogViewed    = false;
-
 #if defined(AUDIO_TEST)
 	lmLoopMode = Server;
-#else
-	lmLoopMode = None;
 #endif
-	dPacketLoss     = 0;
-	dMaxPacketDelay = 0.0f;
 
-	requireRestartToApply = false;
-
-	iMaxLogBlocks       = 0;
-	bLog24HourClock     = true;
-	iChatMessageMargins = 3;
-
-	qpTalkingUI_Position                = UNSPECIFIED_POSITION;
-	bShowTalkingUI                      = false;
-	bTalkingUI_LocalUserStaysVisible    = false;
-	bTalkingUI_AbbreviateChannelNames   = true;
-	bTalkingUI_AbbreviateCurrentChannel = false;
-	bTalkingUI_ShowLocalListeners       = false;
-	iTalkingUI_RelativeFontSize         = 100;
-	iTalkingUI_SilentUserLifeTime       = 10;
-	iTalkingUI_ChannelHierarchyDepth    = 1;
-	iTalkingUI_MaxChannelNameLength     = 20;
-	iTalkingUI_PrefixCharCount          = 3;
-	iTalkingUI_PostfixCharCount         = 2;
-	qsTalkingUI_AbbreviationReplacement = QLatin1String("...");
-
-	qsHierarchyChannelSeparator = QLatin1String("/");
-
-	manualPlugin_silentUserDisplaytime = 1;
-
-	bShortcutEnable             = true;
-	bSuppressMacEventTapWarning = false;
-	bEnableEvdev                = false;
-	bEnableXInput2              = true;
-	bEnableGKey                 = false;
-	bEnableXboxInput            = true;
-	bEnableUIAccess             = true;
 
 #ifdef Q_OS_LINUX
 	if (EnvUtils::waylandIsUsed()) {
@@ -798,20 +572,6 @@ Settings::Settings() {
 	qmMessages[Log::OtherMutedOther] = Settings::LogConsole;
 	qmMessages[Log::UserRenamed]     = Settings::LogConsole;
 	qmMessages[Log::PluginMessage]   = Settings::LogConsole;
-
-	// Default search options
-	searchForUsers       = true;
-	searchForChannels    = true;
-	searchCaseSensitive  = false;
-	searchAsRegex        = false;
-	searchOptionsShown   = false;
-	searchUserAction     = Search::SearchDialog::UserAction::JOIN;
-	searchChannelAction  = Search::SearchDialog::ChannelAction::JOIN;
-	searchDialogPosition = Settings::UNSPECIFIED_POSITION;
-
-	// Default theme
-	themeName      = QLatin1String("Mumble");
-	themeStyleName = QLatin1String("Lite");
 }
 
 bool Settings::doEcho() const {

--- a/src/mumble/Settings.h
+++ b/src/mumble/Settings.h
@@ -17,12 +17,14 @@
 #include <QRectF>
 #include <QSslCertificate>
 #include <QSslKey>
+#include <QStandardPaths>
 #include <QString>
 #include <QStringList>
 #include <QVariant>
 #include <Qt>
 
 #include "EchoCancelOption.h"
+#include "SSL.h"
 #include "SearchDialog.h"
 
 #include <nlohmann/json_fwd.hpp>
@@ -39,26 +41,28 @@ class QSettings;
 // GUI.
 
 struct Shortcut {
-	int iIndex;
-	QList< QVariant > qlButtons;
-	QVariant qvData;
-	bool bSuppress;
+	int iIndex                  = 0;
+	QList< QVariant > qlButtons = {};
+	QVariant qvData             = {};
+	bool bSuppress              = false;
+
 	bool operator<(const Shortcut &) const;
 	bool isServerSpecific() const;
 	bool operator==(const Shortcut &) const;
 };
 
 struct ShortcutTarget {
-	bool bCurrentSelection;
-	bool bUsers;
-	QStringList qlUsers;
-	QList< unsigned int > qlSessions;
-	int iChannel;
-	QString qsGroup;
-	bool bLinks;
-	bool bChildren;
-	bool bForceCenter;
-	ShortcutTarget();
+	bool bCurrentSelection           = false;
+	bool bUsers                      = true;
+	QStringList qlUsers              = {};
+	QList< unsigned int > qlSessions = {};
+	int iChannel                     = -3;
+	QString qsGroup                  = {};
+	bool bLinks                      = false;
+	bool bChildren                   = false;
+	bool bForceCenter                = false;
+
+	ShortcutTarget() = default;
 	bool isServerSpecific() const;
 	bool operator<(const ShortcutTarget &) const;
 	bool operator==(const ShortcutTarget &) const;
@@ -70,10 +74,10 @@ quint32 qHash(const ShortcutTarget &);
 quint32 qHash(const QList< ShortcutTarget > &);
 
 struct PluginSetting {
-	QString path;
-	bool enabled;
-	bool positionalDataEnabled;
-	bool allowKeyboardMonitoring;
+	QString path                 = {};
+	bool enabled                 = false;
+	bool positionalDataEnabled   = false;
+	bool allowKeyboardMonitoring = false;
 
 	friend bool operator==(const PluginSetting &lhs, const PluginSetting &rhs);
 	friend bool operator!=(const PluginSetting &lhs, const PluginSetting &rhs);
@@ -82,78 +86,76 @@ struct PluginSetting {
 
 struct OverlaySettings {
 	enum OverlayPresets { AvatarAndName, LargeSquareAvatar };
-
 	enum OverlayShow { Talking, Active, HomeChannel, LinkedChannels };
-
 	enum OverlaySort { Alphabetical, LastStateChange };
-
 	enum OverlayExclusionMode { LauncherFilterExclusionMode, WhitelistExclusionMode, BlacklistExclusionMode };
 
-	bool bEnable;
+	bool bEnable = false;
 
-	QString qsStyle;
+	QString qsStyle = {};
 
-	OverlayShow osShow;
-	bool bAlwaysSelf;
-	int uiActiveTime; // Time in seconds for a user to stay active after talking
-	OverlaySort osSort;
+	OverlayShow osShow = LinkedChannels;
+	bool bAlwaysSelf   = true;
+	// Time in seconds for a user to stay active after talking
+	int uiActiveTime   = 5;
+	OverlaySort osSort = Alphabetical;
 
-	float fX;
-	float fY;
+	float fX = 1.0f;
+	float fY = 0.0f;
 
-	qreal fZoom;
-	unsigned int uiColumns;
+	qreal fZoom            = 0.875f;
+	unsigned int uiColumns = 1;
 
-	std::array< QColor, 5 > qcUserName;
-	QFont qfUserName;
+	std::array< QColor, 5 > qcUserName = {};
+	QFont qfUserName                   = {};
 
-	QColor qcChannel;
-	QFont qfChannel;
+	QColor qcChannel = QColor(255, 255, 128);
+	QFont qfChannel  = {};
 
-	QColor qcFps;
-	QFont qfFps;
+	QColor qcFps = Qt::white;
+	QFont qfFps  = {};
 
-	qreal fBoxPad;
-	qreal fBoxPenWidth;
-	QColor qcBoxPen;
-	QColor qcBoxFill;
+	qreal fBoxPad      = 0.0f;
+	qreal fBoxPenWidth = 0.0f;
+	QColor qcBoxPen    = QColor(0, 0, 0, 224);
+	QColor qcBoxFill   = QColor(0, 0, 0);
 
-	bool bUserName;
-	bool bChannel;
-	bool bMutedDeafened;
-	bool bAvatar;
-	bool bBox;
-	bool bFps;
-	bool bTime;
+	bool bUserName      = true;
+	bool bChannel       = false;
+	bool bMutedDeafened = true;
+	bool bAvatar        = true;
+	bool bBox           = false;
+	bool bFps           = false;
+	bool bTime          = false;
 
-	qreal fUserName;
-	qreal fChannel;
-	qreal fMutedDeafened;
-	qreal fAvatar;
-	std::array< qreal, 5 > fUser;
-	qreal fFps;
+	qreal fUserName              = 0.0f;
+	qreal fChannel               = 0.0f;
+	qreal fMutedDeafened         = 0.5f;
+	qreal fAvatar                = 0.0f;
+	std::array< qreal, 5 > fUser = {};
+	qreal fFps                   = 0.75f;
 
-	QRectF qrfUserName;
-	QRectF qrfChannel;
-	QRectF qrfMutedDeafened;
-	QRectF qrfAvatar;
-	QRectF qrfFps;
-	QRectF qrfTime;
+	QRectF qrfUserName      = {};
+	QRectF qrfChannel       = {};
+	QRectF qrfMutedDeafened = {};
+	QRectF qrfAvatar        = {};
+	QRectF qrfFps           = QRectF(0.0f, 0.05f, -1, 0.023438f);
+	QRectF qrfTime          = QRectF(0.0f, 0.0f, -1, 0.023438f);
 
-	Qt::Alignment qaUserName;
-	Qt::Alignment qaChannel;
-	Qt::Alignment qaMutedDeafened;
-	Qt::Alignment qaAvatar;
+	Qt::Alignment qaUserName      = Qt::AlignLeft;
+	Qt::Alignment qaChannel       = Qt::AlignLeft;
+	Qt::Alignment qaMutedDeafened = Qt::AlignLeft;
+	Qt::Alignment qaAvatar        = Qt::AlignLeft;
 
-	OverlayExclusionMode oemOverlayExcludeMode;
-	QStringList qslLaunchers;
-	QStringList qslLaunchersExclude;
-	QStringList qslWhitelist;
-	QStringList qslWhitelistExclude;
-	QStringList qslPaths;
-	QStringList qslPathsExclude;
-	QStringList qslBlacklist;
-	QStringList qslBlacklistExclude;
+	OverlayExclusionMode oemOverlayExcludeMode = LauncherFilterExclusionMode;
+	QStringList qslLaunchers                   = {};
+	QStringList qslLaunchersExclude            = {};
+	QStringList qslWhitelist                   = {};
+	QStringList qslWhitelistExclude            = {};
+	QStringList qslPaths                       = {};
+	QStringList qslPathsExclude                = {};
+	QStringList qslBlacklist                   = {};
+	QStringList qslBlacklistExclude            = {};
 
 	OverlaySettings();
 	void setPreset(const OverlayPresets preset = AvatarAndName);
@@ -176,32 +178,50 @@ struct Settings {
 	enum TalkState { Passive, Talking, Whispering, Shouting, MutedTalking };
 	enum IdleAction { Nothing, Deafen, Mute };
 	enum NoiseCancel { NoiseCancelOff, NoiseCancelSpeex, NoiseCancelRNN, NoiseCancelBoth };
+	enum MessageLog {
+		LogNone         = 0x00,
+		LogConsole      = 0x01,
+		LogTTS          = 0x02,
+		LogBalloon      = 0x04,
+		LogSoundfile    = 0x08,
+		LogHighlight    = 0x10,
+		LogMessageLimit = 0x20,
+	};
+	enum WindowLayout { LayoutClassic, LayoutStacked, LayoutHybrid, LayoutCustom };
+	enum AlwaysOnTopBehaviour { OnTopNever, OnTopAlways, OnTopInMinimal, OnTopInNormal };
+	enum ProxyType { NoProxy, HttpProxy, Socks5Proxy };
+	enum RecordingMode { RecordingMixdown, RecordingMultichannel };
+
 	typedef QPair< QList< QSslCertificate >, QSslKey > KeyPair;
 
-	AudioTransmit atTransmit;
-	quint64 uiDoublePush;
-	quint64 pttHold;
-
-	bool bTxAudioCue;
 	static const QString cqsDefaultPushClickOn;
 	static const QString cqsDefaultPushClickOff;
-	QString qsTxAudioCueOn;
-	QString qsTxAudioCueOff;
-
-	bool bTxMuteCue;
 	static const QString cqsDefaultMuteCue;
-	QString qsTxMuteCue;
+	static const QPoint UNSPECIFIED_POSITION;
 
-	bool bTransmitPosition;
-	bool bMute, bDeaf;
-	bool bTTS;
-	bool bUserTop;
-	bool bWhisperFriends;
-	int iMessageLimitUserThreshold;
-	bool bTTSMessageReadBack;
-	bool bTTSNoScope;
-	bool bTTSNoAuthor;
-	int iTTSVolume, iTTSThreshold;
+	AudioTransmit atTransmit = VAD;
+	quint64 uiDoublePush     = 0;
+	quint64 pttHold          = 0;
+
+	bool bTxAudioCue        = false;
+	QString qsTxAudioCueOn  = cqsDefaultPushClickOn;
+	QString qsTxAudioCueOff = cqsDefaultPushClickOn;
+
+	bool bTxMuteCue     = true;
+	QString qsTxMuteCue = cqsDefaultMuteCue;
+
+	bool bTransmitPosition         = false;
+	bool bMute                     = false;
+	bool bDeaf                     = false;
+	bool bTTS                      = false;
+	bool bUserTop                  = true;
+	bool bWhisperFriends           = false;
+	int iMessageLimitUserThreshold = 20;
+	bool bTTSMessageReadBack       = false;
+	bool bTTSNoScope               = false;
+	bool bTTSNoAuthor              = false;
+	int iTTSVolume                 = 75;
+	int iTTSThreshold              = 250;
 	/// The Text-to-Speech language to use. This setting overrides
 	/// the default language for the Text-to-Speech engine, which
 	/// is usually inferred from the current locale.
@@ -210,47 +230,63 @@ struct Settings {
 	///
 	/// The setting is currently only supported by the speech-dispatcher
 	/// backend.
-	QString qsTTSLanguage;
-	int iQuality, iMinLoudness, iVoiceHold, iJitterBufferSize;
-	bool bAllowLowDelay;
-	NoiseCancel noiseCancelMode;
-	int iSpeexNoiseCancelStrength;
-	quint64 uiAudioInputChannelMask;
+	QString qsTTSLanguage = {};
+	int iQuality          = 40000;
+	int iMinLoudness      = 1000;
+	/// Actual mic hold time is (iVoiceHold / 100) seconds, where iVoiceHold is specified in 'frames',
+	/// each of which is has a size of iFrameSize (see AudioInput.h)
+	int iVoiceHold                  = 20;
+	int iJitterBufferSize           = 1;
+	bool bAllowLowDelay             = true;
+	NoiseCancel noiseCancelMode     = NoiseCancelSpeex;
+	int iSpeexNoiseCancelStrength   = -30;
+	quint64 uiAudioInputChannelMask = 0xffffffffffffffffULL;
 
 	// Idle auto actions
-	unsigned int iIdleTime;
-	IdleAction iaeIdleAction;
-	bool bUndoIdleActionUponActivity;
+	unsigned int iIdleTime           = 5 * 60;
+	IdleAction iaeIdleAction         = Nothing;
+	bool bUndoIdleActionUponActivity = false;
 
-	VADSource vsVAD;
-	float fVADmin, fVADmax;
-	int iFramesPerPacket;
-	QString qsAudioInput, qsAudioOutput;
-	float fVolume;
-	float fOtherVolume;
-	bool bAttenuateOthersOnTalk;
-	bool bAttenuateOthers;
-	bool bAttenuateUsersOnPrioritySpeak;
-	bool bOnlyAttenuateSameOutput;
-	bool bAttenuateLoopbacks;
-	int iOutputDelay;
+	VADSource vsVAD                     = Amplitude;
+	float fVADmin                       = 0.80f;
+	float fVADmax                       = 0.98f;
+	int iFramesPerPacket                = 2;
+	QString qsAudioInput                = {};
+	QString qsAudioOutput               = {};
+	float fVolume                       = 1.0f;
+	float fOtherVolume                  = 0.5f;
+	bool bAttenuateOthersOnTalk         = false;
+	bool bAttenuateOthers               = false;
+	bool bAttenuateUsersOnPrioritySpeak = false;
+	bool bOnlyAttenuateSameOutput       = false;
+	bool bAttenuateLoopbacks            = false;
+	int iOutputDelay                    = 5;
 
-	QString qsALSAInput, qsALSAOutput;
-	uint8_t pipeWireInput, pipeWireOutput;
-	QString qsPulseAudioInput, qsPulseAudioOutput;
-	QString qsJackClientName, qsJackAudioOutput;
-	bool bJackStartServer, bJackAutoConnect;
-	QString qsOSSInput, qsOSSOutput;
-	int iPortAudioInput, iPortAudioOutput;
+	QString qsALSAInput        = QStringLiteral("default");
+	QString qsALSAOutput       = QStringLiteral("default");
+	uint8_t pipeWireInput      = 1;
+	uint8_t pipeWireOutput     = 2;
+	QString qsPulseAudioInput  = {};
+	QString qsPulseAudioOutput = {};
+	QString qsJackClientName   = QStringLiteral("mumble");
+	QString qsJackAudioOutput  = QStringLiteral("1");
+	bool bJackStartServer      = false;
+	bool bJackAutoConnect      = true;
+	QString qsOSSInput         = {};
+	QString qsOSSOutput        = {};
+	int iPortAudioInput        = -1; // default device
+	int iPortAudioOutput       = -1; // default device
 
-	bool bASIOEnable;
-	QString qsASIOclass;
-	QList< QVariant > qlASIOmic;
-	QList< QVariant > qlASIOspeaker;
+	bool bASIOEnable                = true;
+	QString qsASIOclass             = {};
+	QList< QVariant > qlASIOmic     = {};
+	QList< QVariant > qlASIOspeaker = {};
 
-	QString qsCoreAudioInput, qsCoreAudioOutput;
+	QString qsCoreAudioInput  = {};
+	QString qsCoreAudioOutput = {};
 
-	QString qsWASAPIInput, qsWASAPIOutput;
+	QString qsWASAPIInput  = {};
+	QString qsWASAPIOutput = {};
 	/// qsWASAPIRole is configured via 'wasapi/role'.
 	/// It is a string explaining Mumble's purpose for opening
 	/// the audio device. This can be used to force Windows
@@ -271,160 +307,157 @@ struct Settings {
 	///
 	/// This is practically a direct mapping of the ERole enum
 	/// from Windows: https://msdn.microsoft.com/en-us/library/windows/desktop/dd370842
-	QString qsWASAPIRole;
+	QString qsWASAPIRole = {};
 
-	bool bExclusiveInput, bExclusiveOutput;
-	EchoCancelOptionID echoOption;
-	bool bPositionalAudio;
-	bool bPositionalHeadphone;
-	float fAudioMinDistance, fAudioMaxDistance, fAudioMaxDistVolume, fAudioBloom;
+	bool bExclusiveInput          = false;
+	bool bExclusiveOutput         = false;
+	EchoCancelOptionID echoOption = EchoCancelOptionID::SPEEX_MIXED;
+	bool bPositionalAudio         = false;
+	bool bPositionalHeadphone     = false;
+	float fAudioMinDistance       = 1.0f;
+	float fAudioMaxDistance       = 15.0f;
+	float fAudioMaxDistVolume     = 0.25f;
+	float fAudioBloom             = 0.5f;
 	/// Contains the settings for each individual plugin. The key in this map is the Hex-represented SHA-1
 	/// hash of the plugin's UTF-8 encoded absolute file-path on the hard-drive.
-	QHash< QString, PluginSetting > qhPluginSettings;
+	QHash< QString, PluginSetting > qhPluginSettings = {};
 
-	OverlaySettings os;
+	OverlaySettings os = {};
 
-	int iOverlayWinHelperRestartCooldownMsec;
-	bool bOverlayWinHelperX86Enable;
-	bool bOverlayWinHelperX64Enable;
+	int iOverlayWinHelperRestartCooldownMsec = 10000;
+	bool bOverlayWinHelperX86Enable          = true;
+	bool bOverlayWinHelperX64Enable          = true;
 
-	int iLCDUserViewMinColWidth;
-	int iLCDUserViewSplitterWidth;
-	QMap< QString, bool > qmLCDDevices;
+	int iLCDUserViewMinColWidth        = 50;
+	int iLCDUserViewSplitterWidth      = 2;
+	QMap< QString, bool > qmLCDDevices = {};
 
-	bool bShortcutEnable;
-	bool bSuppressMacEventTapWarning;
-	bool bEnableEvdev;
-	bool bEnableXInput2;
-	bool bEnableGKey;
-	bool bEnableXboxInput;
+	bool bShortcutEnable             = true;
+	bool bSuppressMacEventTapWarning = false;
+	bool bEnableEvdev                = false;
+	bool bEnableXInput2              = true;
+	bool bEnableGKey                 = false;
+	bool bEnableXboxInput            = true;
 	/// Enable use of UIAccess (Windows's UI automation feature). This allows Mumble to receive WM_INPUT messages when
 	/// an application with elevated privileges is in foreground.
-	bool bEnableUIAccess;
-	QList< Shortcut > qlShortcuts;
+	bool bEnableUIAccess          = true;
+	QList< Shortcut > qlShortcuts = {};
 
-	enum MessageLog {
-		LogNone         = 0x00,
-		LogConsole      = 0x01,
-		LogTTS          = 0x02,
-		LogBalloon      = 0x04,
-		LogSoundfile    = 0x08,
-		LogHighlight    = 0x10,
-		LogMessageLimit = 0x20,
-	};
+	int iMaxLogBlocks       = 0;
+	bool bLog24HourClock    = true;
+	int iChatMessageMargins = 3;
 
-	int iMaxLogBlocks;
-	bool bLog24HourClock;
-	int iChatMessageMargins;
-
-	static const QPoint UNSPECIFIED_POSITION;
-	QPoint qpTalkingUI_Position;
-	bool bShowTalkingUI;
-	bool bTalkingUI_LocalUserStaysVisible;
-	bool bTalkingUI_AbbreviateChannelNames;
-	bool bTalkingUI_AbbreviateCurrentChannel;
-	bool bTalkingUI_ShowLocalListeners;
+	QPoint qpTalkingUI_Position              = UNSPECIFIED_POSITION;
+	bool bShowTalkingUI                      = false;
+	bool bTalkingUI_LocalUserStaysVisible    = false;
+	bool bTalkingUI_AbbreviateChannelNames   = true;
+	bool bTalkingUI_AbbreviateCurrentChannel = false;
+	bool bTalkingUI_ShowLocalListeners       = false;
 	/// relative font size in %
-	int iTalkingUI_RelativeFontSize;
-	int iTalkingUI_SilentUserLifeTime;
-	int iTalkingUI_ChannelHierarchyDepth;
-	int iTalkingUI_MaxChannelNameLength;
-	int iTalkingUI_PrefixCharCount;
-	int iTalkingUI_PostfixCharCount;
-	QString qsTalkingUI_AbbreviationReplacement;
+	int iTalkingUI_RelativeFontSize             = 100;
+	int iTalkingUI_SilentUserLifeTime           = 10;
+	int iTalkingUI_ChannelHierarchyDepth        = 1;
+	int iTalkingUI_MaxChannelNameLength         = 20;
+	int iTalkingUI_PrefixCharCount              = 3;
+	int iTalkingUI_PostfixCharCount             = 2;
+	QString qsTalkingUI_AbbreviationReplacement = QStringLiteral("...");
 
-	QString qsHierarchyChannelSeparator;
+	QString qsHierarchyChannelSeparator = QStringLiteral("/");
 
-	int manualPlugin_silentUserDisplaytime;
+	int manualPlugin_silentUserDisplaytime = 1;
 
-	QMap< int, QString > qmMessageSounds;
-	QMap< int, quint32 > qmMessages;
+	QMap< int, QString > qmMessageSounds = {};
+	QMap< int, quint32 > qmMessages      = {};
 
-	QString qsLanguage;
+	QString qsLanguage = {};
 
 	/// Name of the theme to use. @see Themes
-	QString themeName;
+	QString themeName = QStringLiteral("Mumble");
 	/// Name of the style to use from theme. @see Themes
-	QString themeStyleName;
+	QString themeStyleName = QStringLiteral("Lite");
 
-	QByteArray qbaMainWindowGeometry, qbaMainWindowState, qbaMinimalViewGeometry, qbaMinimalViewState, qbaHeaderState;
-	QByteArray qbaConfigGeometry;
-	enum WindowLayout { LayoutClassic, LayoutStacked, LayoutHybrid, LayoutCustom };
-	WindowLayout wlWindowLayout;
-	ChannelExpand ceExpand;
-	ChannelDrag ceChannelDrag;
-	ChannelDrag ceUserDrag;
-	bool bMinimalView;
-	bool bHideFrame;
-	enum AlwaysOnTopBehaviour { OnTopNever, OnTopAlways, OnTopInMinimal, OnTopInNormal };
-	AlwaysOnTopBehaviour aotbAlwaysOnTop;
-	bool bAskOnQuit;
-	bool bEnableDeveloperMenu;
-	bool bLockLayout;
-	bool bHideInTray;
-	bool bStateInTray;
-	bool bUsage;
-	bool bShowUserCount;
-	bool bShowVolumeAdjustments;
-	bool bShowNicknamesOnly;
-	bool bChatBarUseSelection;
-	bool bFilterHidesEmptyChannels;
-	bool bFilterActive;
-	QByteArray qbaConnectDialogHeader, qbaConnectDialogGeometry;
-	bool bShowContextMenuInMenuBar;
+	QByteArray qbaMainWindowGeometry     = {};
+	QByteArray qbaMainWindowState        = {};
+	QByteArray qbaMinimalViewGeometry    = {};
+	QByteArray qbaMinimalViewState       = {};
+	QByteArray qbaHeaderState            = {};
+	QByteArray qbaConfigGeometry         = {};
+	WindowLayout wlWindowLayout          = LayoutClassic;
+	ChannelExpand ceExpand               = ChannelsWithUsers;
+	ChannelDrag ceChannelDrag            = Ask;
+	ChannelDrag ceUserDrag               = Move;
+	bool bMinimalView                    = false;
+	bool bHideFrame                      = false;
+	AlwaysOnTopBehaviour aotbAlwaysOnTop = OnTopNever;
+	bool bAskOnQuit                      = true;
+	bool bEnableDeveloperMenu            = false;
+	bool bLockLayout                     = false;
+	bool bHideInTray                     = false;
+	bool bStateInTray                    = true;
+	bool bUsage                          = true;
+	bool bShowUserCount                  = false;
+	bool bShowVolumeAdjustments          = true;
+	bool bShowNicknamesOnly              = false;
+	bool bChatBarUseSelection            = false;
+	bool bFilterHidesEmptyChannels       = true;
+	bool bFilterActive                   = false;
+	QByteArray qbaConnectDialogHeader    = {};
+	QByteArray qbaConnectDialogGeometry  = {};
+	bool bShowContextMenuInMenuBar       = false;
 
 	// Search settings
-	bool searchForUsers;
-	bool searchForChannels;
-	bool searchCaseSensitive;
-	bool searchAsRegex;
-	bool searchOptionsShown;
-	Search::SearchDialog::UserAction searchUserAction;
-	Search::SearchDialog::ChannelAction searchChannelAction;
-	QPoint searchDialogPosition;
+	bool searchForUsers                                     = true;
+	bool searchForChannels                                  = true;
+	bool searchCaseSensitive                                = false;
+	bool searchAsRegex                                      = false;
+	bool searchOptionsShown                                 = false;
+	Search::SearchDialog::UserAction searchUserAction       = Search::SearchDialog::UserAction::JOIN;
+	Search::SearchDialog::ChannelAction searchChannelAction = Search::SearchDialog::ChannelAction::JOIN;
+	QPoint searchDialogPosition                             = UNSPECIFIED_POSITION;
 
-	QString qsUsername;
-	QString qsLastServer;
-	ServerShow ssFilter;
+	QString qsUsername   = {};
+	QString qsLastServer = {};
+	ServerShow ssFilter  = ShowReachable;
 
-	QString qsImagePath;
+	QString qsImagePath = QStandardPaths::writableLocation(QStandardPaths::PicturesLocation);
 
-	bool bUpdateCheck;
-	bool bPluginCheck;
-	bool bPluginAutoUpdate;
+	bool bUpdateCheck      = true;
+	bool bPluginCheck      = true;
+	bool bPluginAutoUpdate = false;
 
 	// PTT Button window
-	bool bShowPTTButtonWindow;
-	QByteArray qbaPTTButtonWindowGeometry;
+	bool bShowPTTButtonWindow             = false;
+	QByteArray qbaPTTButtonWindowGeometry = {};
 
 	// Network settings
-	enum ProxyType { NoProxy, HttpProxy, Socks5Proxy };
-	bool bTCPCompat;
-	bool bReconnect;
-	bool bAutoConnect;
-	bool bQoS;
+	bool bTCPCompat   = false;
+	bool bReconnect   = true;
+	bool bAutoConnect = false;
+	bool bQoS         = true;
 	/// Disables the "Public Internet" section in the connect dialog if set.
-	bool bDisablePublicList;
-	ProxyType ptProxyType;
-	QString qsProxyHost, qsProxyUsername, qsProxyPassword;
-	unsigned short usProxyPort;
+	bool bDisablePublicList    = false;
+	ProxyType ptProxyType      = NoProxy;
+	QString qsProxyHost        = {};
+	QString qsProxyUsername    = {};
+	QString qsProxyPassword    = {};
+	unsigned short usProxyPort = 0;
 
 	/// The ping interval in milliseconds. The Mumble client
 	/// will regularly send TCP and UDP pings to the remote
 	/// server. This setting specifies the time (in milliseconds)
 	/// between each ping message.
-	int iPingIntervalMsec;
+	int iPingIntervalMsec = 5000;
 
 	/// The connection timeout duration in milliseconds.
 	/// If a connection is not fully established to the
 	/// server within this duration, the client will
 	/// forcefully disconnect.
-	int iConnectionTimeoutDurationMsec;
+	int iConnectionTimeoutDurationMsec = 30000;
 
 	/// bUdpForceTcpAddr forces Mumble to bind its UDP
 	/// socket to the same address as its TCP
 	/// connection is using.
-	bool bUdpForceTcpAddr;
+	bool bUdpForceTcpAddr = true;
 
 	/// iMaxInFlightTCPPings specifies the maximum
 	/// number of ping messages that the client has
@@ -436,7 +469,7 @@ struct Settings {
 	/// If this setting is assigned a value of 0 or
 	/// a negative number, the TCP ping check is
 	/// disabled.
-	int iMaxInFlightTCPPings;
+	int iMaxInFlightTCPPings = 4;
 
 	/// The service prefix that the WebFetch class will use
 	/// when it constructs its fully-qualified URL. If this
@@ -447,64 +480,65 @@ struct Settings {
 	/// is updated to reflect the received service prefix.
 	///
 	/// For more information, see the documentation for WebFetch::fetch().
-	QString qsServicePrefix;
+	QString qsServicePrefix = {};
 
 	// Network settings - SSL
-	QString qsSslCiphers;
+	QString qsSslCiphers = MumbleSSL::defaultOpenSSLCipherString();
 
 	// Privacy settings
-	bool bHideOS;
+	bool bHideOS = false;
 
-	int iMaxImageWidth;
-	int iMaxImageHeight;
-	KeyPair kpCertificate;
+	// Allow 1024x1024 resolution
+	int iMaxImageWidth  = 1024;
+	int iMaxImageHeight = 1024;
 
-	bool bShowTransmitModeComboBox;
+	KeyPair kpCertificate = {};
+
+	bool bShowTransmitModeComboBox = false;
 
 	// Accessibility
-	bool bHighContrast;
+	bool bHighContrast = false;
 
 	// Recording
-	QString qsRecordingPath;
-	QString qsRecordingFile;
-	enum RecordingMode { RecordingMixdown, RecordingMultichannel };
-	RecordingMode rmRecordingMode;
-	int iRecordingFormat;
+	QString qsRecordingPath       = QStandardPaths::writableLocation(QStandardPaths::DocumentsLocation);
+	QString qsRecordingFile       = QStringLiteral("Mumble-%date-%time-%host-%user");
+	RecordingMode rmRecordingMode = RecordingMixdown;
+	int iRecordingFormat          = 0;
 
 	// Special configuration options not exposed to UI
 
 	/// Codec kill-switch
-	bool bDisableCELT;
+	bool bDisableCELT = false;
 
 	/// Removes the add and edit options in the connect dialog if set.
-	bool disableConnectDialogEditing;
+	bool disableConnectDialogEditing = false;
 
 	/// Asks the user for consent to ping servers in the public server list if not set.
-	bool bPingServersDialogViewed;
+	bool bPingServersDialogViewed = false;
 
 	/// Whether the audio wizard has been shown to the user yet (at some point during Mumble's installation)
-	bool audioWizardShown;
+	bool audioWizardShown = false;
 
 	/// Path to SQLite-DB
-	QString qsDatabaseLocation;
+	QString qsDatabaseLocation = {};
 
 	/// The email address that has been specified most recently in the crash reporter
-	QString crashReportEmail;
+	QString crashReportEmail = {};
 
 	// Nonsaved
-	bool bSuppressIdentity;
-	LoopMode lmLoopMode;
-	float dPacketLoss;
-	float dMaxPacketDelay;
+	bool bSuppressIdentity = false;
+	LoopMode lmLoopMode    = None;
+	float dPacketLoss      = 0.0f;
+	float dMaxPacketDelay  = 0.0f;
 	/// If true settings in this structure require a client restart to apply fully
-	bool requireRestartToApply;
-	QString settingsLocation;
+	bool requireRestartToApply = false;
+	QString settingsLocation   = {};
 	/// A flag indicating whether the current Mumble session has already backed up the settings it was started with,
 	/// before writing new ones.
-	mutable bool createdSettingsBackup;
+	mutable bool createdSettingsBackup = false;
 
 	/// A flag used in order to determine whether or not to offer loading the setting's backup file instead
-	bool mumbleQuitNormally;
+	bool mumbleQuitNormally = false;
 
 	bool doEcho() const;
 	bool doPositionalAudio() const;

--- a/src/mumble/Settings.h
+++ b/src/mumble/Settings.h
@@ -501,7 +501,7 @@ struct Settings {
 	QString settingsLocation;
 	/// A flag indicating whether the current Mumble session has already backed up the settings it was started with,
 	/// before writing new ones.
-	bool createdSettingsBackup;
+	mutable bool createdSettingsBackup;
 
 	/// A flag used in order to determine whether or not to offer loading the setting's backup file instead
 	bool mumbleQuitNormally;

--- a/src/mumble/SettingsKeys.cpp
+++ b/src/mumble/SettingsKeys.cpp
@@ -1,0 +1,37 @@
+// Copyright 2021 The Mumble Developers. All rights reserved.
+// Use of this source code is governed by a BSD-style license
+// that can be found in the LICENSE file at the root of the
+// Mumble source tree or at <https://www.mumble.info/LICENSE>.
+
+#include "SettingsKeys.h"
+
+SettingsKey::SettingsKey(std::initializer_list< std::string > keyIDs) : m_ids(keyIDs.begin(), keyIDs.end()) {
+	if (keyIDs.size() == 0) {
+		// Don't use std::exception here in order to increase the chance of this "exception" remaining uncaught and
+		// therefore crashing the application (if this happens, this is a non-recoverable programmer error).
+		throw "SettingsKey instances must at least contain one ID!";
+	}
+}
+
+SettingsKey::operator const char *() const {
+	// The first entry is considered to be the most recent
+	return m_ids[0].c_str();
+}
+
+SettingsKey::operator nlohmann::json::object_t::key_type() const {
+	// The first entry is considered to be the most recent
+	return m_ids[0].c_str();
+}
+
+nlohmann::json SettingsKey::selectFrom(const nlohmann::json &json) const {
+	// Start with the most recent ID and go through to the oldest one. The first entry with a given ID, that exists,
+	// will be selected.
+	for (std::size_t i = 0; i < m_ids.size(); ++i) {
+		if (json.contains(m_ids[i])) {
+			return json[m_ids[i]];
+		}
+	}
+
+	// Not found
+	return {};
+}

--- a/src/mumble/SettingsKeys.h
+++ b/src/mumble/SettingsKeys.h
@@ -1,0 +1,343 @@
+// Copyright 2021 The Mumble Developers. All rights reserved.
+// Use of this source code is governed by a BSD-style license
+// that can be found in the LICENSE file at the root of the
+// Mumble source tree or at <https://www.mumble.info/LICENSE>.
+
+#ifndef MUMBLE_MUMBLE_SETTINGSKEYS_H_
+#define MUMBLE_MUMBLE_SETTINGSKEYS_H_
+
+#include <initializer_list>
+#include <string>
+#include <vector>
+
+#include <nlohmann/json.hpp>
+
+class SettingsKey {
+public:
+	SettingsKey(std::initializer_list< std::string > keyIDs);
+
+	operator const char *() const;
+	operator nlohmann::json::object_t::key_type() const;
+
+	nlohmann::json selectFrom(const nlohmann::json &json) const;
+
+protected:
+	std::vector< std::string > m_ids;
+};
+
+namespace SettingsKeys {
+
+/*
+ * The idea of these instances is to act as constants for keys that are used in Mumble's settings. Each SettingsKey is
+ * initialized by an array of keys. This is meant to facilitate renaming of keys in the settings. The first name is
+ * always the most recent (the one used for saving new data) and the other ones are tested for consecutively, when
+ * loading settings.
+ */
+
+// Audio settings
+const SettingsKey MUTE_KEY                                    = { "mute" };
+const SettingsKey DEAF_KEY                                    = { "deaf" };
+const SettingsKey TRANSMIT_MODE_KEY                           = { "transmit_mode" };
+const SettingsKey DOUBLE_PUSH_DELAY_KEY                       = { "double_push_delay" };
+const SettingsKey PTT_HOLD_KEY                                = { "ptt_hold" };
+const SettingsKey PLAY_TRANSMIT_CUE_KEY                       = { "play_transmit_cue" };
+const SettingsKey TRANSMIT_CUE_START_KEY                      = { "transmit_cue_start" };
+const SettingsKey TRANSMIT_CUE_STOP_KEY                       = { "transmit_cue_stop" };
+const SettingsKey PLAY_MUTE_CUE_KEY                           = { "play_mute_cue" };
+const SettingsKey MUTE_CUE_KEY                                = { "mute_cue" };
+const SettingsKey AUDIO_QUALITY_KEY                           = { "audio_quality" };
+const SettingsKey LOUDNESS_KEY                                = { "loudness" };
+const SettingsKey VOLUME_KEY                                  = { "volume" };
+const SettingsKey EXTERNAL_APPLICATIONS_VOLUME_KEY            = { "external_applications_volume" };
+const SettingsKey ATTENUATE_EXTERNAL_APPLICATIONS_KEY         = { "attenuate_external_applications" };
+const SettingsKey ATTENUATE_EXTERNAL_APPLICATIONS_ON_TALK_KEY = { "attenuate_external_applications_on_talk" };
+const SettingsKey ATTENUATE_USERS_ON_PRIORITY_SPEAKER_KEY     = { "attenuate_users_on_priority_speaker" };
+const SettingsKey ATTENUATE_ONLY_SAME_OUTPUT_KEY              = { "attenuate_only_same_output" };
+const SettingsKey ATTENUATE_LOOPBACK_KEY                      = { "attenuate_loopback" };
+const SettingsKey VAD_MODE_KEY                                = { "vad_mode" };
+const SettingsKey VAD_MIN_KEY                                 = { "vad_min" };
+const SettingsKey VAD_MAX_KEY                                 = { "vad_max" };
+const SettingsKey NOISE_CANCEL_MODE_KEY                       = { "noise_cancel_mode" };
+const SettingsKey SPEEX_NOISE_CANCEL_STRENGTH_KEY             = { "speex_noise_cancel_strength" };
+const SettingsKey INPUT_CHANNEL_MASK_KEY                      = { "input_channel_mask" };
+const SettingsKey ALLOW_LOW_DELAY_MODE_KEY                    = { "allow_low_delay_mode" };
+const SettingsKey VOICE_HOLD_KEY                              = { "voice_hold" };
+const SettingsKey OUTPUT_DELAY_KEY                            = { "output_delay" };
+const SettingsKey ECHO_CANCEL_MODE_KEY                        = { "echo_cancel_mode" };
+const SettingsKey EXCLUSIVE_INPUT_KEY                         = { "exclusive_input" };
+const SettingsKey EXCLUSIVE_OUTPUT_KEY                        = { "exclusive_output" };
+const SettingsKey INPUT_SYSTEM_KEY                            = { "input_system" };
+const SettingsKey OUTPUT_SYSTEM_KEY                           = { "output_system" };
+const SettingsKey RESTRICT_WHISPERS_TO_FRIENDS_KEY            = { "restrict_whispers_to_friends" };
+const SettingsKey NOTIFICATION_USER_LIMIT_KEY                 = { "notification_user_limit" };
+
+// Idle settings
+const SettingsKey IDLE_TIME_KEY                  = { "idle_time" };
+const SettingsKey IDLE_ACTION_KEY                = { "idle_action" };
+const SettingsKey UNDO_IDLE_ACTION_UPON_ACTIVITY = { "undo_idle_action_upon_activity" };
+
+// Positional audio
+const SettingsKey ENABLE_POSITIONAL_AUDIO_KEY      = { "enable_positional_audio" };
+const SettingsKey POSITIONAL_HEADPHONE_MODE_KEY    = { "use_headphone_mode" };
+const SettingsKey POSITIONAL_MIN_DISTANCE_KEY      = { "minimum_distance" };
+const SettingsKey POSITIONAL_MAX_DISTANCE_KEY      = { "maximum_distance" };
+const SettingsKey POSITIONAL_MIN_VOLUME_KEY        = { "minimum_volume" };
+const SettingsKey POSITIONAL_BLOOM_KEY             = { "bloom" };
+const SettingsKey POSITIONAL_TRANSMIT_POSITION_KEY = { "transmit_position" };
+
+// Network
+const SettingsKey JITTER_BUFFER_SIZE_KEY            = { "jitter_buffer_size" };
+const SettingsKey FRAMES_PER_PACKET_KEY             = { "frames_per_packet" };
+const SettingsKey RESTRICT_TO_TCP_KEY               = { "restrict_to_tcp" };
+const SettingsKey USE_QUALITY_OF_SERVICE_KEY        = { "use_quality_of_service" };
+const SettingsKey AUTO_RECONNECT_KEY                = { "reconnect_automatically" };
+const SettingsKey AUTO_CONNECT_LAST_SERVER_KEY      = { "auto_connect_to_last_server" };
+const SettingsKey PROXY_TYPE_KEY                    = { "proxy_type" };
+const SettingsKey PROXY_HOST_KEY                    = { "proxy_host" };
+const SettingsKey PROXY_PORT_KEY                    = { "proxy_port" };
+const SettingsKey PROXY_USERNAME_KEY                = { "proxy_username" };
+const SettingsKey PROXY_PASSWORD_KEY                = { "proxy_password" };
+const SettingsKey MAX_IMAGE_WIDTH_KEY               = { "max_image_width" };
+const SettingsKey MAX_IMAGE_HEIGHT_KEY              = { "max_image_height" };
+const SettingsKey SERVICE_PREFIX_KEY                = { "service_prefix" };
+const SettingsKey MAX_IN_FLIGHT_TCP_PINGS_KEY       = { "max_in_flight_tcp_pings" };
+const SettingsKey PING_INTERVAL_KEY                 = { "ping_interval" };
+const SettingsKey CONNECTION_TIMEOUT_KEY            = { "connection_timeout" };
+const SettingsKey FORCE_UDP_BIND_TO_TCP_ADDRESS_KEY = { "force_udp_bind_to_tcp_address" };
+const SettingsKey SSL_CIPHERS_KEY                   = { "ssl_ciphers" };
+
+// ASIO
+const SettingsKey ASIO_ENABLE_KEY     = { "enable_asio" };
+const SettingsKey ASIO_CLASS_KEY      = { "asio_class" };
+const SettingsKey ASIO_MICROPHONE_KEY = { "asio_microphone" };
+const SettingsKey ASIO_SPEAKER_KEY    = { "asio_speaker" };
+
+// WASAPI
+const SettingsKey WASAPI_INPUT_KEY  = { "wasapi_input" };
+const SettingsKey WASAPI_OUTPUT_KEY = { "wasapi_output" };
+const SettingsKey WASAPI_ROLE_KEY   = { "wasapi_role" };
+
+// ALSA
+const SettingsKey ALSA_INPUT_KEY  = { "alsa_input" };
+const SettingsKey ALSA_OUTPUT_KEY = { "alsa_output" };
+
+// PipeWire
+const SettingsKey PIPEWIRE_INPUT_KEY  = { "pipewire_input" };
+const SettingsKey PIPEWIRE_OUTPUT_KEY = { "pipewire_output" };
+
+// PulseAudio
+const SettingsKey PULSEAUDIO_INPUT_KEY  = { "pulseaudio_input" };
+const SettingsKey PULSEAUDIO_OUTPUT_KEY = { "pulseaudio_output" };
+
+// Jack Audio
+const SettingsKey JACK_OUTPUT_KEY       = { "jack_output" };
+const SettingsKey JACK_START_SERVER_KEY = { "jack_start_server" };
+const SettingsKey JACK_AUTOCONNECT_KEY  = { "jack_autoconnect" };
+const SettingsKey JACK_CLIENT_NAME_KEY  = { "jack_client_name" };
+
+// OSS
+const SettingsKey OSS_INPUT_KEY  = { "oss_input" };
+const SettingsKey OSS_OUTPUT_KEY = { "oss_output" };
+
+// CoreAudio
+const SettingsKey COREAUDIO_INPUT_KEY  = { "coreaudio_input" };
+const SettingsKey COREAUDIO_OUTPUT_KEY = { "coreaudio_output" };
+
+// PortAudio
+const SettingsKey PORTAUDIO_INPUT_KEY  = { "portaudio_input" };
+const SettingsKey PORTAUDIO_OUTPUT_KEY = { "portaudio_output" };
+
+// TTS
+const SettingsKey TTS_ENABLE_KEY        = { "enable_tts" };
+const SettingsKey TTS_VOLUME_KEY        = { "tts_volume" };
+const SettingsKey TTS_THRESHOLD_KEY     = { "tts_threshold" };
+const SettingsKey TTS_READBACK_KEY      = { "tts_readback" };
+const SettingsKey TTS_IGNORE_SCOPE_KEY  = { "tts_ignore_scope" };
+const SettingsKey TTS_IGNORE_AUTHOR_KEY = { "tts_ignore_author" };
+const SettingsKey TTS_LANGAGE_KEY       = { "tts_language" };
+
+// Privacy
+const SettingsKey HIDE_OS_FROM_SERVER_KEY = { "hide_os_from_server" };
+
+// UI
+const SettingsKey LANGUAGE_KEY                         = { "language" };
+const SettingsKey THEME_KEY                            = { "theme" };
+const SettingsKey THEME_STYLE_KEY                      = { "theme_style" };
+const SettingsKey CHANNEL_EXPANSION_MODE_KEY           = { "channel_expansion_mode" };
+const SettingsKey CHANNEL_DRAG_MODE_KEY                = { "channel_drag_mode" };
+const SettingsKey USER_DRAG_MODE_KEY                   = { "user_drag_mode" };
+const SettingsKey ALWAYS_ON_TOP_KEY                    = { "always_on_top" };
+const SettingsKey ASK_ON_QUIT_KEY                      = { "ask_on_quit" };
+const SettingsKey SHOW_DEVELOPER_MENU_KEY              = { "show_developer_menu" };
+const SettingsKey LOCK_LAYOUT_KEY                      = { "lock_layout" };
+const SettingsKey MINIMAL_VIEW_KEY                     = { "minimal_view" };
+const SettingsKey HIDE_FRAME_KEY                       = { "hide_frame" };
+const SettingsKey DISPLAY_USERS_BEFORE_CHANNELS        = { "display_users_before_channels" };
+const SettingsKey WINDOW_GEOMETRY_KEY                  = { "window_geometry" };
+const SettingsKey WINDOW_GEOMETRY_MINIMAL_VIEW_KEY     = { "minimal_view_window_geometry" };
+const SettingsKey WINDOW_STATE_KEY                     = { "window_state" };
+const SettingsKey WINDOW_STATE_MINIMAL_VIEW_KEY        = { "minimal_view_window_state" };
+const SettingsKey CONFIG_GEOMETRY_KEY                  = { "config_geometry" };
+const SettingsKey WINDOW_LAYOUT_KEY                    = { "window_layout" };
+const SettingsKey OVERLAY_HEADER_STATE                 = { "overlay_header_state" };
+const SettingsKey SERVER_FILTER_MODE_KEY               = { "server_filter_mode" };
+const SettingsKey HIDE_IN_TRAY_KEY                     = { "hide_in_tray" };
+const SettingsKey DISPLAY_TALKING_STATE_IN_TRAY_KEY    = { "display_talking_state_in_tray" };
+const SettingsKey SEND_USAGE_STATISTICS_KEY            = { "send_usage_statistics" };
+const SettingsKey DISPLAY_USER_COUNT_KEY               = { "display_user_count" };
+const SettingsKey DISPLAY_VOLUME_ADJUSTMENTS_KEY       = { "display_volume_adjustments" };
+const SettingsKey DISPLAY_NICKNAMES_ONLY_KEY           = { "display_nicknames_only" };
+const SettingsKey SELECTED_ITEM_AS_CHATBAR_TARGET_KEY  = { "use_selected_item_as_chatbar_target" };
+const SettingsKey FILTER_HIDES_EMPTY_CHANNEL_KEY       = { "filter_hides_empty_channel" };
+const SettingsKey FILTER_ACTIVE_KEY                    = { "filter_active" };
+const SettingsKey CONTEXT_MENU_ENTRIES_IN_MENU_BAR_KEY = { "display_context_menu_entries_in_menu_bar" };
+const SettingsKey CONNECT_DIALOG_GEOMETRY_KEY          = { "connect_dialog_geometry" };
+const SettingsKey CONNECT_DIALOG_HEADER_STATE_KEY      = { "connect_dialog_header_state" };
+const SettingsKey DISPLAY_TRANSMIT_MODE_COMBOBOX_KEY   = { "display_transmit_mode_combobox" };
+const SettingsKey HIGH_CONTRAST_MODE_KEY               = { "high_contrast_mode" };
+const SettingsKey MAX_LOG_LENGTH_KEY                   = { "max_log_length" };
+const SettingsKey USE_24H_CLOCK_KEY                    = { "use_24h_clock_format" };
+const SettingsKey LOG_MESSAGE_MARGINS_KEY              = { "log_message_margins" };
+const SettingsKey DISABLE_PUBLIC_SERVER_LIST_KEY       = { "disable_public_server_list" };
+
+// Last connection
+const SettingsKey LAST_USERNAME_KEY    = { "username" };
+const SettingsKey LAST_SERVER_NAME_KEY = { "server_name" };
+
+// Updates
+const SettingsKey CHECK_FOR_UPDATES_KEY        = { "check_for_updates" };
+const SettingsKey CHECK_FOR_PLUGIN_UPDATES_KEY = { "check_for_plugin_updates" };
+const SettingsKey AUTO_UPDATE_PLUGINS_KEY      = { "auto_update_plugins" };
+
+// Misc
+const SettingsKey DATABASE_LOCATION_KEY                  = { "database_location" };
+const SettingsKey IMAGE_DIRECTORY_KEY                    = { "image_directory" };
+const SettingsKey SERVER_PING_CONSENT_MESSAGE_VIEWED_KEY = { "viewed_server_ping_consent_message" };
+const SettingsKey AUDIO_WIZARD_SHOWN_KEY                 = { "audio_wizard_has_been_shown" };
+const SettingsKey CRASH_EMAIL_ADDRESS_KEY                = { "crash_report_email_address" };
+
+
+// TalkingUI
+const SettingsKey TALKINGUI_POSITION_KEY                   = { "talkingui_position" };
+const SettingsKey SHOW_TALKINGUI_KEY                       = { "display_talkingui" };
+const SettingsKey TALKINGUI_LOCAL_USER_STAYS_VISIBLE_KEY   = { "local_user_stays_visible" };
+const SettingsKey TALKINGUI_ABBREVIATE_CHANNEL_NAMES_KEY   = { "abbreviate_channel_names" };
+const SettingsKey TALKINGUI_ABBREVIATE_CURRENT_CHANNEL_KEY = { "abbreviate_current_channel_name" };
+const SettingsKey TALKINGUI_DISPLAY_LOCAL_LISTENERS_KEY    = { "display_local_listeners" };
+const SettingsKey TALKINGUI_RELATIVE_FONT_SIZE_KEY         = { "relative_font_size" };
+const SettingsKey TALKINGUI_SILENT_USER_LIFETIME_KEY       = { "silent_user_lifetime" };
+const SettingsKey TALKINGUI_CHANNEL_HIERARCHY_DEPTH_KEY    = { "channel_hierarchy_depth" };
+const SettingsKey TALKINGUI_MAX_CHANNEL_NAME_LENGTH_KEY    = { "max_channel_name_length" };
+const SettingsKey TALKINGUI_NAME_PREFIX_COUNT_KEY          = { "name_prefix_count" };
+const SettingsKey TALKINGUI_NAME_POSTFIX_COUNT_KEY         = { "name_postfix_count" };
+const SettingsKey TALKINGUI_ABBREVIATION_REPLACEMENT_KEY   = { "abbreviation_replacement" };
+
+// Channel hierarchy
+const SettingsKey CHANNEL_NAME_SEPARATOR_KEY = { "channel_name_separator" };
+
+// Manual plugin
+const SettingsKey MANUALPLUGIN_SILENT_USER_LIFETIME_KEY = { "silent_user_lifetime" };
+
+// PTT button window
+const SettingsKey DISPLAY_PTTWINDOW_KEY  = { "display_ptt_window" };
+const SettingsKey PTTWINDOW_GEOMETRY_KEY = { "ptt_window_geometry" };
+
+// Recording
+const SettingsKey RECORDING_PATH_KEY   = { "recording_path" };
+const SettingsKey RECORDING_FILE_KEY   = { "recording_file" };
+const SettingsKey RECORDING_MODE_KEY   = { "recording_mode" };
+const SettingsKey RECORDING_FORMAT_KEY = { "recording_format" };
+
+// Hidden
+const SettingsKey DISABLE_CELT_KEY                   = { "disable_celt" };
+const SettingsKey DISABLE_CONNECT_DIALOG_EDITING_KEY = { "disable_connect_dialog_editing" };
+
+// Overlay (win)
+const SettingsKey OVERLAY_WIN_HELPER_ENABLE_x86_KEY            = { "enable_win_overlay_helper_x86" };
+const SettingsKey OVERLAY_WIN_HELPER_ENABLE_x64_KEY            = { "enable_win_overlay_helper_x64" };
+const SettingsKey OVERLAY_WIN_HELPER_RESTART_COOLDOWN_TIME_KEY = { "win_overlay_helper_restart_cooldown_time" };
+
+// LCD
+const SettingsKey LCD_USERVIEW_MIN_COLUMN_WIDTH_KEY = { "lcd_userview_min_column_width" };
+const SettingsKey LCD_USERVIEW_SPLITTER_WIDTH_KEY   = { "lcd_userview_splitter_width" };
+
+// Shortcuts
+const SettingsKey ENABLE_GLOBAL_SHORTCUTS_KEY              = { "enable_global_shortcuts" };
+const SettingsKey SUPPRESS_MACOS_EVENT_TAPPING_WARNING_KEY = { "suppress_macos_event_tapping_message" };
+const SettingsKey ENABLE_EVDEV_KEY                         = { "enable_evdev" };
+const SettingsKey ENABLE_XINPUT2_KEY                       = { "enable_xinput2" };
+const SettingsKey ENABLE_GKEY_KEY                          = { "enable_gkey" };
+const SettingsKey ENABLE_XBOX_WIN_KEY                      = { "enable_xbox_win" };
+const SettingsKey WIN_UIACCESS_KEY                         = { "win_uiaccess" };
+
+// Search
+const SettingsKey SEARCH_FOR_USERS_KEY       = { "search_for_users" };
+const SettingsKey SEARCH_FOR_CHANNELS_KEY    = { "search_for_channels" };
+const SettingsKey SEARCH_CASE_SENSITIVE_KEY  = { "case_sensitive" };
+const SettingsKey SEARCH_REGEX_KEY           = { "regex" };
+const SettingsKey DISPLAY_SEARCH_OPTIONS_KEY = { "display_search_options" };
+const SettingsKey SEARCH_USER_ACTION_KEY     = { "user_action" };
+const SettingsKey SEARCH_CHANNEL_ACTION_KEY  = { "channel_action" };
+const SettingsKey SEARCH_WINDOW_POSITION_KEY = { "search_window_position" };
+
+// Overlay
+const SettingsKey OVERLAY_ENABLE_KEY                = { "enable_overlay" };
+const SettingsKey OVERLAY_STYLE_KEY                 = { "style" };
+const SettingsKey OVERLAY_SHOW_MODE_KEY             = { "show_mode" };
+const SettingsKey OVERLAY_ALWAYS_SELF_KEY           = { "always_self" };
+const SettingsKey OVERLAY_ACTIVE_TIME_KEY           = { "active_time" };
+const SettingsKey OVERLAY_SORT_MODE_KEY             = { "sort_mode" };
+const SettingsKey OVERLAY_X_POS_KEY                 = { "x_position" };
+const SettingsKey OVERLAY_Y_POS_KEY                 = { "y_position" };
+const SettingsKey OVERLAY_ZOOM_KEY                  = { "zoom" };
+const SettingsKey OVERLAY_COLUMNS_KEY               = { "columns" };
+const SettingsKey OVERLAY_USERNAME_COLORS_KEY       = { "username_colors" };
+const SettingsKey OVERLAY_USERNAME_FONT_KEY         = { "username_font" };
+const SettingsKey OVERLAY_CHANNEL_COLOR_KEY         = { "channel_color" };
+const SettingsKey OVERLAY_CHANNEL_FONT_KEY          = { "channel_font" };
+const SettingsKey OVERLAY_FPS_COUNTER_COLOR_KEY     = { "fps_counter_color" };
+const SettingsKey OVERLAY_FPS_COUNTER_FONT_KEY      = { "fps_counter_font" };
+const SettingsKey OVERLAY_BOX_PAD_KEY               = { "box_pad" };
+const SettingsKey OVERLAY_BOX_STROKE_WIDTH_KEY      = { "box_stroke_width" };
+const SettingsKey OVERLAY_BOX_COLOR_KEY             = { "box_color" };
+const SettingsKey OVERLAY_BOX_FILL_COLOR_KEY        = { "box_fill_color" };
+const SettingsKey OVERLAY_SHOW_USERNAME_KEY         = { "show_username" };
+const SettingsKey OVERLAY_SHOW_CHANNEL_KEY          = { "show_channel" };
+const SettingsKey OVERLAY_SHOW_MUTEDEAF_KEY         = { "show_mute_deaf" };
+const SettingsKey OVERLAY_SHOW_AVATAR_KEY           = { "show_avatar" };
+const SettingsKey OVERLAY_SHOW_BOX_KEY              = { "show_box" };
+const SettingsKey OVERLAY_SHOW_FPS_KEY              = { "show_fps_counter" };
+const SettingsKey OVERLAY_SHOW_TIME_KEY             = { "show_time" };
+const SettingsKey OVERLAY_USERNAME_OPACITY_KEY      = { "username_opacity" };
+const SettingsKey OVERLAY_CHANNEL_OPACITY_KEY       = { "channel_opacity" };
+const SettingsKey OVERLAY_MUTEDEAF_OPACITY_KEY      = { "mute_deaf_opacity" };
+const SettingsKey OVERLAY_AVATAR_OPACITY_KEY        = { "avatar_opacity" };
+const SettingsKey OVERLAY_USERS_OPACITIES_KEY       = { "user_opacities" };
+const SettingsKey OVERLAY_FPS_COUNTER_OPACITY_KEY   = { "fps_counter_opacity" };
+const SettingsKey OVERLAY_USERNAME_RECTANGLE_KEY    = { "username_rectangle" };
+const SettingsKey OVERLAY_CHANNEL_RECTANGLE_KEY     = { "channel_rectangle" };
+const SettingsKey OVERLAY_MUTEDEAF_RECTANGLE_KEY    = { "mute_deaf_rectangle" };
+const SettingsKey OVERLAY_AVATAR_RECTANGLE_KEY      = { "avatar_rectangle" };
+const SettingsKey OVERLAY_FPS_COUNTER_RECTANGLE_KEY = { "fps_counter_rectangle" };
+const SettingsKey OVERLAY_TIME_RECTANGLE_KEY        = { "time_rectangle" };
+const SettingsKey OVERLAY_USERNAME_ALIGNMENT_KEY    = { "username_alignment" };
+const SettingsKey OVERLAY_CHANNEL_ALIGNMENT_KEY     = { "channel_alignment" };
+const SettingsKey OVERLAY_MUTEDEAF_ALIGNMENT_KEY    = { "mute_deaf_alignment" };
+const SettingsKey OVERLAY_AVATAR_ALIGNMENT_KEY      = { "avatar_alignment" };
+const SettingsKey OVERLAY_EXCLUSION_MODE_KEY        = { "exclusion_mode" };
+const SettingsKey OVERLAY_LAUNCHERS_KEY             = { "launchers" };
+const SettingsKey OVERLAY_LAUNCHERS_EXCLUDE_KEY     = { "launchers_exclude" };
+const SettingsKey OVERLAY_WHITELIST_KEY             = { "whitelist" };
+const SettingsKey OVERLAY_WHITELIST_EXCLUDE_KEY     = { "whitelist_exclude" };
+const SettingsKey OVERLAY_PATHS_KEY                 = { "paths" };
+const SettingsKey OVERLAY_PATHS_EXCLUDE_KEY         = { "paths_exclude" };
+const SettingsKey OVERLAY_BLACKLIST_KEY             = { "blacklist" };
+const SettingsKey OVERLAY_BLACKLIST_EXCLUDE_KEY     = { "blacklist_exclude" };
+
+
+const SettingsKey SETTINGS_VERSION_KEY = { "settings_version" };
+const SettingsKey CERTIFICATE_KEY      = { "certificate" };
+
+}; // namespace SettingsKeys
+
+#endif // MUMBLE_MUMBLE_SETTINGSKEYS_H_

--- a/src/mumble/SettingsKeys.h
+++ b/src/mumble/SettingsKeys.h
@@ -335,8 +335,9 @@ const SettingsKey OVERLAY_BLACKLIST_KEY             = { "blacklist" };
 const SettingsKey OVERLAY_BLACKLIST_EXCLUDE_KEY     = { "blacklist_exclude" };
 
 
-const SettingsKey SETTINGS_VERSION_KEY = { "settings_version" };
-const SettingsKey CERTIFICATE_KEY      = { "certificate" };
+const SettingsKey SETTINGS_VERSION_KEY     = { "settings_version" };
+const SettingsKey CERTIFICATE_KEY          = { "certificate" };
+const SettingsKey MUMBLE_QUIT_NORMALLY_KEY = { "mumble_has_quit_normally" };
 
 }; // namespace SettingsKeys
 

--- a/src/mumble/SettingsMacros.h
+++ b/src/mumble/SettingsMacros.h
@@ -1,0 +1,392 @@
+// Copyright 2021 The Mumble Developers. All rights reserved.
+// Use of this source code is governed by a BSD-style license
+// that can be found in the LICENSE file at the root of the
+// Mumble source tree or at <https://www.mumble.info/LICENSE>.
+
+
+#ifndef MUMBLE_MUMBLE_SETTINGS_MACROS_H_
+#define MUMBLE_MUMBLE_SETTINGS_MACROS_H_
+
+#include "SettingsKeys.h"
+
+// Mappings between SettingsKey objects and the corresponding fields in the Settings struct
+
+#define MISC_SETTINGS                                                               \
+	PROCESS(misc, DATABASE_LOCATION_KEY, qsDatabaseLocation)                        \
+	PROCESS(misc, IMAGE_DIRECTORY_KEY, qsImagePath)                                 \
+	PROCESS(misc, AUDIO_WIZARD_SHOWN_KEY, audioWizardShown)                         \
+	PROCESS(misc, SERVER_PING_CONSENT_MESSAGE_VIEWED_KEY, bPingServersDialogViewed) \
+	PROCESS(misc, CRASH_EMAIL_ADDRESS_KEY, crashReportEmail)
+
+#define AUDIO_SETTINGS                                                                      \
+	PROCESS(audio, MUTE_KEY, bMute)                                                         \
+	PROCESS(audio, DEAF_KEY, bDeaf)                                                         \
+	PROCESS(audio, TRANSMIT_MODE_KEY, atTransmit)                                           \
+	PROCESS(audio, DOUBLE_PUSH_DELAY_KEY, uiDoublePush)                                     \
+	PROCESS(audio, PTT_HOLD_KEY, pttHold)                                                   \
+	PROCESS(audio, PLAY_TRANSMIT_CUE_KEY, bTxAudioCue)                                      \
+	PROCESS(audio, TRANSMIT_CUE_START_KEY, qsTxAudioCueOn)                                  \
+	PROCESS(audio, TRANSMIT_CUE_STOP_KEY, qsTxAudioCueOff)                                  \
+	PROCESS(audio, PLAY_MUTE_CUE_KEY, bTxMuteCue)                                           \
+	PROCESS(audio, MUTE_CUE_KEY, qsTxMuteCue)                                               \
+	PROCESS(audio, AUDIO_QUALITY_KEY, iQuality)                                             \
+	PROCESS(audio, LOUDNESS_KEY, iMinLoudness)                                              \
+	PROCESS(audio, VOLUME_KEY, fVolume)                                                     \
+	PROCESS(audio, EXTERNAL_APPLICATIONS_VOLUME_KEY, fOtherVolume)                          \
+	PROCESS(audio, ATTENUATE_EXTERNAL_APPLICATIONS_KEY, bAttenuateOthers)                   \
+	PROCESS(audio, ATTENUATE_EXTERNAL_APPLICATIONS_ON_TALK_KEY, bAttenuateOthersOnTalk)     \
+	PROCESS(audio, ATTENUATE_USERS_ON_PRIORITY_SPEAKER_KEY, bAttenuateUsersOnPrioritySpeak) \
+	PROCESS(audio, ATTENUATE_ONLY_SAME_OUTPUT_KEY, bOnlyAttenuateSameOutput)                \
+	PROCESS(audio, ATTENUATE_LOOPBACK_KEY, bAttenuateLoopbacks)                             \
+	PROCESS(audio, VAD_MODE_KEY, vsVAD)                                                     \
+	PROCESS(audio, VAD_MIN_KEY, fVADmin)                                                    \
+	PROCESS(audio, VAD_MAX_KEY, fVADmax)                                                    \
+	PROCESS(audio, NOISE_CANCEL_MODE_KEY, noiseCancelMode)                                  \
+	PROCESS(audio, SPEEX_NOISE_CANCEL_STRENGTH_KEY, iSpeexNoiseCancelStrength)              \
+	PROCESS(audio, INPUT_CHANNEL_MASK_KEY, uiAudioInputChannelMask)                         \
+	PROCESS(audio, ALLOW_LOW_DELAY_MODE_KEY, bAllowLowDelay)                                \
+	PROCESS(audio, VOICE_HOLD_KEY, iVoiceHold)                                              \
+	PROCESS(audio, OUTPUT_DELAY_KEY, iOutputDelay)                                          \
+	PROCESS(audio, ECHO_CANCEL_MODE_KEY, echoOption)                                        \
+	PROCESS(audio, EXCLUSIVE_INPUT_KEY, bExclusiveInput)                                    \
+	PROCESS(audio, EXCLUSIVE_OUTPUT_KEY, bExclusiveOutput)                                  \
+	PROCESS(audio, INPUT_SYSTEM_KEY, qsAudioInput)                                          \
+	PROCESS(audio, OUTPUT_SYSTEM_KEY, qsAudioOutput)                                        \
+	PROCESS(audio, RESTRICT_WHISPERS_TO_FRIENDS_KEY, bWhisperFriends)                       \
+	PROCESS(audio, NOTIFICATION_USER_LIMIT_KEY, iMessageLimitUserThreshold)
+
+
+#define IDLE_SETTINGS                             \
+	PROCESS(idle, IDLE_TIME_KEY, iIdleTime)       \
+	PROCESS(idle, IDLE_ACTION_KEY, iaeIdleAction) \
+	PROCESS(idle, UNDO_IDLE_ACTION_UPON_ACTIVITY, bUndoIdleActionUponActivity)
+
+
+#define POSITIONAL_AUDIO_SETTINGS                                                  \
+	PROCESS(positional_audio, ENABLE_POSITIONAL_AUDIO_KEY, bPositionalAudio)       \
+	PROCESS(positional_audio, POSITIONAL_MIN_DISTANCE_KEY, fAudioMinDistance)      \
+	PROCESS(positional_audio, POSITIONAL_MAX_DISTANCE_KEY, fAudioMaxDistance)      \
+	PROCESS(positional_audio, POSITIONAL_MIN_VOLUME_KEY, fAudioMaxDistVolume)      \
+	PROCESS(positional_audio, POSITIONAL_BLOOM_KEY, fAudioBloom)                   \
+	PROCESS(positional_audio, POSITIONAL_HEADPHONE_MODE_KEY, bPositionalHeadphone) \
+	PROCESS(positional_audio, POSITIONAL_TRANSMIT_POSITION_KEY, bTransmitPosition)
+
+
+#define NETWORK_SETTINGS                                                     \
+	PROCESS(network, JITTER_BUFFER_SIZE_KEY, iJitterBufferSize)              \
+	PROCESS(network, FRAMES_PER_PACKET_KEY, iFramesPerPacket)                \
+	PROCESS(network, RESTRICT_TO_TCP_KEY, bTCPCompat)                        \
+	PROCESS(network, USE_QUALITY_OF_SERVICE_KEY, bQoS)                       \
+	PROCESS(network, AUTO_RECONNECT_KEY, bReconnect)                         \
+	PROCESS(network, AUTO_CONNECT_LAST_SERVER_KEY, bAutoConnect)             \
+	PROCESS(network, PROXY_TYPE_KEY, ptProxyType)                            \
+	PROCESS(network, PROXY_HOST_KEY, qsProxyHost)                            \
+	PROCESS(network, PROXY_PORT_KEY, usProxyPort)                            \
+	PROCESS(network, PROXY_USERNAME_KEY, qsProxyUsername)                    \
+	PROCESS(network, PROXY_PASSWORD_KEY, qsProxyPassword)                    \
+	PROCESS(network, MAX_IMAGE_WIDTH_KEY, iMaxImageWidth)                    \
+	PROCESS(network, MAX_IMAGE_HEIGHT_KEY, iMaxImageHeight)                  \
+	PROCESS(network, SERVICE_PREFIX_KEY, qsServicePrefix)                    \
+	PROCESS(network, MAX_IN_FLIGHT_TCP_PINGS_KEY, iMaxInFlightTCPPings)      \
+	PROCESS(network, PING_INTERVAL_KEY, iPingIntervalMsec)                   \
+	PROCESS(network, CONNECTION_TIMEOUT_KEY, iConnectionTimeoutDurationMsec) \
+	PROCESS(network, FORCE_UDP_BIND_TO_TCP_ADDRESS_KEY, bUdpForceTcpAddr)    \
+	PROCESS(network, SSL_CIPHERS_KEY, qsSslCiphers)
+
+
+#define AUDIO_BACKEND_SETTINGS                                        \
+	PROCESS(audio_backend, ASIO_ENABLE_KEY, bASIOEnable)              \
+	PROCESS(audio_backend, ASIO_CLASS_KEY, qsASIOclass)               \
+	PROCESS(audio_backend, ASIO_MICROPHONE_KEY, qlASIOmic)            \
+	PROCESS(audio_backend, ASIO_SPEAKER_KEY, qlASIOspeaker)           \
+	PROCESS(audio_backend, WASAPI_INPUT_KEY, qsWASAPIInput)           \
+	PROCESS(audio_backend, WASAPI_OUTPUT_KEY, qsWASAPIOutput)         \
+	PROCESS(audio_backend, WASAPI_ROLE_KEY, qsWASAPIRole)             \
+	PROCESS(audio_backend, ALSA_INPUT_KEY, qsALSAInput)               \
+	PROCESS(audio_backend, ALSA_OUTPUT_KEY, qsALSAOutput)             \
+	PROCESS(audio_backend, PIPEWIRE_INPUT_KEY, pipeWireInput)         \
+	PROCESS(audio_backend, PIPEWIRE_OUTPUT_KEY, pipeWireOutput)       \
+	PROCESS(audio_backend, PULSEAUDIO_INPUT_KEY, qsPulseAudioInput)   \
+	PROCESS(audio_backend, PULSEAUDIO_OUTPUT_KEY, qsPulseAudioOutput) \
+	PROCESS(audio_backend, JACK_OUTPUT_KEY, qsJackAudioOutput)        \
+	PROCESS(audio_backend, JACK_START_SERVER_KEY, bJackStartServer)   \
+	PROCESS(audio_backend, JACK_AUTOCONNECT_KEY, bJackAutoConnect)    \
+	PROCESS(audio_backend, JACK_CLIENT_NAME_KEY, qsJackClientName)    \
+	PROCESS(audio_backend, OSS_INPUT_KEY, qsOSSInput)                 \
+	PROCESS(audio_backend, OSS_OUTPUT_KEY, qsOSSOutput)               \
+	PROCESS(audio_backend, COREAUDIO_INPUT_KEY, qsCoreAudioInput)     \
+	PROCESS(audio_backend, COREAUDIO_OUTPUT_KEY, qsCoreAudioOutput)   \
+	PROCESS(audio_backend, PORTAUDIO_INPUT_KEY, iPortAudioInput)      \
+	PROCESS(audio_backend, PORTAUDIO_OUTPUT_KEY, iPortAudioOutput)
+
+
+#define TTS_SETTINGS                                    \
+	PROCESS(tts, TTS_ENABLE_KEY, bTTS)                  \
+	PROCESS(tts, TTS_VOLUME_KEY, iTTSVolume)            \
+	PROCESS(tts, TTS_THRESHOLD_KEY, iTTSThreshold)      \
+	PROCESS(tts, TTS_READBACK_KEY, bTTSMessageReadBack) \
+	PROCESS(tts, TTS_IGNORE_SCOPE_KEY, bTTSNoScope)     \
+	PROCESS(tts, TTS_IGNORE_AUTHOR_KEY, bTTSNoAuthor)   \
+	PROCESS(tts, TTS_LANGAGE_KEY, qsTTSLanguage)
+
+
+#define PRIVACY_SETTINGS PROCESS(privacy, HIDE_OS_FROM_SERVER_KEY, bHideOS)
+
+
+#define UI_SETTINGS                                                              \
+	PROCESS(ui, LANGUAGE_KEY, qsLanguage)                                        \
+	PROCESS(ui, THEME_KEY, themeName)                                            \
+	PROCESS(ui, THEME_STYLE_KEY, themeStyleName)                                 \
+	PROCESS(ui, CHANNEL_EXPANSION_MODE_KEY, ceExpand)                            \
+	PROCESS(ui, CHANNEL_DRAG_MODE_KEY, ceChannelDrag)                            \
+	PROCESS(ui, USER_DRAG_MODE_KEY, ceUserDrag)                                  \
+	PROCESS(ui, ALWAYS_ON_TOP_KEY, aotbAlwaysOnTop)                              \
+	PROCESS(ui, ASK_ON_QUIT_KEY, bAskOnQuit)                                     \
+	PROCESS(ui, SHOW_DEVELOPER_MENU_KEY, bEnableDeveloperMenu)                   \
+	PROCESS(ui, LOCK_LAYOUT_KEY, bLockLayout)                                    \
+	PROCESS(ui, MINIMAL_VIEW_KEY, bMinimalView)                                  \
+	PROCESS(ui, HIDE_FRAME_KEY, bHideFrame)                                      \
+	PROCESS(ui, DISPLAY_USERS_BEFORE_CHANNELS, bUserTop)                         \
+	PROCESS(ui, WINDOW_GEOMETRY_KEY, qbaMainWindowGeometry)                      \
+	PROCESS(ui, WINDOW_GEOMETRY_MINIMAL_VIEW_KEY, qbaMinimalViewGeometry)        \
+	PROCESS(ui, WINDOW_STATE_KEY, qbaMainWindowState)                            \
+	PROCESS(ui, WINDOW_STATE_MINIMAL_VIEW_KEY, qbaMinimalViewState)              \
+	PROCESS(ui, CONFIG_GEOMETRY_KEY, qbaConfigGeometry)                          \
+	PROCESS(ui, WINDOW_LAYOUT_KEY, wlWindowLayout)                               \
+	PROCESS(ui, OVERLAY_HEADER_STATE, qbaHeaderState)                            \
+	PROCESS(ui, SERVER_FILTER_MODE_KEY, ssFilter)                                \
+	PROCESS(ui, HIDE_IN_TRAY_KEY, bHideInTray)                                   \
+	PROCESS(ui, DISPLAY_TALKING_STATE_IN_TRAY_KEY, bStateInTray)                 \
+	PROCESS(ui, SEND_USAGE_STATISTICS_KEY, bUsage)                               \
+	PROCESS(ui, DISPLAY_USER_COUNT_KEY, bShowUserCount)                          \
+	PROCESS(ui, DISPLAY_VOLUME_ADJUSTMENTS_KEY, bShowVolumeAdjustments)          \
+	PROCESS(ui, DISPLAY_NICKNAMES_ONLY_KEY, bShowNicknamesOnly)                  \
+	PROCESS(ui, SELECTED_ITEM_AS_CHATBAR_TARGET_KEY, bChatBarUseSelection)       \
+	PROCESS(ui, FILTER_HIDES_EMPTY_CHANNEL_KEY, bFilterHidesEmptyChannels)       \
+	PROCESS(ui, FILTER_ACTIVE_KEY, bFilterActive)                                \
+	PROCESS(ui, CONTEXT_MENU_ENTRIES_IN_MENU_BAR_KEY, bShowContextMenuInMenuBar) \
+	PROCESS(ui, CONNECT_DIALOG_GEOMETRY_KEY, qbaConnectDialogGeometry)           \
+	PROCESS(ui, CONNECT_DIALOG_HEADER_STATE_KEY, qbaConnectDialogHeader)         \
+	PROCESS(ui, DISPLAY_TRANSMIT_MODE_COMBOBOX_KEY, bShowTransmitModeComboBox)   \
+	PROCESS(ui, HIGH_CONTRAST_MODE_KEY, bHighContrast)                           \
+	PROCESS(ui, MAX_LOG_LENGTH_KEY, iMaxLogBlocks)                               \
+	PROCESS(ui, USE_24H_CLOCK_KEY, bLog24HourClock)                              \
+	PROCESS(ui, LOG_MESSAGE_MARGINS_KEY, iChatMessageMargins)                    \
+	PROCESS(ui, DISABLE_PUBLIC_SERVER_LIST_KEY, bDisablePublicList)
+
+
+#define UPDATE_SETTINGS                                         \
+	PROCESS(update, CHECK_FOR_UPDATES_KEY, bUpdateCheck)        \
+	PROCESS(update, CHECK_FOR_PLUGIN_UPDATES_KEY, bPluginCheck) \
+	PROCESS(update, AUTO_UPDATE_PLUGINS_KEY, bPluginAutoUpdate)
+
+
+#define LAST_CONNECTION_SETTINGS                            \
+	PROCESS(last_connection, LAST_USERNAME_KEY, qsUsername) \
+	PROCESS(last_connection, LAST_SERVER_NAME_KEY, qsLastServer)
+
+
+#define TALKINGUI_SETTINGS                                                                            \
+	PROCESS(talkingui, TALKINGUI_POSITION_KEY, qpTalkingUI_Position)                                  \
+	PROCESS(talkingui, SHOW_TALKINGUI_KEY, bShowTalkingUI)                                            \
+	PROCESS(talkingui, TALKINGUI_LOCAL_USER_STAYS_VISIBLE_KEY, bTalkingUI_LocalUserStaysVisible)      \
+	PROCESS(talkingui, TALKINGUI_ABBREVIATE_CHANNEL_NAMES_KEY, bTalkingUI_AbbreviateChannelNames)     \
+	PROCESS(talkingui, TALKINGUI_ABBREVIATE_CURRENT_CHANNEL_KEY, bTalkingUI_AbbreviateCurrentChannel) \
+	PROCESS(talkingui, TALKINGUI_DISPLAY_LOCAL_LISTENERS_KEY, bTalkingUI_ShowLocalListeners)          \
+	PROCESS(talkingui, TALKINGUI_RELATIVE_FONT_SIZE_KEY, iTalkingUI_RelativeFontSize)                 \
+	PROCESS(talkingui, TALKINGUI_SILENT_USER_LIFETIME_KEY, iTalkingUI_SilentUserLifeTime)             \
+	PROCESS(talkingui, TALKINGUI_CHANNEL_HIERARCHY_DEPTH_KEY, iTalkingUI_ChannelHierarchyDepth)       \
+	PROCESS(talkingui, TALKINGUI_MAX_CHANNEL_NAME_LENGTH_KEY, iTalkingUI_MaxChannelNameLength)        \
+	PROCESS(talkingui, TALKINGUI_NAME_PREFIX_COUNT_KEY, iTalkingUI_PrefixCharCount)                   \
+	PROCESS(talkingui, TALKINGUI_NAME_POSTFIX_COUNT_KEY, iTalkingUI_PostfixCharCount)                 \
+	PROCESS(talkingui, TALKINGUI_ABBREVIATION_REPLACEMENT_KEY, qsTalkingUI_AbbreviationReplacement)
+
+
+#define CHANNEL_HIERARCHY_SETTINGS PROCESS(channel_hierarchy, CHANNEL_NAME_SEPARATOR_KEY, qsHierarchyChannelSeparator)
+
+
+#define MANUAL_PLUGIN_SETTINGS \
+	PROCESS(manual_plugin, MANUALPLUGIN_SILENT_USER_LIFETIME_KEY, manualPlugin_silentUserDisplaytime)
+
+
+#define PTT_WINDOW_SETTINGS                                          \
+	PROCESS(ptt_window, DISPLAY_PTTWINDOW_KEY, bShowPTTButtonWindow) \
+	PROCESS(ptt_window, PTTWINDOW_GEOMETRY_KEY, qbaPTTButtonWindowGeometry)
+
+
+#define RECORDING_SETTINGS                                  \
+	PROCESS(recording, RECORDING_PATH_KEY, qsRecordingPath) \
+	PROCESS(recording, RECORDING_FILE_KEY, qsRecordingFile) \
+	PROCESS(recording, RECORDING_MODE_KEY, rmRecordingMode) \
+	PROCESS(recording, RECORDING_FORMAT_KEY, iRecordingFormat)
+
+
+#define HIDDEN_SETTINGS                             \
+	PROCESS(hidden, DISABLE_CELT_KEY, bDisableCELT) \
+	PROCESS(hidden, DISABLE_CONNECT_DIALOG_EDITING_KEY, disableConnectDialogEditing)
+
+
+#define WIN_OVERLAY_SETTINGS                                                            \
+	PROCESS(win_overlay, OVERLAY_WIN_HELPER_ENABLE_x86_KEY, bOverlayWinHelperX86Enable) \
+	PROCESS(win_overlay, OVERLAY_WIN_HELPER_ENABLE_x64_KEY, bOverlayWinHelperX64Enable) \
+	PROCESS(win_overlay, OVERLAY_WIN_HELPER_RESTART_COOLDOWN_TIME_KEY, iOverlayWinHelperRestartCooldownMsec)
+
+
+#define LCD_SETTINGS                                                         \
+	PROCESS(lcd, LCD_USERVIEW_MIN_COLUMN_WIDTH_KEY, iLCDUserViewMinColWidth) \
+	PROCESS(lcd, LCD_USERVIEW_SPLITTER_WIDTH_KEY, iLCDUserViewSplitterWidth)
+
+
+#define SHORTCUTS_SETTINGS                                                                    \
+	PROCESS(shortcuts, ENABLE_GLOBAL_SHORTCUTS_KEY, bShortcutEnable)                          \
+	PROCESS(shortcuts, SUPPRESS_MACOS_EVENT_TAPPING_WARNING_KEY, bSuppressMacEventTapWarning) \
+	PROCESS(shortcuts, ENABLE_EVDEV_KEY, bEnableEvdev)                                        \
+	PROCESS(shortcuts, ENABLE_XINPUT2_KEY, bEnableXInput2)                                    \
+	PROCESS(shortcuts, ENABLE_GKEY_KEY, bEnableGKey)                                          \
+	PROCESS(shortcuts, ENABLE_XBOX_WIN_KEY, bEnableXboxInput)                                 \
+	PROCESS(shortcuts, WIN_UIACCESS_KEY, bEnableUIAccess)
+
+
+#define SEARCH_SETTINGS                                             \
+	PROCESS(search, SEARCH_FOR_USERS_KEY, searchForUsers)           \
+	PROCESS(search, SEARCH_FOR_CHANNELS_KEY, searchForChannels)     \
+	PROCESS(search, SEARCH_CASE_SENSITIVE_KEY, searchCaseSensitive) \
+	PROCESS(search, SEARCH_REGEX_KEY, searchAsRegex)                \
+	PROCESS(search, DISPLAY_SEARCH_OPTIONS_KEY, searchOptionsShown) \
+	PROCESS(search, SEARCH_USER_ACTION_KEY, searchUserAction)       \
+	PROCESS(search, SEARCH_CHANNEL_ACTION_KEY, searchChannelAction) \
+	PROCESS(search, SEARCH_WINDOW_POSITION_KEY, searchDialogPosition)
+
+
+#define OVERLAY_SETTINGS                                                 \
+	PROCESS(overlay, OVERLAY_ENABLE_KEY, bEnable)                        \
+	PROCESS(overlay, OVERLAY_STYLE_KEY, qsStyle)                         \
+	PROCESS(overlay, OVERLAY_SHOW_MODE_KEY, osShow)                      \
+	PROCESS(overlay, OVERLAY_ALWAYS_SELF_KEY, bAlwaysSelf)               \
+	PROCESS(overlay, OVERLAY_ACTIVE_TIME_KEY, uiActiveTime)              \
+	PROCESS(overlay, OVERLAY_SORT_MODE_KEY, osSort)                      \
+	PROCESS(overlay, OVERLAY_X_POS_KEY, fX)                              \
+	PROCESS(overlay, OVERLAY_Y_POS_KEY, fY)                              \
+	PROCESS(overlay, OVERLAY_ZOOM_KEY, fZoom)                            \
+	PROCESS(overlay, OVERLAY_COLUMNS_KEY, uiColumns)                     \
+	PROCESS(overlay, OVERLAY_USERNAME_COLORS_KEY, qcUserName)            \
+	PROCESS(overlay, OVERLAY_USERNAME_FONT_KEY, qfUserName)              \
+	PROCESS(overlay, OVERLAY_CHANNEL_COLOR_KEY, qcChannel)               \
+	PROCESS(overlay, OVERLAY_CHANNEL_FONT_KEY, qfChannel)                \
+	PROCESS(overlay, OVERLAY_FPS_COUNTER_COLOR_KEY, qcFps)               \
+	PROCESS(overlay, OVERLAY_FPS_COUNTER_FONT_KEY, qfFps)                \
+	PROCESS(overlay, OVERLAY_BOX_PAD_KEY, fBoxPad)                       \
+	PROCESS(overlay, OVERLAY_BOX_STROKE_WIDTH_KEY, fBoxPenWidth)         \
+	PROCESS(overlay, OVERLAY_BOX_COLOR_KEY, qcBoxPen)                    \
+	PROCESS(overlay, OVERLAY_BOX_FILL_COLOR_KEY, qcBoxFill)              \
+	PROCESS(overlay, OVERLAY_SHOW_USERNAME_KEY, bUserName)               \
+	PROCESS(overlay, OVERLAY_SHOW_CHANNEL_KEY, bChannel)                 \
+	PROCESS(overlay, OVERLAY_SHOW_MUTEDEAF_KEY, bMutedDeafened)          \
+	PROCESS(overlay, OVERLAY_SHOW_AVATAR_KEY, bAvatar)                   \
+	PROCESS(overlay, OVERLAY_SHOW_BOX_KEY, bBox)                         \
+	PROCESS(overlay, OVERLAY_SHOW_FPS_KEY, bFps)                         \
+	PROCESS(overlay, OVERLAY_SHOW_TIME_KEY, bTime)                       \
+	PROCESS(overlay, OVERLAY_USERNAME_OPACITY_KEY, fUserName)            \
+	PROCESS(overlay, OVERLAY_CHANNEL_OPACITY_KEY, fChannel)              \
+	PROCESS(overlay, OVERLAY_MUTEDEAF_OPACITY_KEY, fMutedDeafened)       \
+	PROCESS(overlay, OVERLAY_AVATAR_OPACITY_KEY, fAvatar)                \
+	PROCESS(overlay, OVERLAY_USERS_OPACITIES_KEY, fUser)                 \
+	PROCESS(overlay, OVERLAY_FPS_COUNTER_OPACITY_KEY, fFps)              \
+	PROCESS(overlay, OVERLAY_USERNAME_RECTANGLE_KEY, qrfUserName)        \
+	PROCESS(overlay, OVERLAY_CHANNEL_RECTANGLE_KEY, qrfChannel)          \
+	PROCESS(overlay, OVERLAY_MUTEDEAF_RECTANGLE_KEY, qrfMutedDeafened)   \
+	PROCESS(overlay, OVERLAY_AVATAR_RECTANGLE_KEY, qrfAvatar)            \
+	PROCESS(overlay, OVERLAY_FPS_COUNTER_RECTANGLE_KEY, qrfFps)          \
+	PROCESS(overlay, OVERLAY_TIME_RECTANGLE_KEY, qrfTime)                \
+	PROCESS(overlay, OVERLAY_USERNAME_ALIGNMENT_KEY, qaUserName)         \
+	PROCESS(overlay, OVERLAY_CHANNEL_ALIGNMENT_KEY, qaChannel)           \
+	PROCESS(overlay, OVERLAY_MUTEDEAF_ALIGNMENT_KEY, qaMutedDeafened)    \
+	PROCESS(overlay, OVERLAY_AVATAR_ALIGNMENT_KEY, qaAvatar)             \
+	PROCESS(overlay, OVERLAY_EXCLUSION_MODE_KEY, oemOverlayExcludeMode)  \
+	PROCESS(overlay, OVERLAY_LAUNCHERS_KEY, qslLaunchers)                \
+	PROCESS(overlay, OVERLAY_LAUNCHERS_EXCLUDE_KEY, qslLaunchersExclude) \
+	PROCESS(overlay, OVERLAY_WHITELIST_KEY, qslWhitelist)                \
+	PROCESS(overlay, OVERLAY_WHITELIST_EXCLUDE_KEY, qslWhitelistExclude) \
+	PROCESS(overlay, OVERLAY_PATHS_KEY, qslPaths)                        \
+	PROCESS(overlay, OVERLAY_PATHS_EXCLUDE_KEY, qslPathsExclude)         \
+	PROCESS(overlay, OVERLAY_BLACKLIST_KEY, qslBlacklist)                \
+	PROCESS(overlay, OVERLAY_BLACKLIST_EXCLUDE_KEY, qslBlacklistExclude)
+
+
+#define PROCESS_ALL_SETTINGS   \
+	MISC_SETTINGS              \
+	AUDIO_SETTINGS             \
+	IDLE_SETTINGS              \
+	POSITIONAL_AUDIO_SETTINGS  \
+	NETWORK_SETTINGS           \
+	AUDIO_BACKEND_SETTINGS     \
+	TTS_SETTINGS               \
+	PRIVACY_SETTINGS           \
+	UI_SETTINGS                \
+	UPDATE_SETTINGS            \
+	LAST_CONNECTION_SETTINGS   \
+	TALKINGUI_SETTINGS         \
+	CHANNEL_HIERARCHY_SETTINGS \
+	MANUAL_PLUGIN_SETTINGS     \
+	PTT_WINDOW_SETTINGS        \
+	RECORDING_SETTINGS         \
+	HIDDEN_SETTINGS            \
+	WIN_OVERLAY_SETTINGS       \
+	LCD_SETTINGS               \
+	SHORTCUTS_SETTINGS         \
+	SEARCH_SETTINGS
+
+
+#define PROCESS_ALL_OVERLAY_SETTINGS OVERLAY_SETTINGS
+
+
+#define PROCESS_ALL_SETTINGS_WITH_INTERMEDIATE_OPERATION \
+	MISC_SETTINGS                                        \
+	INTERMEDIATE_OPERATION                               \
+	AUDIO_SETTINGS                                       \
+	INTERMEDIATE_OPERATION                               \
+	IDLE_SETTINGS                                        \
+	INTERMEDIATE_OPERATION                               \
+	POSITIONAL_AUDIO_SETTINGS                            \
+	INTERMEDIATE_OPERATION                               \
+	NETWORK_SETTINGS                                     \
+	INTERMEDIATE_OPERATION                               \
+	AUDIO_BACKEND_SETTINGS                               \
+	INTERMEDIATE_OPERATION                               \
+	TTS_SETTINGS                                         \
+	INTERMEDIATE_OPERATION                               \
+	PRIVACY_SETTINGS                                     \
+	INTERMEDIATE_OPERATION                               \
+	UI_SETTINGS                                          \
+	INTERMEDIATE_OPERATION                               \
+	UPDATE_SETTINGS                                      \
+	INTERMEDIATE_OPERATION                               \
+	LAST_CONNECTION_SETTINGS                             \
+	INTERMEDIATE_OPERATION                               \
+	TALKINGUI_SETTINGS                                   \
+	INTERMEDIATE_OPERATION                               \
+	CHANNEL_HIERARCHY_SETTINGS                           \
+	INTERMEDIATE_OPERATION                               \
+	MANUAL_PLUGIN_SETTINGS                               \
+	INTERMEDIATE_OPERATION                               \
+	PTT_WINDOW_SETTINGS                                  \
+	INTERMEDIATE_OPERATION                               \
+	RECORDING_SETTINGS                                   \
+	INTERMEDIATE_OPERATION                               \
+	HIDDEN_SETTINGS                                      \
+	INTERMEDIATE_OPERATION                               \
+	WIN_OVERLAY_SETTINGS                                 \
+	INTERMEDIATE_OPERATION                               \
+	LCD_SETTINGS                                         \
+	INTERMEDIATE_OPERATION                               \
+	SHORTCUTS_SETTINGS                                   \
+	INTERMEDIATE_OPERATION                               \
+	SEARCH_SETTINGS                                      \
+	INTERMEDIATE_OPERATION
+
+#define PROCESS_ALL_OVERLAY_SETTINGS_WITH_INTERMEDIATE_OPERATION \
+	OVERLAY_SETTINGS                                             \
+	INTERMEDIATE_OPERATION
+
+
+#endif // MUMBLE_MUMBLE_SETTINGS_MACROS_H_

--- a/src/mumble/Usage.cpp
+++ b/src/mumble/Usage.cpp
@@ -30,8 +30,8 @@ Usage::Usage(QObject *p) : QObject(p) {
 
 void Usage::registerUsage() {
 	if (!Global::get().s.bUsage
-		|| Global::get().s.uiUpdateCounter
-			   == 0) // Only register usage if allowed by the user and first wizard run has finished
+		|| Version::getRaw() < Version::getRaw(
+			   "1.2.3")) // Only register usage if allowed by the user and first wizard run has finished
 		return;
 
 	QDomDocument doc;

--- a/src/mumble/main.cpp
+++ b/src/mumble/main.cpp
@@ -776,6 +776,8 @@ int main(int argc, char **argv) {
 	if (!Global::get().bQuit)
 		res = a.exec();
 
+	// Indicate that this was a regular shutdown
+	Global::get().s.mumbleQuitNormally = true;
 	Global::get().s.save();
 
 	url.clear();

--- a/src/mumble/main.cpp
+++ b/src/mumble/main.cpp
@@ -169,6 +169,7 @@ int main(int argc, char **argv) {
 
 	// This argument has to be parsed first, since it's value is needed to create the global struct,
 	// which other switches are modifying. If it is parsed first, the order of the arguments does not matter.
+	QString settingsFile;
 	QStringList args = a.arguments();
 	const int index  = std::max(args.lastIndexOf(QLatin1String("-c")), args.lastIndexOf(QLatin1String("--config")));
 	if (index >= 0) {
@@ -176,6 +177,7 @@ int main(int argc, char **argv) {
 			QFile inifile(args.at(index + 1));
 			if (inifile.exists() && inifile.permissions().testFlag(QFile::WriteUser)) {
 				Global::g_global_struct = new Global(args.at(index + 1));
+				settingsFile            = args.at(index + 1);
 			} else {
 				printf("%s", qPrintable(MainWindow::tr("Configuration file %1 does not exist or is not writable.\n")
 											.arg(args.at(index + 1))));
@@ -541,7 +543,11 @@ int main(int argc, char **argv) {
 #endif
 
 	// Load preferences
-	Global::get().s.load();
+	if (settingsFile.isEmpty()) {
+		Global::get().s.load();
+	} else {
+		Global::get().s.load(settingsFile);
+	}
 
 	// Check whether we need to enable accessibility features
 #ifdef Q_OS_WIN
@@ -699,46 +705,11 @@ int main(int argc, char **argv) {
 
 	a.setQuitOnLastWindowClosed(false);
 
-	// Configuration updates
-	bool runaudiowizard = false;
-	switch (Global::get().s.uiUpdateCounter) {
-		case 0:
-			// Previous version was an pre 1.2.3 release or this is the first run
-			runaudiowizard = true;
-			// Fallthrough
-		case 1:
-			// Previous versions used old idle action style, convert it
-			if (Global::get().s.iIdleTime == 5 * 60) { // New default
-				Global::get().s.iaeIdleAction = Settings::Nothing;
-			} else {
-				Global::get().s.iIdleTime     = 60 * qRound(Global::get().s.iIdleTime / 60.); // Round to minutes
-				Global::get().s.iaeIdleAction = Settings::Deafen;                             // Old behavior
-			}
-			// Fallthrough
-#ifdef Q_OS_WIN
-		case 2: {
-			QList< Shortcut > &shortcuts              = Global::get().s.qlShortcuts;
-			const QList< Shortcut > migratedShortcuts = GlobalShortcutWin::migrateSettings(shortcuts);
-			if (shortcuts.size() > migratedShortcuts.size()) {
-				const uint32_t num = shortcuts.size() - migratedShortcuts.size();
-				QMessageBox::warning(
-					nullptr, QObject::tr("Shortcuts migration incomplete"),
-					QObject::tr("Unfortunately %1 shortcut(s) could not be migrated.\nYou can register them again.")
-						.arg(num));
-			}
-
-			shortcuts = migratedShortcuts;
-		}
-#endif
-	}
-
-	if (runaudiowizard) {
+	if (!Global::get().s.audioWizardShown) {
 		AudioWizard *aw = new AudioWizard(Global::get().mw);
 		aw->exec();
 		delete aw;
 	}
-
-	Global::get().s.uiUpdateCounter = 3;
 
 	if (!CertWizard::validateCert(Global::get().s.kpCertificate)) {
 		QFile qf(qdCert.absoluteFilePath(QLatin1String("MumbleAutomaticCertificateBackup.p12")));

--- a/src/mumble/mumble_ar.ts
+++ b/src/mumble/mumble_ar.ts
@@ -4619,10 +4619,6 @@ The setting only applies for new messages, the already shown ones will retain th
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>File is not a configuration file.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Settings merged from file.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6319,6 +6315,10 @@ Valid options are:
         <source>Mumble - Minimal View</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Invalid settings file encountered.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>Manual</name>
@@ -7625,6 +7625,26 @@ See &lt;a href=&quot;https://wiki.mumble.info/wiki/Installing_Mumble&quot;&gt;th
     <message>
         <source>Unfortunately %1 shortcut(s) could not be migrated.
 You can register them again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Potentially broken settings</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Load backup settings?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>It seems that Mumble did not perform a normal shutdown. If you did not intentionally kill the application, this could mean that the used settings caused a crash. Do you want to load the setting&apos;s backup instead?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The backed-up settings also seem to have been saved without Mumble exiting normally (potentially indicating a crash).</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>If you experience repeated crashes with these settings, you might have to manually delete the settings files at &lt;pre&gt;%1&lt;/pre&gt; and &lt;pre&gt;%2&lt;/pre&gt; in order to reset all settings to their default value.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/mumble/mumble_bg.ts
+++ b/src/mumble/mumble_bg.ts
@@ -4616,10 +4616,6 @@ The setting only applies for new messages, the already shown ones will retain th
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>File is not a configuration file.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Settings merged from file.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6316,6 +6312,10 @@ Valid options are:
         <source>Mumble - Minimal View</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Invalid settings file encountered.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>Manual</name>
@@ -7622,6 +7622,26 @@ See &lt;a href=&quot;https://wiki.mumble.info/wiki/Installing_Mumble&quot;&gt;th
     <message>
         <source>Unfortunately %1 shortcut(s) could not be migrated.
 You can register them again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Potentially broken settings</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Load backup settings?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>It seems that Mumble did not perform a normal shutdown. If you did not intentionally kill the application, this could mean that the used settings caused a crash. Do you want to load the setting&apos;s backup instead?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The backed-up settings also seem to have been saved without Mumble exiting normally (potentially indicating a crash).</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>If you experience repeated crashes with these settings, you might have to manually delete the settings files at &lt;pre&gt;%1&lt;/pre&gt; and &lt;pre&gt;%2&lt;/pre&gt; in order to reset all settings to their default value.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/mumble/mumble_br.ts
+++ b/src/mumble/mumble_br.ts
@@ -4615,10 +4615,6 @@ The setting only applies for new messages, the already shown ones will retain th
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>File is not a configuration file.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Settings merged from file.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6315,6 +6311,10 @@ Valid options are:
         <source>Mumble - Minimal View</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Invalid settings file encountered.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>Manual</name>
@@ -7621,6 +7621,26 @@ See &lt;a href=&quot;https://wiki.mumble.info/wiki/Installing_Mumble&quot;&gt;th
     <message>
         <source>Unfortunately %1 shortcut(s) could not be migrated.
 You can register them again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Potentially broken settings</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Load backup settings?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>It seems that Mumble did not perform a normal shutdown. If you did not intentionally kill the application, this could mean that the used settings caused a crash. Do you want to load the setting&apos;s backup instead?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The backed-up settings also seem to have been saved without Mumble exiting normally (potentially indicating a crash).</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>If you experience repeated crashes with these settings, you might have to manually delete the settings files at &lt;pre&gt;%1&lt;/pre&gt; and &lt;pre&gt;%2&lt;/pre&gt; in order to reset all settings to their default value.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/mumble/mumble_ca.ts
+++ b/src/mumble/mumble_ca.ts
@@ -4621,10 +4621,6 @@ The setting only applies for new messages, the already shown ones will retain th
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>File is not a configuration file.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Settings merged from file.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6321,6 +6317,10 @@ Valid options are:
         <source>Mumble - Minimal View</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Invalid settings file encountered.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>Manual</name>
@@ -7627,6 +7627,26 @@ See &lt;a href=&quot;https://wiki.mumble.info/wiki/Installing_Mumble&quot;&gt;th
     <message>
         <source>Unfortunately %1 shortcut(s) could not be migrated.
 You can register them again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Potentially broken settings</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Load backup settings?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>It seems that Mumble did not perform a normal shutdown. If you did not intentionally kill the application, this could mean that the used settings caused a crash. Do you want to load the setting&apos;s backup instead?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The backed-up settings also seem to have been saved without Mumble exiting normally (potentially indicating a crash).</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>If you experience repeated crashes with these settings, you might have to manually delete the settings files at &lt;pre&gt;%1&lt;/pre&gt; and &lt;pre&gt;%2&lt;/pre&gt; in order to reset all settings to their default value.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/mumble/mumble_cs.ts
+++ b/src/mumble/mumble_cs.ts
@@ -4670,10 +4670,6 @@ The setting only applies for new messages, the already shown ones will retain th
         <translation>Soubor neexistuje</translation>
     </message>
     <message>
-        <source>File is not a configuration file.</source>
-        <translation>Soubor není soubor nastavení.</translation>
-    </message>
-    <message>
         <source>Settings merged from file.</source>
         <translation>Nastavení sloučena ze souboru.</translation>
     </message>
@@ -6375,6 +6371,10 @@ Valid options are:
         <source>Mumble - Minimal View</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Invalid settings file encountered.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>Manual</name>
@@ -7685,6 +7685,26 @@ See &lt;a href=&quot;https://wiki.mumble.info/wiki/Installing_Mumble&quot;&gt;th
     <message>
         <source>Unfortunately %1 shortcut(s) could not be migrated.
 You can register them again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Potentially broken settings</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Load backup settings?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>It seems that Mumble did not perform a normal shutdown. If you did not intentionally kill the application, this could mean that the used settings caused a crash. Do you want to load the setting&apos;s backup instead?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The backed-up settings also seem to have been saved without Mumble exiting normally (potentially indicating a crash).</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>If you experience repeated crashes with these settings, you might have to manually delete the settings files at &lt;pre&gt;%1&lt;/pre&gt; and &lt;pre&gt;%2&lt;/pre&gt; in order to reset all settings to their default value.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/mumble/mumble_cy.ts
+++ b/src/mumble/mumble_cy.ts
@@ -4619,10 +4619,6 @@ The setting only applies for new messages, the already shown ones will retain th
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>File is not a configuration file.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Settings merged from file.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6319,6 +6315,10 @@ Valid options are:
         <source>Mumble - Minimal View</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Invalid settings file encountered.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>Manual</name>
@@ -7625,6 +7625,26 @@ See &lt;a href=&quot;https://wiki.mumble.info/wiki/Installing_Mumble&quot;&gt;th
     <message>
         <source>Unfortunately %1 shortcut(s) could not be migrated.
 You can register them again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Potentially broken settings</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Load backup settings?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>It seems that Mumble did not perform a normal shutdown. If you did not intentionally kill the application, this could mean that the used settings caused a crash. Do you want to load the setting&apos;s backup instead?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The backed-up settings also seem to have been saved without Mumble exiting normally (potentially indicating a crash).</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>If you experience repeated crashes with these settings, you might have to manually delete the settings files at &lt;pre&gt;%1&lt;/pre&gt; and &lt;pre&gt;%2&lt;/pre&gt; in order to reset all settings to their default value.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/mumble/mumble_da.ts
+++ b/src/mumble/mumble_da.ts
@@ -4668,10 +4668,6 @@ The setting only applies for new messages, the already shown ones will retain th
         <translation>Filen eksisterer ikke</translation>
     </message>
     <message>
-        <source>File is not a configuration file.</source>
-        <translation>Filen er ikke en konfigurationsfil.</translation>
-    </message>
-    <message>
         <source>Settings merged from file.</source>
         <translation>Indstillinger fletted fra fil.</translation>
     </message>
@@ -6371,6 +6367,10 @@ Valid options are:
         <source>Mumble - Minimal View</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Invalid settings file encountered.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>Manual</name>
@@ -7681,6 +7681,26 @@ See &lt;a href=&quot;https://wiki.mumble.info/wiki/Installing_Mumble&quot;&gt;th
     <message>
         <source>Unfortunately %1 shortcut(s) could not be migrated.
 You can register them again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Potentially broken settings</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Load backup settings?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>It seems that Mumble did not perform a normal shutdown. If you did not intentionally kill the application, this could mean that the used settings caused a crash. Do you want to load the setting&apos;s backup instead?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The backed-up settings also seem to have been saved without Mumble exiting normally (potentially indicating a crash).</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>If you experience repeated crashes with these settings, you might have to manually delete the settings files at &lt;pre&gt;%1&lt;/pre&gt; and &lt;pre&gt;%2&lt;/pre&gt; in order to reset all settings to their default value.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/mumble/mumble_de.ts
+++ b/src/mumble/mumble_de.ts
@@ -4677,10 +4677,6 @@ Die Einstellung gilt nur für neue Nachrichten, die bereits angezeigten behalten
         <translation>Datei existiert nicht</translation>
     </message>
     <message>
-        <source>File is not a configuration file.</source>
-        <translation>Die Datei ist keine Konfigurationsdatei.</translation>
-    </message>
-    <message>
         <source>Settings merged from file.</source>
         <translation>Einstellungen aus Datei eingelesen.</translation>
     </message>
@@ -6464,6 +6460,10 @@ Erlaubte Optionen sind:
         <source>Mumble - Minimal View</source>
         <translation>Mumble - Minimalansicht</translation>
     </message>
+    <message>
+        <source>Invalid settings file encountered.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>Manual</name>
@@ -7779,6 +7779,26 @@ Infos hierzu finden Sie im &lt;a href=&quot;https://wiki.mumble.info/wiki/Instal
 You can register them again.</source>
         <translation>Leider konnte(n) %1 Tastenkürzel nicht migriert werden.
 Sie können sie jedoch erneut registrieren.</translation>
+    </message>
+    <message>
+        <source>Potentially broken settings</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Load backup settings?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>It seems that Mumble did not perform a normal shutdown. If you did not intentionally kill the application, this could mean that the used settings caused a crash. Do you want to load the setting&apos;s backup instead?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The backed-up settings also seem to have been saved without Mumble exiting normally (potentially indicating a crash).</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>If you experience repeated crashes with these settings, you might have to manually delete the settings files at &lt;pre&gt;%1&lt;/pre&gt; and &lt;pre&gt;%2&lt;/pre&gt; in order to reset all settings to their default value.</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/src/mumble/mumble_el.ts
+++ b/src/mumble/mumble_el.ts
@@ -4677,10 +4677,6 @@ The setting only applies for new messages, the already shown ones will retain th
         <translation>Το αρχείο δεν υπάρχει</translation>
     </message>
     <message>
-        <source>File is not a configuration file.</source>
-        <translation>Το αρχείο δεν είναι αρχείο ρυθμίσεων.</translation>
-    </message>
-    <message>
         <source>Settings merged from file.</source>
         <translation>Οι ρυθμίσεις συγχωνεύθηκαν από το αρχείο.</translation>
     </message>
@@ -6468,6 +6464,10 @@ mumble://[&lt;username&gt;[:&lt;password&gt;]@]&lt;host&gt;[:&lt;port&gt;][/&lt;
         <source>Mumble - Minimal View</source>
         <translation>Mumble - Ελάχιστη προβολή</translation>
     </message>
+    <message>
+        <source>Invalid settings file encountered.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>Manual</name>
@@ -7783,6 +7783,26 @@ See &lt;a href=&quot;https://wiki.mumble.info/wiki/Installing_Mumble&quot;&gt;th
 You can register them again.</source>
         <translation>Δυστυχώς, δεν ήταν δυνατή η μετεγκατάσταση %1 συντόμευσης.
 Μπορείτε να τις καταχωρήσετε ξανά.</translation>
+    </message>
+    <message>
+        <source>Potentially broken settings</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Load backup settings?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>It seems that Mumble did not perform a normal shutdown. If you did not intentionally kill the application, this could mean that the used settings caused a crash. Do you want to load the setting&apos;s backup instead?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The backed-up settings also seem to have been saved without Mumble exiting normally (potentially indicating a crash).</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>If you experience repeated crashes with these settings, you might have to manually delete the settings files at &lt;pre&gt;%1&lt;/pre&gt; and &lt;pre&gt;%2&lt;/pre&gt; in order to reset all settings to their default value.</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/src/mumble/mumble_en.ts
+++ b/src/mumble/mumble_en.ts
@@ -4614,10 +4614,6 @@ The setting only applies for new messages, the already shown ones will retain th
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>File is not a configuration file.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Settings merged from file.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6314,6 +6310,10 @@ Valid options are:
         <source>Mumble - Minimal View</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Invalid settings file encountered.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>Manual</name>
@@ -7620,6 +7620,26 @@ See &lt;a href=&quot;https://wiki.mumble.info/wiki/Installing_Mumble&quot;&gt;th
     <message>
         <source>Unfortunately %1 shortcut(s) could not be migrated.
 You can register them again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Potentially broken settings</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Load backup settings?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>It seems that Mumble did not perform a normal shutdown. If you did not intentionally kill the application, this could mean that the used settings caused a crash. Do you want to load the setting&apos;s backup instead?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The backed-up settings also seem to have been saved without Mumble exiting normally (potentially indicating a crash).</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>If you experience repeated crashes with these settings, you might have to manually delete the settings files at &lt;pre&gt;%1&lt;/pre&gt; and &lt;pre&gt;%2&lt;/pre&gt; in order to reset all settings to their default value.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/mumble/mumble_en_GB.ts
+++ b/src/mumble/mumble_en_GB.ts
@@ -4651,10 +4651,6 @@ The setting only applies for new messages, the already shown ones will retain th
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>File is not a configuration file.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Settings merged from file.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6351,6 +6347,10 @@ Valid options are:
         <source>Mumble - Minimal View</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Invalid settings file encountered.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>Manual</name>
@@ -7657,6 +7657,26 @@ See &lt;a href=&quot;https://wiki.mumble.info/wiki/Installing_Mumble&quot;&gt;th
     <message>
         <source>Unfortunately %1 shortcut(s) could not be migrated.
 You can register them again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Potentially broken settings</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Load backup settings?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>It seems that Mumble did not perform a normal shutdown. If you did not intentionally kill the application, this could mean that the used settings caused a crash. Do you want to load the setting&apos;s backup instead?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The backed-up settings also seem to have been saved without Mumble exiting normally (potentially indicating a crash).</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>If you experience repeated crashes with these settings, you might have to manually delete the settings files at &lt;pre&gt;%1&lt;/pre&gt; and &lt;pre&gt;%2&lt;/pre&gt; in order to reset all settings to their default value.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/mumble/mumble_eo.ts
+++ b/src/mumble/mumble_eo.ts
@@ -4626,10 +4626,6 @@ The setting only applies for new messages, the already shown ones will retain th
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>File is not a configuration file.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Settings merged from file.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6327,6 +6323,10 @@ Valid options are:
         <source>Mumble - Minimal View</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Invalid settings file encountered.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>Manual</name>
@@ -7633,6 +7633,26 @@ See &lt;a href=&quot;https://wiki.mumble.info/wiki/Installing_Mumble&quot;&gt;th
     <message>
         <source>Unfortunately %1 shortcut(s) could not be migrated.
 You can register them again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Potentially broken settings</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Load backup settings?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>It seems that Mumble did not perform a normal shutdown. If you did not intentionally kill the application, this could mean that the used settings caused a crash. Do you want to load the setting&apos;s backup instead?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The backed-up settings also seem to have been saved without Mumble exiting normally (potentially indicating a crash).</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>If you experience repeated crashes with these settings, you might have to manually delete the settings files at &lt;pre&gt;%1&lt;/pre&gt; and &lt;pre&gt;%2&lt;/pre&gt; in order to reset all settings to their default value.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/mumble/mumble_es.ts
+++ b/src/mumble/mumble_es.ts
@@ -4677,10 +4677,6 @@ La configuración solo se aplica a los mensajes nuevos, los que ya se muestran c
         <translation>El archivo no existe</translation>
     </message>
     <message>
-        <source>File is not a configuration file.</source>
-        <translation>El archivo no es un archivo de configuración.</translation>
-    </message>
-    <message>
         <source>Settings merged from file.</source>
         <translation>Opciones combinadas desde el archivo.</translation>
     </message>
@@ -6385,6 +6381,10 @@ Valid options are:
         <source>Mumble - Minimal View</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Invalid settings file encountered.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>Manual</name>
@@ -7697,6 +7697,26 @@ Vea &lt;a href=&quot;https://wiki.mumble.info/wiki/Installing_Mumble&quot;&gt;la
     <message>
         <source>Unfortunately %1 shortcut(s) could not be migrated.
 You can register them again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Potentially broken settings</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Load backup settings?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>It seems that Mumble did not perform a normal shutdown. If you did not intentionally kill the application, this could mean that the used settings caused a crash. Do you want to load the setting&apos;s backup instead?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The backed-up settings also seem to have been saved without Mumble exiting normally (potentially indicating a crash).</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>If you experience repeated crashes with these settings, you might have to manually delete the settings files at &lt;pre&gt;%1&lt;/pre&gt; and &lt;pre&gt;%2&lt;/pre&gt; in order to reset all settings to their default value.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/mumble/mumble_et.ts
+++ b/src/mumble/mumble_et.ts
@@ -4616,10 +4616,6 @@ The setting only applies for new messages, the already shown ones will retain th
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>File is not a configuration file.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Settings merged from file.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6316,6 +6312,10 @@ Valid options are:
         <source>Mumble - Minimal View</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Invalid settings file encountered.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>Manual</name>
@@ -7622,6 +7622,26 @@ See &lt;a href=&quot;https://wiki.mumble.info/wiki/Installing_Mumble&quot;&gt;th
     <message>
         <source>Unfortunately %1 shortcut(s) could not be migrated.
 You can register them again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Potentially broken settings</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Load backup settings?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>It seems that Mumble did not perform a normal shutdown. If you did not intentionally kill the application, this could mean that the used settings caused a crash. Do you want to load the setting&apos;s backup instead?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The backed-up settings also seem to have been saved without Mumble exiting normally (potentially indicating a crash).</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>If you experience repeated crashes with these settings, you might have to manually delete the settings files at &lt;pre&gt;%1&lt;/pre&gt; and &lt;pre&gt;%2&lt;/pre&gt; in order to reset all settings to their default value.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/mumble/mumble_eu.ts
+++ b/src/mumble/mumble_eu.ts
@@ -4633,10 +4633,6 @@ The setting only applies for new messages, the already shown ones will retain th
         <translation>Fitxategia ez da existitzen</translation>
     </message>
     <message>
-        <source>File is not a configuration file.</source>
-        <translation>Fitxategia ez da konfigurazio fitxategia</translation>
-    </message>
-    <message>
         <source>Settings merged from file.</source>
         <translation>Ezarpenak fitxategitik batu dira.</translation>
     </message>
@@ -6336,6 +6332,10 @@ Valid options are:
         <source>Mumble - Minimal View</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Invalid settings file encountered.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>Manual</name>
@@ -7642,6 +7642,26 @@ See &lt;a href=&quot;https://wiki.mumble.info/wiki/Installing_Mumble&quot;&gt;th
     <message>
         <source>Unfortunately %1 shortcut(s) could not be migrated.
 You can register them again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Potentially broken settings</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Load backup settings?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>It seems that Mumble did not perform a normal shutdown. If you did not intentionally kill the application, this could mean that the used settings caused a crash. Do you want to load the setting&apos;s backup instead?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The backed-up settings also seem to have been saved without Mumble exiting normally (potentially indicating a crash).</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>If you experience repeated crashes with these settings, you might have to manually delete the settings files at &lt;pre&gt;%1&lt;/pre&gt; and &lt;pre&gt;%2&lt;/pre&gt; in order to reset all settings to their default value.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/mumble/mumble_fa_IR.ts
+++ b/src/mumble/mumble_fa_IR.ts
@@ -4614,10 +4614,6 @@ The setting only applies for new messages, the already shown ones will retain th
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>File is not a configuration file.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Settings merged from file.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6314,6 +6310,10 @@ Valid options are:
         <source>Mumble - Minimal View</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Invalid settings file encountered.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>Manual</name>
@@ -7620,6 +7620,26 @@ See &lt;a href=&quot;https://wiki.mumble.info/wiki/Installing_Mumble&quot;&gt;th
     <message>
         <source>Unfortunately %1 shortcut(s) could not be migrated.
 You can register them again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Potentially broken settings</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Load backup settings?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>It seems that Mumble did not perform a normal shutdown. If you did not intentionally kill the application, this could mean that the used settings caused a crash. Do you want to load the setting&apos;s backup instead?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The backed-up settings also seem to have been saved without Mumble exiting normally (potentially indicating a crash).</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>If you experience repeated crashes with these settings, you might have to manually delete the settings files at &lt;pre&gt;%1&lt;/pre&gt; and &lt;pre&gt;%2&lt;/pre&gt; in order to reset all settings to their default value.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/mumble/mumble_fi.ts
+++ b/src/mumble/mumble_fi.ts
@@ -4677,10 +4677,6 @@ Tämä vaikuttaa vain uusiin viesteihin, vanhojen viestien aikaleima ei muutu.</
         <translation>Tiedostoa ei löydy</translation>
     </message>
     <message>
-        <source>File is not a configuration file.</source>
-        <translation>Tiedosto ei ole asetustiedosto.</translation>
-    </message>
-    <message>
         <source>Settings merged from file.</source>
         <translation>Asetukset määritetty tiedostosta.</translation>
     </message>
@@ -6427,6 +6423,10 @@ Valid options are:
         <source>Mumble - Minimal View</source>
         <translation>Mumble - Minimaalinen näkymä</translation>
     </message>
+    <message>
+        <source>Invalid settings file encountered.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>Manual</name>
@@ -7742,6 +7742,26 @@ Lisätietoa löydät &lt;a href=&quot;https://wiki.mumble.info/wiki/Installing_M
 You can register them again.</source>
         <translation>Valitettavasti %1 pikanäppäin(tä) ei voitu rekisteröidä.
 Voit rekisteröidä ne uudelleen.</translation>
+    </message>
+    <message>
+        <source>Potentially broken settings</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Load backup settings?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>It seems that Mumble did not perform a normal shutdown. If you did not intentionally kill the application, this could mean that the used settings caused a crash. Do you want to load the setting&apos;s backup instead?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The backed-up settings also seem to have been saved without Mumble exiting normally (potentially indicating a crash).</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>If you experience repeated crashes with these settings, you might have to manually delete the settings files at &lt;pre&gt;%1&lt;/pre&gt; and &lt;pre&gt;%2&lt;/pre&gt; in order to reset all settings to their default value.</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/src/mumble/mumble_fr.ts
+++ b/src/mumble/mumble_fr.ts
@@ -4676,10 +4676,6 @@ Le paramètre ne s&apos;applique qu&apos;aux nouveaux messages, ceux déjà affi
         <translation>Fichier inexistant</translation>
     </message>
     <message>
-        <source>File is not a configuration file.</source>
-        <translation>Le fichier n&apos;est pas un fichier de configuration.</translation>
-    </message>
-    <message>
         <source>Settings merged from file.</source>
         <translation>Paramètres fusionnés à partir du fichier.</translation>
     </message>
@@ -6386,6 +6382,10 @@ Valid options are:
         <source>Mumble - Minimal View</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Invalid settings file encountered.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>Manual</name>
@@ -7697,6 +7697,26 @@ See &lt;a href=&quot;https://wiki.mumble.info/wiki/Installing_Mumble&quot;&gt;th
     <message>
         <source>Unfortunately %1 shortcut(s) could not be migrated.
 You can register them again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Potentially broken settings</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Load backup settings?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>It seems that Mumble did not perform a normal shutdown. If you did not intentionally kill the application, this could mean that the used settings caused a crash. Do you want to load the setting&apos;s backup instead?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The backed-up settings also seem to have been saved without Mumble exiting normally (potentially indicating a crash).</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>If you experience repeated crashes with these settings, you might have to manually delete the settings files at &lt;pre&gt;%1&lt;/pre&gt; and &lt;pre&gt;%2&lt;/pre&gt; in order to reset all settings to their default value.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/mumble/mumble_gl.ts
+++ b/src/mumble/mumble_gl.ts
@@ -4617,10 +4617,6 @@ The setting only applies for new messages, the already shown ones will retain th
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>File is not a configuration file.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Settings merged from file.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6317,6 +6313,10 @@ Valid options are:
         <source>Mumble - Minimal View</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Invalid settings file encountered.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>Manual</name>
@@ -7623,6 +7623,26 @@ See &lt;a href=&quot;https://wiki.mumble.info/wiki/Installing_Mumble&quot;&gt;th
     <message>
         <source>Unfortunately %1 shortcut(s) could not be migrated.
 You can register them again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Potentially broken settings</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Load backup settings?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>It seems that Mumble did not perform a normal shutdown. If you did not intentionally kill the application, this could mean that the used settings caused a crash. Do you want to load the setting&apos;s backup instead?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The backed-up settings also seem to have been saved without Mumble exiting normally (potentially indicating a crash).</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>If you experience repeated crashes with these settings, you might have to manually delete the settings files at &lt;pre&gt;%1&lt;/pre&gt; and &lt;pre&gt;%2&lt;/pre&gt; in order to reset all settings to their default value.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/mumble/mumble_he.ts
+++ b/src/mumble/mumble_he.ts
@@ -4665,10 +4665,6 @@ The setting only applies for new messages, the already shown ones will retain th
         <translation>קובץ לא קיים</translation>
     </message>
     <message>
-        <source>File is not a configuration file.</source>
-        <translation>קובץ אינו קובץ תצורה.</translation>
-    </message>
-    <message>
         <source>Settings merged from file.</source>
         <translation>הגדרות מוזגו מן קובץ.</translation>
     </message>
@@ -6367,6 +6363,10 @@ Valid options are:
         <source>Mumble - Minimal View</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Invalid settings file encountered.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>Manual</name>
@@ -7677,6 +7677,26 @@ See &lt;a href=&quot;https://wiki.mumble.info/wiki/Installing_Mumble&quot;&gt;th
     <message>
         <source>Unfortunately %1 shortcut(s) could not be migrated.
 You can register them again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Potentially broken settings</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Load backup settings?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>It seems that Mumble did not perform a normal shutdown. If you did not intentionally kill the application, this could mean that the used settings caused a crash. Do you want to load the setting&apos;s backup instead?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The backed-up settings also seem to have been saved without Mumble exiting normally (potentially indicating a crash).</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>If you experience repeated crashes with these settings, you might have to manually delete the settings files at &lt;pre&gt;%1&lt;/pre&gt; and &lt;pre&gt;%2&lt;/pre&gt; in order to reset all settings to their default value.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/mumble/mumble_hu.ts
+++ b/src/mumble/mumble_hu.ts
@@ -4663,10 +4663,6 @@ The setting only applies for new messages, the already shown ones will retain th
         <translation>A fájl nem létezik</translation>
     </message>
     <message>
-        <source>File is not a configuration file.</source>
-        <translation>A fájl nem egy beállításokat tartalmazó fájl.</translation>
-    </message>
-    <message>
         <source>Settings merged from file.</source>
         <translation>Beállítások összefésülve a fájlból.</translation>
     </message>
@@ -6367,6 +6363,10 @@ Valid options are:
         <source>Mumble - Minimal View</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Invalid settings file encountered.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>Manual</name>
@@ -7674,6 +7674,26 @@ See &lt;a href=&quot;https://wiki.mumble.info/wiki/Installing_Mumble&quot;&gt;th
     <message>
         <source>Unfortunately %1 shortcut(s) could not be migrated.
 You can register them again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Potentially broken settings</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Load backup settings?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>It seems that Mumble did not perform a normal shutdown. If you did not intentionally kill the application, this could mean that the used settings caused a crash. Do you want to load the setting&apos;s backup instead?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The backed-up settings also seem to have been saved without Mumble exiting normally (potentially indicating a crash).</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>If you experience repeated crashes with these settings, you might have to manually delete the settings files at &lt;pre&gt;%1&lt;/pre&gt; and &lt;pre&gt;%2&lt;/pre&gt; in order to reset all settings to their default value.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/mumble/mumble_it.ts
+++ b/src/mumble/mumble_it.ts
@@ -4677,10 +4677,6 @@ Questa impostazione si applica solo ai nuovi messaggi, quelli già mostrati mant
         <translation>Il file non esiste</translation>
     </message>
     <message>
-        <source>File is not a configuration file.</source>
-        <translation>Il file non è un file di configurazione.</translation>
-    </message>
-    <message>
         <source>Settings merged from file.</source>
         <translation>Impostazioni importate dal file.</translation>
     </message>
@@ -6468,6 +6464,10 @@ Le opzioni valide sono:
         <source>Mumble - Minimal View</source>
         <translation>Mumble - Interfaccia Minimale</translation>
     </message>
+    <message>
+        <source>Invalid settings file encountered.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>Manual</name>
@@ -7783,6 +7783,26 @@ Controlla &lt;a href=&quot;https://wiki.mumble.info/wiki/Installing_Mumble&quot;
 You can register them again.</source>
         <translation>Sfortunatamente la shortcut %1 non può essere migrata.
 Puoi registrarle di nuovo.</translation>
+    </message>
+    <message>
+        <source>Potentially broken settings</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Load backup settings?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>It seems that Mumble did not perform a normal shutdown. If you did not intentionally kill the application, this could mean that the used settings caused a crash. Do you want to load the setting&apos;s backup instead?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The backed-up settings also seem to have been saved without Mumble exiting normally (potentially indicating a crash).</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>If you experience repeated crashes with these settings, you might have to manually delete the settings files at &lt;pre&gt;%1&lt;/pre&gt; and &lt;pre&gt;%2&lt;/pre&gt; in order to reset all settings to their default value.</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/src/mumble/mumble_ja.ts
+++ b/src/mumble/mumble_ja.ts
@@ -4664,10 +4664,6 @@ The setting only applies for new messages, the already shown ones will retain th
         <translation>ファイルが存在しません</translation>
     </message>
     <message>
-        <source>File is not a configuration file.</source>
-        <translation>設定ファイルが見つかりません。</translation>
-    </message>
-    <message>
         <source>Settings merged from file.</source>
         <translation>設定をファイルからマージする。</translation>
     </message>
@@ -6365,6 +6361,10 @@ Valid options are:
         <source>Mumble - Minimal View</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Invalid settings file encountered.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>Manual</name>
@@ -7675,6 +7675,26 @@ See &lt;a href=&quot;https://wiki.mumble.info/wiki/Installing_Mumble&quot;&gt;th
     <message>
         <source>Unfortunately %1 shortcut(s) could not be migrated.
 You can register them again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Potentially broken settings</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Load backup settings?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>It seems that Mumble did not perform a normal shutdown. If you did not intentionally kill the application, this could mean that the used settings caused a crash. Do you want to load the setting&apos;s backup instead?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The backed-up settings also seem to have been saved without Mumble exiting normally (potentially indicating a crash).</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>If you experience repeated crashes with these settings, you might have to manually delete the settings files at &lt;pre&gt;%1&lt;/pre&gt; and &lt;pre&gt;%2&lt;/pre&gt; in order to reset all settings to their default value.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/mumble/mumble_ko.ts
+++ b/src/mumble/mumble_ko.ts
@@ -4676,10 +4676,6 @@ The setting only applies for new messages, the already shown ones will retain th
         <translation>파일이 존재하지 않음</translation>
     </message>
     <message>
-        <source>File is not a configuration file.</source>
-        <translation>파일이 구성 파일이 아닙니다.</translation>
-    </message>
-    <message>
         <source>Settings merged from file.</source>
         <translation>파일에서 설정이 병합되었습니다.</translation>
     </message>
@@ -6467,6 +6463,10 @@ mumble://[&lt;유저이름&gt;[:&lt;비밀번호&gt;]@]&lt;호스트&gt;[:&lt;�
         <source>Mumble - Minimal View</source>
         <translation>Mumble - 최소 보기</translation>
     </message>
+    <message>
+        <source>Invalid settings file encountered.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>Manual</name>
@@ -7782,6 +7782,26 @@ See &lt;a href=&quot;https://wiki.mumble.info/wiki/Installing_Mumble&quot;&gt;th
 You can register them again.</source>
         <translation>유감스럽게도 %1 단축키(들)가 이동되지 않았습니다.
 다시 등록할 수 있습니다.</translation>
+    </message>
+    <message>
+        <source>Potentially broken settings</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Load backup settings?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>It seems that Mumble did not perform a normal shutdown. If you did not intentionally kill the application, this could mean that the used settings caused a crash. Do you want to load the setting&apos;s backup instead?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The backed-up settings also seem to have been saved without Mumble exiting normally (potentially indicating a crash).</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>If you experience repeated crashes with these settings, you might have to manually delete the settings files at &lt;pre&gt;%1&lt;/pre&gt; and &lt;pre&gt;%2&lt;/pre&gt; in order to reset all settings to their default value.</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/src/mumble/mumble_lt.ts
+++ b/src/mumble/mumble_lt.ts
@@ -4647,10 +4647,6 @@ The setting only applies for new messages, the already shown ones will retain th
         <translation>Failo nėra</translation>
     </message>
     <message>
-        <source>File is not a configuration file.</source>
-        <translation>Failas nėra konfigūracijos failas.</translation>
-    </message>
-    <message>
         <source>Settings merged from file.</source>
         <translation>Nustatymai sulieti iš failo.</translation>
     </message>
@@ -6408,6 +6404,10 @@ Galioja šios parinktys:
         <source>Mumble - Minimal View</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Invalid settings file encountered.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>Manual</name>
@@ -7718,6 +7718,26 @@ See &lt;a href=&quot;https://wiki.mumble.info/wiki/Installing_Mumble&quot;&gt;th
     <message>
         <source>Unfortunately %1 shortcut(s) could not be migrated.
 You can register them again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Potentially broken settings</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Load backup settings?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>It seems that Mumble did not perform a normal shutdown. If you did not intentionally kill the application, this could mean that the used settings caused a crash. Do you want to load the setting&apos;s backup instead?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The backed-up settings also seem to have been saved without Mumble exiting normally (potentially indicating a crash).</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>If you experience repeated crashes with these settings, you might have to manually delete the settings files at &lt;pre&gt;%1&lt;/pre&gt; and &lt;pre&gt;%2&lt;/pre&gt; in order to reset all settings to their default value.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/mumble/mumble_nl.ts
+++ b/src/mumble/mumble_nl.ts
@@ -4677,10 +4677,6 @@ Deze instelling geldt voor nieuwe berichten, vermits getoonden conformeren aan h
         <translation>Bestand bestaat niet</translation>
     </message>
     <message>
-        <source>File is not a configuration file.</source>
-        <translation>Bestand geen configuratiebestand.</translation>
-    </message>
-    <message>
         <source>Settings merged from file.</source>
         <translation>Instellingen uit bestand samengevoegd.</translation>
     </message>
@@ -6468,6 +6464,10 @@ Geldige opties zijn:
         <source>Mumble - Minimal View</source>
         <translation>Mumble - Minimale Weergave</translation>
     </message>
+    <message>
+        <source>Invalid settings file encountered.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>Manual</name>
@@ -7783,6 +7783,26 @@ Zie &lt;a href=&quot;https://wiki.mumble.info/wiki/Installing_Mumble&quot;&gt;de
 You can register them again.</source>
         <translation>Helaas kon(den) %1 sneltoets(en) niet gemigreerd worden.
 Je kunt ze opnieuw registreren.</translation>
+    </message>
+    <message>
+        <source>Potentially broken settings</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Load backup settings?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>It seems that Mumble did not perform a normal shutdown. If you did not intentionally kill the application, this could mean that the used settings caused a crash. Do you want to load the setting&apos;s backup instead?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The backed-up settings also seem to have been saved without Mumble exiting normally (potentially indicating a crash).</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>If you experience repeated crashes with these settings, you might have to manually delete the settings files at &lt;pre&gt;%1&lt;/pre&gt; and &lt;pre&gt;%2&lt;/pre&gt; in order to reset all settings to their default value.</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/src/mumble/mumble_no.ts
+++ b/src/mumble/mumble_no.ts
@@ -4690,10 +4690,6 @@ Har kun innvirkning for nye meldinger. Gamle meldinger vises i foregående tidsf
         <translation>Filen finnes ikke</translation>
     </message>
     <message>
-        <source>File is not a configuration file.</source>
-        <translation>Filen er ikke en oppsettsfil.</translation>
-    </message>
-    <message>
         <source>Settings merged from file.</source>
         <translation>Innstillinger innflettet fra fil.</translation>
     </message>
@@ -6399,6 +6395,10 @@ Valid options are:
         <source>Mumble - Minimal View</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Invalid settings file encountered.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>Manual</name>
@@ -7710,6 +7710,26 @@ See &lt;a href=&quot;https://wiki.mumble.info/wiki/Installing_Mumble&quot;&gt;th
     <message>
         <source>Unfortunately %1 shortcut(s) could not be migrated.
 You can register them again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Potentially broken settings</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Load backup settings?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>It seems that Mumble did not perform a normal shutdown. If you did not intentionally kill the application, this could mean that the used settings caused a crash. Do you want to load the setting&apos;s backup instead?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The backed-up settings also seem to have been saved without Mumble exiting normally (potentially indicating a crash).</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>If you experience repeated crashes with these settings, you might have to manually delete the settings files at &lt;pre&gt;%1&lt;/pre&gt; and &lt;pre&gt;%2&lt;/pre&gt; in order to reset all settings to their default value.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/mumble/mumble_oc.ts
+++ b/src/mumble/mumble_oc.ts
@@ -4616,10 +4616,6 @@ The setting only applies for new messages, the already shown ones will retain th
         <translation>Lo fichièr existís pas</translation>
     </message>
     <message>
-        <source>File is not a configuration file.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Settings merged from file.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6316,6 +6312,10 @@ Valid options are:
         <source>Mumble - Minimal View</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Invalid settings file encountered.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>Manual</name>
@@ -7622,6 +7622,26 @@ See &lt;a href=&quot;https://wiki.mumble.info/wiki/Installing_Mumble&quot;&gt;th
     <message>
         <source>Unfortunately %1 shortcut(s) could not be migrated.
 You can register them again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Potentially broken settings</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Load backup settings?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>It seems that Mumble did not perform a normal shutdown. If you did not intentionally kill the application, this could mean that the used settings caused a crash. Do you want to load the setting&apos;s backup instead?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The backed-up settings also seem to have been saved without Mumble exiting normally (potentially indicating a crash).</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>If you experience repeated crashes with these settings, you might have to manually delete the settings files at &lt;pre&gt;%1&lt;/pre&gt; and &lt;pre&gt;%2&lt;/pre&gt; in order to reset all settings to their default value.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/mumble/mumble_pl.ts
+++ b/src/mumble/mumble_pl.ts
@@ -4678,10 +4678,6 @@ Ustawienie dotyczy tylko nowych wiadomości, te już pokazane zachowają poprzed
         <translation>Plik nie istnieje</translation>
     </message>
     <message>
-        <source>File is not a configuration file.</source>
-        <translation>Plik nie jest plikiem konfiguracyjnym.</translation>
-    </message>
-    <message>
         <source>Settings merged from file.</source>
         <translation>Ustawienia połączone z pliku.</translation>
     </message>
@@ -6469,6 +6465,10 @@ Prawidłowe opcje to:
         <source>Mumble - Minimal View</source>
         <translation>Mumble - Widok minimalny</translation>
     </message>
+    <message>
+        <source>Invalid settings file encountered.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>Manual</name>
@@ -7784,6 +7784,26 @@ Zobacz &lt;a href=&quot;https://wiki.mumble.info/wiki/Installing_Mumble&quot;&gt
 You can register them again.</source>
         <translation>Niestety nie można zmigrować %1 skrótu(-ów).
 Możesz je ponownie zarejestrować.</translation>
+    </message>
+    <message>
+        <source>Potentially broken settings</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Load backup settings?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>It seems that Mumble did not perform a normal shutdown. If you did not intentionally kill the application, this could mean that the used settings caused a crash. Do you want to load the setting&apos;s backup instead?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The backed-up settings also seem to have been saved without Mumble exiting normally (potentially indicating a crash).</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>If you experience repeated crashes with these settings, you might have to manually delete the settings files at &lt;pre&gt;%1&lt;/pre&gt; and &lt;pre&gt;%2&lt;/pre&gt; in order to reset all settings to their default value.</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/src/mumble/mumble_pt_BR.ts
+++ b/src/mumble/mumble_pt_BR.ts
@@ -4677,10 +4677,6 @@ Essa configuração só se aplica para novas mensagens. As mensagens já exibida
         <translation>Arquivo não existe</translation>
     </message>
     <message>
-        <source>File is not a configuration file.</source>
-        <translation>Arquivo não é de configuração.</translation>
-    </message>
-    <message>
         <source>Settings merged from file.</source>
         <translation>Configurações combinadas de arquivo.</translation>
     </message>
@@ -6386,6 +6382,10 @@ Valid options are:
         <source>Mumble - Minimal View</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Invalid settings file encountered.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>Manual</name>
@@ -7699,6 +7699,26 @@ Consulte a &lt;a href=&quot;https://wiki.mumble.info/wiki/Installing_Mumble&quot
     <message>
         <source>Unfortunately %1 shortcut(s) could not be migrated.
 You can register them again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Potentially broken settings</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Load backup settings?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>It seems that Mumble did not perform a normal shutdown. If you did not intentionally kill the application, this could mean that the used settings caused a crash. Do you want to load the setting&apos;s backup instead?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The backed-up settings also seem to have been saved without Mumble exiting normally (potentially indicating a crash).</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>If you experience repeated crashes with these settings, you might have to manually delete the settings files at &lt;pre&gt;%1&lt;/pre&gt; and &lt;pre&gt;%2&lt;/pre&gt; in order to reset all settings to their default value.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/mumble/mumble_pt_PT.ts
+++ b/src/mumble/mumble_pt_PT.ts
@@ -4677,10 +4677,6 @@ Essa configuração só se aplica para novas mensagens. As mensagens já exibida
         <translation>Ficheiro não existe</translation>
     </message>
     <message>
-        <source>File is not a configuration file.</source>
-        <translation>Ficheiro não é de configuração.</translation>
-    </message>
-    <message>
         <source>Settings merged from file.</source>
         <translation>Configurações combinadas de ficheiro.</translation>
     </message>
@@ -6386,6 +6382,10 @@ Valid options are:
         <source>Mumble - Minimal View</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Invalid settings file encountered.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>Manual</name>
@@ -7699,6 +7699,26 @@ Consulte a &lt;a href=&quot;https://wiki.mumble.info/wiki/Installing_Mumble&quot
     <message>
         <source>Unfortunately %1 shortcut(s) could not be migrated.
 You can register them again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Potentially broken settings</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Load backup settings?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>It seems that Mumble did not perform a normal shutdown. If you did not intentionally kill the application, this could mean that the used settings caused a crash. Do you want to load the setting&apos;s backup instead?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The backed-up settings also seem to have been saved without Mumble exiting normally (potentially indicating a crash).</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>If you experience repeated crashes with these settings, you might have to manually delete the settings files at &lt;pre&gt;%1&lt;/pre&gt; and &lt;pre&gt;%2&lt;/pre&gt; in order to reset all settings to their default value.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/mumble/mumble_ro.ts
+++ b/src/mumble/mumble_ro.ts
@@ -4620,10 +4620,6 @@ The setting only applies for new messages, the already shown ones will retain th
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>File is not a configuration file.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Settings merged from file.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6320,6 +6316,10 @@ Valid options are:
         <source>Mumble - Minimal View</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Invalid settings file encountered.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>Manual</name>
@@ -7626,6 +7626,26 @@ See &lt;a href=&quot;https://wiki.mumble.info/wiki/Installing_Mumble&quot;&gt;th
     <message>
         <source>Unfortunately %1 shortcut(s) could not be migrated.
 You can register them again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Potentially broken settings</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Load backup settings?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>It seems that Mumble did not perform a normal shutdown. If you did not intentionally kill the application, this could mean that the used settings caused a crash. Do you want to load the setting&apos;s backup instead?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The backed-up settings also seem to have been saved without Mumble exiting normally (potentially indicating a crash).</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>If you experience repeated crashes with these settings, you might have to manually delete the settings files at &lt;pre&gt;%1&lt;/pre&gt; and &lt;pre&gt;%2&lt;/pre&gt; in order to reset all settings to their default value.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/mumble/mumble_ru.ts
+++ b/src/mumble/mumble_ru.ts
@@ -4631,10 +4631,6 @@ The setting only applies for new messages, the already shown ones will retain th
         <translation>Файл не найден</translation>
     </message>
     <message>
-        <source>File is not a configuration file.</source>
-        <translation>Файл не является файлом конфигурации.</translation>
-    </message>
-    <message>
         <source>Settings merged from file.</source>
         <translation>Настройки импортированы из файла.</translation>
     </message>
@@ -6422,6 +6418,10 @@ mumble://[&lt;имя пользователя&gt;[:&lt;пароль&gt;]@]&lt;х
         <source>Mumble - Minimal View</source>
         <translation>Mumble - Минимальный вид</translation>
     </message>
+    <message>
+        <source>Invalid settings file encountered.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>Manual</name>
@@ -7736,6 +7736,26 @@ See &lt;a href=&quot;https://wiki.mumble.info/wiki/Installing_Mumble&quot;&gt;th
 You can register them again.</source>
         <translation>К сожалению, %1 ярлык(ов) не удалось перенести.
 Вы можете зарегистрировать их снова.</translation>
+    </message>
+    <message>
+        <source>Potentially broken settings</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Load backup settings?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>It seems that Mumble did not perform a normal shutdown. If you did not intentionally kill the application, this could mean that the used settings caused a crash. Do you want to load the setting&apos;s backup instead?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The backed-up settings also seem to have been saved without Mumble exiting normally (potentially indicating a crash).</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>If you experience repeated crashes with these settings, you might have to manually delete the settings files at &lt;pre&gt;%1&lt;/pre&gt; and &lt;pre&gt;%2&lt;/pre&gt; in order to reset all settings to their default value.</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/src/mumble/mumble_si.ts
+++ b/src/mumble/mumble_si.ts
@@ -5477,10 +5477,6 @@ Valid actions are:
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>File is not a configuration file.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Settings merged from file.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6276,6 +6272,10 @@ Valid options are:
     </message>
     <message>
         <source>Mumble - Minimal View</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Invalid settings file encountered.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -7580,6 +7580,26 @@ See &lt;a href=&quot;https://wiki.mumble.info/wiki/Installing_Mumble&quot;&gt;th
     <message>
         <source>Unfortunately %1 shortcut(s) could not be migrated.
 You can register them again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Potentially broken settings</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Load backup settings?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>It seems that Mumble did not perform a normal shutdown. If you did not intentionally kill the application, this could mean that the used settings caused a crash. Do you want to load the setting&apos;s backup instead?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The backed-up settings also seem to have been saved without Mumble exiting normally (potentially indicating a crash).</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>If you experience repeated crashes with these settings, you might have to manually delete the settings files at &lt;pre&gt;%1&lt;/pre&gt; and &lt;pre&gt;%2&lt;/pre&gt; in order to reset all settings to their default value.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/mumble/mumble_sq.ts
+++ b/src/mumble/mumble_sq.ts
@@ -5569,10 +5569,6 @@ Valid actions are:
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>File is not a configuration file.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Settings merged from file.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6278,6 +6274,10 @@ Otherwise abort and check your certificate and username.</source>
     </message>
     <message>
         <source>Mumble - Minimal View</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Invalid settings file encountered.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -7582,6 +7582,26 @@ See &lt;a href=&quot;https://wiki.mumble.info/wiki/Installing_Mumble&quot;&gt;th
     <message>
         <source>Unfortunately %1 shortcut(s) could not be migrated.
 You can register them again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Potentially broken settings</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Load backup settings?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>It seems that Mumble did not perform a normal shutdown. If you did not intentionally kill the application, this could mean that the used settings caused a crash. Do you want to load the setting&apos;s backup instead?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The backed-up settings also seem to have been saved without Mumble exiting normally (potentially indicating a crash).</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>If you experience repeated crashes with these settings, you might have to manually delete the settings files at &lt;pre&gt;%1&lt;/pre&gt; and &lt;pre&gt;%2&lt;/pre&gt; in order to reset all settings to their default value.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/mumble/mumble_sv.ts
+++ b/src/mumble/mumble_sv.ts
@@ -4677,10 +4677,6 @@ Inställningen gäller endast för nya meddelanden, de redan visade meddelandena
         <translation>Filen finns ej</translation>
     </message>
     <message>
-        <source>File is not a configuration file.</source>
-        <translation>Filen är inte en konfigurationsfil.</translation>
-    </message>
-    <message>
         <source>Settings merged from file.</source>
         <translation>Inställningar sammanslagna från fil.</translation>
     </message>
@@ -6409,6 +6405,10 @@ Valid options are:
         <source>Mumble - Minimal View</source>
         <translation>Mumble - Minimal vy</translation>
     </message>
+    <message>
+        <source>Invalid settings file encountered.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>Manual</name>
@@ -7722,6 +7722,26 @@ Se &lt;a href=&quot;https://wiki.mumble.info/wiki/Installing_Mumble&quot;&gt;Mum
     <message>
         <source>Unfortunately %1 shortcut(s) could not be migrated.
 You can register them again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Potentially broken settings</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Load backup settings?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>It seems that Mumble did not perform a normal shutdown. If you did not intentionally kill the application, this could mean that the used settings caused a crash. Do you want to load the setting&apos;s backup instead?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The backed-up settings also seem to have been saved without Mumble exiting normally (potentially indicating a crash).</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>If you experience repeated crashes with these settings, you might have to manually delete the settings files at &lt;pre&gt;%1&lt;/pre&gt; and &lt;pre&gt;%2&lt;/pre&gt; in order to reset all settings to their default value.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/mumble/mumble_te.ts
+++ b/src/mumble/mumble_te.ts
@@ -4627,10 +4627,6 @@ The setting only applies for new messages, the already shown ones will retain th
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>File is not a configuration file.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Settings merged from file.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6327,6 +6323,10 @@ Valid options are:
         <source>Mumble - Minimal View</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Invalid settings file encountered.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>Manual</name>
@@ -7639,6 +7639,26 @@ See &lt;a href=&quot;https://wiki.mumble.info/wiki/Installing_Mumble&quot;&gt;th
     <message>
         <source>Unfortunately %1 shortcut(s) could not be migrated.
 You can register them again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Potentially broken settings</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Load backup settings?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>It seems that Mumble did not perform a normal shutdown. If you did not intentionally kill the application, this could mean that the used settings caused a crash. Do you want to load the setting&apos;s backup instead?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The backed-up settings also seem to have been saved without Mumble exiting normally (potentially indicating a crash).</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>If you experience repeated crashes with these settings, you might have to manually delete the settings files at &lt;pre&gt;%1&lt;/pre&gt; and &lt;pre&gt;%2&lt;/pre&gt; in order to reset all settings to their default value.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/mumble/mumble_th.ts
+++ b/src/mumble/mumble_th.ts
@@ -4614,10 +4614,6 @@ The setting only applies for new messages, the already shown ones will retain th
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>File is not a configuration file.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Settings merged from file.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6314,6 +6310,10 @@ Valid options are:
         <source>Mumble - Minimal View</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Invalid settings file encountered.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>Manual</name>
@@ -7620,6 +7620,26 @@ See &lt;a href=&quot;https://wiki.mumble.info/wiki/Installing_Mumble&quot;&gt;th
     <message>
         <source>Unfortunately %1 shortcut(s) could not be migrated.
 You can register them again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Potentially broken settings</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Load backup settings?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>It seems that Mumble did not perform a normal shutdown. If you did not intentionally kill the application, this could mean that the used settings caused a crash. Do you want to load the setting&apos;s backup instead?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The backed-up settings also seem to have been saved without Mumble exiting normally (potentially indicating a crash).</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>If you experience repeated crashes with these settings, you might have to manually delete the settings files at &lt;pre&gt;%1&lt;/pre&gt; and &lt;pre&gt;%2&lt;/pre&gt; in order to reset all settings to their default value.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/mumble/mumble_tr.ts
+++ b/src/mumble/mumble_tr.ts
@@ -4676,10 +4676,6 @@ Bu ayar sadece yeni mesajlara uygulanır, zaten görüntülenmiş olanlar öncek
         <translation>Dosya mevcut değil</translation>
     </message>
     <message>
-        <source>File is not a configuration file.</source>
-        <translation>Dosya yapılandırma dosyası değil.</translation>
-    </message>
-    <message>
         <source>Settings merged from file.</source>
         <translation>Ayarlar dosyadan birleştirildi.</translation>
     </message>
@@ -6467,6 +6463,10 @@ Geçerli seçenekler şunlardır:
         <source>Mumble - Minimal View</source>
         <translation>Mumble - Minimal Görünüm</translation>
     </message>
+    <message>
+        <source>Invalid settings file encountered.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>Manual</name>
@@ -7782,6 +7782,26 @@ Ne tür alternatifler olduğunu görmek için &lt;a href=&quot;https://wiki.mumb
 You can register them again.</source>
         <translation>Ne yazık ki %1 kısayol geçirilemedi.
 Bunları tekrar kaydedebilirsiniz.</translation>
+    </message>
+    <message>
+        <source>Potentially broken settings</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Load backup settings?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>It seems that Mumble did not perform a normal shutdown. If you did not intentionally kill the application, this could mean that the used settings caused a crash. Do you want to load the setting&apos;s backup instead?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The backed-up settings also seem to have been saved without Mumble exiting normally (potentially indicating a crash).</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>If you experience repeated crashes with these settings, you might have to manually delete the settings files at &lt;pre&gt;%1&lt;/pre&gt; and &lt;pre&gt;%2&lt;/pre&gt; in order to reset all settings to their default value.</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/src/mumble/mumble_uk.ts
+++ b/src/mumble/mumble_uk.ts
@@ -4616,10 +4616,6 @@ The setting only applies for new messages, the already shown ones will retain th
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>File is not a configuration file.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Settings merged from file.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6316,6 +6312,10 @@ Valid options are:
         <source>Mumble - Minimal View</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Invalid settings file encountered.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>Manual</name>
@@ -7622,6 +7622,26 @@ See &lt;a href=&quot;https://wiki.mumble.info/wiki/Installing_Mumble&quot;&gt;th
     <message>
         <source>Unfortunately %1 shortcut(s) could not be migrated.
 You can register them again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Potentially broken settings</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Load backup settings?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>It seems that Mumble did not perform a normal shutdown. If you did not intentionally kill the application, this could mean that the used settings caused a crash. Do you want to load the setting&apos;s backup instead?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The backed-up settings also seem to have been saved without Mumble exiting normally (potentially indicating a crash).</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>If you experience repeated crashes with these settings, you might have to manually delete the settings files at &lt;pre&gt;%1&lt;/pre&gt; and &lt;pre&gt;%2&lt;/pre&gt; in order to reset all settings to their default value.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/mumble/mumble_zh_CN.ts
+++ b/src/mumble/mumble_zh_CN.ts
@@ -4676,10 +4676,6 @@ The setting only applies for new messages, the already shown ones will retain th
         <translation>文件不存在</translation>
     </message>
     <message>
-        <source>File is not a configuration file.</source>
-        <translation>文件不是配置文件。</translation>
-    </message>
-    <message>
         <source>Settings merged from file.</source>
         <translation>从文件合并设置。</translation>
     </message>
@@ -6467,6 +6463,10 @@ mumble://[&lt;用户名&gt;[:&lt;密码&gt;]@]&lt;主机名&gt;[:&lt;端口&gt;]
         <source>Mumble - Minimal View</source>
         <translation>Mumble - 最小化视图</translation>
     </message>
+    <message>
+        <source>Invalid settings file encountered.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>Manual</name>
@@ -7782,6 +7782,26 @@ See &lt;a href=&quot;https://wiki.mumble.info/wiki/Installing_Mumble&quot;&gt;th
 You can register them again.</source>
         <translation>很不幸，无法迁移 %1 个快捷键。
 您可以重新设置它们。</translation>
+    </message>
+    <message>
+        <source>Potentially broken settings</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Load backup settings?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>It seems that Mumble did not perform a normal shutdown. If you did not intentionally kill the application, this could mean that the used settings caused a crash. Do you want to load the setting&apos;s backup instead?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The backed-up settings also seem to have been saved without Mumble exiting normally (potentially indicating a crash).</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>If you experience repeated crashes with these settings, you might have to manually delete the settings files at &lt;pre&gt;%1&lt;/pre&gt; and &lt;pre&gt;%2&lt;/pre&gt; in order to reset all settings to their default value.</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/src/mumble/mumble_zh_HK.ts
+++ b/src/mumble/mumble_zh_HK.ts
@@ -4614,10 +4614,6 @@ The setting only applies for new messages, the already shown ones will retain th
         <translation>檔案不存在</translation>
     </message>
     <message>
-        <source>File is not a configuration file.</source>
-        <translation>此檔案不是設定檔。</translation>
-    </message>
-    <message>
         <source>Settings merged from file.</source>
         <translation>合併設定檔。</translation>
     </message>
@@ -6319,6 +6315,10 @@ Valid options are:
         <source>Mumble - Minimal View</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Invalid settings file encountered.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>Manual</name>
@@ -7629,6 +7629,26 @@ See &lt;a href=&quot;https://wiki.mumble.info/wiki/Installing_Mumble&quot;&gt;th
     <message>
         <source>Unfortunately %1 shortcut(s) could not be migrated.
 You can register them again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Potentially broken settings</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Load backup settings?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>It seems that Mumble did not perform a normal shutdown. If you did not intentionally kill the application, this could mean that the used settings caused a crash. Do you want to load the setting&apos;s backup instead?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The backed-up settings also seem to have been saved without Mumble exiting normally (potentially indicating a crash).</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>If you experience repeated crashes with these settings, you might have to manually delete the settings files at &lt;pre&gt;%1&lt;/pre&gt; and &lt;pre&gt;%2&lt;/pre&gt; in order to reset all settings to their default value.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/mumble/mumble_zh_TW.ts
+++ b/src/mumble/mumble_zh_TW.ts
@@ -4642,10 +4642,6 @@ The setting only applies for new messages, the already shown ones will retain th
         <translation>檔案不存在</translation>
     </message>
     <message>
-        <source>File is not a configuration file.</source>
-        <translation>不是設定檔。</translation>
-    </message>
-    <message>
         <source>Settings merged from file.</source>
         <translation>合併設定檔。</translation>
     </message>
@@ -6342,6 +6338,10 @@ Valid options are:
         <source>Mumble - Minimal View</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Invalid settings file encountered.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>Manual</name>
@@ -7651,6 +7651,26 @@ See &lt;a href=&quot;https://wiki.mumble.info/wiki/Installing_Mumble&quot;&gt;th
     <message>
         <source>Unfortunately %1 shortcut(s) could not be migrated.
 You can register them again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Potentially broken settings</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Load backup settings?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>It seems that Mumble did not perform a normal shutdown. If you did not intentionally kill the application, this could mean that the used settings caused a crash. Do you want to load the setting&apos;s backup instead?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The backed-up settings also seem to have been saved without Mumble exiting normally (potentially indicating a crash).</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>If you experience repeated crashes with these settings, you might have to manually delete the settings files at &lt;pre&gt;%1&lt;/pre&gt; and &lt;pre&gt;%2&lt;/pre&gt; in order to reset all settings to their default value.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/tests/CMakeLists.txt
+++ b/src/tests/CMakeLists.txt
@@ -16,6 +16,10 @@ endmacro()
 
 if(client)
 	use_test("TestXMLTools")
+	if(NOT "${CMAKE_SYSTEM_NAME}" STREQUAL "FreeBSD")
+		# For some reason Qt segfaults when executing this test on FreeBSD without a display (even when using the offscreen plugin)
+		use_test("TestSettingsJSONSerialization")
+	endif()
 endif()
 
 if(server)

--- a/src/tests/TestSettingsJSONSerialization/CMakeLists.txt
+++ b/src/tests/TestSettingsJSONSerialization/CMakeLists.txt
@@ -1,0 +1,55 @@
+# Copyright 2021 The Mumble Developers. All rights reserved.
+# Use of this source code is governed by a BSD-style license
+# that can be found in the LICENSE file at the root of the
+# Mumble source tree or at <https://www.mumble.info/LICENSE>.
+
+find_pkg(Qt5 COMPONENTS Widgets REQUIRED)
+
+# kpCertificate: We can't create a value for that on-the-fly, so we have to exclude it from the test
+# All other: These settings are not saved
+set(IGNORED_FIELDS
+	"kpCertificate,bSuppressIdentity,lmLoopMode,dPacketLoss,dMaxPacketDelay,requireRestartToApply,settingsLocation,createdSettingsBackup")
+
+include(FindPythonInterpreter)
+
+set(PYTHON_HINTS
+	"C:/Python39-x64" # Path on the AppVeyor CI server
+)
+
+find_python_interpreter(
+	VERSION 3
+	INTERPRETER_OUT_VAR PYTHON_INTERPRETER
+	HINTS ${PYTHON_HINTS}
+	REQUIRED
+)
+
+set(TEST_CASE_SOURCE_FILE "${CMAKE_CURRENT_BINARY_DIR}/TestSettingsJSONSerialization.cpp")
+set(SETTINGS_HEADER "${CMAKE_SOURCE_DIR}/src/mumble/Settings.h")
+
+if(NOT EXISTS "${SETTINGS_HEADER}")
+	message(FATAL_ERROR "Unable to locate Settings header at \"${SETTINGS_HEADER}\"")
+endif()
+
+# Generate the test-case's source file
+add_custom_command(
+	OUTPUT "${TEST_CASE_SOURCE_FILE}"
+	COMMAND "${PYTHON_INTERPRETER}" "${CMAKE_CURRENT_SOURCE_DIR}/generate_test_case.py" --settings-header "${SETTINGS_HEADER}"
+		--settings-struct-nam Settings --ignore-fields "${IGNORED_FIELDS}" --output-file "${TEST_CASE_SOURCE_FILE}"
+	COMMENT "Generating test-case for 'SettingsJSONSerialization'"
+	DEPENDS "generate_test_case.py" "${CMAKE_SOURCE_DIR}/src/mumble/Settings.h"
+		"${CMAKE_SOURCE_DIR}/src/mumble/JSONSerialization.h"
+)
+
+add_executable(TestSettingsJSONSerialization "${TEST_CASE_SOURCE_FILE}")
+target_link_libraries(TestSettingsJSONSerialization PRIVATE mumble_client_object_lib)
+target_link_libraries(TestSettingsJSONSerialization PRIVATE Qt5::Test)
+
+set_target_properties(TestSettingsJSONSerialization PROPERTIES AUTOMOC ON)
+
+
+add_test(
+	NAME TestSettingsJSONSerialization
+	COMMAND $<TARGET_FILE:TestSettingsJSONSerialization>
+	# Specifying the working directory is necessary, to make sure the dependent DLLs are found (on Windows)
+	WORKING_DIRECTORY "${CMAKE_BINARY_DIR}"
+)

--- a/src/tests/TestSettingsJSONSerialization/generate_test_case.py
+++ b/src/tests/TestSettingsJSONSerialization/generate_test_case.py
@@ -1,0 +1,306 @@
+#!/usr/bin/env python3
+
+import argparse
+import re
+from collections import OrderedDict
+
+defaultValues = {}
+structs = {}
+
+def extractFields(classDefinition):
+    # Bring all declarations on a single line
+    classDefinition = re.sub(r",\s+", ",", classDefinition)
+    # Make sure there are no spaces in templates
+    classDefinition = classDefinition.replace("< ", "<").replace(" >", ">")
+    # Remove function definitions (aka: lines that contain a parenthesis)
+    classDefinition = re.sub(r".*\(.*", "", classDefinition)
+    # Remove enum declarations
+    classDefinition = re.sub(r"enum\s*\w+\s*\{.*?\};", "", classDefinition, flags=re.DOTALL)
+    # remove semuicolons
+    classDefinition = classDefinition.replace(";", "")
+    # Remove "unsigned" type specifier
+    classDefinition = classDefinition.replace("unsigned ", "")
+    # Remove "mutable" keyword
+    classDefinition = classDefinition.replace("mutable ", "")
+    # Remove comments
+    classDefinition = re.sub(r"//.*", "", classDefinition)
+
+    fields = OrderedDict()
+    for currentLine in classDefinition.split("\n"):
+        currentLine = currentLine.strip()
+
+        if currentLine.startswith("//") or currentLine in ["private:", "public:"]:
+            continue
+
+        words = currentLine.split()
+
+        if len(words) == 0:
+            continue
+
+        if words[0] in ["enum", "typedef", "struct"] or "static" in words:
+            continue
+
+        if len(words) > 2:
+            # Comma-separated lists
+            names = "".join(words[1:])
+            words = [words[0], names]
+
+        assert len(words) == 2, "Expected remaining lines to be of form <type> <name(s)>"
+
+        for currentFieldName in words[1].split(","):
+            currentFieldName = currentFieldName.strip()
+
+            if not currentFieldName:
+                continue
+
+            fields[currentFieldName] = words[0]
+
+    return fields
+
+
+def extractClassDefinition(className, contents, classIdentifier = "class"):
+    definition = contents[contents.find(classIdentifier + " " + className) :]
+    curlyBrackets = 0
+    endIndex = 0
+    for c in definition:
+        if c == '{':
+            curlyBrackets += 1
+        elif c == '}':
+            curlyBrackets -= 1
+
+            if curlyBrackets == 0:
+                break
+        
+        endIndex += 1
+
+    assert curlyBrackets == 0
+
+    definition = definition[0 : endIndex]
+
+    return definition
+
+
+def getTemplateArguments(templateDef):
+    relevantContent = templateDef[templateDef.find("<") + 1 : templateDef.rfind(">")]
+
+    # Nested templates not yet supported
+    assert not "<" in relevantContent
+
+    args = relevantContent.split(",")
+    args = [x.strip() for x in args]
+
+    return args
+
+
+def getDefaultValueForType(dataType):
+    if dataType in ["int", "short", "long", "float", "double", "qreal"] or dataType.startswith("qint") or dataType.startswith("quint") or \
+        dataType.startswith("uint"):
+        return "42"
+    elif dataType in ["bool"]:
+        return "true"
+    elif dataType in ["QString", "std::string"]:
+        return "\"My String\""
+    elif dataType in ["QByteArray"]:
+        return "QByteArray::fromStdString(\"My ByteArray\")"
+    elif dataType in ["QPoint"]:
+        return "{ 4, 2 }"
+    elif dataType in ["QVariant"]:
+        return "QVariant(15)"
+    elif dataType in ["QStringList"]:
+        return "QStringList({ QStringLiteral(\"Another string\") })"
+    elif dataType in ["QColor"]:
+        return "QColor(QLatin1String(\"indigo\"))"
+    elif dataType in ["QFont"]:
+        return "QFont(QLatin1String(\"Helvetica\"))"
+    elif dataType in ["QRect", "QRectF"]:
+        return "{ 3, 5, 10, 7 }"
+    elif dataType in ["QSize", "QSizeF"]:
+        return "{ 8, 12 }"
+    elif dataType in ["AudioTransmit"]:
+        return "Settings::PushToTalk"
+    elif dataType in ["VADSource"]:
+        return "Settings::SignalToNoise"
+    elif dataType in ["LoopMode"]:
+        return "Settings::Server"
+    elif dataType in ["ChannelExpand"]:
+        return "Settings::AllChannels"
+    elif dataType in ["ChannelDrag"]:
+        return "Settings::DoNothing"
+    elif dataType in ["ServerShow"]:
+        return "Settings::ShowPopulated"
+    elif dataType in ["IdleAction"]:
+        return "Settings::Deafen"
+    elif dataType in ["NoiseCancel"]:
+        return "Settings::NoiseCancelSpeex"
+    elif dataType in ["EchoCancelOptionID"]:
+        return "EchoCancelOptionID::SPEEX_MULTICHANNEL"
+    elif dataType in ["OverlayShow"]:
+        return "OverlaySettings::HomeChannel"
+    elif dataType in ["OverlayShow"]:
+        return "OverlaySettings::HomeChannel"
+    elif dataType in ["OverlaySort"]:
+        return "OverlaySettings::LastStateChange"
+    elif dataType in ["OverlayExclusionMode"]:
+        return "OverlaySettings::BlacklistExclusionMode"
+    elif dataType in ["Qt::Alignment"]:
+        return "Qt::AlignJustify | Qt::AlignBaseline"
+    elif dataType in ["WindowLayout"]:
+        return "Settings::LayoutHybrid"
+    elif dataType in ["AlwaysOnTopBehaviour"]:
+        return "Settings::OnTopAlways"
+    elif dataType in ["Search::SearchDialog::UserAction"]:
+        return "Search::SearchDialog::UserAction::NONE"
+    elif dataType in ["Search::SearchDialog::ChannelAction"]:
+        return "Search::SearchDialog::ChannelAction::NONE"
+    elif dataType in ["ProxyType"]:
+        return "Settings::Socks5Proxy"
+    elif dataType in ["RecordingMode"]:
+        return "Settings::RecordingMultichannel"
+    elif dataType.startswith("QMap") or dataType.startswith("QHash"):
+        types = getTemplateArguments(dataType)
+
+        assert len(types) == 2
+
+        return "{ {" + getDefaultValueForType(types[0]) + ", " + getDefaultValueForType(types[1]) + "} }"
+    elif dataType.startswith("QList"):
+        types = getTemplateArguments(dataType)
+
+        assert len(types) == 1
+
+        return "{ " + getDefaultValueForType(types[0]) + " }"
+    elif dataType.startswith("std::array"):
+        args = getTemplateArguments(dataType)
+
+        # std::array< Type, Size >
+        assert len(args) == 2
+
+        args[1] = int(args[1])
+
+        string = "{ "
+        for _ in range(args[1]):
+            string += getDefaultValueForType(args[0]) + ", "
+
+        if args[1] > 0:
+            # remove trailing comma
+            string = string[:-len(", ")]
+
+        return string + " }"
+    elif dataType in ["KeyPair"]:
+        # We can't really create a certificate here, so we have to use a default-constructed value
+        return "{}"
+
+    if dataType in defaultValues:
+        return defaultValues[dataType]
+
+    raise RuntimeError("No known default value for type " + dataType)
+
+
+
+def generateTestBody(settingsFields, settingsClassName, excludeFields = []):
+    contents = "#include <QObject>\n"
+    contents += "#include <QtTest>\n"
+    contents += "#include \"" + settingsClassName + ".h\"\n"
+    contents += "#include \"JSONSerialization.h\"\n"
+    contents += "#include <nlohmann/json.hpp>\n"
+    contents += "\n"
+    contents += "class TestSettingsJSONSerialization : public QObject {\n"
+    contents += "\tQ_OBJECT\n"
+    contents += "\t" + settingsClassName + " createSettingsInstance() const {\n"
+    contents += "\t\t" + settingsClassName + " settings;\n"
+    for fieldName in settingsFields:
+        if fieldName in excludeFields:
+            continue
+        if settingsFields[fieldName] == "OverlaySettings":
+            for overlayField in structs["OverlaySettings"]:
+                contents += "\t\tsettings." + fieldName + "." + overlayField + " = "\
+                        + getDefaultValueForType(structs["OverlaySettings"][overlayField]) + ";"
+        elif settingsFields[fieldName] == "bool":
+            # For boolean values, we simply use the inverse of whatever the default is
+            contents += "\t\tsettings." + fieldName + " = !settings." + fieldName + ";\n"
+        else:
+            contents += "\t\tsettings." + fieldName + " = " + getDefaultValueForType(settingsFields[fieldName]) + ";\n"
+    contents += "\n"
+    contents += "\t\treturn settings;\n"
+    contents += "\t}\n"
+    contents += "\n"
+
+    contents += "private slots:\n"
+    contents += "\tvoid noDefaultValuesMatched() {\n"
+    contents += "\t\tconst " + settingsClassName + " defaults;\n"
+    contents += "\t\tconst " + settingsClassName + " myInstance = createSettingsInstance();\n"
+    for fieldName in settingsFields:
+        if fieldName in excludeFields:
+            continue
+        contents += "\t\tQVERIFY2(defaults." + fieldName + "!= myInstance." + fieldName  + ", \"Field '" \
+                + fieldName + "' was set to its default value (breaking underlying assumption of the following test)\");\n"
+    contents += "\t}\n"
+    contents += "\n"
+    contents += "\tvoid testJSONSerialization() {\n"
+    contents += "\t\tconst " + settingsClassName + " original = createSettingsInstance();\n"
+    contents += "\t\tnlohmann::json jsonRepresentation = original;\n"
+    contents += "\t\tconst " + settingsClassName + " deserialized = jsonRepresentation;\n"
+    contents += "\n"
+    for fieldName in settingsFields:
+        if fieldName in excludeFields:
+            continue
+        else:
+            contents += "\t\tQCOMPARE(original." + fieldName + ", deserialized." + fieldName + ");\n"
+    contents += "\t}\n"
+    contents += "};\n"
+    contents += "\n"
+    contents += "QTEST_MAIN(TestSettingsJSONSerialization)\n"
+    contents += "#include \"TestSettingsJSONSerialization.moc\"\n"
+
+    return contents
+
+
+def generateDefaultConstruction(structName, fields):
+    contents =  structName + "{"
+    for currentField in fields:
+        contents += "/*" + currentField + "*/ " + getDefaultValueForType(fields[currentField]) + ","
+
+    if len(fields) > 0:
+        # remove trailing comma
+        contents = contents[:-1]
+
+    return contents + "}"
+
+
+
+def main():
+    parser = argparse.ArgumentParser("Generates the test case for the JSON (de)serialization of the settings struct")
+    parser.add_argument("--settings-header", help="The path to the header file containing the definition of the Settings struct", metavar="PATH",
+            required = True)
+    parser.add_argument("--settings-struct-name", help="The name of the settings struct", default="Settings")
+    parser.add_argument("--ignore-fields", help="A comma-separated list of fields in the settings struct to exclude from the test", default="kpCertificate")
+    parser.add_argument("--output-file", help="Path to where the output shall be written. If none is given, the result is written to stdout", metavar="PATH")
+
+    args = parser.parse_args()
+
+    headerContents = open(args.settings_header, "r").read()
+
+    for currentMatch in re.finditer(r"struct\s*(\w+)\s\{", headerContents):
+        definition = extractClassDefinition(currentMatch.group(1), headerContents[currentMatch.start() : ], classIdentifier="struct")
+
+        fields = extractFields(definition)
+
+        defaultValues[currentMatch.group(1)] = generateDefaultConstruction(currentMatch.group(1), fields)
+
+        structs[currentMatch.group(1)] = fields
+
+    ignoredFields = args.ignore_fields.split(",")
+    ignoredFields = [x.strip() for x in ignoredFields]
+
+    contents = generateTestBody(structs[args.settings_struct_name], args.settings_struct_name, excludeFields=ignoredFields)
+
+    if args.output_file:
+        outFile = open(args.output_file, "w")
+        outFile.write(contents)
+    else:
+        print(contents)
+
+
+
+
+if __name__ == "__main__":
+    main()

--- a/src/tests/TestSettingsJSONSerialization/generate_test_case.py
+++ b/src/tests/TestSettingsJSONSerialization/generate_test_case.py
@@ -16,14 +16,16 @@ def extractFields(classDefinition):
     classDefinition = re.sub(r".*\(.*", "", classDefinition)
     # Remove enum declarations
     classDefinition = re.sub(r"enum\s*\w+\s*\{.*?\};", "", classDefinition, flags=re.DOTALL)
-    # remove semuicolons
-    classDefinition = classDefinition.replace(";", "")
     # Remove "unsigned" type specifier
     classDefinition = classDefinition.replace("unsigned ", "")
     # Remove "mutable" keyword
     classDefinition = classDefinition.replace("mutable ", "")
     # Remove comments
     classDefinition = re.sub(r"//.*", "", classDefinition)
+    # Remove default value assignments
+    classDefinition = re.sub(r"\s*=[^;]+;", ";", classDefinition)
+    # remove semicolons
+    classDefinition = classDefinition.replace(";", "")
 
     fields = OrderedDict()
     for currentLine in classDefinition.split("\n"):


### PR DESCRIPTION
This PR streamlines the settings format on all OS and (hopefully) increases the readability
of the settings file A LOT (more or less self-explaining settings identifiers instead of some
weird terms or variable names only understood by the core devs themselves (if at all)).

In addition to and surrounding this feature, several changes, improvements and fixes on
the general topic of handling settings are included as well. See individual commit messages
for details.

Fixes #1940

As an aside: This change is an important step towards being able to provide portable Mumble
installations.

### Checks

- [x] My commits follow the [commit guidelines](https://github.com/mumble-voip/mumble/blob/master/COMMIT_GUIDELINES.md)

