### PR TITLE
REFAC(client): Streamline function naming

### DIFF
--- a/src/mumble/MainWindow.cpp
+++ b/src/mumble/MainWindow.cpp
@@ -2730,7 +2730,7 @@ void MainWindow::on_qaRecording_triggered() {
 }
 
 void MainWindow::on_qaAudioTTS_triggered() {
-	toggleAudioTTS(qaAudioTTS->isChecked());
+	enableAudioTTS(qaAudioTTS->isChecked());
 }
 
 void MainWindow::on_qaAudioStats_triggered() {
@@ -3323,7 +3323,7 @@ void MainWindow::on_gsAudioTTS_triggered(bool down, QVariant) {
 		return;
 	}
 
-	toggleAudioTTS(!Global::get().s.bTTS);
+	enableAudioTTS(!Global::get().s.bTTS);
 }
 
 void MainWindow::on_gsHelpAbout_triggered(bool down, QVariant) {
@@ -4135,8 +4135,8 @@ void MainWindow::openCertWizardDialog() {
 	delete cw;
 }
 
-void MainWindow::toggleAudioTTS(const bool &newState) {
-	Global::get().s.bTTS = newState;
+void MainWindow::enableAudioTTS(bool enable) {
+	Global::get().s.bTTS = enable;
 }
 
 void MainWindow::openAboutDialog() {

--- a/src/mumble/MainWindow.h
+++ b/src/mumble/MainWindow.h
@@ -427,7 +427,7 @@ public:
 	void openConfigDialog();
 	void openAudioWizardDialog();
 	void openCertWizardDialog();
-	void toggleAudioTTS(const bool &newState);
+	void enableAudioTTS(bool enable);
 	void openAboutDialog();
 	void openAboutQtDialog();
 	void versionCheck();


### PR DESCRIPTION
The function was called "toggle*" and yet it didn't toggle anything but instead only acted as a setter for the respective property. Therefore, the naming has been adjusted accordingly.


### Checks

- [x] My commits follow the [commit guidelines](https://github.com/mumble-voip/mumble/blob/master/COMMIT_GUIDELINES.md)

