### PR TITLE
FIX(client): Prevent local muted users from triggering attenuation

### DIFF
--- a/src/mumble/AudioOutput.cpp
+++ b/src/mumble/AudioOutput.cpp
@@ -449,14 +449,19 @@ bool AudioOutput::mix(void *outbuff, unsigned int frameCount) {
 	// Get the users that are currently talking (and are thus serving as an audio source)
 	QMultiHash< const ClientUser *, AudioOutputBuffer * >::const_iterator it = qmOutputs.constBegin();
 	while (it != qmOutputs.constEnd()) {
+		const ClientUser *user    = it.key();
 		AudioOutputBuffer *buffer = it.value();
+
 		if (!buffer->prepareSampleBuffer(frameCount)) {
 			qlDel.append(buffer);
-		} else {
+		} else if (!user) {
 			qlMix.append(buffer);
+		} else {
+			if (!user->bLocalMute) {
+				qlMix.append(buffer);
+			}
 
-			const ClientUser *user = it.key();
-			if (user && user->bPrioritySpeaker) {
+			if (user->bPrioritySpeaker) {
 				prioritySpeakerActive = true;
 			}
 		}


### PR DESCRIPTION
When 'while others users talk' attenuation is enabled, unmuted users still trigger attenuation even if they are locally muted.

The fix is don't add local muted users' audio source to the mixing for the audio output

Fixes #6247


### Checks

- [x] My commits follow the [commit guidelines](https://github.com/mumble-voip/mumble/blob/master/COMMIT_GUIDELINES.md)

