### PR TITLE
Backport "Merge PR #5768: FIX(client, ui): Don't display unsupported ACL" to 1.4.x

### DIFF
--- a/src/mumble/ACLEditor.cpp
+++ b/src/mumble/ACLEditor.cpp
@@ -146,10 +146,12 @@ ACLEditor::ACLEditor(int channelid, const MumbleProto::ACL &mea, QWidget *p) : Q
 		QString name       = ChanACL::permName(perm);
 
 		if (!name.isEmpty()) {
-			// If the server's version is less than 1.4.0 then it won't support the new permission to reset a
-			// comment/avatar. Skipping this iteration of the loop prevents checkboxes for it being added to the UI.
-			if ((Global::get().sh->uiVersion < 0x010400) && (perm == ChanACL::ResetUserContent))
+			// If the server's version is less than 1.4.0 then it won't support the new permissions.
+			// Skipping this iteration of the loop prevents checkboxes for it being added to the UI.
+			if (Global::get().sh->uiVersion < Version::toRaw(1, 4, 0)
+				&& (perm == ChanACL::ResetUserContent || perm == ChanACL::Listen)) {
 				continue;
+			}
 
 			QCheckBox *qcb;
 			l = new QLabel(name, qgbACLpermissions);


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `1.4.x`:
 - [Merge PR #5768: FIX(client, ui): Don't display unsupported ACL](https://github.com/mumble-voip/mumble/pull/5768)

<!--- Backport version: 8.4.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)