### PR TITLE
Backport "Merge PR #6570: FIX(client): Prevent sending plain text on fast CTRL+V + ENTER" to 1.5.x

### DIFF
--- a/src/mumble/CustomElements.h
+++ b/src/mumble/CustomElements.h
@@ -34,6 +34,7 @@ private:
 	QString qsHistoryTemp;
 	int iHistoryIndex;
 	static const int MAX_HISTORY = 50;
+	bool m_justPasted;
 
 protected:
 	QString qsDefaultText;

--- a/src/mumble/GlobalShortcut_unix.h
+++ b/src/mumble/GlobalShortcut_unix.h
@@ -63,6 +63,7 @@ protected:
 // if left defined
 #undef None
 #undef KeyPress
+#undef KeyRelease
 #undef FontChange
 
 #endif


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `1.5.x`:
 - [Merge PR #6570: FIX(client): Prevent sending plain text on fast CTRL+V + ENTER](https://github.com/mumble-voip/mumble/pull/6570)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)