### PR TITLE
Backport "DOCS: Document missing option in murmur.ini" to 1.4.x

### DIFF
--- a/scripts/murmur.ini
+++ b/scripts/murmur.ini
@@ -165,6 +165,14 @@ users=100
 messageburst=5
 messagelimit=1
 
+; Similar to messagelimit and messageburst, but these options apply specifically
+; to "plugin-messages". That is messages that Mumble plugins send from client
+; to client. The rate-limit collectively applies to all plugins active on a given
+; client. That means if plugin A exhausts this limit and plugin B then attempts
+; to send another message, the message from plugin B will be rate-limited.
+; pluginmessagelimit=1
+; pluginmessageburst=5
+
 ; Respond to UDP ping packets.
 ;
 ; Setting to true exposes the current user count, the maximum user count, and
@@ -254,7 +262,7 @@ allowping=true
 ; adjust the registerName variable.
 ; See http://developer.apple.com/networking/bonjour/index.html for more information
 ; about bonjour.
-;bonjour=True
+;bonjour=true
 
 ; If you have a proper SSL certificate, you can provide the filenames here.
 ; Otherwise, Murmur will create its own certificate automatically.
@@ -320,11 +328,11 @@ allowping=true
 
 ; If this options is enabled, only clients which have a certificate are allowed
 ; to connect.
-;certrequired=False
+;certrequired=false
 
 ; If enabled, clients are sent information about the servers version and operating
 ; system.
-;sendversion=True
+;sendversion=true
 
 ; You can set a recommended minimum version for your server, and clients will
 ; be notified in their log when they connect if their client does not meet the
@@ -361,12 +369,12 @@ allowping=true
 
 ; This sets password hash storage to legacy mode (1.2.4 and before)
 ; (Note that setting this to true is insecure and should not be used unless absolutely necessary)
-;legacyPasswordHash=false
+;legacypasswordhash=false
 
 ; By default a strong amount of PBKDF2 iterations are chosen automatically. If >0 this setting
 ; overrides the automatic benchmark and forces a specific number of iterations.
 ; (Note that you should only change this value if you know what you are doing)
-;kdfIterations=-1
+;kdfiterations=-1
 
 ; In order to prevent misconfigured, impolite or malicious clients from
 ; affecting the low-latency of other users, Murmur has a rudimentary global-ban
@@ -384,12 +392,12 @@ allowping=true
 ; settings out will cause Murmur to use the defaults:
 ;
 ; To avoid autobanning successful connection attempts from the same IP address,
-; set autobanSuccessfulConnections=False.
+; set autobanSuccessfulConnections=false.
 ;
 ;autobanAttempts=10
 ;autobanTimeframe=120
 ;autobanTime=300
-;autobanSuccessfulConnections=True
+;autobanSuccessfulConnections=true
 
 ; Enables logging of group changes. This means that every time a group in a
 ; channel changes, the server will log all groups and their members from before
@@ -404,6 +412,27 @@ allowping=true
 ; 1.4.0.
 ;
 ;logaclchanges=false
+
+; A flag dictating whether clients may use the built-in recording function. Newer
+; clients will respect this option in the UI (e.g. disable the recording feature
+; in the UI). Additionally any client that tries to start a recording is kicked
+; from the server with a corresponding message, if recording is disabled.
+; Default is true. This option was introduced with Murmur 1.5.0.
+;
+; allowRecording=true
+
+; The amount of allowed listener proxies in a single channel. It defaults to -1
+; meaning that there is no limit. Set to 0 to disable Channel Listeners altogether.
+; This option has been introduced with 1.4.0.
+; listenersperchannel=5
+
+; The amount of listener proxies a single user may have. It defaults to -1 meaning
+; that there is no limit. Set to 0 to disable Channel Listeners altogether.
+; This option has been introduced with 1.4.0.
+; listenersperuser=2
+
+
+; forceExternalAuth=false
 
 ; You can configure any of the configuration options for Ice here. We recommend
 ; leave the defaults as they are.


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `1.4.x`:
 - [DOCS: Document missing option in murmur.ini](https://github.com/mumble-voip/mumble/pull/5753)

<!--- Backport version: 8.4.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)