### PR TITLE
FIX(server): Crash due to dereferencing invalid iterator

### DIFF
--- a/src/murmur/AudioReceiverBuffer.h
+++ b/src/murmur/AudioReceiverBuffer.h
@@ -68,6 +68,14 @@ public:
 		ReceiverRange< Iterator > range;
 		range.begin = begin;
 
+		if (begin == end) {
+			// In this case, it is invalid to dereference begin (as is done further down) and thus we have to
+			// return early instead.
+			range.end = end;
+
+			return range;
+		}
+
 		// Find a range, such that all receivers in [begin, end) are compatible in the sense that they will all receive
 		// the exact same audio packet (thus: no re-encoding required between sending the packet to them).
 		range.end = std::lower_bound(begin, end, *begin, [](const AudioReceiver &lhs, const AudioReceiver &rhs) {

--- a/src/tests/TestAudioReceiverBuffer/TestAudioReceiverBuffer.cpp
+++ b/src/tests/TestAudioReceiverBuffer/TestAudioReceiverBuffer.cpp
@@ -270,6 +270,19 @@ private slots:
 
 		qDebug() << "Sample receiver list required" << requiredReencodings << "encoding steps";
 	}
+
+	void test_emptyRange() {
+		AudioReceiverBuffer buffer;
+
+		std::vector< AudioReceiver > receivers = buffer.getReceivers(true);
+
+		QVERIFY(receivers.empty());
+
+		ReceiverRange< std::vector< AudioReceiver >::iterator > range =
+			AudioReceiverBuffer::getReceiverRange(receivers.begin(), receivers.end());
+
+		QCOMPARE(range.begin, range.end);
+	}
 };
 
 QTEST_MAIN(TestAudioReceiverBuffer)


### PR DESCRIPTION
1d45d991aa4d53b6c1bd7d7cae0126a21f3991e1 refactored the audio processing
on the server and introduced the new AudioReceiverBuffer class. In the
function that is responsible for obtaining the current range of
receivers that shall obtain the identical audio packet, the passed begin
iterator was always dereferenced. However, in the case in which the
receiver list is actually empty begin == end and therefore dereferencing
the begin iterator is undefined behavior.

This could lead to the entire server crashing (or could work just fine -
UB is great at this) but in any case, this is a severe problem.

The fix consists of a simple check for this specific situation and an
early return in that case.


### Checks

- [x] My commits follow the [commit guidelines](https://github.com/mumble-voip/mumble/blob/master/COMMIT_GUIDELINES.md)

