### PR TITLE
Backport "Merge PR #6261: FIX(client,markdown): Don't end code-blocks on first backtick" to 1.5.x

### DIFF
--- a/src/mumble/Markdown.cpp
+++ b/src/mumble/Markdown.cpp
@@ -267,7 +267,7 @@ bool processMarkdownInlineCode(QString &str, int &offset) {
 bool processMarkdownCodeBlock(QString &str, int &offset) {
 	// Code blocks are marked as ```code```
 	// Also consume a potential following newline as the <pre> tag will cause a linebreak anyways
-	static const QRegularExpression s_regex(QLatin1String("```.*\\n([^`]+)```(\\r\\n|\\n|\\r)?"));
+	static const QRegularExpression s_regex(QLatin1String("```.*\\n([^]*?)```(\\r\\n|\\n|\\r)?"));
 
 	QRegularExpressionMatch match =
 		s_regex.match(str, offset, QRegularExpression::NormalMatch, QRegularExpression::AnchoredMatchOption);


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `1.5.x`:
 - [Merge PR #6261: FIX(client,markdown): Don't end code-blocks on first backtick](https://github.com/mumble-voip/mumble/pull/6261)

<!--- Backport version: 8.9.3 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)