### PR TITLE
Backport "Merge PR #5834: FIX(client, ui): Don't allow manual toggling of minimal view note" to 1.4.x

### DIFF
--- a/src/mumble/MainWindow.cpp
+++ b/src/mumble/MainWindow.cpp
@@ -702,7 +702,15 @@ void MainWindow::updateTransmitModeComboBox(Settings::AudioTransmit newMode) {
 
 QMenu *MainWindow::createPopupMenu() {
 	if ((Global::get().s.wlWindowLayout == Settings::LayoutCustom) && !Global::get().s.bLockLayout) {
-		return QMainWindow::createPopupMenu();
+		// We have to explicitly create a menu here instead of simply referring to QMainWindow::createPopupMenu as we
+		// don't want a toggle for showing/hiding the minimal view note (which is also present as a QDockWidget). Thus,
+		// we have to explicitly add only those widgets that we really want to be toggleable.
+		QMenu *menu = new QMenu(this);
+		menu->addAction(qdwChat->toggleViewAction());
+		menu->addAction(qdwLog->toggleViewAction());
+		menu->addAction(qtIconToolbar->toggleViewAction());
+
+		return menu;
 	}
 
 	return nullptr;


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `1.4.x`:
 - [Merge PR #5834: FIX(client, ui): Don't allow manual toggling of minimal view note](https://github.com/mumble-voip/mumble/pull/5834)

<!--- Backport version: 8.4.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)