### PR TITLE
FIX(server): Change server thread name to "mumble-server" instead of "Main"

### DIFF
--- a/src/murmur/Server.cpp
+++ b/src/murmur/Server.cpp
@@ -79,7 +79,7 @@ QSslSocket *SslServer::nextPendingSSLConnection() {
 
 
 Server::Server(int snum, QObject *p) : QThread(p) {
-	tracy::SetThreadName("Main");
+	tracy::SetThreadName("mumble-server");
 
 	bValid     = true;
 	iServerNum = snum;


### PR DESCRIPTION
Fixes #6552
