### PR TITLE
FEAT(server): Flag bot connections, so user count does not get inflated by them

### DIFF
--- a/src/Mumble.proto
+++ b/src/Mumble.proto
@@ -41,6 +41,8 @@ message Authenticate {
 	// A list of CELT bitstream version constants supported by the client.
 	repeated int32 celt_versions = 4;
 	optional bool opus = 5 [default = false];
+	// 0 = REGULAR, 1 = BOT
+	optional int32 client_type = 6 [default = 0];
 }
 
 // Sent by the client to notify the server that the client is still alive.

--- a/src/murmur/ClientType.h
+++ b/src/murmur/ClientType.h
@@ -1,0 +1,9 @@
+#ifndef MUMBLE_MURMUR_CLIENT_TYPE_H_
+#define MUMBLE_MURMUR_CLIENT_TYPE_H_
+
+enum class ClientType {
+	REGULAR,
+	BOT,
+};
+
+#endif

--- a/src/murmur/Messages.cpp
+++ b/src/murmur/Messages.cpp
@@ -6,6 +6,7 @@
 #include "ACL.h"
 #include "Channel.h"
 #include "ChannelListenerManager.h"
+#include "ClientType.h"
 #include "Connection.h"
 #include "Group.h"
 #include "Meta.h"
@@ -599,6 +600,17 @@ void Server::msgAuthenticate(ServerUser *uSource, MumbleProto::Authenticate &msg
 		}
 
 		sendMessage(uSource, mptm);
+	}
+
+	switch (msg.client_type()) {
+		case static_cast< int >(ClientType::BOT):
+			uSource->m_clientType = ClientType::BOT;
+			m_botCount++;
+			break;
+		case static_cast< int >(ClientType::REGULAR):
+			// No-op (also applies to unknown values of msg.client_type())
+			// (The default client type is regular anyway, so we don't need to change anything here)
+			break;
 	}
 
 	log(uSource, "Authenticated");

--- a/src/murmur/Server.cpp
+++ b/src/murmur/Server.cpp
@@ -7,6 +7,7 @@
 
 #include "ACL.h"
 #include "Channel.h"
+#include "ClientType.h"
 #include "Connection.h"
 #include "EnvUtils.h"
 #include "Group.h"
@@ -641,7 +642,7 @@ gsl::span< const Mumble::Protocol::byte >
 		pingData.requestAdditionalInformation = false;
 
 		pingData.serverVersion                 = Version::get();
-		pingData.userCount                     = qhUsers.size();
+		pingData.userCount                     = qhUsers.size() - m_botCount;
 		pingData.maxUserCount                  = iMaxUsers;
 		pingData.maxBandwidthPerUser           = iMaxBandwidth;
 		pingData.containsAdditionalInformation = true;
@@ -1661,6 +1662,10 @@ void Server::connectionClosed(QAbstractSocket::SocketError err, const QString &r
 		MumbleProto::UserRemove mpur;
 		mpur.set_session(u->uiSession);
 		sendExcept(u, mpur);
+
+		if (u->m_clientType == ClientType::BOT) {
+			m_botCount--;
+		}
 
 		emit userDisconnected(u);
 	}

--- a/src/murmur/Server.h
+++ b/src/murmur/Server.h
@@ -126,6 +126,7 @@ public:
 	QString qsWelcomeTextFile;
 	bool bCertRequired;
 	bool bForceExternalAuth;
+	unsigned int m_botCount = 0;
 
 	QString qsRegName;
 	QString qsRegPassword;

--- a/src/murmur/ServerUser.cpp
+++ b/src/murmur/ServerUser.cpp
@@ -5,6 +5,7 @@
 
 #include "ServerUser.h"
 
+#include "ClientType.h"
 #include "Meta.h"
 #include "Server.h"
 
@@ -15,8 +16,9 @@
 ServerUser::ServerUser(Server *p, QSslSocket *socket)
 	: Connection(p, socket), User(), s(nullptr), leakyBucket(p->iMessageLimit, p->iMessageBurst),
 	  m_pluginMessageBucket(5, 20) {
-	sState     = ServerUser::Connected;
-	sUdpSocket = INVALID_SOCKET;
+	sState       = ServerUser::Connected;
+	m_clientType = ClientType::REGULAR;
+	sUdpSocket   = INVALID_SOCKET;
 
 	memset(&saiUdpAddress, 0, sizeof(saiUdpAddress));
 	memset(&saiTcpLocalAddress, 0, sizeof(saiTcpLocalAddress));

--- a/src/murmur/ServerUser.h
+++ b/src/murmur/ServerUser.h
@@ -12,6 +12,7 @@
 #	include "win.h"
 #endif
 
+#include "ClientType.h"
 #include "Connection.h"
 #include "HostAddress.h"
 #include "Timer.h"
@@ -108,6 +109,7 @@ protected:
 public:
 	enum State { Connected, Authenticated };
 	State sState;
+	ClientType m_clientType;
 	operator QString() const;
 
 	float dUDPPingAvg, dUDPPingVar;


### PR DESCRIPTION
Extended Authenticate message by int ```client_type``` in ```Mumble.proto``` so server knows what type of connection it is(for now it's just 0 for ```REGULAR``` and 1 for ```BOT```). Next I created header file called ```ClientType.h``` where I define enum class for types of connections. This enum is easily extendable for any special connection types in future.

In ```Server.h``` I extended Server class by ```m_botCount``` attribute.

In ```Messages.cpp``` I extended ```msgAuthenticate``` function by a check at the end before authentication log that checks whether connection type is regular or bot and if it's a bot then it increments ```m_botCount``` by one. It also sets ```client_type``` for ```ServerUser```.

Before disconnect in ```Server.cpp``` I check if ```ServerUser``` is ```BOT``` and if yes I decrement ```m_botCount``` by one. In the final user count, ```m_botCount``` gets subtracted from the user count to show real user count.

Implements #5461

### Checks

- [ x ] My commits follow the [commit guidelines](https://github.com/mumble-voip/mumble/blob/master/COMMIT_GUIDELINES.md)