### PR TITLE
Backport "Merge PR #5884: CI(github-actions): Fix workflow file syntax" to 1.4.x

### DIFF
--- a/.github/workflows/release_dispatch.yml
+++ b/.github/workflows/release_dispatch.yml
@@ -13,4 +13,4 @@ jobs:
               with:
                   token: ${{ secrets.DOCKER_REPO_ACCCESS_TOKEN }}
                   event-type: new_release
-                  client_payload: '{ "tag": "${{ github.event.release.tag_name }}", "is_latest": "${{ github.event.release.commitish == master }}" }'
+                  client_payload: '{ "tag": "${{ github.event.release.tag_name }}", "is_latest": "${{ github.event.release.commitish == "master" }}" }'


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `1.4.x`:
 - [Merge PR #5884: CI(github-actions): Fix workflow file syntax](https://github.com/mumble-voip/mumble/pull/5884)

<!--- Backport version: 8.4.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)