### PR TITLE
FIX(client): Correctly remember muted state across restarts

### DIFF
--- a/src/mumble/MainWindow.cpp
+++ b/src/mumble/MainWindow.cpp
@@ -136,7 +136,6 @@ MainWindow::MainWindow(QWidget *p)
 #endif
 	forceQuit     = false;
 	restartOnQuit = false;
-	bAutoUnmute   = false;
 
 	Channel::add(Channel::ROOT_ID, tr("Root"));
 
@@ -2716,7 +2715,7 @@ void MainWindow::on_qaAudioDeaf_triggered() {
 		return;
 	}
 
-	if (!qaAudioDeaf->isChecked() && bAutoUnmute) {
+	if (!qaAudioDeaf->isChecked() && Global::get().s.unmuteOnUndeaf) {
 		qaAudioDeaf->setChecked(true);
 		qaAudioMute->setChecked(false);
 		on_qaAudioMute_triggered();
@@ -2730,13 +2729,13 @@ void MainWindow::on_qaAudioDeaf_triggered() {
 	Global::get().s.bDeaf = qaAudioDeaf->isChecked();
 
 	if (Global::get().s.bDeaf && !Global::get().s.bMute) {
-		bAutoUnmute           = true;
-		Global::get().s.bMute = true;
+		Global::get().s.unmuteOnUndeaf = true;
+		Global::get().s.bMute          = true;
 		qaAudioMute->setChecked(true);
 		Global::get().l->log(Log::SelfDeaf, tr("Muted and deafened."));
 	} else if (Global::get().s.bDeaf) {
 		Global::get().l->log(Log::SelfDeaf, tr("Deafened."));
-		bAutoUnmute = false;
+		Global::get().s.unmuteOnUndeaf = false;
 	} else {
 		Global::get().l->log(Log::SelfUndeaf, tr("Undeafened."));
 	}

--- a/src/mumble/MainWindow.h
+++ b/src/mumble/MainWindow.h
@@ -125,7 +125,6 @@ public:
 	bool forceQuit;
 	/// Restart the client after shutdown
 	bool restartOnQuit;
-	bool bAutoUnmute;
 
 	/// Contains the cursor whose position is immediately before the image to
 	/// save when activating the "Save Image As..." context menu item.

--- a/src/mumble/Settings.h
+++ b/src/mumble/Settings.h
@@ -230,6 +230,7 @@ struct Settings {
 	QString qsTxMuteCue = cqsDefaultMuteCue;
 
 	bool bTransmitPosition         = false;
+	bool unmuteOnUndeaf            = false;
 	bool bMute                     = false;
 	bool bDeaf                     = false;
 	bool bTTS                      = false;

--- a/src/mumble/SettingsKeys.h
+++ b/src/mumble/SettingsKeys.h
@@ -35,6 +35,7 @@ namespace SettingsKeys {
  */
 
 // Audio settings
+const SettingsKey UNMUTE_ON_UNDEAF_KEY                        = { "unmute_on_undeaf" };
 const SettingsKey MUTE_KEY                                    = { "mute" };
 const SettingsKey DEAF_KEY                                    = { "deaf" };
 const SettingsKey TRANSMIT_MODE_KEY                           = { "transmit_mode" };

--- a/src/mumble/SettingsMacros.h
+++ b/src/mumble/SettingsMacros.h
@@ -19,6 +19,7 @@
 	PROCESS(misc, CRASH_EMAIL_ADDRESS_KEY, crashReportEmail)
 
 #define AUDIO_SETTINGS                                                                      \
+	PROCESS(audio, UNMUTE_ON_UNDEAF_KEY, unmuteOnUndeaf)                                    \
 	PROCESS(audio, MUTE_KEY, bMute)                                                         \
 	PROCESS(audio, DEAF_KEY, bDeaf)                                                         \
 	PROCESS(audio, TRANSMIT_MODE_KEY, atTransmit)                                           \


### PR DESCRIPTION
Previously, only the "mute" and "deaf" states were saved to the settings file. However, when a user deafens themselves without muting first, Mumble will automatically unmute the user as soon as they undeafen. The "autoUnmute" state was not saved in the settings though, leading to the state "deafened (muted implied)" being reduced to "deafened and muted".

This commit moves the autoUnmute state from being a local member of MainWindow to the settings file allowing to preserve the "deafened (muted implied)" state.

Fixes #6393