### PR TITLE
FIX(client): Crash when loading settings

### DIFF
--- a/src/mumble/ConfigDialog.cpp
+++ b/src/mumble/ConfigDialog.cpp
@@ -200,8 +200,9 @@ void ConfigDialog::on_qlwIcons_currentItemChanged(QListWidgetItem *current, QLis
 		QWidget *w = qhPages.value(qmIconWidgets.value(current));
 		if (w)
 			qswPages->setCurrentWidget(w);
-
-		updateTabOrder();
+		if (previous) {
+			updateTabOrder();
+		}
 	}
 }
 


### PR DESCRIPTION
The settings page could not be opened after the user clicked on the settings button in the main window.

The problem is due to tab button ordering function. This function is called before buttons are created. That's why application throws an assertion error.

Fixes #6421


### Checks

- [x] My commits follow the [commit guidelines](https://github.com/mumble-voip/mumble/blob/master/COMMIT_GUIDELINES.md)

