### PR TITLE
FIX(client): Fix incorrect WASAPI sound device handling

### DIFF
--- a/src/mumble/WASAPI.cpp
+++ b/src/mumble/WASAPI.cpp
@@ -352,7 +352,7 @@ static IMMDevice *openNamedOrDefaultDevice(const QString &name, EDataFlow dataFl
 	IMMDevice *pDevice = nullptr;
 	// Try to find a device pointer for |name|.
 	if (!name.isEmpty()) {
-		static std::vector< wchar_t > devname;
+		std::vector< wchar_t > devname;
 		devname.resize(name.length() + 1);
 		int len      = name.toWCharArray(devname.data());
 		devname[len] = 0;


### PR DESCRIPTION
In b5a67c05fb54e030ddadf6219e350fb2ac9eb7f6 a refactor took place which removed some compiler warnings.
In WASAPI.cpp a STACKVAR was swapped for a static std::vector,
which led to some unforeseen consequences and total audio input
failure on some systems.

This commit removes the static modifier as it is not needed there
anyway.

Fixes #6356