### PR TITLE
CHANGE(client): Disable RNNoise by default

### DIFF
--- a/src/mumble/Settings.cpp
+++ b/src/mumble/Settings.cpp
@@ -499,9 +499,6 @@ Settings::Settings() {
 	qRegisterMetaType< Search::SearchDialog::ChannelAction >("SearchDialog::ChannelAction");
 
 
-#ifdef USE_RNNOISE
-	noiseCancelMode = NoiseCancelRNN;
-#endif
 #ifdef Q_OS_MACOS
 	// The echo cancellation feature on macOS is experimental and known to be able to cause problems
 	// (e.g. muting the user instead of only cancelling echo - https://github.com/mumble-voip/mumble/issues/4912)

--- a/src/tests/TestSettingsJSONSerialization/generate_test_case.py
+++ b/src/tests/TestSettingsJSONSerialization/generate_test_case.py
@@ -133,7 +133,7 @@ def getDefaultValueForType(dataType):
     elif dataType in ["IdleAction"]:
         return "Settings::Deafen"
     elif dataType in ["NoiseCancel"]:
-        return "Settings::NoiseCancelSpeex"
+        return "Settings::NoiseCancelBoth"
     elif dataType in ["EchoCancelOptionID"]:
         return "EchoCancelOptionID::SPEEX_MULTICHANNEL"
     elif dataType in ["OverlayShow"]:


### PR DESCRIPTION
In the 1.4.230 release, we enabled RNNoise by default as there have been
lots of reports of how well it works. However, after the release we saw
numerous reports complaining about bad audio quality, which was traced
back to having RNNoise enabled.

For some reason the outcome of having RNNoise enabled is very different
in different scenarios. Sometimes it works miraculously well and other
times it worsens the audio quality to an unbearable level.

There seems to be a higher chance of RNNoise messing up, when using
Windows, but the same effect has also been observed on Linux. It might
also depend on the quality of the used microphone (better quality = less
noise -> RNNoise starts doing weird stuff), but we don't have any
definitive clues yet.

Because of this, we will change the default noise cancelling mode back
to Speex so that everyone for whom RNNoise actually works, cna enable
it, but we don't kill the experience for many folks by using an
unsuitable default value.

Fixes #5448


### Checks

- [x] My commits follow the [commit guidelines](https://github.com/mumble-voip/mumble/blob/master/COMMIT_GUIDELINES.md)

