### PR TITLE
MAINT: Finish removing bundled opus git module

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -25,5 +25,3 @@
 [submodule "3rdparty/SPSCQueue"]
 	path = 3rdparty/SPSCQueue
 	url = https://github.com/rigtorp/SPSCQueue.git
-[submodule "opus"]
-	url = https://github.com/mumble-voip/opus.git


### PR DESCRIPTION
One of the tools (Gentoo Portage) I occasionally use to build mumble from git  breaks with a submodule without a path. Finishes the removal started in commit d11fd05 by removing the second 3rdparty/opus section and url (without path) added in commit 60d0a86.


### Checks

- [x] My commits follow the [commit guidelines](https://github.com/mumble-voip/mumble/blob/master/COMMIT_GUIDELINES.md)

