### PR TITLE
BUILD(server): Fix TERM signal not forwarded in docker container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -73,4 +73,4 @@ RUN mkdir /var/lib/murmur && \
 EXPOSE 64738/tcp 64738/udp 50051
 USER murmur
 
-CMD /usr/bin/mumble-server -v -fg -ini /etc/murmur/murmur.ini
+CMD ["/usr/bin/mumble-server", "-v", "-fg", "-ini", "/etc/murmur/murmur.ini"]


### PR DESCRIPTION
By using the list form, no shell is spawned and the TERM signal is forwarded to the mumble-server process


### Checks

- [X] My commits follow the [commit guidelines](https://github.com/mumble-voip/mumble/blob/master/COMMIT_GUIDELINES.md)

