### PR TITLE
FIX(client): Broken link targets with percent signs

### DIFF
--- a/src/mumble/Markdown.cpp
+++ b/src/mumble/Markdown.cpp
@@ -105,7 +105,7 @@ bool processMarkdownLink(QString &str, int &offset) {
 		}
 
 		QString replacement =
-			QString::fromLatin1("<a href=\"%1\">%2</a>").arg(unescapeURL(url)).arg(match.captured(1).toHtmlEscaped());
+			QString::fromLatin1("<a href=\"%1\">%2</a>").arg(unescapeURL(url), match.captured(1).toHtmlEscaped());
 		str.replace(match.capturedStart(), match.capturedEnd() - match.capturedStart(), replacement);
 
 		offset += replacement.size();
@@ -326,8 +326,7 @@ bool processPlainLink(QString &str, int &offset) {
 			url = QStringLiteral("https://") + url;
 		}
 
-		QString replacement =
-			QString::fromLatin1("<a href=\"%1\">%2</a>").arg(unescapeURL(url)).arg(url.toHtmlEscaped());
+		QString replacement = QString::fromLatin1("<a href=\"%1\">%2</a>").arg(unescapeURL(url), url.toHtmlEscaped());
 		str.replace(match.capturedStart(), match.capturedEnd() - match.capturedStart(), replacement);
 
 		offset += replacement.size();


### PR DESCRIPTION
When sending a link that contains a percent followed by a digit, where
the digit is <= 2 (e.g. %1), the link's target would be messed up as the
respective %x would be treated as an argument replacement specifier by
Qt (and would thus be replaced by some replacement text).

The reason for this lies in the use of two consecutive calls to
QString::arg, where the second call will gladly try to replace any new
replacement specifications introduced with the first replacement.

The solution is to use an overload of QString::arg, that takes both
replacement texts at the same time and applies them in one go. This
specifically allows to ignore any newly introduced replacement
specifications.

The bug has been introduced with the introduction of Markdown support in
2da3f0d39e37e6bf10318d174744bb7e7924794b but has been masked by a bug
that stopped link recognition at percent signs. This has been fixed in
727049c52681eeccca5d7dbec6997cb6fe92cea1 and since then also appears for
plain links (for markdown-style links using the []() syntax the bug was
probably present throughout).

Fixes #5819


### Checks

- [x] My commits follow the [commit guidelines](https://github.com/mumble-voip/mumble/blob/master/COMMIT_GUIDELINES.md)

