### PR TITLE
Backport "MAINT(ci): Various maintenance work related to CI configs" to 1.5.x

### DIFF
--- a/.ci/azure-pipelines/install-environment_linux.bash
+++ b/.ci/azure-pipelines/install-environment_linux.bash
@@ -7,11 +7,31 @@
 
 sudo apt-get update
 
-sudo apt-get -y install build-essential g++-multilib ninja-build pkg-config \
-                        qt5-default qttools5-dev qttools5-dev-tools libqt5svg5-dev \
-                        libboost-dev libssl-dev libprotobuf-dev protobuf-compiler libprotoc-dev \
-                        libcap-dev libxi-dev \
-                        libasound2-dev libasound2-plugins libasound2-plugins-extra\
-                        libogg-dev libsndfile1-dev libopus-dev libspeechd-dev \
-                        libavahi-compat-libdnssd-dev libzeroc-ice-dev \
-						zsync appstream libpoco-dev
+sudo apt -y install \
+	build-essential \
+	g++-multilib \
+	ninja-build \
+	pkg-config \
+	qtbase5-dev \
+	qttools5-dev \
+	qttools5-dev-tools \
+	libqt5svg5-dev \
+	libboost-dev \
+	libssl-dev \
+	libprotobuf-dev \
+	protobuf-compiler \
+	libprotoc-dev \
+	libcap-dev \
+	libxi-dev \
+	libasound2-dev \
+	libasound2-plugins \
+	libasound2-plugins-extra \
+	libogg-dev \
+	libsndfile1-dev \
+	libopus-dev \
+	libspeechd-dev \
+	libavahi-compat-libdnssd-dev \
+	libzeroc-ice-dev \
+	zsync \
+	appstream \
+	libpoco-dev

--- a/.ci/azure-pipelines/main-pr.yml
+++ b/.ci/azure-pipelines/main-pr.yml
@@ -43,7 +43,7 @@ jobs:
     workspace:
       clean: all
     pool:
-      vmImage: 'macOS-11'
+      vmImage: 'macOS-12'
     variables:
       MUMBLE_ENVIRONMENT_VERSION: 'mumble_env.x64-osx-release.2023-12-31.6a3ce9c65'
       MUMBLE_ENVIRONMENT_TRIPLET: 'x64-osx-release'

--- a/.ci/azure-pipelines/main-pr.yml
+++ b/.ci/azure-pipelines/main-pr.yml
@@ -35,7 +35,7 @@ jobs:
     workspace:
       clean: all
     pool:
-      vmImage: 'ubuntu-20.04'
+      vmImage: 'ubuntu-22.04'
     steps:
     - template: steps_linux.yml
 

--- a/.ci/azure-pipelines/main.yml
+++ b/.ci/azure-pipelines/main.yml
@@ -33,7 +33,7 @@ jobs:
     workspace:
       clean: all
     pool:
-      vmImage: 'ubuntu-20.04'
+      vmImage: 'ubuntu-22.04'
     steps:
     - template: steps_linux.yml
 

--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Backport Action
-        uses: sqren/backport-github-action@v9.5.1
+        uses: sorenlouv/backport-github-action@v9.5.1
         with:
           github_token: ${{ secrets.BACKPORT_TOKEN }}
           auto_backport_label_prefix: auto-backport-to-

--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -8,16 +8,9 @@ jobs:
   backport:
     name: Backport PR
     runs-on: ubuntu-latest
-    if: |
-      github.event.pull_request.merged == true
-      && contains(github.event.pull_request.labels.*.name, 'backport-needed')
-      && (
-        (github.event.action == 'labeled' && github.event.label.name == 'backport-needed')
-        || (github.event.action == 'closed')
-      )
     steps:
       - name: Backport Action
-        uses: sqren/backport-github-action@v8.9.3
+        uses: sqren/backport-github-action@v9.5.1
         with:
           github_token: ${{ secrets.BACKPORT_TOKEN }}
           auto_backport_label_prefix: auto-backport-to-

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -46,7 +46,7 @@ jobs:
     strategy:
         fail-fast: false
         matrix:
-            os: [ubuntu-20.04, ubuntu-22.04]
+            os: [ubuntu-22.04, ubuntu-24.04]
             type: [shared] # Currently the "static" build doesn't work for Linux systems
             arch: [64bit]
             

--- a/.github/workflows/code-ql.yml
+++ b/.github/workflows/code-ql.yml
@@ -36,13 +36,13 @@ jobs:
       contents: read
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
           submodules: 'recursive'
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v2
+      uses: github/codeql-action/init@v3
       with:
           languages: python, cpp
 
@@ -66,4 +66,4 @@ jobs:
       shell: bash
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v2
+      uses: github/codeql-action/analyze@v3

--- a/.github/workflows/code-ql.yml
+++ b/.github/workflows/code-ql.yml
@@ -24,7 +24,11 @@ jobs:
     needs: pre_run
     if: needs.pre_run.outputs.should_skip != 'true'
 
-    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        os: [ubuntu-latest]
+
+    runs-on: ${{ matrix.os }}
 
     permissions:
       security-events: write
@@ -45,7 +49,7 @@ jobs:
     - uses: ./.github/actions/install-dependencies
       with:
           type: shared
-          os: ubuntu-20.04
+          os: ${{ matrix.os }}
           arch: 64bit
 
     - name: Create build dir

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -4,7 +4,11 @@ on: [pull_request]
 
 jobs:
   pr-checks:
-    runs-on: ubuntu-20.04
+    strategy:
+      matrix:
+        os: [ubuntu-latest]
+
+    runs-on: ${{ matrix.os }}
 
     steps:
 
@@ -32,7 +36,7 @@ jobs:
     - uses: ./.github/actions/install-dependencies
       with:
           type: shared
-          os: ubuntu-20.04
+          os: ${{ matrix.os }}
           arch: 64bit
 
     - name: Generate compile-command DB

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -16,7 +16,7 @@ jobs:
       run: sudo apt install python3
       shell: bash
 
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
           # Assume that there are not >200 new commits that need checking
           fetch-depth: 200
@@ -44,8 +44,8 @@ jobs:
       shell: bash
 
     - name: Check code formatting
-      uses: jidicula/clang-format-action@v3.5.2
+      uses: jidicula/clang-format-action@v4.13.0
       with:
           clang-format-version: '10'
           check-path: '.'
-          exclude-regex: '(3rdparty/*|build/*)'
+          exclude-regex: '(\\.git/.*|3rdparty/.*|build/.*|.*proto$)'

--- a/.github/workflows/release_dispatch.yml
+++ b/.github/workflows/release_dispatch.yml
@@ -9,7 +9,7 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - name: "Dispatch release to mumble-docker repo"
-              uses: peter-evans/repository-dispatch@v2
+              uses: peter-evans/repository-dispatch@v3
               with:
                   token: ${{ secrets.DOCKER_REPO_ACCCESS_TOKEN }}
                   event-type: new_release

--- a/.github/workflows/stale_issues.yml
+++ b/.github/workflows/stale_issues.yml
@@ -11,7 +11,7 @@ jobs:
     permissions:
       issues: write
     steps:
-      - uses: actions/stale@v5
+      - uses: actions/stale@v9
         with:
           days-before-issue-stale: 14
           days-before-issue-close:  7
@@ -31,7 +31,7 @@ jobs:
     permissions:
       issues: write
     steps:
-      - uses: actions/stale@v5
+      - uses: actions/stale@v9
         with:
           days-before-issue-stale: 4
           days-before-issue-close: 3


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `1.5.x`:
 - [Merge PR #6494: MAINT(ci): Various maintenance work related to CI configs](https://github.com/mumble-voip/mumble/pull/6494)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)