### PR TITLE
Backport "Merge PR #6179: FIX(client): Fix speex bug, introduced through double fix" to 1.5.x

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -6,7 +6,7 @@
 	url = https://github.com/mumble-voip/mach_override.git
 [submodule "3rdparty/speexdsp"]
 	path = 3rdparty/speexdsp
-	url = https://github.com/mumble-voip/speexdsp.git
+	url = https://github.com/xiph/speexdsp.git
 [submodule "3rdparty/rnnoise-src"]
 	path = 3rdparty/rnnoise-src
 	url = https://github.com/mumble-voip/rnnoise.git


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `1.5.x`:
 - [Merge PR #6179: FIX(client): Fix speex bug, introduced through double fix](https://github.com/mumble-voip/mumble/pull/6179)

<!--- Backport version: 8.9.3 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)