### PR TITLE
FIX(client): Use correct off audio cue

### DIFF
--- a/src/mumble/Settings.h
+++ b/src/mumble/Settings.h
@@ -222,7 +222,7 @@ struct Settings {
 	bool audioCueEnabledPTT = true;
 	bool audioCueEnabledVAD = false;
 	QString qsTxAudioCueOn  = cqsDefaultPushClickOn;
-	QString qsTxAudioCueOff = cqsDefaultPushClickOn;
+	QString qsTxAudioCueOff = cqsDefaultPushClickOff;
 
 	bool bTxMuteCue     = true;
 	bool muteCueShown   = false;


### PR DESCRIPTION
The off audio cue was incorrectly using on in a new configuration.
This commit sets the off audio cue to the correct one.

Fixes #6614


### Checks

- [x] My commits follow the [commit guidelines](https://github.com/mumble-voip/mumble/blob/master/COMMIT_GUIDELINES.md)

