### PR TITLE
Backport "Merge PR #6256: FIX(client,theme): Use fixed dark font color for themeless notice labels" to 1.5.x

### DIFF
--- a/src/mumble/Themes.cpp
+++ b/src/mumble/Themes.cpp
@@ -144,5 +144,6 @@ bool Themes::readStylesheet(const QString &stylesheetFn, QString &stylesheetCont
 
 QString Themes::getDefaultStylesheet() {
 	return QLatin1String(".log-channel{text-decoration:none;}.log-user{text-decoration:none;}p{margin:0;}#qwMacWarning,"
-						 "#qwInlineNotice{background-color:#FFFEDC;border-radius:5px;border:1px solid #B5B59E;}");
+						 "#qwInlineNotice{background-color:#FFFEDC;border-radius:5px;border:1px solid #B5B59E;}"
+						 "#qwMacWarning > QLabel,#qwInlineNotice > QLabel{color:#333;}");
 }


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `1.5.x`:
 - [Merge PR #6256: FIX(client,theme): Use fixed dark font color for themeless notice labels](https://github.com/mumble-voip/mumble/pull/6256)

<!--- Backport version: 8.9.3 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)