### PR TITLE
Backport "Merge PR #6011: CI(appveyor): Update to latest image version" to 1.5.x

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -3,7 +3,7 @@
 # that can be found in the LICENSE file at the root of the
 # Mumble source tree or at <https://www.mumble.info/LICENSE>.
 
-image: Visual Studio 2019
+image: Visual Studio 2022
 
 clone_depth: 1
 skip_branch_with_pr: true


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `1.5.x`:
 - [Merge PR #6011: CI(appveyor): Update to latest image version](https://github.com/mumble-voip/mumble/pull/6011)

<!--- Backport version: 8.9.3 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)