### PR TITLE
FIX(client): Prevent loading unwanted Opus version

### DIFF
--- a/src/mumble/OpusCodec.cpp
+++ b/src/mumble/OpusCodec.cpp
@@ -42,32 +42,28 @@ OpusCodec::OpusCodec() {
 	alternatives << QString::fromLatin1("opus0.dll");
 	alternatives << QString::fromLatin1("opus.dll");
 #endif
-	foreach (const QString &lib, alternatives) {
-		qlOpus.setFileName(MumbleApplication::instance()->applicationVersionRootPath() + QLatin1String("/") + lib);
-		if (qlOpus.load()) {
-			bValid = true;
-			break;
-		}
 
+
+	QStringList basePaths;
+	basePaths << MumbleApplication::instance()->applicationVersionRootPath() + "/";
 #ifdef Q_OS_MAC
-		qlOpus.setFileName(QApplication::instance()->applicationDirPath() + QLatin1String("/../Codecs/") + lib);
-		if (qlOpus.load()) {
-			bValid = true;
-			break;
-		}
+	basePaths << QApplication::instance()->applicationDirPath() + "/../Codecs/";
 #endif
-
 #ifdef MUMBLE_LIBRARY_PATH
-		qlOpus.setFileName(QLatin1String(MUMTEXT(MUMBLE_LIBRARY_PATH) "/") + lib);
-		if (qlOpus.load()) {
-			bValid = true;
-			break;
-		}
+	basePaths << MUMTEXT(MUMBLE_LIBRARY_PATH) "/";
 #endif
+	basePaths << ""; // General search without telling it a particular path to look for
 
-		qlOpus.setFileName(lib);
-		if (qlOpus.load()) {
-			bValid = true;
+	for (const QString &basePath : basePaths) {
+		for (const QString &libName : alternatives) {
+			qlOpus.setFileName(basePath + libName);
+			if (qlOpus.load()) {
+				bValid = true;
+				break;
+			}
+		}
+
+		if (bValid) {
 			break;
 		}
 	}


### PR DESCRIPTION
This commit ensures that we first try all names for the different base paths in turn, before we fall back for a generic search for that lib based only on the given name.
Otherwise, e.g. the system Opus library could be used instead of the bundled version compiled together with Mumble.


### Checks

- [x] My commits follow the [commit guidelines](https://github.com/mumble-voip/mumble/blob/master/COMMIT_GUIDELINES.md)

