### PR TITLE
CI(macos): Use correct build env on macOS nightly builds

### DIFF
--- a/.ci/azure-pipelines/main.yml
+++ b/.ci/azure-pipelines/main.yml
@@ -44,7 +44,7 @@ jobs:
     pool:
       vmImage: 'macOS-11'
     variables:
-      MUMBLE_ENVIRONMENT_VERSION: 'macos-static-1.5.x~2021-07-27~64f88807.x64'
+      MUMBLE_ENVIRONMENT_VERSION: 'macos-static-1.5.x~2022-05-17~cd7e2c9.x64'
     steps:
     - template: steps_macos.yml
       parameters:


### PR DESCRIPTION
### Checks

- [x] My commits follow the [commit guidelines](https://github.com/mumble-voip/mumble/blob/master/COMMIT_GUIDELINES.md)

