### PR TITLE
Backport "FIX(client, ui): Minimal view not always working" to 1.4.x

### DIFF
--- a/src/mumble/MainWindow.cpp
+++ b/src/mumble/MainWindow.cpp
@@ -1249,13 +1249,6 @@ void MainWindow::setupView(bool toggle_minimize) {
 		menuBar()->removeAction(qmDeveloper->menuAction());
 	}
 
-	if (!showit) {
-		qdwLog->setVisible(showit);
-		qdwChat->setVisible(showit);
-		qtIconToolbar->setVisible(showit);
-	}
-	menuBar()->setVisible(showit);
-
 	if (toggle_minimize) {
 		if (!showit) {
 			if (!Global::get().s.qbaMinimalViewGeometry.isNull())
@@ -1274,6 +1267,13 @@ void MainWindow::setupView(bool toggle_minimize) {
 			   geometry().height() - newgeom.height() + geom.height());
 		move(geom.x(), geom.y());
 	}
+
+
+	// Hide/Show respective UI elements
+	qdwLog->setVisible(showit);
+	qdwChat->setVisible(showit);
+	qtIconToolbar->setVisible(showit);
+	menuBar()->setVisible(showit);
 
 	// Display the Transmit Mode Dropdown, if configured to do so, otherwise
 	// hide it.


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `1.4.x`:
 - [FIX(client, ui): Minimal view not always working](https://github.com/mumble-voip/mumble/pull/5777)

<!--- Backport version: 8.4.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)