### PR TITLE
Backport "Merge PR #5646: FIX(server): Improve rememberchannelduration compare logic" to 1.4.x

### DIFF
--- a/src/murmur/ServerDB.h
+++ b/src/murmur/ServerDB.h
@@ -68,10 +68,6 @@ public:
 private:
 	static void loadOrSetupMetaPBKDF2IterationCount(QSqlQuery &query);
 	static void writeSUPW(int srvnum, const QString &pwHash, const QString &saltHash, const QVariant &kdfIterations);
-
-public slots:
-	/// Clear last_disconnect date of every user of the server
-	void clearLastDisconnect(Server *);
 };
 
 #endif

--- a/src/murmur/main.cpp
+++ b/src/murmur/main.cpp
@@ -559,8 +559,6 @@ int main(int argc, char **argv) {
 
 	meta = new Meta();
 
-	QObject::connect(meta, SIGNAL(started(Server *)), &db, SLOT(clearLastDisconnect(Server *)));
-
 #ifdef Q_OS_UNIX
 	// It doesn't matter that this code comes after the forking because detach is
 	// set to false when readPw is set to true.


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `1.4.x`:
 - [Merge PR #5646: FIX(server): Improve rememberchannelduration compare logic](https://github.com/mumble-voip/mumble/pull/5646)

<!--- Backport version: 8.4.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)