### PR TITLE
FEAT(client): Add shortcut to send plain text messages

### DIFF
--- a/src/mumble/CustomElements.cpp
+++ b/src/mumble/CustomElements.cpp
@@ -237,7 +237,11 @@ bool ChatbarTextEdit::event(QEvent *evt) {
 			const QString msg = toPlainText();
 			if (!msg.isEmpty()) {
 				addToHistory(msg);
-				emit entered(msg);
+				if (kev->modifiers() & Qt::ControlModifier) {
+					emit ctrlEnterPressed(msg);
+				} else {
+					emit entered(msg);
+				}
 			}
 			return true;
 		}

--- a/src/mumble/CustomElements.h
+++ b/src/mumble/CustomElements.h
@@ -63,6 +63,7 @@ signals:
 	void backtabPressed(void);
 	void ctrlSpacePressed(void);
 	void entered(QString);
+	void ctrlEnterPressed(QString);
 	void pastedImage(QString);
 public slots:
 	void pasteAndSend_triggered();

--- a/src/mumble/MainWindow.h
+++ b/src/mumble/MainWindow.h
@@ -313,7 +313,7 @@ public slots:
 	void destroyUserInformation();
 	void trayAboutToShow();
 	void sendChatbarMessage(QString msg);
-	void sendChatbarText(QString msg);
+	void sendChatbarText(QString msg, bool plainText = false);
 	void pttReleased();
 	void whisperReleased(QVariant scdata);
 	void onResetAudio();


### PR DESCRIPTION
Add the ability to press Ctrl+Enter to send a plain text message while
preserving line breaks. This adds an easy way of preserving messages
with line breaks without having to resort to using Markdown.

Implements #5707


### Checks

- [x] My commits follow the [commit guidelines](https://github.com/mumble-voip/mumble/blob/master/COMMIT_GUIDELINES.md)

