### PR TITLE
BUILD(overlay): Remove dead code

### DIFF
--- a/src/mumble/Overlay_macx.mm
+++ b/src/mumble/Overlay_macx.mm
@@ -203,17 +203,6 @@ void OverlayClient::updateMouse() {
 	}
 
 	QPixmap pm = qmCursors.value(csShape);
-	if (pm.isNull()) {
-		NSImage *img = [cursor image];
-		CGImageRef cgimg = nullptr;
-		NSArray *reps = [img representations];
-		for (NSUInteger i = 0; i < [reps count]; i++) {
-			NSImageRep *rep = [reps objectAtIndex:i];
-			if ([rep class] == [NSBitmapImageRep class]) {
-				cgimg = [(NSBitmapImageRep *)rep CGImage];
-			}
-		}
-	}
 
 	NSPoint p = [cursor hotSpot];
 	iOffsetX = (int) p.x;


### PR DESCRIPTION
The removed code was part of some logic introduced in
f6d9c4f7b57bc8163f392bdf50bda520f107b72f but the functional parts have
been removed when getting rid of all Qt4-specific code parts.

This left a few now unused variables in the code which in more recent
compiler versions would cause a warning (and thus in the default
settings a build error).

Since the code doesn't do anything anymore, this commit fully removes
the remaining parts of this code snippet.

Fixes #5724


### Checks

- [x] My commits follow the [commit guidelines](https://github.com/mumble-voip/mumble/blob/master/COMMIT_GUIDELINES.md)

