### PR TITLE
Backport "Merge PR #6454: FIX(server): Allow to move temporary channels provided sufficient per…" to 1.5.x

### DIFF
--- a/src/murmur/Messages.cpp
+++ b/src/murmur/Messages.cpp
@@ -1423,8 +1423,10 @@ void Server::msgChannelState(ServerUser *uSource, MumbleProto::ChannelState &msg
 				return;
 			}
 
-			if (!hasPermission(uSource, p, ChanACL::MakeChannel)) {
-				PERM_DENIED(uSource, p, ChanACL::MakeChannel);
+			QFlags< ChanACL::Perm > parentMakePermission =
+				c->bTemporary ? ChanACL::MakeTempChannel : ChanACL::MakeChannel;
+			if (!hasPermission(uSource, p, parentMakePermission)) {
+				PERM_DENIED(uSource, p, parentMakePermission);
 				return;
 			}
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `1.5.x`:
 - [Merge PR #6454: FIX(server): Allow to move temporary channels provided sufficient per…](https://github.com/mumble-voip/mumble/pull/6454)

<!--- Backport version: 8.9.3 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)