### PR TITLE
CHANGE(server): Make tracy build optional

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -173,15 +173,12 @@ if(qssldiffiehellmanparameters)
 	target_compile_definitions(shared PUBLIC "USE_QSSLDIFFIEHELLMANPARAMETERS")
 endif()
 
-# Note: We always include and link against Tracy but it is only enabled, if we set the TRACY_ENABLE cmake option
-# to ON, before including the respective subdirectory
-set(TRACY_ENABLE ${tracy} CACHE BOOL "" FORCE)
-set(TRACY_ON_DEMAND ON CACHE BOOL "" FORCE)
-add_subdirectory("${3RDPARTY_DIR}/tracy" "tracy")
-disable_warnings_for_all_targets_in("${3RDPARTY_DIR}/tracy")
-message(STATUS "Tracy: ${TRACY_ENABLE}")
+if(tracy)
+    add_subdirectory("${3RDPARTY_DIR}/tracy" "tracy")
+    disable_warnings_for_all_targets_in("${3RDPARTY_DIR}/tracy")
 
-target_link_libraries(shared PUBLIC Tracy::TracyClient)
+    target_link_libraries(shared PUBLIC Tracy::TracyClient)
+endif()
 
 # Add the GSL
 if(bundled-gsl)

--- a/src/mumble/CMakeLists.txt
+++ b/src/mumble/CMakeLists.txt
@@ -854,6 +854,10 @@ if(dbus AND NOT WIN32 AND NOT APPLE)
 	target_link_libraries(mumble_client_object_lib PUBLIC Qt5::DBus)
 endif()
 
+if(tracy)
+    target_compile_definitions(mumble_client PRIVATE "USE_TRACY")
+endif()
+
 if(translations)
 	# Glob for all translation files in the source dir
 	file(GLOB TS_FILES "${CMAKE_CURRENT_SOURCE_DIR}/*.ts")

--- a/src/murmur/AudioReceiverBuffer.cpp
+++ b/src/murmur/AudioReceiverBuffer.cpp
@@ -8,7 +8,11 @@
 #include <algorithm>
 #include <cassert>
 
+#ifdef USE_TRACY
 #include <Tracy.hpp>
+#else
+#define ZoneScoped
+#endif
 
 AudioReceiver::AudioReceiver(ServerUser &receiver, Mumble::Protocol::audio_context_t context,
 							 const VolumeAdjustment &volumeAdjustment)

--- a/src/murmur/AudioReceiverBuffer.h
+++ b/src/murmur/AudioReceiverBuffer.h
@@ -14,7 +14,11 @@
 #include <unordered_map>
 #include <vector>
 
+#ifdef USE_TRACY
 #include <Tracy.hpp>
+#else
+#define ZoneScoped
+#endif
 
 class AudioReceiver {
 public:

--- a/src/murmur/CMakeLists.txt
+++ b/src/murmur/CMakeLists.txt
@@ -198,6 +198,10 @@ if(dbus AND NOT WIN32 AND NOT APPLE)
 	target_link_libraries(mumble-server PRIVATE Qt5::DBus)
 endif()
 
+if(tracy)
+    target_compile_definitions(mumble-server PRIVATE "USE_TRACY")
+endif()
+
 if(ice)
 	find_pkg(Ice
 		COMPONENTS

--- a/src/murmur/Messages.cpp
+++ b/src/murmur/Messages.cpp
@@ -22,7 +22,11 @@
 
 #include <cassert>
 
+#ifdef USE_TRACY
 #include <Tracy.hpp>
+#else
+#define ZoneScoped
+#endif
 
 #define RATELIMIT(user)                   \
 	if (user->leakyBucket.ratelimit(1)) { \


### PR DESCRIPTION
Instead of always building and linking Tracy even if it's disabled, make tracy completely optional.

### Checks

- [x] My commits follow the [commit guidelines](https://github.com/mumble-voip/mumble/blob/master/COMMIT_GUIDELINES.md)

