### PR TITLE
FIX(client): Register simultaneous mouse button presses separately

### DIFF
--- a/src/mumble/GlobalShortcut_win.cpp
+++ b/src/mumble/GlobalShortcut_win.cpp
@@ -510,55 +510,47 @@ void GlobalShortcutWin::on_keyboardMessage(const uint16_t flags, uint16_t scanCo
 }
 
 void GlobalShortcutWin::on_mouseMessage(const uint16_t flags, const uint16_t data) {
-	InputMouse input;
-	bool down;
-
-	switch (flags) {
-		case RI_MOUSE_BUTTON_1_DOWN:
-			input = InputMouse::Left;
-			down  = true;
-			break;
-		case RI_MOUSE_BUTTON_1_UP:
-			input = InputMouse::Left;
-			down  = false;
-			break;
-		case RI_MOUSE_BUTTON_2_DOWN:
-			input = InputMouse::Right;
-			down  = true;
-			break;
-		case RI_MOUSE_BUTTON_2_UP:
-			input = InputMouse::Right;
-			down  = false;
-			break;
-		case RI_MOUSE_BUTTON_3_DOWN:
-			input = InputMouse::Middle;
-			down  = true;
-			break;
-		case RI_MOUSE_BUTTON_3_UP:
-			input = InputMouse::Middle;
-			down  = false;
-			break;
-		case RI_MOUSE_BUTTON_4_DOWN:
-			input = InputMouse::Side_1;
-			down  = true;
-			break;
-		case RI_MOUSE_BUTTON_4_UP:
-			input = InputMouse::Side_1;
-			down  = false;
-			break;
-		case RI_MOUSE_BUTTON_5_DOWN:
-			input = InputMouse::Side_2;
-			down  = true;
-			break;
-		case RI_MOUSE_BUTTON_5_UP:
-			input = InputMouse::Side_2;
-			down  = false;
-			break;
-		default:
-			return;
+	// Multiple mouse transitions can be contained in a single message.
+	// See https://docs.microsoft.com/en-us/windows/win32/api/winuser/ns-winuser-rawmouse.
+	if (flags & RI_MOUSE_BUTTON_1_DOWN) {
+		handleButton(QVariant::fromValue(InputMouse::Left), true);
 	}
 
-	handleButton(QVariant::fromValue(input), down);
+	if (flags & RI_MOUSE_BUTTON_1_UP) {
+		handleButton(QVariant::fromValue(InputMouse::Left), false);
+	}
+
+	if (flags & RI_MOUSE_BUTTON_2_DOWN) {
+		handleButton(QVariant::fromValue(InputMouse::Right), true);
+	}
+
+	if (flags & RI_MOUSE_BUTTON_2_UP) {
+		handleButton(QVariant::fromValue(InputMouse::Right), false);
+	}
+
+	if (flags & RI_MOUSE_BUTTON_3_DOWN) {
+		handleButton(QVariant::fromValue(InputMouse::Middle), true);
+	}
+
+	if (flags & RI_MOUSE_BUTTON_3_UP) {
+		handleButton(QVariant::fromValue(InputMouse::Middle), false);
+	}
+
+	if (flags & RI_MOUSE_BUTTON_4_DOWN) {
+		handleButton(QVariant::fromValue(InputMouse::Side_1), true);
+	}
+
+	if (flags & RI_MOUSE_BUTTON_4_UP) {
+		handleButton(QVariant::fromValue(InputMouse::Side_1), false);
+	}
+
+	if (flags & RI_MOUSE_BUTTON_5_DOWN) {
+		handleButton(QVariant::fromValue(InputMouse::Side_2), true);
+	}
+
+	if (flags & RI_MOUSE_BUTTON_5_UP) {
+		handleButton(QVariant::fromValue(InputMouse::Side_2), false);
+	}
 }
 
 GlobalShortcutWin::DeviceMap::iterator GlobalShortcutWin::addDevice(const HANDLE deviceHandle) {


### PR DESCRIPTION
Prior to the implementaiton of raw mouse input, a low-level mouse hook was used for capturing mouse events. Windows would emit a single WM_* event per button state change. With the move to capturing raw mouse input events, it was expected that this behavior remained, despite now needing to listen for WM_INPUT events.

However, unlike when using the low-level hook, WM_INPUT events can contain data for multiple simultaneous mouse state changes. If this occurred, Mumble would register none of the state changes.

Changing the logic to account for multiple state changes in a single event correctly allows for all states changes to be registered.

Fixes mumble-voip#5706


### Checks

- [x] My commits follow the [commit guidelines](https://github.com/mumble-voip/mumble/blob/master/COMMIT_GUIDELINES.md)

