### PR TITLE
Fix the QComboBoxes in ACLEditor

### DIFF
--- a/src/mumble/ACLEditor.cpp
+++ b/src/mumble/ACLEditor.cpp
@@ -652,7 +652,18 @@ void ACLEditor::ACLEnableCheck() {
 
 		if (as->iUserId == -1) {
 			qcbACLUser->clearEditText();
-			qcbACLGroup->addItem(as->qsGroup);
+
+			bool found = false;
+			for (int i = 0; i < qcbACLGroup->count(); i++) {
+				if (qcbACLGroup->itemText(i) == as->qsGroup) {
+					found = true;
+					break;
+				}
+			}
+			if (!found) {
+				qcbACLGroup->addItem(as->qsGroup);
+			}
+
 			qcbACLGroup->setCurrentIndex(qcbACLGroup->findText(as->qsGroup, Qt::MatchExactly));
 		} else {
 			qcbACLUser->setEditText(userName(as->iUserId));

--- a/src/mumble/ACLEditor.cpp
+++ b/src/mumble/ACLEditor.cpp
@@ -169,6 +169,14 @@ ACLEditor::ACLEditor(unsigned int channelid, const MumbleProto::ACL &mea, QWidge
 	qcbACLUser->installEventFilter(focusEventObserver);
 	connect(focusEventObserver, &FocusEventObserver::focusOutObserved, this, &ACLEditor::qcbACLUser_focusLost);
 
+	KeyEventObserver *keyEventObserver = new KeyEventObserver(this, QEvent::KeyPress, false, { Qt::Key_Space });
+	qcbACLGroup->installEventFilter(keyEventObserver);
+	connect(keyEventObserver, &KeyEventObserver::keyEventObserved, this, &ACLEditor::qcbACLGroup_spacePressed);
+
+	keyEventObserver = new KeyEventObserver(this, QEvent::KeyPress, false, { Qt::Key_Space });
+	qcbACLUser->installEventFilter(keyEventObserver);
+	connect(keyEventObserver, &KeyEventObserver::keyEventObserved, this, &ACLEditor::qcbACLUser_spacePressed);
+
 	foreach (User *u, ClientUser::c_qmUsers) {
 		if (u->iId >= 0) {
 			qhNameCache.insert(u->iId, u->qsName);
@@ -857,6 +865,20 @@ void ACLEditor::qcbACLUser_focusLost() {
 	}
 
 	on_qcbACLUser_activated(qcbACLUser->currentText());
+}
+
+void ACLEditor::qcbACLGroup_spacePressed() {
+	if (!qcbACLGroup->currentText().isEmpty()) {
+		return;
+	}
+	qcbACLGroup->showPopup();
+}
+
+void ACLEditor::qcbACLUser_spacePressed() {
+	if (!qcbACLUser->currentText().isEmpty()) {
+		return;
+	}
+	qcbACLUser->showPopup();
 }
 
 void ACLEditor::on_qcbACLGroup_activated(const QString &text) {

--- a/src/mumble/ACLEditor.h
+++ b/src/mumble/ACLEditor.h
@@ -92,6 +92,8 @@ public slots:
 	void ACLPermissions_clicked();
 	void qcbACLGroup_focusLost();
 	void qcbACLUser_focusLost();
+	void qcbACLGroup_spacePressed();
+	void qcbACLUser_spacePressed();
 
 	void on_qcbGroupList_activated(const QString &text);
 	void on_qcbGroupList_editTextChanged(const QString &text);

--- a/src/mumble/ACLEditor.h
+++ b/src/mumble/ACLEditor.h
@@ -88,8 +88,10 @@ public slots:
 	void on_qcbACLApplyHere_clicked(bool checked);
 	void on_qcbACLApplySubs_clicked(bool checked);
 	void on_qcbACLGroup_activated(const QString &text);
-	void on_qcbACLUser_activated();
+	void on_qcbACLUser_activated(const QString &text);
 	void ACLPermissions_clicked();
+	void qcbACLGroup_focusLost();
+	void qcbACLUser_focusLost();
 
 	void on_qcbGroupList_activated(const QString &text);
 	void on_qcbGroupList_editTextChanged(const QString &text);

--- a/src/mumble/widgets/EventFilters.cpp
+++ b/src/mumble/widgets/EventFilters.cpp
@@ -152,3 +152,24 @@ bool SkipFocusEventFilter::eventFilter(QObject *obj, QEvent *event) {
 
 	return QObject::eventFilter(obj, event);
 }
+
+FocusEventObserver::FocusEventObserver(QObject *parent, bool consume) : QObject(parent), m_consume(consume) {
+}
+
+bool FocusEventObserver::eventFilter(QObject *obj, QEvent *event) {
+	QWidget *widget = static_cast< QWidget * >(obj);
+
+	if (widget && event->type() == QEvent::FocusAboutToChange) {
+		QFocusEvent *focusEvent = static_cast< QFocusEvent * >(event);
+
+		if (!widget->hasFocus() && focusEvent->gotFocus()) {
+			emit focusInObserved(focusEvent->reason());
+			return m_consume;
+		} else if (widget->hasFocus() && !focusEvent->gotFocus()) {
+			emit focusOutObserved(focusEvent->reason());
+			return m_consume;
+		}
+	}
+
+	return QObject::eventFilter(obj, event);
+}

--- a/src/mumble/widgets/EventFilters.h
+++ b/src/mumble/widgets/EventFilters.h
@@ -94,4 +94,21 @@ protected:
 	bool eventFilter(QObject *obj, QEvent *event) override;
 };
 
+class FocusEventObserver : public QObject {
+	Q_OBJECT
+
+public:
+	FocusEventObserver(QObject *parent, bool consume);
+
+protected:
+	bool eventFilter(QObject *obj, QEvent *event) override;
+
+signals:
+	void focusInObserved(Qt::FocusReason reason);
+	void focusOutObserved(Qt::FocusReason reason);
+
+private:
+	bool m_consume;
+};
+
 #endif


### PR DESCRIPTION
This contains 3 commits.

The first makes the QComboBoxes in the ACLEditor commit changes when they lose focus, even if the entry was not autocompleted.

The second automatically pops up the QComboBox menu when the user hits space in an empty QComboBox for accessibility reasons

The third removes the redundant entries from the group combo box

Fixes #2359
