### PR TITLE
CI: Remove x86 Windows build(s), update build environment(s)

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -23,7 +23,7 @@ environment:
 
   matrix:
     - MUMBLE_ENVIRONMENT_TRIPLET: 'x64-windows-static-md'
-      MUMBLE_ENVIRONMENT_VERSION: 'windows-static-1.5.x~2021-07-27~64f88807.x64'
+      MUMBLE_ENVIRONMENT_VERSION: 'windows-static-1.5.x~2022-05-17~cd7e2c9.x64'
       VCVARS_PATH: 'C:/Program Files (x86)/Microsoft Visual Studio/2019/Community/VC/Auxiliary/Build/vcvars64.bat'
 
 install:

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -25,9 +25,6 @@ environment:
     - MUMBLE_ENVIRONMENT_TRIPLET: 'x64-windows-static-md'
       MUMBLE_ENVIRONMENT_VERSION: 'windows-static-1.5.x~2021-07-27~64f88807.x64'
       VCVARS_PATH: 'C:/Program Files (x86)/Microsoft Visual Studio/2019/Community/VC/Auxiliary/Build/vcvars64.bat'
-    - MUMBLE_ENVIRONMENT_TRIPLET: 'x86-windows-static-md'
-      MUMBLE_ENVIRONMENT_VERSION: 'windows-static-1.5.x~2021-07-27~64f88807.x86'
-      VCVARS_PATH: 'C:/Program Files (x86)/Microsoft Visual Studio/2019/Community/VC/Auxiliary/Build/vcvarsamd64_x86.bat'
 
 install:
   - ps: .ci/install-environment_windows.ps1

--- a/.ci/azure-pipelines/main-pr.yml
+++ b/.ci/azure-pipelines/main-pr.yml
@@ -24,7 +24,7 @@ jobs:
     pool:
       vmImage: 'windows-2022'
     variables:
-      MUMBLE_ENVIRONMENT_VERSION: 'windows-static-1.5.x~2021-07-27~64f88807.x64'
+      MUMBLE_ENVIRONMENT_VERSION: 'windows-static-1.5.x~2022-05-17~cd7e2c9.x64'
       MUMBLE_ENVIRONMENT_TRIPLET: 'x64-windows-static-md'
       VCVARS_PATH: 'C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvars64.bat'
     steps:
@@ -46,7 +46,7 @@ jobs:
     pool:
       vmImage: 'macOS-latest'
     variables:
-      MUMBLE_ENVIRONMENT_VERSION: 'macos-static-1.5.x~2021-07-27~64f88807.x64'
+      MUMBLE_ENVIRONMENT_VERSION: 'macos-static-1.5.x~2022-05-17~cd7e2c9.x64'
     steps:
     - template: steps_macos.yml
       parameters:

--- a/.ci/azure-pipelines/main-pr.yml
+++ b/.ci/azure-pipelines/main-pr.yml
@@ -32,21 +32,6 @@ jobs:
       parameters:
         arch: 'x64'
 
-  - job: Windows_x86
-    workspace:
-      clean: all
-    timeoutInMinutes: 120
-    pool:
-      vmImage: 'windows-2022'
-    variables:
-      MUMBLE_ENVIRONMENT_VERSION: 'windows-static-1.5.x~2021-07-27~64f88807.x86'
-      MUMBLE_ENVIRONMENT_TRIPLET: 'x86-windows-static-md'
-      VCVARS_PATH: 'C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvarsamd64_x86.bat'
-    steps:
-    - template: steps_windows.yml
-      parameters:
-        arch: 'x86'
-
   - job: Linux
     workspace:
       clean: all

--- a/.ci/azure-pipelines/main.yml
+++ b/.ci/azure-pipelines/main.yml
@@ -22,7 +22,7 @@ jobs:
     pool:
       vmImage: 'windows-2022'
     variables:
-      MUMBLE_ENVIRONMENT_VERSION: 'windows-static-1.5.x~2021-07-27~64f88807.x64'
+      MUMBLE_ENVIRONMENT_VERSION: 'windows-static-1.5.x~2022-05-17~cd7e2c9.x64'
       MUMBLE_ENVIRONMENT_TRIPLET: 'x64-windows-static-md'
       VCVARS_PATH: 'C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvars64.bat'
     steps:

--- a/.ci/azure-pipelines/main.yml
+++ b/.ci/azure-pipelines/main.yml
@@ -30,21 +30,6 @@ jobs:
       parameters:
         arch: 'x64'
 
-  - job: Windows_x86
-    workspace:
-      clean: all
-    timeoutInMinutes: 120
-    pool:
-      vmImage: 'windows-2022'
-    variables:
-      MUMBLE_ENVIRONMENT_VERSION: 'windows-static-1.5.x~2021-07-27~64f88807.x86'
-      MUMBLE_ENVIRONMENT_TRIPLET: 'x86-windows-static-md'
-      VCVARS_PATH: 'C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvarsamd64_x86.bat'
-    steps:
-    - template: steps_windows.yml
-      parameters:
-        arch: 'x86'
-
   - job: Linux
     workspace:
       clean: all


### PR DESCRIPTION
f999081ab82d0a70843036bd2ebb2629921facde enabled the MySQL plugin for Qt.

Turns out its master dependency (libmysql) cannot be built for x86:
microsoft/vcpkg#11214

This issue leaves us with two choices:

1. Get rid of x86 builds altogether.
2. x64 builds with MySQL plugin, x86 ones without. Potential confusion.

We asked on our Matrix channel whether anyone used official x86 releases.
Nobody did, which is a very good thing considering x86 (32 bit) CPUs are no more.

In addition to that, Microsoft dropped the platform with Windows 10 2004.