### PR TITLE
Backport "BUILD(cmake): Find and link Poco::XML" to 1.4.x

### DIFF
--- a/src/mumble/CMakeLists.txt
+++ b/src/mumble/CMakeLists.txt
@@ -384,11 +384,16 @@ target_include_directories(mumble
 		"${PLUGINS_DIR}"
 )
 
-find_pkg(Poco COMPONENTS Zip)
+find_pkg(Poco
+	COMPONENTS
+		XML
+		Zip
+)
 
 if(TARGET Poco::Zip)
 	target_link_libraries(mumble
 		PRIVATE
+			Poco::XML
 			Poco::Zip
 	)
 else()


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `1.4.x`:
 - [BUILD(cmake): Find and link Poco::XML](https://github.com/mumble-voip/mumble/pull/5616)

<!--- Backport version: 8.1.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)