### PR TITLE
BUILD: Use correct type for num locks

### DIFF
--- a/src/SSLLocks.cpp
+++ b/src/SSLLocks.cpp
@@ -10,6 +10,8 @@
 
 #include <openssl/crypto.h>
 
+#include <cassert>
+
 static QMutex **locks = nullptr;
 
 void locking_callback(int mode, int type, const char *, int) {
@@ -47,9 +49,10 @@ unsigned long id_callback() {
 }
 
 void SSLLocks::initialize() {
-	unsigned int nlocks = CRYPTO_num_locks();
+	int nlocks = CRYPTO_num_locks();
+	assert(nlocks >= 0);
 
-	locks = reinterpret_cast< QMutex ** >(calloc(nlocks, sizeof(void *)));
+	locks = reinterpret_cast< QMutex ** >(calloc(static_cast< std::size_t >(nlocks), sizeof(void *)));
 	if (!locks) {
 		qFatal("SSLLocks: unable to allocate locks array");
 
@@ -60,7 +63,7 @@ void SSLLocks::initialize() {
 		exit(1);
 	}
 
-	for (unsigned int i = 0; i < nlocks; i++) {
+	for (unsigned int i = 0; i < static_cast< std::size_t >(nlocks); i++) {
 		locks[i] = new QMutex;
 	}
 


### PR DESCRIPTION
The CRYPTO_num_locks function of OpenSSL returns an int, but we assigned the value to an unsigned int, leading to a compiler warning about a potential sign change.
This is no issue on newer systems as apparently OpenSSL has removed these functions at some point and replaced them with a macro that evaluates to a numeric constant (1). However, on older systems such as CentOS 7, this function still seems to exist and there it actually matters that we are using a wrong type.

Fixes #6467


### Checks

- [x] My commits follow the [commit guidelines](https://github.com/mumble-voip/mumble/blob/master/COMMIT_GUIDELINES.md)

