### PR TITLE
FIX(client, ui): Fix log scroll position after loading resources

### DIFF
--- a/src/mumble/CustomElements.cpp
+++ b/src/mumble/CustomElements.cpp
@@ -22,33 +22,17 @@
 LogTextBrowser::LogTextBrowser(QWidget *p) : QTextBrowser(p) {
 }
 
-bool LogTextBrowser::event(QEvent *e) {
-	if (e->type() == LogDocumentResourceAddedEvent::Type) {
-		scrollLogToBottom();
-	}
-	return QTextBrowser::event(e);
-}
-
 int LogTextBrowser::getLogScroll() {
 	return verticalScrollBar()->value();
-}
-
-int LogTextBrowser::getLogScrollMaximum() {
-	return verticalScrollBar()->maximum();
 }
 
 void LogTextBrowser::setLogScroll(int scroll_pos) {
 	verticalScrollBar()->setValue(scroll_pos);
 }
 
-void LogTextBrowser::scrollLogToBottom() {
-	// Without the call to processEvents, the scrollbar sometimes ends up in an
-	// incorrect position after an image is sent to the chat log.
-	//
-	// See: https://github.com/mumble-voip/mumble/issues/2504
-	QApplication::processEvents();
-
-	verticalScrollBar()->setValue(verticalScrollBar()->maximum());
+bool LogTextBrowser::isScrolledToBottom() {
+	const QScrollBar *scrollBar = verticalScrollBar();
+	return scrollBar->value() == scrollBar->maximum();
 }
 
 

--- a/src/mumble/CustomElements.h
+++ b/src/mumble/CustomElements.h
@@ -15,16 +15,13 @@ class LogTextBrowser : public QTextBrowser {
 private:
 	Q_OBJECT
 	Q_DISABLE_COPY(LogTextBrowser)
-protected:
-	bool event(QEvent *e) Q_DECL_OVERRIDE;
 
 public:
 	LogTextBrowser(QWidget *p = nullptr);
 
 	int getLogScroll();
-	int getLogScrollMaximum();
 	void setLogScroll(int scroll_pos);
-	void scrollLogToBottom();
+	bool isScrolledToBottom();
 };
 
 class ChatbarTextEdit : public QTextEdit {

--- a/src/mumble/Log.h
+++ b/src/mumble/Log.h
@@ -181,15 +181,6 @@ private:
 public:
 	LogDocument(QObject *p = nullptr);
 	QVariant loadResource(int, const QUrl &) Q_DECL_OVERRIDE;
-public slots:
-	void finished();
-};
-
-class LogDocumentResourceAddedEvent : public QEvent {
-public:
-	static const QEvent::Type Type = static_cast< QEvent::Type >(20145);
-
-	LogDocumentResourceAddedEvent();
 };
 
 Q_DECLARE_METATYPE(Log::MsgType)


### PR DESCRIPTION
In my previous PR (https://github.com/mumble-voip/mumble/pull/6290) addressing this bug, I wrote:
> The issue seems to be caused by the scrollbar sometimes being in an
> inconsistent state immediately after a message is sent, but not any
> longer.
>
> My workaround is to add a call to QApplication::processEvents before
> setting the scrollbar to its maximum position to avoid the inconsistent
> state.

I have found that this change only reduces the likelihood of the incorrect scroll behaviour from happening: it is still reproducible after the log grows past a certain size.

In my testing since then, the cause of the "inconsistent state" described previously seems to be the following: When images (whose contents are stored in a base64-encoded data URL) are inserted into the log, they are
not loaded immediately. Instead, they are "fetched" (although no actual network request occurs) by the `loadResource` implementation on `LogDocument`. The "fetching" is triggered by the call to `setHtml` in the `Log::validHtml` method. However, the code which sets the scroll bar to stay at the bottom runs immediately (i.e. not asynchronously) in the
`Log::log` method. There also seems to be a hack that forces a re-layout by sending a "font changed" event.

The intended behaviour appears to be that when a log entry is added the log will scroll to the bottom if the entry is a message sent by the user themselves, OR if the log was already scrolled to the bottom before the entry was added.

The previous solution in place addressing the asynchronous image loading was dispatching a `LogDocumentResourceAddedEvent` when the image is loaded whose handler scrolls the log to the bottom, but this causes 2 problems:

First, the handler for this event always scrolls the log to the bottom no matter what, which means messages containing images are handled differently from the intended scrolling behaviour, i.e. messages containing images ALWAYS cause the log to scroll to the bottom instead of obeying the rules described above.

Second, it seemingly causes the issue described in https://github.com/mumble-voip/mumble/issues/2504. It looks like there's a race condition when the scroll position is set from the main thread as well as in an event handler. I couldn't get to the bottom of the exact source of the issue because there is so much deferred execution going on, but I am confident that adding resources/forcing re-layout events from an event handler is to blame.

My current solution is to remove as much of this asynchronous code as possible. The use of a `QNetworkReply` seems to be leftover from when Mumble supported remote images in chat. As described above, this implementation was problematic and its complexity is no longer needed, so I changed the implementation of `LogDocument::loadResource` to simply check that the image URL is valid and has the `data://` scheme and then just fall back to QTextDocument::loadResource`.

Implementing the solution this way eliminates the need for `LogDocumentResourceAddedEvent` because everything happens in order as expected and there is no need to "correct" the scroll value after the image gets loaded. I therefore removed this class and the associated code.

The default behaviour of `QTextEdit` is that it scrolls to the bottom whenever contents are added. `LogTextBrowser::scrollLogToBottom` seems to be a workaround to try to get the log to stay at the bottom despite
the scroll bar jumping issue. With my solution, this method can be removed, and we only need to worry about "restoring" the previous scroll value when a message from another user arrives and the log isn't already scrolled to the bottom.