### PR TITLE
Backport "Merge PR #6191: BUILD(cmake): Fix detection of unbundled GSL" to 1.5.x

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -219,8 +219,8 @@ else()
 	# GSL since version 3)
 	find_pkg("Microsoft.GSL")
 
-	if (TARGET GSL)
-		target_link_libraries(shared PUBLIC GSL)
+	if (TARGET Microsoft.GSL::GSL)
+		target_link_libraries(shared PUBLIC Microsoft.GSL::GSL)
 	else()
 		# If the above failed, it could mean that there is an installation of GSL < v3.0 on this system, which does not yet
 		# provide cmake support for finding it. Thus, we have to use our custom Find-script.


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `1.5.x`:
 - [Merge PR #6191: BUILD(cmake): Fix detection of unbundled GSL](https://github.com/mumble-voip/mumble/pull/6191)

<!--- Backport version: 8.9.3 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)