### PR TITLE
MAINT: Extend changelog script

### DIFF
--- a/scripts/generateChangelog.py
+++ b/scripts/generateChangelog.py
@@ -39,6 +39,7 @@ def main():
 
     mergeCommitPattern = re.compile("^([0-9a-f]+)\s*[Mm]erge\s.+?#(\d+):?\s*(.+)$", re.MULTILINE)
     backportCommitPattern = re.compile("^[Bb]ackport\s*\"(.*)\".*$")
+    mergePrefixPattern = re.compile("^Merge PR #\d+:")
 
     commits = cmd(["git", "log" ,"--format=oneline",  "--date=short", "{}..{}".format(args.FROM_TAG, args.TO_TAG)]).split("\n")
 
@@ -65,6 +66,9 @@ def main():
         if backportMatch:
             # This commit is a backport commit where the actual commit title is the bit in the quotes
             commitTitle = backportMatch.group(1)
+
+            if re.match(mergePrefixPattern, commitTitle):
+                commitTitle = commitTitle[ commitTitle.find(":") + 1 : ]
 
         try:
             commit = CommitMessage(commitTitle)


### PR DESCRIPTION
Sometimes backport commits still have a "Merged PR xxx" part in them,
which we have to strip before processing the message. This is exactly
what this commit adds to the existing changelog script.


### Checks

- [x] My commits follow the [commit guidelines](https://github.com/mumble-voip/mumble/blob/master/COMMIT_GUIDELINES.md)

