### PR TITLE
FIX(ui): User and channel status icons take display scaling into account

### DIFF
--- a/src/mumble/UserView.h
+++ b/src/mumble/UserView.h
@@ -16,16 +16,14 @@ class UserDelegate : public QStyledItemDelegate {
 private:
 	Q_OBJECT
 	Q_DISABLE_COPY(UserDelegate)
-public:
-	UserDelegate(QObject *parent = nullptr);
-	void paint(QPainter *painter, const QStyleOptionViewItem &option, const QModelIndex &index) const Q_DECL_OVERRIDE;
 
-	//! Width/height in px of user/channel flag icons
-	const static int FLAG_ICON_DIMENSION;
-	//! Padding in px around user/channel flag icons
-	const static int FLAG_ICON_PADDING;
-	//! Width/height in px of user/channel flags including padding
-	const static int FLAG_DIMENSION;
+	int m_flagTotalDimension;
+	int m_flagIconPadding;
+	int m_flagIconDimension;
+
+public:
+	UserDelegate(QObject *parent, int flagTotalDimension, int flagIconPadding, int flagIconDimension);
+	void paint(QPainter *painter, const QStyleOptionViewItem &option, const QModelIndex &index) const Q_DECL_OVERRIDE;
 
 public slots:
 	bool helpEvent(QHelpEvent *event, QAbstractItemView *view, const QStyleOptionViewItem &option,
@@ -36,6 +34,9 @@ class UserView : public QTreeView {
 private:
 	Q_OBJECT
 	Q_DISABLE_COPY(UserView)
+
+	int m_flagTotalDimension;
+
 protected:
 	void mouseReleaseEvent(QMouseEvent *) Q_DECL_OVERRIDE;
 	void keyPressEvent(QKeyEvent *) Q_DECL_OVERRIDE;
@@ -46,6 +47,7 @@ public:
 	void keyboardSearch(const QString &search) Q_DECL_OVERRIDE;
 	void dataChanged(const QModelIndex &topLeft, const QModelIndex &bottomRight,
 					 const QVector< int > &roles = QVector< int >()) Q_DECL_OVERRIDE;
+
 public slots:
 	void nodeActivated(const QModelIndex &idx);
 	void updateChannel(const QModelIndex &index);


### PR DESCRIPTION
Fixes #5632 (duplicates: #3773 #3412)

Similar to [``TalkingUI``](https://github.com/mumble-voip/mumble/blob/master/src/mumble/TalkingUIEntry.cpp#L127), this commit changes the way the size of the user status icons is determined.
|scaling|before|after|
|----|----|----|
|100%|![13100](https://user-images.githubusercontent.com/1348773/182947678-e43b3233-a66e-4529-b26d-78109851fd7a.png)|![15100](https://user-images.githubusercontent.com/1348773/182947705-6049ea00-a110-4c06-b4d3-4eca18ab88a3.png)|
|200%|![13200](https://user-images.githubusercontent.com/1348773/182947762-9ada8e46-ff63-4337-936e-d48fbe1c8fdf.png)|![15200](https://user-images.githubusercontent.com/1348773/182947794-0eac3aef-6c2b-4115-9dbd-50161447ff22.png)|

Should probably be tested on other fractional scaling (I can only do 100% and 200%)