### PR TITLE
DOCS/MAINT: Update vcpkg dependency list

### DIFF
--- a/docs/dev/build-instructions/build_static.md
+++ b/docs/dev/build-instructions/build_static.md
@@ -42,7 +42,8 @@ their README file.
 
 Once vcpkg is installed on your system, you have to switch into the directory vcpkg is installed in and then install the following packages:
 ```
-qt5-base
+qt5-base[mysqlplugin]
+qt5-base[postgresqlplugin]
 qt5-svg
 qt5-tools
 qt5-translations
@@ -53,9 +54,10 @@ libvorbis
 libogg
 libflac
 libsndfile
-libmariadb
+protobuf
 zlib
 ```
+On Windows, you'll also have to install the `mdnsresponder` package.
 
 The command for installing a package is `vcpkg install <packageName> --triplet <triplet>` where `<packageName>` is to be replaced with the name of the
 package you want to install and `<triplet>` is the desired target triplet. We recommend using these triplets:

--- a/scripts/vcpkg/get_mumble_dependencies.ps1
+++ b/scripts/vcpkg/get_mumble_dependencies.ps1
@@ -12,6 +12,7 @@ $mumble_deps = "qt5-base[mysqlplugin]",
                "qt5-tools",
                "qt5-translations",
                "boost-accumulators",
+               "opus"
                "poco",
                "libvorbis",
                "libogg",

--- a/scripts/vcpkg/get_mumble_dependencies.sh
+++ b/scripts/vcpkg/get_mumble_dependencies.sh
@@ -47,6 +47,7 @@ mumble_deps='qt5-base[mysqlplugin],
             qt5-tools,
             qt5-translations,
             boost-accumulators,
+            opus
             poco,
             libvorbis,
             libogg,


### PR DESCRIPTION
The different dependency lists have become out-of-sync and/or out-of-date.

This should remedy problems as encountered in #6163.


### Checks

- [x] My commits follow the [commit guidelines](https://github.com/mumble-voip/mumble/blob/master/COMMIT_GUIDELINES.md)

