### PR TITLE
BUILD(cmake): Fix server-only builds

### DIFF
--- a/src/murmur/CMakeLists.txt
+++ b/src/murmur/CMakeLists.txt
@@ -194,7 +194,7 @@ if(NOT WIN32 AND NOT APPLE)
 			"DBus.h"
 	)
 
-	target_compile_definitions(mumble_client_object_lib PUBLIC "USE_DBUS")
+	target_compile_definitions(mumble-server PUBLIC "USE_DBUS")
 	target_link_libraries(mumble-server PRIVATE Qt5::DBus)
 endif()
 


### PR DESCRIPTION
In #6002 the dbus option was removed and on Linux systems DBus was unconditionally enabled. However, in the server's cmake file a copy&paste error was introduced that would produce an error if the client was not built alongside the server.

This commit fixes this error and therefore makes server-only builds possible again.


### Checks

- [x] My commits follow the [commit guidelines](https://github.com/mumble-voip/mumble/blob/master/COMMIT_GUIDELINES.md)

