### PR TITLE
FIX(client, server): Remove redundant OpenSSL locking callback check

### DIFF
--- a/src/SSL.cpp
+++ b/src/SSL.cpp
@@ -24,18 +24,7 @@ void MumbleSSL::initialize() {
 	SSL_library_init(); // Safe to discard return value, per OpenSSL man pages.
 	SSL_load_error_strings();
 
-	// Determine if a locking callback has not been set.
-	// This should be the case if there are multiple copies
-	// of OpensSSL in the address space. This is mostly due
-	// to Qt dynamically loading OpenSSL when it is not
-	// configured with -openssl-linked.
-	//
-	// If we detect that no locking callback is configured, we
-	// have to set it up ourselves to allow multi-threaded use
-	// of OpenSSL.
-	if (!CRYPTO_get_locking_callback()) {
-		SSLLocks::initialize();
-	}
+	SSLLocks::initialize();
 }
 
 void MumbleSSL::destroy() {


### PR DESCRIPTION
`CRYPTO_get_locking_callback()` has been defined to NULL since OpenSSL 1.1.0.  This check therefore doesn't do anything in any supported version of OpenSSL.

This fixes the following compiler error that I saw with GCC 14:

```
/build/source/src/SSL.cpp: In static member function ‘static void MumbleSSL::initialize()’: /build/source/src/SSL.cpp:36:14: error: converting to ‘bool’ from ‘std::nullptr_t’ requires direct-initialization [-fpermissive]
   36 |         if (!CRYPTO_get_locking_callback()) {
      |              ^~~~~~~~~~~~~~~~~~~~~~~~~~~
```

### Checks

- [x] My commits follow the [commit guidelines](https://github.com/mumble-voip/mumble/blob/master/COMMIT_GUIDELINES.md)

