### PR TITLE
Backport "Merge PR #6598: FIX(plugins): Load correct pages for modules" to 1.5.x

### DIFF
--- a/plugins/HostWindows.cpp
+++ b/plugins/HostWindows.cpp
@@ -34,6 +34,7 @@ Modules HostWindows::modules() const {
 
 	const auto snapshotHandle = CreateToolhelp32Snapshot(TH32CS_SNAPMODULE | TH32CS_SNAPMODULE32, m_pid);
 	if (snapshotHandle == INVALID_HANDLE_VALUE) {
+		CloseHandle(processHandle);
 		return {};
 	}
 
@@ -51,7 +52,11 @@ Modules HostWindows::modules() const {
 		MEMORY_BASIC_INFORMATION64 mbi;
 		auto address = reinterpret_cast< procptr_t >(me.modBaseAddr);
 		while (VirtualQueryEx(processHandle, reinterpret_cast< LPCVOID >(address),
-							  reinterpret_cast< PMEMORY_BASIC_INFORMATION >(&mbi), sizeof(mbi))) {
+							  reinterpret_cast< PMEMORY_BASIC_INFORMATION >(&mbi), sizeof(mbi))
+			   /* Only enumerate pages that belong to the allocation for this module.
+				* This stops if it sees a page for a different allocation, belonging
+				* to another module or dynamic memory, or gap between pages. */
+			   && (mbi.AllocationBase == reinterpret_cast< procptr_t >(me.modBaseAddr))) {
 			MemoryRegion region{};
 			region.address = address;
 			region.size    = mbi.RegionSize;


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `1.5.x`:
 - [Merge PR #6598: FIX(plugins): Load correct pages for modules](https://github.com/mumble-voip/mumble/pull/6598)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)