### PR TITLE
FIX(client) : Fixed config directory path assignment

### DIFF
--- a/src/mumble/Database.cpp
+++ b/src/mumble/Database.cpp
@@ -5,6 +5,7 @@
 
 #include "Database.h"
 
+#include "EnvUtils.h"
 #include "MumbleApplication.h"
 #include "Net.h"
 #include "Utils.h"
@@ -47,7 +48,12 @@ bool Database::findOrCreateDatabase() {
 	datapaths << Global::get().qdBasePath.absolutePath();
 	datapaths << QStandardPaths::writableLocation(QStandardPaths::DataLocation);
 #if defined(Q_OS_UNIX) && !defined(Q_OS_MAC)
-	datapaths << QDir::homePath() + QLatin1String("/.config/Mumble");
+	QString configDirectory = EnvUtils::getenv(QLatin1String("XDG_CONFIG_HOME"));
+	if (configDirectory.isEmpty()) {
+		configDirectory = QDir::homePath() + QLatin1String("/.config");
+	}
+	configDirectory += QLatin1String("/Mumble");
+	datapaths << configDirectory;
 #endif
 	datapaths << QDir::homePath();
 	datapaths << QDir::currentPath();


### PR DESCRIPTION
Config directory path in Linux should be picked from XDG_CONFIG_HOME environment variable.

Fixes #6029 

### Checks

- [X] My commits follow the [commit guidelines](https://github.com/mumble-voip/mumble/blob/master/COMMIT_GUIDELINES.md)

