### PR TITLE
Backport "CI: Add dispatch for new releases" to 1.4.x

### DIFF
--- a/.github/workflows/release_dispatch.yml
+++ b/.github/workflows/release_dispatch.yml
@@ -1,0 +1,16 @@
+name: Dispatch new release
+
+on:
+    release:
+        types: [ published ]
+
+jobs:
+    dispatch:
+        runs-on: ubuntu-latest
+        steps:
+            - name: "Dispatch release to mumble-docker repo"
+              uses: peter-evans/repository-dispatch@v2
+              with:
+                  token: ${{ secrets.DOCKER_REPO_ACCCESS_TOKEN }}
+                  event-type: new_release
+                  client_payload: '{ "tag": "${{ github.event.release.tag_name }}", "is_latest": "${{ github.event.release.commitish == master }}" }'


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `1.4.x`:
 - [CI: Add dispatch for new releases](https://github.com/mumble-voip/mumble/pull/5649)

<!--- Backport version: 8.4.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)