### PR TITLE
Backport "Merge PR #6486: FIX(client): Do not spam log when adjusting volume of clients without certificate" to 1.5.x

### DIFF
--- a/src/mumble/UserLocalVolumeSlider.cpp
+++ b/src/mumble/UserLocalVolumeSlider.cpp
@@ -11,6 +11,7 @@
 #include "Global.h"
 
 UserLocalVolumeSlider::UserLocalVolumeSlider(QWidget *parent) : VolumeSliderWidgetAction(parent) {
+	connect(m_volumeSlider, &QSlider::sliderReleased, this, &UserLocalVolumeSlider::on_VolumeSlider_sliderReleased);
 }
 
 void UserLocalVolumeSlider::setUser(unsigned int sessionId) {
@@ -40,10 +41,15 @@ void UserLocalVolumeSlider::on_VolumeSlider_changeCompleted() {
 	if (user) {
 		if (!user->qsHash.isEmpty()) {
 			Global::get().db->setUserLocalVolume(user->qsHash, user->getLocalVolumeAdjustments());
-		} else {
-			Global::get().mw->logChangeNotPermanent(QObject::tr("Local Volume Adjustment..."), user);
 		}
 
 		updateLabelValue();
+	}
+}
+
+void UserLocalVolumeSlider::on_VolumeSlider_sliderReleased() {
+	ClientUser *user = ClientUser::get(m_clientSession);
+	if (user && user->qsHash.isEmpty()) {
+		Global::get().mw->logChangeNotPermanent(QObject::tr("Local Volume Adjustment..."), user);
 	}
 }

--- a/src/mumble/UserLocalVolumeSlider.h
+++ b/src/mumble/UserLocalVolumeSlider.h
@@ -25,6 +25,7 @@ public:
 private slots:
 	void on_VolumeSlider_valueChanged(int value) override;
 	void on_VolumeSlider_changeCompleted() override;
+	void on_VolumeSlider_sliderReleased();
 };
 
 #endif


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `1.5.x`:
 - [Merge PR #6486: FIX(client): Do not spam log when adjusting volume of clients without certificate](https://github.com/mumble-voip/mumble/pull/6486)

<!--- Backport version: 8.9.3 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)