### PR TITLE
FEAT(server): Add disable textchat

### DIFF
--- a/src/murmur/Server.cpp
+++ b/src/murmur/Server.cpp
@@ -2310,6 +2310,10 @@ bool Server::isTextAllowed(QString &text, bool &changed) {
 		if ((iMaxTextMessageLength == 0) && (iMaxImageMessageLength == 0))
 			return true;
 
+		// Don't allow any messages of any length
+		if ((iMaxTextMessageLength == -1) && (iMaxImageMessageLength == -1))
+			return false;
+
 		// Over Image limit? (If so, always fail)
 		if ((iMaxImageMessageLength != 0) && (length > iMaxImageMessageLength))
 			return false;


### PR DESCRIPTION
The lowest allowed value for `textmessagelength` and `imagemessagelength` was 1. Setting these to 0 will allow any length. 
With these changes you can effectively disable text chat all together like requested here  #2679
I use these changes on my personal server as I don't want people to use the text chat on mumble.
 
These changes don't interfere with anything.

Implements #2679

### Checks

- [x] My commits follow the [commit guidelines](https://github.com/mumble-voip/mumble/blob/master/COMMIT_GUIDELINES.md)

