### PR TITLE
DOCS(docker): Fix file and doc references

### DIFF
--- a/docs/DockerCompose.md
+++ b/docs/DockerCompose.md
@@ -4,13 +4,13 @@
 
 1. Create a new directory and switch to it.
 
-2. Create the file `docker-compose.yml` and copy the [default docker-compose.yml](../scripts/docker-compose.yml) into it.
+2. Create the file `docker-compose.yml` and fill it according to the [docker-compose section in mumble-docker/README.md](https://github.com/mumble-voip/mumble-docker/blob/master/README.md#running-the-container-1).
 
 3. Create the directory `data` and make `1000` its owner.
 
-4. Create the file `murmur.ini` and copy the [default murmur.ini](../scripts/murmur.ini) into it.
+4. Create the file `mumble-server.ini` and copy the [default mumble-server.ini](../auxiliary_files/mumble-server.ini) into it.
 
-5. Change `database` in `murmur.ini` to `/var/lib/murmur/murmur.sqlite`.
+5. Change `database` in `mumble-server.ini` to `/var/lib/mumble-server/mumble-server.sqlite`.
 
 6. Run `docker-compose up -d`. Append the `--build` switch to force rebuilding, if needed (e.g. new commits since last build).
 


### PR DESCRIPTION
PR #5838 commit 81bb8f70 removed the `docker-compose.yml` file in this repository. It points to our mumble-docker repository for docker related things. In that repository, we do not currently have a default or example docker compose configuration file. The README in that repository does have a description for it, so we link to that now.

Update the relative file path reference `murmur.ini` -> `mumble-server-ini`.

Update `database` path 'murmur' -> 'mumble-server'. I did not test or verify this change. Even if it is incorrect or does not work, I assume it to be *more correct*. Even if nobody chooses to test or verify it in this doc-update-changeset, I think that's preferable.


### Checks

- [x] My commits follow the [commit guidelines](https://github.com/mumble-voip/mumble/blob/master/COMMIT_GUIDELINES.md)

