### PR TITLE
Backport "MAINT(vcpkg): Install protobuf" to 1.4.x

### DIFF
--- a/scripts/vcpkg/get_mumble_dependencies.ps1
+++ b/scripts/vcpkg/get_mumble_dependencies.ps1
@@ -19,6 +19,7 @@ $mumble_deps = "qt5-base",
                "libsndfile",
                "libmariadb",
                "mdnsresponder",
+               "protobuf",
                "zlib", 
                "zeroc-ice"
 

--- a/scripts/vcpkg/get_mumble_dependencies.sh
+++ b/scripts/vcpkg/get_mumble_dependencies.sh
@@ -53,6 +53,7 @@ mumble_deps='qt5-base,
             libflac,
             libsndfile,
             libmariadb,
+            protobuf,
             zlib,
             zeroc-ice'
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `1.4.x`:
 - [Merge PR #5676: MAINT(vcpkg): Install protobuf](https://github.com/mumble-voip/mumble/pull/5676)

<!--- Backport version: 8.1.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)