### PR TITLE
Backport "CI: Use new build-number script" to 1.4.x

### DIFF
--- a/.ci/azure-pipelines/build_linux.bash
+++ b/.ci/azure-pipelines/build_linux.bash
@@ -19,12 +19,9 @@
 #  MUMBLE_BUILD_NUMBER_TOKEN      - Access token for the build number page on our server.
 #
 
-if [[ -n "$MUMBLE_BUILD_NUMBER_TOKEN" ]]; then
-	VERSION=$(python "scripts/mumble-version.py")
-	BUILD_NUMBER=$(curl "https://mumble.info/get-build-number?commit=${BUILD_SOURCEVERSION}&version=${VERSION}&token=${MUMBLE_BUILD_NUMBER_TOKEN}")
-else
-	BUILD_NUMBER=0
-fi
+VERSION=$("./scripts/mumble-version.py")
+BUILD_NUMBER=$("./scripts/mumble-build-number.py" --commit "${BUILD_SOURCEVERSION}" --version "${VERSION}" \
+	--password "${MUMBLE_BUILD_NUMBER_TOKEN}" --default 0)
 
 cd $BUILD_BINARIESDIRECTORY
 

--- a/.ci/azure-pipelines/build_macos.bash
+++ b/.ci/azure-pipelines/build_macos.bash
@@ -30,12 +30,9 @@
 #  MUMBLE_BUILD_NUMBER_TOKEN           - Access token for the build number page on our server.
 #
 
-if [[ -n "$MUMBLE_BUILD_NUMBER_TOKEN" ]]; then
-	VERSION=$(python "scripts/mumble-version.py")
-	BUILD_NUMBER=$(curl "https://mumble.info/get-build-number?commit=${BUILD_SOURCEVERSION}&version=${VERSION}&token=${MUMBLE_BUILD_NUMBER_TOKEN}")
-else
-	BUILD_NUMBER=0
-fi
+VERSION=$("./scripts/mumble-version.py")
+BUILD_NUMBER=$("./scripts/mumble-build-number.py" --commit "${BUILD_SOURCEVERSION}" --version "${VERSION}" \
+	--password "${MUMBLE_BUILD_NUMBER_TOKEN}" --default 0)
 
 cd $BUILD_BINARIESDIRECTORY
 

--- a/.ci/build_windows.bat
+++ b/.ci/build_windows.bat
@@ -28,15 +28,8 @@
 :: https://stackoverflow.com/a/6362922
 for /f "tokens=* USEBACKQ" %%g in (`python "scripts\mumble-version.py"`) do (set "VERSION=%%g")
 
-:: For some really stupid reason we can't have this statement and the one where we set the VERSION variable in the same if body as
-:: in that case the variable substitution of that variable in the expression below fails (is replaced with empty string)
-:: Also we can't anything else inside the if body as this will cause the curl command to always be executed.
-if defined MUMBLE_BUILD_NUMBER_TOKEN (
-	for /f "tokens=* USEBACKQ" %%g in (`curl "https://mumble.info/get-build-number?commit=%MUMBLE_SOURCE_COMMIT%&version=%VERSION%&token=%MUMBLE_BUILD_NUMBER_TOKEN%"`) do (set "BUILD_NUMBER=%%g")
-) else (
-	echo Build number token not set - defaulting to 0
-	set BUILD_NUMBER=0
-)
+for /f "tokens=* USEBACKQ" %%g in (`python "scripts\mumble-build-number.py" --commit "%MUMBLE_SOURCE_COMMIT%" --version "%VERSION%" ^
+	--password "%MUMBLE_BUILD_NUMBER_TOKEN%" --default 0`) do (set "BUILD_NUMBER=%%g")
 
 :: Create build directory if it doesn't exist.
 if not exist "%MUMBLE_BUILD_DIRECTORY%" mkdir "%MUMBLE_BUILD_DIRECTORY%


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `1.4.x`:
 - [CI: Use new build-number script](https://github.com/mumble-voip/mumble/pull/5410)

<!--- Backport version: 8.4.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)