### PR TITLE
BUILD(cmake): Fix syntax error

### DIFF
--- a/cmake/qt-utils.cmake
+++ b/cmake/qt-utils.cmake
@@ -81,7 +81,7 @@ function(include_translations OUT_VAR OUT_DIR TS_FILES)
 
 		if(COMP_RESULT EQUAL 0)
 			# Files are equal -> Don't overwrite
-		elseif(COMP_RESULT 1)
+		elseif(COMP_RESULT EQUAL 1)
 			# Files are different -> overwrite
 			file(RENAME "${TMP_PATH}" "${QRC_PATH}")
 		else()


### PR DESCRIPTION
See also https://github.com/mumble-voip/mumble/discussions/5956 for how this manifested itself, if encountered.


### Checks

- [x] My commits follow the [commit guidelines](https://github.com/mumble-voip/mumble/blob/master/COMMIT_GUIDELINES.md)

