### PR TITLE
Backport "Merge PR #6499: FIX(client, plugins): Wrong sample count in plugin callback" to 1.5.x

### DIFF
--- a/src/mumble/AudioInput.cpp
+++ b/src/mumble/AudioInput.cpp
@@ -1090,7 +1090,9 @@ void AudioInput::encodeAudioFrame(AudioChunk chunk) {
 	EncodingOutputBuffer buffer;
 	Q_ASSERT(buffer.size() >= static_cast< size_t >(iAudioQuality / 100 * iAudioFrames / 8));
 
-	emit audioInputEncountered(psSource, iFrameSize, iMicChannels, SAMPLE_RATE, bIsSpeech);
+	assert(iFrameSize % iMicChannels == 0);
+	const unsigned int samplesPerChannel = iFrameSize / iMicChannels;
+	emit audioInputEncountered(psSource, samplesPerChannel, iMicChannels, SAMPLE_RATE, bIsSpeech);
 
 	int len = 0;
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `1.5.x`:
 - [Merge PR #6499: FIX(client, plugins): Wrong sample count in plugin callback](https://github.com/mumble-voip/mumble/pull/6499)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)