### PR TITLE
FEAT(client, ui): separate ipv4 and ipv6 in ServerItem tooltip

### DIFF
--- a/src/HostAddress.cpp
+++ b/src/HostAddress.cpp
@@ -135,22 +135,29 @@ quint32 qHash(const HostAddress &ha) {
 	return (ha.hash[0] ^ ha.hash[1] ^ ha.hash[2] ^ ha.hash[3]);
 }
 
-QString HostAddress::toString() const {
+QString HostAddress::toString(bool bracketEnclosed) const {
 	if (isV6()) {
 		if (isValid()) {
-			QString qs;
+			QString str;
+			const char *squareBracketOpen  = "";
+			const char *squareBracketClose = "";
+			if (bracketEnclosed) {
+				squareBracketOpen  = "[";
+				squareBracketClose = "]";
+			}
 #if QT_VERSION >= 0x050500
-			qs = QString::asprintf("[%x:%x:%x:%x:%x:%x:%x:%x]", ntohs(shorts[0]), ntohs(shorts[1]), ntohs(shorts[2]),
-								   ntohs(shorts[3]), ntohs(shorts[4]), ntohs(shorts[5]), ntohs(shorts[6]),
-								   ntohs(shorts[7]));
+			str = QString::asprintf("%s%x:%x:%x:%x:%x:%x:%x:%x%s", squareBracketOpen, ntohs(shorts[0]),
+									ntohs(shorts[1]), ntohs(shorts[2]), ntohs(shorts[3]), ntohs(shorts[4]),
+									ntohs(shorts[5]), ntohs(shorts[6]), ntohs(shorts[7]), squareBracketClose);
 #else
 			// sprintf() has been deprecated in Qt 5.5 in favor for the static QString::asprintf()
-			qs.sprintf("[%x:%x:%x:%x:%x:%x:%x:%x]", ntohs(shorts[0]), ntohs(shorts[1]), ntohs(shorts[2]),
-					   ntohs(shorts[3]), ntohs(shorts[4]), ntohs(shorts[5]), ntohs(shorts[6]), ntohs(shorts[7]));
+			str.sprintf("%s%x:%x:%x:%x:%x:%x:%x:%x%s", squareBracketOpen, ntohs(shorts[0]), ntohs(shorts[1]),
+						ntohs(shorts[2]), ntohs(shorts[3]), ntohs(shorts[4]), ntohs(shorts[5]), ntohs(shorts[6]),
+						ntohs(shorts[7]), squareBracketClose);
 #endif
-			return qs.replace(QRegExp(QLatin1String("(:0)+")), QLatin1String(":"));
+			return str.replace(QRegExp(QLatin1String("(:0)+")), QLatin1String(":"));
 		} else {
-			return QLatin1String("[::]");
+			return bracketEnclosed ? QLatin1String("[::]") : QLatin1String("::");
 		}
 	} else {
 		return QHostAddress(ntohl(hash[3])).toString();

--- a/src/HostAddress.h
+++ b/src/HostAddress.h
@@ -35,7 +35,7 @@ struct HostAddress {
 
 	bool match(const HostAddress &, int bits) const;
 
-	QString toString() const;
+	QString toString(bool bracketEnclosed = true) const;
 
 	std::string toStdString() const;
 	QHostAddress toAddress() const;

--- a/src/mumble/ConnectDialog.cpp
+++ b/src/mumble/ConnectDialog.cpp
@@ -473,11 +473,23 @@ QVariant ServerItem::data(int column, int role) const {
 					return uiUsers ? QString::fromLatin1("%1/%2 ").arg(uiUsers).arg(uiMaxUsers) : QVariant();
 			}
 		} else if (role == Qt::ToolTipRole) {
-			QStringList qsl;
+			QStringList ipv4List;
+			QStringList ipv6List;
 			foreach (const ServerAddress &addr, qlAddresses) {
-				const QString qsAddress = addr.host.toString() + QLatin1String(":")
-										  + QString::number(static_cast< unsigned long >(addr.port));
-				qsl << qsAddress.toHtmlEscaped();
+				const QString address = addr.host.toString(false).toHtmlEscaped();
+				if (addr.host.isV6()) {
+					ipv6List << address;
+				} else {
+					ipv4List << address;
+				}
+			}
+			QString ipv4 = "-";
+			QString ipv6 = "-";
+			if (!ipv4List.isEmpty()) {
+				ipv4 = ipv4List.join(QLatin1String(", "));
+			}
+			if (!ipv6List.isEmpty()) {
+				ipv6 = ipv6List.join(QLatin1String(", "));
 			}
 
 			double ploss = 100.0;
@@ -500,7 +512,9 @@ QVariant ServerItem::data(int column, int role) const {
 					  .arg(ConnectDialog::tr("Port"))
 					  .arg(usPort)
 				  + QString::fromLatin1("<tr><th align=left>%1</th><td>%2</td></tr>")
-						.arg(ConnectDialog::tr("Addresses"), qsl.join(QLatin1String(", ")));
+						.arg(ConnectDialog::tr("IPv4 address"), ipv4)
+				  + QString::fromLatin1("<tr><th align=left>%1</th><td>%2</td></tr>")
+						.arg(ConnectDialog::tr("IPv6 address"), ipv6);
 
 			if (!qsUrl.isEmpty())
 				qs += QString::fromLatin1("<tr><th align=left>%1</th><td>%2</td></tr>")

--- a/src/mumble/mumble_ar.ts
+++ b/src/mumble/mumble_ar.ts
@@ -3016,10 +3016,6 @@ Are you sure you wish to replace your certificate?
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Addresses</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Website</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3049,6 +3045,14 @@ Are you sure you wish to replace your certificate?
     </message>
     <message>
         <source>Version</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>IPv4 address</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>IPv6 address</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/mumble/mumble_bg.ts
+++ b/src/mumble/mumble_bg.ts
@@ -3013,10 +3013,6 @@ Are you sure you wish to replace your certificate?
         <translation>Порт</translation>
     </message>
     <message>
-        <source>Addresses</source>
-        <translation>Адреси</translation>
-    </message>
-    <message>
         <source>Website</source>
         <translation>Сайт</translation>
     </message>
@@ -3047,6 +3043,14 @@ Are you sure you wish to replace your certificate?
     <message>
         <source>Version</source>
         <translation>Версия</translation>
+    </message>
+    <message>
+        <source>IPv4 address</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>IPv6 address</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/src/mumble/mumble_br.ts
+++ b/src/mumble/mumble_br.ts
@@ -3012,10 +3012,6 @@ Are you sure you wish to replace your certificate?
         <translation>Porzh</translation>
     </message>
     <message>
-        <source>Addresses</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Website</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3046,6 +3042,14 @@ Are you sure you wish to replace your certificate?
     <message>
         <source>Version</source>
         <translation>Stumm</translation>
+    </message>
+    <message>
+        <source>IPv4 address</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>IPv6 address</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/src/mumble/mumble_ca.ts
+++ b/src/mumble/mumble_ca.ts
@@ -1958,7 +1958,7 @@ Mumble està en desenvolupament continu i l&apos;equip de desenvolupament vol ce
     </message>
     <message>
         <source>%1 ms</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">%1 ms</translation>
     </message>
     <message>
         <source>Enables attenuation of other applications while users talk to you</source>
@@ -2058,23 +2058,23 @@ Speak loudly, as when you are annoyed or excited. Decrease the volume in the sou
     </message>
     <message>
         <source>Input device</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">Dispositiu d&apos;entrada</translation>
     </message>
     <message>
         <source>Output system</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">Sistema de sortida</translation>
     </message>
     <message>
         <source>Output device</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">Dispositiu de sortida</translation>
     </message>
     <message>
         <source>Output delay</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">Retard de sortida</translation>
     </message>
     <message>
         <source>Maximum amplification</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">Amplificació màxima</translation>
     </message>
     <message>
         <source>VAD level</source>
@@ -2602,7 +2602,7 @@ Are you sure you wish to replace your certificate?
     <name>ChanACL</name>
     <message>
         <source>None</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">Cap</translation>
     </message>
     <message>
         <source>Traverse</source>
@@ -3038,16 +3038,12 @@ Are you sure you wish to replace your certificate?
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Addresses</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Website</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Packet loss</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">Pèrdua de paquets</translation>
     </message>
     <message>
         <source>Ping (80%)</source>
@@ -3055,7 +3051,7 @@ Are you sure you wish to replace your certificate?
     </message>
     <message>
         <source>%1 ms</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">%1 ms</translation>
     </message>
     <message>
         <source>Ping (95%)</source>
@@ -3071,6 +3067,14 @@ Are you sure you wish to replace your certificate?
     </message>
     <message>
         <source>Version</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>IPv4 address</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>IPv6 address</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -3912,7 +3916,7 @@ This field describes the size of an LCD device. The size is given either in pixe
     </message>
     <message>
         <source>Volume</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">Volum</translation>
     </message>
     <message>
         <source>Volume of Text-To-Speech Engine</source>
@@ -4073,7 +4077,7 @@ The setting only applies for new messages, the already shown ones will retain th
     </message>
     <message>
         <source>None</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">Cap</translation>
     </message>
     <message>
         <source>Only with users</source>
@@ -4822,11 +4826,11 @@ The setting only applies for new messages, the already shown ones will retain th
     </message>
     <message>
         <source>Continuous</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">Continuu</translation>
     </message>
     <message>
         <source>Voice Activity</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">Activitat de veu</translation>
     </message>
     <message>
         <source>Push-to-Talk</source>
@@ -5633,7 +5637,7 @@ Otherwise abort and check your certificate and username.</source>
     <message>
         <source>Server</source>
         <comment>message from</comment>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">Servidor</translation>
     </message>
     <message>
         <source>Failed to load Opus, it will not be available for audio encoding/decoding.</source>
@@ -6603,7 +6607,7 @@ Valid options are:
     </message>
     <message>
         <source>Submit anonymous statistics to the Mumble project</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">Enviar estadístiques anònimes al projecte Mumble</translation>
     </message>
     <message>
         <source>Submit anonymous statistics</source>
@@ -7201,7 +7205,7 @@ To upgrade these files to their latest versions, click the button below.</source
     </message>
     <message>
         <source>Enable</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">Activar</translation>
     </message>
     <message>
         <source>PA</source>
@@ -7594,7 +7598,7 @@ See &lt;a href=&quot;https://wiki.mumble.info/wiki/Installing_Mumble&quot;&gt;th
     </message>
     <message>
         <source>Access to the microphone was denied. Please allow Mumble to use the microphone by changing the settings in System Preferences -&gt; Security &amp; Privacy -&gt; Privacy -&gt; Microphone.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">S&apos;ha denegat l&apos;accés al micròfon. Permet que Mumble utilitzi el micròfon canviant la configuració a Preferències del sistema -&gt; Seguretat i privadesa -&gt; Privadesa -&gt; Micròfon.</translation>
     </message>
     <message>
         <source>If enabled this tries to cancel out echo from the audio stream.</source>
@@ -7765,7 +7769,7 @@ You can register them again.</source>
     <name>Search::SearchDialog</name>
     <message>
         <source>None</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">Cap</translation>
     </message>
     <message>
         <source>Join</source>
@@ -8876,7 +8880,7 @@ Please contact your server administrator for further information.</source>
     <name>WASAPIInput</name>
     <message>
         <source>Access to the microphone was denied. Please check that your operating system&apos;s microphone settings allow Mumble to use the microphone.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">S&apos;a denegat l&apos;accés al micròfon. Comproveu que la configuració del micròfon del vostre sistema operatiu permet que Mumble utilitzi el micròfon.</translation>
     </message>
 </context>
 <context>

--- a/src/mumble/mumble_cs.ts
+++ b/src/mumble/mumble_cs.ts
@@ -3054,10 +3054,6 @@ Jste si jisti, že chcete certifikát nahradit?
         <translation>Port</translation>
     </message>
     <message>
-        <source>Addresses</source>
-        <translation>Adresy</translation>
-    </message>
-    <message>
         <source>Website</source>
         <translation>Internetová stránka</translation>
     </message>
@@ -3088,6 +3084,14 @@ Jste si jisti, že chcete certifikát nahradit?
     <message>
         <source>Version</source>
         <translation>Verze</translation>
+    </message>
+    <message>
+        <source>IPv4 address</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>IPv6 address</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/src/mumble/mumble_cy.ts
+++ b/src/mumble/mumble_cy.ts
@@ -3016,10 +3016,6 @@ Are you sure you wish to replace your certificate?
         <translation>Porth</translation>
     </message>
     <message>
-        <source>Addresses</source>
-        <translation>Cyfeiriad</translation>
-    </message>
-    <message>
         <source>Website</source>
         <translation>Gwefan</translation>
     </message>
@@ -3050,6 +3046,14 @@ Are you sure you wish to replace your certificate?
     <message>
         <source>Version</source>
         <translation>Fersiwn</translation>
+    </message>
+    <message>
+        <source>IPv4 address</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>IPv6 address</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/src/mumble/mumble_da.ts
+++ b/src/mumble/mumble_da.ts
@@ -3052,10 +3052,6 @@ Er du sikker på du vil erstatte dit certifikat?
         <translation>Port</translation>
     </message>
     <message>
-        <source>Addresses</source>
-        <translation>Adresser</translation>
-    </message>
-    <message>
         <source>Website</source>
         <translation>Websted</translation>
     </message>
@@ -3086,6 +3082,14 @@ Er du sikker på du vil erstatte dit certifikat?
     <message>
         <source>Version</source>
         <translation>Version</translation>
+    </message>
+    <message>
+        <source>IPv4 address</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>IPv6 address</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/src/mumble/mumble_de.ts
+++ b/src/mumble/mumble_de.ts
@@ -3053,10 +3053,6 @@ Sind Sie sicher, dass Sie Ihr Zertifikat ersetzen möchten?
         <translation>Port</translation>
     </message>
     <message>
-        <source>Addresses</source>
-        <translation>Adressen</translation>
-    </message>
-    <message>
         <source>Website</source>
         <translation>Webseite</translation>
     </message>
@@ -3087,6 +3083,14 @@ Sind Sie sicher, dass Sie Ihr Zertifikat ersetzen möchten?
     <message>
         <source>Version</source>
         <translation>Version</translation>
+    </message>
+    <message>
+        <source>IPv4 address</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>IPv6 address</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/src/mumble/mumble_el.ts
+++ b/src/mumble/mumble_el.ts
@@ -3053,10 +3053,6 @@ Are you sure you wish to replace your certificate?
         <translation>Θύρα</translation>
     </message>
     <message>
-        <source>Addresses</source>
-        <translation>Διευθύνσεις</translation>
-    </message>
-    <message>
         <source>Website</source>
         <translation>Δικτυακός τόπος</translation>
     </message>
@@ -3087,6 +3083,14 @@ Are you sure you wish to replace your certificate?
     <message>
         <source>Version</source>
         <translation>Έκδοση</translation>
+    </message>
+    <message>
+        <source>IPv4 address</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>IPv6 address</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/src/mumble/mumble_en.ts
+++ b/src/mumble/mumble_en.ts
@@ -3011,10 +3011,6 @@ Are you sure you wish to replace your certificate?
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Addresses</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Website</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3044,6 +3040,14 @@ Are you sure you wish to replace your certificate?
     </message>
     <message>
         <source>Version</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>IPv4 address</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>IPv6 address</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/mumble/mumble_en_GB.ts
+++ b/src/mumble/mumble_en_GB.ts
@@ -3045,10 +3045,6 @@ Are you sure you wish to replace your certificate?
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Addresses</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Website</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3078,6 +3074,14 @@ Are you sure you wish to replace your certificate?
     </message>
     <message>
         <source>Version</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>IPv4 address</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>IPv6 address</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/mumble/mumble_eo.ts
+++ b/src/mumble/mumble_eo.ts
@@ -3020,10 +3020,6 @@ Are you sure you wish to replace your certificate?
         <translation>Pordo</translation>
     </message>
     <message>
-        <source>Addresses</source>
-        <translation>Adresoj</translation>
-    </message>
-    <message>
         <source>Website</source>
         <translation>Retejo</translation>
     </message>
@@ -3054,6 +3050,14 @@ Are you sure you wish to replace your certificate?
     <message>
         <source>Version</source>
         <translation>Versio</translation>
+    </message>
+    <message>
+        <source>IPv4 address</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>IPv6 address</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/src/mumble/mumble_es.ts
+++ b/src/mumble/mumble_es.ts
@@ -3053,10 +3053,6 @@ Are you sure you wish to replace your certificate?
         <translation>Puerto</translation>
     </message>
     <message>
-        <source>Addresses</source>
-        <translation>Direcciones</translation>
-    </message>
-    <message>
         <source>Website</source>
         <translation>Página web</translation>
     </message>
@@ -3087,6 +3083,14 @@ Are you sure you wish to replace your certificate?
     <message>
         <source>Version</source>
         <translation>Versión</translation>
+    </message>
+    <message>
+        <source>IPv4 address</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>IPv6 address</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/src/mumble/mumble_et.ts
+++ b/src/mumble/mumble_et.ts
@@ -3013,10 +3013,6 @@ Are you sure you wish to replace your certificate?
         <translation>Port</translation>
     </message>
     <message>
-        <source>Addresses</source>
-        <translation>Aadressid</translation>
-    </message>
-    <message>
         <source>Website</source>
         <translation>Veebisait</translation>
     </message>
@@ -3047,6 +3043,14 @@ Are you sure you wish to replace your certificate?
     <message>
         <source>Version</source>
         <translation>Versioon</translation>
+    </message>
+    <message>
+        <source>IPv4 address</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>IPv6 address</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/src/mumble/mumble_eu.ts
+++ b/src/mumble/mumble_eu.ts
@@ -3023,10 +3023,6 @@ adierazten du.</translation>
         <translation>Portua</translation>
     </message>
     <message>
-        <source>Addresses</source>
-        <translation>Helbidea</translation>
-    </message>
-    <message>
         <source>Website</source>
         <translation>Web orria</translation>
     </message>
@@ -3057,6 +3053,14 @@ adierazten du.</translation>
     <message>
         <source>Version</source>
         <translation>Bertsioa</translation>
+    </message>
+    <message>
+        <source>IPv4 address</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>IPv6 address</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/src/mumble/mumble_fa_IR.ts
+++ b/src/mumble/mumble_fa_IR.ts
@@ -3011,10 +3011,6 @@ Are you sure you wish to replace your certificate?
         <translation>پورت</translation>
     </message>
     <message>
-        <source>Addresses</source>
-        <translation>ادرس ها</translation>
-    </message>
-    <message>
         <source>Website</source>
         <translation>تارنما</translation>
     </message>
@@ -3044,6 +3040,14 @@ Are you sure you wish to replace your certificate?
     </message>
     <message>
         <source>Version</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>IPv4 address</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>IPv6 address</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/mumble/mumble_fi.ts
+++ b/src/mumble/mumble_fi.ts
@@ -3053,10 +3053,6 @@ Haluatko varmasti korvata varmenteen?
         <translation>Portti</translation>
     </message>
     <message>
-        <source>Addresses</source>
-        <translation>Osoitteet</translation>
-    </message>
-    <message>
         <source>Website</source>
         <translation>Nettisivu</translation>
     </message>
@@ -3087,6 +3083,14 @@ Haluatko varmasti korvata varmenteen?
     <message>
         <source>Version</source>
         <translation>Versio</translation>
+    </message>
+    <message>
+        <source>IPv4 address</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>IPv6 address</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/src/mumble/mumble_fr.ts
+++ b/src/mumble/mumble_fr.ts
@@ -3053,10 +3053,6 @@ Are you sure you wish to replace your certificate?
         <translation>Port</translation>
     </message>
     <message>
-        <source>Addresses</source>
-        <translation>Adresses</translation>
-    </message>
-    <message>
         <source>Website</source>
         <translation>Site internet</translation>
     </message>
@@ -3087,6 +3083,14 @@ Are you sure you wish to replace your certificate?
     <message>
         <source>Version</source>
         <translation>Version</translation>
+    </message>
+    <message>
+        <source>IPv4 address</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>IPv6 address</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/src/mumble/mumble_gl.ts
+++ b/src/mumble/mumble_gl.ts
@@ -3014,10 +3014,6 @@ Are you sure you wish to replace your certificate?
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Addresses</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Website</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3047,6 +3043,14 @@ Are you sure you wish to replace your certificate?
     </message>
     <message>
         <source>Version</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>IPv4 address</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>IPv6 address</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/mumble/mumble_he.ts
+++ b/src/mumble/mumble_he.ts
@@ -3050,10 +3050,6 @@ Are you sure you wish to replace your certificate?
         <translation>פורט</translation>
     </message>
     <message>
-        <source>Addresses</source>
-        <translation>כתובות</translation>
-    </message>
-    <message>
         <source>Website</source>
         <translation>אתר רשת</translation>
     </message>
@@ -3084,6 +3080,14 @@ Are you sure you wish to replace your certificate?
     <message>
         <source>Version</source>
         <translation>גירסא</translation>
+    </message>
+    <message>
+        <source>IPv4 address</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>IPv6 address</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/src/mumble/mumble_hu.ts
+++ b/src/mumble/mumble_hu.ts
@@ -3042,10 +3042,6 @@ Biztos abban, hogy le akarja cserélni a tanúsítványát?
         <translation>Port</translation>
     </message>
     <message>
-        <source>Addresses</source>
-        <translation>IP-cím</translation>
-    </message>
-    <message>
         <source>Website</source>
         <translation>Honlap</translation>
     </message>
@@ -3076,6 +3072,14 @@ Biztos abban, hogy le akarja cserélni a tanúsítványát?
     <message>
         <source>Version</source>
         <translation>Kiszolgáló verziója</translation>
+    </message>
+    <message>
+        <source>IPv4 address</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>IPv6 address</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/src/mumble/mumble_it.ts
+++ b/src/mumble/mumble_it.ts
@@ -3053,10 +3053,6 @@ Sei sicuro di voler sostituire il tuo certificato?
         <translation>Porta</translation>
     </message>
     <message>
-        <source>Addresses</source>
-        <translation>Indirizzi</translation>
-    </message>
-    <message>
         <source>Website</source>
         <translation>Sito web</translation>
     </message>
@@ -3087,6 +3083,14 @@ Sei sicuro di voler sostituire il tuo certificato?
     <message>
         <source>Version</source>
         <translation>Versione</translation>
+    </message>
+    <message>
+        <source>IPv4 address</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>IPv6 address</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/src/mumble/mumble_ja.ts
+++ b/src/mumble/mumble_ja.ts
@@ -3048,10 +3048,6 @@ Are you sure you wish to replace your certificate?
         <translation>ポート</translation>
     </message>
     <message>
-        <source>Addresses</source>
-        <translation>アドレス</translation>
-    </message>
-    <message>
         <source>Website</source>
         <translation>WEBサイト</translation>
     </message>
@@ -3082,6 +3078,14 @@ Are you sure you wish to replace your certificate?
     <message>
         <source>Version</source>
         <translation>バージョン</translation>
+    </message>
+    <message>
+        <source>IPv4 address</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>IPv6 address</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/src/mumble/mumble_ko.ts
+++ b/src/mumble/mumble_ko.ts
@@ -3052,10 +3052,6 @@ Are you sure you wish to replace your certificate?
         <translation>포트</translation>
     </message>
     <message>
-        <source>Addresses</source>
-        <translation>주소</translation>
-    </message>
-    <message>
         <source>Website</source>
         <translation>웹사이트</translation>
     </message>
@@ -3086,6 +3082,14 @@ Are you sure you wish to replace your certificate?
     <message>
         <source>Version</source>
         <translation>버전</translation>
+    </message>
+    <message>
+        <source>IPv4 address</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>IPv6 address</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/src/mumble/mumble_lt.ts
+++ b/src/mumble/mumble_lt.ts
@@ -3043,10 +3043,6 @@ Ar tikrai norite pakeisti savo liudijimą?
         <translation>Prievadas</translation>
     </message>
     <message>
-        <source>Addresses</source>
-        <translation>Adresai</translation>
-    </message>
-    <message>
         <source>Website</source>
         <translation>Tinklalapis</translation>
     </message>
@@ -3077,6 +3073,14 @@ Ar tikrai norite pakeisti savo liudijimą?
     <message>
         <source>Version</source>
         <translation>Versija</translation>
+    </message>
+    <message>
+        <source>IPv4 address</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>IPv6 address</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/src/mumble/mumble_nl.ts
+++ b/src/mumble/mumble_nl.ts
@@ -3053,10 +3053,6 @@ Weet je zeker dat je je certificaat wil vervangen?
         <translation>Poort</translation>
     </message>
     <message>
-        <source>Addresses</source>
-        <translation>Adressen</translation>
-    </message>
-    <message>
         <source>Website</source>
         <translation>Website</translation>
     </message>
@@ -3087,6 +3083,14 @@ Weet je zeker dat je je certificaat wil vervangen?
     <message>
         <source>Version</source>
         <translation>Versie</translation>
+    </message>
+    <message>
+        <source>IPv4 address</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>IPv6 address</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/src/mumble/mumble_no.ts
+++ b/src/mumble/mumble_no.ts
@@ -3067,10 +3067,6 @@ Er du sikker på at du vil erstatte ditt sertifikat?
         <translation>Port</translation>
     </message>
     <message>
-        <source>Addresses</source>
-        <translation>Adresser</translation>
-    </message>
-    <message>
         <source>Website</source>
         <translation>Nettside</translation>
     </message>
@@ -3101,6 +3097,14 @@ Er du sikker på at du vil erstatte ditt sertifikat?
     <message>
         <source>Version</source>
         <translation>Versjon</translation>
+    </message>
+    <message>
+        <source>IPv4 address</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>IPv6 address</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/src/mumble/mumble_oc.ts
+++ b/src/mumble/mumble_oc.ts
@@ -3013,10 +3013,6 @@ Are you sure you wish to replace your certificate?
         <translation>Pòrt</translation>
     </message>
     <message>
-        <source>Addresses</source>
-        <translation>Adreças</translation>
-    </message>
-    <message>
         <source>Website</source>
         <translation>Site web</translation>
     </message>
@@ -3047,6 +3043,14 @@ Are you sure you wish to replace your certificate?
     <message>
         <source>Version</source>
         <translation>Version</translation>
+    </message>
+    <message>
+        <source>IPv4 address</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>IPv6 address</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/src/mumble/mumble_pl.ts
+++ b/src/mumble/mumble_pl.ts
@@ -3054,10 +3054,6 @@ Czy na pewno chcesz zastąpić swój bieżący certyfikat?
         <translation>Port</translation>
     </message>
     <message>
-        <source>Addresses</source>
-        <translation>Adresy</translation>
-    </message>
-    <message>
         <source>Website</source>
         <translation>Strona WWW</translation>
     </message>
@@ -3088,6 +3084,14 @@ Czy na pewno chcesz zastąpić swój bieżący certyfikat?
     <message>
         <source>Version</source>
         <translation>Wersja</translation>
+    </message>
+    <message>
+        <source>IPv4 address</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>IPv6 address</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/src/mumble/mumble_pt_BR.ts
+++ b/src/mumble/mumble_pt_BR.ts
@@ -3053,10 +3053,6 @@ Você tem certeza de que quer substituir o seu certificado?
         <translation>Porta</translation>
     </message>
     <message>
-        <source>Addresses</source>
-        <translation>Endereços</translation>
-    </message>
-    <message>
         <source>Website</source>
         <translation>Página web</translation>
     </message>
@@ -3087,6 +3083,14 @@ Você tem certeza de que quer substituir o seu certificado?
     <message>
         <source>Version</source>
         <translation>Versão</translation>
+    </message>
+    <message>
+        <source>IPv4 address</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>IPv6 address</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/src/mumble/mumble_pt_PT.ts
+++ b/src/mumble/mumble_pt_PT.ts
@@ -3053,10 +3053,6 @@ Tem certeza de que quer substituir o seu certificado?
         <translation>Porta</translation>
     </message>
     <message>
-        <source>Addresses</source>
-        <translation>Endereços</translation>
-    </message>
-    <message>
         <source>Website</source>
         <translation>Página web</translation>
     </message>
@@ -3087,6 +3083,14 @@ Tem certeza de que quer substituir o seu certificado?
     <message>
         <source>Version</source>
         <translation>Versão</translation>
+    </message>
+    <message>
+        <source>IPv4 address</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>IPv6 address</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/src/mumble/mumble_ro.ts
+++ b/src/mumble/mumble_ro.ts
@@ -3017,10 +3017,6 @@ Are you sure you wish to replace your certificate?
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Addresses</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Website</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3050,6 +3046,14 @@ Are you sure you wish to replace your certificate?
     </message>
     <message>
         <source>Version</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>IPv4 address</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>IPv6 address</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/mumble/mumble_ru.ts
+++ b/src/mumble/mumble_ru.ts
@@ -3054,10 +3054,6 @@ Are you sure you wish to replace your certificate?
         <translation>Порт</translation>
     </message>
     <message>
-        <source>Addresses</source>
-        <translation>IP-адрес</translation>
-    </message>
-    <message>
         <source>Website</source>
         <translation>Веб-сайт</translation>
     </message>
@@ -3088,6 +3084,14 @@ Are you sure you wish to replace your certificate?
     <message>
         <source>Version</source>
         <translation>Версия</translation>
+    </message>
+    <message>
+        <source>IPv4 address</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>IPv6 address</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/src/mumble/mumble_si.ts
+++ b/src/mumble/mumble_si.ts
@@ -2937,10 +2937,6 @@ Are you sure you wish to replace your certificate?
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Addresses</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Website</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3026,6 +3022,14 @@ Are you sure you wish to replace your certificate?
     </message>
     <message>
         <source>Failed to fetch server list</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>IPv4 address</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>IPv6 address</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/mumble/mumble_sq.ts
+++ b/src/mumble/mumble_sq.ts
@@ -2939,10 +2939,6 @@ Are you sure you wish to replace your certificate?
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Addresses</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Website</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3028,6 +3024,14 @@ Are you sure you wish to replace your certificate?
     </message>
     <message>
         <source>Failed to fetch server list</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>IPv4 address</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>IPv6 address</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/mumble/mumble_sv.ts
+++ b/src/mumble/mumble_sv.ts
@@ -3053,10 +3053,6 @@ Are you sure you wish to replace your certificate?
         <translation>Port</translation>
     </message>
     <message>
-        <source>Addresses</source>
-        <translation>Adress</translation>
-    </message>
-    <message>
         <source>Website</source>
         <translation>Hemsida</translation>
     </message>
@@ -3087,6 +3083,14 @@ Are you sure you wish to replace your certificate?
     <message>
         <source>Version</source>
         <translation>Version</translation>
+    </message>
+    <message>
+        <source>IPv4 address</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>IPv6 address</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/src/mumble/mumble_te.ts
+++ b/src/mumble/mumble_te.ts
@@ -3024,10 +3024,6 @@ Are you sure you wish to replace your certificate?
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Addresses</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Website</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3057,6 +3053,14 @@ Are you sure you wish to replace your certificate?
     </message>
     <message>
         <source>Version</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>IPv4 address</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>IPv6 address</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/mumble/mumble_th.ts
+++ b/src/mumble/mumble_th.ts
@@ -3011,10 +3011,6 @@ Are you sure you wish to replace your certificate?
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Addresses</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Website</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3044,6 +3040,14 @@ Are you sure you wish to replace your certificate?
     </message>
     <message>
         <source>Version</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>IPv4 address</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>IPv6 address</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/mumble/mumble_tr.ts
+++ b/src/mumble/mumble_tr.ts
@@ -3052,10 +3052,6 @@ Sertifikanızı değiştirmek istediğinize emin misiniz?
         <translation>Bağlantı noktası</translation>
     </message>
     <message>
-        <source>Addresses</source>
-        <translation>Adresler</translation>
-    </message>
-    <message>
         <source>Website</source>
         <translation>Ağ sitesi</translation>
     </message>
@@ -3086,6 +3082,14 @@ Sertifikanızı değiştirmek istediğinize emin misiniz?
     <message>
         <source>Version</source>
         <translation>Sürüm</translation>
+    </message>
+    <message>
+        <source>IPv4 address</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>IPv6 address</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/src/mumble/mumble_uk.ts
+++ b/src/mumble/mumble_uk.ts
@@ -3013,10 +3013,6 @@ Are you sure you wish to replace your certificate?
         <translation>Порт</translation>
     </message>
     <message>
-        <source>Addresses</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Website</source>
         <translation>Веб-сайт</translation>
     </message>
@@ -3046,6 +3042,14 @@ Are you sure you wish to replace your certificate?
     </message>
     <message>
         <source>Version</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>IPv4 address</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>IPv6 address</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/mumble/mumble_zh_CN.ts
+++ b/src/mumble/mumble_zh_CN.ts
@@ -3052,10 +3052,6 @@ Are you sure you wish to replace your certificate?
         <translation>端口</translation>
     </message>
     <message>
-        <source>Addresses</source>
-        <translation>地址</translation>
-    </message>
-    <message>
         <source>Website</source>
         <translation>网页</translation>
     </message>
@@ -3086,6 +3082,14 @@ Are you sure you wish to replace your certificate?
     <message>
         <source>Version</source>
         <translation>版本</translation>
+    </message>
+    <message>
+        <source>IPv4 address</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>IPv6 address</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/src/mumble/mumble_zh_HK.ts
+++ b/src/mumble/mumble_zh_HK.ts
@@ -3011,10 +3011,6 @@ Are you sure you wish to replace your certificate?
         <translation>連接埠</translation>
     </message>
     <message>
-        <source>Addresses</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Website</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3045,6 +3041,14 @@ Are you sure you wish to replace your certificate?
     <message>
         <source>Version</source>
         <translation>版本</translation>
+    </message>
+    <message>
+        <source>IPv4 address</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>IPv6 address</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/src/mumble/mumble_zh_TW.ts
+++ b/src/mumble/mumble_zh_TW.ts
@@ -3029,10 +3029,6 @@ Are you sure you wish to replace your certificate?
         <translation>埠號</translation>
     </message>
     <message>
-        <source>Addresses</source>
-        <translation>網址</translation>
-    </message>
-    <message>
         <source>Website</source>
         <translation>網站</translation>
     </message>
@@ -3063,6 +3059,14 @@ Are you sure you wish to replace your certificate?
     <message>
         <source>Version</source>
         <translation>版本</translation>
+    </message>
+    <message>
+        <source>IPv4 address</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>IPv6 address</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>


### PR DESCRIPTION
The "Addresses" field in the ServerItem tooltip shows both ipv4 and ipv6
addresses. The order of addresses in this field is not determined.
In the wild it is randomized. As discussed in #5696 it is better to implement
a concrete ordering to prevent user confusion. To further improve the
readability of the addresses we split the addresses field in two fields
called "IPv4 address" and "IPv6 address". The ipv4 address is now always
shown above the ipv6 address.

Implements #5696

Co-Authored-By: [GuybrushThreepwoodII](https://github.com/GuybrushThreepwoodII)


### Checks

- [X] My commits follow the [commit guidelines](https://github.com/mumble-voip/mumble/blob/master/COMMIT_GUIDELINES.md)

