### PR TITLE
Backport "Merge PR #5821: FIX(client): Broken link targets with percent signs" to 1.4.x

### DIFF
--- a/src/mumble/Markdown.cpp
+++ b/src/mumble/Markdown.cpp
@@ -105,7 +105,7 @@ bool processMarkdownLink(QString &str, int &offset) {
 		}
 
 		QString replacement =
-			QString::fromLatin1("<a href=\"%1\">%2</a>").arg(unescapeURL(url)).arg(match.captured(1).toHtmlEscaped());
+			QString::fromLatin1("<a href=\"%1\">%2</a>").arg(unescapeURL(url), match.captured(1).toHtmlEscaped());
 		str.replace(match.capturedStart(), match.capturedEnd() - match.capturedStart(), replacement);
 
 		offset += replacement.size();
@@ -327,8 +327,7 @@ bool processPlainLink(QString &str, int &offset) {
 			url = QStringLiteral("http://") + url;
 		}
 
-		QString replacement =
-			QString::fromLatin1("<a href=\"%1\">%2</a>").arg(unescapeURL(url)).arg(url.toHtmlEscaped());
+		QString replacement = QString::fromLatin1("<a href=\"%1\">%2</a>").arg(unescapeURL(url), url.toHtmlEscaped());
 		str.replace(match.capturedStart(), match.capturedEnd() - match.capturedStart(), replacement);
 
 		offset += replacement.size();


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `1.4.x`:
 - [Merge PR #5821: FIX(client): Broken link targets with percent signs](https://github.com/mumble-voip/mumble/pull/5821)

<!--- Backport version: 8.4.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)