### PR TITLE
DOCS(git): Add PR and merge commit guidance to commit guidelines

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -2,4 +2,5 @@
 ### Checks
 
 - [ ] My commits follow the [commit guidelines](https://github.com/mumble-voip/mumble/blob/master/COMMIT_GUIDELINES.md)
+- [ ] My pull request title follows the [commit guidelines](https://github.com/mumble-voip/mumble/blob/master/COMMIT_GUIDELINES.md)
 

--- a/COMMIT_GUIDELINES.md
+++ b/COMMIT_GUIDELINES.md
@@ -154,6 +154,25 @@ FIX(client): Crash when loading settings
 MAINT: Add XY to README
 ```
 
+## Pull Requests and Merge Commits
+
+Merge commits shall follow the same commit guidelines and format as "normal" commits.
+They include a pull reqeust reference at the end.
+
+For example:
+
+```
+FEAT(client): Add ReNameNoise as a replacement for RNNoise (#6364)
+```
+
+Pull requests, when accepted, ultimately become merge commits (merging the enclosed commits). Consequently:
+
+**Pull requests should be created with a title and description following the commit guidelines and format.**
+
+A pull request and merge commit encloses one or multiple commits.
+Each commit has their own title and descriptions of changes.
+The pull request and merge commit should title and describe the changeset overall in a summarizing manner.
+
 -----
 
 This guide was inspired by https://github.com/bluejava/git-commit-guide


### PR DESCRIPTION
Implements #6385

Our `scripts/generate_changelog.py` script `pr_number_pattern` already supports PR numbers in the form `(#<nr>)`. [1]

The GitHub repository can be configured to merge with PR `title + (#<nr>) + desc` by default, which would follow these suggested rules.

[1]: https://github.com/mumble-voip/mumble/blob/56f03e8d7e5f9cf9d1a318d3a1858db4e09c06ab/scripts/generate_changelog.py#L22-L24
