### PR TITLE
 Backport "Merge PR #6404: MAINT: The OCB design is in the public domain " to 1.5.x

### DIFF
--- a/src/crypto/CryptStateOCB2.cpp
+++ b/src/crypto/CryptStateOCB2.cpp
@@ -5,11 +5,9 @@
 
 /*
  * This code implements OCB-AES128.
- * In the US, OCB is covered by patents. The inventor has given a license
- * to all programs distributed under the GPL.
- * Mumble is BSD (revised) licensed, meaning you can use the code in a
- * closed-source program. If you do, you'll have to either replace
- * OCB with something else or get yourself a license.
+ * The algorithm design was dedicated to the public domain.
+ * https://www.cs.ucdavis.edu/~rogaway/ocb/license.htm
+ * https://www.cs.ucdavis.edu/~rogaway/ocb/ocb-faq.htm
  */
 
 #include <QtCore/QtGlobal>


### PR DESCRIPTION
This will backport the following commits from master to 1.5.x:

* [Merge PR 6404: MAINT: The OCB design is in the public domain](https://github.com/mumble-voip/mumble/pull/6404)

Rationale for back-porting: openSUSE source license checker bot triggers on the patent comment.

Fixes #6403