### PR TITLE
FIX(client): Prefer selected tree item for context menu creation

### DIFF
--- a/src/mumble/MainWindow.cpp
+++ b/src/mumble/MainWindow.cpp
@@ -741,6 +741,35 @@ ClientUser *MainWindow::getContextMenuUser() {
 	return nullptr;
 }
 
+ContextMenuTarget MainWindow::getContextMenuTargets() {
+	ContextMenuTarget target;
+
+	if (Global::get().uiSession != 0) {
+		QModelIndex idx;
+
+		if (!qpContextPosition.isNull())
+			idx = qtvUsers->indexAt(qpContextPosition);
+
+		if (!idx.isValid())
+			idx = qtvUsers->currentIndex();
+
+		target.user    = pmModel->getUser(idx);
+		target.channel = pmModel->getChannel(idx);
+
+		if (cuContextUser)
+			target.user = cuContextUser.data();
+
+		if (cContextChannel)
+			target.channel = cContextChannel.data();
+	}
+
+	cuContextUser     = target.user;
+	cContextChannel   = target.channel;
+	qpContextPosition = QPoint();
+
+	return target;
+}
+
 bool MainWindow::handleSpecialContextMenu(const QUrl &url, const QPoint &pos_, bool focus) {
 	if (url.scheme() == QString::fromLatin1("clientid")) {
 		bool ok = false;
@@ -1550,23 +1579,7 @@ void MainWindow::voiceRecorderDialog_finished(int) {
 }
 
 void MainWindow::qmUser_aboutToShow() {
-	ClientUser *p = nullptr;
-	if (Global::get().uiSession != 0) {
-		QModelIndex idx;
-		if (!qpContextPosition.isNull())
-			idx = qtvUsers->indexAt(qpContextPosition);
-
-		if (!idx.isValid())
-			idx = qtvUsers->currentIndex();
-
-		p = pmModel->getUser(idx);
-
-		if (cuContextUser)
-			p = cuContextUser.data();
-	}
-
-	cuContextUser     = p;
-	qpContextPosition = QPoint();
+	ClientUser *p = getContextMenuTargets().user;
 
 	const ClientUser *self = ClientUser::get(Global::get().uiSession);
 	bool isSelf            = p == self;
@@ -1695,23 +1708,7 @@ void MainWindow::qmUser_aboutToShow() {
 }
 
 void MainWindow::qmListener_aboutToShow() {
-	ClientUser *p = nullptr;
-	if (Global::get().uiSession != 0) {
-		QModelIndex idx;
-		if (!qpContextPosition.isNull())
-			idx = qtvUsers->indexAt(qpContextPosition);
-
-		if (!idx.isValid())
-			idx = qtvUsers->currentIndex();
-
-		p = pmModel->getUser(idx);
-
-		if (cuContextUser)
-			p = cuContextUser.data();
-	}
-
-	cuContextUser     = p;
-	qpContextPosition = QPoint();
+	ClientUser *p = getContextMenuTargets().user;
 
 	bool self = p && (p->uiSession == Global::get().uiSession);
 
@@ -2155,25 +2152,9 @@ void MainWindow::on_qmConfig_aboutToShow() {
 }
 
 void MainWindow::qmChannel_aboutToShow() {
+	Channel *c = getContextMenuTargets().channel;
+
 	qmChannel->clear();
-
-	Channel *c = nullptr;
-	if (Global::get().uiSession != 0) {
-		QModelIndex idx;
-		if (!qpContextPosition.isNull())
-			idx = qtvUsers->indexAt(qpContextPosition);
-
-		if (!idx.isValid())
-			idx = qtvUsers->currentIndex();
-
-		c = pmModel->getChannel(idx);
-
-		if (cContextChannel)
-			c = cContextChannel.data();
-	}
-
-	cContextChannel   = c;
-	qpContextPosition = QPoint();
 
 	if (c && c->iId != ClientUser::get(Global::get().uiSession)->cChannel->iId) {
 		qmChannel->addAction(qaChannelJoin);

--- a/src/mumble/MainWindow.cpp
+++ b/src/mumble/MainWindow.cpp
@@ -756,11 +756,11 @@ ContextMenuTarget MainWindow::getContextMenuTargets() {
 		target.user    = pmModel->getUser(idx);
 		target.channel = pmModel->getChannel(idx);
 
-		if (cuContextUser)
-			target.user = cuContextUser.data();
+		if (!target.user)
+			target.user = getContextMenuUser();
 
-		if (cContextChannel)
-			target.channel = cContextChannel.data();
+		if (!target.channel)
+			target.channel = getContextMenuChannel();
 	}
 
 	cuContextUser     = target.user;

--- a/src/mumble/MainWindow.h
+++ b/src/mumble/MainWindow.h
@@ -44,6 +44,11 @@ class SearchDialog;
 
 struct ShortcutTarget;
 
+struct ContextMenuTarget {
+	ClientUser *user = nullptr;
+	Channel *channel = nullptr;
+};
+
 class MessageBoxEvent : public QEvent {
 public:
 	QString msg;
@@ -196,6 +201,7 @@ protected:
 	bool handleSpecialContextMenu(const QUrl &url, const QPoint &pos_, bool focus = false);
 	Channel *getContextMenuChannel();
 	ClientUser *getContextMenuUser();
+	ContextMenuTarget getContextMenuTargets();
 
 public slots:
 	void on_qmServer_aboutToShow();


### PR DESCRIPTION
Fixes #3090

Thise merge request contains 2 commits:

1) The shared/copied code for user, listener and channel context menu target selection is unified

2) Adds a ``nullptr`` check to make sure the selected user/channel is used in context menus rather than the most recently used context item. This was an oversight in 4f5089fe30a

## TODO:

- [x] Refactor
- [x] Check listener context menu
- [ ] Rebase if necessary