### PR TITLE
Backport "Merge PR #6235: DOCS: Change encoding to UTF-8 & clean up error msg in FAQ" to 1.5.x

### DIFF
--- a/docs/dev/build-instructions/build_static.md
+++ b/docs/dev/build-instructions/build_static.md
@@ -253,7 +253,7 @@ Ref: https://github.com/microsoft/vcpkg/issues/13217
 When installing the dependency zlib via vcpkg, it may fail to locate the include file `afxres.h` (when building its mdnsresponder dependency).
 
 ```
-dll.rc(10): fatal error RC1015: cannot open include file 'afxres.h'. [[…]\vcpkg\buildtrees\mdnsresponder\src\ponder-878-e7e3a9a271.clean\mDNSWindows\DLL\dnssd.vcxproj]
+dll.rc(10): fatal error RC1015: cannot open include file 'afxres.h'.
 ```
 
 To resolve this, ensure MFC has been installed in your Visual Studio installation.


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `1.5.x`:
 - [Merge PR #6235: DOCS: Change encoding to UTF-8 & clean up error msg in FAQ](https://github.com/mumble-voip/mumble/pull/6235)

<!--- Backport version: 8.9.3 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)