### PR TITLE
FIX(client): Prevent sending plain text on fast CTRL+V + ENTER

### DIFF
--- a/src/mumble/CustomElements.h
+++ b/src/mumble/CustomElements.h
@@ -34,6 +34,7 @@ private:
 	QString qsHistoryTemp;
 	int iHistoryIndex;
 	static const int MAX_HISTORY = 50;
+	bool m_justPasted;
 
 protected:
 	QString qsDefaultText;

--- a/src/mumble/GlobalShortcut_unix.h
+++ b/src/mumble/GlobalShortcut_unix.h
@@ -63,6 +63,7 @@ protected:
 // if left defined
 #undef None
 #undef KeyPress
+#undef KeyRelease
 #undef FontChange
 
 #endif


### PR DESCRIPTION
**FIX(client): Prevent sending plain text on fast CTRL+V + ENTER**
In e658c4a0e094d2af82d5f425e90d4c73d5cfc9ef plain text sending was added. Due to the
way Qt handles events, a regression was introduced where
very fast inputs would wrongly trigger the plain text send code
branch - removing e.g. links from chat messages.

This commit introduces a member to keep track when a paste event
happend, and prevents subsequent plain text sends until the CTRL
key was released at least once. This also means that pasting
and then purposefully sending plain text now requires the user to
lift the CTRL key once before hitting ENTER.

Fixes #6568