### PR TITLE
FIX(client, ui): Make hiding UI elements persistent again

### DIFF
--- a/src/mumble/MainWindow.cpp
+++ b/src/mumble/MainWindow.cpp
@@ -1334,10 +1334,13 @@ void MainWindow::setupView(bool toggle_minimize) {
 	}
 
 
-	// Hide/Show respective UI elements
-	qdwLog->setVisible(showit);
-	qdwChat->setVisible(showit);
-	qtIconToolbar->setVisible(showit);
+	// Explicitly hide UI elements, if we're entering minimal view
+	// Note that showing them again is handled above via restoreState/restoreGeometry calls
+	if (!showit) {
+		qdwLog->setVisible(false);
+		qdwChat->setVisible(false);
+		qtIconToolbar->setVisible(false);
+	}
 	menuBar()->setVisible(showit);
 
 	if (showit) {


### PR DESCRIPTION
Due to a regression introduced in
6aa88691e16c807b998301f2cbecfda599ef4592 when hiding individual UI
components (e.g. the icon toolbar) - possible when using a custom
layout - these elements would re-appear after restarting Mumble (or
after applying the settings or after exiting minimal view).

The reason is that the state of whether or not a given UI component is
shown or not is saved as the window's geometry. In the above commit we
added code that explicitly shows or hides these elements after the
geometry has been restored, thus overwriting the visibility changes of
this geometry restoration.

The fix for this problem is to only explicitly hide the elements when
entering minimal view but let the showing be handled by restoring the
window's geometry. Thus, only those elements are shown again, that have
previously been visible as well (and thus have not been explicitly
hidden by the user).

Fixes #5832


### Checks

- [x] My commits follow the [commit guidelines](https://github.com/mumble-voip/mumble/blob/master/COMMIT_GUIDELINES.md)

