### PR TITLE
CI(freebsd): Build with C++17 

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -12,7 +12,7 @@ freebsd_task:
   fetch_submodules_script: git submodule --quiet update --init --recursive
   build_script:
   - mkdir build && cd build
-  - cmake -G Ninja -DCMAKE_BUILD_TYPE=Release -DCMAKE_UNITY_BUILD=ON -Dtests=ON -Dsymbols=ON ..
+  - cmake -G Ninja -DCMAKE_BUILD_TYPE=Release -DCMAKE_UNITY_BUILD=ON -Dtests=ON -Dsymbols=ON -DCMAKE_CXX_STANDARD=17 ..
   - cmake --build .
   test_script:
   - cd build

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -37,16 +37,18 @@ project(mumble
 set(3RDPARTY_DIR "${CMAKE_SOURCE_DIR}/3rdparty")
 set(PLUGINS_DIR "${CMAKE_SOURCE_DIR}/plugins")
 
-set(CMAKE_CXX_STANDARD 14)
-set(CMAKE_CXX_EXTENSIONS OFF)
-set(CMAKE_OSX_DEPLOYMENT_TARGET 10.13)
-
 list(APPEND CMAKE_MODULE_PATH
 	"${CMAKE_SOURCE_DIR}/cmake"
 	"${CMAKE_SOURCE_DIR}/cmake/FindModules"
 	"${3RDPARTY_DIR}/FindPythonInterpreter"
 	"${3RDPARTY_DIR}/cmake-compiler-flags"
 )
+
+if(NOT DEFINED CMAKE_CXX_STANDARD)
+	set(CMAKE_CXX_STANDARD 14)
+endif()
+set(CMAKE_CXX_EXTENSIONS OFF)
+set(CMAKE_OSX_DEPLOYMENT_TARGET 10.13)
 
 
 include(pkg-utils)


### PR DESCRIPTION
The protobuf version on the FreeBSD CI image that we are using requires
C++17.

### Checks

- [x] My commits follow the [commit guidelines](https://github.com/mumble-voip/mumble/blob/master/COMMIT_GUIDELINES.md)

