### PR TITLE
BUILD(cmake): remove -ffast-math and -ftree-vectorize

### DIFF
--- a/cmake/compiler.cmake
+++ b/cmake/compiler.cmake
@@ -76,8 +76,6 @@ elseif(UNIX OR MINGW)
 		add_compile_options(
 			"-O3"
 			"-march=native"
-			"-ffast-math"
-			"-ftree-vectorize"
 		)
 	endif()
 
@@ -128,7 +126,7 @@ elseif(UNIX OR MINGW)
 			add_compile_options("-g")
 		endif()
 	endif()
-endif() 
+endif()
 
 function(target_disable_warnings TARGET)
 	if(MSVC)


### PR DESCRIPTION
because they block compilation (fast-math)
or are part of -O3 (tree-vectorize)


### Checks

- [x] My commits follow the [commit guidelines](https://github.com/mumble-voip/mumble/blob/master/COMMIT_GUIDELINES.md)

