### PR TITLE
FIX(client): Fix memory leaks due to BIO_NOCLOSE flag

### DIFF
--- a/src/mumble/Cert.cpp
+++ b/src/mumble/Cert.cpp
@@ -436,8 +436,7 @@ Settings::KeyPair CertWizard::importCert(QByteArray data, const QString &pw) {
 	Settings::KeyPair kp;
 	int ret = 0;
 
-	mem = BIO_new_mem_buf(data.data(), static_cast< int >(data.size()));
-	Q_UNUSED(BIO_set_close(mem, BIO_NOCLOSE));
+	mem  = BIO_new_mem_buf(data.data(), static_cast< int >(data.size()));
 	pkcs = d2i_PKCS12_bio(mem, nullptr);
 	if (pkcs) {
 		ret = PKCS12_parse(pkcs, nullptr, &pkey, &x509, &certs);

--- a/src/murmur/Cert.cpp
+++ b/src/murmur/Cert.cpp
@@ -32,13 +32,11 @@ bool Server::isKeyForCert(const QSslKey &key, const QSslCertificate &cert) {
 	EVP_PKEY *pkey = nullptr;
 	BIO *mem       = nullptr;
 
-	mem = BIO_new_mem_buf(qbaKey.data(), static_cast< int >(qbaKey.size()));
-	Q_UNUSED(BIO_set_close(mem, BIO_NOCLOSE));
+	mem  = BIO_new_mem_buf(qbaKey.data(), static_cast< int >(qbaKey.size()));
 	pkey = d2i_PrivateKey_bio(mem, nullptr);
 	BIO_free(mem);
 
-	mem = BIO_new_mem_buf(qbaCert.data(), static_cast< int >(qbaCert.size()));
-	Q_UNUSED(BIO_set_close(mem, BIO_NOCLOSE));
+	mem  = BIO_new_mem_buf(qbaCert.data(), static_cast< int >(qbaCert.size()));
 	x509 = d2i_X509_bio(mem, nullptr);
 	BIO_free(mem);
 	mem = nullptr;


### PR DESCRIPTION
BIO_set_close with BIO_NOCLOSE argument leads to OpenSSL not (fully)
deleting the allocated BIO struct under the assumption that the user
code has taken ownership of it. However, in our case, this is not the
case and therefore OpenSSL should do the deletion as usual.

The flag was probably introduced under the assumption that the component
that either is or isn't deleted by OpenSSL was the externally provided
buffer that is wrapped into a BIO object via BIO_new_mem_buf. However,
this is not the case. OpenSSL doesn't take ownership of the provided
buffer and therefore also doesn't delete it.

Closes https://github.com/mumble-voip/mumble/issues/6603

### Checks

- [x] My commits follow the [commit guidelines](https://github.com/mumble-voip/mumble/blob/master/COMMIT_GUIDELINES.md)

