### PR TITLE
CI(windows): Auto-determine path to vcvars script

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -24,7 +24,6 @@ environment:
   matrix:
     - MUMBLE_ENVIRONMENT_TRIPLET: 'x64-windows-static-md'
       MUMBLE_ENVIRONMENT_VERSION: 'windows-static-1.5.x~2022-05-17~cd7e2c9.x64'
-      VCVARS_PATH: 'C:/Program Files (x86)/Microsoft Visual Studio/2022/Community/VC/Auxiliary/Build/vcvars64.bat'
 
 install:
   - ps: .ci/install-environment_windows.ps1

--- a/.ci/azure-pipelines/main-pr.yml
+++ b/.ci/azure-pipelines/main-pr.yml
@@ -26,7 +26,6 @@ jobs:
     variables:
       MUMBLE_ENVIRONMENT_VERSION: 'windows-static-1.5.x~2022-05-17~cd7e2c9.x64'
       MUMBLE_ENVIRONMENT_TRIPLET: 'x64-windows-static-md'
-      VCVARS_PATH: 'C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvars64.bat'
     steps:
     - template: steps_windows.yml
       parameters:

--- a/.ci/azure-pipelines/main.yml
+++ b/.ci/azure-pipelines/main.yml
@@ -24,7 +24,6 @@ jobs:
     variables:
       MUMBLE_ENVIRONMENT_VERSION: 'windows-static-1.5.x~2022-05-17~cd7e2c9.x64'
       MUMBLE_ENVIRONMENT_TRIPLET: 'x64-windows-static-md'
-      VCVARS_PATH: 'C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvars64.bat'
     steps:
     - template: steps_windows.yml
       parameters:

--- a/.ci/build_windows.bat
+++ b/.ci/build_windows.bat
@@ -36,6 +36,9 @@ if not exist "%MUMBLE_BUILD_DIRECTORY%" mkdir "%MUMBLE_BUILD_DIRECTORY%
 
 cd "%MUMBLE_BUILD_DIRECTORY%"
 
+for /f "tokens=* USEBACKQ" %%g in (`vswhere -latest -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64 ^
+	-property installationPath`) do ( set "VCVARS_PATH=%%g\VC\Auxiliary\Build\vcvars64.bat" )
+
 call "%VCVARS_PATH%"
 
 set PATH=%PATH%;C:\WixSharp

--- a/.ci/install-environment_windows.ps1
+++ b/.ci/install-environment_windows.ps1
@@ -125,5 +125,6 @@ Download -source "https://github.com/oleg-shilo/wixsharp/releases/download/v1.19
 Write-Host "Exracting WixSharp to C:/WixSharp..."
 Invoke-Command 7z x "WixSharp.7z" "-oC:/WixSharp"
 
+choco install vswhere
 
 Write-Host "Build environment successfully installed"


### PR DESCRIPTION
This way, we won't have to update the path every time we update the used Visual Studio version (and find the correct one via trial & error).
This solution makes use of Microsoft's vswhere script (see https://github.com/microsoft/vswhere) to locate the VS installation directory. Based on that, we assemble the required path.

### Checks

- [x] My commits follow the [commit guidelines](https://github.com/mumble-voip/mumble/blob/master/COMMIT_GUIDELINES.md)

