### PR TITLE
FIX(client): Fix PulseAudio regression by nulling buffer

### DIFF
--- a/src/mumble/PulseAudio.cpp
+++ b/src/mumble/PulseAudio.cpp
@@ -660,6 +660,8 @@ void PulseAudioSystem::write_callback(pa_stream *s, size_t bytes, void *userdata
 		pas->bAttenuating = (Global::get().bAttenuateOthers || Global::get().s.bAttenuateOthers);
 
 	} else {
+		std::fill(buffer.begin(), buffer.end(), 0);
+
 		// attenuate if intructed to (self-activated)
 		pas->bAttenuating = Global::get().bAttenuateOthers;
 	}


### PR DESCRIPTION
In b5a67c05f a buffer in the PulseAudio backend was made static, but at the same time the memset(0) was removed.
In combination, that lead to a bug where the last few frames of any given audio played back was repeated until something else filled the buffer.

This commit adds a simple fill to the buffer where the memset(0) previously was fixing the bug.

Exact bug location: https://github.com/mumble-voip/mumble/commit/b5a67c05fb54e030ddadf6219e350fb2ac9eb7f6#diff-3468a698a1554e9292714294b8c8766bff543c8b4949c3fa02ad833084bf2867L648-R665
