### PR TITLE
FEAT(client): Clear local mutes on Mumble restart

### DIFF
--- a/src/mumble/Database.cpp
+++ b/src/mumble/Database.cpp
@@ -399,6 +399,12 @@ void Database::setLocalMuted(const QString &hash, bool muted) {
 	execQueryAndLogFailure(query);
 }
 
+void Database::clearLocalMuted() {
+	QSqlQuery query(db);
+	query.prepare(QLatin1String("DELETE FROM `muted`"));
+	execQueryAndLogFailure(query);
+}
+
 ChannelFilterMode Database::getChannelFilterMode(const QByteArray &server_cert_digest, const unsigned int channel_id) {
 	QSqlQuery query(db);
 

--- a/src/mumble/Database.h
+++ b/src/mumble/Database.h
@@ -48,6 +48,7 @@ public:
 
 	bool isLocalMuted(const QString &hash);
 	void setLocalMuted(const QString &hash, bool muted);
+	void clearLocalMuted();
 
 	float getUserLocalVolume(const QString &hash);
 	void setUserLocalVolume(const QString &hash, float volume);

--- a/src/mumble/main.cpp
+++ b/src/mumble/main.cpp
@@ -658,6 +658,7 @@ int main(int argc, char **argv) {
 
 	// Initialize database
 	Global::get().db = new Database(QLatin1String("main"));
+	Global::get().db->clearLocalMuted();
 
 #ifdef USE_ZEROCONF
 	// Initialize zeroconf


### PR DESCRIPTION
Previously, local muted users would be muted persistently basically forever. This meant that local muting a client could end up being confusing down the line (e.g days later) when the user forgot that they muted someone.
As a means of self-moderation though, local mutes should also not expire when the muted client reconnects or something similar.

This commit clears the all local mutes in the client when Mumble starts.

Fixes #5983