### PR TITLE
BUILD(client): Fix warning about unused variable

### DIFF
--- a/src/mumble/GlobalShortcut_macx.mm
+++ b/src/mumble/GlobalShortcut_macx.mm
@@ -119,6 +119,9 @@ CGEventRef GlobalShortcutMac::callback(CGEventTapProxy proxy, CGEventType type,
 			[pool release];
 			return nullptr;
 		}
+#else
+	// Mark forward as unused in this case
+	(void) forward;
 #endif
 	return suppress ? nullptr : event;
 }


### PR DESCRIPTION
When building on a Mac -Doverlay=OFF, the compiler would produce a
warning about an unused variable in the macOS shortcut implementation.

This commit silences the warning, by explicitly marking the variable in
question as unused.

Fixes #5636


### Checks

- [x] My commits follow the [commit guidelines](https://github.com/mumble-voip/mumble/blob/master/COMMIT_GUIDELINES.md)

