### PR TITLE
Backport "Merge PR #6536: BUILD: Fix compiler warnings on 32bit architectures" to 1.5.x

### DIFF
--- a/src/MumbleProtocol.cpp
+++ b/src/MumbleProtocol.cpp
@@ -781,7 +781,7 @@ namespace Protocol {
 		}
 
 
-		m_audioData.payload = gsl::span< byte >(payloadBegin, payloadSize);
+		m_audioData.payload = gsl::span< byte >(payloadBegin, static_cast< std::size_t >(payloadSize));
 
 		if (stream.left() == 3 * sizeof(float)) {
 			// If there are further bytes after the audio payload, this means that there is positional data attached to

--- a/src/mumble/Audio.cpp
+++ b/src/mumble/Audio.cpp
@@ -43,7 +43,7 @@ void LoopUser::addFrame(const Mumble::Protocol::AudioData &audioData) {
 		QMutexLocker l(&qmLock);
 		bool restart = (qetLastFetch.elapsed() > 100);
 
-		long time = qetTicker.elapsed();
+		qint64 time = qetTicker.elapsed();
 
 		float r;
 		if (restart)

--- a/src/mumble/AudioOutput.cpp
+++ b/src/mumble/AudioOutput.cpp
@@ -616,12 +616,13 @@ bool AudioOutput::mix(void *outbuff, unsigned int frameCount) {
 					if (speech->bStereo) {
 						// Mix down stereo to mono. TODO: stereo record support
 						// frame: for a stereo stream, the [LR] pair inside ...[LR]LRLRLR.... is a frame
-						for (unsigned int i = 0; i < frameCount; ++i) {
-							recbuff[i] += (pfBuffer[2 * i] / 2.0f + pfBuffer[2 * i + 1] / 2.0f) * volumeAdjustment;
+						for (std::size_t i = 0; i < frameCount; ++i) {
+							recbuff.get()[i] +=
+								(pfBuffer[2 * i] / 2.0f + pfBuffer[2 * i + 1] / 2.0f) * volumeAdjustment;
 						}
 					} else {
-						for (unsigned int i = 0; i < frameCount; ++i) {
-							recbuff[i] += pfBuffer[i] * volumeAdjustment;
+						for (std::size_t i = 0; i < frameCount; ++i) {
+							recbuff.get()[i] += pfBuffer[i] * volumeAdjustment;
 						}
 					}
 

--- a/src/murmur/Server.cpp
+++ b/src/murmur/Server.cpp
@@ -1041,7 +1041,7 @@ void Server::sendMessage(ServerUser &u, const unsigned char *data, int len, QByt
 			((reinterpret_cast< quint64 >(ebuffer.data()) + 8) & static_cast< quint64 >(~7)) + 4);
 #else
 		std::vector< char > bufVec;
-		bufVec.resize(len + 4);
+		bufVec.resize(static_cast< std::size_t >(len + 4));
 		char *buffer    = bufVec.data();
 #endif
 		{


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `1.5.x`:
 - [Merge PR #6536: BUILD: Fix compiler warnings on 32bit architectures](https://github.com/mumble-voip/mumble/pull/6536)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)