### PR TITLE
Backport "Merge PR #5843: BUILD(build): Fix -mbig-obj test" to 1.4.x

### DIFF
--- a/cmake/compiler.cmake
+++ b/cmake/compiler.cmake
@@ -79,7 +79,7 @@ elseif(UNIX OR MINGW)
 	)
 
 	# Avoid "File too big" error
-	check_cxx_compiler_flag("Wa,-mbig-obj" COMPILER_HAS_MBIG_OBJ)
+	check_cxx_compiler_flag("-Wa,-mbig-obj" COMPILER_HAS_MBIG_OBJ)
 	if (${COMPILER_HAS_MBIG_OBJ})
 		add_compile_options("-Wa,-mbig-obj")
 	endif()


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `1.4.x`:
 - [Merge PR #5843: BUILD(build): Fix -mbig-obj test](https://github.com/mumble-voip/mumble/pull/5843)

<!--- Backport version: 8.4.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)