### PR TITLE
FIX(server): Don't silently ignore errors in INI

### DIFF
--- a/src/murmur/Meta.cpp
+++ b/src/murmur/Meta.cpp
@@ -209,6 +209,18 @@ void MetaParams::read(QString fname) {
 	qsSettings = new QSettings(qsAbsSettingsFilePath, QSettings::IniFormat);
 	qsSettings->setIniCodec("UTF-8");
 
+	qsSettings->sync();
+	switch (qsSettings->status()) {
+		case QSettings::NoError:
+			break;
+		case QSettings::AccessError:
+			qFatal("Access error while trying to access %s", qPrintable(qsSettings->fileName()));
+			break;
+		case QSettings::FormatError:
+			qFatal("Your INI file at %s is invalid - check for syntax errors!", qPrintable(qsSettings->fileName()));
+			break;
+	}
+
 	qWarning("Initializing settings from %s (basepath %s)", qPrintable(qsSettings->fileName()),
 			 qPrintable(qdBasePath.absolutePath()));
 


### PR DESCRIPTION
In theory these changes should cause the server to no longer silently
ignore encountered INI syntax errors.

In practice however, it seems that it is pretty much impossible to
create an INI file that Qt actually considers erroneous and thus this
code essentially doesn't work. But in case Qt ever fixes this weird
behavior, at least in theory Mumble users should immediately profit from
it.

Fixes #5749


### Checks

- [x] My commits follow the [commit guidelines](https://github.com/mumble-voip/mumble/blob/master/COMMIT_GUIDELINES.md)

