### PR TITLE
Backport "FIX(positional-audio): Update GTAV plugin to version 1.59.2612" to 1.4.x

### DIFF
--- a/plugins/gtav/Game.cpp
+++ b/plugins/gtav/Game.cpp
@@ -31,16 +31,16 @@ Mumble_PositionalDataErrorCode Game::init() {
 
 	// Check if we can get meaningful data from it
 	const std::string expected_name = "Grand Theft Auto V";
-	if (m_proc.peekString(m_moduleBase + 0x1E264D3, expected_name.length()) == expected_name) {
+	if (m_proc.peekString(m_moduleBase + 0x192D120, expected_name.length()) == expected_name) {
 		// Steam version
-		m_stateAddr      = m_moduleBase + 0x296F830;
-		m_avatarPosAddr  = m_moduleBase + 0x1D57310;
-		m_cameraPosAddr  = m_moduleBase + 0x1DA5FA0;
-		m_avatarDirAddr  = m_moduleBase + 0x204FB70;
-		m_avatarAxisAddr = m_moduleBase + 0x204FB60;
-		m_cameraDirAddr  = m_moduleBase + 0x1FDA9F0;
-		m_cameraAxisAddr = m_moduleBase + 0x1FDA9E0;
-		m_playerAddr     = m_moduleBase + 0x297CBB4;
+		m_stateAddr      = m_moduleBase + 0x2970F70;
+		m_avatarPosAddr  = m_moduleBase + 0x1FDCD70;
+		m_cameraPosAddr  = m_moduleBase + 0x1FDCD80;
+		m_avatarDirAddr  = m_moduleBase + 0x20510E0;
+		m_avatarAxisAddr = m_moduleBase + 0x20510D0;
+		m_cameraDirAddr  = m_moduleBase + 0x20510A0;
+		m_cameraAxisAddr = m_moduleBase + 0x20510B0;
+		m_playerAddr     = m_moduleBase + 0x297E2F4;
 	} else if (m_proc.peekString(0x180D4D8, expected_name.length()) == expected_name) {
 		// Retail version
 		m_stateAddr      = m_moduleBase + 0x2733490;

--- a/plugins/gtav/gtav.cpp
+++ b/plugins/gtav/gtav.cpp
@@ -43,7 +43,7 @@ void mumble_releaseResource(const void *) {
 
 mumble_version_t mumble_getVersion() {
 	// we reuse the GTA version as plugin version
-	return { 1, 58, 2545 };
+	return { 1, 59, 2612 };
 }
 
 MumbleStringWrapper mumble_getAuthor() {
@@ -59,7 +59,7 @@ MumbleStringWrapper mumble_getAuthor() {
 
 MumbleStringWrapper mumble_getDescription() {
 	static const char description[] = "Provides positional audio functionality for GTA V. "
-									  "Supports GTA V version 1.58 Build 2545 (Steam) and 1.38 (Retail). "
+									  "Supports GTA V version 1.59 Build 2612 (Steam) and 1.38 (Retail). "
 									  "Also provides identity based on username.";
 
 	MumbleStringWrapper wrapper;


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `1.4.x`:
 - [FIX(positional-audio): Update GTAV plugin to version 1.59.2612](https://github.com/mumble-voip/mumble/pull/5679)

<!--- Backport version: 8.4.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)