### PR TITLE
Backport "BUILD: Fix missing <cstdint> include" to 1.4.x

### DIFF
--- a/plugins/Module.h
+++ b/plugins/Module.h
@@ -6,6 +6,7 @@
 #ifndef MODULE_H
 #define MODULE_H
 
+#include <cstdint>
 #include <set>
 #include <string>
 #include <unordered_map>


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `1.4.x`:
 - [BUILD: Fix missing <cstdint> include](https://github.com/mumble-voip/mumble/pull/5703)

<!--- Backport version: 8.4.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)