### PR TITLE
MAINT: Only run backport action when PR is merged

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -7,6 +7,7 @@ on:
 jobs:
   backport:
     name: Backport PR
+    if: github.event.pull_request.merged == true
     runs-on: ubuntu-latest
     steps:
       - name: Backport Action


### PR DESCRIPTION
### Checks

- [x] My commits follow the [commit guidelines](https://github.com/mumble-voip/mumble/blob/master/COMMIT_GUIDELINES.md)

