### PR TITLE
FIX(client, plugins): Wrong sample count in plugin callback

### DIFF
--- a/src/mumble/AudioInput.cpp
+++ b/src/mumble/AudioInput.cpp
@@ -1092,7 +1092,9 @@ void AudioInput::encodeAudioFrame(AudioChunk chunk) {
 	EncodingOutputBuffer buffer;
 	Q_ASSERT(buffer.size() >= static_cast< size_t >(iAudioQuality / 100 * iAudioFrames / 8));
 
-	emit audioInputEncountered(psSource, iFrameSize, iMicChannels, SAMPLE_RATE, bIsSpeech);
+	assert(iFrameSize % iMicChannels == 0);
+	const unsigned int samplesPerChannel = iFrameSize / iMicChannels;
+	emit audioInputEncountered(psSource, samplesPerChannel, iMicChannels, SAMPLE_RATE, bIsSpeech);
 
 	int len = 0;
 


### PR DESCRIPTION
In the mumble_onAudioInput callback that plugins can use, the sampleCount parameter was actually wrong for all cases in which the input had more than a single channel. Instead of the sample count per channel, the total sample count (across all channels) was passed along.

Fixes #6464


### Checks

- [x] My commits follow the [commit guidelines](https://github.com/mumble-voip/mumble/blob/master/COMMIT_GUIDELINES.md)

