### PR TITLE
FIX(client): Fix AudioWizard echo cancellation checkbox

### DIFF
--- a/src/mumble/AudioWizard.h
+++ b/src/mumble/AudioWizard.h
@@ -20,6 +20,8 @@ private:
 	Q_OBJECT
 	Q_DISABLE_COPY(AudioWizard)
 
+	void updateEchoCheckbox(AudioInputRegistrar *air);
+
 	/// Which echo cancellation is usable depends on the audio backend and the device combination.
 	/// This function will iterate through the list of available echo cancellation in the audio backend and check with
 	/// the backend whether this echo cancellation option works for current device combination.


### PR DESCRIPTION
The echo cancellation checkbox had two separate, but similar problems:

1) It would never load in a checked state when you open up the AudioWizard

2) It would also never load the correct checked state representing the user settings when switching AudioInput or AudioOutput systems.

The first problem can be traced back to commit 010437556dc81b4ed2e16baba65447c32fda61cd where the state of qcbEcho depends on the selected element of the AudioOutput dropdown menu, before it has been filled.

The second problem probably goes back to 2991d2093a0fa0d9060afbe0004af9d3383f48e0 where the enabled state of the qcbEcho checkbox was updated on changing audio systems, but the checked state was not reloaded.

This commit refactors the code (swaps initializing input and output) and adds a shared method to update the qcbEcho checkbox appropriately.

Fixes #6544