### PR TITLE
BUILD(cmake): Find and link Poco::XML 

### DIFF
--- a/src/mumble/CMakeLists.txt
+++ b/src/mumble/CMakeLists.txt
@@ -411,11 +411,16 @@ target_include_directories(mumble_client_object_lib
 		"${PLUGINS_DIR}"
 )
 
-find_pkg(Poco COMPONENTS Zip)
+find_pkg(Poco
+	COMPONENTS
+		XML
+		Zip
+)
 
 if(TARGET Poco::Zip)
 	target_link_libraries(mumble_client_object_lib
 		PUBLIC
+			Poco::XML
 			Poco::Zip
 	)
 else()


### PR DESCRIPTION
Without this, building against the latest poco snapshot results in errors like:

    /usr/bin/ld: /builddir/build/BUILD/mumble-1.4.230.src/src/mumble/PluginManifest.cpp:72: undefined reference to `typeinfo for Poco::XML::Element'


### Checks

- [x] My commits follow the [commit guidelines](https://github.com/mumble-voip/mumble/blob/master/COMMIT_GUIDELINES.md)

