### PR TITLE
FIX(server, rpc): Don't send useless UserState message

### DIFF
--- a/src/murmur/RPC.cpp
+++ b/src/murmur/RPC.cpp
@@ -408,10 +408,6 @@ void Server::setListenerVolumeAdjustment(ServerUser *user, const Channel *cChann
 	MumbleProto::UserState mpus;
 	mpus.set_session(user->uiSession);
 
-	if (!broadcastListenerVolumeAdjustments) {
-		sendExcept(user, mpus);
-	}
-
 	MumbleProto::UserState::VolumeAdjustment *volume_adjustment = mpus.add_listening_volume_adjustment();
 	volume_adjustment->set_listening_channel(cChannel->iId);
 	volume_adjustment->set_volume_adjustment(volumeAdjustment.factor);


### PR DESCRIPTION
As it was, the sent UserState message would have only contained the user's session ID, which in and of itself is absolutely useless. Thus, it is better to not send a UserState message in this case.


### Checks

- [x] My commits follow the [commit guidelines](https://github.com/mumble-voip/mumble/blob/master/COMMIT_GUIDELINES.md)

