### PR TITLE
MAINT: Sort input file list

### DIFF
--- a/scripts/generate_flag_qrc.py
+++ b/scripts/generate_flag_qrc.py
@@ -39,7 +39,7 @@ def main():
     # Get a list of all flag SVGs
     flags = []
 
-    for fn in os.listdir(args.flag_dir):
+    for fn in sorted(os.listdir(args.flag_dir)):
         if not fn.lower().endswith('svg'):
             continue
         


### PR DESCRIPTION
Sort input file list, so that `mumble_flags.qrc` builds in a reproducible way in spite of non-deterministic filesystem readdir order.

See https://reproducible-builds.org/ for why this is good.


### Checks

- [X] My commits follow the [commit guidelines](https://github.com/mumble-voip/mumble/blob/master/COMMIT_GUIDELINES.md)

Without this patch, I got
```diff
--- /home/abuild/rpmbuild/BUILD/mumble-1.5.517/build/mumble_flags.qrc      2023-06-09 05:38:13.972000000 +0000
+++ /home/abuild/rpmbuild/BUILD/mumble-1.5.517/build/mumble_flags.qrc     2039-07-11 18:54:57.716000000 +0000
@@ -1,262 +1,262 @@
 <!DOCTYPE RCC>
 <RCC version="1.0">
 <qresource>
-<file alias="flags/ru.svg">../icons/flags/ru.svg</file>
-<file alias="flags/ic.svg">../icons/flags/ic.svg</file>
-<file alias="flags/lk.svg">../icons/flags/lk.svg</file>
...
+<file alias="flags/et.svg">../icons/flags/et.svg</file>
+<file alias="flags/pf.svg">../icons/flags/pf.svg</file>
+<file alias="flags/ly.svg">../icons/flags/ly.svg</file>
```
which caused variations in `qrc_mumble_flags.cpp` and thus the resulting mumble binary.