### PR TITLE
FIX(client): Save local volume adjustment when clicking slider bar

### DIFF
--- a/src/mumble/VolumeSliderWidgetAction.cpp
+++ b/src/mumble/VolumeSliderWidgetAction.cpp
@@ -63,6 +63,8 @@ VolumeSliderWidgetAction::VolumeSliderWidgetAction(QWidget *parent)
 			&VolumeSliderWidgetAction::on_VolumeSlider_changeCompleted);
 	connect(wheelEventFilter, &MouseWheelEventObserver::wheelEventObserved, this,
 			&VolumeSliderWidgetAction::on_VolumeSlider_changeCompleted);
+	connect(mouseEventFilter, &MouseClickEventObserver::clickEventObserved, this,
+			&VolumeSliderWidgetAction::on_VolumeSlider_changeCompleted);
 
 	UpDownKeyEventFilter *eventFilter = new UpDownKeyEventFilter(this);
 	m_volumeSlider->installEventFilter(eventFilter);


### PR DESCRIPTION
Since ed988e646af57eeeb2e47a0d077549999c23957f, clicking the slider bar of the local volume adjustment slider would correctly update the label and (temporarily) also update the user volume.
However, since clicking on the slider bar does not fire a "sliderReleased" event, the value was not saved to the local volume adjustment database leading to it "randomly" resetting.

This commit adds an additional signal/slot connection to save the value when the slider bar is clicked.
