### PR TITLE
Default theme optimization.

### DIFF
--- a/themes/Default/Dark.qss
+++ b/themes/Default/Dark.qss
@@ -49,7 +49,7 @@ QObject::handle,
 QObject::tab-bar,
 QObject::tab,
 QObject::section {
-  font-family: "Segoe UI", Frutiger, "Frutiger Linotype", "Dejavu Sans", "Helvetica Neue", Arial, sans-serif;
+  font-family: "Segoe UI", Frutiger, "Frutiger Linotype", "Dejavu Sans", "Helvetica Neue", "Microsoft YaHei UI", "PingFang SC", "Noto Sans SC", Arial, sans-serif;
   font-size: 10pt;
   margin: 0;
   padding: 0;

--- a/themes/Default/Lite.qss
+++ b/themes/Default/Lite.qss
@@ -49,7 +49,7 @@ QObject::handle,
 QObject::tab-bar,
 QObject::tab,
 QObject::section {
-  font-family: "Segoe UI", Frutiger, "Frutiger Linotype", "Dejavu Sans", "Helvetica Neue", Arial, sans-serif;
+  font-family: "Segoe UI", Frutiger, "Frutiger Linotype", "Dejavu Sans", "Helvetica Neue", "Microsoft YaHei UI", "PingFang SC", "Noto Sans SC", Arial, sans-serif;
   font-size: 10pt;
   margin: 0;
   padding: 0;


### PR DESCRIPTION
Add some font-family to fix the display experience of Chinese character.

In fact, it just adds the default font of Windows, Linux, Mac and other operating systems in the font-add, in the case of unspecified fonts, using the Chinese operating system of Windows will call the font "Simsun" as the UD Font, it is very bad, so I fixed it! So I fixed it.


