### PR TITLE
FIX(server,settings,log): announce if settings file is not present

### DIFF
--- a/src/murmur/Meta.cpp
+++ b/src/murmur/Meta.cpp
@@ -228,8 +228,13 @@ void MetaParams::read(QString fname) {
 			break;
 	}
 
-	qWarning("Initializing settings from %s (basepath %s)", qPrintable(qsSettings->fileName()),
-			 qPrintable(qdBasePath.absolutePath()));
+	if (QFile::exists(qsAbsSettingsFilePath)) {
+		qWarning("Initializing settings from %s (basepath %s)", qPrintable(qsSettings->fileName()),
+				 qPrintable(qdBasePath.absolutePath()));
+	} else {
+		qWarning("No ini file at %s (basepath %s). Initializing with default settings.",
+				 qPrintable(qsSettings->fileName()), qPrintable(qdBasePath.absolutePath()));
+	}
 
 	QString qsHost = qsSettings->value("host", QString()).toString();
 	if (!qsHost.isEmpty()) {

--- a/src/murmur/Meta.cpp
+++ b/src/murmur/Meta.cpp
@@ -199,7 +199,6 @@ void MetaParams::read(QString fname) {
 			}
 		}
 		if (qsAbsSettingsFilePath.isEmpty()) {
-			QDir::root().mkpath(qdBasePath.absolutePath());
 			qdBasePath            = QDir(datapaths.at(0));
 			qsAbsSettingsFilePath = qdBasePath.absolutePath() + QLatin1String("/mumble-server.ini");
 		}


### PR DESCRIPTION
Apparently, QSettings does not care if the specified settings file exists or not. Therefore, no keys will be loaded into the settings as if the file was empty. We specifically check for the missing file to not reference a ghost file in the logs.

Fixes #6077


### Checks

- [x] My commits follow the [commit guidelines](https://github.com/mumble-voip/mumble/blob/master/COMMIT_GUIDELINES.md)

