### PR TITLE
REFAC(macos,overlay): Remove unused symbol

### DIFF
--- a/overlay_gl/init_mac.c
+++ b/overlay_gl/init_mac.c
@@ -124,9 +124,8 @@ __attribute__((constructor)) static void initializeLibrary() {
 
 	ods("!");
 
-	void *nsgl = NULL, *cgl = NULL;
-	nsgl = dlsym(RTLD_DEFAULT, "NSClassFromString");
-	cgl  = dlsym(RTLD_DEFAULT, "CGLFlushDrawable");
+	void *nsgl = NULL;
+	nsgl       = dlsym(RTLD_DEFAULT, "NSClassFromString");
 
 	/* Check for GL symbol availability */
 	if (!(AVAIL_ALL_GLSYM)) {


### PR DESCRIPTION
The cgl symbol was resolved but never used, which triggered a warning
in our macOS CI.


### Checks

- [x] My commits follow the [commit guidelines](https://github.com/mumble-voip/mumble/blob/master/COMMIT_GUIDELINES.md)

