### PR TITLE
Backport "Merge PR #6574: FIX(client): Save local volume adjustment when clicking slider bar" to 1.5.x

### DIFF
--- a/src/mumble/VolumeSliderWidgetAction.cpp
+++ b/src/mumble/VolumeSliderWidgetAction.cpp
@@ -63,6 +63,8 @@ VolumeSliderWidgetAction::VolumeSliderWidgetAction(QWidget *parent)
 			&VolumeSliderWidgetAction::on_VolumeSlider_changeCompleted);
 	connect(wheelEventFilter, &MouseWheelEventObserver::wheelEventObserved, this,
 			&VolumeSliderWidgetAction::on_VolumeSlider_changeCompleted);
+	connect(mouseEventFilter, &MouseClickEventObserver::clickEventObserved, this,
+			&VolumeSliderWidgetAction::on_VolumeSlider_changeCompleted);
 
 	UpDownKeyEventFilter *eventFilter = new UpDownKeyEventFilter(this);
 	m_volumeSlider->installEventFilter(eventFilter);


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `1.5.x`:
 - [Merge PR #6574: FIX(client): Save local volume adjustment when clicking slider bar](https://github.com/mumble-voip/mumble/pull/6574)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)