### PR TITLE
Backport "Merge PR #5671: CI(azure): Switch to using python3 instead of python" to 1.4.x

### DIFF
--- a/.ci/azure-pipelines/assertNoTranslationChanges.sh
+++ b/.ci/azure-pipelines/assertNoTranslationChanges.sh
@@ -18,7 +18,7 @@ git config user.name "CI"
 git config user.email "ci@mumble.info"
 
 # Execute updatetranslations that'll commit any translation changes
-python $updateScript --ci-mode
+python3 $updateScript --ci-mode
 echo
 
 # Ger new commit hash

--- a/.ci/azure-pipelines/release_macos.bash
+++ b/.ci/azure-pipelines/release_macos.bash
@@ -13,7 +13,7 @@
 #                                 repository is downloaded.
 #
 
-VERSION=$(python "scripts/mumble-version.py")
+VERSION=$(python3 "scripts/mumble-version.py")
 
 cd $BUILD_BINARIESDIRECTORY
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `1.4.x`:
 - [Merge PR #5671: CI(azure): Switch to using python3 instead of python](https://github.com/mumble-voip/mumble/pull/5671)

<!--- Backport version: 8.1.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)