### PR TITLE
DOCS(ice): Add Channel.temporary read-only notice

### DIFF
--- a/src/murmur/MumbleServer.ice
+++ b/src/murmur/MumbleServer.ice
@@ -117,7 +117,7 @@ module MumbleServer
 		IntList links;
 		/** Description of channel. Shown as tooltip for this channel. */
 		string description;
-		/** Channel is temporary, and will be removed when the last user leaves it. */
+		/** Channel is temporary, and will be removed when the last user leaves it. Read-only. */
 		bool temporary;
 		/** Position of the channel which is used in Client for sorting. */
 		int position;


### PR DESCRIPTION
The Mumble Client UI offers the temporary checkbox only in the Add Channel dialog, not in the Edit Channel dialog.

For Ice consumers it is not obvious that the temporary flag is read-only, and setting it may work but has no effect.
In https://github.com/mumble-voip/mumo/issues/26 it was reported as having no effect.
I did not verify but it is consistent to the Mumble Client UI, hence I am suggesting extending the slice documentation to make this limitation more obvious.