### PR TITLE
BUILD(positional-audio): Fix missing <memory> include

### DIFF
--- a/plugins/gtav/gtav.cpp
+++ b/plugins/gtav/gtav.cpp
@@ -9,6 +9,7 @@
 #include "mumble_positional_audio_utils.h"
 
 #include <cstring>
+#include <memory>
 
 static std::unique_ptr< Game > game;
 


### PR DESCRIPTION
Without the change the build fails on upcoming gcc-12 as:

    /build/mumble/plugins/gtav/gtav.cpp:13:13:
      error: 'unique_ptr' in namespace 'std' does not name a template type
       13 | static std::unique_ptr< Game > game;
          |             ^~~~~~~~~~
    /build/mumble/plugins/gtav/gtav.cpp:12:1:
      note: 'std::unique_ptr' is defined in header '<memory>';
        did you forget to '#include <memory>'?
       11 | #include <cstring>
      +++ |+#include <memory>
       12 |



### Checks

- [x] My commits follow the [commit guidelines](https://github.com/mumble-voip/mumble/blob/master/COMMIT_GUIDELINES.md)