### PR TITLE
Backport "Merge PR #6498: MAINT: Update backport config" to 1.5.x

### DIFF
--- a/.backportrc.json
+++ b/.backportrc.json
@@ -1,11 +1,17 @@
 {
-	"upstream": "mumble-voip/mumble",
+	"repoName": "mumble",
+	"repoOwner": "mumble-voip",
 	"targetBranchChoices": [
-		{ "name": "1.5.x", "checked": true },
+		{
+			"name": "1.5.x",
+			"checked": true
+		},
 		"1.4.x"
 	],
-	"targetPRLabels": ["backport"],
+	"targetPRLabels": [
+		"backport"
+	],
 	"fork": true,
 	"multipleCommits": true,
-	"prTitle": "Backport \"{commitMessages}\" to {targetBranch}"
+	"prTitle": "Backport \"{{commitMessages}}\" to {{targetBranch}}"
 }


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `1.5.x`:
 - [Merge PR #6498: MAINT: Update backport config](https://github.com/mumble-voip/mumble/pull/6498)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)