### PR TITLE
FIX(server): Update suppress state on ACL change

### DIFF
--- a/src/murmur/Server.cpp
+++ b/src/murmur/Server.cpp
@@ -2118,6 +2118,31 @@ void Server::clearACLCache(User *p) {
 				if (u->sState == ServerUser::Authenticated)
 					flushClientPermissionCache(u, mppq);
 		}
+
+		// A change in ACLs could also change a user's suppression state
+		MumbleProto::UserState mpus;
+		auto processingFunction = [&](ServerUser *user) {
+			bool maySpeak = ChanACL::hasPermission(user, user->cChannel, ChanACL::Speak, &acCache);
+
+			if (maySpeak == user->bSuppress) {
+				// Mirror a user's ability to speak in the current channel (by means of the ACLs) in the suppress
+				// property (not being allowed to speak -> suppressed and vice versa)
+				user->bSuppress = !maySpeak;
+
+				mpus.Clear();
+				mpus.set_session(user->uiSession);
+				mpus.set_suppress(true);
+				sendAll(mpus);
+			}
+		};
+
+		if (p) {
+			processingFunction(static_cast< ServerUser * >(p));
+		} else {
+			for (ServerUser *currentUser : qhUsers) {
+				processingFunction(currentUser);
+			}
+		}
 	}
 
 	// A change in ACLs means that the user might be able to whisper


### PR DESCRIPTION
The suppress state of a user represents whether the user is currently in
a channel in which they don't have the Speak ACL. As of now this state
is only updated whenever the user switches channel.

However, the suppress state should also change, if the ACL for a given
channel change. This is what the current commit does. If this is not
done, a user will be able to continue speaking in a channel where they
should not be able to and only if they leave and re-join the channel
will the new ACL take effect.

To avoid such a situation, the current code updates the suppress state
every time the ACL change.

Fixes #5264


### Checks

- [x] My commits follow the [commit guidelines](https://github.com/mumble-voip/mumble/blob/master/COMMIT_GUIDELINES.md)

