### PR TITLE
Backport "Merge PR #6103: FIX(client): PipeWire crash" to 1.5.x

### DIFF
--- a/src/mumble/PipeWire.cpp
+++ b/src/mumble/PipeWire.cpp
@@ -213,13 +213,14 @@ PipeWireEngine::~PipeWireEngine() {
 		return;
 	}
 
+	if (m_stream) {
+		pws->pw_stream_destroy(m_stream);
+	}
+
 	if (m_thread) {
 		pws->pw_thread_loop_destroy(m_thread);
 	}
 
-	if (m_stream) {
-		pws->pw_stream_destroy(m_stream);
-	}
 
 	if (m_loop) {
 		pws->pw_loop_destroy(m_loop);


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `1.5.x`:
 - [Merge PR #6103: FIX(client): PipeWire crash](https://github.com/mumble-voip/mumble/pull/6103)

<!--- Backport version: 8.9.3 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)