### PR TITLE
FIX(client): Fix using the keyboad to change local volume adjustment

### DIFF
--- a/src/mumble/CMakeLists.txt
+++ b/src/mumble/CMakeLists.txt
@@ -289,6 +289,8 @@ set(MUMBLE_SOURCES
 
 	"widgets/CompletablePage.cpp"
 	"widgets/CompletablePage.h"
+	"widgets/EventFilters.cpp"
+	"widgets/EventFilters.h"
 	"widgets/MUComboBox.cpp"
 	"widgets/MUComboBox.h"
 	"widgets/MultiStyleWidgetWrapper.cpp"

--- a/src/mumble/ListenerVolumeSlider.cpp
+++ b/src/mumble/ListenerVolumeSlider.cpp
@@ -7,10 +7,14 @@
 #include "Channel.h"
 #include "ChannelListenerManager.h"
 #include "ServerHandler.h"
-#include "VolumeAdjustment.h"
 #include "Global.h"
 
-ListenerVolumeSlider::ListenerVolumeSlider(QWidget *parent) : VolumeSliderWidgetAction(parent) {
+ListenerVolumeSlider::ListenerVolumeSlider(QWidget *parent) : VolumeSliderWidgetAction(parent), m_currentSendDelay(0) {
+	connect(&m_sendTimer, &QTimer::timeout, this, &ListenerVolumeSlider::sendToServer);
+	connect(&m_resetTimer, &QTimer::timeout, this, [=]() { m_currentSendDelay = 0; });
+
+	m_sendTimer.setSingleShot(true);
+	m_resetTimer.setSingleShot(true);
 }
 
 void ListenerVolumeSlider::setListenedChannel(const Channel &channel) {
@@ -28,7 +32,7 @@ void ListenerVolumeSlider::on_VolumeSlider_valueChanged(int value) {
 	displayTooltip(value);
 }
 
-void ListenerVolumeSlider::on_VolumeSlider_sliderReleased() {
+void ListenerVolumeSlider::on_VolumeSlider_changeCompleted() {
 	ServerHandlerPtr handler = Global::get().sh;
 
 	if (!handler || !m_channel || !m_volumeSlider) {
@@ -39,18 +43,42 @@ void ListenerVolumeSlider::on_VolumeSlider_sliderReleased() {
 
 	if (handler->m_version >= Mumble::Protocol::PROTOBUF_INTRODUCTION_VERSION) {
 		// With the new audio protocol, volume adjustments for listeners are handled on the server and thus we want
-		// to avoid spamming updates to the adjustments, which is why we only update them once the slider is released.
-		MumbleProto::UserState mpus;
-		mpus.set_session(Global::get().uiSession);
+		// to avoid spamming updates to the adjustments, which is why we only update them with a delay.
 
-		MumbleProto::UserState::VolumeAdjustment *adjustmentMsg = mpus.add_listening_volume_adjustment();
-		adjustmentMsg->set_listening_channel(m_channel->iId);
-		adjustmentMsg->set_volume_adjustment(adjustment.factor);
+		if (m_cachedChannelID == m_channel->iId && m_cachedAdjustment == adjustment) {
+			return;
+		}
 
-		handler->sendMessage(mpus);
+		m_cachedChannelID  = m_channel->iId;
+		m_cachedAdjustment = adjustment;
+
+		// Timer values: 0, 50, 150, 350, 750, 1000 (ms)
+		m_resetTimer.stop();
+		m_sendTimer.start(m_currentSendDelay);
+		m_currentSendDelay = std::min(1000u, (m_currentSendDelay + 25) * 2);
+
 	} else {
 		// Before the new audio protocol, volume adjustments for listeners are handled locally
 		Global::get().channelListenerManager->setListenerVolumeAdjustment(Global::get().uiSession, m_channel->iId,
 																		  adjustment);
 	}
+}
+
+void ListenerVolumeSlider::sendToServer() {
+	ServerHandlerPtr handler = Global::get().sh;
+
+	m_resetTimer.start(3000);
+
+	if (!handler) {
+		return;
+	}
+
+	MumbleProto::UserState mpus;
+	mpus.set_session(Global::get().uiSession);
+
+	MumbleProto::UserState::VolumeAdjustment *adjustmentMsg = mpus.add_listening_volume_adjustment();
+	adjustmentMsg->set_listening_channel(m_cachedChannelID);
+	adjustmentMsg->set_volume_adjustment(m_cachedAdjustment.factor);
+
+	handler->sendMessage(mpus);
 }

--- a/src/mumble/ListenerVolumeSlider.h
+++ b/src/mumble/ListenerVolumeSlider.h
@@ -6,7 +6,10 @@
 #ifndef MUMBLE_MUMBLE_LISTENERLOCALVOLUMESLIDER_H_
 #define MUMBLE_MUMBLE_LISTENERLOCALVOLUMESLIDER_H_
 
+#include "VolumeAdjustment.h"
 #include "VolumeSliderWidgetAction.h"
+
+#include <QTimer>
 
 class Channel;
 
@@ -20,12 +23,20 @@ public:
 	void setListenedChannel(const Channel &channel);
 
 private:
-	/// The channel of the listener proxy this dialog is operating on
+	/// The channel of the listener proxy this widget is operating on
 	const Channel *m_channel;
+
+	QTimer m_sendTimer;
+	QTimer m_resetTimer;
+	unsigned int m_currentSendDelay;
+	int m_cachedChannelID;
+	VolumeAdjustment m_cachedAdjustment;
+
+	void sendToServer();
 
 private slots:
 	void on_VolumeSlider_valueChanged(int value) override;
-	void on_VolumeSlider_sliderReleased() override;
+	void on_VolumeSlider_changeCompleted() override;
 };
 
 #endif

--- a/src/mumble/UserLocalVolumeSlider.cpp
+++ b/src/mumble/UserLocalVolumeSlider.cpp
@@ -35,7 +35,7 @@ void UserLocalVolumeSlider::on_VolumeSlider_valueChanged(int value) {
 	}
 }
 
-void UserLocalVolumeSlider::on_VolumeSlider_sliderReleased() {
+void UserLocalVolumeSlider::on_VolumeSlider_changeCompleted() {
 	ClientUser *user = ClientUser::get(m_clientSession);
 	if (user) {
 		if (!user->qsHash.isEmpty()) {

--- a/src/mumble/UserLocalVolumeSlider.h
+++ b/src/mumble/UserLocalVolumeSlider.h
@@ -13,7 +13,7 @@ class ClientUser;
 class UserLocalVolumeSlider : public VolumeSliderWidgetAction {
 	Q_OBJECT
 
-	/// The session ID for the user that the dialog is changing the volume for.
+	/// The session ID for the user that the widget is changing the volume for.
 	unsigned int m_clientSession;
 
 public:
@@ -24,7 +24,7 @@ public:
 
 private slots:
 	void on_VolumeSlider_valueChanged(int value);
-	void on_VolumeSlider_sliderReleased();
+	void on_VolumeSlider_changeCompleted();
 };
 
 #endif

--- a/src/mumble/VolumeSliderWidgetAction.h
+++ b/src/mumble/VolumeSliderWidgetAction.h
@@ -27,7 +27,7 @@ protected:
 
 protected slots:
 	virtual void on_VolumeSlider_valueChanged(int){};
-	virtual void on_VolumeSlider_sliderReleased(){};
+	virtual void on_VolumeSlider_changeCompleted(){};
 };
 
 #endif

--- a/src/mumble/widgets/EventFilters.cpp
+++ b/src/mumble/widgets/EventFilters.cpp
@@ -1,0 +1,68 @@
+// Copyright 2023 The Mumble Developers. All rights reserved.
+// Use of this source code is governed by a BSD-style license
+// that can be found in the LICENSE file at the root of the
+// Mumble source tree or at <https://www.mumble.info/LICENSE>.
+
+#include "EventFilters.h"
+
+#include <algorithm>
+
+#include <QKeyEvent>
+#include <QWheelEvent>
+#include <QWidget>
+
+KeyEventObserver::KeyEventObserver(QObject *parent, QEvent::Type eventType, bool consume, std::vector< Qt::Key > keys)
+	: QObject(parent), m_eventType(eventType), m_consume(consume), m_keys(std::move(keys)) {
+}
+
+bool KeyEventObserver::eventFilter(QObject *obj, QEvent *event) {
+	QWidget *widget = static_cast< QWidget * >(obj);
+
+	if (!widget || !widget->hasFocus()) {
+		return false;
+	}
+
+	QKeyEvent *keyEvent = static_cast< QKeyEvent * >(event);
+
+	if (!keyEvent || keyEvent->type() != m_eventType) {
+		return false;
+	}
+
+	Qt::Key key = static_cast< Qt::Key >(keyEvent->key());
+
+	if (std::find(m_keys.begin(), m_keys.end(), key) == m_keys.end()) {
+		return false;
+	}
+
+	emit keyEventObserved();
+
+	return m_consume;
+}
+
+MouseWheelEventObserver::MouseWheelEventObserver(QObject *parent, std::vector< Qt::ScrollPhase > phases, bool consume)
+	: QObject(parent), m_phases(std::move(phases)), m_consume(consume) {
+}
+
+bool MouseWheelEventObserver::eventFilter(QObject *obj, QEvent *event) {
+	QWidget *widget = static_cast< QWidget * >(obj);
+
+	if (!widget || !widget->isVisible()) {
+		return false;
+	}
+
+	QWheelEvent *wheelEvent = static_cast< QWheelEvent * >(event);
+
+	if (!wheelEvent) {
+		return false;
+	}
+
+	Qt::ScrollPhase phase = wheelEvent->phase();
+
+	if (std::find(m_phases.begin(), m_phases.end(), phase) == m_phases.end()) {
+		return false;
+	}
+
+	emit wheelEventObserved(wheelEvent->pixelDelta());
+
+	return m_consume;
+}

--- a/src/mumble/widgets/EventFilters.h
+++ b/src/mumble/widgets/EventFilters.h
@@ -1,0 +1,50 @@
+// Copyright 2023 The Mumble Developers. All rights reserved.
+// Use of this source code is governed by a BSD-style license
+// that can be found in the LICENSE file at the root of the
+// Mumble source tree or at <https://www.mumble.info/LICENSE>.
+
+#ifndef MUMBLE_MUMBLE_WIDGETS_EVENTFILTERS_H_
+#define MUMBLE_MUMBLE_WIDGETS_EVENTFILTERS_H_
+
+#include <vector>
+
+#include <QEvent>
+#include <QObject>
+#include <QPoint>
+
+class KeyEventObserver : public QObject {
+	Q_OBJECT
+
+public:
+	KeyEventObserver(QObject *parent, QEvent::Type eventType, bool consume, std::vector< Qt::Key > keys);
+
+protected:
+	bool eventFilter(QObject *obj, QEvent *event) override;
+
+signals:
+	void keyEventObserved();
+
+private:
+	QEvent::Type m_eventType;
+	bool m_consume;
+	std::vector< Qt::Key > m_keys;
+};
+
+class MouseWheelEventObserver : public QObject {
+	Q_OBJECT
+
+public:
+	MouseWheelEventObserver(QObject *parent, std::vector< Qt::ScrollPhase > phases, bool consume);
+
+protected:
+	bool eventFilter(QObject *obj, QEvent *event) override;
+
+signals:
+	void wheelEventObserved(QPoint delta);
+
+private:
+	std::vector< Qt::ScrollPhase > m_phases;
+	bool m_consume;
+};
+
+#endif


### PR DESCRIPTION
Previously, when using keyboard arrows, the new slider widget action applied the new local volume but did not save it. That was because it used the sliderReleased event to save the value, which is not triggered by keyboard updates.

We could simply save the local volume on every sliderChange instead of on sliderRelease, but that would cause many writes to the disk in a short period of time and possibly lag the client.

This commit introduces an event filter in addition to the sliderChanged event, which is observing key releases. If the slider has focus and left/right is released, it is then calling the save slot of the slider.

Fixes #6211 

