### PR TITLE
Backport "Merge PR #6442: FIX(client): Remove placeholder wrapping in ChatBar" to 1.5.x

### DIFF
--- a/src/mumble/CustomElements.h
+++ b/src/mumble/CustomElements.h
@@ -29,6 +29,7 @@ private:
 	Q_OBJECT
 	Q_DISABLE_COPY(ChatbarTextEdit)
 	void inFocus(bool);
+	void applyPlaceholder();
 	QStringList qslHistory;
 	QString qsHistoryTemp;
 	int iHistoryIndex;

--- a/src/mumble/QtWidgetUtils.cpp
+++ b/src/mumble/QtWidgetUtils.cpp
@@ -38,7 +38,7 @@ namespace QtUtils {
 			QTextCursor cursor(&doc);
 			cursor.movePosition(QTextCursor::End);
 
-			const QString elidedPostfix = "...";
+			const QString elidedPostfix = "…";
 			QFontMetrics metric(doc.defaultFont());
 #if QT_VERSION >= QT_VERSION_CHECK(5, 11, 0)
 			uint32_t postfixWidth = static_cast< std::uint32_t >(metric.horizontalAdvance(elidedPostfix));


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `1.5.x`:
 - [Merge PR #6442: FIX(client): Remove placeholder wrapping in ChatBar](https://github.com/mumble-voip/mumble/pull/6442)

<!--- Backport version: 8.9.3 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)