### PR TITLE
CI(azure): Switch to using python3 instead of python

### DIFF
--- a/.ci/azure-pipelines/assertNoTranslationChanges.sh
+++ b/.ci/azure-pipelines/assertNoTranslationChanges.sh
@@ -18,7 +18,7 @@ git config user.name "CI"
 git config user.email "ci@mumble.info"
 
 # Execute updatetranslations that'll commit any translation changes
-python $updateScript --ci-mode
+python3 $updateScript --ci-mode
 echo
 
 # Ger new commit hash

--- a/.ci/azure-pipelines/release_macos.bash
+++ b/.ci/azure-pipelines/release_macos.bash
@@ -13,7 +13,7 @@
 #                                 repository is downloaded.
 #
 
-VERSION=$(python "scripts/mumble-version.py")
+VERSION=$(python3 "scripts/mumble-version.py")
 
 cd $BUILD_BINARIESDIRECTORY
 


### PR DESCRIPTION
### Checks

- [x] My commits follow the [commit guidelines](https://github.com/mumble-voip/mumble/blob/master/COMMIT_GUIDELINES.md)

