### PR TITLE
CHANGE(client): Make https default link protocol

### DIFF
--- a/src/mumble/Markdown.cpp
+++ b/src/mumble/Markdown.cpp
@@ -322,9 +322,8 @@ bool processPlainLink(QString &str, int &offset) {
 		QString url = match.captured(0);
 
 		if (url.startsWith(QLatin1String("www"), Qt::CaseInsensitive)) {
-			// Link is missing a protocol specification.
-			// Use http as the default
-			url = QStringLiteral("http://") + url;
+			// Link is missing a protocol specification - use https as the default
+			url = QStringLiteral("https://") + url;
 		}
 
 		QString replacement =


### PR DESCRIPTION
Having plain http as the default means that a site, even though able to support https, will be able to fall back to using the insecure and outdated protocol.

Furthermore, major browsers already support https by default, falling back to legacy http in the cases where a website does not support https connections, e.g. [Chromium](https://blog.chromium.org/2021/03/a-safer-default-for-navigation-https.html), [Firefox](https://blog.mozilla.org/security/2021/08/10/firefox-91-introduces-https-by-default-in-private-browsing/).

Therefore, this commit makes it so that a link without a protocol specification will have `https://` prefixed to be clickable instead of `http://`.

### Checks

- [x] My commits follow the [commit guidelines](https://github.com/mumble-voip/mumble/blob/master/COMMIT_GUIDELINES.md)

