### PR TITLE
Add donation link to AppStream Metadata

### DIFF
--- a/auxiliary_files/config_files/info.mumble.Mumble.appdata.xml.in
+++ b/auxiliary_files/config_files/info.mumble.Mumble.appdata.xml.in
@@ -17,6 +17,7 @@
 	<url type="homepage">@CMAKE_PROJECT_HOMEPAGE_URL@</url>
 	<url type="bugtracker">https://github.com/mumble-voip/mumble/issues</url>
 	<url type="help">https://wiki.mumble.info/wiki/Main_Page</url>
+	<url type="donation">https://liberapay.com/mumble</url>
 	<url type="translate">https://wiki.mumble.info/wiki/Language_Translation</url>
 	<launchable type="desktop-id">info.mumble.Mumble.desktop</launchable>
 	<screenshots>


### PR DESCRIPTION
See [AppStream format documentation](https://www.freedesktop.org/software/appstream/docs/chap-Metadata.html#tag-url). Took donation URL from `.github/FUNDING.yml`.

### Checks

- [x] My commits follow the [commit guidelines](https://github.com/mumble-voip/mumble/blob/master/COMMIT_GUIDELINES.md)

