### PR TITLE
BUILD: Disable MSVC 17.8 warning for stdext::checked_array_iterator

### DIFF
--- a/cmake/compiler.cmake
+++ b/cmake/compiler.cmake
@@ -66,6 +66,9 @@ if(MSVC)
 			"/ignore:4099"
 		)
 	endif()
+
+	# Workaround for MSVC 17.8 breaking change. (fixed in Qt 5.15.17)
+	add_compile_definitions(_SILENCE_STDEXT_ARR_ITERS_DEPRECATION_WARNING)
 elseif(UNIX OR MINGW)
 	add_compile_options(
 		"-fvisibility=hidden"


### PR DESCRIPTION
Let's disable the Qt < 5.15.17 specific warning until #6516 is merged