### PR TITLE
FIX(theme): update fallback path for skins

### DIFF
--- a/src/mumble/Themes.cpp
+++ b/src/mumble/Themes.cpp
@@ -74,7 +74,7 @@ bool Themes::applyConfigured() {
 
 	QStringList skinPaths;
 	skinPaths << qssFile.path();
-	skinPaths << QLatin1String(":/themes/Mumble"); // Some skins might want to fall-back on our built-in resources
+	skinPaths << QLatin1String(":/themes/Default"); // Some skins might want to fall-back on our built-in resources
 
 	QString themeQss = QString::fromUtf8(file.readAll());
 	setTheme(themeQss, skinPaths);


### PR DESCRIPTION
Change the skin fallback path from `themes/Mumble` to `themes/Default`
to reflect the change during the integration of the theme submodule.


### Checks

- [x] My commits follow the [commit guidelines](https://github.com/mumble-voip/mumble/blob/master/COMMIT_GUIDELINES.md)

