### PR TITLE
FIX(server): Don't ignore explicit PermissionQuery

### DIFF
--- a/src/murmur/Server.h
+++ b/src/murmur/Server.h
@@ -322,7 +322,7 @@ public:
 
 	bool hasPermission(ServerUser *p, Channel *c, QFlags< ChanACL::Perm > perm);
 	QFlags< ChanACL::Perm > effectivePermissions(ServerUser *p, Channel *c);
-	void sendClientPermission(ServerUser *u, Channel *c, bool updatelast = false);
+	void sendClientPermission(ServerUser *u, Channel *c, bool explicitlyRequested = false);
 	void flushClientPermissionCache(ServerUser *u, MumbleProto::PermissionQuery &mpqq);
 	void clearACLCache(User *p = nullptr);
 	void clearWhisperTargetCache();


### PR DESCRIPTION
7439bc4fe6b423ff0d36d3b1d529e474c14e9b01 introduced the ability for
clients to query for their permissions in any given channel. Since that
commit also added an automatic permissions broadcast for channels that a
client enters (and also its parent channel), it also introduced a
system to keep track of whether a given permission set has already been
broadcast to a given client. Supposedly this was meant as to not flood
the client with PermissionQuery messages if it just keeps switching
between the same channels (and thus already knows about the respective
permissions after having joined a channel for the first time).

Oddly enough though, when a client explicitly requests to be informed
about a channel's permissions, the cache would also be consolidated and
if the server was under the impression that the client already knows
about these permissions, its explicit query would simply be ignored.

This is of course nonsense, since ultimately it is the client who knows
whether it wants to be informed about those permissions (again) or not.

Therefore, this commit ensures that explicit queries are always
answered. No need to consolidate the cache and decide on whether the
server feels like answering or not.

Fixes #5699


### Checks

- [x] My commits follow the [commit guidelines](https://github.com/mumble-voip/mumble/blob/master/COMMIT_GUIDELINES.md)

