### PR TITLE
FIX(server): Allow to move temporary channels provided sufficient per…

### DIFF
--- a/src/murmur/Messages.cpp
+++ b/src/murmur/Messages.cpp
@@ -1423,8 +1423,10 @@ void Server::msgChannelState(ServerUser *uSource, MumbleProto::ChannelState &msg
 				return;
 			}
 
-			if (!hasPermission(uSource, p, ChanACL::MakeChannel)) {
-				PERM_DENIED(uSource, p, ChanACL::MakeChannel);
+			QFlags< ChanACL::Perm > parentMakePermission =
+				c->bTemporary ? ChanACL::MakeTempChannel : ChanACL::MakeChannel;
+			if (!hasPermission(uSource, p, parentMakePermission)) {
+				PERM_DENIED(uSource, p, parentMakePermission);
 				return;
 			}
 


### PR DESCRIPTION
Previously it was not possible to move temporary channels at all. This appears to be not deliberate as the move failed with a "denied MakeChannel" message. Most likely, this is due to an oversight in efbba85c606f48c1b where temporary channel movement was simply not considered.

This commit fixes the ACL check to look for MakeTempChannel instead of MakeChannel when appropriate.

Fixes #1162
