### PR TITLE
Backport "Merge PR #5503: BUILD(client): CELT: Require version 0.7.x when using the system library" to 1.4.x

### DIFF
--- a/src/mumble/CMakeLists.txt
+++ b/src/mumble/CMakeLists.txt
@@ -677,6 +677,10 @@ if(bundled-celt)
 	install_library(celt mumble_client)
 else()
 	find_pkg(celt REQUIRED)
+	if(${celt_VERSION} VERSION_LESS          0.7 OR
+	   ${celt_VERSION} VERSION_GREATER_EQUAL 0.8)
+		message(FATAL_ERROR "CELT 0.7.x is required, found ${celt_VERSION}!")
+	endif()
 	target_include_directories(mumble PRIVATE ${celt_INCLUDE_DIRS})
 endif()
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `1.4.x`:
 - [Merge PR #5503: BUILD(client): CELT: Require version 0.7.x when using the system library](https://github.com/mumble-voip/mumble/pull/5503)

<!--- Backport version: 8.4.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)