### PR TITLE
FIX(client): Capture "this" explicitly in lambdas

### DIFF
--- a/src/mumble/GlobalShortcut.cpp
+++ b/src/mumble/GlobalShortcut.cpp
@@ -93,7 +93,7 @@ ShortcutActionWidget::ShortcutActionWidget(QWidget *p) : QWidget(p) {
 	adjustSize();
 
 	KeyEventObserver *eventFilter = new KeyEventObserver(this, QEvent::KeyPress, true, { Qt::Key_Space });
-	connect(eventFilter, &KeyEventObserver::keyEventObserved, this, [=]() { m_comboBox->showPopup(); });
+	connect(eventFilter, &KeyEventObserver::keyEventObserved, this, [this]() { m_comboBox->showPopup(); });
 	installEventFilter(eventFilter);
 
 	QTreeWidget *treeWidget = qobject_cast< QTreeWidget * >(p->parentWidget());
@@ -385,7 +385,7 @@ ShortcutTargetWidget::ShortcutTargetWidget(QWidget *p) : QFrame(p) {
 	l->addWidget(qtbEdit);
 
 	KeyEventObserver *eventFilter = new KeyEventObserver(this, QEvent::KeyPress, true, { Qt::Key_Space });
-	connect(eventFilter, &KeyEventObserver::keyEventObserved, this, [=]() { qtbEdit->click(); });
+	connect(eventFilter, &KeyEventObserver::keyEventObserved, this, [this]() { qtbEdit->click(); });
 	installEventFilter(eventFilter);
 
 	QMetaObject::connectSlotsByName(this);
@@ -402,7 +402,7 @@ TextEditWidget::TextEditWidget(QWidget *p) : QWidget(p) {
 
 	KeyEventObserver *eventFilter = new KeyEventObserver(this, QEvent::KeyPress, true, { Qt::Key_Space });
 	connect(eventFilter, &KeyEventObserver::keyEventObserved, this,
-			[=]() { m_lineEdit->setFocus(Qt::MouseFocusReason); });
+			[this]() { m_lineEdit->setFocus(Qt::MouseFocusReason); });
 	installEventFilter(eventFilter);
 
 	QMetaObject::connectSlotsByName(this);

--- a/src/mumble/ListenerVolumeSlider.cpp
+++ b/src/mumble/ListenerVolumeSlider.cpp
@@ -11,7 +11,7 @@
 
 ListenerVolumeSlider::ListenerVolumeSlider(QWidget *parent) : VolumeSliderWidgetAction(parent), m_currentSendDelay(0) {
 	connect(&m_sendTimer, &QTimer::timeout, this, &ListenerVolumeSlider::sendToServer);
-	connect(&m_resetTimer, &QTimer::timeout, this, [=]() { m_currentSendDelay = 0; });
+	connect(&m_resetTimer, &QTimer::timeout, this, [this]() { m_currentSendDelay = 0; });
 
 	m_sendTimer.setSingleShot(true);
 	m_resetTimer.setSingleShot(true);

--- a/src/mumble/VolumeSliderWidgetAction.cpp
+++ b/src/mumble/VolumeSliderWidgetAction.cpp
@@ -45,13 +45,13 @@ VolumeSliderWidgetAction::VolumeSliderWidgetAction(QWidget *parent)
 	// clicks on the slider bar.
 	MouseClickEventObserver *mouseEventFilter = new MouseClickEventObserver(this, false);
 	m_volumeSlider->installEventFilter(mouseEventFilter);
-	connect(mouseEventFilter, &MouseClickEventObserver::clickEventObserved, this, [=]() {
+	connect(mouseEventFilter, &MouseClickEventObserver::clickEventObserved, this, [this]() {
 		m_volumeSlider->setFocus(Qt::TabFocusReason);
 		updateLabelValue(false);
 	});
 
 	// Also update the label explicitly when the slider body is released.
-	connect(m_volumeSlider, &QSlider::sliderReleased, this, [=]() {
+	connect(m_volumeSlider, &QSlider::sliderReleased, this, [this]() {
 		m_volumeSlider->setFocus(Qt::TabFocusReason);
 		updateLabelValue(false);
 	});


### PR DESCRIPTION
```cpp
src/mumble/GlobalShortcut.cpp:96:74: error: implicit capture of 'this' with a capture default of '=' is deprecated [-Werror,-Wdeprecated-this-capture]
   96 |         connect(eventFilter, &KeyEventObserver::keyEventObserved, this, [=]() { m_comboBox->showPopup(); });
      |                                                                                 ^
src/mumble/GlobalShortcut.cpp:388:74: error: implicit capture of 'this' with a capture default of '=' is deprecated [-Werror,-Wdeprecated-this-capture]
  388 |         connect(eventFilter, &KeyEventObserver::keyEventObserved, this, [=]() { qtbEdit->click(); });
      |                                                                                 ^
src/mumble/GlobalShortcut.cpp:405:12: error: implicit capture of 'this' with a capture default of '=' is deprecated [-Werror,-Wdeprecated-this-capture]
  405 |                         [=]() { m_lineEdit->setFocus(Qt::MouseFocusReason); });
      |                                 ^

src/mumble/ListenerVolumeSlider.cpp:14:57: error: implicit capture of 'this' with a capture default of '=' is deprecated [-Werror,-Wdeprecated-this-capture]
   14 |         connect(&m_resetTimer, &QTimer::timeout, this, [=]() { m_currentSendDelay = 0; });
      |                                                                ^
```