### PR TITLE
FIX(server): Allow unregistered users to transmit access tokens

### DIFF
--- a/src/murmur/Messages.cpp
+++ b/src/murmur/Messages.cpp
@@ -221,28 +221,6 @@ void Server::msgAuthenticate(ServerUser *uSource, MumbleProto::Authenticate &msg
 
 	uSource->iId = id >= 0 ? id : -1;
 
-	if (uSource->iId >= 0) {
-		if (msg.tokens_size() > 0) {
-			// Set the access tokens for the newly connected user
-			QStringList qsl;
-
-			for (int i = 0; i < msg.tokens_size(); ++i) {
-				qsl << u8(msg.tokens(i));
-			}
-
-			{
-				QMutexLocker qml(&qmCache);
-				uSource->qslAccessTokens = qsl;
-			}
-		}
-
-		// Clear cache as the "auth" ACL depends on the user id
-		// and any cached ACL won't have taken that into account yet
-		// Also, if we set access tokens above, we have to reset
-		// the ACL cache anyway.
-		clearACLCache(uSource);
-	}
-
 	QString reason;
 	MumbleProto::Reject_RejectType rtType = MumbleProto::Reject_RejectType_None;
 
@@ -292,6 +270,28 @@ void Server::msgAuthenticate(ServerUser *uSource, MumbleProto::Authenticate &msg
 		reason = QString::fromLatin1("A certificate is required to connect to this server");
 		rtType = MumbleProto::Reject_RejectType_NoCertificate;
 		ok     = false;
+	}
+
+	if (ok) {
+		if (msg.tokens_size() > 0) {
+			// Set the access tokens for the newly connected user
+			QStringList qsl;
+
+			for (int i = 0; i < msg.tokens_size(); ++i) {
+				qsl << u8(msg.tokens(i));
+			}
+
+			{
+				QMutexLocker qml(&qmCache);
+				uSource->qslAccessTokens = qsl;
+			}
+		}
+
+		// Clear cache as the "auth" ACL depends on the user id
+		// and any cached ACL won't have taken that into account yet
+		// Also, if we set access tokens above, we have to reset
+		// the ACL cache anyway.
+		clearACLCache(uSource);
 	}
 
 	Channel *lc       = nullptr;


### PR DESCRIPTION
In 635d71960f cache invalidation for access tokens was added. A check for ``uSource->iId >= 0`` was added which was intended to only parse access tokens, if the ``authenticate`` method was not returning an error code.

As it turns out though, ``uSource->iId`` will be -1 for unREGISTERED users instead of unAUTHENTICATED users which lead to a bug where unregistered users would not have the correct channel access when connecting to the server. A subsequent update of their tokens would fix that.

This commit moves the respective code block down and changes the condition to ``ok``, which should now behave as originally intended.

Fixes #6334