### PR TITLE
FIX(client,theme): Use fixed dark font color for themeless notice labels

### DIFF
--- a/src/mumble/Themes.cpp
+++ b/src/mumble/Themes.cpp
@@ -144,5 +144,6 @@ bool Themes::readStylesheet(const QString &stylesheetFn, QString &stylesheetCont
 
 QString Themes::getDefaultStylesheet() {
 	return QLatin1String(".log-channel{text-decoration:none;}.log-user{text-decoration:none;}p{margin:0;}#qwMacWarning,"
-						 "#qwInlineNotice{background-color:#FFFEDC;border-radius:5px;border:1px solid #B5B59E;}");
+						 "#qwInlineNotice{background-color:#FFFEDC;border-radius:5px;border:1px solid #B5B59E;}"
+						 "#qwMacWarning > QLabel,#qwInlineNotice > QLabel{color:#333;}");
 }


### PR DESCRIPTION
Previously, all "notice" labels had no font color assigned. That means they would use the selected themes default font color. This is fine, if the user would select any theme in Mumble.
However, if the user would select the 'None' theme, the font color would default to the systems default font color. And, if the user had a dark system theme, that would usually mean a very bright font color.
That very bright font color clashes with the hard-coded faint yellow and is therefore hard to read.

This commit hard-codes a dark font color for the notices. This will of course still be overwritten by the Mumble themes, if selected.

Fixes #6160