### PR TITLE
BUILD: Disable warnings-as-errors

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -54,7 +54,7 @@ option(tests "Build tests" OFF)
 option(optimize "Build a heavily optimized version, specific to the machine it's being compiled on." OFF)
 option(static "Build static binaries." OFF)
 option(symbols "Build binaries in a way that allows easier debugging." OFF)
-option(warnings-as-errors "All warnings are treated as errors." ON)
+option(warnings-as-errors "All warnings are treated as errors." OFF)
 
 option(overlay "Build overlay." ON)
 option(packaging "Build package." OFF)

--- a/docs/dev/build-instructions/cmake_options.md
+++ b/docs/dev/build-instructions/cmake_options.md
@@ -242,7 +242,7 @@ Check for updates by default.
 ### warnings-as-errors
 
 All warnings are treated as errors.
-(Default: ON)
+(Default: OFF)
 
 ### wasapi
 


### PR DESCRIPTION
As the 1.4.x series is in feature-frozen mode, having this enabled by
default does no good (no active development happening on it anymore,
anyway)


### Checks

- [x] My commits follow the [commit guidelines](https://github.com/mumble-voip/mumble/blob/master/COMMIT_GUIDELINES.md)

