### PR TITLE
Backport "Merge PR #6231: FIX(server,settings,log): announce if settings file is not present" to 1.5.x

### DIFF
--- a/src/murmur/Meta.cpp
+++ b/src/murmur/Meta.cpp
@@ -228,8 +228,13 @@ void MetaParams::read(QString fname) {
 			break;
 	}
 
-	qWarning("Initializing settings from %s (basepath %s)", qPrintable(qsSettings->fileName()),
-			 qPrintable(qdBasePath.absolutePath()));
+	if (QFile::exists(qsAbsSettingsFilePath)) {
+		qWarning("Initializing settings from %s (basepath %s)", qPrintable(qsSettings->fileName()),
+				 qPrintable(qdBasePath.absolutePath()));
+	} else {
+		qWarning("No ini file at %s (basepath %s). Initializing with default settings.",
+				 qPrintable(qsSettings->fileName()), qPrintable(qdBasePath.absolutePath()));
+	}
 
 	QString qsHost = qsSettings->value("host", QString()).toString();
 	if (!qsHost.isEmpty()) {

--- a/src/murmur/Meta.cpp
+++ b/src/murmur/Meta.cpp
@@ -199,7 +199,6 @@ void MetaParams::read(QString fname) {
 			}
 		}
 		if (qsAbsSettingsFilePath.isEmpty()) {
-			QDir::root().mkpath(qdBasePath.absolutePath());
 			qdBasePath            = QDir(datapaths.at(0));
 			qsAbsSettingsFilePath = qdBasePath.absolutePath() + QLatin1String("/mumble-server.ini");
 		}


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `1.5.x`:
 - [Merge PR #6231: FIX(server,settings,log): announce if settings file is not present](https://github.com/mumble-voip/mumble/pull/6231)

<!--- Backport version: 8.9.3 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)