### PR TITLE
BUILD(cmake): Improve LTO handling

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -94,12 +94,9 @@ elseif(CMAKE_BUILD_TYPE STREQUAL "Debug")
         "-DDEBUG"
         "-DSNAPSHOT_BUILD"
     )
-
-	# Disable LTO in Debug builds in order to reduce time required for linking
-	set(LTO_DEFAULT OFF)
 endif()
 
-option(lto "Enables link-time optimizations" ${LTO_DEFAULT})
+option(lto "Enables link-time optimizations for release builds" ${LTO_DEFAULT})
 
 include(compiler)
 include(os)
@@ -108,14 +105,14 @@ target_architecture(MUMBLE_TARGET_ARCH)
 string(TOLOWER "${MUMBLE_TARGET_ARCH}" MUMBLE_TARGET_ARCH)
 
 message(STATUS "##################################################")
-message(STATUS "Mumble version:          ${PROJECT_VERSION}")
-message(STATUS "Architecture:            ${MUMBLE_TARGET_ARCH}")
+message(STATUS "Mumble version:              ${PROJECT_VERSION}")
+message(STATUS "Architecture:                ${MUMBLE_TARGET_ARCH}")
 if(NOT IS_MULTI_CONFIG)
-    message(STATUS "Build type:              ${CMAKE_BUILD_TYPE}")
+    message(STATUS "Build type:                  ${CMAKE_BUILD_TYPE}")
 else()
     message(STATUS "Using multi-config generator that will determine build type on-the-fly")
 endif()
-message(STATUS "Using LTO:               ${lto}")
+message(STATUS "Using LTO in release builds: ${lto}")
 message(STATUS "##################################################")
 
 include(install-paths)
@@ -162,6 +159,7 @@ add_compile_definitions(MUMBLE_TARGET_OS="${MUMBLE_TARGET_OS}")
 
 
 set(CMAKE_UNITY_BUILD_BATCH_SIZE 40)
+set(CMAKE_INTERPROCEDURAL_OPTIMIZATION_RELEASE ${lto})
 
 if(client OR server)
 	add_subdirectory(src)

--- a/docs/dev/build-instructions/cmake_options.md
+++ b/docs/dev/build-instructions/cmake_options.md
@@ -106,7 +106,7 @@ Build support for JackAudio.
 
 ### lto
 
-Enables link-time optimizations
+Enables link-time optimizations for release builds
 (Default: ${LTO_DEFAULT})
 
 ### manual-plugin

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -36,8 +36,6 @@ find_pkg(Protobuf REQUIRED)
 
 add_library(shared STATIC)
 
-set_property(TARGET shared PROPERTY INTERPROCEDURAL_OPTIMIZATION ${lto})
-
 protobuf_generate(LANGUAGE cpp TARGET shared PROTOS ${PROTO_FILE} OUT_VAR BUILT_PROTO_FILES)
 protobuf_generate(LANGUAGE cpp TARGET shared PROTOS ${UDP_PROTO_FILE} OUT_VAR BUILT_UDP_PROTO_FILES)
 

--- a/src/mumble/CMakeLists.txt
+++ b/src/mumble/CMakeLists.txt
@@ -382,9 +382,6 @@ add_custom_command(
 target_sources(mumble PRIVATE "ApplicationPalette.h")
 target_include_directories(mumble PRIVATE "${CMAKE_CURRENT_BINARY_DIR}")
 
-set_property(TARGET mumble_client_object_lib PROPERTY INTERPROCEDURAL_OPTIMIZATION ${lto})
-set_property(TARGET mumble PROPERTY INTERPROCEDURAL_OPTIMIZATION ${lto})
-
 target_link_libraries(mumble mumble_client_object_lib)
 
 target_compile_definitions(mumble_client_object_lib

--- a/src/murmur/CMakeLists.txt
+++ b/src/murmur/CMakeLists.txt
@@ -57,8 +57,6 @@ else()
 	add_executable(mumble-server ${MURMUR_SOURCES})
 endif()
 
-set_property(TARGET mumble-server PROPERTY INTERPROCEDURAL_OPTIMIZATION ${lto})
-
 set_target_properties(mumble-server
 	PROPERTIES
 		AUTOMOC ON


### PR DESCRIPTION
Instead of having a fixed setting that affects all build modes, we now set LTO only for release builds (but then for all targets). This has the advantage that a dev doesn't have to switch LTO on and off when switching between Release and Debug builds.


### Checks

- [x] My commits follow the [commit guidelines](https://github.com/mumble-voip/mumble/blob/master/COMMIT_GUIDELINES.md)

