### PR TITLE
FEAT(client): Introduced new mumble API to link and unlink

### DIFF
--- a/plugins/MumblePlugin.h
+++ b/plugins/MumblePlugin.h
@@ -43,7 +43,7 @@
 #		define MUMBLE_PLUGIN_API_MAJOR_MACRO 1
 #	endif
 #	ifndef MUMBLE_PLUGIN_API_MINOR_MACRO
-#		define MUMBLE_PLUGIN_API_MINOR_MACRO 2
+#		define MUMBLE_PLUGIN_API_MINOR_MACRO 3
 #	endif
 #	ifndef MUMBLE_PLUGIN_API_PATCH_MACRO
 #		define MUMBLE_PLUGIN_API_PATCH_MACRO 0
@@ -233,6 +233,7 @@ enum Mumble_ErrorCode {
 	MUMBLE_EC_DATA_ID_TOO_LONG,
 	MUMBLE_EC_API_REQUEST_TIMEOUT,
 	MUMBLE_EC_OPERATION_UNSUPPORTED_BY_SERVER,
+	MUMBLE_EC_LINK_CHANNEL_NOT_FOUND,
 };
 
 /**
@@ -1807,7 +1808,38 @@ struct MUMBLE_API_STRUCT_NAME {
 	 */
 	mumble_error_t(MUMBLE_PLUGIN_CALLING_CONVENTION *playSample)(mumble_plugin_id_t callerID,
 																 const char *samplePath PARAM_v1_2(float volume));
+
+#	if SELECTED_API_VERSION >= MUMBLE_PLUGIN_VERSION_CHECK(1, 3, 0)
+
+	/**
+	 *
+	 * Requests Mumble to link the given channel to the given linkID.
+	 *
+	 * @param callerID The ID of the plugin calling this function
+	 * @param channelID The ID of the channel to link
+	 * @param linkID The ID of the base channel to link to
+	 * @returns The error code. If everything went well, STATUS_OK will be returned.
+	 */
+	mumble_error_t(MUMBLE_PLUGIN_CALLING_CONVENTION *requestChannelLink)(mumble_plugin_id_t callerID,
+																		 mumble_channelid_t channelID,
+																		 mumble_channelid_t linkID);
+
+	/**
+	 *
+	 * Requests Mumble to unlink the given channel to the given unlinkID.
+	 *
+	 * @param callerID The ID of the plugin calling this function
+	 * @param channelID The ID of the channel to unlink
+	 * @param unlinkID The ID of the base channel to unlink to
+	 * @returns The error code. If everything went well, STATUS_OK will be returned.
+	 */
+	mumble_error_t(MUMBLE_PLUGIN_CALLING_CONVENTION *requestChannelUnlink)(mumble_plugin_id_t callerID,
+																		   mumble_channelid_t channelID,
+																		   mumble_channelid_t unlinkID);
+#	endif
 };
+
+
 
 #	ifdef MUMBLE_PLUGIN_CREATE_MUMBLE_API_TYPEDEF
 /**

--- a/src/mumble/API.h
+++ b/src/mumble/API.h
@@ -91,14 +91,14 @@ public slots:
 								mumble_channelid_t channelID, const char **name,
 								std::shared_ptr< api_promise_t > promise);
 	void getAllUsers_v_1_0_x(mumble_plugin_id_t callerID, mumble_connection_t connection, mumble_userid_t **users,
-							 size_t *userCount, std::shared_ptr< api_promise_t > promise);
+							 std::size_t *userCount, std::shared_ptr< api_promise_t > promise);
 	void getAllChannels_v_1_0_x(mumble_plugin_id_t callerID, mumble_connection_t connection,
-								mumble_channelid_t **channels, size_t *channelCount,
+								mumble_channelid_t **channels, std::size_t *channelCount,
 								std::shared_ptr< api_promise_t > promise);
 	void getChannelOfUser_v_1_0_x(mumble_plugin_id_t callerID, mumble_connection_t connection, mumble_userid_t userID,
 								  mumble_channelid_t *channelID, std::shared_ptr< api_promise_t > promise);
 	void getUsersInChannel_v_1_0_x(mumble_plugin_id_t callerID, mumble_connection_t connection,
-								   mumble_channelid_t channelID, mumble_userid_t **users, size_t *userCount,
+								   mumble_channelid_t channelID, mumble_userid_t **users, std::size_t *userCount,
 								   std::shared_ptr< api_promise_t > promise);
 	void getLocalUserTransmissionMode_v_1_0_x(mumble_plugin_id_t callerID, mumble_transmission_mode_t *transmissionMode,
 											  std::shared_ptr< api_promise_t > promise);
@@ -153,13 +153,17 @@ public slots:
 	void setMumbleSetting_string_v_1_0_x(mumble_plugin_id_t callerID, mumble_settings_key_t key, const char *value,
 										 std::shared_ptr< api_promise_t > promise);
 	void sendData_v_1_0_x(mumble_plugin_id_t callerID, mumble_connection_t connection, const mumble_userid_t *users,
-						  size_t userCount, const uint8_t *data, size_t dataLength, const char *dataID,
+						  std::size_t userCount, const uint8_t *data, std::size_t dataLength, const char *dataID,
 						  std::shared_ptr< api_promise_t > promise);
 	void log_v_1_0_x(mumble_plugin_id_t callerID, const char *message, std::shared_ptr< api_promise_t > promise);
 	void playSample_v_1_0_x(mumble_plugin_id_t callerID, const char *samplePath,
 							std::shared_ptr< api_promise_t > promise);
 	void playSample_v_1_2_x(mumble_plugin_id_t callerID, const char *samplePath, float volume,
 							std::shared_ptr< api_promise_t > promise);
+	void requestChannelLink_v_1_3_x(mumble_plugin_id_t callerID, mumble_channelid_t channelID,
+									mumble_channelid_t linkID, std::shared_ptr< api_promise_t > promise);
+	void requestChannelUnlink_v_1_3_x(mumble_plugin_id_t callerID, mumble_channelid_t channelID,
+									  mumble_channelid_t unlinkID, std::shared_ptr< api_promise_t > promise);
 
 
 private:
@@ -173,6 +177,9 @@ MumbleAPI_v_1_0_x getMumbleAPI_v_1_0_x();
 
 /// @returns The Mumble API struct (v1.2.x)
 MumbleAPI_v_1_2_x getMumbleAPI_v_1_2_x();
+
+/// @returns The Mumble API struct (v1.3.x)
+MumbleAPI_v_1_3_x getMumbleAPI_v_1_3_x();
 
 /// Converts from the Qt key-encoding to the API's key encoding.
 ///

--- a/src/mumble/MumbleAPI_structs.h
+++ b/src/mumble/MumbleAPI_structs.h
@@ -15,6 +15,17 @@
 // First, include the latest plugin API header file completely
 #include "MumblePlugin.h"
 
+// Now, include all older API structs for backward compatibility
+// Re-include the API definition
+#undef EXTERNAL_MUMBLE_PLUGIN_MUMBLE_API_
+// But this time, overwrite the version
+#undef MUMBLE_PLUGIN_API_MAJOR_MACRO
+#define MUMBLE_PLUGIN_API_MAJOR_MACRO 1
+#undef MUMBLE_PLUGIN_API_MINOR_MACRO
+#define MUMBLE_PLUGIN_API_MINOR_MACRO 2
+
+#include "MumblePlugin.h"
+
 
 // Re-include the API definition
 #undef EXTERNAL_MUMBLE_PLUGIN_MUMBLE_API_

--- a/src/mumble/Plugin.cpp
+++ b/src/mumble/Plugin.cpp
@@ -329,6 +329,9 @@ mumble_error_t Plugin::init() {
 	} else if (apiVersion >= mumble_version_t({ 1, 2, 0 }) && apiVersion < mumble_version_t({ 1, 3, 0 })) {
 		MumbleAPI_v_1_2_x api = API::getMumbleAPI_v_1_2_x();
 		registerAPIFunctions(&api);
+	} else if (apiVersion >= mumble_version_t({ 1, 3, 0 }) && apiVersion < mumble_version_t({ 1, 4, 0 })) {
+		MumbleAPI_v_1_3_x api = API::getMumbleAPI_v_1_3_x();
+		registerAPIFunctions(&api);
 	} else {
 		// The API version could not be obtained -> this is an invalid plugin that shouldn't have been loaded in the
 		// first place


### PR DESCRIPTION
This patch introduces a new API to link and unlink the given channels to the given link ids.


### Checks

- [x] My commits follow the [commit guidelines](https://github.com/mumble-voip/mumble/blob/master/COMMIT_GUIDELINES.md)

