### PR TITLE
FIX(client): Audio wizard being shown repeatedly

### DIFF
--- a/src/mumble/main.cpp
+++ b/src/mumble/main.cpp
@@ -713,6 +713,8 @@ int main(int argc, char **argv) {
 		AudioWizard *aw = new AudioWizard(Global::get().mw);
 		aw->exec();
 		delete aw;
+
+		Global::get().s.audioWizardShown = true;
 	}
 
 	if (!CertWizard::validateCert(Global::get().s.kpCertificate)) {

--- a/src/mumble/main.cpp
+++ b/src/mumble/main.cpp
@@ -56,6 +56,8 @@
 #include <QtGui/QDesktopServices>
 #include <QtWidgets/QMessageBox>
 
+#include <memory>
+
 #ifdef USE_DBUS
 #	include <QtDBus/QDBusInterface>
 #endif
@@ -710,9 +712,8 @@ int main(int argc, char **argv) {
 	a.setQuitOnLastWindowClosed(false);
 
 	if (!Global::get().s.audioWizardShown) {
-		AudioWizard *aw = new AudioWizard(Global::get().mw);
-		aw->exec();
-		delete aw;
+		auto wizard = std::make_unique< AudioWizard >(Global::get().mw);
+		wizard->exec();
 
 		Global::get().s.audioWizardShown = true;
 	}


### PR DESCRIPTION
The switch to a new settings format messed up the setting for whether or
not the audio wizard has been shown already or not. For new
installations, the wizard would be shown, but the fact that it has been
shown is not reflected in the settings causing the wizard to be re-shown
upon a restart.

This commit fixes this by making sure that the respective setting is set
after the wizard has been shown for the first time.


### Checks

- [x] My commits follow the [commit guidelines](https://github.com/mumble-voip/mumble/blob/master/COMMIT_GUIDELINES.md)

