### PR TITLE
Backport "Merge PR #6027: CI(github-actions): Avoid duplicate runs" to 1.5.x

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,7 +11,21 @@ env:
 
 
 jobs:
+  pre_run:
+    runs-on: ubuntu-latest
+    outputs:
+      should_skip: ${{ steps.skip_check.outputs.should_skip }}
+    steps:
+      - id: skip_check
+        uses: fkirc/skip-duplicate-actions@v5
+        with:
+          concurrent_skipping: same_content_newer
+          skip_after_successful_duplicate: 'true'
+
   build:
+    needs: pre_run
+    if: needs.pre_run.outputs.should_skip != 'true'
+
     strategy:
         fail-fast: false
         matrix:

--- a/.github/workflows/code-ql.yml
+++ b/.github/workflows/code-ql.yml
@@ -6,7 +6,7 @@ env:
   # Customize the CMake build type here (Release, Debug, RelWithDebInfo, etc.)
   BUILD_TYPE: Release
   CMAKE_OPTIONS: |
-      -Dtests=OFF -Dsymbols=ON
+      -Dtests=OFF -Dsymbols=ON -Dwarnings-as-errors=OFF
 
 jobs:
   pre_run:
@@ -24,10 +24,15 @@ jobs:
     needs: pre_run
     if: needs.pre_run.outputs.should_skip != 'true'
 
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
+
+    permissions:
+      security-events: write
+      actions: read
+      contents: read
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
           submodules: 'recursive'
 

--- a/.github/workflows/code-ql.yml
+++ b/.github/workflows/code-ql.yml
@@ -9,7 +9,21 @@ env:
       -Dtests=OFF -Dsymbols=ON
 
 jobs:
+  pre_run:
+    runs-on: ubuntu-latest
+    outputs:
+      should_skip: ${{ steps.skip_check.outputs.should_skip }}
+    steps:
+      - id: skip_check
+        uses: fkirc/skip-duplicate-actions@v5
+        with:
+          concurrent_skipping: same_content_newer
+          skip_after_successful_duplicate: 'true'
+
   CodeQL-Build:
+    needs: pre_run
+    if: needs.pre_run.outputs.should_skip != 'true'
+
     runs-on: ubuntu-20.04
 
     steps:


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `1.5.x`:
 - [Merge PR #6027: CI(github-actions): Avoid duplicate runs](https://github.com/mumble-voip/mumble/pull/6027)

<!--- Backport version: 8.9.3 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)