### PR TITLE
REFAC(client): Replace <codecvt> usage

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -8,7 +8,7 @@ freebsd_instance:
 freebsd_task:
   pkg_script:
   - pkg update && pkg upgrade -y
-  - pkg install -y git ninja pkgconf cmake qt5-buildtools qt5-qmake qt5-linguisttools qt5-concurrent qt5-network qt5-xml qt5-sql qt5-svg qt5-testlib boost-libs libsndfile protobuf ice avahi-libdns poco opus
+  - pkg install -y git ninja pkgconf cmake qt5-buildtools qt5-qmake qt5-linguisttools qt5-concurrent qt5-network qt5-xml qt5-sql qt5-svg qt5-testlib boost-libs libsndfile protobuf ice37 avahi-libdns poco opus
   fetch_submodules_script: git submodule --quiet update --init --recursive
   build_script:
   - mkdir build && cd build

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,9 +1,9 @@
-# Copyright 2019-2023 The Mumble Developers. All rights reserved.
+# Copyright 2019-2024 The Mumble Developers. All rights reserved.
 # Use of this source code is governed by a BSD-style license
 # that can be found in the LICENSE file at the root of the
 # Mumble source tree or at <https://www.mumble.info/LICENSE>.
 freebsd_instance:
-  image: freebsd-13-2-release-amd64
+  image_family: freebsd-14-0
 
 freebsd_task:
   pkg_script:

--- a/.gitmodules
+++ b/.gitmodules
@@ -31,3 +31,6 @@
 [submodule "3rdparty/flag-icons"]
 	path = 3rdparty/flag-icons
 	url = https://github.com/lipis/flag-icons.git
+[submodule "3rdparty/utfcpp"]
+	path = 3rdparty/utfcpp
+	url = https://github.com/mumble-voip/utfcpp.git

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -166,6 +166,8 @@ set(CMAKE_UNITY_BUILD_BATCH_SIZE 40)
 set(CMAKE_INTERPROCEDURAL_OPTIMIZATION ${lto})
 set(CMAKE_INTERPROCEDURAL_OPTIMIZATION_DEBUG OFF)
 
+add_subdirectory(${3RDPARTY_DIR}/utfcpp)
+
 if(client OR server)
 	add_subdirectory(src)
 endif()

--- a/plugins/CMakeLists.txt
+++ b/plugins/CMakeLists.txt
@@ -106,7 +106,7 @@ foreach(CURRENT_PLUGIN IN LISTS AVAILABLE_PLUGINS)
 
 	if(WIN32)
 		target_compile_definitions(${CURRENT_PLUGIN} PRIVATE "OS_WINDOWS")
-		target_link_libraries(${CURRENT_PLUGIN} user32.lib)
+		target_link_libraries(${CURRENT_PLUGIN} PRIVATE user32.lib)
 
 		# Shared library on Windows (e.g. ".dll")
 		set_target_properties(${CURRENT_PLUGIN} PROPERTIES RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/plugins")

--- a/plugins/HostWindows.h
+++ b/plugins/HostWindows.h
@@ -12,6 +12,8 @@ using procid_t = uint64_t;
 
 class HostWindows {
 protected:
+	static std::string utf16To8(const std::wstring &wstr);
+
 	procid_t m_pid;
 	void *m_handle;
 

--- a/plugins/ProcessBase.cpp
+++ b/plugins/ProcessBase.cpp
@@ -113,16 +113,3 @@ procptr_t ProcessBase::findPattern(const std::vector< uint8_t > &pattern, procpt
 
 	return 0;
 }
-
-procid_t ProcessBase::find(const std::string &name, const std::multimap< std::wstring, unsigned long long int > &pids) {
-	if (pids.empty()) {
-		return 0;
-	}
-
-	const auto iter = pids.find(utf8ToUtf16(name));
-	if (iter == pids.cend()) {
-		return 0;
-	}
-
-	return iter->second;
-}

--- a/plugins/ProcessBase.h
+++ b/plugins/ProcessBase.h
@@ -107,8 +107,6 @@ public:
 	/// Returns 0 if the pattern is not found.
 	procptr_t findPattern(const std::vector< uint8_t > &pattern, procptr_t address, const size_t size);
 
-	static procid_t find(const std::string &name, const std::multimap< std::wstring, unsigned long long int > &pids);
-
 	ProcessBase(const procid_t id, const std::string &name);
 	virtual ~ProcessBase();
 };

--- a/plugins/amongus/CMakeLists.txt
+++ b/plugins/amongus/CMakeLists.txt
@@ -17,3 +17,5 @@ if(WIN32)
 else()
 	target_sources(amongus PRIVATE "../HostLinux.cpp")
 endif()
+
+target_link_libraries(amongus PRIVATE utfcpp)

--- a/plugins/amongus/Game.cpp
+++ b/plugins/amongus/Game.cpp
@@ -5,7 +5,9 @@
 
 #include "Game.h"
 
-#include "mumble_positional_audio_utils.h"
+#include <sstream>
+
+#include <utf8/cpp11.h>
 
 Game::Game(const procid_t id, const std::string name) : m_proc(id, name) {
 }
@@ -91,11 +93,15 @@ std::string Game::string(const procptr_t address) {
 
 	std::u16string string;
 	string.resize(object.fields.length);
-	if (m_proc.peek(address + sizeof(object), &string[0], sizeof(char16_t) * string.size())) {
-		return utf16ToUtf8(string.data());
+	if (!m_proc.peek(address + sizeof(object), &string[0], sizeof(char16_t) * string.size())) {
+		return {};
 	}
 
-	return {};
+	try {
+		return utf8::utf16to8(string);
+	} catch (const utf8::invalid_utf16 &) {
+		return {};
+	}
 }
 
 const std::string &Game::context(const AmongUsClient_Fields &fields) {

--- a/plugins/cod2/cod2.cpp
+++ b/plugins/cod2/cod2.cpp
@@ -75,12 +75,12 @@ static int fetch(float *avatarPos, float *avatarFront, float *avatarTop, float *
 static int tryLock(const std::multimap< std::wstring, unsigned long long int > &pids) {
 	const std::string name = "CoD2MP_s.exe";
 
-	const auto id = ProcessBase::find(name, pids);
-	if (!id) {
+	const auto iter = pids.find(std::wstring(name.cbegin(), name.cend()));
+	if (iter == pids.cend()) {
 		return false;
 	}
 
-	process = std::make_unique< ProcessWindows >(id, name);
+	process = std::make_unique< ProcessWindows >(iter->second, name);
 	if (!process->isOk()) {
 		process.reset();
 		return false;

--- a/plugins/link/CMakeLists.txt
+++ b/plugins/link/CMakeLists.txt
@@ -23,3 +23,5 @@ target_include_directories(link PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}")
 target_include_directories(link_tester PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}")
 
 set_target_properties(link_tester PROPERTIES RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}")
+
+target_link_libraries(link PRIVATE utfcpp)

--- a/plugins/mumble_positional_audio_utils.h
+++ b/plugins/mumble_positional_audio_utils.h
@@ -7,9 +7,7 @@
 #define MUMBLE_POSITIONAL_AUDIO_UTILS_H_
 
 #include <cmath>
-#include <codecvt>
 #include <fstream>
-#include <locale>
 #include <sstream>
 #include <vector>
 
@@ -24,38 +22,6 @@ union SingleSplit4Bytes {
 
 	constexpr SingleSplit4Bytes(const uint32_t value) : single(value) {}
 };
-
-/// Converts from UTF-8 to UTF-16.
-static inline std::wstring utf8ToUtf16(const std::string &str) {
-	try {
-		std::wstring_convert< std::codecvt_utf8_utf16< wchar_t > > conv;
-		return conv.from_bytes(str);
-	} catch (std::range_error &) {
-		return {};
-	}
-}
-
-/// Converts from UTF-16 to UTF-8.
-/// Meant to be used when "wchar_t" is 2 bytes, usually with Windows processes.
-static inline std::string utf16ToUtf8(const std::u16string &str) {
-	try {
-		std::wstring_convert< std::codecvt_utf8_utf16< char16_t >, char16_t > conv;
-		return conv.to_bytes(str);
-	} catch (std::range_error &) {
-		return {};
-	}
-}
-
-/// Converts from UTF-16 to UTF-8.
-/// Meant to be used when "wchar_t" is 4 bytes, usually with Linux processes.
-static inline std::string utf16ToUtf8(const std::u32string &str) {
-	try {
-		std::wstring_convert< std::codecvt_utf8_utf16< char32_t >, char32_t > conv;
-		return conv.to_bytes(str);
-	} catch (std::range_error &) {
-		return {};
-	}
-}
 
 // escape lossily converts the given
 // string to ASCII, replacing any

--- a/plugins/se/se.cpp
+++ b/plugins/se/se.cpp
@@ -195,10 +195,12 @@ static bool tryInit(const std::multimap< std::wstring, unsigned long long int > 
 	};
 
 	for (const auto &name : names) {
-		const auto id = ProcessBase::find(name, pids);
-		if (!id) {
+		const auto iter = pids.find(std::wstring(name.cbegin(), name.cend()));
+		if (iter == pids.cend()) {
 			continue;
 		}
+
+		const auto id = iter->second;
 #ifdef OS_WINDOWS
 		proc.reset(new ProcessWindows(id, name));
 #else

--- a/plugins/ut99/CMakeLists.txt
+++ b/plugins/ut99/CMakeLists.txt
@@ -4,3 +4,5 @@
 # Mumble source tree or at <https://www.mumble.info/LICENSE>.
 
 add_library(ut99 SHARED "ut99.cpp")
+
+target_link_libraries(ut99 PRIVATE utfcpp)

--- a/plugins/ut99/ut99.cpp
+++ b/plugins/ut99/ut99.cpp
@@ -38,7 +38,8 @@
 #include "mumble_legacy_plugin.h"
 
 #include "mumble_positional_audio_main.h"
-#include "mumble_positional_audio_utils.h"
+
+#include <utf8/cpp11.h>
 
 procptr_t posptr;
 procptr_t frtptr;
@@ -153,9 +154,13 @@ static int fetch(float *avatar_pos, float *avatar_front, float *avatar_top, floa
 	}
 
 	std::ostringstream contextss;
-	contextss << "{"
-			  << "\"servername\":\"" << utf16ToUtf8(servername) << "\""
-			  << "}";
+	contextss << "{";
+	try {
+		contextss << "\"servername\":\"" << utf8::utf16to8(servername) << "\"";
+	} catch (const utf8::invalid_utf16 &) {
+		contextss << "\"servername\":\" null";
+	}
+	contextss << "}";
 
 	context = contextss.str();
 

--- a/src/mumble/CMakeLists.txt
+++ b/src/mumble/CMakeLists.txt
@@ -540,6 +540,7 @@ endif()
 target_link_libraries(mumble_client_object_lib
 	PUBLIC
 		shared
+		utfcpp
 		Qt5::Concurrent
 		Qt5::Sql
 		Qt5::Svg

--- a/src/mumble/GlobalShortcut_win.h
+++ b/src/mumble/GlobalShortcut_win.h
@@ -134,6 +134,8 @@ protected:
 	std::unique_ptr< GKeyLibrary > m_gkey;
 #endif
 	DeviceMap::iterator addDevice(const HANDLE deviceHandle);
+
+	static std::string utf16To8(const std::wstring &wstr);
 };
 
 #endif


### PR DESCRIPTION
Deprecated in C++17 and slated for removal in C++26.

Unfortunately no standard replacement is available yet.