### PR TITLE
Backport "Merge PR #6059: MAINT: Finish removing bundled opus git module" to 1.5.x

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -25,5 +25,3 @@
 [submodule "3rdparty/SPSCQueue"]
 	path = 3rdparty/SPSCQueue
 	url = https://github.com/rigtorp/SPSCQueue.git
-[submodule "opus"]
-	url = https://github.com/mumble-voip/opus.git


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `1.5.x`:
 - [Merge PR #6059: MAINT: Finish removing bundled opus git module](https://github.com/mumble-voip/mumble/pull/6059)

<!--- Backport version: 8.9.3 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)