### PR TITLE
FIX(ui): Remove duplicate entry for "What's this?" in UserModel

### DIFF
--- a/src/mumble/UserModel.cpp
+++ b/src/mumble/UserModel.cpp
@@ -703,8 +703,6 @@ QVariant UserModel::otherRoles(const QModelIndex &idx, int role) const {
 												   "valign=\"middle\">%5</td></tr>"
 												   "<tr><td><img src=\"skin:talking_muted.svg\" height=64 /></td><td "
 												   "valign=\"middle\">%6</td></tr>"
-												   "<tr><td><img src=\"skin:talking_muted.svg\" height=64 /></td><td "
-												   "valign=\"middle\">%6</td></tr>"
 												   "<tr><td><img src=\"skin:ear.svg\" height=64 /></td><td "
 												   "valign=\"middle\">%7</td></tr>"
 												   "</table>")


### PR DESCRIPTION
Removed the duplicate entry for "Talking while being muted on your end"
from the "What's this?" text for users in the TreeView.

Fixes #5793

