### PR TITLE
Backport "Merge PR #6172: DOCS/MAINT: Update vcpkg dependency list" to 1.5.x

### DIFF
--- a/docs/dev/build-instructions/build_static.md
+++ b/docs/dev/build-instructions/build_static.md
@@ -42,7 +42,8 @@ their README file.
 
 Once vcpkg is installed on your system, you have to switch into the directory vcpkg is installed in and then install the following packages:
 ```
-qt5-base
+qt5-base[mysqlplugin]
+qt5-base[postgresqlplugin]
 qt5-svg
 qt5-tools
 qt5-translations
@@ -53,9 +54,10 @@ libvorbis
 libogg
 libflac
 libsndfile
-libmariadb
+protobuf
 zlib
 ```
+On Windows, you'll also have to install the `mdnsresponder` package.
 
 The command for installing a package is `vcpkg install <packageName> --triplet <triplet>` where `<packageName>` is to be replaced with the name of the
 package you want to install and `<triplet>` is the desired target triplet. We recommend using these triplets:

--- a/scripts/vcpkg/get_mumble_dependencies.ps1
+++ b/scripts/vcpkg/get_mumble_dependencies.ps1
@@ -12,6 +12,7 @@ $mumble_deps = "qt5-base[mysqlplugin]",
                "qt5-tools",
                "qt5-translations",
                "boost-accumulators",
+               "opus"
                "poco",
                "libvorbis",
                "libogg",

--- a/scripts/vcpkg/get_mumble_dependencies.sh
+++ b/scripts/vcpkg/get_mumble_dependencies.sh
@@ -47,6 +47,7 @@ mumble_deps='qt5-base[mysqlplugin],
             qt5-tools,
             qt5-translations,
             boost-accumulators,
+            opus
             poco,
             libvorbis,
             libogg,


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `1.5.x`:
 - [Merge PR #6172: DOCS/MAINT: Update vcpkg dependency list](https://github.com/mumble-voip/mumble/pull/6172)

<!--- Backport version: 8.9.3 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)