### PR TITLE
Always show user count in connect dialog

### DIFF
--- a/src/mumble/ConnectDialog.cpp
+++ b/src/mumble/ConnectDialog.cpp
@@ -470,7 +470,7 @@ QVariant ServerItem::data(int column, int role) const {
 				case 1:
 					return (dPing > 0.0) ? QString::number(uiPing) : QVariant();
 				case 2:
-					return uiUsers ? QString::fromLatin1("%1/%2 ").arg(uiUsers).arg(uiMaxUsers) : QVariant();
+					return QString::fromLatin1("%1/%2 ").arg(uiUsers).arg(uiMaxUsers);
 			}
 		} else if (role == Qt::ToolTipRole) {
 			QStringList ipv4List;


### PR DESCRIPTION
I recently started using Mumble and created my own server. However, the connect dialog doesn't always show the user count. It does if I hover over the server. It made me think that there was something wrong with server and really confused me. This commit adds it in and shows `0/maxusers`. A couple lines down there's no ternary for displaying the same thing. 

![image](https://github.com/mumble-voip/mumble/assets/8362329/816cda71-31df-44e5-a3e3-e1c1c8d3d1dc)

### Checks

- [x] My commits follow the [commit guidelines](https://github.com/mumble-voip/mumble/blob/master/COMMIT_GUIDELINES.md)

