### PR TITLE
FIX(client, ui): Don't allow manual toggling of minimal view note

### DIFF
--- a/src/mumble/MainWindow.cpp
+++ b/src/mumble/MainWindow.cpp
@@ -728,7 +728,15 @@ void MainWindow::updateTransmitModeComboBox(Settings::AudioTransmit newMode) {
 
 QMenu *MainWindow::createPopupMenu() {
 	if ((Global::get().s.wlWindowLayout == Settings::LayoutCustom) && !Global::get().s.bLockLayout) {
-		return QMainWindow::createPopupMenu();
+		// We have to explicitly create a menu here instead of simply referring to QMainWindow::createPopupMenu as we
+		// don't want a toggle for showing/hiding the minimal view note (which is also present as a QDockWidget). Thus,
+		// we have to explicitly add only those widgets that we really want to be toggleable.
+		QMenu *menu = new QMenu(this);
+		menu->addAction(qdwChat->toggleViewAction());
+		menu->addAction(qdwLog->toggleViewAction());
+		menu->addAction(qtIconToolbar->toggleViewAction());
+
+		return menu;
 	}
 
 	return nullptr;


### PR DESCRIPTION
In 39047d2a57a9288262c5f303d96798a1b1692b8d a new note was added for
when a user enters minimal view but is not connected to a server.
Incidentally, this caused the new note to appear in the popup menu
appearing as a context menu when using a custom layout, which in theory
would allow a manual toggling of that note's visibility. However, this
is not what we want and thus this commit makes sure that this popup menu
only contains entries for UI elements that we really want to be manually
toggelable.


### Checks

- [x] My commits follow the [commit guidelines](https://github.com/mumble-voip/mumble/blob/master/COMMIT_GUIDELINES.md)

