### PR TITLE
Backport "Merge PR #6075: FIX(plugins): Use atomic operations in Link plugin" to 1.5.x

### DIFF
--- a/plugins/link/LinkedMem.h
+++ b/plugins/link/LinkedMem.h
@@ -19,34 +19,36 @@
 #endif
 
 // NOTE: To prevent possible undefined behavior in
-// `SharedMemory::write`, this struct must not
-// have any padding.
+// `SharedMemory::write` and `SharedMemory::reset`, this
+// struct must not have any padding, and no members may
+// have indeterminate bits when this struct is
+// default-constructed.
 struct LinkedMem {
 #ifdef _WIN32
-	UINT32 uiVersion;
-	DWORD uiTick;
+	UINT32 uiVersion = 0;
+	DWORD uiTick     = 0;
 #else
-	uint32_t uiVersion;
-	uint32_t uiTick;
+	uint32_t uiVersion    = 0;
+	uint32_t uiTick       = 0;
 #endif
-	float fAvatarPosition[3];
-	float fAvatarFront[3];
-	float fAvatarTop[3];
-	wchar_t name[256];
-	float fCameraPosition[3];
-	float fCameraFront[3];
-	float fCameraTop[3];
-	wchar_t identity[256];
+	float fAvatarPosition[3] = { 0 };
+	float fAvatarFront[3]    = { 0 };
+	float fAvatarTop[3]      = { 0 };
+	wchar_t name[256]        = { 0 };
+	float fCameraPosition[3] = { 0 };
+	float fCameraFront[3]    = { 0 };
+	float fCameraTop[3]      = { 0 };
+	wchar_t identity[256]    = { 0 };
 #ifdef _WIN32
-	UINT32 context_len;
+	UINT32 context_len = 0;
 #else
-	uint32_t context_len;
+	uint32_t context_len  = 0;
 #endif
-	unsigned char context[256];
-	wchar_t description[2048];
+	unsigned char context[256] = { 0 };
+	wchar_t description[2048]  = { 0 };
 };
 
-static const char *getLinkedMemoryName() {
+static inline const char *getLinkedMemoryName() {
 #ifdef _WIN32
 	return "MumbleLink";
 #else

--- a/plugins/link/LinkedMem.h
+++ b/plugins/link/LinkedMem.h
@@ -18,6 +18,9 @@
 #	include <unistd.h>
 #endif
 
+// NOTE: To prevent possible undefined behavior in
+// `SharedMemory::write`, this struct must not
+// have any padding.
 struct LinkedMem {
 #ifdef _WIN32
 	UINT32 uiVersion;

--- a/plugins/link/SharedMemory.h
+++ b/plugins/link/SharedMemory.h
@@ -28,7 +28,15 @@ public:
 
 	int lastError() const;
 
-	void *mapMemory(const char *name, std::size_t size);
+	bool mapMemory(const char *name, std::size_t size);
+
+	bool isMemoryMapped();
+
+	void read(void *dest, std::size_t size);
+
+	void write(const void *source, std::size_t size);
+
+	void fillWithZero();
 
 private:
 	void *m_data;

--- a/plugins/link/SharedMemory.h
+++ b/plugins/link/SharedMemory.h
@@ -17,30 +17,29 @@
 #	include <string>
 #endif
 
+struct LinkedMem;
+
 class SharedMemory {
 public:
 	explicit SharedMemory();
 	~SharedMemory();
 
-	std::size_t size();
-
 	void close();
 
 	int lastError() const;
 
-	bool mapMemory(const char *name, std::size_t size);
+	bool mapMemory(const char *name);
 
-	bool isMemoryMapped();
+	bool isMemoryMapped() const;
 
-	void read(void *dest, std::size_t size);
+	LinkedMem read() const;
 
-	void write(const void *source, std::size_t size);
+	void write(const LinkedMem &source);
 
-	void fillWithZero();
+	void reset();
 
 private:
 	void *m_data;
-	std::size_t m_size;
 	int m_error;
 
 #ifdef _WIN32

--- a/plugins/link/link.cpp
+++ b/plugins/link/link.cpp
@@ -43,7 +43,7 @@ static std::uint64_t getTimeSinceEpoch() {
 mumble_error_t mumble_init(mumble_plugin_id_t id) {
 	UNUSED(id);
 
-	if (!sharedMem.mapMemory(getLinkedMemoryName(), sizeof(LinkedMem))) {
+	if (!sharedMem.mapMemory(getLinkedMemoryName())) {
 		std::cerr << "Link plugin: Failed to setup shared memory: " << sharedMem.lastError() << std::endl;
 
 		return MUMBLE_EC_INTERNAL_ERROR;
@@ -117,8 +117,7 @@ uint8_t mumble_initPositionalData(const char *const *programNames, const uint64_
 		return MUMBLE_PDEC_ERROR_TEMP;
 	}
 
-	LinkedMem lm;
-	sharedMem.read(&lm, sizeof(lm));
+	LinkedMem lm = sharedMem.read();
 
 	if ((lm.uiVersion == 1) || (lm.uiVersion == 2)) {
 		if (lm.uiTick != last_tick) {
@@ -162,8 +161,7 @@ bool mumble_fetchPositionalData(float *avatarPos, float *avatarDir, float *avata
 	SET_TO_ZERO(cameraDir);
 	SET_TO_ZERO(cameraAxis);
 
-	LinkedMem lm;
-	sharedMem.read(&lm, sizeof(lm));
+	LinkedMem lm = sharedMem.read();
 
 	if (lm.uiTick != last_tick) {
 		last_tick      = lm.uiTick;
@@ -231,7 +229,7 @@ void mumble_shutdownPositionalData() {
 	pluginContext.clear();
 	pluginIdentity.clear();
 
-	sharedMem.fillWithZero();
+	sharedMem.reset();
 }
 
 MumbleStringWrapper mumble_getPositionalDataContextPrefix() {

--- a/plugins/link/link.cpp
+++ b/plugins/link/link.cpp
@@ -29,7 +29,6 @@ std::string pluginContext;
 std::string pluginIdentity;
 
 SharedMemory sharedMem;
-LinkedMem *lm = nullptr;
 
 std::uint32_t last_tick     = 0;
 std::int64_t last_tick_time = 0;
@@ -44,9 +43,7 @@ static std::uint64_t getTimeSinceEpoch() {
 mumble_error_t mumble_init(mumble_plugin_id_t id) {
 	UNUSED(id);
 
-	lm = static_cast< LinkedMem * >(sharedMem.mapMemory(getLinkedMemoryName(), sizeof(LinkedMem)));
-
-	if (!lm) {
+	if (!sharedMem.mapMemory(getLinkedMemoryName(), sizeof(LinkedMem))) {
 		std::cerr << "Link plugin: Failed to setup shared memory: " << sharedMem.lastError() << std::endl;
 
 		return MUMBLE_EC_INTERNAL_ERROR;
@@ -116,19 +113,22 @@ uint8_t mumble_initPositionalData(const char *const *programNames, const uint64_
 	UNUSED(programPIDs);
 	UNUSED(programCount);
 
-	if (!lm) {
+	if (!sharedMem.isMemoryMapped()) {
 		return MUMBLE_PDEC_ERROR_TEMP;
 	}
 
-	if ((lm->uiVersion == 1) || (lm->uiVersion == 2)) {
-		if (lm->uiTick != last_tick) {
-			last_tick      = lm->uiTick;
+	LinkedMem lm;
+	sharedMem.read(&lm, sizeof(lm));
+
+	if ((lm.uiVersion == 1) || (lm.uiVersion == 2)) {
+		if (lm.uiTick != last_tick) {
+			last_tick      = lm.uiTick;
 			last_tick_time = getTimeSinceEpoch();
 
 			wchar_t buff[2048];
 
-			if (lm->name[0]) {
-				wcsncpy(buff, lm->name, 256);
+			if (lm.name[0]) {
+				wcsncpy(buff, lm.name, 256);
 				buff[255]       = 0;
 				applicationName = std::wstring_convert< std::codecvt_utf8< wchar_t > >().to_bytes(buff);
 
@@ -136,8 +136,8 @@ uint8_t mumble_initPositionalData(const char *const *programNames, const uint64_
 				pluginName += " (" + applicationName + ")";
 			}
 
-			if (lm->description[0]) {
-				wcsncpy(buff, lm->description, 2048);
+			if (lm.description[0]) {
+				wcsncpy(buff, lm.description, 2048);
 				buff[2047]        = 0;
 				pluginDescription = std::wstring_convert< std::codecvt_utf8< wchar_t > >().to_bytes(buff);
 			}
@@ -162,42 +162,45 @@ bool mumble_fetchPositionalData(float *avatarPos, float *avatarDir, float *avata
 	SET_TO_ZERO(cameraDir);
 	SET_TO_ZERO(cameraAxis);
 
-	if (lm->uiTick != last_tick) {
-		last_tick      = lm->uiTick;
+	LinkedMem lm;
+	sharedMem.read(&lm, sizeof(lm));
+
+	if (lm.uiTick != last_tick) {
+		last_tick      = lm.uiTick;
 		last_tick_time = getTimeSinceEpoch();
 	} else if ((getTimeSinceEpoch() - last_tick_time) > 5000) {
 		return false;
 	}
 
-	if ((lm->uiVersion != 1) && (lm->uiVersion != 2)) {
+	if ((lm.uiVersion != 1) && (lm.uiVersion != 2)) {
 		return false;
 	}
 
 	for (int i = 0; i < 3; ++i) {
-		avatarPos[i]  = lm->fAvatarPosition[i];
-		avatarDir[i]  = lm->fAvatarFront[i];
-		avatarAxis[i] = lm->fAvatarTop[i];
+		avatarPos[i]  = lm.fAvatarPosition[i];
+		avatarDir[i]  = lm.fAvatarFront[i];
+		avatarAxis[i] = lm.fAvatarTop[i];
 	}
 
-	if (lm->uiVersion == 2) {
+	if (lm.uiVersion == 2) {
 		for (int i = 0; i < 3; ++i) {
-			cameraPos[i]  = lm->fCameraPosition[i];
-			cameraDir[i]  = lm->fCameraFront[i];
-			cameraAxis[i] = lm->fCameraTop[i];
+			cameraPos[i]  = lm.fCameraPosition[i];
+			cameraDir[i]  = lm.fCameraFront[i];
+			cameraAxis[i] = lm.fCameraTop[i];
 		}
 
-		if (lm->context_len > 255) {
-			lm->context_len = 255;
+		if (lm.context_len > 255) {
+			lm.context_len = 255;
 		}
-		lm->identity[255] = 0;
+		lm.identity[255] = 0;
 
-		pluginContext.assign(reinterpret_cast< const char * >(lm->context), lm->context_len);
-		pluginIdentity = std::wstring_convert< std::codecvt_utf8< wchar_t > >().to_bytes(lm->identity);
+		pluginContext.assign(reinterpret_cast< const char * >(lm.context), lm.context_len);
+		pluginIdentity = std::wstring_convert< std::codecvt_utf8< wchar_t > >().to_bytes(lm.identity);
 	} else {
 		for (int i = 0; i < 3; ++i) {
-			cameraPos[i]  = lm->fAvatarPosition[i];
-			cameraDir[i]  = lm->fAvatarFront[i];
-			cameraAxis[i] = lm->fAvatarTop[i];
+			cameraPos[i]  = lm.fAvatarPosition[i];
+			cameraDir[i]  = lm.fAvatarFront[i];
+			cameraAxis[i] = lm.fAvatarTop[i];
 		}
 
 		pluginContext.clear();
@@ -228,9 +231,7 @@ void mumble_shutdownPositionalData() {
 	pluginContext.clear();
 	pluginIdentity.clear();
 
-	lm->uiTick = last_tick = 0;
-	lm->uiVersion          = 0;
-	lm->name[0]            = 0;
+	sharedMem.fillWithZero();
 }
 
 MumbleStringWrapper mumble_getPositionalDataContextPrefix() {

--- a/plugins/link/link_tester.cpp
+++ b/plugins/link/link_tester.cpp
@@ -19,25 +19,27 @@
 #include <thread>
 
 SharedMemory sharedMem;
-LinkedMem *lm = nullptr;
+LinkedMem lm;
 std::random_device dev;
 std::mt19937 rng(dev());
 std::uniform_real_distribution< float > generator(0, 100);
 
 void initMumble() {
-	lm = static_cast< LinkedMem * >(sharedMem.mapMemory(getLinkedMemoryName(), sizeof(LinkedMem)));
+	sharedMem.mapMemory(getLinkedMemoryName(), sizeof(LinkedMem));
+
+	std::memset(&lm, 0, sizeof(lm));
 }
 
 void updateMumble() {
-	if (!lm)
+	if (!sharedMem.isMemoryMapped())
 		return;
 
-	if (lm->uiVersion != 2) {
-		wcsncpy(lm->name, L"TestLink", 256);
-		wcsncpy(lm->description, L"TestLink is a test of the Link plugin.", 2048);
-		lm->uiVersion = 2;
+	if (lm.uiVersion != 2) {
+		wcsncpy(lm.name, L"TestLink", 256);
+		wcsncpy(lm.description, L"TestLink is a test of the Link plugin.", 2048);
+		lm.uiVersion = 2;
 	}
-	lm->uiTick++;
+	lm.uiTick++;
 
 	// Left handed coordinate system.
 	// X positive towards "right".
@@ -47,45 +49,46 @@ void updateMumble() {
 	// 1 unit = 1 meter
 
 	// Unit vector pointing out of the avatar's eyes aka "At"-vector.
-	lm->fAvatarFront[0] = 0.0f;
-	lm->fAvatarFront[1] = 0.0f;
-	lm->fAvatarFront[2] = 1.0f;
+	lm.fAvatarFront[0] = 0.0f;
+	lm.fAvatarFront[1] = 0.0f;
+	lm.fAvatarFront[2] = 1.0f;
 
 	// Unit vector pointing out of the top of the avatar's head aka "Up"-vector (here Top points straight up).
-	lm->fAvatarTop[0] = 0.0f;
-	lm->fAvatarTop[1] = 1.0f;
-	lm->fAvatarTop[2] = 0.0f;
+	lm.fAvatarTop[0] = 0.0f;
+	lm.fAvatarTop[1] = 1.0f;
+	lm.fAvatarTop[2] = 0.0f;
 
 	// Position of the avatar (here standing slightly off the origin)
-	lm->fAvatarPosition[0] = generator(rng);
-	lm->fAvatarPosition[1] = generator(rng);
-	lm->fAvatarPosition[2] = generator(rng);
+	lm.fAvatarPosition[0] = generator(rng);
+	lm.fAvatarPosition[1] = generator(rng);
+	lm.fAvatarPosition[2] = generator(rng);
 
 	// Same as avatar but for the camera.
-	lm->fCameraPosition[0] = 0.0f;
-	lm->fCameraPosition[1] = 0.0f;
-	lm->fCameraPosition[2] = 0.0f;
+	lm.fCameraPosition[0] = 0.0f;
+	lm.fCameraPosition[1] = 0.0f;
+	lm.fCameraPosition[2] = 0.0f;
 
-	lm->fCameraFront[0] = 0.0f;
-	lm->fCameraFront[1] = 0.0f;
-	lm->fCameraFront[2] = 1.0f;
+	lm.fCameraFront[0] = 0.0f;
+	lm.fCameraFront[1] = 0.0f;
+	lm.fCameraFront[2] = 1.0f;
 
-	lm->fCameraTop[0] = 0.0f;
-	lm->fCameraTop[1] = 1.0f;
-	lm->fCameraTop[2] = 0.0f;
+	lm.fCameraTop[0] = 0.0f;
+	lm.fCameraTop[1] = 1.0f;
+	lm.fCameraTop[2] = 0.0f;
 
 	// Identifier which uniquely identifies a certain player in a context (e.g. the ingame name).
-	wcsncpy(lm->identity, L"Unique ID", 256);
+	wcsncpy(lm.identity, L"Unique ID", 256);
 	// Context should be equal for players which should be able to hear each other positional and
 	// differ for those who shouldn't (e.g. it could contain the server+port and team)
-	memcpy(lm->context, "ContextBlob\x00\x01\x02\x03\x04", 16);
-	lm->context_len = 16;
+	memcpy(lm.context, "ContextBlob\x00\x01\x02\x03\x04", 16);
+	lm.context_len = 16;
+
+	sharedMem.write(&lm, sizeof(lm));
 }
 
 void signalHandler(int signum) {
 	std::cout << "Interrupt signal (" << signum << ") received - shutting down..." << std::endl;
 
-	lm = nullptr;
 	sharedMem.close();
 
 	std::exit(signum);
@@ -96,7 +99,7 @@ int main() {
 
 	initMumble();
 
-	if (!lm) {
+	if (!sharedMem.isMemoryMapped()) {
 		std::cerr << "Failed to create shared memory region (" << sharedMem.lastError() << ")" << std::endl;
 		return 1;
 	}

--- a/plugins/link/link_tester.cpp
+++ b/plugins/link/link_tester.cpp
@@ -25,9 +25,9 @@ std::mt19937 rng(dev());
 std::uniform_real_distribution< float > generator(0, 100);
 
 void initMumble() {
-	sharedMem.mapMemory(getLinkedMemoryName(), sizeof(LinkedMem));
+	sharedMem.mapMemory(getLinkedMemoryName());
 
-	std::memset(&lm, 0, sizeof(lm));
+	lm = LinkedMem();
 }
 
 void updateMumble() {
@@ -83,7 +83,7 @@ void updateMumble() {
 	memcpy(lm.context, "ContextBlob\x00\x01\x02\x03\x04", 16);
 	lm.context_len = 16;
 
-	sharedMem.write(&lm, sizeof(lm));
+	sharedMem.write(lm);
 }
 
 void signalHandler(int signum) {


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `1.5.x`:
 - [Merge PR #6075: FIX(plugins): Use atomic operations in Link plugin](https://github.com/mumble-voip/mumble/pull/6075)

<!--- Backport version: 8.9.3 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)