### PR TITLE
MAINT(vcpkg): Install protobuf

### DIFF
--- a/scripts/vcpkg/get_mumble_dependencies.ps1
+++ b/scripts/vcpkg/get_mumble_dependencies.ps1
@@ -18,6 +18,7 @@ $mumble_deps = "qt5-base[mysqlplugin]",
                "libflac",
                "libsndfile",
                "mdnsresponder",
+               "protobuf",
                "zlib", 
                "zeroc-ice-mumble"
 

--- a/scripts/vcpkg/get_mumble_dependencies.sh
+++ b/scripts/vcpkg/get_mumble_dependencies.sh
@@ -52,6 +52,7 @@ mumble_deps='qt5-base[mysqlplugin],
             libogg,
             libflac,
             libsndfile,
+            protobuf,
             zlib,
             zeroc-ice-mumble'
 


### PR DESCRIPTION
It probably used to be a dependency of at least another package we install.