### PR TITLE
FEAT(client): Automatically sync theme with OS color scheme

### DIFF
--- a/src/mumble/MainWindow.cpp
+++ b/src/mumble/MainWindow.cpp
@@ -86,16 +86,6 @@
 #	include <dbt.h>
 #endif
 
-
-#include <QFile>
-#include <QGuiApplication>
-#include <QPalette>
-#include <QSettings>
-#include <QStyleHints>
-#include <QTextStream>
-
-
-
 #include <algorithm>
 
 MessageBoxEvent::MessageBoxEvent(QString m) : QEvent(static_cast< QEvent::Type >(MB_QEVENT)) {
@@ -208,7 +198,6 @@ MainWindow::MainWindow(QWidget *p)
 					 &PluginManager::on_serverSynchronized);
 
 	QAccessible::installFactory(AccessibleSlider::semanticSliderFactory);
-
 }
 
 void MainWindow::createActions() {

--- a/src/mumble/MainWindow.cpp
+++ b/src/mumble/MainWindow.cpp
@@ -127,9 +127,7 @@ MainWindow::MainWindow(QWidget *p)
 	else
 		SvgIcon::addSvgPixmapsToIcon(qiIcon, QLatin1String("skin:mumble.svg"));
 #else
-	{
-		SvgIcon::addSvgPixmapsToIcon(qiIcon, QLatin1String("skin:mumble.svg"));
-	}
+	{ SvgIcon::addSvgPixmapsToIcon(qiIcon, QLatin1String("skin:mumble.svg")); }
 
 	// Set application icon except on MacOSX, where the window-icon
 	// shown in the title-bar usually serves as a draggable version of the
@@ -211,8 +209,7 @@ MainWindow::MainWindow(QWidget *p)
 
 	QAccessible::installFactory(AccessibleSlider::semanticSliderFactory);
 
-	// Theme application
-	applyTheme(); // Apply the light or dark theme during initialization
+	applyTheme();
 }
 
 void MainWindow::applyTheme() {
@@ -225,6 +222,7 @@ void MainWindow::applyTheme() {
 		if (configuredStyle->name == "Auto") {
 #if QT_VERSION >= QT_VERSION_CHECK(6, 5, 0)
 			auto colorScheme = QGuiApplication::styleHints()->colorScheme();
+
 			if (colorScheme == Qt::ColorScheme::Dark) {
 				setStyleSheet(loadStyleSheet(darkThemePath)); // Apply dark theme
 			} else {
@@ -283,7 +281,6 @@ QString MainWindow::loadStyleSheet(const QString &path) {
 	}
 	return QString(); // Return empty if the file cannot be loaded
 }
-
 
 void MainWindow::createActions() {
 	gsPushTalk = new GlobalShortcut(this, GlobalShortcutType::PushToTalk, tr("Push-to-Talk", "Global Shortcut"));
@@ -841,7 +838,6 @@ void MainWindow::changeEvent(QEvent *e) {
 		QTimer::singleShot(0, this, SLOT(hide()));
 	}
 #endif
-
 	if (e->type() == QEvent::ThemeChange) {
 		applyTheme();
 	}

--- a/src/mumble/MainWindow.cpp
+++ b/src/mumble/MainWindow.cpp
@@ -209,77 +209,6 @@ MainWindow::MainWindow(QWidget *p)
 
 	QAccessible::installFactory(AccessibleSlider::semanticSliderFactory);
 
-	applyTheme();
-}
-
-void MainWindow::applyTheme() {
-	boost::optional< ThemeInfo::StyleInfo > configuredStyle = Themes::getConfiguredStyle(Global::get().s);
-
-	QString lightThemePath = ":/themes/Default/Lite.qss"; // Default light theme path
-	QString darkThemePath  = ":/themes/Default/Dark.qss"; // Default dark theme path
-
-	if (configuredStyle) {
-		if (configuredStyle->name == "Auto") {
-#if QT_VERSION >= QT_VERSION_CHECK(6, 5, 0)
-			auto colorScheme = QGuiApplication::styleHints()->colorScheme();
-
-			if (colorScheme == Qt::ColorScheme::Dark) {
-				setStyleSheet(loadStyleSheet(darkThemePath)); // Apply dark theme
-			} else {
-				setStyleSheet(loadStyleSheet(lightThemePath)); // Apply light theme
-			}
-#else
-			bool isDarkTheme = detectSystemTheme();
-			if (isDarkTheme) {
-				setStyleSheet(loadStyleSheet(darkThemePath)); // Apply dark theme
-			} else {
-				setStyleSheet(loadStyleSheet(lightThemePath)); // Apply light theme
-			}
-#endif
-		} else if (configuredStyle->themeName == "none") {
-			setStyleSheet(""); // Clear the stylesheet if "None" is selected
-		} else {
-			QString themePath =
-				QString(":/themes/%1/%2.qss").arg(configuredStyle->themeName).arg(configuredStyle->name);
-			setStyleSheet(loadStyleSheet(themePath)); // Apply the selected theme and style
-		}
-	} else {
-		// Handle the case where no theme is configured (fallback to default behavior)
-		setStyleSheet(loadStyleSheet(lightThemePath)); // Default to light theme
-	}
-}
-
-bool MainWindow::detectSystemTheme() {
-#if QT_VERSION >= QT_VERSION_CHECK(6, 5, 0)
-	return false; // This should not be called for Qt 6.5 and above
-#else
-// Custom method to detect dark theme for Qt 6.2 and below
-#	ifdef Q_OS_WIN
-	QSettings settings("HKEY_CURRENT_USER\\Software\\Microsoft\\Windows\\CurrentVersion\\Themes\\Personalize",
-					   QSettings::NativeFormat);
-	return settings.value("AppsUseLightTheme", 1).toInt() == 0; // 0 means dark mode
-#	else
-	// Fallback for other OSes
-	QByteArray platform = qgetenv("QT_QPA_PLATFORM");
-	if (platform.contains("darkmode=2")) {
-		return true;
-	} else if (platform.contains("darkmode=1")) {
-		QPalette defaultPalette;
-		return defaultPalette.color(QPalette::WindowText).lightness()
-			   > defaultPalette.color(QPalette::Window).lightness();
-	}
-	return false;
-#	endif
-#endif
-}
-
-QString MainWindow::loadStyleSheet(const QString &path) {
-	QFile file(path);
-	if (file.open(QFile::ReadOnly | QFile::Text)) {
-		QTextStream stream(&file);
-		return stream.readAll(); // Return the stylesheet content
-	}
-	return QString(); // Return empty if the file cannot be loaded
 }
 
 void MainWindow::createActions() {
@@ -839,7 +768,7 @@ void MainWindow::changeEvent(QEvent *e) {
 	}
 #endif
 	if (e->type() == QEvent::ThemeChange) {
-		applyTheme();
+		Themes::apply();
 	}
 }
 

--- a/src/mumble/MainWindow.h
+++ b/src/mumble/MainWindow.h
@@ -220,9 +220,6 @@ protected:
 	ContextMenuTarget getContextMenuTargets();
 
 	void autocompleteUsername();
-	void applyTheme();
-	bool detectSystemTheme();
-	QString loadStyleSheet(const QString &path);
 
 public slots:
 	void on_qmServer_aboutToShow();

--- a/src/mumble/MainWindow.h
+++ b/src/mumble/MainWindow.h
@@ -221,6 +221,10 @@ protected:
 
 	void autocompleteUsername();
 
+	void applyTheme();
+	bool detectSystemTheme();
+	QString loadStyleSheet(const QString &path);
+
 public slots:
 	void on_qmServer_aboutToShow();
 	void on_qaServerConnect_triggered(bool autoconnect = false);

--- a/src/mumble/MainWindow.h
+++ b/src/mumble/MainWindow.h
@@ -220,7 +220,6 @@ protected:
 	ContextMenuTarget getContextMenuTargets();
 
 	void autocompleteUsername();
-
 	void applyTheme();
 	bool detectSystemTheme();
 	QString loadStyleSheet(const QString &path);

--- a/src/mumble/Themes.h
+++ b/src/mumble/Themes.h
@@ -31,6 +31,9 @@ public:
 	/// @note Can only apply a theme before MainWindow etc. is opened
 	static bool apply();
 
+	/// Detects current OS theme
+	static bool detectSystemTheme();
+
 	/// Return a theme name to theme map
 	static ThemeMap getThemes();
 

--- a/src/mumble/Themes.h
+++ b/src/mumble/Themes.h
@@ -66,6 +66,9 @@ private:
 	/// If a the file is is available, the function returns true.
 	/// If no file is available, it returns false.
 	static bool readStylesheet(const QString &stylesheetFn, QString &stylesheetContent);
+
+	/// Member variable to store the current theme path
+	static QString currentThemePath;
 };
 
 #endif // MUMBLE_MUMBLE_THEMES_H_

--- a/themes/Default/theme.ini
+++ b/themes/Default/theme.ini
@@ -1,11 +1,15 @@
 [theme]
 name=Mumble
-styles=dark,lite
+styles=dark,lite,auto
 [dark]
 name=Dark
 qss=Dark.qss
 qss_MAC=OSX Dark.qss
 [lite]
 name=Lite
+qss=Lite.qss
+qss_MAC=OSX Lite.qss
+[auto]
+name=Auto
 qss=Lite.qss
 qss_MAC=OSX Lite.qss


### PR DESCRIPTION
This update introduces an automatic theme switch that changes based on the OS color scheme at startup and during runtime. This feature is implemented for Qt 6.2 and includes compatibility for Qt 6.5 once Mumble upgrades.

Implements #6515


### Checks

- [x] My commits follow the [commit guidelines](https://github.com/mumble-voip/mumble/blob/master/COMMIT_GUIDELINES.md)

