### PR TITLE
FIX(client): Percent encoded links not clickable

### DIFF
--- a/src/mumble/Markdown.cpp
+++ b/src/mumble/Markdown.cpp
@@ -310,9 +310,10 @@ bool processMarkdownCodeBlock(QString &str, int &offset) {
 /// @returns Whether a replacement has been made
 bool processPlainLink(QString &str, int &offset) {
 	// We support links with prefixed protocol (e.g. https://bla.com) and prefixed with www (e.g. www.bla.com)
+	// The last part of the regex matches percent encoded characters in the url
 	// See also https://stackoverflow.com/a/1547940/3907364
 	static const QRegularExpression s_regex(
-		QLatin1String("([a-zA-Z]+://|[wW][wW][wW]\\.)[A-Za-z0-9-._~:/?#\\[\\]@!$&'()*+,;=]+"));
+		QLatin1String("([a-zA-Z]+://|[wW][wW][wW]\\.)([A-Za-z0-9-._~:/?#\\[\\]@!$&'()*+,;=]|%[a-fA-F0-9]{2})+"));
 
 	QRegularExpressionMatch match =
 		s_regex.match(str, offset, QRegularExpression::NormalMatch, QRegularExpression::AnchoredMatchOption);


### PR DESCRIPTION
If a link contains any percent encoded characters (e.g. umlauts),
the markdown parser sets a wrong offset, thus resulting in a cut off
link in the log.

This is fixed by adjusting the url parsing regex to include a percent
symbol.


### Checks

- [x] My commits follow the [commit guidelines](https://github.com/mumble-voip/mumble/blob/master/COMMIT_GUIDELINES.md)

