### PR TITLE
MAINT: Fix mumble-build-number.py script

### DIFF
--- a/scripts/mumble-build-number.py
+++ b/scripts/mumble-build-number.py
@@ -9,16 +9,22 @@
 
 import argparse
 import urllib.request
+import urllib.parse
 import sys
 
 def fetch_build_number(commit = None, version = None, password = None):
     if commit is None or version is None:
         return None
 
-    query = "https://mumble.info/get-build-number?commit=" + commit + "&version=" + version
+    parameter = {
+        "commit": commit,
+        "version": version
+    }
 
     if not password is None:
-        query += "&token=" + password
+        parameter["token"] = password
+
+    query = "https://mumble.info/get-build-number?" + urllib.parse.urlencode(parameter)
 
     try:
         request = urllib.request.urlopen(query)


### PR DESCRIPTION
Previously the script would assemble the query URL by taking the
individual parameters literally. However, for certain inputs this could
lead to an invalid URL, resulting in an error 400 (Bad Request) when
attempting to make this query to the server.

In order to avoid these situations, the parameters are now properly
encoded (quoted) before being inserted into the query URL. Thus, we
ensure to always produce valid URLs.


### Checks

- [x] My commits follow the [commit guidelines](https://github.com/mumble-voip/mumble/blob/master/COMMIT_GUIDELINES.md)

