### PR TITLE
FIX(positional-audio): Fix Source Engine plugin not working on Windows

### DIFF
--- a/plugins/se/se.cpp
+++ b/plugins/se/se.cpp
@@ -19,7 +19,11 @@
 
 std::unique_ptr< ProcessBase > proc;
 
+#ifdef OS_WINDOWS
+static constexpr bool isWin32 = true;
+#else
 static bool isWin32 = false;
+#endif
 
 #include "client.h"
 #include "common.h"


### PR DESCRIPTION
The bug was introduced in #4536.

It was only reported last year and because of a side effect: consistent lag for the entire application.
That's something that should be dealt with independently.