### PR TITLE
Backport "Merge PR #6426: FIX(client): Crash when loading settings" to 1.5.x

### DIFF
--- a/src/mumble/ConfigDialog.cpp
+++ b/src/mumble/ConfigDialog.cpp
@@ -200,8 +200,9 @@ void ConfigDialog::on_qlwIcons_currentItemChanged(QListWidgetItem *current, QLis
 		QWidget *w = qhPages.value(qmIconWidgets.value(current));
 		if (w)
 			qswPages->setCurrentWidget(w);
-
-		updateTabOrder();
+		if (previous) {
+			updateTabOrder();
+		}
 	}
 }
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `1.5.x`:
 - [Merge PR #6426: FIX(client): Crash when loading settings](https://github.com/mumble-voip/mumble/pull/6426)

<!--- Backport version: 8.9.3 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)