### PR TITLE
CI(codeql): Upgrade CodeQL action version v1 -> v2

### DIFF
--- a/.github/workflows/code-ql.yml
+++ b/.github/workflows/code-ql.yml
@@ -19,7 +19,7 @@ jobs:
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v1
+      uses: github/codeql-action/init@v2
       with:
           languages: python, cpp
 
@@ -43,4 +43,4 @@ jobs:
       shell: bash
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v1
+      uses: github/codeql-action/analyze@v2


### PR DESCRIPTION
CodeQL Action v2 was released 2022-03-30.

Deprecation of v1 is scheduled for December 2022. [1]

Fixes a CI warning.

[1] https://github.blog/changelog/2022-04-27-code-scanning-deprecation-of-codeql-action-v1/
