### PR TITLE
FIX(server): Explicitly set parsed timestamps to UTC for rememberchannelduration

### DIFF
--- a/src/murmur/ServerDB.cpp
+++ b/src/murmur/ServerDB.cpp
@@ -2225,12 +2225,14 @@ int Server::readLastChannel(int id) {
 		}
 
 		QDateTime last_active = QDateTime::fromString(query.value(1).toString(), Qt::ISODate);
+		last_active.setTimeSpec(Qt::UTC);
 		QDateTime last_disconnect;
 
 		// NULL column for last_disconnect will yield an empty invalid QDateTime object.
 		// Using that object with QDateTime::secsTo() will return 0 as per Qt specification.
 		if (!query.value(2).isNull()) {
 			last_disconnect = QDateTime::fromString(query.value(2).toString(), Qt::ISODate);
+			last_disconnect.setTimeSpec(Qt::UTC);
 		}
 
 		if (last_active.secsTo(last_disconnect) <= 0) {


### PR DESCRIPTION
Remember when [I asked why the code was using ``setTimeSpec``](https://github.com/mumble-voip/mumble/pull/5646#discussion_r863694635)? This is actually needed, because the database itself contains UTC and we tell Qt that we do NOT have to cast again. The issue is only really noticeable on certain server local times.

This MR simply adds the ``setTimeSpec`` calls back. It should fix rememerchannelduration, if and only if all database backends use UTC by default (which is assumed in the rest of mumble's code I suppose). If other database backends may use the server's local time, there is a much larger issue here which needs to be addressed.

I noticed this while testing #5907 

Commit message:

In ccbf4072c the rememberchannelduration logic was improved. An explicit call to 'setTimeSpec(Qt::UTC)' was removed, because it was assumed that 'secsTo' would already be sufficient as it converts both inputs to UTC automatically. Due to an oversight this lead to a regression.

The reason setTimeSpec is acutally needed is because the DB already contains UTC values. The setTimeSpec call tells Qt that the loaded values are actually already UTC and do not have to be converted. Without the call to setTimeSpec, the DB values are effectively converted twice, which gives rememberchannelduration an offset based on the server local time.
