### PR TITLE
CI(github-actions): Update Ubuntu runners

### DIFF
--- a/.github/actions/install-dependencies/install_ubuntu_shared_64bit.sh
+++ b/.github/actions/install-dependencies/install_ubuntu_shared_64bit.sh
@@ -7,7 +7,7 @@ sudo apt -y install \
 	g++-multilib \
 	ninja-build \
 	pkg-config \
-	qt5-default \
+	qtbase5-dev \
 	qttools5-dev \
 	qttools5-dev-tools \
 	libqt5svg5-dev \

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
         fail-fast: false
         matrix:
-            os: [ubuntu-18.04, ubuntu-20.04]
+            os: [ubuntu-20.04, ubuntu-22.04]
             type: [shared] # Currently the "static" build doesn't work for Linux systems
             arch: [64bit]
             


### PR DESCRIPTION
We were still using a runner on Ubuntu 18.04, which is getting deprecated by GitHub in the near future. In order to avoid having failing CI jobs due to that and also in order to keep up with changes in Ubuntu, we now build on 20.04 and 22.04 instead.


### Checks

- [x] My commits follow the [commit guidelines](https://github.com/mumble-voip/mumble/blob/master/COMMIT_GUIDELINES.md)

