### PR TITLE
Update LICENSE

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -2,7 +2,7 @@ Copyright (C) 2005-2022 The Mumble Developers
 
 A list of The Mumble Developers can be found in the
 AUTHORS file at the root of the Mumble source tree
-or at <https://www.mumble.info/AUTHORS>.
+or at <https://web.archive.org/web/20181129131413/https://www.mumble.info/AUTHORS>.
 
 All rights reserved.
 


### PR DESCRIPTION
the official link gives a 404: Not Found, the one on the internet archive is from 2018


### Checks

- [ ] My commits follow the [commit guidelines](https://github.com/mumble-voip/mumble/blob/master/COMMIT_GUIDELINES.md)

