### PR TITLE
Backport "Merge PR #6117: FIX(server): Actually use the settings provided pluginmessagelimit and -burst" to 1.5.x

### DIFF
--- a/src/murmur/ServerUser.cpp
+++ b/src/murmur/ServerUser.cpp
@@ -15,7 +15,7 @@
 
 ServerUser::ServerUser(Server *p, QSslSocket *socket)
 	: Connection(p, socket), User(), s(nullptr), leakyBucket(p->iMessageLimit, p->iMessageBurst),
-	  m_pluginMessageBucket(5, 20) {
+	  m_pluginMessageBucket(p->iPluginMessageLimit, p->iPluginMessageBurst) {
 	sState       = ServerUser::Connected;
 	m_clientType = ClientType::REGULAR;
 	sUdpSocket   = INVALID_SOCKET;

--- a/src/murmur/ServerUser.h
+++ b/src/murmur/ServerUser.h
@@ -76,7 +76,7 @@ class Server;
 class LeakyBucket {
 private:
 	/// The amount of tokens that are drained per second.
-	/// (The sze of the whole in the bucket)
+	/// (The size of the whole in the bucket)
 	unsigned int m_tokensPerSec;
 	/// The maximum amount of tokens that may be encountered.
 	/// (The capacity of the bucket)


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `1.5.x`:
 - [Merge PR #6117: FIX(server): Actually use the settings provided pluginmessagelimit and -burst](https://github.com/mumble-voip/mumble/pull/6117)

<!--- Backport version: 8.9.3 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)