### PR TITLE
BUILD(macos): Fix plugins not getting bundled 

### DIFF
--- a/macx/scripts/osxdist.py
+++ b/macx/scripts/osxdist.py
@@ -151,7 +151,7 @@ class AppBundle(object):
 		dst = os.path.join(self.bundle, 'Contents', 'Plugins')
 		if not os.path.exists(dst):
 			os.makedirs(dst)
-		for plugin in glob.glob('plugins/*.dylib'):
+		for plugin in glob.glob(os.path.join(options.binary_dir, 'plugins') + '/*.dylib'):
 			shutil.copy(plugin, dst)
 
 	def update_plist(self):


### PR DESCRIPTION
If the osxdist script was not executed within the build directory, it
would not bundle the built plugins (most notably the Link plugin) as it
was using a relative path and was ignoring the binary dir command-line
option.

This is remedied by this PR.

Fixes https://github.com/mumble-voip/mumble/issues/5571

### Checks

- [x] My commits follow the [commit guidelines](https://github.com/mumble-voip/mumble/blob/master/COMMIT_GUIDELINES.md)

