### PR TITLE
MAINT: Downgrade Opus submodule 

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
-[submodule "opus"]
+[submodule "3rdparty/opus"]
 	path = 3rdparty/opus
 	url = https://gitlab.xiph.org/xiph/opus.git
 [submodule "3rdparty/minhook"]

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "3rdparty/opus"]
 	path = 3rdparty/opus
-	url = https://gitlab.xiph.org/xiph/opus.git
+	url = https://github.com/mumble-voip/opus.git
 [submodule "3rdparty/minhook"]
 	path = 3rdparty/minhook
 	url = https://github.com/mumble-voip/minhook.git
@@ -25,3 +25,5 @@
 [submodule "3rdparty/gsl"]
 	path = 3rdparty/gsl
 	url = https://github.com/microsoft/GSL.git
+[submodule "opus"]
+	url = https://github.com/mumble-voip/opus.git

--- a/docs/dev/build-instructions/cmake_options.md
+++ b/docs/dev/build-instructions/cmake_options.md
@@ -139,6 +139,11 @@ Build a heavily optimized version, specific to the machine it's being compiled o
 (No description available)
 (Default: ON)
 
+### OPUS_BUILD_TESTS
+
+(No description available)
+(Default: OFF)
+
 ### OPUS_STACK_PROTECTOR
 
 (No description available)

--- a/src/mumble/CMakeLists.txt
+++ b/src/mumble/CMakeLists.txt
@@ -696,6 +696,7 @@ endif()
 
 if(bundled-opus)
 	option(OPUS_BUILD_SHARED_LIBRARY "" ON)
+	option(OPUS_BUILD_TESTS "" OFF)
 	if(MINGW)
 		option(OPUS_STACK_PROTECTOR "" OFF)
 	endif()


### PR DESCRIPTION
Since newer Opus versions appear to cause crashes under some
circumstances, we downgrade our Opus submodule to point to the latest
stable release, which is v1.3.1 from 2019.

We will only be able to upgrade again, once the underlying issue causing
the crashes has been identified and fixed.

Fixes https://github.com/mumble-voip/mumble/issues/5302

-----

Old PR description (outdated)

Since our last update, there have been several fixes contributed to the
upstream repo. Thus, we should update our submodule to include these
fixes. In particular
- https://github.com/xiph/opus/commit/ec64b3c5b7abd621dfddee6b4cc115298e5d6803
- https://github.com/xiph/opus/commit/12a356e431d1b2d3531d3d73de330bf9ee9be48b
- https://github.com/xiph/opus/commit/ccb42e05cc6eb98a15874b9695361025b3ee17ab

### Checks

- [x] My commits follow the [commit guidelines](https://github.com/mumble-voip/mumble/blob/master/COMMIT_GUIDELINES.md)

