### PR TITLE
Backport "CI: Also fetch build number token on GA"

### DIFF
--- a/.github/workflows/build.sh
+++ b/.github/workflows/build.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 
 set -e
+set -x
 
 buildDir="${GITHUB_WORKSPACE}/build"
 

--- a/.github/workflows/build.sh
+++ b/.github/workflows/build.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+
+set -e
+
+buildDir="${GITHUB_WORKSPACE}/build"
+
+mkdir "$buildDir"
+
+cd "$buildDir"
+
+VERSION=$("${GITHUB_WORKSPACE}/scripts/mumble-version.py")
+BUILD_NUMBER=$("${GITHUB_WORKSPACE}/scripts/mumble-build-number.py" --commit "${GITHUB_SHA}" --version "${VERSION}" \
+	--password "${MUMBLE_BUILD_NUMBER_TOKEN}" --default 0)
+
+# Run cmake with all necessary options
+cmake -G Ninja \
+	  -S "$GITHUB_WORKSPACE" \
+	  -DCMAKE_BUILD_TYPE=$BUILD_TYPE \
+	  -DBUILD_NUMBER=$BUILD_NUMBER \
+	  $CMAKE_OPTIONS \
+      -DCMAKE_UNITY_BUILD=ON \
+	  $ADDITIONAL_CMAKE_OPTIONS \
+	  $VCPKG_CMAKE_OPTIONS
+
+# Actually build
+cmake --build . --config $BUILD_TYPE
+

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,9 +27,10 @@ jobs:
       shell: bash
 
 
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
           submodules: 'recursive'
+          fetch-depth: 1
 
 
     - name: Set environment variables

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -50,22 +50,14 @@ jobs:
           arch: ${{ matrix.arch }}
 
 
-    - name: Create build dir
-      run: cmake -E make_directory ${{runner.workspace}}/build
-
-    - name: Run CMake
-      run: |
-          cmake -G Ninja -S $GITHUB_WORKSPACE -B ${{runner.workspace}}/build -DCMAKE_BUILD_TYPE=$BUILD_TYPE $CMAKE_OPTIONS \
-          -DCMAKE_UNITY_BUILD=ON $ADDITIONAL_CMAKE_OPTIONS $VCPKG_CMAKE_OPTIONS
-      shell: bash
-
     - name: Build
-      working-directory: ${{runner.workspace}}/build
-      run: cmake --build . --config $BUILD_TYPE
+      run: ./.github/workflows/build.sh
       shell: bash
+      env:
+          MUMBLE_BUILD_NUMBER_TOKEN: ${{ secrets.BUILD_NUMBER_TOKEN }}
 
     - name: Test
-      working-directory: ${{runner.workspace}}/build
+      working-directory: ${{ github.workspace }}/build
       shell: bash
-      run: ctest -v -C $BUILD_TYPE
+      run: QT_QPA_PLATFORM=offscreen ctest --output-on-failure -C $BUILD_TYPE
 

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -12,7 +12,7 @@ jobs:
       run: sudo apt install python3
       shell: bash
 
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
           # Assume that there are not >200 new commits that need checking
           fetch-depth: 200

--- a/.github/workflows/set_environment_variables.sh
+++ b/.github/workflows/set_environment_variables.sh
@@ -1,5 +1,8 @@
 #!/usr/bin/env bash
 
+set -e
+set -x
+
 os=$1
 build_type=$2
 arch=$3

--- a/scripts/mumble-build-number.py
+++ b/scripts/mumble-build-number.py
@@ -38,11 +38,11 @@ def main():
             always succeed.", type=int)
     args = parser.parse_args()
 
-    if not args.password is None and args.password.strip():
+    if not args.password is None and args.password.strip() == "":
         # An empty password is considered to be no password at all
         args.password = None
 
-    buildNumber = fetch_build_number(commit = args.commit, version = args.version, password = args.version)
+    buildNumber = fetch_build_number(commit = args.commit, version = args.version, password = args.password)
 
     if buildNumber is None and not args.default is None:
         buildNumber = args.default

--- a/scripts/mumble-build-number.py
+++ b/scripts/mumble-build-number.py
@@ -1,0 +1,60 @@
+#!/usr/bin/env python3
+#
+# Copyright 2022 The Mumble Developers. All rights reserved.
+# Use of this source code is governed by a BSD-style license
+# that can be found in the LICENSE file at the root of the
+# Mumble source tree or at <https://www.mumble.info/LICENSE>.
+#
+# This script fetches the build number for a given commit
+
+import argparse
+import urllib.request
+import sys
+
+def fetch_build_number(commit = None, version = None, password = None):
+    if commit is None or version is None:
+        return None
+
+    query = "https://mumble.info/get-build-number?commit=" + commit + "&version=" + version
+
+    if not password is None:
+        query += "&token=" + password
+
+    try:
+        request = urllib.request.urlopen(query)
+        answer = request.read().decode("utf-8")
+
+        return int(answer)
+    except urllib.error.HTTPError:
+        # The request failed
+        return None
+
+def main():
+    parser = argparse.ArgumentParser("This script will fetch the build number for the given commit hash")
+    parser.add_argument("--commit", help="The hash of the commit to fetch the build number for", metavar="HASH", required=True)
+    parser.add_argument("--version", help="The Mumble version the given commit belongs to (e.g. 1.4)", metavar="VERSION", required=True)
+    parser.add_argument("--password", help="The password to use in order to gain write access on the server")
+    parser.add_argument("--default", help="The default build number to use, in case none can be fetched. Note that this will cause this script to\
+            always succeed.", type=int)
+    args = parser.parse_args()
+
+    if not args.password is None and args.password.strip():
+        # An empty password is considered to be no password at all
+        args.password = None
+
+    buildNumber = fetch_build_number(commit = args.commit, version = args.version, password = args.version)
+
+    if buildNumber is None and not args.default is None:
+        buildNumber = args.default
+
+    if buildNumber is None:
+        print("[ERROR]: Failed to fetch the build number for commit " + args.commit + " in Mumble v" + args.version, file=sys.stderr)
+
+        sys.exit(1)
+    else:
+        print(buildNumber)
+        sys.exit(0)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Backport of #5641 

### Checks

- [x] My commits follow the [commit guidelines](https://github.com/mumble-voip/mumble/blob/master/COMMIT_GUIDELINES.md)

