### PR TITLE
FIX(client, ui): Don't display unsupported ACL

### DIFF
--- a/src/mumble/ACLEditor.cpp
+++ b/src/mumble/ACLEditor.cpp
@@ -147,10 +147,12 @@ ACLEditor::ACLEditor(int channelid, const MumbleProto::ACL &mea, QWidget *p) : Q
 		QString name       = ChanACL::permName(perm);
 
 		if (!name.isEmpty()) {
-			// If the server's version is less than 1.4.0 then it won't support the new permission to reset a
-			// comment/avatar. Skipping this iteration of the loop prevents checkboxes for it being added to the UI.
-			if ((Global::get().sh->uiVersion < 0x010400) && (perm == ChanACL::ResetUserContent))
+			// If the server's version is less than 1.4.0 then it won't support the new permissions.
+			// Skipping this iteration of the loop prevents checkboxes for it being added to the UI.
+			if (Global::get().sh->uiVersion < Version::toRaw(1, 4, 0)
+				&& (perm == ChanACL::ResetUserContent || perm == ChanACL::Listen)) {
 				continue;
+			}
 
 			QCheckBox *qcb;
 			l = new QLabel(name, qgbACLpermissions);


### PR DESCRIPTION
If a recent client (1.4 or newer) was to connect to a pre-1.4 server and
decide to edit a channel's ACL, the user would be presented with the
option to configure the Listen ACL. However, since the server is too old
to know about this particular ACL, setting it will have no effect. Thus,
to the end user this creates the impression that something is broken.

This commit ensures that the Listen ACL is only shown, if the server one
is currently connected to, is recent enough to know about this ACL.

Fixes #5692


### Checks

- [x] My commits follow the [commit guidelines](https://github.com/mumble-voip/mumble/blob/master/COMMIT_GUIDELINES.md)

