### PR TITLE
BUILD(cmake): Disable warnings as errors by default

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -74,7 +74,7 @@ check_ipo_supported(RESULT LTO_DEFAULT)
 option(optimize "Build a heavily optimized version, specific to the machine it's being compiled on." OFF)
 option(static "Build static binaries." OFF)
 option(symbols "Build binaries in a way that allows easier debugging." OFF)
-option(warnings-as-errors "All warnings are treated as errors." ON)
+option(warnings-as-errors "All warnings are treated as errors." OFF)
 
 option(client "Build the client (Mumble)" ON)
 option(server "Build the server (Murmur)" ON)

--- a/docs/dev/build-instructions/cmake_options.md
+++ b/docs/dev/build-instructions/cmake_options.md
@@ -242,7 +242,7 @@ Check for updates by default.
 ### warnings-as-errors
 
 All warnings are treated as errors.
-(Default: ON)
+(Default: OFF)
 
 ### wasapi
 


### PR DESCRIPTION
### Checks

- [x] My commits follow the [commit guidelines](https://github.com/mumble-voip/mumble/blob/master/COMMIT_GUIDELINES.md)

