### PR TITLE
Backport "Merge PR #6484: MAINT(ci): Upgrade to macOS 12 on Azure Pipelines" to 1.5.x

### DIFF
--- a/.ci/azure-pipelines/main.yml
+++ b/.ci/azure-pipelines/main.yml
@@ -41,7 +41,7 @@ jobs:
     workspace:
       clean: all
     pool:
-      vmImage: 'macOS-11'
+      vmImage: 'macOS-12'
     variables:
       MUMBLE_ENVIRONMENT_VERSION: 'mumble_env.x64-osx-release.2023-12-31.6a3ce9c65'
       MUMBLE_ENVIRONMENT_TRIPLET: 'x64-osx-release'


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `1.5.x`:
 - [Merge PR #6484: MAINT(ci): Upgrade to macOS 12 on Azure Pipelines](https://github.com/mumble-voip/mumble/pull/6484)

<!--- Backport version: 8.9.3 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)