### PR TITLE
Backport "Merge PR #5835: BUILD(appstream): Include release date" to 1.4.x

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,6 +12,7 @@ if(${CMAKE_VERSION} VERSION_GREATER_EQUAL "3.20.0")
 endif()
 
 set(BUILD_NUMBER CACHE STRING "The build number of the current build. Will be used in Mumble's version to make sure newer builds upgrade older installations properly.")
+set(BUILD_RELEASE_DATE CACHE STRING "The release date to be used in the generated appstream metadata.")
 
 if ("${BUILD_NUMBER}" STREQUAL "")
 	if(packaging)

--- a/scripts/info.mumble.Mumble.appdata.xml.in
+++ b/scripts/info.mumble.Mumble.appdata.xml.in
@@ -31,7 +31,7 @@
 	</screenshots>
 
 	<releases>
-		<release type="stable" version="@CMAKE_PROJECT_VERSION@"/>
+		<release type="stable" version="@CMAKE_PROJECT_VERSION@" date="@BUILD_RELEASE_DATE@" />
 	</releases>
 	<provides>
 		<binary>mumble</binary>


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `1.4.x`:
 - [Merge PR #5835: BUILD(appstream): Include release date](https://github.com/mumble-voip/mumble/pull/5835)

<!--- Backport version: 8.4.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)