### PR TITLE
FIX(client): Limit size of the chat bar

### DIFF
--- a/src/mumble/CustomElements.cpp
+++ b/src/mumble/CustomElements.cpp
@@ -107,7 +107,7 @@ ChatbarTextEdit::ChatbarTextEdit(QWidget *p) : QTextEdit(p), iHistoryIndex(-1) {
 	setHorizontalScrollBarPolicy(Qt::ScrollBarAlwaysOff);
 	setVerticalScrollBarPolicy(Qt::ScrollBarAlwaysOff);
 	setMinimumHeight(0);
-	connect(this, SIGNAL(textChanged()), SLOT(doResize()));
+	connect(this, &ChatbarTextEdit::textChanged, this, &ChatbarTextEdit::doResize);
 
 	bDefaultVisible = true;
 	setDefaultText(tr("<center>Type chat message here</center>"));
@@ -121,10 +121,12 @@ QSize ChatbarTextEdit::minimumSizeHint() const {
 }
 
 QSize ChatbarTextEdit::sizeHint() const {
-	QSize sh                 = QTextEdit::sizeHint();
-	const int minHeight      = minimumSizeHint().height();
-	const int documentHeight = static_cast< int >(document()->documentLayout()->documentSize().height());
-	sh.setHeight(std::max(minHeight, documentHeight));
+	QSize sh                    = QTextEdit::sizeHint();
+	const int minHeight         = minimumSizeHint().height();
+	const int documentHeight    = static_cast< int >(document()->documentLayout()->documentSize().height());
+	const int chatBarLineHeight = QFontMetrics(ChatbarTextEdit::font()).height();
+
+	sh.setHeight(std::max(minHeight, std::min(chatBarLineHeight * 10, documentHeight)));
 	const_cast< ChatbarTextEdit * >(this)->setMaximumHeight(sh.height());
 	return sh;
 }
@@ -144,7 +146,8 @@ void ChatbarTextEdit::doResize() {
 }
 
 void ChatbarTextEdit::doScrollbar() {
-	setVerticalScrollBarPolicy(sizeHint().height() > height() ? Qt::ScrollBarAlwaysOn : Qt::ScrollBarAlwaysOff);
+	const int documentHeight = static_cast< int >(document()->documentLayout()->documentSize().height());
+	setVerticalScrollBarPolicy(documentHeight > height() ? Qt::ScrollBarAlwaysOn : Qt::ScrollBarAlwaysOff);
 	ensureCursorVisible();
 }
 


### PR DESCRIPTION
Previously, the chat bar QTextEdit was unlimited in screen space size and would start stretching the main window and chat log, if messages were too large.
This resulted in the window becoming unusable unless you would manually resize the window down again.

This commit adds a sensible limit to how much of the chat bar can be visible at once. Currently, this limit is set to 10 times the font height. After that the chat bar will stop growing in screen space and instead start showing a scrollbar.

Fixes #6528
Fixes #1320

![screencast2](https://github.com/user-attachments/assets/db0772a8-bfbe-4d99-8edc-8361d087b9a2)

