### PR TITLE
Backport "Merge PR #5772: FIX(ui): User and channel status icons take display scaling into account" to 1.4.x

### DIFF
--- a/src/mumble/UserView.h
+++ b/src/mumble/UserView.h
@@ -16,16 +16,14 @@ class UserDelegate : public QStyledItemDelegate {
 private:
 	Q_OBJECT
 	Q_DISABLE_COPY(UserDelegate)
-public:
-	UserDelegate(QObject *parent = nullptr);
-	void paint(QPainter *painter, const QStyleOptionViewItem &option, const QModelIndex &index) const Q_DECL_OVERRIDE;
 
-	//! Width/height in px of user/channel flag icons
-	const static int FLAG_ICON_DIMENSION;
-	//! Padding in px around user/channel flag icons
-	const static int FLAG_ICON_PADDING;
-	//! Width/height in px of user/channel flags including padding
-	const static int FLAG_DIMENSION;
+	int m_flagTotalDimension;
+	int m_flagIconPadding;
+	int m_flagIconDimension;
+
+public:
+	UserDelegate(QObject *parent, int flagTotalDimension, int flagIconPadding, int flagIconDimension);
+	void paint(QPainter *painter, const QStyleOptionViewItem &option, const QModelIndex &index) const Q_DECL_OVERRIDE;
 
 public slots:
 	bool helpEvent(QHelpEvent *event, QAbstractItemView *view, const QStyleOptionViewItem &option,
@@ -36,6 +34,9 @@ class UserView : public QTreeView {
 private:
 	Q_OBJECT
 	Q_DISABLE_COPY(UserView)
+
+	int m_flagTotalDimension;
+
 protected:
 	void mouseReleaseEvent(QMouseEvent *) Q_DECL_OVERRIDE;
 	void keyPressEvent(QKeyEvent *) Q_DECL_OVERRIDE;
@@ -46,6 +47,7 @@ public:
 	void keyboardSearch(const QString &search) Q_DECL_OVERRIDE;
 	void dataChanged(const QModelIndex &topLeft, const QModelIndex &bottomRight,
 					 const QVector< int > &roles = QVector< int >()) Q_DECL_OVERRIDE;
+
 public slots:
 	void nodeActivated(const QModelIndex &idx);
 	void updateChannel(const QModelIndex &index);


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `1.4.x`:
 - [Merge PR #5772: FIX(ui): User and channel status icons take display scaling into account](https://github.com/mumble-voip/mumble/pull/5772)

<!--- Backport version: 8.4.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)