### PR TITLE
Backport "Merge PR #6226: MAINT: Update Windows build env to latest version" to 1.5.x

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -23,7 +23,7 @@ environment:
 
   matrix:
     - MUMBLE_ENVIRONMENT_TRIPLET: 'x64-windows-static-md'
-      MUMBLE_ENVIRONMENT_VERSION: 'windows-static-1.5.x~2022-05-17~cd7e2c9.x64'
+      MUMBLE_ENVIRONMENT_VERSION: 'windows-static-1.5.x~2023-10-06~0310159.x64'
 
 install:
   - ps: .ci/install-environment_windows.ps1

--- a/.ci/azure-pipelines/main-pr.yml
+++ b/.ci/azure-pipelines/main-pr.yml
@@ -24,7 +24,7 @@ jobs:
     pool:
       vmImage: 'windows-2022'
     variables:
-      MUMBLE_ENVIRONMENT_VERSION: 'windows-static-1.5.x~2022-05-17~cd7e2c9.x64'
+      MUMBLE_ENVIRONMENT_VERSION: 'windows-static-1.5.x~2023-10-06~0310159.x64'
       MUMBLE_ENVIRONMENT_TRIPLET: 'x64-windows-static-md'
     steps:
     - template: steps_windows.yml

--- a/.ci/azure-pipelines/main.yml
+++ b/.ci/azure-pipelines/main.yml
@@ -22,7 +22,7 @@ jobs:
     pool:
       vmImage: 'windows-2022'
     variables:
-      MUMBLE_ENVIRONMENT_VERSION: 'windows-static-1.5.x~2022-05-17~cd7e2c9.x64'
+      MUMBLE_ENVIRONMENT_VERSION: 'windows-static-1.5.x~2023-10-06~0310159.x64'
       MUMBLE_ENVIRONMENT_TRIPLET: 'x64-windows-static-md'
     steps:
     - template: steps_windows.yml


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `1.5.x`:
 - [Merge PR #6226: MAINT: Update Windows build env to latest version](https://github.com/mumble-voip/mumble/pull/6226)

<!--- Backport version: 8.9.3 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)