### PR TITLE
BUILD: Set timezone on release date for reproducibility

### DIFF
--- a/auxiliary_files/CMakeLists.txt
+++ b/auxiliary_files/CMakeLists.txt
@@ -8,7 +8,7 @@ include(pkg-utils)
 
 if(NOT BUILD_RELEASE_DATE)
 	# If BUILD_RELEASE_DATE has not been set, default to time of build
-	string(TIMESTAMP BUILD_RELEASE_DATE "%Y-%m-%d")
+	string(TIMESTAMP BUILD_RELEASE_DATE "%Y-%m-%d" UTC)
 endif()
 
 if(overlay)


### PR DESCRIPTION
To make the build reproducible, it's needed to set the timezone as otherwise the date could vary based on the timezone of the build server.

Link: https://bugs.debian.org/1060254


### Checks

- [x] My commits follow the [commit guidelines](https://github.com/mumble-voip/mumble/blob/master/COMMIT_GUIDELINES.md)

