### PR TITLE
Backport "BUILD(cmake, overlay): Include missing CMake module" to 1.4.x

### DIFF
--- a/overlay_gl/CMakeLists.txt
+++ b/overlay_gl/CMakeLists.txt
@@ -5,6 +5,8 @@
 
 # Overlay payload for UNIX-like systems.
 
+include(CheckIncludeFile)
+
 if(${CMAKE_SYSTEM_PROCESSOR} STREQUAL "x86_64" OR ${CMAKE_SYSTEM_PROCESSOR} STREQUAL "amd64")
 	option(overlay-xcompile "Build 32 bit overlay library, necessary for the overlay to work with 32 bit processes." ON)
 endif()


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `1.4.x`:
 - [BUILD(cmake, overlay): Include missing CMake module](https://github.com/mumble-voip/mumble/pull/5752)

<!--- Backport version: 8.4.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)