### PR TITLE
FEAT(client): disable pipewire input stream while muted

### DIFF
--- a/src/mumble/AudioInput.cpp
+++ b/src/mumble/AudioInput.cpp
@@ -257,6 +257,8 @@ AudioInput::AudioInput()
 	iHoldFrames     = 0;
 	iBufferedFrames = 0;
 
+	bUserIsMuted = false;
+
 	bResetProcessor = true;
 
 	bEchoMulti = false;
@@ -1240,4 +1242,20 @@ void AudioInput::flushCheck(const QByteArray &frame, bool terminator, std::int32
 
 bool AudioInput::isAlive() const {
 	return isRunning();
+}
+
+void AudioInput::onUserMuteDeafStateChanged() {
+	const ClientUser *user = qobject_cast< ClientUser * >(QObject::sender());
+	updateUserMuteDeafState(user);
+}
+
+void AudioInput::updateUserMuteDeafState(const ClientUser *user) {
+	bool bMuted = user->bSuppress || user->bSelfMute;
+	if (bUserIsMuted != bMuted) {
+		bUserIsMuted = bMuted;
+		onUserMutedChanged();
+	}
+}
+
+void AudioInput::onUserMutedChanged() {
 }

--- a/src/mumble/AudioInput.h
+++ b/src/mumble/AudioInput.h
@@ -264,6 +264,9 @@ protected:
 	void initializeMixer();
 
 	static void adjustBandwidth(int bitspersec, int &bitrate, int &frames, bool &allowLowDelay);
+
+	bool bUserIsMuted;
+
 signals:
 	void doDeaf();
 	void doMute();
@@ -308,6 +311,14 @@ public:
 	void run() Q_DECL_OVERRIDE = 0;
 	virtual bool isAlive() const;
 	bool isTransmitting() const;
+
+	void updateUserMuteDeafState(const ClientUser *user);
+
+protected:
+	virtual void onUserMutedChanged();
+
+public slots:
+	void onUserMuteDeafStateChanged();
 };
 
 #endif

--- a/src/mumble/Messages.cpp
+++ b/src/mumble/Messages.cpp
@@ -170,6 +170,13 @@ void MainWindow::msgServerSync(const MumbleProto::ServerSync &msg) {
 	connect(user, SIGNAL(prioritySpeakerStateChanged()), this, SLOT(userStateChanged()));
 	connect(user, SIGNAL(recordingStateChanged()), this, SLOT(userStateChanged()));
 
+	AudioInputPtr audioIn = Global::get().ai;
+	if (audioIn) {
+		audioIn->updateUserMuteDeafState(user);
+		QObject::connect(user, &ClientUser::muteDeafStateChanged, audioIn.get(),
+						 &AudioInput::onUserMuteDeafStateChanged);
+	}
+
 	qstiIcon->setToolTip(tr("Mumble: %1").arg(Channel::get(Channel::ROOT_ID)->qsName.toHtmlEscaped()));
 
 	// Update QActions and menus

--- a/src/mumble/PipeWire.h
+++ b/src/mumble/PipeWire.h
@@ -36,6 +36,7 @@ public:
 
 	pw_buffer *dequeueBuffer();
 	void queueBuffer(pw_buffer *buffer);
+	void setActive(bool active);
 
 	PipeWireEngine(const char *category, void *param, const std::function< void(void *param) > callback);
 	~PipeWireEngine();
@@ -78,11 +79,14 @@ protected:
 	void (*pw_thread_loop_destroy)(pw_thread_loop *loop);
 	int (*pw_thread_loop_start)(pw_thread_loop *loop);
 	int (*pw_thread_loop_stop)(pw_thread_loop *loop);
+	void (*pw_thread_loop_lock)(pw_thread_loop *loop);
+	void (*pw_thread_loop_unlock)(pw_thread_loop *loop);
 
 	pw_properties *(*pw_properties_new)(const char *key, ...);
 
 	pw_stream *(*pw_stream_new_simple)(pw_loop *loop, const char *name, pw_properties *props,
 									   const pw_stream_events *events, void *data);
+	int (*pw_stream_set_active)(pw_stream *stream, bool active);
 	void (*pw_stream_destroy)(pw_stream *stream);
 	int (*pw_stream_connect)(pw_stream *stream, uint32_t direction, uint32_t target_id, uint32_t flags,
 							 const spa_pod **params, uint32_t n_params);
@@ -105,6 +109,8 @@ protected:
 	std::unique_ptr< PipeWireEngine > m_engine;
 
 	static void processCallback(void *param);
+
+	void onUserMutedChanged() override;
 
 private:
 	Q_OBJECT


### PR DESCRIPTION
When the user is muted and/or suppressed in Mumble, there is no reason to keep the audio stream running (unless the mute cue is enabled).

Disabling/suspending the pipewire stream has the advantage of allowing upstream nodes to suspend themselves as well. When using resource-heavy system-wide audio filters (e.g. via pipewire filter-chain) such as DeepFilterNet, this can save significant amounts of CPU time.

The actual implementation for this in `PipeWire.h/cpp` is dead simple with just 3 function calls, but letting the `AudioInput` know the mute state was a bit more complex. Please let me know in case there is a better approach - I would be happy to change it.

The onUserMutedChanged can potentially be used by other audio backends in the future to implement similar functionality.

### Checks

- [x] My commits follow the [commit guidelines](https://github.com/mumble-voip/mumble/blob/master/COMMIT_GUIDELINES.md)

