### PR TITLE
Backport "Merge PR #5554: FIX(client): Context and identity not getting cleared" to 1.4.x

### DIFF
--- a/src/mumble/PluginManager.cpp
+++ b/src/mumble/PluginManager.cpp
@@ -943,6 +943,24 @@ void PluginManager::on_syncPositionalData() {
 				}
 			}
 		}
+	} else {
+		QMutexLocker mLock(&m_sentDataMutex);
+
+		if (!m_sentData.identity.isEmpty() || !m_sentData.context.isEmpty()) {
+			// The server has been sent non-empty identity and/or context but we are now no longer able to fetch
+			// positional data. That means that the respective plugin has been unlinked and thus we want to clear the
+			// identity and context set on the server.
+			MumbleProto::UserState mpus;
+			mpus.set_plugin_context("");
+			mpus.set_plugin_identity("");
+
+			if (Global::get().sh) {
+				Global::get().sh->sendMessage(mpus);
+			}
+
+			m_sentData.identity.clear();
+			m_sentData.context.clear();
+		}
 	}
 }
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `1.4.x`:
 - [Merge PR #5554: FIX(client): Context and identity not getting cleared](https://github.com/mumble-voip/mumble/pull/5554)

<!--- Backport version: 8.4.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)