### PR TITLE
Backport "MAINT: Only run backport action when PR is merged" to 1.5.x

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -7,6 +7,7 @@ on:
 jobs:
   backport:
     name: Backport PR
+    if: github.event.pull_request.merged == true
     runs-on: ubuntu-latest
     steps:
       - name: Backport Action


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `1.5.x`:
 - [Merge PR #6496: MAINT: Only run backport action when PR is merged](https://github.com/mumble-voip/mumble/pull/6496)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)