### PR TITLE
CI: Add dispatch for new releases

### DIFF
--- a/.github/workflows/release_dispatch.yml
+++ b/.github/workflows/release_dispatch.yml
@@ -1,0 +1,16 @@
+name: Dispatch new release
+
+on:
+    release:
+        types: [ published ]
+
+jobs:
+    dispatch:
+        runs-on: ubuntu-latest
+        steps:
+            - name: "Dispatch release to mumble-docker repo"
+              uses: peter-evans/repository-dispatch@v2
+              with:
+                  token: ${{ secrets.DOCKER_REPO_ACCCESS_TOKEN }}
+                  event-type: new_release
+                  client_payload: '{ "tag": "${{ github.event.release.tag_name }}", "is_latest": "${{ github.event.release.commitish == master }}" }'


### PR DESCRIPTION
This will trigger a workflow in mumble-voip/mumble-docker every time
we release a new version here.

### Checks

- [x] My commits follow the [commit guidelines](https://github.com/mumble-voip/mumble/blob/master/COMMIT_GUIDELINES.md)

