### PR TITLE
FIX(client): Fix crash on mono pos. audio warning from audio thread

### DIFF
--- a/src/mumble/AudioOutput.cpp
+++ b/src/mumble/AudioOutput.cpp
@@ -415,7 +415,7 @@ void AudioOutput::initializeMixer(const unsigned int *chanmasks, bool forceheadp
 	qWarning("AudioOutput: Initialized %d channel %d hz mixer", iChannels, iMixerFreq);
 
 	if (Global::get().s.bPositionalAudio && iChannels == 1) {
-		Global::get().l->logOrDefer(Log::Warning, tr("Positional audio cannot work with mono output devices!"));
+		Log::logOrDefer(Log::Warning, tr("Positional audio cannot work with mono output devices!"));
 	}
 }
 

--- a/src/mumble/Log.cpp
+++ b/src/mumble/Log.cpp
@@ -707,6 +707,15 @@ QString Log::validHtml(const QString &html, QTextCursor *tc) {
 
 void Log::log(MsgType mt, const QString &console, const QString &terse, bool ownMessage, const QString &overrideTTS,
 			  bool ignoreTTS) {
+	if (QThread::currentThread() != thread()) {
+		// Invoke in main thread in order to keep the Qt gods on our side by not calling any UI
+		// functions from a separate thread (can lead to program crashes)
+		QMetaObject::invokeMethod(this, "log", Qt::QueuedConnection, Q_ARG(Log::MsgType, mt),
+								  Q_ARG(const QString &, console), Q_ARG(const QString &, terse),
+								  Q_ARG(bool, ownMessage), Q_ARG(const QString &, overrideTTS), Q_ARG(bool, ignoreTTS));
+		return;
+	}
+
 	QDateTime dt = QDateTime::currentDateTime();
 
 	int ignore = qmIgnore.value(mt);


### PR DESCRIPTION
Merge request #5247 introduced a warning that is triggered when Mumble is configured to use positional audio and only a single channel output is configured.

However, this warning is emitted from the audio thread and therefore causes a crash. This is because Qt does not want to add child QObjects from any other thread than main.

This commit makes sure the static version of ``logOrDefer`` is called and also adds a check to ``Log::log`` to forward the call to the main thread, if necessary.

The ``invokeMethod`` construct is the same idea as
https://github.com/mumble-voip/mumble/blob/b75fe546ab6e5f32204e20df7ee3ceb8ce70262c/src/mumble/API_v_1_x_x.cpp#L1587-L1593

Fixes #6507