### PR TITLE
Backport "Merge PR #5677: CHANGE(client): Disable RNNoise by default" to 1.4.x

### DIFF
--- a/src/mumble/Settings.cpp
+++ b/src/mumble/Settings.cpp
@@ -326,14 +326,10 @@ Settings::Settings() {
 	iVoiceHold                     = 50;
 	iJitterBufferSize              = 1;
 	iFramesPerPacket               = 2;
-#ifdef USE_RNNOISE
-	noiseCancelMode = NoiseCancelRNN;
-#else
-	noiseCancelMode = NoiseCancelSpeex;
-#endif
-	iSpeexNoiseCancelStrength = -30;
-	bAllowLowDelay            = true;
-	uiAudioInputChannelMask   = 0xffffffffffffffffULL;
+	noiseCancelMode                = NoiseCancelSpeex;
+	iSpeexNoiseCancelStrength      = -30;
+	bAllowLowDelay                 = true;
+	uiAudioInputChannelMask        = 0xffffffffffffffffULL;
 
 	// Idle auto actions
 	iIdleTime                   = 5 * 60;


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `1.4.x`:
 - [Merge PR #5677: CHANGE(client): Disable RNNoise by default](https://github.com/mumble-voip/mumble/pull/5677)

<!--- Backport version: 8.4.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)