### PR TITLE
CI: Also fetch build number token on GA

### DIFF
--- a/.github/workflows/build.sh
+++ b/.github/workflows/build.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 
 set -e
+set -x
 
 buildDir="${GITHUB_WORKSPACE}/build"
 

--- a/.github/workflows/build.sh
+++ b/.github/workflows/build.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+
+set -e
+
+buildDir="${GITHUB_WORKSPACE}/build"
+
+mkdir "$buildDir"
+
+cd "$buildDir"
+
+VERSION=$("${GITHUB_WORKSPACE}/scripts/mumble-version.py")
+BUILD_NUMBER=$("${GITHUB_WORKSPACE}/scripts/mumble-build-number.py" --commit "${GITHUB_SHA}" --version "${VERSION}" \
+	--password "${MUMBLE_BUILD_NUMBER_TOKEN}" --default 0)
+
+# Run cmake with all necessary options
+cmake -G Ninja \
+	  -S "$GITHUB_WORKSPACE" \
+	  -DCMAKE_BUILD_TYPE=$BUILD_TYPE \
+	  -DBUILD_NUMBER=$BUILD_NUMBER \
+	  $CMAKE_OPTIONS \
+      -DCMAKE_UNITY_BUILD=ON \
+	  $ADDITIONAL_CMAKE_OPTIONS \
+	  $VCPKG_CMAKE_OPTIONS
+
+# Actually build
+cmake --build . --config $BUILD_TYPE
+

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,9 +27,10 @@ jobs:
       shell: bash
 
 
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
           submodules: 'recursive'
+          fetch-depth: 1
 
 
     - name: Set environment variables

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -50,22 +50,14 @@ jobs:
           arch: ${{ matrix.arch }}
 
 
-    - name: Create build dir
-      run: cmake -E make_directory ${{runner.workspace}}/build
-
-    - name: Run CMake
-      run: |
-          cmake -G Ninja -S $GITHUB_WORKSPACE -B ${{runner.workspace}}/build -DCMAKE_BUILD_TYPE=$BUILD_TYPE $CMAKE_OPTIONS \
-          -DCMAKE_UNITY_BUILD=ON $ADDITIONAL_CMAKE_OPTIONS $VCPKG_CMAKE_OPTIONS
-      shell: bash
-
     - name: Build
-      working-directory: ${{runner.workspace}}/build
-      run: cmake --build . --config $BUILD_TYPE
+      run: ./.github/workflows/build.sh
       shell: bash
+      env:
+          MUMBLE_BUILD_NUMBER_TOKEN: ${{ secrets.BUILD_NUMBER_TOKEN }}
 
     - name: Test
-      working-directory: ${{runner.workspace}}/build
+      working-directory: ${{ github.workspace }}/build
       shell: bash
-      run: QT_QPA_PLATFORM=offscreen ctest -output-on-failure -C $BUILD_TYPE
+      run: QT_QPA_PLATFORM=offscreen ctest --output-on-failure -C $BUILD_TYPE
 

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -12,7 +12,7 @@ jobs:
       run: sudo apt install python3
       shell: bash
 
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
           # Assume that there are not >200 new commits that need checking
           fetch-depth: 200

--- a/.github/workflows/set_environment_variables.sh
+++ b/.github/workflows/set_environment_variables.sh
@@ -1,5 +1,8 @@
 #!/usr/bin/env bash
 
+set -e
+set -x
+
 os=$1
 build_type=$2
 arch=$3


### PR DESCRIPTION
GitHub Actions previously did not use the build number token. This is
changed by this commit. In order to to so, the build process has been
outsourced into its own script.


### Checks

- [x] My commits follow the [commit guidelines](https://github.com/mumble-voip/mumble/blob/master/COMMIT_GUIDELINES.md)

