### PR TITLE
Backport "Merge PR #6510: FIX(client): Fix crash on mono pos. audio warning from audio thread" to 1.5.x

### DIFF
--- a/src/mumble/AudioOutput.cpp
+++ b/src/mumble/AudioOutput.cpp
@@ -415,7 +415,7 @@ void AudioOutput::initializeMixer(const unsigned int *chanmasks, bool forceheadp
 	qWarning("AudioOutput: Initialized %d channel %d hz mixer", iChannels, iMixerFreq);
 
 	if (Global::get().s.bPositionalAudio && iChannels == 1) {
-		Global::get().l->logOrDefer(Log::Warning, tr("Positional audio cannot work with mono output devices!"));
+		Log::logOrDefer(Log::Warning, tr("Positional audio cannot work with mono output devices!"));
 	}
 }
 

--- a/src/mumble/Log.cpp
+++ b/src/mumble/Log.cpp
@@ -707,6 +707,15 @@ QString Log::validHtml(const QString &html, QTextCursor *tc) {
 
 void Log::log(MsgType mt, const QString &console, const QString &terse, bool ownMessage, const QString &overrideTTS,
 			  bool ignoreTTS) {
+	if (QThread::currentThread() != thread()) {
+		// Invoke in main thread in order to keep the Qt gods on our side by not calling any UI
+		// functions from a separate thread (can lead to program crashes)
+		QMetaObject::invokeMethod(this, "log", Qt::QueuedConnection, Q_ARG(Log::MsgType, mt),
+								  Q_ARG(const QString &, console), Q_ARG(const QString &, terse),
+								  Q_ARG(bool, ownMessage), Q_ARG(const QString &, overrideTTS), Q_ARG(bool, ignoreTTS));
+		return;
+	}
+
 	QDateTime dt = QDateTime::currentDateTime();
 
 	int ignore = qmIgnore.value(mt);


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `1.5.x`:
 - [Merge PR #6510: FIX(client): Fix crash on mono pos. audio warning from audio thread](https://github.com/mumble-voip/mumble/pull/6510)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)