### PR TITLE
Priority speakers and temporary channels

### DIFF
--- a/src/murmur/Messages.cpp
+++ b/src/murmur/Messages.cpp
@@ -788,13 +788,27 @@ void Server::msgUserState(ServerUser *uSource, MumbleProto::UserState &msg) {
 			PERM_DENIED_TYPE(SuperUser);
 			return;
 		}
-		if (uSource->cChannel->bTemporary) {
-			PERM_DENIED_TYPE(TemporaryChannel);
-			return;
-		}
 		if (!hasPermission(uSource, pDstServerUser->cChannel, ChanACL::MuteDeafen) || msg.suppress()) {
 			PERM_DENIED(uSource, pDstServerUser->cChannel, ChanACL::MuteDeafen);
 			return;
+		}
+	}
+
+	if (msg.has_mute() || msg.has_deaf() || msg.has_suppress()) {
+		if (pDstServerUser->cChannel->bTemporary) {
+			// If the destination user is inside a temporary channel,
+			// the source user needs to have the MuteDeafen ACL in the first
+			// non-temporary parent channel.
+
+			Channel *c = pDstServerUser->cChannel;
+			while (c && c->bTemporary) {
+				c = c->cParent;
+			}
+
+			if (!c || !hasPermission(uSource, c, ChanACL::MuteDeafen)) {
+				PERM_DENIED_TYPE(TemporaryChannel);
+				return;
+			}
 		}
 	}
 

--- a/src/murmur/Server.cpp
+++ b/src/murmur/Server.cpp
@@ -1980,6 +1980,12 @@ void Server::userEnterChannel(User *p, Channel *c, MumbleProto::UserState &mpus)
 			p->bSuppress = !mayspeak;
 			mpus.set_suppress(p->bSuppress);
 		}
+
+		if (p->bPrioritySpeaker) {
+			// Clear priority speaker flag when switching channels
+			p->bPrioritySpeaker = false;
+			mpus.set_priority_speaker(p->bPrioritySpeaker);
+		}
 	}
 
 	clearACLCache(p);


### PR DESCRIPTION
This MR contains two changes:

1) Clear the priority speaker flag on channel switch (#5334)
2) Change how the temporary channel mute/deaf permission check is performed. Also: Allow priority speaker in temporary channels. (#1877)


Fixes #5334
Fixes #1877

See also: #5296 #3584