### PR TITLE
FIX(client, ui): Fix log incorrectly scrolling up

### DIFF
--- a/src/mumble/CustomElements.cpp
+++ b/src/mumble/CustomElements.cpp
@@ -22,11 +22,6 @@
 LogTextBrowser::LogTextBrowser(QWidget *p) : QTextBrowser(p) {
 }
 
-void LogTextBrowser::resizeEvent(QResizeEvent *e) {
-	scrollLogToBottom();
-	QTextBrowser::resizeEvent(e);
-}
-
 bool LogTextBrowser::event(QEvent *e) {
 	if (e->type() == LogDocumentResourceAddedEvent::Type) {
 		scrollLogToBottom();

--- a/src/mumble/CustomElements.cpp
+++ b/src/mumble/CustomElements.cpp
@@ -42,6 +42,12 @@ void LogTextBrowser::setLogScroll(int scroll_pos) {
 }
 
 void LogTextBrowser::scrollLogToBottom() {
+	// Without the call to processEvents, the scrollbar sometimes ends up in an
+	// incorrect position after an image is sent to the chat log.
+	//
+	// See: https://github.com/mumble-voip/mumble/issues/2504
+	QApplication::processEvents();
+
 	verticalScrollBar()->setValue(verticalScrollBar()->maximum());
 }
 

--- a/src/mumble/CustomElements.h
+++ b/src/mumble/CustomElements.h
@@ -16,7 +16,6 @@ private:
 	Q_OBJECT
 	Q_DISABLE_COPY(LogTextBrowser)
 protected:
-	void resizeEvent(QResizeEvent *e) Q_DECL_OVERRIDE;
 	bool event(QEvent *e) Q_DECL_OVERRIDE;
 
 public:


### PR DESCRIPTION
When the chat log is detected to be scrolled all the way to the bottom, it is set to the bottom again when new entries are added to the chat log.

The detection works properly, but sometimes (especially when an image is pasted into the chat box) the scroll bar ends up in an incorrect position.

When the chat log ends up in this incorrect state, subsequent calls to `scrollLogToBottom` still work correctly, i.e. resizing the window (which triggers this function) will correctly set the chat log scroll bar to the bottom.

Therefore, the issue seems to be caused by the scrollbar sometimes being in an inconsistent state *immediately* after a message is sent, but not any longer.

My workaround is to add a call to `QApplication::processEvents` before setting the scrollbar to its maximum position to avoid the inconsistent state.

As discussed before, this seems to be an upstream bug in Qt, but my workaround nevertheless seems to fix the issue in my testing.

I have not been able to reproduce the bug locally since applying my changes.

Fixes #2504


### Checks

- [x] My commits follow the [commit guidelines](https://github.com/mumble-voip/mumble/blob/master/COMMIT_GUIDELINES.md)

