### PR TITLE
FEAT(client): Introduced new mumble API

### DIFF
--- a/plugins/MumblePlugin.h
+++ b/plugins/MumblePlugin.h
@@ -43,7 +43,7 @@
 #		define MUMBLE_PLUGIN_API_MAJOR_MACRO 1
 #	endif
 #	ifndef MUMBLE_PLUGIN_API_MINOR_MACRO
-#		define MUMBLE_PLUGIN_API_MINOR_MACRO 2
+#		define MUMBLE_PLUGIN_API_MINOR_MACRO 3
 #	endif
 #	ifndef MUMBLE_PLUGIN_API_PATCH_MACRO
 #		define MUMBLE_PLUGIN_API_PATCH_MACRO 0
@@ -1515,6 +1515,42 @@ struct MUMBLE_API_STRUCT_NAME {
 																			mumble_channelid_t channelID,
 																			const char **description);
 
+#	if SELECTED_API_VERSION >= MUMBLE_PLUGIN_VERSION_CHECK(1, 3, 0)
+
+	/**
+	 * Checks whether the linkedChannelID is linked to channelID.
+	 *
+	 * @param callerID The ID of the plugin calling this function
+	 * @param connection The ID of the server-connection
+	 * @param channelID The ID of the channel
+	 * @param linkedChannelID The ID of the linked channel
+	 * @param[out] linked A pointer to where the result of the check
+	 * @returns The error code. If everything went well, STATUS_OK will be returned.
+	 */
+	mumble_error_t(MUMBLE_PLUGIN_CALLING_CONVENTION *isChannelLinkedTo)(mumble_plugin_id_t callerID,
+																		mumble_connection_t connection,
+																		mumble_channelid_t channelID,
+																		mumble_channelid_t linkedChannelID,
+																		bool *linked);
+
+	/**
+	 * Gets the channel set the given channel is linked to.
+	 *
+	 * @param callerID The ID of the plugin calling this function
+	 * @param connection The ID of the server-connection
+	 * @param channelID The ID of the channel
+	 * @param[out] channels The set of channel IDs linked to the channelID
+	 * @param[out] channelCount The amount of linked channels
+	 * @returns The error code. If everything went well, STATUS_OK will be returned. Only then the passed pointers
+	 * may be accessed.
+	 */
+	mumble_error_t(MUMBLE_PLUGIN_CALLING_CONVENTION *getLinkedChannels)(mumble_plugin_id_t callerID,
+																		mumble_connection_t connection,
+																		mumble_channelid_t channelID,
+																		mumble_channelid_t **channels,
+																		size_t *channelCount);
+
+#	endif
 
 	// -------- Request functions --------
 
@@ -1608,7 +1644,97 @@ struct MUMBLE_API_STRUCT_NAME {
 																				 mumble_connection_t connection,
 																				 const char *comment);
 
+#	if SELECTED_API_VERSION >= MUMBLE_PLUGIN_VERSION_CHECK(1, 3, 0)
 
+	/**
+	 * Requests Mumble to link all channels in the given set to each other.
+	 *
+	 * @param callerID The ID of the plugin calling this function
+	 * @param connection The ID of the server-connection
+	 * @param channelSet The set of channel IDs to link
+	 * @param channelCount The number of elements in the channel list
+	 * @returns The error code. If everything went well, STATUS_OK will be returned.
+	 */
+	mumble_error_t(MUMBLE_PLUGIN_CALLING_CONVENTION *requestLinkChannels)(mumble_plugin_id_t callerID,
+																		  mumble_connection_t connection,
+																		  mumble_channelid_t *channelSet,
+																		  size_t channelCount);
+
+	/**
+	 * Requests Mumble to remove any existing links between the provided channel and channels in the provided set.
+	 *
+	 * @param callerID The ID of the plugin calling this function
+	 * @param connection The ID of the server-connection
+	 * @param channelID The ID of the channel to unlink
+	 * @param channelSet The set of channel IDs to remove link from the channelID
+	 * @param channelCount The number of elements in the channel set
+	 * @returns The error code. If everything went well, STATUS_OK will be returned.
+	 */
+	mumble_error_t(MUMBLE_PLUGIN_CALLING_CONVENTION *requestUnlinkChannels)(mumble_plugin_id_t callerID,
+																			mumble_connection_t connection,
+																			mumble_channelid_t channelID,
+																			mumble_channelid_t *channelSet,
+																			size_t channelCount);
+
+
+	/**
+	 * Requests Mumble to remove all links between the provided channels.
+	 *
+	 * @param callerID The ID of the plugin calling this function
+	 * @param connection The ID of the server-connection
+	 * @param channelSet The set of channel IDs to remove link
+	 * @param channelCount The number of elements in the channel set
+	 * @returns The error code. If everything went well, STATUS_OK will be returned.
+	 */
+	mumble_error_t(MUMBLE_PLUGIN_CALLING_CONVENTION *requestUnlinkGivenChannels)(mumble_plugin_id_t callerID,
+																				 mumble_connection_t connection,
+																				 mumble_channelid_t *channelSet,
+																				 size_t channelCount);
+
+
+	/**
+	 * Starts to listen channel set
+	 *
+	 * @param callerID The ID of the plugin calling this function
+	 * @param connection The ID of the server-connection
+	 * @param channelSet The set of channel IDs to listen
+	 * @param channelCount The number of elements in the channel set
+	 * @returns The error code. If everything went well, STATUS_OK will be returned.
+	 */
+	mumble_error_t(MUMBLE_PLUGIN_CALLING_CONVENTION *requestStartListeningToChannels)(mumble_plugin_id_t callerID,
+																					  mumble_connection_t connection,
+																					  mumble_channelid_t *channelSet,
+																					  size_t channelCount);
+
+	/**
+	 * Stops to listen channel set
+	 *
+	 * @param callerID The ID of the plugin calling this function
+	 * @param connection The ID of the server-connection
+	 * @param channelSet The set of channel IDs to stop listen
+	 * @param channelCount The number of elements in the channel set
+	 * @returns The error code. If everything went well, STATUS_OK will be returned.
+	 */
+	mumble_error_t(MUMBLE_PLUGIN_CALLING_CONVENTION *requestStopListeningToChannels)(mumble_plugin_id_t callerID,
+																					 mumble_connection_t connection,
+																					 mumble_channelid_t *channelSet,
+																					 size_t channelCount);
+
+	/**
+	 * Send text message to the given user
+	 *
+	 * @param callerID The ID of the plugin calling this function
+	 * @param connection The ID of the server-connection
+	 * @param userID The ID of the user to send the message
+	 * @param message The message to send
+	 * @returns The error code. If everything went well, STATUS_OK will be returned.
+	 */
+	mumble_error_t(MUMBLE_PLUGIN_CALLING_CONVENTION *requestSendUserTextMessage)(mumble_plugin_id_t callerID,
+																				 mumble_connection_t connection,
+																				 mumble_userid_t userID,
+																				 const char *message);
+
+#	endif
 
 	// -------- Find functions --------
 

--- a/src/mumble/API.h
+++ b/src/mumble/API.h
@@ -107,6 +107,9 @@ public slots:
 	void isLocalUserMuted_v_1_0_x(mumble_plugin_id_t callerID, bool *muted, std::shared_ptr< api_promise_t > promise);
 	void isLocalUserDeafened_v_1_0_x(mumble_plugin_id_t callerID, bool *deafened,
 									 std::shared_ptr< api_promise_t > promise);
+	void isChannelLinkedTo_v_1_3_x(mumble_plugin_id_t callerID, mumble_connection_t connection,
+								   mumble_channelid_t channelID, mumble_channelid_t linkedChannelID, bool *linked,
+								   std::shared_ptr< api_promise_t > promise);
 	void getUserHash_v_1_0_x(mumble_plugin_id_t callerID, mumble_connection_t connection, mumble_userid_t userID,
 							 const char **hash, std::shared_ptr< api_promise_t > promise);
 	void getServerHash_v_1_0_x(mumble_plugin_id_t callerID, mumble_connection_t connection, const char **hash,
@@ -119,6 +122,9 @@ public slots:
 	void getChannelDescription_v_1_0_x(mumble_plugin_id_t callerID, mumble_connection_t connection,
 									   mumble_channelid_t channelID, const char **description,
 									   std::shared_ptr< api_promise_t > promise);
+	void getLinkedChannels_v_1_3_x(mumble_plugin_id_t callerID, mumble_connection_t connection,
+								   mumble_channelid_t channelID, mumble_channelid_t **channels,
+								   std::size_t *channelCount, std::shared_ptr< api_promise_t > promise);
 	void requestUserMove_v_1_0_x(mumble_plugin_id_t callerID, mumble_connection_t connection, mumble_userid_t userID,
 								 mumble_channelid_t channelID, const char *password,
 								 std::shared_ptr< api_promise_t > promise);
@@ -132,6 +138,24 @@ public slots:
 									  std::shared_ptr< api_promise_t > promise);
 	void requestSetLocalUserComment_v_1_0_x(mumble_plugin_id_t callerID, mumble_connection_t connection,
 											const char *comment, std::shared_ptr< api_promise_t > promise);
+	void requestLinkChannels_v_1_3_x(mumble_plugin_id_t callerID, mumble_connection_t connection,
+									 mumble_channelid_t *channelList, std::size_t channelCount,
+									 std::shared_ptr< api_promise_t > promise);
+	void requestUnlinkChannels_v_1_3_x(mumble_plugin_id_t callerID, mumble_connection_t connection,
+									   mumble_channelid_t channelID, mumble_channelid_t *unlinkList,
+									   std::size_t unlinkCount, std::shared_ptr< api_promise_t > promise);
+	void requestUnlinkGivenChannels_v_1_3_x(mumble_plugin_id_t callerID, mumble_connection_t connection,
+											mumble_channelid_t *unlinkList, std::size_t unlinkCount,
+											std::shared_ptr< api_promise_t > promise);
+	void requestStartListeningToChannels_v_1_3_x(mumble_plugin_id_t callerID, mumble_connection_t connection,
+												 mumble_channelid_t *channelList, std::size_t channelCount,
+												 std::shared_ptr< api_promise_t > promise);
+	void requestStopListeningToChannels_v_1_3_x(mumble_plugin_id_t callerID, mumble_connection_t connection,
+												mumble_channelid_t *channelList, std::size_t channelCount,
+												std::shared_ptr< api_promise_t > promise);
+	void requestSendUserTextMessage_v_1_3_x(mumble_plugin_id_t callerID, mumble_connection_t connection,
+											mumble_userid_t userID, const char *message,
+											std::shared_ptr< api_promise_t > promise);
 	void findUserByName_v_1_0_x(mumble_plugin_id_t callerID, mumble_connection_t connection, const char *userName,
 								mumble_userid_t *userID, std::shared_ptr< api_promise_t > promise);
 	void findChannelByName_v_1_0_x(mumble_plugin_id_t callerID, mumble_connection_t connection, const char *channelName,
@@ -173,6 +197,9 @@ MumbleAPI_v_1_0_x getMumbleAPI_v_1_0_x();
 
 /// @returns The Mumble API struct (v1.2.x)
 MumbleAPI_v_1_2_x getMumbleAPI_v_1_2_x();
+
+/// @returns The Mumble API struct (v1.3.x)
+MumbleAPI_v_1_3_x getMumbleAPI_v_1_3_x();
 
 /// Converts from the Qt key-encoding to the API's key encoding.
 ///

--- a/src/mumble/MumbleAPI_structs.h
+++ b/src/mumble/MumbleAPI_structs.h
@@ -15,6 +15,17 @@
 // First, include the latest plugin API header file completely
 #include "MumblePlugin.h"
 
+// Now, include all older API structs for backward compatibility
+// Re-include the API definition
+#undef EXTERNAL_MUMBLE_PLUGIN_MUMBLE_API_
+// But this time, overwrite the version
+#undef MUMBLE_PLUGIN_API_MAJOR_MACRO
+#define MUMBLE_PLUGIN_API_MAJOR_MACRO 1
+#undef MUMBLE_PLUGIN_API_MINOR_MACRO
+#define MUMBLE_PLUGIN_API_MINOR_MACRO 2
+
+#include "MumblePlugin.h"
+
 
 // Re-include the API definition
 #undef EXTERNAL_MUMBLE_PLUGIN_MUMBLE_API_

--- a/src/mumble/Plugin.cpp
+++ b/src/mumble/Plugin.cpp
@@ -329,6 +329,9 @@ mumble_error_t Plugin::init() {
 	} else if (apiVersion >= mumble_version_t({ 1, 2, 0 }) && apiVersion < mumble_version_t({ 1, 3, 0 })) {
 		MumbleAPI_v_1_2_x api = API::getMumbleAPI_v_1_2_x();
 		registerAPIFunctions(&api);
+	} else if (apiVersion >= mumble_version_t({ 1, 3, 0 }) && apiVersion < mumble_version_t({ 1, 4, 0 })) {
+		MumbleAPI_v_1_3_x api = API::getMumbleAPI_v_1_3_x();
+		registerAPIFunctions(&api);
 	} else {
 		// The API version could not be obtained -> this is an invalid plugin that shouldn't have been loaded in the
 		// first place

--- a/src/mumble/ServerHandler.cpp
+++ b/src/mumble/ServerHandler.cpp
@@ -1104,10 +1104,48 @@ void ServerHandler::addChannelLink(unsigned int channel, unsigned int link) {
 	sendMessage(mpcs);
 }
 
+void ServerHandler::addChannelLinks(const unsigned int channelCount, const unsigned int *channelSet) {
+	if (channelCount < 2) {
+		return;
+	}
+	MumbleProto::ChannelState mpcs;
+	mpcs.set_channel_id(channelSet[0]);
+	for (unsigned int i = 1; i < channelCount; i++) {
+		mpcs.add_links_add(channelSet[i]);
+	}
+	sendMessage(mpcs);
+}
+
 void ServerHandler::removeChannelLink(unsigned int channel, unsigned int link) {
 	MumbleProto::ChannelState mpcs;
 	mpcs.set_channel_id(channel);
 	mpcs.add_links_remove(link);
+	sendMessage(mpcs);
+}
+
+void ServerHandler::removeChannelLinks(unsigned int channel, const unsigned int channelCount,
+									   const unsigned int *channelSet) {
+	if (channelCount < 1) {
+		return;
+	}
+	MumbleProto::ChannelState mpcs;
+	mpcs.set_channel_id(channel);
+	for (unsigned int i = 0; i < channelCount; i++) {
+		mpcs.add_links_remove(channelSet[i]);
+	}
+	sendMessage(mpcs);
+}
+
+void ServerHandler::removeChannelLinks(const unsigned int channelCount, const unsigned int *channelSet) {
+	if (channelCount < 2) {
+		return;
+	}
+	MumbleProto::ChannelState mpcs;
+	unsigned int link = channelSet[0];
+	for (unsigned int i = 1; i < channelCount; i++) {
+		mpcs.set_channel_id(link);
+		mpcs.add_links_remove(channelSet[i]);
+	}
 	sendMessage(mpcs);
 }
 

--- a/src/mumble/ServerHandler.h
+++ b/src/mumble/ServerHandler.h
@@ -173,7 +173,11 @@ public:
 	void setTokens(const QStringList &tokens);
 	void removeChannel(unsigned int channel);
 	void addChannelLink(unsigned int channel, unsigned int link);
+	void addChannelLinks(const unsigned int channelCount, const unsigned int *channelSet);
 	void removeChannelLink(unsigned int channel, unsigned int link);
+	void removeChannelLinks(const unsigned int channel, const unsigned int channelCount,
+							const unsigned int *channelSet);
+	void removeChannelLinks(const unsigned int channelCount, const unsigned int *channelSet);
 	void requestChannelPermissions(unsigned int channel);
 	void setSelfMuteDeafState(bool mute, bool deaf);
 	void announceRecordingState(bool recording);


### PR DESCRIPTION
This patch introduces a new API to link, unlink, start to listen, stop the listen the channels and send the messages to the plugins


### Checks

- [ ] My commits follow the [commit guidelines](https://github.com/mumble-voip/mumble/blob/master/COMMIT_GUIDELINES.md)

