### PR TITLE
BUILD(client,server): Include time.h instead of sys/time.h

### DIFF
--- a/src/Timer.cpp
+++ b/src/Timer.cpp
@@ -96,7 +96,7 @@ quint64 Timer::now() {
 #elif defined(Q_OS_UNIX)
 #	include <errno.h>
 #	include <string.h>
-#	include <sys/time.h>
+#	include <time.h>
 #	include <unistd.h>
 #	if defined(_POSIX_TIMERS) && defined(_POSIX_MONOTONIC_CLOCK)
 quint64 Timer::now() {


### PR DESCRIPTION
Including sys/time.h instead of time.h was causing compile errors in
certain environments.

Related: f6a546b7f673540c261a07b6e6a1047eabe8022c

Fixes #5546


### Checks

- [x] My commits follow the [commit guidelines](https://github.com/mumble-voip/mumble/blob/master/COMMIT_GUIDELINES.md)

