### PR TITLE
BUILD: Always build Tracy as static library

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -177,9 +177,16 @@ endif()
 # to ON, before including the respective subdirectory
 set(TRACY_ENABLE ${tracy} CACHE BOOL "" FORCE)
 set(TRACY_ON_DEMAND ON CACHE BOOL "" FORCE)
+# We force to build Tracy as a static library in order to not create a dependency on the respective .so file
+# (can cause issues for packagers as that dependency is retained even though Tracy is disabled)
+set(PREV_BUILD_SHARED_LIBS ${BUILD_SHARED_LIBS})
+set(BUILD_SHARED_LIBS OFF CACHE BOOL "" FORCE)
 add_subdirectory("${3RDPARTY_DIR}/tracy" "tracy")
 disable_warnings_for_all_targets_in("${3RDPARTY_DIR}/tracy")
 message(STATUS "Tracy: ${TRACY_ENABLE}")
+
+# Restore whatever BUILD_SHARED_LIBS was set to before
+set(BUILD_SHARED_LIBS ${PREV_BUILD_SHARED_LIBS} CACHE BOOL "" FORCE)
 
 target_link_libraries(shared PUBLIC Tracy::TracyClient)
 


### PR DESCRIPTION
This has the advantage of not creating a dependency on the respective
.so/.dll which will be present, even if Tracy support is actually
disabled for the binary. This in turn can cause some issues for
packagers.


### Checks

- [x] My commits follow the [commit guidelines](https://github.com/mumble-voip/mumble/blob/master/COMMIT_GUIDELINES.md)

