### PR TITLE
MAINT(ci): Upgrade to macOS 12 on Azure Pipelines

### DIFF
--- a/.ci/azure-pipelines/main.yml
+++ b/.ci/azure-pipelines/main.yml
@@ -41,7 +41,7 @@ jobs:
     workspace:
       clean: all
     pool:
-      vmImage: 'macOS-11'
+      vmImage: 'macOS-12'
     variables:
       MUMBLE_ENVIRONMENT_VERSION: 'mumble_env.x64-osx-release.2023-12-31.6a3ce9c65'
       MUMBLE_ENVIRONMENT_TRIPLET: 'x64-osx-release'


### PR DESCRIPTION
The macOS 11 image has been deprecated and is likely to (or already has been?) be removed entirely.


### Checks

- [x] My commits follow the [commit guidelines](https://github.com/mumble-voip/mumble/blob/master/COMMIT_GUIDELINES.md)

