### PR TITLE
Backport "Merge PR #6268: FIX(plugins): Compilation with new unified header" to 1.5.x

### DIFF
--- a/plugins/MumblePlugin.h
+++ b/plugins/MumblePlugin.h
@@ -1211,6 +1211,9 @@ mumble_version_t mumble_getPluginFunctionsVersion() {
 			MUMBLE_ECONCAT(MUMBLE_ECONCAT(MumbleAPI_v, MUMBLE_PLUGIN_API_MAJOR_MACRO), MUMBLE_PLUGIN_API_MINOR_MACRO), \
 			x)
 
+#	undef MUMBLE_API_CAST
+#	define MUMBLE_API_CAST(ptr) (*((MUMBLE_API_STRUCT_NAME *) ptr))
+
 // Define some helper macros to make version-specific changes to the API functions
 #	define SELECTED_API_VERSION                                                                  \
 		MUMBLE_PLUGIN_VERSION_CHECK(MUMBLE_PLUGIN_API_MAJOR_MACRO, MUMBLE_PLUGIN_API_MINOR_MACRO, \
@@ -1811,10 +1814,10 @@ struct MUMBLE_API_STRUCT_NAME {
  * Typedef for the Mumble API struct for convenient (unversioned) access
  */
 typedef struct MUMBLE_API_STRUCT_NAME MumbleAPI;
+typedef struct MUMBLE_API_STRUCT_NAME mumble_api_t;
 #	endif
 
 #	undef SELECTED_API_VERSION
-#	undef MUMBLE_API_STRUCT_NAME
 #	undef PARAM_v1_2
 
 #endif // EXTERNAL_MUMBLE_PLUGIN_MUMBLE_API_

--- a/plugins/deadLockPlugin/deadLockPlugin.cpp
+++ b/plugins/deadLockPlugin/deadLockPlugin.cpp
@@ -5,8 +5,7 @@
 
 // Include the definitions of the plugin functions
 // Not that this will also include ../PluginComponents.h
-#include "../MumbleAPI_v_1_0_x.h"
-#include "../MumblePlugin_v_1_0_x.h"
+#include "../MumblePlugin.h"
 
 #include <condition_variable>
 #include <cstring>
@@ -14,7 +13,7 @@
 #include <mutex>
 #include <thread>
 
-MumbleAPI_v_1_0_x mumAPI;
+MumbleAPI mumAPI;
 mumble_connection_t activeConnection;
 mumble_plugin_id_t ownID;
 std::mutex dummyMutex;

--- a/plugins/testPlugin/testPlugin.cpp
+++ b/plugins/testPlugin/testPlugin.cpp
@@ -5,8 +5,7 @@
 
 // Include the definitions of the plugin functions
 // Not that this will also include ../PluginComponents.h
-#include "../MumbleAPI_v_1_0_x.h"
-#include "../MumblePlugin_v_1_0_x.h"
+#include "../MumblePlugin.h"
 
 #include <cstring>
 #include <iostream>


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `1.5.x`:
 - [Merge PR #6268: FIX(plugins): Compilation with new unified header](https://github.com/mumble-voip/mumble/pull/6268)

<!--- Backport version: 8.9.3 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)