### PR TITLE
FIX(client): Do not spam log when adjusting volume of clients without certificate

### DIFF
--- a/src/mumble/UserLocalVolumeSlider.cpp
+++ b/src/mumble/UserLocalVolumeSlider.cpp
@@ -11,6 +11,7 @@
 #include "Global.h"
 
 UserLocalVolumeSlider::UserLocalVolumeSlider(QWidget *parent) : VolumeSliderWidgetAction(parent) {
+	connect(m_volumeSlider, &QSlider::sliderReleased, this, &UserLocalVolumeSlider::on_VolumeSlider_sliderReleased);
 }
 
 void UserLocalVolumeSlider::setUser(unsigned int sessionId) {
@@ -40,10 +41,15 @@ void UserLocalVolumeSlider::on_VolumeSlider_changeCompleted() {
 	if (user) {
 		if (!user->qsHash.isEmpty()) {
 			Global::get().db->setUserLocalVolume(user->qsHash, user->getLocalVolumeAdjustments());
-		} else {
-			Global::get().mw->logChangeNotPermanent(QObject::tr("Local Volume Adjustment..."), user);
 		}
 
 		updateLabelValue();
+	}
+}
+
+void UserLocalVolumeSlider::on_VolumeSlider_sliderReleased() {
+	ClientUser *user = ClientUser::get(m_clientSession);
+	if (user && user->qsHash.isEmpty()) {
+		Global::get().mw->logChangeNotPermanent(QObject::tr("Local Volume Adjustment..."), user);
 	}
 }

--- a/src/mumble/UserLocalVolumeSlider.h
+++ b/src/mumble/UserLocalVolumeSlider.h
@@ -25,6 +25,7 @@ public:
 private slots:
 	void on_VolumeSlider_valueChanged(int value) override;
 	void on_VolumeSlider_changeCompleted() override;
+	void on_VolumeSlider_sliderReleased();
 };
 
 #endif


### PR DESCRIPTION
In #5776 the local volume adjustment sliders were moved into the user context menu. A log warning message appears, if you adjust the volume of a client without certificate.
Due to a combination of Qt's buggy MouseWheel events and the oversight that volume changes to the DB happen much more frequently with that change, the log warning messages are spammed way to often now in that case.

This commit moves the log warning message explicitly into a separate slot on slider release. Note: We "lose" the warning message for other input methods that are not "releasing the slider", but given the fact that certificates are pretty prevalent now and dragging the slider is likely the most often used input method, this will likely affect a very little amount of users.

Fixes #6462