### PR TITLE
BUILD(appstream): Include release date

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,6 +14,7 @@ if(${CMAKE_VERSION} VERSION_GREATER_EQUAL "3.20.0")
 endif()
 
 set(BUILD_NUMBER CACHE STRING "The build number of the current build. Will be used in Mumble's version to make sure newer builds upgrade older installations properly.")
+set(BUILD_RELEASE_DATE CACHE STRING "The release date to be used in the generated appstream metadata.")
 
 if ("${BUILD_NUMBER}" STREQUAL "")
 	if(packaging)

--- a/scripts/info.mumble.Mumble.appdata.xml.in
+++ b/scripts/info.mumble.Mumble.appdata.xml.in
@@ -27,7 +27,7 @@
 	</screenshots>
 
 	<releases>
-		<release type="stable" version="@CMAKE_PROJECT_VERSION@"/>
+		<release type="stable" version="@CMAKE_PROJECT_VERSION@" date="@BUILD_RELEASE_DATE@" />
 	</releases>
 	<provides>
 		<binary>mumble</binary>


### PR DESCRIPTION
Flathub requires this now.

This is done in the same way as the build number.


### Checks

- [x] My commits follow the [commit guidelines](https://github.com/mumble-voip/mumble/blob/master/COMMIT_GUIDELINES.md)

