### PR TITLE
Backport "Merge PR #6025: CI(appveyor): Use release signing" to 1.5.x

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -43,6 +43,6 @@ artifacts:
 
 deploy:
   - provider: Webhook
-    url: https://app.signpath.io/API/v1/79916aba-7a9f-448d-91c6-fb83593b59d3/Integrations/AppVeyor?ProjectSlug=mumble&SigningPolicySlug=test-signing
+    url: https://app.signpath.io/API/v1/79916aba-7a9f-448d-91c6-fb83593b59d3/Integrations/AppVeyor?ProjectSlug=mumble&SigningPolicySlug=release-signing
     authorization:
       secure: WKbGSfFSHTtODf6eHRSHPAobctJli48O/VoMpCYTuIlITl2piOpCH6igCRDX4EuJTzgDX45H34tVfPuNzSMdLA==


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `1.5.x`:
 - [Merge PR #6025: CI(appveyor): Use release signing](https://github.com/mumble-voip/mumble/pull/6025)

<!--- Backport version: 8.9.3 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)