### PR TITLE
MAINT(github): Drop forums web-link from issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,8 +1,5 @@
 blank_issues_enabled: false
 contact_links:
-  - name: Forums
-    url: https://forums.mumble.info/
-    about: The Mumble forums. Here you can discuss stuff or get help and support.
   - name: Public Matrix channel
     url: https://matrix.to/#/#mumble:matrix.org
     about: The public Mumble chatroom.


### PR DESCRIPTION
Drop obsolete, archived forums web-link from issue templates


### Checks

- [x] My commits follow the [commit guidelines](https://github.com/mumble-voip/mumble/blob/master/COMMIT_GUIDELINES.md)

