### PR TITLE
Backport "Merge PR #6502: MAINT(ci): Don't run backport action on backport PRs" to 1.5.x

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   backport:
     name: Backport PR
-    if: github.event.pull_request.merged == true
+    if: github.event.pull_request.merged == true && !(contains(github.event.pull_request.labels.*.name, 'backport'))
     runs-on: ubuntu-latest
     steps:
       - name: Backport Action


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `1.5.x`:
 - [Merge PR #6502: MAINT(ci): Don&#x27;t run backport action on backport PRs](https://github.com/mumble-voip/mumble/pull/6502)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)