### PR TITLE
BUILD(client,server): Fix warning for always true assert

### DIFF
--- a/src/MumbleProtocol.cpp
+++ b/src/MumbleProtocol.cpp
@@ -335,7 +335,7 @@ namespace Protocol {
 		m_audioMessage.Clear();
 
 		static_assert(AudioContext::BEGIN == 0, "AudioContext::BEGIN is not zero (breaks assumption)");
-		static_assert(AudioContext::END >= 0, "AudioContext::END is negative (breaks assumption)");
+		static_assert(AudioContext::END > 0, "AudioContext::END is not positive (breaks assumption)");
 		m_preEncodedContext.resize(AudioContext::END);
 
 		// Pre-encode the expected voice audio contexts.


### PR DESCRIPTION
Received compiler warning of an assert that is always true.
The assert checked if variable is negative but it is an unsigned variable.

unsigned at: 
https://github.com/mumble-voip/mumble/blob/74faaba32ea94f9654d461e5e544cf0d7ad36dd8/src/MumbleProtocol.h#L64
https://github.com/mumble-voip/mumble/blob/74faaba32ea94f9654d461e5e544cf0d7ad36dd8/src/MumbleProtocol.h#L96
https://github.com/mumble-voip/mumble/blob/74faaba32ea94f9654d461e5e544cf0d7ad36dd8/src/MumbleProtocol.h#L105


fixes: 
gcc (GCC) 11.2.0
manjaro
```
Building CXX object src/CMakeFiles/shared.dir/MumbleProtocol.cpp.o
/home/pat/Desktop/eclipse/mumble/src/MumbleProtocol.cpp: In member function ‘void Mumble::Protocol::UDPAudioEncoder<role>::preparePreEncodedSnippets()’:
/home/pat/Desktop/eclipse/mumble/src/MumbleProtocol.cpp:338:49: error: comparison is always true due to limited range of data type [-Werror=type-limits]
  338 |                 static_assert(AudioContext::END >= 0, "AudioContext::END is negative (breaks assumption)");
      |                               ~~~~~~~~~~~~~~~~~~^~~~

```

### Checks

- [x] My commits follow the [commit guidelines](https://github.com/mumble-voip/mumble/blob/master/COMMIT_GUIDELINES.md)

