### PR TITLE
FEAT(client): Add "View Description" context action to channels

### DIFF
--- a/src/mumble/MainWindow.h
+++ b/src/mumble/MainWindow.h
@@ -287,6 +287,7 @@ public slots:
 	void on_qaChannelHide_triggered();
 	void on_qaChannelPin_triggered();
 	void on_qaChannelCopyURL_triggered();
+	void on_qaChannelDescriptionView_triggered();
 	void on_qaAudioReset_triggered();
 	void on_qaAudioMute_triggered();
 	void on_qaAudioDeaf_triggered();

--- a/src/mumble/MainWindow.ui
+++ b/src/mumble/MainWindow.ui
@@ -933,6 +933,14 @@ the channel's context menu.</string>
     <string>&amp;Pin When Filtering</string>
    </property>
   </action>
+  <action name="qaChannelDescriptionView">
+   <property name="text">
+    <string>Vie&amp;w Description</string>
+   </property>
+   <property name="toolTip">
+    <string>View full channel description in a separate window</string>
+   </property>
+  </action>
   <action name="qaUserCommentView">
    <property name="text">
     <string>Vie&amp;w Comment</string>

--- a/src/mumble/UserModel.h
+++ b/src/mumble/UserModel.h
@@ -62,6 +62,8 @@ public:
 	void wipe();
 };
 
+enum class BlobRequestType { None, Window, Tooltip };
+
 class UserModel : public QAbstractItemModel {
 	friend struct ModelItem;
 	friend class UserView;
@@ -196,6 +198,7 @@ public:
 
 	QVariant otherRoles(const QModelIndex &idx, int role) const;
 
+	BlobRequestType blobRequestType;
 	unsigned int uiSessionComment;
 	int iChannelDescription;
 


### PR DESCRIPTION
Previously, channel descriptions could only be viewed as a pop-up which does not allow text selection/copying and doesn't allow you to scroll through descriptions to large to fit on your screen.

User comments already support this use case via the "View Comment" context menu action on users which opens their comment in a separate window.

This commit adds a "View Description" context menu action to channels which works the same way as the "View Comment" action.

Fixes #6525 

### Checks

- [x] My commits follow the [commit guidelines](https://github.com/mumble-voip/mumble/blob/master/COMMIT_GUIDELINES.md)

