### PR TITLE
FIX(client, Markdown): Code blocks end on three backticks (```) witho…

### DIFF
--- a/src/mumble/Markdown.cpp
+++ b/src/mumble/Markdown.cpp
@@ -267,7 +267,7 @@ bool processMarkdownInlineCode(QString &str, int &offset) {
 bool processMarkdownCodeBlock(QString &str, int &offset) {
 	// Code blocks are marked as ```code```
 	// Also consume a potential following newline as the <pre> tag will cause a linebreak anyways
-	static const QRegularExpression s_regex(QLatin1String("```.*\\n([^`]+)```(\\r\\n|\\n|\\r)?"));
+	static const QRegularExpression s_regex(QLatin1String("```.*\\n([^]*?)```(\\r\\n|\\n|\\r)?"));
 
 	QRegularExpressionMatch match =
 		s_regex.match(str, offset, QRegularExpression::NormalMatch, QRegularExpression::AnchoredMatchOption);


### PR DESCRIPTION
…ut interruption by any other pattern of backticks in the code.

The regex identifying the code blocks of a string in the function `processMarkdownCodeBlock` was here changed from trying to close a code block at its first backtick to only close it by three consecutive backticks.

This allows the use of backticks in code blocks without accidentally cancelling the code block. One example of the content it allows is formatted strings in JavaScript, another is ASCII art containing backticks that do not match the end signature of a code block.

For explanation on how the changed regex operates, see [Regex Match all characters between two strings](https://stackoverflow.com/a/72543781).


### Checks

- [X] My commits follow the [commit guidelines](https://github.com/mumble-voip/mumble/blob/master/COMMIT_GUIDELINES.md)

