### PR TITLE
FIX(client): Fixes link context menu creation for channels

### DIFF
--- a/src/mumble/Log.cpp
+++ b/src/mumble/Log.cpp
@@ -509,7 +509,7 @@ QString Log::msgColor(const QString &text, LogColorType t) {
 }
 
 QString Log::formatChannel(::Channel *c) {
-	return QString::fromLatin1("<a href='channelid://%1/%3' class='log-channel'>%2</a>")
+	return QString::fromLatin1("<a href='channelid://id.%1/%3' class='log-channel'>%2</a>")
 		.arg(c->iId)
 		.arg(c->qsName.toHtmlEscaped())
 		.arg(QString::fromLatin1(Global::get().sh->qbaDigest.toBase64()));
@@ -539,7 +539,7 @@ QString Log::formatClientUser(ClientUser *cu, LogColorType t, const QString &dis
 	if (cu) {
 		QString name = (displayName.isNull() ? cu->qsName : displayName).toHtmlEscaped();
 		if (cu->qsHash.isEmpty()) {
-			return QString::fromLatin1("<a href='clientid://%2/%4' class='log-user log-%1'>%3</a>")
+			return QString::fromLatin1("<a href='clientid://id.%2/%4' class='log-user log-%1'>%3</a>")
 				.arg(className)
 				.arg(cu->uiSession)
 				.arg(name)


### PR DESCRIPTION
The commit 902fe5841ca03f59b introduced links in the log for users and channels. This either never worked correctly, or regressed due to an undocumented behavior change in Qt. The 'channelid' stored in the host part of a QUrl is automatically converted to an IP address (e.g. '1' -> '0.0.0.1') which lets the channel lookup fail. A different code path for clients was present, so the issue was not observed often (or at all) there.

This commit changes the host part composition to contain a string (e.g. '1' > 'id.1') and makes sure this new string is parsed correctly.

Fixes #2961
