### PR TITLE
FIX(client): Data dir migration issues

### DIFF
--- a/src/mumble/Database.cpp
+++ b/src/mumble/Database.cpp
@@ -95,11 +95,6 @@ Database::Database(const QString &dbname) {
 		if (configuredLocation.exists()) {
 			db.setDatabaseName(Global::get().s.qsDatabaseLocation);
 			db.open();
-		} else if (!Global::get().migratedDBPath.isEmpty()) {
-			// Assume that we don't find the DB, because we have migrated it
-			db.setDatabaseName(Global::get().migratedDBPath);
-			db.open();
-			qWarning("Using migrated DB at %s", qUtf8Printable(Global::get().migratedDBPath));
 		} else {
 			int result = QMessageBox::critical(nullptr, QLatin1String("Mumble"),
 											   tr("The database file '%1' set in the configuration file does not "

--- a/src/mumble/Global.cpp
+++ b/src/mumble/Global.cpp
@@ -76,6 +76,10 @@ void Global::migrateDataDir(const QDir &toDir) {
 				if (currentInfo.fileName() == "mumble.sqlite") {
 					migratedDBPath = QDir(toDir.absoluteFilePath(currentInfo.fileName())).canonicalPath();
 				}
+				if (currentInfo.isDir() && currentInfo.fileName() == "Plugins") {
+					migratedPluginDirPath = { currentInfo.canonicalFilePath(),
+											  QDir(toDir.absoluteFilePath(currentInfo.fileName())).canonicalPath() };
+				}
 			}
 
 			// Only consider the first path in the list (which is expected to be the most recent one)

--- a/src/mumble/Global.h
+++ b/src/mumble/Global.h
@@ -39,6 +39,11 @@ class TalkingUI;
 
 class QNetworkAccessManager;
 
+struct MigratedPath {
+	QString oldPath;
+	QString newPath;
+};
+
 struct Global Q_DECL_FINAL {
 private:
 	Q_DISABLE_COPY(Global)
@@ -116,6 +121,7 @@ public:
 	static const char ccHappyEaster[];
 
 	QString migratedDBPath;
+	MigratedPath migratedPluginDirPath;
 
 	Global(const QString &qsConfigPath = QString());
 	~Global() = default;

--- a/src/mumble/Settings.h
+++ b/src/mumble/Settings.h
@@ -32,6 +32,7 @@
 #include <array>
 
 class QSettings;
+struct MigratedPath;
 
 // Global helper classes to spread variables around across threads
 // especially helpful to initialize things like the stored
@@ -552,6 +553,8 @@ struct Settings {
 	void load();
 
 	void legacyLoad(const QString &path = {});
+
+	void migratePluginSettings(const MigratedPath &path);
 
 private:
 	void verifySettingsKeys() const;

--- a/src/mumble/main.cpp
+++ b/src/mumble/main.cpp
@@ -558,6 +558,9 @@ int main(int argc, char **argv) {
 		// crash.
 		Global::get().s.qsDatabaseLocation = Global::get().migratedDBPath;
 
+		// Also update all plugin settings that might be affected by the migration
+		Global::get().s.migratePluginSettings(Global::get().migratedPluginDirPath);
+
 		Global::get().s.save();
 	}
 

--- a/src/mumble/main.cpp
+++ b/src/mumble/main.cpp
@@ -552,6 +552,14 @@ int main(int argc, char **argv) {
 	} else {
 		Global::get().s.load(settingsFile);
 	}
+	if (!Global::get().migratedDBPath.isEmpty()) {
+		// We have migrated the DB to a new location. Make sure that the settings hold the correct (new) path and that
+		// this path is written to disk immediately in order to minimize the risk of losing this information due to a
+		// crash.
+		Global::get().s.qsDatabaseLocation = Global::get().migratedDBPath;
+
+		Global::get().s.save();
+	}
 
 	// Check whether we need to enable accessibility features
 #ifdef Q_OS_WIN


### PR DESCRIPTION
This PR contains fixes related to the migration of the data directory as performed
in #5531.

The following issues are fixed
1. The database wouldn't be found on Windows, after the migration has been performed (after having restarted Mumble once)
2. Plugin settings were lost due their explicit dependence on the plugin's path

### Checks

- [x] My commits follow the [commit guidelines](https://github.com/mumble-voip/mumble/blob/master/COMMIT_GUIDELINES.md)

