### PR TITLE
BUILD(server): allow users to specify the UID/GID for the murmur user

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -44,8 +44,12 @@ RUN make -j $(nproc)
 FROM ubuntu:focal
 
 ARG DEBIAN_FRONTEND=noninteractive
+ARG UID=1000
+ARG GID=1000
 
-RUN adduser murmur
+RUN groupadd --gid $GID murmur \
+	&& useradd --uid $UID --gid $GID murmur
+
 RUN apt-get update && apt-get install --no-install-recommends -y \
 	libcap2 \
 	libzeroc-ice3.7 \

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ![Mumble screenshot](screenshots/Mumble.png)
 
-# Mumble - Open Source voice-chat software 
+# Mumble - Open Source voice-chat software
 
 [![https://www.mumble.info](https://img.shields.io/badge/Website-https%3A%2F%2Fwww.mumble.info-blue?style=for-the-badge)](https://www.mumble.info)
 
@@ -120,10 +120,15 @@ murmurd [-supw <password>] [-ini <inifile>] [-fg] [v]
 #### Build and run from Docker
 
 On recent Docker versions you can build images directly from sources on GitHub:
-```
+```bash
 docker build --pull -t mumble-server github.com/mumble-voip/mumble#master
 ```
 Example `--pull`s each time to check for updated base image, then downloads and builds `master` branch.
+
+You can also specify user id (UID) and group id (GID) for the *murmur* user in the image. This allows users who use bind mount volumes to use the same UID/GID in the container as in the host:
+```bash
+docker build --pull -t mumble-server --build-arg UID=1234 --build-arg GID=1234 github.com/mumble-voip/mumble#master
+```
 
 ### OpenGL Overlay
 


### PR DESCRIPTION
the the docker image that is built by default uses murmur user to run
the server. When users use bind mount volumes the host system is
expected to match the permissions (UID/GID) of the created murmur user
or else they will get permission errors

this change allows users who build the docker image to specify which
user id and group id to be used in the docker image

Closes #5634


### Checks

- [x] My commits follow the [commit guidelines](https://github.com/mumble-voip/mumble/blob/master/COMMIT_GUIDELINES.md)

