### PR TITLE
Backport "Merge PR #6245: FIX(positional-audio): Fix Source Engine plugin not working on Windows" to 1.5.x

### DIFF
--- a/plugins/se/se.cpp
+++ b/plugins/se/se.cpp
@@ -19,7 +19,11 @@
 
 std::unique_ptr< ProcessBase > proc;
 
+#ifdef OS_WINDOWS
+static constexpr bool isWin32 = true;
+#else
 static bool isWin32 = false;
+#endif
 
 #include "client.h"
 #include "common.h"


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `1.5.x`:
 - [Merge PR #6245: FIX(positional-audio): Fix Source Engine plugin not working on Windows](https://github.com/mumble-voip/mumble/pull/6245)

<!--- Backport version: 8.9.3 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)