### PR TITLE
FIX(client): Fix the size_t type for QT invoke functions in API.

### DIFF
--- a/src/mumble/API.h
+++ b/src/mumble/API.h
@@ -91,14 +91,14 @@ public slots:
 								mumble_channelid_t channelID, const char **name,
 								std::shared_ptr< api_promise_t > promise);
 	void getAllUsers_v_1_0_x(mumble_plugin_id_t callerID, mumble_connection_t connection, mumble_userid_t **users,
-							 size_t *userCount, std::shared_ptr< api_promise_t > promise);
+							 std::size_t *userCount, std::shared_ptr< api_promise_t > promise);
 	void getAllChannels_v_1_0_x(mumble_plugin_id_t callerID, mumble_connection_t connection,
-								mumble_channelid_t **channels, size_t *channelCount,
+								mumble_channelid_t **channels, std::size_t *channelCount,
 								std::shared_ptr< api_promise_t > promise);
 	void getChannelOfUser_v_1_0_x(mumble_plugin_id_t callerID, mumble_connection_t connection, mumble_userid_t userID,
 								  mumble_channelid_t *channelID, std::shared_ptr< api_promise_t > promise);
 	void getUsersInChannel_v_1_0_x(mumble_plugin_id_t callerID, mumble_connection_t connection,
-								   mumble_channelid_t channelID, mumble_userid_t **users, size_t *userCount,
+								   mumble_channelid_t channelID, mumble_userid_t **users, std::size_t *userCount,
 								   std::shared_ptr< api_promise_t > promise);
 	void getLocalUserTransmissionMode_v_1_0_x(mumble_plugin_id_t callerID, mumble_transmission_mode_t *transmissionMode,
 											  std::shared_ptr< api_promise_t > promise);
@@ -153,7 +153,7 @@ public slots:
 	void setMumbleSetting_string_v_1_0_x(mumble_plugin_id_t callerID, mumble_settings_key_t key, const char *value,
 										 std::shared_ptr< api_promise_t > promise);
 	void sendData_v_1_0_x(mumble_plugin_id_t callerID, mumble_connection_t connection, const mumble_userid_t *users,
-						  size_t userCount, const uint8_t *data, size_t dataLength, const char *dataID,
+						  std::size_t userCount, const uint8_t *data, std::size_t dataLength, const char *dataID,
 						  std::shared_ptr< api_promise_t > promise);
 	void log_v_1_0_x(mumble_plugin_id_t callerID, const char *message, std::shared_ptr< api_promise_t > promise);
 	void playSample_v_1_0_x(mumble_plugin_id_t callerID, const char *samplePath,

--- a/src/mumble/API_v_1_x_x.cpp
+++ b/src/mumble/API_v_1_x_x.cpp
@@ -1714,14 +1714,15 @@ C_WRAPPER(getChannelName_v_1_0_x)
 #undef ARG_NAMES
 
 #define TYPED_ARGS \
-	mumble_plugin_id_t callerID, mumble_connection_t connection, mumble_userid_t **users, size_t *userCount
+	mumble_plugin_id_t callerID, mumble_connection_t connection, mumble_userid_t **users, std::size_t *userCount
 #define ARG_NAMES callerID, connection, users, userCount
 C_WRAPPER(getAllUsers_v_1_0_x)
 #undef TYPED_ARGS
 #undef ARG_NAMES
 
-#define TYPED_ARGS \
-	mumble_plugin_id_t callerID, mumble_connection_t connection, mumble_channelid_t **channels, size_t *channelCount
+#define TYPED_ARGS                                                                              \
+	mumble_plugin_id_t callerID, mumble_connection_t connection, mumble_channelid_t **channels, \
+		std::size_t *channelCount
 #define ARG_NAMES callerID, connection, channels, channelCount
 C_WRAPPER(getAllChannels_v_1_0_x)
 #undef TYPED_ARGS
@@ -1736,7 +1737,7 @@ C_WRAPPER(getChannelOfUser_v_1_0_x)
 
 #define TYPED_ARGS                                                                             \
 	mumble_plugin_id_t callerID, mumble_connection_t connection, mumble_channelid_t channelID, \
-		mumble_userid_t **userList, size_t *userCount
+		mumble_userid_t **userList, std::size_t *userCount
 #define ARG_NAMES callerID, connection, channelID, userList, userCount
 C_WRAPPER(getUsersInChannel_v_1_0_x)
 #undef TYPED_ARGS
@@ -1899,9 +1900,9 @@ C_WRAPPER(setMumbleSetting_string_v_1_0_x)
 #undef TYPED_ARGS
 #undef ARG_NAMES
 
-#define TYPED_ARGS                                                                                               \
-	mumble_plugin_id_t callerID, mumble_connection_t connection, const mumble_userid_t *users, size_t userCount, \
-		const uint8_t *data, size_t dataLength, const char *dataID
+#define TYPED_ARGS                                                                                                    \
+	mumble_plugin_id_t callerID, mumble_connection_t connection, const mumble_userid_t *users, std::size_t userCount, \
+		const uint8_t *data, std::size_t dataLength, const char *dataID
 #define ARG_NAMES callerID, connection, users, userCount, data, dataLength, dataID
 C_WRAPPER(sendData_v_1_0_x)
 #undef TYPED_ARGS


### PR DESCRIPTION
QT invoke functions use the size_t type from std:: and some of the API functions that calls these invoke functions using the size_t type from the global namespace.This commit fixes the size_t type as std::size_t for these QT invoke functions.


### Checks

- [x] My commits follow the [commit guidelines](https://github.com/mumble-voip/mumble/blob/master/COMMIT_GUIDELINES.md)

