### PR TITLE
BUILD(vcpkg): Add missing comma in get_mumble_dependencies

### DIFF
--- a/scripts/vcpkg/get_mumble_dependencies.ps1
+++ b/scripts/vcpkg/get_mumble_dependencies.ps1
@@ -12,7 +12,7 @@ $mumble_deps = "qt5-base[mysqlplugin]",
                "qt5-tools",
                "qt5-translations",
                "boost-accumulators",
-               "opus"
+               "opus",
                "poco",
                "libvorbis",
                "libogg",

--- a/scripts/vcpkg/get_mumble_dependencies.sh
+++ b/scripts/vcpkg/get_mumble_dependencies.sh
@@ -47,7 +47,7 @@ mumble_deps='qt5-base[mysqlplugin],
             qt5-tools,
             qt5-translations,
             boost-accumulators,
-            opus
+            opus,
             poco,
             libvorbis,
             libogg,


### PR DESCRIPTION
Fixes broken vcpkg dependency installation due to missing comma in the install scripts.


### Checks

- [x] My commits follow the [commit guidelines](https://github.com/mumble-voip/mumble/blob/master/COMMIT_GUIDELINES.md)

