### PR TITLE
FIX(client): Registered AudioOutputBuffer as qRegisterMetaType

### DIFF
--- a/src/mumble/AudioOutput.cpp
+++ b/src/mumble/AudioOutput.cpp
@@ -31,6 +31,8 @@ QMap< QString, AudioOutputRegistrar * > *AudioOutputRegistrar::qmNew;
 QString AudioOutputRegistrar::current = QString();
 
 AudioOutputRegistrar::AudioOutputRegistrar(const QString &n, int p) : name(n), priority(p) {
+	qRegisterMetaType< AudioOutputBuffer * >("AudioOutputBuffer *");
+
 	if (!qmNew)
 		qmNew = new QMap< QString, AudioOutputRegistrar * >();
 	qmNew->insert(name, this);


### PR DESCRIPTION
### Checks
- [ x] My commits follow the [commit guidelines](https://github.com/mumble-voip/mumble/blob/master/COMMIT_GUIDELINES.md)

FIX(client): Registered the AudioOutputBuffer as qRegisterMetaType

Just a QT registration missing for the AudioOutputBuffer. Being only a single required registration I didn't make a separate function for it -- it's just in the constructor.

Fixes: https://github.com/mumble-voip/mumble/issues/6569
