### PR TITLE
FIX(client): Icon not used on Plasma Wayland session

### DIFF
--- a/src/mumble/main.cpp
+++ b/src/mumble/main.cpp
@@ -157,6 +157,10 @@ int main(int argc, char **argv) {
 	a.setOrganizationDomain(QLatin1String("mumble.sourceforge.net"));
 	a.setQuitOnLastWindowClosed(false);
 
+#if QT_VERSION >= 0x050700
+	a.setDesktopFileName("info.mumble.Mumble");
+#endif
+
 #if QT_VERSION >= 0x050100
 	a.setAttribute(Qt::AA_UseHighDpiPixmaps);
 #endif


### PR DESCRIPTION
In a Plasma Wayland session the Mumble icon was not used in the task bar,
instead the generic Wayland icon shows up.
Setting the desktop file name resolves this.

Fixes #4851


### Checks

- [x] My commits follow the [commit guidelines](https://github.com/mumble-voip/mumble/blob/master/COMMIT_GUIDELINES.md)

