### PR TITLE
FIX(client): Invalid code-block regex

### DIFF
--- a/src/mumble/Markdown.cpp
+++ b/src/mumble/Markdown.cpp
@@ -267,7 +267,7 @@ bool processMarkdownInlineCode(QString &str, int &offset) {
 bool processMarkdownCodeBlock(QString &str, int &offset) {
 	// Code blocks are marked as ```code```
 	// Also consume a potential following newline as the <pre> tag will cause a linebreak anyways
-	static const QRegularExpression s_regex(QLatin1String("```.*\\n([^]*?)```(\\r\\n|\\n|\\r)?"));
+	static const QRegularExpression s_regex(QLatin1String("```.*\\n((?:[^`]|``?[^`]?)*)```(\\r\\n|\\n|\\r)?"));
 
 	QRegularExpressionMatch match =
 		s_regex.match(str, offset, QRegularExpression::NormalMatch, QRegularExpression::AnchoredMatchOption);


### PR DESCRIPTION
Turns out that the regex introduced in #6261 was using syntax that Qt doesn't support.

Therefore, the regex has been replaced with a valid one that should be functionally identical.


### Checks

- [x] My commits follow the [commit guidelines](https://github.com/mumble-voip/mumble/blob/master/COMMIT_GUIDELINES.md)

