### PR TITLE
Backport "Merge PR #5833: FIX(client, ui): Make hiding UI elements persistent again" to 1.4.x

### DIFF
--- a/src/mumble/MainWindow.cpp
+++ b/src/mumble/MainWindow.cpp
@@ -1298,10 +1298,13 @@ void MainWindow::setupView(bool toggle_minimize) {
 	}
 
 
-	// Hide/Show respective UI elements
-	qdwLog->setVisible(showit);
-	qdwChat->setVisible(showit);
-	qtIconToolbar->setVisible(showit);
+	// Explicitly hide UI elements, if we're entering minimal view
+	// Note that showing them again is handled above via restoreState/restoreGeometry calls
+	if (!showit) {
+		qdwLog->setVisible(false);
+		qdwChat->setVisible(false);
+		qtIconToolbar->setVisible(false);
+	}
 	menuBar()->setVisible(showit);
 
 	// Display the Transmit Mode Dropdown, if configured to do so, otherwise


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `1.4.x`:
 - [Merge PR #5833: FIX(client, ui): Make hiding UI elements persistent again](https://github.com/mumble-voip/mumble/pull/5833)

<!--- Backport version: 8.4.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)