### PR TITLE
BUILD(cmake): Cross-compile overlay on M1 macs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -171,7 +171,7 @@ if(g15 AND WIN32)
 	add_subdirectory("helpers/g15helper")
 endif()
 
-if(APPLE AND CMAKE_SYSTEM_PROCESSOR MATCHES "arm64")
+if(APPLE AND MUMBLE_TARGET_ARCH MATCHES "arm.*")
 	# mach_override doesn't support ARM
 	# https://github.com/rentzsch/mach_override/issues/6
 	set(overlay OFF CACHE BOOL "" FORCE)


### PR DESCRIPTION
The overlay doesn't work on ARM Macs, so we disable it on these machines. However, the CMAKE_SYSTEM_PROCESSOR variable doesn't always hold the target architecture and as it turned out it contained the host arch on our M1 macOS builder, causing the overlay to be disabled for our x86 macOS binaries that were cross-compiled from our M1 machine.

Therefore, we now leverage the system we also use to detect the target architecture for passing it as a macro to our code.


### Checks

- [x] My commits follow the [commit guidelines](https://github.com/mumble-voip/mumble/blob/master/COMMIT_GUIDELINES.md)

