### PR TITLE
FIX(client): Positional audio fixes

### DIFF
--- a/src/mumble/AudioConfigDialog.cpp
+++ b/src/mumble/AudioConfigDialog.cpp
@@ -866,22 +866,22 @@ void AudioOutputDialog::on_qsbMinimumDistance_valueChanged(double value) {
 	qsMinDistance->setValue(value * 10);
 
 	// Ensure that max distance is always a least 1m larger than min distance
-	qsMaxDistance->setValue(std::max(qsMaxDistance->value(), static_cast< int >(value * 10) + 1));
+	qsMaxDistance->setValue(std::max(qsMaxDistance->value(), static_cast< int >(value * 10) + 10));
 }
 
 void AudioOutputDialog::on_qsMaxDistance_valueChanged(int value) {
 	QSignalBlocker blocker(qsbMaximumDistance);
 	qsbMaximumDistance->setValue(value / 10.0f);
 
-	// Ensure that max distance is always a least 1m larger than min distance
+	// Ensure that min distance is always a least 1m less than max distance
 	qsbMinimumDistance->setValue(std::min(qsbMinimumDistance->value(), (value / 10.0) - 1));
 }
 void AudioOutputDialog::on_qsbMaximumDistance_valueChanged(double value) {
 	QSignalBlocker blocker(qsMaxDistance);
 	qsMaxDistance->setValue(value * 10);
 
-	// Ensure that max distance is always a least 1m larger than min distance
-	qsMinDistance->setValue(std::min(qsMinDistance->value(), static_cast< int >(value * 10) - 1));
+	// Ensure that min distance is always a least 1m less than max distance
+	qsMinDistance->setValue(std::min(qsMinDistance->value(), static_cast< int >(value * 10) - 10));
 }
 
 void AudioOutputDialog::on_qsMinimumVolume_valueChanged(int value) {

--- a/src/mumble/ManualPlugin.cpp
+++ b/src/mumble/ManualPlugin.cpp
@@ -23,7 +23,7 @@ static QPointer< Manual > mDlg = nullptr;
 static bool bLinkable          = false;
 static bool bActive            = true;
 
-static int iAzimuth   = 180;
+static int iAzimuth   = 0;
 static int iElevation = 0;
 
 static const QString defaultContext  = QString::fromLatin1("Mumble");
@@ -52,8 +52,8 @@ Manual::Manual(QWidget *p) : QDialog(p) {
 	// The center of the indicator's circle will represent the current position
 	indicator.addEllipse(QRectF(-indicatorDiameter / 2, -indicatorDiameter / 2, indicatorDiameter, indicatorDiameter));
 	// A line will indicate the indicator's orientation (azimuth)
-	indicator.moveTo(0, indicatorDiameter / 2);
-	indicator.lineTo(0, indicatorDiameter);
+	indicator.moveTo(0, -indicatorDiameter / 2);
+	indicator.lineTo(0, -indicatorDiameter);
 
 	m_qgiPosition = m_qgsScene->addPath(indicator);
 


### PR DESCRIPTION
This MR contains 3 commits, each related to problems in the current implementation of positional audio.

The problems that are fixed are:

1) The manual position plugin listener indicator was facing the wrong direction
2) The sliders for minimum and maximum positional distance did not properly load values
3) The use case for minimum volume = 0 is broken

Fixes #6149 