### PR TITLE
Backport "Merge PR #6615: FIX(client): Use correct off audio cue" to 1.5.x

### DIFF
--- a/src/mumble/Settings.h
+++ b/src/mumble/Settings.h
@@ -223,7 +223,7 @@ struct Settings {
 	bool audioCueEnabledPTT = true;
 	bool audioCueEnabledVAD = false;
 	QString qsTxAudioCueOn  = cqsDefaultPushClickOn;
-	QString qsTxAudioCueOff = cqsDefaultPushClickOn;
+	QString qsTxAudioCueOff = cqsDefaultPushClickOff;
 
 	bool bTxMuteCue     = true;
 	bool muteCueShown   = false;


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `1.5.x`:
 - [Merge PR #6615: FIX(client): Use correct off audio cue](https://github.com/mumble-voip/mumble/pull/6615)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)