### PR TITLE
Backport "Merge PR #5587: BUILD(positional-audio): Fix missing <memory> include" to 1.4.x

### DIFF
--- a/plugins/gtav/gtav.cpp
+++ b/plugins/gtav/gtav.cpp
@@ -9,6 +9,7 @@
 #include "mumble_positional_audio_utils.h"
 
 #include <cstring>
+#include <memory>
 
 static std::unique_ptr< Game > game;
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `1.4.x`:
 - [Merge PR #5587: BUILD(positional-audio): Fix missing <memory> include](https://github.com/mumble-voip/mumble/pull/5587)

<!--- Backport version: 8.4.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)