### PR TITLE
FIX(client): Use correct font size for scaling status icons

### DIFF
--- a/src/mumble/UserView.cpp
+++ b/src/mumble/UserView.cpp
@@ -109,10 +109,9 @@ bool UserDelegate::helpEvent(QHelpEvent *evt, QAbstractItemView *view, const QSt
 	return QStyledItemDelegate::helpEvent(evt, view, option, index);
 }
 
-UserView::UserView(QWidget *p) : QTreeView(p) {
-	m_userDelegate = new UserDelegate(this);
+UserView::UserView(QWidget *p) : QTreeView(p), m_userDelegate(make_qt_unique< UserDelegate >(this)) {
 	adjustIcons();
-	setItemDelegate(m_userDelegate);
+	setItemDelegate(m_userDelegate.get());
 
 	// Because in Qt fonts take some time to initialize properly, we have to delay the call
 	// to adjustIcons a bit in order to give the fonts the necessary time (so we can read out

--- a/src/mumble/UserView.h
+++ b/src/mumble/UserView.h
@@ -10,6 +10,7 @@
 #include <QtWidgets/QStyledItemDelegate>
 #include <QtWidgets/QTreeView>
 
+#include "QtUtils.h"
 #include "Timer.h"
 
 class UserDelegate : public QStyledItemDelegate {
@@ -37,7 +38,7 @@ private:
 	Q_DISABLE_COPY(UserView)
 
 	int m_iconTotalDimension;
-	UserDelegate *m_userDelegate;
+	qt_unique_ptr< UserDelegate > m_userDelegate;
 	void adjustIcons();
 
 protected:

--- a/src/mumble/UserView.h
+++ b/src/mumble/UserView.h
@@ -17,13 +17,14 @@ private:
 	Q_OBJECT
 	Q_DISABLE_COPY(UserDelegate)
 
-	int m_flagTotalDimension;
-	int m_flagIconPadding;
-	int m_flagIconDimension;
+	int m_iconTotalDimension;
+	int m_iconIconPadding;
+	int m_iconIconDimension;
 
 public:
-	UserDelegate(QObject *parent, int flagTotalDimension, int flagIconPadding, int flagIconDimension);
+	UserDelegate(QObject *parent);
 	void paint(QPainter *painter, const QStyleOptionViewItem &option, const QModelIndex &index) const Q_DECL_OVERRIDE;
+	void adjustIcons(int iconTotalDimension, int iconIconPadding, int iconIconDimension);
 
 public slots:
 	bool helpEvent(QHelpEvent *event, QAbstractItemView *view, const QStyleOptionViewItem &option,
@@ -35,7 +36,9 @@ private:
 	Q_OBJECT
 	Q_DISABLE_COPY(UserView)
 
-	int m_flagTotalDimension;
+	int m_iconTotalDimension;
+	UserDelegate *m_userDelegate;
+	void adjustIcons();
 
 protected:
 	void mouseReleaseEvent(QMouseEvent *) Q_DECL_OVERRIDE;


### PR DESCRIPTION
This merge requests fixes an oversight in #5772 on my part

Fixes one of the issues mentioned in #5817 

I misunderstood the code at hand a little. Especially, I introduced [this line](https://github.com/mumble-voip/mumble/blob/master/src/mumble/UserView.cpp#L114). It was supposed to use the font used by the TreeView to determine the icon size. However, I now realize ``p`` refers to the MainWindow and not the TreeView (UserView INHERITS TreeView), so it was using the wrong font metric.

**Why was this not caught?**
This is coincidentally related to the log text issues #5820. As far as I can tell, the log text uses the exact same font object I was basing my calculations of.
For SOME platforms/Qt the Log text size was decreased for *reasons* that are out of scope of the problem hat hand. All platforms that I used for testing (Ubuntu Linux with XFCE and GNOME) did not have the log font size decrease problem (see screenshots of original MR).
That means when the log text had the same font size as the TreeView, this problem was not visible.

**Solution:**
In this MR the icon calculation is moved to UserDelegate's paint function. Which is admittedly slightly ugly, but the only way to implement this properly I think. Alternatively, we could try to use the font of QTreeView, but I do not know if the font values are correct in its constructor.

**TODO:**

- [x] Need to test a thing