### PR TITLE
BUILD(cmake): Build/install celt as module

### DIFF
--- a/3rdparty/celt-0.7.0-build/CMakeLists.txt
+++ b/3rdparty/celt-0.7.0-build/CMakeLists.txt
@@ -9,12 +9,10 @@ if(NOT EXISTS "${CELT_SRC_DIR}/COPYING")
 	)
 endif()
 
-add_library(celt SHARED)
+add_library(celt MODULE)
 
 # Celt doesn't work in unity builds
 set_target_properties(celt PROPERTIES UNITY_BUILD FALSE)
-
-set_target_properties(celt PROPERTIES VERSION "0.7.0")
 
 target_compile_definitions(celt PRIVATE "HAVE_CONFIG_H")
 

--- a/macx/scripts/osxdist.py
+++ b/macx/scripts/osxdist.py
@@ -138,7 +138,7 @@ class AppBundle(object):
 		dst = os.path.join(self.bundle, 'Contents', 'Codecs')
  		if not os.path.exists(dst):
 			os.makedirs(dst)
-		codecs = (os.path.join(options.binary_dir, 'libcelt0.0.7.0.dylib'), os.path.join(options.binary_dir, 'libopus.dylib'))
+		codecs = (os.path.join(options.binary_dir, 'libcelt0.so'), os.path.join(options.binary_dir, 'libopus.dylib'))
 		for codec in codecs:
 			if os.path.exists(codec):
 				shutil.copy(codec, dst)
@@ -298,7 +298,7 @@ def package_client():
 			os.path.join(options.binary_dir, 'Mumble.app'),
 			os.path.join(options.binary_dir, 'Mumble.app/Contents/Plugins/liblink.dylib'),
 			os.path.join(options.binary_dir, 'Mumble.app/Contents/Plugins/libmanual.dylib'),
-			os.path.join(options.binary_dir, 'Mumble.app/Contents/Codecs/libcelt0.0.7.0.dylib'),
+			os.path.join(options.binary_dir, 'Mumble.app/Contents/Codecs/libcelt0.so'),
 			os.path.join(options.binary_dir, 'Mumble.app/Contents/Codecs/libopus.dylib'),
 			os.path.join(options.binary_dir, 'Mumble.app/Contents/MacOS/mumble-g15-helper'),
 		)

--- a/src/mumble/CELTCodec.cpp
+++ b/src/mumble/CELTCodec.cpp
@@ -37,29 +37,25 @@ CELTCodec::CELTCodec(const QString &celt_version) {
 	qlCELT.setLoadHints(QLibrary::ResolveAllSymbolsHint);
 
 	QStringList alternatives;
-#if defined(Q_OS_MAC)
-	alternatives << QString::fromLatin1("libcelt0.%1.dylib").arg(celt_version);
-	alternatives << QString::fromLatin1("celt0.%1.dylib").arg(celt_version);
-	alternatives << QString::fromLatin1("libcelt.%1.dylib").arg(celt_version);
-	alternatives << QString::fromLatin1("celt.%1.dylib").arg(celt_version);
-#elif defined(Q_OS_UNIX)
-	alternatives << QString::fromLatin1("libcelt0.so.%1").arg(celt_version);
-	alternatives << QString::fromLatin1("libcelt.so.%1").arg(celt_version);
-	alternatives << QString::fromLatin1("celt.so.%1").arg(celt_version);
+#if defined(Q_OS_MAC) || defined(Q_OS_UNIX)
+	alternatives << QString::fromLatin1("libcelt0.so");
+	alternatives << QString::fromLatin1("libcelt.so");
+	alternatives << QString::fromLatin1("celt0.so");
+	alternatives << QString::fromLatin1("celt.so");
 #else
 	int cpuinfo[4];
 	__cpuid(cpuinfo, 1);
 	if (cpuinfo[3] & 0x02000000) {
 		if (cpuinfo[3] & 0x04000000) {
 			if (cpuinfo[2] & 0x00000001) {
-				alternatives << QString::fromLatin1("celt0.%1.sse3.dll").arg(celt_version);
+				alternatives << QString::fromLatin1("celt0.sse3.dll");
 			}
-			alternatives << QString::fromLatin1("celt0.%1.sse2.dll").arg(celt_version);
+			alternatives << QString::fromLatin1("celt0.sse2.dll");
 		}
-		alternatives << QString::fromLatin1("celt0.%1.sse.dll").arg(celt_version);
+		alternatives << QString::fromLatin1("celt0.sse.dll");
 	}
 
-	alternatives << QString::fromLatin1("celt0.%1.dll").arg(celt_version);
+	alternatives << QString::fromLatin1("celt0.dll");
 #endif
 	foreach (const QString &lib, alternatives) {
 		qlCELT.setFileName(MumbleApplication::instance()->applicationVersionRootPath() + QLatin1String("/") + lib);


### PR DESCRIPTION
It loaded at runtime using dlopen(3) thus should be of type `MODULE`
not `SHARED` (dynamically linked) as per cmake docs[0].

This makes cmake's `install()` create an unversioned file as expected,
e.g. libcelt0.so on OpenBSD.

Account for all existing module names without versions now.

0: https://cmake.org/cmake/help/latest/command/add_library.html#id2

PP: This came up on OpenBSD where shared library versions are controlled
by the ports infrastructure and not the software itself;  improving
automated cmake handling showed that a) the file libcelt0.so.0.7.0 had
a wrong version scheme (OpenBSD uses .so.<maj>.<min>) and b) is not a
dynammically linked library but just a module.

Thus building celt as a module and shipping libcelt0.so aligns with
OpenBSD's ports infrastructure and the way mumble actually uses celt.


### Checks

- [ ] My commits follow the [commit guidelines](https://github.com/mumble-voip/mumble/blob/master/COMMIT_GUIDELINES.md)

