### PR TITLE
FIX(client): PipeWire crash

### DIFF
--- a/src/mumble/PipeWire.cpp
+++ b/src/mumble/PipeWire.cpp
@@ -213,13 +213,14 @@ PipeWireEngine::~PipeWireEngine() {
 		return;
 	}
 
+	if (m_stream) {
+		pws->pw_stream_destroy(m_stream);
+	}
+
 	if (m_thread) {
 		pws->pw_thread_loop_destroy(m_thread);
 	}
 
-	if (m_stream) {
-		pws->pw_stream_destroy(m_stream);
-	}
 
 	if (m_loop) {
 		pws->pw_loop_destroy(m_loop);


### PR DESCRIPTION
When destroying the PipeWire object we first destroyed the thread loop and then the stream, but this has to be done in reverse order in order to avoid crashes.

Fixes #6101


### Checks

- [x] My commits follow the [commit guidelines](https://github.com/mumble-voip/mumble/blob/master/COMMIT_GUIDELINES.md)

