### PR TITLE
CI(github-actions): Ensure build number tagging

### DIFF
--- a/.github/workflows/build.sh
+++ b/.github/workflows/build.sh
@@ -9,15 +9,11 @@ mkdir "$buildDir"
 
 cd "$buildDir"
 
-VERSION=$("${GITHUB_WORKSPACE}/scripts/mumble-version.py")
-BUILD_NUMBER=$("${GITHUB_WORKSPACE}/scripts/mumble-build-number.py" --commit "${GITHUB_SHA}" --version "${VERSION}" \
-	--password "${MUMBLE_BUILD_NUMBER_TOKEN}" --default 0)
-
 # Run cmake with all necessary options
 cmake -G Ninja \
 	  -S "$GITHUB_WORKSPACE" \
 	  -DCMAKE_BUILD_TYPE=$BUILD_TYPE \
-	  -DBUILD_NUMBER=$BUILD_NUMBER \
+	  -DBUILD_NUMBER=$MUMBLE_BUILD_NUMBER \
 	  $CMAKE_OPTIONS \
       -DCMAKE_UNITY_BUILD=ON \
 	  -Ddisplay-install-paths=ON \

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,7 +11,7 @@ env:
 
 
 jobs:
-  pre_run:
+  skip_test:
     runs-on: ubuntu-latest
     outputs:
       should_skip: ${{ steps.skip_check.outputs.should_skip }}
@@ -22,9 +22,26 @@ jobs:
           concurrent_skipping: same_content_newer
           skip_after_successful_duplicate: 'true'
 
+  fetch_build_number:
+    runs-on: ubuntu-latest
+    outputs:
+      build_number: ${{ steps.fetch.outputs.build_number }}
+    steps:
+      - uses: actions/checkout@v3
+        with:
+            fetch-depth: 1
+      - id: fetch
+        shell: bash
+        run: |
+          echo "build_number=$( '${{ github. workspace }}/scripts/mumble-build-number.py' \
+            --commit ${{ github.sha }} --version $( '${{ github.workspace }}/scripts/mumble-version.py' ) \
+            --password '${{ secrets.BUILD_NUMBER_TOKEN }}' --default 0 )" >> $GITHUB_OUTPUT
+
+
   build:
-    needs: pre_run
-    if: needs.pre_run.outputs.should_skip != 'true'
+    needs: [ skip_test, fetch_build_number ]
+
+    if: needs.skip_test.outputs.should_skip != 'true'
 
     strategy:
         fail-fast: false
@@ -69,7 +86,7 @@ jobs:
       run: ./.github/workflows/build.sh
       shell: bash
       env:
-          MUMBLE_BUILD_NUMBER_TOKEN: ${{ secrets.BUILD_NUMBER_TOKEN }}
+          MUMBLE_BUILD_NUMBER: ${{ needs.fetch_build_number.outputs.build_number }}
 
     - name: Test
       working-directory: ${{ github.workspace }}/build


### PR DESCRIPTION
If the actual build is skipped due to a duplicate workflow run, the build  number script won't run. This can be problematic if this would have been the only place where the script runs for the given commit as that'll mean that for this commit no build number will be tagged on our central server.

Therefore, we now fetch the build number in a separate step that will not be skipped, if the build itself is skipped.


### Checks

- [x] My commits follow the [commit guidelines](https://github.com/mumble-voip/mumble/blob/master/COMMIT_GUIDELINES.md)

