### PR TITLE
FEAT(client): Add popup when mute cue is activated for the first time

### DIFF
--- a/src/mumble/AudioConfigDialog.cpp
+++ b/src/mumble/AudioConfigDialog.cpp
@@ -129,6 +129,8 @@ void AudioInputDialog::load(const Settings &r) {
 	qlePushClickPathOn->setText(r.qsTxAudioCueOn);
 	qlePushClickPathOff->setText(r.qsTxAudioCueOff);
 	qleMuteCuePath->setText(r.qsTxMuteCue);
+	s.muteCueShown = r.muteCueShown;
+
 
 	loadComboBox(qcbTransmit, r.atTransmit);
 	loadSlider(qsTransmitHold, r.iVoiceHold);
@@ -439,6 +441,7 @@ void AudioInputDialog::on_qcbMuteCue_clicked(bool b) {
 	qleMuteCuePath->setEnabled(b);
 	qpbMuteCueBrowse->setEnabled(b);
 	qpbMuteCuePreview->setEnabled(b);
+	s.muteCueShown = true;
 }
 
 void AudioInputDialog::on_qpbMuteCueBrowse_clicked() {

--- a/src/mumble/AudioInput.cpp
+++ b/src/mumble/AudioInput.cpp
@@ -286,6 +286,7 @@ AudioInput::AudioInput() : opusBuffer(Global::get().s.iFramesPerPacket * (SAMPLE
 
 	connect(this, SIGNAL(doDeaf()), Global::get().mw->qaAudioDeaf, SLOT(trigger()), Qt::QueuedConnection);
 	connect(this, SIGNAL(doMute()), Global::get().mw->qaAudioMute, SLOT(trigger()), Qt::QueuedConnection);
+	connect(this, SIGNAL(doMuteCue()), Global::get().mw, SLOT(on_muteCuePopup_triggered()));
 }
 
 AudioInput::~AudioInput() {
@@ -1048,6 +1049,7 @@ void AudioInput::encodeAudioFrame(AudioChunk chunk) {
 				if (!qetLastMuteCue.isValid() || qetLastMuteCue.elapsed() > MUTE_CUE_DELAY) {
 					qetLastMuteCue.start();
 					ao->playSample(Global::get().s.qsTxMuteCue, Global::get().s.cueVolume);
+					emit doMuteCue();
 				}
 			}
 		}

--- a/src/mumble/AudioInput.h
+++ b/src/mumble/AudioInput.h
@@ -266,6 +266,7 @@ protected:
 signals:
 	void doDeaf();
 	void doMute();
+	void doMuteCue();
 	/// A signal emitted if audio input is being encountered
 	///
 	/// @param inputPCM The encountered input PCM

--- a/src/mumble/Global.cpp
+++ b/src/mumble/Global.cpp
@@ -107,6 +107,7 @@ Global::Global(const QString &qsConfigPath) {
 	bCenterPosition = false;
 	bPosTest        = false;
 	bInAudioWizard  = false;
+	inConfigUI      = false;
 	iAudioPathTime  = 0;
 	iAudioBandwidth = -1;
 	iMaxBandwidth   = -1;

--- a/src/mumble/Global.h
+++ b/src/mumble/Global.h
@@ -83,6 +83,7 @@ public:
 	bool bCenterPosition;
 	bool bPosTest;
 	bool bInAudioWizard;
+	bool inConfigUI;
 #ifdef USE_OVERLAY
 	OverlayClient *ocIntercept;
 #endif

--- a/src/mumble/MainWindow.cpp
+++ b/src/mumble/MainWindow.cpp
@@ -4093,6 +4093,8 @@ void MainWindow::openAudioStatsDialog() {
 void MainWindow::openConfigDialog() {
 	ConfigDialog *dlg = new ConfigDialog(this);
 
+	Global::get().inConfigUI = true;
+
 	QObject::connect(dlg, &ConfigDialog::settingsAccepted, Global::get().talkingUI, &TalkingUI::on_settingsChanged);
 
 	if (dlg->exec() == QDialog::Accepted) {
@@ -4115,6 +4117,8 @@ void MainWindow::openConfigDialog() {
 			}
 		}
 	}
+
+	Global::get().inConfigUI = false;
 
 	delete dlg;
 }
@@ -4146,4 +4150,25 @@ void MainWindow::openAboutQtDialog() {
 
 void MainWindow::versionCheck() {
 	new VersionCheck(false, this);
+}
+
+void MainWindow::on_muteCuePopup_triggered() {
+	if (Global::get().s.muteCueShown || Global::get().inConfigUI) {
+		return;
+	}
+
+	Global::get().s.muteCueShown = true;
+	QMessageBox mb(
+		QMessageBox::Warning, QLatin1String("Mumble"),
+		tr("That sound was the mute cue. It activates when you speak while muted. Would you like to keep it enabled?"),
+		QMessageBox::NoButton, this);
+	QPushButton *accept = mb.addButton(tr("Yes"), QMessageBox::YesRole);
+	QPushButton *reject = mb.addButton(tr("No"), QMessageBox::NoRole);
+	mb.setDefaultButton(accept);
+	mb.setEscapeButton(accept);
+	mb.exec();
+
+	if (mb.clickedButton() == reject) {
+		Global::get().s.bTxMuteCue = false;
+	}
 }

--- a/src/mumble/MainWindow.h
+++ b/src/mumble/MainWindow.h
@@ -350,6 +350,7 @@ public slots:
 	void context_triggered();
 	void updateTarget();
 	void updateMenuPermissions();
+	void on_muteCuePopup_triggered();
 	/// Handles state changes like talking mode changes and mute/unmute
 	/// or priority speaker flag changes for the gui user
 	void userStateChanged();

--- a/src/mumble/Settings.h
+++ b/src/mumble/Settings.h
@@ -226,6 +226,7 @@ struct Settings {
 	QString qsTxAudioCueOff = cqsDefaultPushClickOn;
 
 	bool bTxMuteCue     = true;
+	bool muteCueShown   = false;
 	QString qsTxMuteCue = cqsDefaultMuteCue;
 
 	bool bTransmitPosition         = false;

--- a/src/mumble/SettingsKeys.h
+++ b/src/mumble/SettingsKeys.h
@@ -46,6 +46,7 @@ const SettingsKey TRANSMIT_CUE_START_KEY                      = { "transmit_cue_
 const SettingsKey TRANSMIT_CUE_STOP_KEY                       = { "transmit_cue_stop" };
 const SettingsKey PLAY_MUTE_CUE_KEY                           = { "play_mute_cue" };
 const SettingsKey MUTE_CUE_KEY                                = { "mute_cue" };
+const SettingsKey MUTE_CUE_POPUP_SHOWN                        = { "mute_cue_popup_shown" };
 const SettingsKey AUDIO_QUALITY_KEY                           = { "audio_quality" };
 const SettingsKey LOUDNESS_KEY                                = { "loudness" };
 const SettingsKey VOLUME_KEY                                  = { "volume" };

--- a/src/mumble/SettingsMacros.h
+++ b/src/mumble/SettingsMacros.h
@@ -30,6 +30,7 @@
 	PROCESS(audio, TRANSMIT_CUE_STOP_KEY, qsTxAudioCueOff)                                  \
 	PROCESS(audio, PLAY_MUTE_CUE_KEY, bTxMuteCue)                                           \
 	PROCESS(audio, MUTE_CUE_KEY, qsTxMuteCue)                                               \
+	PROCESS(audio, MUTE_CUE_POPUP_SHOWN, muteCueShown)                                      \
 	PROCESS(audio, AUDIO_QUALITY_KEY, iQuality)                                             \
 	PROCESS(audio, LOUDNESS_KEY, iMinLoudness)                                              \
 	PROCESS(audio, VOLUME_KEY, fVolume)                                                     \

--- a/src/mumble/mumble_ar.ts
+++ b/src/mumble/mumble_ar.ts
@@ -6618,6 +6618,18 @@ Valid options are:
         <source>This will check if mumble is up to date</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>That sound was the mute cue. It activates when you speak while muted. Would you like to keep it enabled?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Yes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>No</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>Manual</name>

--- a/src/mumble/mumble_bg.ts
+++ b/src/mumble/mumble_bg.ts
@@ -6615,6 +6615,18 @@ Valid options are:
         <source>This will check if mumble is up to date</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>That sound was the mute cue. It activates when you speak while muted. Would you like to keep it enabled?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Yes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>No</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>Manual</name>

--- a/src/mumble/mumble_br.ts
+++ b/src/mumble/mumble_br.ts
@@ -6614,6 +6614,18 @@ Valid options are:
         <source>This will check if mumble is up to date</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>That sound was the mute cue. It activates when you speak while muted. Would you like to keep it enabled?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Yes</source>
+        <translation type="unfinished">Ya</translation>
+    </message>
+    <message>
+        <source>No</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>Manual</name>

--- a/src/mumble/mumble_ca.ts
+++ b/src/mumble/mumble_ca.ts
@@ -6640,6 +6640,18 @@ Valid options are:
         <source>This will check if mumble is up to date</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>That sound was the mute cue. It activates when you speak while muted. Would you like to keep it enabled?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Yes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>No</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>Manual</name>

--- a/src/mumble/mumble_cs.ts
+++ b/src/mumble/mumble_cs.ts
@@ -6674,6 +6674,18 @@ Valid options are:
         <source>This will check if mumble is up to date</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>That sound was the mute cue. It activates when you speak while muted. Would you like to keep it enabled?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Yes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>No</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>Manual</name>

--- a/src/mumble/mumble_cy.ts
+++ b/src/mumble/mumble_cy.ts
@@ -6618,6 +6618,18 @@ Valid options are:
         <source>This will check if mumble is up to date</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>That sound was the mute cue. It activates when you speak while muted. Would you like to keep it enabled?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Yes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>No</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>Manual</name>

--- a/src/mumble/mumble_da.ts
+++ b/src/mumble/mumble_da.ts
@@ -6670,6 +6670,18 @@ Valid options are:
         <source>This will check if mumble is up to date</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>That sound was the mute cue. It activates when you speak while muted. Would you like to keep it enabled?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Yes</source>
+        <translation type="unfinished">Ja</translation>
+    </message>
+    <message>
+        <source>No</source>
+        <translation type="unfinished">Nej</translation>
+    </message>
 </context>
 <context>
     <name>Manual</name>

--- a/src/mumble/mumble_de.ts
+++ b/src/mumble/mumble_de.ts
@@ -6761,6 +6761,18 @@ Gültige Optionen sind:
         <source>This will check if mumble is up to date</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>That sound was the mute cue. It activates when you speak while muted. Would you like to keep it enabled?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Yes</source>
+        <translation type="unfinished">Ja</translation>
+    </message>
+    <message>
+        <source>No</source>
+        <translation type="unfinished">Nein</translation>
+    </message>
 </context>
 <context>
     <name>Manual</name>

--- a/src/mumble/mumble_el.ts
+++ b/src/mumble/mumble_el.ts
@@ -6768,6 +6768,18 @@ mumble://[&lt;username&gt;[:&lt;password&gt;]@]&lt;host&gt;[:&lt;port&gt;][/&lt;
         <source>This will check if mumble is up to date</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>That sound was the mute cue. It activates when you speak while muted. Would you like to keep it enabled?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Yes</source>
+        <translation type="unfinished">Ναι</translation>
+    </message>
+    <message>
+        <source>No</source>
+        <translation type="unfinished">Όχι</translation>
+    </message>
 </context>
 <context>
     <name>Manual</name>

--- a/src/mumble/mumble_en.ts
+++ b/src/mumble/mumble_en.ts
@@ -6613,6 +6613,18 @@ Valid options are:
         <source>This will check if mumble is up to date</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>That sound was the mute cue. It activates when you speak while muted. Would you like to keep it enabled?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Yes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>No</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>Manual</name>

--- a/src/mumble/mumble_en_GB.ts
+++ b/src/mumble/mumble_en_GB.ts
@@ -6667,6 +6667,18 @@ Valid options are:
         <source>This will check if mumble is up to date</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>That sound was the mute cue. It activates when you speak while muted. Would you like to keep it enabled?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Yes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>No</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>Manual</name>

--- a/src/mumble/mumble_eo.ts
+++ b/src/mumble/mumble_eo.ts
@@ -6626,6 +6626,18 @@ Valid options are:
         <source>This will check if mumble is up to date</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>That sound was the mute cue. It activates when you speak while muted. Would you like to keep it enabled?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Yes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>No</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>Manual</name>

--- a/src/mumble/mumble_es.ts
+++ b/src/mumble/mumble_es.ts
@@ -6769,6 +6769,18 @@ Las opciones válidas son:
         <source>This will check if mumble is up to date</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>That sound was the mute cue. It activates when you speak while muted. Would you like to keep it enabled?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Yes</source>
+        <translation type="unfinished">Sí</translation>
+    </message>
+    <message>
+        <source>No</source>
+        <translation type="unfinished">No</translation>
+    </message>
 </context>
 <context>
     <name>Manual</name>

--- a/src/mumble/mumble_et.ts
+++ b/src/mumble/mumble_et.ts
@@ -6615,6 +6615,18 @@ Valid options are:
         <source>This will check if mumble is up to date</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>That sound was the mute cue. It activates when you speak while muted. Would you like to keep it enabled?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Yes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>No</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>Manual</name>

--- a/src/mumble/mumble_eu.ts
+++ b/src/mumble/mumble_eu.ts
@@ -6635,6 +6635,18 @@ Valid options are:
         <source>This will check if mumble is up to date</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>That sound was the mute cue. It activates when you speak while muted. Would you like to keep it enabled?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Yes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>No</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>Manual</name>

--- a/src/mumble/mumble_fa_IR.ts
+++ b/src/mumble/mumble_fa_IR.ts
@@ -6615,6 +6615,18 @@ Valid options are:
         <source>This will check if mumble is up to date</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>That sound was the mute cue. It activates when you speak while muted. Would you like to keep it enabled?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Yes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>No</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>Manual</name>

--- a/src/mumble/mumble_fi.ts
+++ b/src/mumble/mumble_fi.ts
@@ -6767,6 +6767,18 @@ Hyväksytyt valinnat ovat
         <source>This will check if mumble is up to date</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>That sound was the mute cue. It activates when you speak while muted. Would you like to keep it enabled?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Yes</source>
+        <translation type="unfinished">Kyllä</translation>
+    </message>
+    <message>
+        <source>No</source>
+        <translation type="unfinished">Ei</translation>
+    </message>
 </context>
 <context>
     <name>Manual</name>

--- a/src/mumble/mumble_fr.ts
+++ b/src/mumble/mumble_fr.ts
@@ -6775,6 +6775,18 @@ Les options valides sont :
         <source>This will check if mumble is up to date</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>That sound was the mute cue. It activates when you speak while muted. Would you like to keep it enabled?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Yes</source>
+        <translation type="unfinished">Oui</translation>
+    </message>
+    <message>
+        <source>No</source>
+        <translation type="unfinished">Non</translation>
+    </message>
 </context>
 <context>
     <name>Manual</name>

--- a/src/mumble/mumble_gl.ts
+++ b/src/mumble/mumble_gl.ts
@@ -6616,6 +6616,18 @@ Valid options are:
         <source>This will check if mumble is up to date</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>That sound was the mute cue. It activates when you speak while muted. Would you like to keep it enabled?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Yes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>No</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>Manual</name>

--- a/src/mumble/mumble_he.ts
+++ b/src/mumble/mumble_he.ts
@@ -6666,6 +6666,18 @@ Valid options are:
         <source>This will check if mumble is up to date</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>That sound was the mute cue. It activates when you speak while muted. Would you like to keep it enabled?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Yes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>No</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>Manual</name>

--- a/src/mumble/mumble_hi.ts
+++ b/src/mumble/mumble_hi.ts
@@ -6577,6 +6577,18 @@ Valid options are:
         <source>This will check if mumble is up to date</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>That sound was the mute cue. It activates when you speak while muted. Would you like to keep it enabled?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Yes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>No</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>Manual</name>

--- a/src/mumble/mumble_hu.ts
+++ b/src/mumble/mumble_hu.ts
@@ -6666,6 +6666,18 @@ Valid options are:
         <source>This will check if mumble is up to date</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>That sound was the mute cue. It activates when you speak while muted. Would you like to keep it enabled?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Yes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>No</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>Manual</name>

--- a/src/mumble/mumble_it.ts
+++ b/src/mumble/mumble_it.ts
@@ -6708,6 +6708,18 @@ Valid options are:
         <source>This will check if mumble is up to date</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>That sound was the mute cue. It activates when you speak while muted. Would you like to keep it enabled?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Yes</source>
+        <translation type="unfinished">Sì</translation>
+    </message>
+    <message>
+        <source>No</source>
+        <translation type="unfinished">No</translation>
+    </message>
 </context>
 <context>
     <name>Manual</name>

--- a/src/mumble/mumble_ja.ts
+++ b/src/mumble/mumble_ja.ts
@@ -6664,6 +6664,18 @@ Valid options are:
         <source>This will check if mumble is up to date</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>That sound was the mute cue. It activates when you speak while muted. Would you like to keep it enabled?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Yes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>No</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>Manual</name>

--- a/src/mumble/mumble_ko.ts
+++ b/src/mumble/mumble_ko.ts
@@ -6707,6 +6707,18 @@ Valid options are:
         <source>This will check if mumble is up to date</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>That sound was the mute cue. It activates when you speak while muted. Would you like to keep it enabled?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Yes</source>
+        <translation type="unfinished">예</translation>
+    </message>
+    <message>
+        <source>No</source>
+        <translation type="unfinished">아니요</translation>
+    </message>
 </context>
 <context>
     <name>Manual</name>

--- a/src/mumble/mumble_lt.ts
+++ b/src/mumble/mumble_lt.ts
@@ -6649,6 +6649,18 @@ Valid options are:
         <source>This will check if mumble is up to date</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>That sound was the mute cue. It activates when you speak while muted. Would you like to keep it enabled?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Yes</source>
+        <translation type="unfinished">Taip</translation>
+    </message>
+    <message>
+        <source>No</source>
+        <translation type="unfinished">Ne</translation>
+    </message>
 </context>
 <context>
     <name>Manual</name>

--- a/src/mumble/mumble_nl.ts
+++ b/src/mumble/mumble_nl.ts
@@ -6708,6 +6708,18 @@ Valid options are:
         <source>This will check if mumble is up to date</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>That sound was the mute cue. It activates when you speak while muted. Would you like to keep it enabled?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Yes</source>
+        <translation type="unfinished">Ja</translation>
+    </message>
+    <message>
+        <source>No</source>
+        <translation type="unfinished">Neen</translation>
+    </message>
 </context>
 <context>
     <name>Manual</name>

--- a/src/mumble/mumble_no.ts
+++ b/src/mumble/mumble_no.ts
@@ -6723,6 +6723,18 @@ Valid options are:
         <source>This will check if mumble is up to date</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>That sound was the mute cue. It activates when you speak while muted. Would you like to keep it enabled?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Yes</source>
+        <translation type="unfinished">Ja</translation>
+    </message>
+    <message>
+        <source>No</source>
+        <translation type="unfinished">Nei</translation>
+    </message>
 </context>
 <context>
     <name>Manual</name>

--- a/src/mumble/mumble_oc.ts
+++ b/src/mumble/mumble_oc.ts
@@ -6615,6 +6615,18 @@ Valid options are:
         <source>This will check if mumble is up to date</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>That sound was the mute cue. It activates when you speak while muted. Would you like to keep it enabled?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Yes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>No</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>Manual</name>

--- a/src/mumble/mumble_pl.ts
+++ b/src/mumble/mumble_pl.ts
@@ -6769,6 +6769,18 @@ Prawidłowe opcje to:
         <source>This will check if mumble is up to date</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>That sound was the mute cue. It activates when you speak while muted. Would you like to keep it enabled?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Yes</source>
+        <translation type="unfinished">Tak</translation>
+    </message>
+    <message>
+        <source>No</source>
+        <translation type="unfinished">Nie</translation>
+    </message>
 </context>
 <context>
     <name>Manual</name>

--- a/src/mumble/mumble_pt_BR.ts
+++ b/src/mumble/mumble_pt_BR.ts
@@ -6709,6 +6709,18 @@ Valid options are:
         <source>This will check if mumble is up to date</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>That sound was the mute cue. It activates when you speak while muted. Would you like to keep it enabled?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Yes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>No</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>Manual</name>

--- a/src/mumble/mumble_pt_PT.ts
+++ b/src/mumble/mumble_pt_PT.ts
@@ -6686,6 +6686,18 @@ Valid options are:
         <source>This will check if mumble is up to date</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>That sound was the mute cue. It activates when you speak while muted. Would you like to keep it enabled?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Yes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>No</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>Manual</name>

--- a/src/mumble/mumble_ro.ts
+++ b/src/mumble/mumble_ro.ts
@@ -6623,6 +6623,18 @@ Valid options are:
         <source>This will check if mumble is up to date</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>That sound was the mute cue. It activates when you speak while muted. Would you like to keep it enabled?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Yes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>No</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>Manual</name>

--- a/src/mumble/mumble_ru.ts
+++ b/src/mumble/mumble_ru.ts
@@ -6709,6 +6709,18 @@ Valid options are:
         <source>This will check if mumble is up to date</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>That sound was the mute cue. It activates when you speak while muted. Would you like to keep it enabled?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Yes</source>
+        <translation type="unfinished">Да</translation>
+    </message>
+    <message>
+        <source>No</source>
+        <translation type="unfinished">Нет</translation>
+    </message>
 </context>
 <context>
     <name>Manual</name>

--- a/src/mumble/mumble_si.ts
+++ b/src/mumble/mumble_si.ts
@@ -6577,6 +6577,18 @@ Valid options are:
         <source>This will check if mumble is up to date</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>That sound was the mute cue. It activates when you speak while muted. Would you like to keep it enabled?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Yes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>No</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>Manual</name>

--- a/src/mumble/mumble_sk.ts
+++ b/src/mumble/mumble_sk.ts
@@ -6581,6 +6581,18 @@ Valid options are:
         <source>This will check if mumble is up to date</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>That sound was the mute cue. It activates when you speak while muted. Would you like to keep it enabled?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Yes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>No</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>Manual</name>

--- a/src/mumble/mumble_sq.ts
+++ b/src/mumble/mumble_sq.ts
@@ -6579,6 +6579,18 @@ Valid options are:
         <source>This will check if mumble is up to date</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>That sound was the mute cue. It activates when you speak while muted. Would you like to keep it enabled?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Yes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>No</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>Manual</name>

--- a/src/mumble/mumble_sv.ts
+++ b/src/mumble/mumble_sv.ts
@@ -6767,6 +6767,18 @@ Giltiga värden för options är:
         <source>This will check if mumble is up to date</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>That sound was the mute cue. It activates when you speak while muted. Would you like to keep it enabled?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Yes</source>
+        <translation type="unfinished">Ja</translation>
+    </message>
+    <message>
+        <source>No</source>
+        <translation type="unfinished">Nej</translation>
+    </message>
 </context>
 <context>
     <name>Manual</name>

--- a/src/mumble/mumble_te.ts
+++ b/src/mumble/mumble_te.ts
@@ -6626,6 +6626,18 @@ Valid options are:
         <source>This will check if mumble is up to date</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>That sound was the mute cue. It activates when you speak while muted. Would you like to keep it enabled?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Yes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>No</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>Manual</name>

--- a/src/mumble/mumble_th.ts
+++ b/src/mumble/mumble_th.ts
@@ -6613,6 +6613,18 @@ Valid options are:
         <source>This will check if mumble is up to date</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>That sound was the mute cue. It activates when you speak while muted. Would you like to keep it enabled?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Yes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>No</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>Manual</name>

--- a/src/mumble/mumble_tr.ts
+++ b/src/mumble/mumble_tr.ts
@@ -6769,6 +6769,18 @@ Geçerli seçenekler şunlardır:
         <source>This will check if mumble is up to date</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>That sound was the mute cue. It activates when you speak while muted. Would you like to keep it enabled?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Yes</source>
+        <translation type="unfinished">Evet</translation>
+    </message>
+    <message>
+        <source>No</source>
+        <translation type="unfinished">Hayır</translation>
+    </message>
 </context>
 <context>
     <name>Manual</name>

--- a/src/mumble/mumble_uk.ts
+++ b/src/mumble/mumble_uk.ts
@@ -6623,6 +6623,18 @@ Valid options are:
         <source>This will check if mumble is up to date</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>That sound was the mute cue. It activates when you speak while muted. Would you like to keep it enabled?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Yes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>No</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>Manual</name>

--- a/src/mumble/mumble_zh_CN.ts
+++ b/src/mumble/mumble_zh_CN.ts
@@ -6767,6 +6767,18 @@ mumble://[&lt;用户名&gt;[:&lt;密码&gt;]@]&lt;主机名&gt;[:&lt;端口&gt;]
         <source>This will check if mumble is up to date</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>That sound was the mute cue. It activates when you speak while muted. Would you like to keep it enabled?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Yes</source>
+        <translation type="unfinished">是</translation>
+    </message>
+    <message>
+        <source>No</source>
+        <translation type="unfinished">否</translation>
+    </message>
 </context>
 <context>
     <name>Manual</name>

--- a/src/mumble/mumble_zh_HK.ts
+++ b/src/mumble/mumble_zh_HK.ts
@@ -6618,6 +6618,18 @@ Valid options are:
         <source>This will check if mumble is up to date</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>That sound was the mute cue. It activates when you speak while muted. Would you like to keep it enabled?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Yes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>No</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>Manual</name>

--- a/src/mumble/mumble_zh_TW.ts
+++ b/src/mumble/mumble_zh_TW.ts
@@ -6641,6 +6641,18 @@ Valid options are:
         <source>This will check if mumble is up to date</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>That sound was the mute cue. It activates when you speak while muted. Would you like to keep it enabled?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Yes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>No</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>Manual</name>


### PR DESCRIPTION
As requested in #6094 this commit implements a popup to inform the user that the mute cue just played while also giving them the option to keep it enabled or not.

For that a new slot function was added in the MainWindow Class along with a signal function in the AudioInput class.  These use a new boolean variable in the Settings Class to check if the popup has been shown and a boolean variable in the Global Class to check if the Configuration UI is open.

The popup works by emitting a signal from the AudioInput class to the MainWindow Class.

Fixes #6094


### Checks

- [x] My commits follow the [commit guidelines](https://github.com/mumble-voip/mumble/blob/master/COMMIT_GUIDELINES.md)

