### PR TITLE
Backport "Merge PR #5641: CI: Also fetch build number token on GA" to 1.4.x

### DIFF
--- a/.github/workflows/build.sh
+++ b/.github/workflows/build.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+
+set -e
+
+buildDir="${GITHUB_WORKSPACE}/build"
+
+mkdir "$buildDir"
+
+cd "$buildDir"
+
+VERSION=$("${GITHUB_WORKSPACE}/scripts/mumble-version.py")
+BUILD_NUMBER=$("${GITHUB_WORKSPACE}/scripts/mumble-build-number.py" --commit "${GITHUB_SHA}" --version "${VERSION}" \
+	--password "${MUMBLE_BUILD_NUMBER_TOKEN}" --default 0)
+
+# Run cmake with all necessary options
+cmake -G Ninja \
+	  -S "$GITHUB_WORKSPACE" \
+	  -DCMAKE_BUILD_TYPE=$BUILD_TYPE \
+	  -DBUILD_NUMBER=$BUILD_NUMBER \
+	  $CMAKE_OPTIONS \
+      -DCMAKE_UNITY_BUILD=ON \
+	  $ADDITIONAL_CMAKE_OPTIONS \
+	  $VCPKG_CMAKE_OPTIONS
+
+# Actually build
+cmake --build . --config $BUILD_TYPE
+

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -50,22 +50,14 @@ jobs:
           arch: ${{ matrix.arch }}
 
 
-    - name: Create build dir
-      run: cmake -E make_directory ${{runner.workspace}}/build
-
-    - name: Run CMake
-      run: |
-          cmake -G Ninja -S $GITHUB_WORKSPACE -B ${{runner.workspace}}/build -DCMAKE_BUILD_TYPE=$BUILD_TYPE $CMAKE_OPTIONS \
-          -DCMAKE_UNITY_BUILD=ON $ADDITIONAL_CMAKE_OPTIONS $VCPKG_CMAKE_OPTIONS
-      shell: bash
-
     - name: Build
-      working-directory: ${{runner.workspace}}/build
-      run: cmake --build . --config $BUILD_TYPE
+      run: ./.github/workflows/build.sh
       shell: bash
+      env:
+          MUMBLE_BUILD_NUMBER_TOKEN: ${{ secrets.BUILD_NUMBER_TOKEN }}
 
     - name: Test
-      working-directory: ${{runner.workspace}}/build
+      working-directory: ${{ github.workspace }}/build
       shell: bash
-      run: ctest -v -C $BUILD_TYPE
+      run: QT_QPA_PLATFORM=offscreen ctest --output-on-failure -C $BUILD_TYPE
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `1.4.x`:
 - [Merge PR #5641: CI: Also fetch build number token on GA](https://github.com/mumble-voip/mumble/pull/5641)

<!--- Backport version: 8.4.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)