### PR TITLE
Backport "Merge PR #5550: BUILD(client,server): Include time.h instead of sys/time.h" to 1.4.x

### DIFF
--- a/src/Timer.cpp
+++ b/src/Timer.cpp
@@ -96,7 +96,7 @@ quint64 Timer::now() {
 #elif defined(Q_OS_UNIX)
 #	include <errno.h>
 #	include <string.h>
-#	include <sys/time.h>
+#	include <time.h>
 #	include <unistd.h>
 #	if defined(_POSIX_TIMERS) && defined(_POSIX_MONOTONIC_CLOCK)
 quint64 Timer::now() {


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `1.4.x`:
 - [Merge PR #5550: BUILD(client,server): Include time.h instead of sys/time.h](https://github.com/mumble-voip/mumble/pull/5550)

<!--- Backport version: 8.4.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)