### PR TITLE
FIX(client): Use SPSC queue for global shortcuts on Windows

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -22,5 +22,8 @@
 [submodule "3rdparty/gsl"]
 	path = 3rdparty/gsl
 	url = https://github.com/microsoft/GSL.git
+[submodule "3rdparty/SPSCQueue"]
+	path = 3rdparty/SPSCQueue
+	url = https://github.com/rigtorp/SPSCQueue.git
 [submodule "opus"]
 	url = https://github.com/mumble-voip/opus.git

--- a/src/mumble/CMakeLists.txt
+++ b/src/mumble/CMakeLists.txt
@@ -595,12 +595,17 @@ if(WIN32)
 		target_link_libraries(mumble_client_object_lib PUBLIC Qt5::QWindowsIntegrationPlugin)
 	endif()
 
+	add_subdirectory("${3RDPARTY_DIR}/SPSCQueue" "${CMAKE_CURRENT_BINARY_DIR}/SPSCQueue" EXCLUDE_FROM_ALL)
 	add_subdirectory("${3RDPARTY_DIR}/xinputcheck-build" "${CMAKE_CURRENT_BINARY_DIR}/xinputcheck" EXCLUDE_FROM_ALL)
 
 	# Disable all warnings that the xinputcheck code may emit
 	disable_warnings_for_all_targets_in("${3RDPARTY_DIR}/xinputcheck-build")
 
-	target_link_libraries(mumble_client_object_lib PUBLIC xinputcheck)
+	target_link_libraries(mumble_client_object_lib
+		PUBLIC
+			SPSCQueue
+			xinputcheck
+	)
 
 	if(MSVC)
 		target_link_libraries(mumble_client_object_lib


### PR DESCRIPTION
We've been receiving quite a few reports about the program seemingly freezing, such as
https://forums.mumble.info/topic/14467-14-conflict-with-flight-control-rudder-pedals.

Turns out there are HID devices, namely advanced controllers, that constantly send packets.
The reason behind the behavior is probably to prevent games from losing track of the physical state.

Qt's event dispatcher blows up and consumes all resources, leading to:

```
QEventDispatcherWin32::registerTimer: Failed to create a timer (The current process has used all of its system allowance of handles for Window Manager objects.)
```

As a result, the UI completely freezes due to events not being processed anymore.
This commit fixes the issue by using an SPSC (Single Producer Single Consumer) queue.

The event loop and 20 ms timer are removed. The latter was strictly used for XInput and G-keys polling.
Both backends still work, potentially better than before: no more polling!
Whenever a HID message is received, the relevant code is executed.