### PR TITLE
FIX(client): Update tab order in AudioInput.ui

### DIFF
--- a/src/mumble/AudioInput.ui
+++ b/src/mumble/AudioInput.ui
@@ -1188,7 +1188,7 @@
   <tabstop>qcbEcho</tabstop>
   <tabstop>qrbNoiseSupDeactivated</tabstop>
   <tabstop>qrbNoiseSupSpeex</tabstop>
-  <tabstop>qrbNoiseSupRNNoise</tabstop>
+  <tabstop>qrbNoiseSupReNameNoise</tabstop>
   <tabstop>qrbNoiseSupBoth</tabstop>
   <tabstop>qsSpeexNoiseSupStrength</tabstop>
   <tabstop>qcbEnableCuePTT</tabstop>


### PR DESCRIPTION
In #6364 RNNoise was replaced with ReNameNoise. I missed the tab-order in AudioInput.ui and it sill contained the old name for the UI element leading to compile-time warnings.
This commit fixes the tab-order.

