### PR TITLE
CHANGE(client): Make RNNoise the default setting instead of Speex

### DIFF
--- a/src/mumble/Settings.h
+++ b/src/mumble/Settings.h
@@ -258,7 +258,7 @@ struct Settings {
 	int iVoiceHold                  = 20;
 	int iJitterBufferSize           = 1;
 	bool bAllowLowDelay             = true;
-	NoiseCancel noiseCancelMode     = NoiseCancelSpeex;
+	NoiseCancel noiseCancelMode     = NoiseCancelRNN;
 	int iSpeexNoiseCancelStrength   = -30;
 	quint64 uiAudioInputChannelMask = 0xffffffffffffffffULL;
 


### PR DESCRIPTION
I want to propose this change as I don't think the average user would prefer Speex over RNNoise if it is available.

For me the steps I usually go through to get new users setup with mumble is:

1. Guide them in how to download and install the client
2. Tell them to follow the audio wizard
3. Show them how to connect to a server
4. Notice that noise is picked up by their microphone and guide them how to turn on RNNoise.

This patch would eliminate step `4.` and save quite a bit of time as it usually takes the new users a while to be able to find the setting. Sometimes the RNNoise step takes twice as long as the other three combined, so I would be really happy if this change were accepted.

### Checks

- [x] My commits follow the [commit guidelines](https://github.com/mumble-voip/mumble/blob/master/COMMIT_GUIDELINES.md)

