### PR TITLE
FIX(client): Remove placeholder wrapping in ChatBar

### DIFF
--- a/src/mumble/CustomElements.h
+++ b/src/mumble/CustomElements.h
@@ -29,6 +29,7 @@ private:
 	Q_OBJECT
 	Q_DISABLE_COPY(ChatbarTextEdit)
 	void inFocus(bool);
+	void applyPlaceholder();
 	QStringList qslHistory;
 	QString qsHistoryTemp;
 	int iHistoryIndex;

--- a/src/mumble/QtWidgetUtils.cpp
+++ b/src/mumble/QtWidgetUtils.cpp
@@ -38,7 +38,7 @@ namespace QtUtils {
 			QTextCursor cursor(&doc);
 			cursor.movePosition(QTextCursor::End);
 
-			const QString elidedPostfix = "...";
+			const QString elidedPostfix = "…";
 			QFontMetrics metric(doc.defaultFont());
 #if QT_VERSION >= QT_VERSION_CHECK(5, 11, 0)
 			uint32_t postfixWidth = static_cast< std::uint32_t >(metric.horizontalAdvance(elidedPostfix));


### PR DESCRIPTION
We simulate placeholder text by setting the actual value of the text edit to "qsDefaultText". This allows us to use html in the placeholder text.
However, the entire text is being displayed no matter the window size. That can lead to annoying automatic resizing while typing and sending messages.

This commit changes the behavior of the ChatBar to switch the wrap mode and elide the text depending on whether we are currently displaying placeholder text.

Fixes #1823
