### PR TITLE
Backport "Merge PR #6478: FIX(client): Update tab order in AudioInput.ui" to 1.5.x

### DIFF
--- a/src/mumble/AudioInput.ui
+++ b/src/mumble/AudioInput.ui
@@ -1188,7 +1188,7 @@
   <tabstop>qcbEcho</tabstop>
   <tabstop>qrbNoiseSupDeactivated</tabstop>
   <tabstop>qrbNoiseSupSpeex</tabstop>
-  <tabstop>qrbNoiseSupRNNoise</tabstop>
+  <tabstop>qrbNoiseSupReNameNoise</tabstop>
   <tabstop>qrbNoiseSupBoth</tabstop>
   <tabstop>qsSpeexNoiseSupStrength</tabstop>
   <tabstop>qcbEnableCuePTT</tabstop>


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `1.5.x`:
 - [Merge PR #6478: FIX(client): Update tab order in AudioInput.ui](https://github.com/mumble-voip/mumble/pull/6478)

<!--- Backport version: 8.9.3 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)