### PR TITLE
FIX(positional-audio): Force 8 bytes alignment for CCameraAngles in GTAV plugin

### DIFF
--- a/plugins/gtav/structs.h
+++ b/plugins/gtav/structs.h
@@ -118,7 +118,7 @@ struct CCameraManagerAngles {
 	ptr_t cameraAngles; // CCameraAngles *
 };
 
-struct CCameraAngles {
+struct alignas(8) CCameraAngles {
 	uint8_t pad1[960];
 	ptr_t playerAngles; // CPlayerAngles *
 	uint8_t pad2[60];


### PR DESCRIPTION
https://en.cppreference.com/w/cpp/language/alignas

This fixes compilation when the implicit alignment is not 8 bytes.

It can be the case with 32 bit targets.

---

Fixes #5849.