### PR TITLE
FIX(theme): Adapt Qt behavior change regarding padding in QMenu

### DIFF
--- a/src/mumble/MainWindow.ui
+++ b/src/mumble/MainWindow.ui
@@ -228,7 +228,7 @@
     <string>Shows a dialog of registered servers, and also allows quick-connect.</string>
    </property>
    <property name="iconVisibleInMenu">
-    <bool>false</bool>
+    <bool>true</bool>
    </property>
   </action>
   <action name="qaServerDisconnect">
@@ -277,7 +277,7 @@
     <string>This will show extended information about the connection to the server.</string>
    </property>
    <property name="iconVisibleInMenu">
-    <bool>false</bool>
+    <bool>true</bool>
    </property>
   </action>
   <action name="qaUserKick">
@@ -562,7 +562,7 @@
     <enum>QAction::PreferencesRole</enum>
    </property>
    <property name="iconVisibleInMenu">
-    <bool>false</bool>
+    <bool>true</bool>
    </property>
   </action>
   <action name="qaFilterToggle">
@@ -773,6 +773,13 @@ the channel's context menu.</string>
    <property name="whatsThis">
     <string>This will add the user as a friend, so you can recognize him on this and other servers.</string>
    </property>
+   <property name="icon">
+    <iconset>
+     <normaloff>skin:emblems/emblem-favorite.svg</normaloff>skin:emblems/emblem-favorite.svg</iconset>
+   </property>
+   <property name="iconVisibleInMenu">
+    <bool>true</bool>
+   </property>
   </action>
   <action name="qaUserFriendRemove">
    <property name="text">
@@ -875,6 +882,13 @@ the channel's context menu.</string>
    <property name="toolTip">
     <string>Query server for connection information for user</string>
    </property>
+   <property name="icon">
+    <iconset>
+     <normaloff>skin:Information_icon.svg</normaloff>skin:Information_icon.svg</iconset>
+   </property>
+   <property name="iconVisibleInMenu">
+    <bool>true</bool>
+   </property>
   </action>
   <action name="qaSelfComment">
    <property name="icon">
@@ -888,7 +902,7 @@ the channel's context menu.</string>
     <string>Change your own comment</string>
    </property>
    <property name="iconVisibleInMenu">
-    <bool>false</bool>
+    <bool>true</bool>
    </property>
   </action>
   <action name="qaSelfRegister">
@@ -927,7 +941,7 @@ the channel's context menu.</string>
     <string>Recording</string>
    </property>
    <property name="iconVisibleInMenu">
-    <bool>false</bool>
+    <bool>true</bool>
    </property>
   </action>
   <action name="qaShow">

--- a/themes/Default/Dark.qss
+++ b/themes/Default/Dark.qss
@@ -197,9 +197,14 @@ QMenu {
 QMenu::item {
   border: 1px solid transparent;
   color: #d8d8d8;
-  padding: 5px 16px;
-  padding-left: 25px;
+  padding: 5px;
+  padding-right: 16px;
+  padding-left: 8px;
   border-radius: 2px;
+}
+
+QMenu::icon {
+  left: 4px;
 }
 
 QMenu::item:selected {
@@ -215,12 +220,6 @@ QMenu::item:disabled {
 QMenu::separator {
   background: #555;
   height: 1px;
-}
-
-QMenu::indicator {
-  padding-top: 2px;
-  height: 25px;
-  width: 25px;
 }
 
 QPushButton {
@@ -708,8 +707,11 @@ QTreeView::indicator {
 }
 
 QMenu::indicator {
+  padding-top: 2px;
   width: 12px;
+  height: 12px;
   left: 6px;
+  margin-right: 8px;
 }
 
 QCheckBox::indicator:checked,
@@ -1052,15 +1054,15 @@ TalkingUI > * {
   background-color: #191919;
 }
 
-TalkingUI [selected=false] {
+TalkingUI [selected="false"] {
   background-color: #191919;
 }
 
-TalkingUI [selected=false]:hover {
+TalkingUI [selected="false"]:hover {
   background-color: #333;
 }
 
-TalkingUI [selected=true] {
+TalkingUI [selected="true"] {
   background-color: #3e4f5e;
   border: 1px solid #3e4f5e;
 }

--- a/themes/Default/Lite.qss
+++ b/themes/Default/Lite.qss
@@ -197,9 +197,14 @@ QMenu {
 QMenu::item {
   border: 1px solid transparent;
   color: #111;
-  padding: 5px 16px;
-  padding-left: 25px;
+  padding: 5px;
+  padding-right: 16px;
+  padding-left: 8px;
   border-radius: 2px;
+}
+
+QMenu::icon {
+  left: 4px;
 }
 
 QMenu::item:selected {
@@ -215,12 +220,6 @@ QMenu::item:disabled {
 QMenu::separator {
   background: #D5D5D5;
   height: 1px;
-}
-
-QMenu::indicator {
-  padding-top: 2px;
-  height: 25px;
-  width: 25px;
 }
 
 QPushButton {
@@ -708,8 +707,11 @@ QTreeView::indicator {
 }
 
 QMenu::indicator {
+  padding-top: 2px;
   width: 12px;
+  height: 12px;
   left: 6px;
+  margin-right: 8px;
 }
 
 QCheckBox::indicator:checked,
@@ -1052,15 +1054,15 @@ TalkingUI > * {
   background-color: #FFF;
 }
 
-TalkingUI [selected=false] {
+TalkingUI [selected="false"] {
   background-color: #FFF;
 }
 
-TalkingUI [selected=false]:hover {
+TalkingUI [selected="false"]:hover {
   background-color: #eee;
 }
 
-TalkingUI [selected=true] {
+TalkingUI [selected="true"] {
   background-color: #dcedf5;
   border: 1px solid #97b5c6;
 }

--- a/themes/Default/source/Imports/Base Theme.scss
+++ b/themes/Default/source/Imports/Base Theme.scss
@@ -217,9 +217,15 @@ QMenu::item
 {
 	border:1px solid transparent;
 	color:$sub-text;
-	padding:$base-padding + 1 $base-padding * 4;
-	padding-left:25px;
+	padding:$base-padding + 1;
+	padding-right:$base-padding * 4;
+	padding-left:$base-padding * 2;
 	border-radius:$base-border-radius;
+}
+
+QMenu::icon
+{
+	left:$base-padding;
 }
 
 QMenu::item:selected
@@ -238,13 +244,6 @@ QMenu::separator
 {
 	background:$sub-highlight;
 	height:1px;
-}
-
-QMenu::indicator
-{
-	padding-top: 2px;
-	height:25px;
-	width:25px;
 }
 
 QPushButton
@@ -809,8 +808,11 @@ QTreeView::indicator,
 
 QMenu::indicator
 {
-	width: 12px;
-	left: 6px;
+	padding-top:2px;
+	width:12px;
+	height:12px;
+	left:6px;
+	margin-right:8px;
 }
 
 QCheckBox::indicator:checked,


### PR DESCRIPTION
Fixes #5462 

This merge request contains **two** commits:

1) The padding for QMenu items is adjusted according to the Qt behavior change described [here](https://bugreports.qt.io/browse/QTBUG-78238?focusedCommentId=488799&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-488799). It has the side effect that menus without either icon or check-mark are now not reserving space on the left (see new help menu).

| before | after |
| --------  | -------- |
|![screen1](https://user-images.githubusercontent.com/1348773/182615026-b87de977-47f5-473b-8aea-ced73e514b90.png)|![screen1b](https://user-images.githubusercontent.com/1348773/182615091-2292e765-43c6-46a8-a0f4-4db4fb6260cf.png)|
|![screen2](https://user-images.githubusercontent.com/1348773/182615118-5b32d0d6-5905-45e8-93aa-4bf2e85524ce.png)|![screen2b](https://user-images.githubusercontent.com/1348773/182615141-fb00a0c1-5730-478c-af06-12c307da4163.png)|

~~**This needs additional testing for Qt >= 5.14.1, because of the fix for [QTBUG-80506](https://bugreports.qt.io/browse/QTBUG-80506) described [here](https://codereview.qt-project.org/c/qt/qtbase/+/283714)**
If QMenus without icons, but WITH checkable items are too far right with Qt >= 5.14.1 (and also I understand all the padding bug reports at Qt correctly), the [right margin of indicator](https://github.com/mumble-voip/mumble/compare/master...Hartmnt:mumble:fix_menu_pad#diff-4b7f9f59d458fda01046691423c7a3647815929b4626713d012082d196c463bbR714) needs to be removed~~

I think this change is good to go for Qt >= 5.12. For Qt 6 I do not know.

2) The second commit enables icons in the Menu Bar menus, if they are not check able and an appropriate icon already exists.
I consider the merge of the second commit optional.
![screen3](https://user-images.githubusercontent.com/1348773/182615952-a43fb300-c5c9-46b6-a5e8-43d8cfa36cb7.png)

