### PR TITLE
FIX(client): Use IPv4 HostAddress representation where applicable

### DIFF
--- a/src/HostAddress.cpp
+++ b/src/HostAddress.cpp
@@ -137,7 +137,11 @@ bool HostAddress::isValid() const {
 }
 
 QHostAddress HostAddress::toAddress() const {
-	return QHostAddress(m_byteRepresentation.data());
+	QHostAddress address = QHostAddress(m_byteRepresentation.data());
+	if (!isV6()) {
+		address.setAddress(address.toIPv4Address());
+	}
+	return address;
 }
 
 QByteArray HostAddress::toByteArray() const {


### PR DESCRIPTION
In 6c565689 the HostAddress was refactored. A check for ``isV6`` when creating a QHostAddress was removed. However, the QHostAddress determines the (IPv4 vs IPv6) distinction at construction time. This resulted in some regressions both visual and functional.

This commit reintroduces the distinction.

Fixes #6349