### PR TITLE
Backport "Merge PR #6192: BUILD(cmake, overlay): Install 32-bit lib on FreeBSD" to 1.5.x

### DIFF
--- a/overlay_gl/CMakeLists.txt
+++ b/overlay_gl/CMakeLists.txt
@@ -96,6 +96,11 @@ if(NOT APPLE)
 					"-ldl"
 					"-lrt"
 			)
+		endif()
+	endif()
+
+	if(${CMAKE_SYSTEM_NAME} STREQUAL "Linux" OR ${CMAKE_SYSTEM_NAME} STREQUAL "FreeBSD")
+		if(TARGET overlay_gl_x86)
 			# install 32bit overlay library
 			install(TARGETS overlay_gl_x86 LIBRARY DESTINATION "${MUMBLE_INSTALL_LIBDIR}")
 		endif()


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `1.5.x`:
 - [Merge PR #6192: BUILD(cmake, overlay): Install 32-bit lib on FreeBSD](https://github.com/mumble-voip/mumble/pull/6192)

<!--- Backport version: 8.9.3 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)