### PR TITLE
BUILD: Fix missing <cstdint> include

### DIFF
--- a/plugins/Module.h
+++ b/plugins/Module.h
@@ -6,6 +6,7 @@
 #ifndef MODULE_H
 #define MODULE_H
 
+#include <cstdint>
 #include <set>
 #include <string>
 #include <unordered_map>


### PR DESCRIPTION
Without the change mumble build fails on this week's gcc-13 snapshot as:

    plugins/Module.h:13:9: error: 'uint64_t' does not name a type
       13 | typedef uint64_t procptr_t;
          |         ^~~~~~~~
    plugins/Module.h:12:1: note: 'uint64_t' is defined in header '<cstdint>';
      did you forget to '#include <cstdint>'?
       11 | #include <unordered_map>
      +++ |+#include <cstdint>
       12 |


### Checks

- [x] My commits follow the [commit guidelines](https://github.com/mumble-voip/mumble/blob/master/COMMIT_GUIDELINES.md)

