### PR TITLE
Backport "Merge PR #6559: FIX(server): Change server thread name to "mumble-server" instead of "Main"" to 1.5.x

### DIFF
--- a/src/murmur/Server.cpp
+++ b/src/murmur/Server.cpp
@@ -78,7 +78,7 @@ QSslSocket *SslServer::nextPendingSSLConnection() {
 
 
 Server::Server(int snum, QObject *p) : QThread(p) {
-	tracy::SetThreadName("Main");
+	tracy::SetThreadName("mumble-server");
 
 	bValid     = true;
 	iServerNum = snum;


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `1.5.x`:
 - [Merge PR #6559: FIX(server): Change server thread name to &quot;mumble-server&quot; instead of &quot;Main&quot;](https://github.com/mumble-voip/mumble/pull/6559)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)