### PR TITLE
BUILD(cmake, overlay): Install 32-bit lib on FreeBSD

### DIFF
--- a/overlay_gl/CMakeLists.txt
+++ b/overlay_gl/CMakeLists.txt
@@ -96,6 +96,11 @@ if(NOT APPLE)
 					"-ldl"
 					"-lrt"
 			)
+		endif()
+	endif()
+
+	if(${CMAKE_SYSTEM_NAME} STREQUAL "Linux" OR ${CMAKE_SYSTEM_NAME} STREQUAL "FreeBSD")
+		if(TARGET overlay_gl_x86)
 			# install 32bit overlay library
 			install(TARGETS overlay_gl_x86 LIBRARY DESTINATION "${MUMBLE_INSTALL_LIBDIR}")
 		endif()


### PR DESCRIPTION
Despite the 32-bit library building on FreeBSD-amd64 when the overlay-xcompile option is enabled, it never gets installed.


### Checks

- [x] My commits follow the [commit guidelines](https://github.com/mumble-voip/mumble/blob/master/COMMIT_GUIDELINES.md)

