### PR TITLE
BUILD(build): Fix -mbig-obj test

### DIFF
--- a/cmake/compiler.cmake
+++ b/cmake/compiler.cmake
@@ -67,7 +67,7 @@ elseif(UNIX OR MINGW)
 	)
 
 	# Avoid "File too big" error
-	check_cxx_compiler_flag("Wa,-mbig-obj" COMPILER_HAS_MBIG_OBJ)
+	check_cxx_compiler_flag("-Wa,-mbig-obj" COMPILER_HAS_MBIG_OBJ)
 	if (${COMPILER_HAS_MBIG_OBJ})
 		add_compile_options("-Wa,-mbig-obj")
 	endif()


### PR DESCRIPTION
Fix a typo in the `COMPILER_HAS_MBIG_OBJ` test which fixes this failure:
```
c++: warning: Wa,-mbig-obj: linker input file unused because linking not done
c++: error: Wa,-mbig-obj: linker input file not found: No such file or directory
```

### Checks

- [x] My commits follow the [commit guidelines](https://github.com/mumble-voip/mumble/blob/master/COMMIT_GUIDELINES.md)

