### PR TITLE
BUILD(cmake, overlay): Include missing CMake module

### DIFF
--- a/overlay_gl/CMakeLists.txt
+++ b/overlay_gl/CMakeLists.txt
@@ -5,6 +5,8 @@
 
 # Overlay payload for UNIX-like systems.
 
+include(CheckIncludeFile)
+
 if(${CMAKE_SYSTEM_PROCESSOR} STREQUAL "x86_64" OR ${CMAKE_SYSTEM_PROCESSOR} STREQUAL "amd64")
 	if(NOT ${CMAKE_SYSTEM_NAME} STREQUAL "OpenBSD")
 		option(overlay-xcompile "Build 32 bit overlay library, necessary for the overlay to work with 32 bit processes." ON)


### PR DESCRIPTION
We use the CHECK_INCLUDE_FILE macro without previously including the
corresponding CMake module. This usually still works as the Opus CMake
files include the same module and apparently are loaded before
processing the overlay CMakeLists.txt. Thus, thee Opus code fixes this
issue for us by accident.

However, when building without the bundled Opus version, this leads to a
build error as in this case the Opus CMake scripts are not processed by
us.

Fixes #5742


### Checks

- [x] My commits follow the [commit guidelines](https://github.com/mumble-voip/mumble/blob/master/COMMIT_GUIDELINES.md)

