### PR TITLE
Backport "Merge PR #5874: CI(github-actions): Automatically publish to WinGet" to 1.4.x

### DIFF
--- a/.github/workflows/winget.yml
+++ b/.github/workflows/winget.yml
@@ -1,0 +1,25 @@
+name: Publish to WinGet
+on:
+  release:
+    types: [released]
+jobs:
+  publish:
+    runs-on: windows-latest # action can only be run on windows
+    steps:
+      - name: Publish Mumble client
+        uses: vedantmgoyal2009/winget-releaser@latest
+        with:
+          identifier: Mumble.Mumble.Client
+          installers-regex: mumble_client.*.msi$
+          token: ${{ secrets.WINGET_TOKEN }}
+
+      # The action will clone winget-pkgs again, to start fresh
+      - name: Clean working directory
+        run: Remove-Item -Recurse -Force .\winget-pkgs\
+
+      - name: Publish Mumble server
+        uses: vedantmgoyal2009/winget-releaser@latest
+        with:
+          identifier: Mumble.Mumble.Server
+          installers-regex: mumble_server.*.msi$
+          token: ${{ secrets.WINGET_TOKEN }}


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `1.4.x`:
 - [Merge PR #5874: CI(github-actions): Automatically publish to WinGet](https://github.com/mumble-voip/mumble/pull/5874)

<!--- Backport version: 8.4.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)