### PR TITLE
CI(azure): Pin to VS2022

### DIFF
--- a/.ci/azure-pipelines/main-pr.yml
+++ b/.ci/azure-pipelines/main-pr.yml
@@ -22,11 +22,11 @@ jobs:
       clean: all
     timeoutInMinutes: 90
     pool:
-      vmImage: 'windows-latest'
+      vmImage: 'windows-2022'
     variables:
       MUMBLE_ENVIRONMENT_VERSION: 'windows-static-1.5.x~2021-07-27~64f88807.x64'
       MUMBLE_ENVIRONMENT_TRIPLET: 'x64-windows-static-md'
-      VCVARS_PATH: 'C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Auxiliary\Build\vcvars64.bat'
+      VCVARS_PATH: 'C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvars64.bat'
     steps:
     - template: steps_windows.yml
       parameters:
@@ -37,11 +37,11 @@ jobs:
       clean: all
     timeoutInMinutes: 120
     pool:
-      vmImage: 'windows-latest'
+      vmImage: 'windows-2022'
     variables:
       MUMBLE_ENVIRONMENT_VERSION: 'windows-static-1.5.x~2021-07-27~64f88807.x86'
       MUMBLE_ENVIRONMENT_TRIPLET: 'x86-windows-static-md'
-      VCVARS_PATH: 'C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Auxiliary\Build\vcvarsamd64_x86.bat'
+      VCVARS_PATH: 'C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvarsamd64_x86.bat'
     steps:
     - template: steps_windows.yml
       parameters:

--- a/.ci/azure-pipelines/main.yml
+++ b/.ci/azure-pipelines/main.yml
@@ -20,11 +20,11 @@ jobs:
       clean: all
     timeoutInMinutes: 90
     pool:
-      vmImage: 'windows-latest'
+      vmImage: 'windows-2022'
     variables:
       MUMBLE_ENVIRONMENT_VERSION: 'windows-static-1.5.x~2021-07-27~64f88807.x64'
       MUMBLE_ENVIRONMENT_TRIPLET: 'x64-windows-static-md'
-      VCVARS_PATH: 'C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Auxiliary\Build\vcvars64.bat'
+      VCVARS_PATH: 'C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvars64.bat'
     steps:
     - template: steps_windows.yml
       parameters:
@@ -35,11 +35,11 @@ jobs:
       clean: all
     timeoutInMinutes: 120
     pool:
-      vmImage: 'windows-latest'
+      vmImage: 'windows-2022'
     variables:
       MUMBLE_ENVIRONMENT_VERSION: 'windows-static-1.5.x~2021-07-27~64f88807.x86'
       MUMBLE_ENVIRONMENT_TRIPLET: 'x86-windows-static-md'
-      VCVARS_PATH: 'C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Auxiliary\Build\vcvarsamd64_x86.bat'
+      VCVARS_PATH: 'C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvarsamd64_x86.bat'
     steps:
     - template: steps_windows.yml
       parameters:


### PR DESCRIPTION
The automatic upgrade from VS2019 to VS2022 broke our build and in order
to prevent that in the future, we now pin the used VS version to 2022.
Later upgrades will have to be performed explicitly.


### Checks

- [x] My commits follow the [commit guidelines](https://github.com/mumble-voip/mumble/blob/master/COMMIT_GUIDELINES.md)

