### PR TITLE
Backport "Merge PR #5750: FIX(client): properly verify certificates when SRV records are used" to 1.4.x

### DIFF
--- a/src/ServerResolver.cpp
+++ b/src/ServerResolver.cpp
@@ -91,7 +91,7 @@ void ServerResolverPrivate::hostResolved(QHostInfo hostInfo) {
 		foreach (QHostAddress ha, resolvedAddresses) { addresses << HostAddress(ha); }
 
 		qint64 priority = normalizeSrvPriority(record.priority(), record.weight());
-		m_resolved << ServerResolverRecord(m_origHostname, record.port(), priority, addresses);
+		m_resolved << ServerResolverRecord(record.target(), record.port(), priority, addresses);
 	}
 
 	m_srvQueueRemain -= 1;

--- a/src/mumble/ServerHandler.cpp
+++ b/src/mumble/ServerHandler.cpp
@@ -353,10 +353,16 @@ void ServerHandler::hostnameResolved() {
 	// Create the list of target host:port pairs
 	// that the ServerHandler should try to connect to.
 	QList< ServerAddress > ql;
+	QHash< ServerAddress, QString > qh;
 	foreach (ServerResolverRecord record, records) {
-		foreach (HostAddress addr, record.addresses()) { ql.append(ServerAddress(addr, record.port())); }
+		foreach (HostAddress addr, record.addresses()) {
+			auto sa = ServerAddress(addr, record.port());
+			ql.append(sa);
+			qh[sa] = record.hostname();
+		}
 	}
 	qlAddresses = ql;
+	qhHostnames = qh;
 
 	// Exit the event loop with 'success' status code,
 	// to continue connecting to the server.
@@ -386,7 +392,7 @@ void ServerHandler::run() {
 		qbaDigest               = QByteArray();
 		bStrong                 = true;
 		qtsSock                 = new QSslSocket(this);
-		qtsSock->setPeerVerifyName(qsHostName);
+		qtsSock->setPeerVerifyName(qhHostnames[saTargetServer]);
 
 		if (!Global::get().s.bSuppressIdentity && CertWizard::validateCert(Global::get().s.kpCertificate)) {
 			qtsSock->setPrivateKey(Global::get().s.kpCertificate.second);

--- a/src/mumble/ServerHandler.h
+++ b/src/mumble/ServerHandler.h
@@ -103,6 +103,7 @@ public:
 	boost::shared_ptr< VoiceRecorder > recorder;
 	QSslSocket *qtsSock;
 	QList< ServerAddress > qlAddresses;
+	QHash< ServerAddress, QString > qhHostnames;
 	ServerAddress saTargetServer;
 
 	unsigned int uiVersion;


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `1.4.x`:
 - [Merge PR #5750: FIX(client): properly verify certificates when SRV records are used](https://github.com/mumble-voip/mumble/pull/5750)

<!--- Backport version: 8.4.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)