### PR TITLE
FIX(client, theme): Chinese characters not displayed properly (scss modified)

### DIFF
--- a/themes/Default/Dark.qss
+++ b/themes/Default/Dark.qss
@@ -49,7 +49,7 @@ QObject::handle,
 QObject::tab-bar,
 QObject::tab,
 QObject::section {
-  font-family: "Segoe UI", Frutiger, "Frutiger Linotype", "Dejavu Sans", "Helvetica Neue", Arial, sans-serif;
+  font-family: "Segoe UI", Frutiger, "Frutiger Linotype", "Dejavu Sans", "Helvetica Neue", "Microsoft YaHei UI", "PingFang SC", "Noto Sans SC", Arial, sans-serif;
   font-size: 10pt;
   margin: 0;
   padding: 0;
@@ -1066,15 +1066,15 @@ TalkingUI > * {
   background-color: #191919;
 }
 
-TalkingUI [selected="false"] {
+TalkingUI [selected=false] {
   background-color: #191919;
 }
 
-TalkingUI [selected="false"]:hover {
+TalkingUI [selected=false]:hover {
   background-color: #333;
 }
 
-TalkingUI [selected="true"] {
+TalkingUI [selected=true] {
   background-color: #3e4f5e;
   border: 1px solid #3e4f5e;
 }

--- a/themes/Default/Lite.qss
+++ b/themes/Default/Lite.qss
@@ -49,7 +49,7 @@ QObject::handle,
 QObject::tab-bar,
 QObject::tab,
 QObject::section {
-  font-family: "Segoe UI", Frutiger, "Frutiger Linotype", "Dejavu Sans", "Helvetica Neue", Arial, sans-serif;
+  font-family: "Segoe UI", Frutiger, "Frutiger Linotype", "Dejavu Sans", "Helvetica Neue", "Microsoft YaHei UI", "PingFang SC", "Noto Sans SC", Arial, sans-serif;
   font-size: 10pt;
   margin: 0;
   padding: 0;
@@ -1066,15 +1066,15 @@ TalkingUI > * {
   background-color: #FFF;
 }
 
-TalkingUI [selected="false"] {
+TalkingUI [selected=false] {
   background-color: #FFF;
 }
 
-TalkingUI [selected="false"]:hover {
+TalkingUI [selected=false]:hover {
   background-color: #eee;
 }
 
-TalkingUI [selected="true"] {
+TalkingUI [selected=true] {
   background-color: #dcedf5;
   border: 1px solid #97b5c6;
 }

--- a/themes/Default/source/Imports/Dark Definitions.scss
+++ b/themes/Default/source/Imports/Dark Definitions.scss
@@ -73,7 +73,7 @@ $checkbox: url(skin:controls/checkbox_check_dark.svg);
 $checkbox-disabled: url(skin:controls/checkbox_check_disabled.svg);
 $link: #39a5dd;
 
-$font-family: "Segoe UI", Frutiger, "Frutiger Linotype", "Dejavu Sans", "Helvetica Neue", Arial, sans-serif;
+$font-family: "Segoe UI", Frutiger, "Frutiger Linotype", "Dejavu Sans", "Helvetica Neue", "Microsoft YaHei UI", "PingFang SC", "Noto Sans SC", Arial, sans-serif;
 $font-size-bigger: 13pt;
 $font-size-big: 12pt;
 $font-size-normal: 10pt;

--- a/themes/Default/source/Imports/Lite Definitions.scss
+++ b/themes/Default/source/Imports/Lite Definitions.scss
@@ -73,7 +73,7 @@ $checkbox: url(skin:controls/checkbox_check_lite.svg);
 $checkbox-disabled: url(skin:controls/checkbox_check_disabled.svg);
 $link: #0b8eb2;
 
-$font-family: "Segoe UI", Frutiger, "Frutiger Linotype", "Dejavu Sans", "Helvetica Neue", Arial, sans-serif;
+$font-family: "Segoe UI", Frutiger, "Frutiger Linotype", "Dejavu Sans", "Helvetica Neue", "Microsoft YaHei UI", "PingFang SC", "Noto Sans SC", Arial, sans-serif;
 $font-size-bigger: 13pt;
 $font-size-big: 12pt;
 $font-size-normal: 10pt;


### PR DESCRIPTION
This commit adds some font families to the default themes that improve the displaying of Chinese characters.

Added Windows(Microsoft YaHei), Linux(Noto Sans SC), Mac(PingFang SC) default Chinese fonts in the default theme's font-family, which can avoid the system calling fonts such as Simsun by default and bring bad display effect. I put it in front of Arial and sans-serif, and behind other fonts, so as to avoid affecting the display of non-CJK fonts on the operating system.

I modified the scss code as requested, and I'm sorry to restart a pull request again because I'm not familiar with using git yet.

### Checks

- [x] My commits follow the [commit guidelines](https://github.com/mumble-voip/mumble/blob/master/COMMIT_GUIDELINES.md)

