### PR TITLE
FIX(ui): Preserve other check-box states if All messages was checked

### DIFF
--- a/src/mumble/Log.cpp
+++ b/src/mumble/Log.cpp
@@ -190,6 +190,7 @@ void LogConfig::updateSelectAllButtons() {
 		}
 	}
 
+	const QSignalBlocker blocker(qtwMessages);
 	allMessagesItem->setCheckState(ColConsole, allConsoleChecked ? Qt::Checked : Qt::Unchecked);
 	allMessagesItem->setCheckState(ColNotification, allNotificationChecked ? Qt::Checked : Qt::Unchecked);
 	allMessagesItem->setCheckState(ColHighlight, allHighlightChecked ? Qt::Checked : Qt::Unchecked);


### PR DESCRIPTION
In the 'Messages' settings, when disabling a single notification method for a single message type, all check-boxes will disappear in that column if 'All messages' was checked to begin with. This is because the automatic unchecking of the 'All messages' check-box is treated as if the user actually clicked it. Using a `QSignalBlocker` before unchecking the 'All messages' fixes the issue

Fixes #6302


### Checks

- [x] My commits follow the [commit guidelines](https://github.com/mumble-voip/mumble/blob/master/COMMIT_GUIDELINES.md)

