### PR TITLE
Backport "Merge PR #6611: FIX(client): Fix AudioWizard echo cancellation checkbox" to 1.5.x

### DIFF
--- a/src/mumble/AudioWizard.h
+++ b/src/mumble/AudioWizard.h
@@ -20,6 +20,8 @@ private:
 	Q_OBJECT
 	Q_DISABLE_COPY(AudioWizard)
 
+	void updateEchoCheckbox(AudioInputRegistrar *air);
+
 	/// Which echo cancellation is usable depends on the audio backend and the device combination.
 	/// This function will iterate through the list of available echo cancellation in the audio backend and check with
 	/// the backend whether this echo cancellation option works for current device combination.


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `1.5.x`:
 - [Merge PR #6611: FIX(client): Fix AudioWizard echo cancellation checkbox](https://github.com/mumble-voip/mumble/pull/6611)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)