### PR TITLE
CI(backport): Prevent CI failure for non-backported PRs

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -6,8 +6,17 @@ on:
 
 jobs:
   backport:
-    name: Backport PR
-    if: github.event.pull_request.merged == true && !(contains(github.event.pull_request.labels.*.name, 'backport'))
+  - name: Check labels
+    id: label_check
+    uses: docker://agilepathway/pull-request-label-checker:latest
+    with:
+      prefix_mode: true
+      all_of: auto-backport-to-
+      repo_token: ${{ secrets.GITHUB_TOKEN }}
+      allow_failure: true
+
+  - name: Backport PR
+    if: github.event.pull_request.merged == true && steps.label_check.outputs.label_check == 'success'
     runs-on: ubuntu-latest
     steps:
       - name: Backport Action


### PR DESCRIPTION
With these changes, the backport action should only run on PRs that have an explicit auto-backport-xxx label


### Checks

- [x] My commits follow the [commit guidelines](https://github.com/mumble-voip/mumble/blob/master/COMMIT_GUIDELINES.md)

