### PR TITLE
Backport "Merge PR #5530: FIX(client): Fix PipeWire not being usable in Flatpaks" to 1.4.x

### DIFF
--- a/src/mumble/PipeWire.cpp
+++ b/src/mumble/PipeWire.cpp
@@ -128,7 +128,15 @@ void PipeWireInit::destroy() {
 static PipeWireInit pwi;
 
 PipeWireSystem::PipeWireSystem() : m_ok(false), m_users(0) {
-	const QStringList names{ "libpipewire.so", "libpipewire-0.3.so" };
+	// clang-format off
+	const QStringList names {
+		// Common names used by Linux distributions.
+		"libpipewire.so",
+		"libpipewire-0.3.so",
+		// Name used by the Flatpak FreeDesktop runtime.
+		"libpipewire-0.3.so.0"
+	};
+	// clang-format on
 
 	for (const auto &name : names) {
 		m_lib.setFileName(name);


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `1.4.x`:
 - [Merge PR #5530: FIX(client): Fix PipeWire not being usable in Flatpaks](https://github.com/mumble-voip/mumble/pull/5530)

<!--- Backport version: 8.4.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)