### PR TITLE
BUILD(cmake): the "optimize" option

### DIFF
--- a/cmake/compiler.cmake
+++ b/cmake/compiler.cmake
@@ -72,7 +72,7 @@ elseif(UNIX OR MINGW)
 		add_compile_options("-Wa,-mbig-obj")
 	endif()
 
-	if(options)
+	if(optimize)
 		add_compile_options(
 			"-O3"
 			"-march=native"


### PR DESCRIPTION
typo.
Also fast-math is not compatiple with opus and rnnoise, so the build fails as is.


### Checks

- [x] My commits follow the [commit guidelines](https://github.com/mumble-voip/mumble/blob/master/COMMIT_GUIDELINES.md)

