### PR TITLE
Backport "Merge PR #5536: FIX(client): Icon not used on Plasma Wayland session" to 1.4.x

### DIFF
--- a/src/mumble/main.cpp
+++ b/src/mumble/main.cpp
@@ -157,6 +157,10 @@ int main(int argc, char **argv) {
 	a.setOrganizationDomain(QLatin1String("mumble.sourceforge.net"));
 	a.setQuitOnLastWindowClosed(false);
 
+#if QT_VERSION >= 0x050700
+	a.setDesktopFileName("info.mumble.Mumble");
+#endif
+
 #if QT_VERSION >= 0x050100
 	a.setAttribute(Qt::AA_UseHighDpiPixmaps);
 #endif


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `1.4.x`:
 - [Merge PR #5536: FIX(client): Icon not used on Plasma Wayland session](https://github.com/mumble-voip/mumble/pull/5536)

<!--- Backport version: 8.4.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)