### PR TITLE
Backport "Merge PR #5564: FIX(client): Percent encoded links not clickable" to 1.4.x

### DIFF
--- a/src/mumble/Markdown.cpp
+++ b/src/mumble/Markdown.cpp
@@ -310,9 +310,10 @@ bool processMarkdownCodeBlock(QString &str, int &offset) {
 /// @returns Whether a replacement has been made
 bool processPlainLink(QString &str, int &offset) {
 	// We support links with prefixed protocol (e.g. https://bla.com) and prefixed with www (e.g. www.bla.com)
+	// The last part of the regex matches percent encoded characters in the url
 	// See also https://stackoverflow.com/a/1547940/3907364
 	static const QRegularExpression s_regex(
-		QLatin1String("([a-zA-Z]+://|[wW][wW][wW]\\.)[A-Za-z0-9-._~:/?#\\[\\]@!$&'()*+,;=]+"));
+		QLatin1String("([a-zA-Z]+://|[wW][wW][wW]\\.)([A-Za-z0-9-._~:/?#\\[\\]@!$&'()*+,;=]|%[a-fA-F0-9]{2})+"));
 
 	QRegularExpressionMatch match =
 		s_regex.match(str, offset, QRegularExpression::NormalMatch, QRegularExpression::AnchoredMatchOption);


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `1.4.x`:
 - [Merge PR #5564: FIX(client): Percent encoded links not clickable](https://github.com/mumble-voip/mumble/pull/5564)

<!--- Backport version: 8.4.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)