### PR TITLE
CI(macos): Use azure-hosted runner

### DIFF
--- a/.ci/azure-pipelines/main-pr.yml
+++ b/.ci/azure-pipelines/main-pr.yml
@@ -44,7 +44,7 @@ jobs:
     workspace:
       clean: all
     pool:
-      vmImage: 'macOS-latest'
+      vmImage: 'macOS-11'
     variables:
       MUMBLE_ENVIRONMENT_VERSION: 'macos-static-1.5.x~2022-05-17~cd7e2c9.x64'
     steps:

--- a/.ci/azure-pipelines/main.yml
+++ b/.ci/azure-pipelines/main.yml
@@ -42,11 +42,10 @@ jobs:
     workspace:
       clean: all
     pool:
-      name: "Default"
-      demands:
-      - agent.os -equals Darwin
+      vmImage: 'macOS-11'
     variables:
-      MUMBLE_ENVIRONMENT_STORE: '~/MumbleBuild'
-      MUMBLE_ENVIRONMENT_VERSION: 'latest-1.5.x'
+      MUMBLE_ENVIRONMENT_VERSION: 'macos-static-1.5.x~2021-07-27~64f88807.x64'
     steps:
     - template: steps_macos.yml
+      parameters:
+        installEnvironment: true


### PR DESCRIPTION
We used to use a self-hosted macOS CI runner but since we were only
using that for Nightly builds, we frequently ran into situations where
some issue was only appearing there which meant that while for the PR
the CI succeeded, it would fail after the change had been merged in.

As this is not a desirable situation, this commit makes sure that we are
using the same macOS runner for all CI runs. For simplicity we are using
the Azure hosted ones for that purpose.


### Checks

- [x] My commits follow the [commit guidelines](https://github.com/mumble-voip/mumble/blob/master/COMMIT_GUIDELINES.md)

