### PR TITLE
Backport "Merge PR #6584: FIX(client): Specify version when loading/saving MainWindow state" to 1.5.x

### DIFF
--- a/cmake/project-utils.cmake
+++ b/cmake/project-utils.cmake
@@ -3,6 +3,23 @@
 # that can be found in the LICENSE file at the root of the
 # Mumble source tree or at <https://www.mumble.info/LICENSE>.
 
+# This function calculates the SHA3-256 hash of the given FILE.
+# The hash is written in numerical form (sum of bytes) into HASH.
+function(get_numerical_file_hash FILE HASH)
+	file(SHA3_256 ${FILE} HEX_HASH)
+
+	# Split the hex hash string into pairs (each one representing a single byte).
+	string(REGEX MATCHALL ".." BYTES ${HEX_HASH})
+
+	set(NUMERICAL 0)
+
+	foreach(BYTE ${BYTES})
+		math(EXPR NUMERICAL "${NUMERICAL} + 0x${BYTE}" OUTPUT_FORMAT DECIMAL)
+	endforeach()
+
+	set(${HASH} ${NUMERICAL} PARENT_SCOPE)
+endfunction()
+
 # This function gets all included subdirectories in the given DIR recursively.
 # It'll write the found subdirs into SUBDIRS.
 # Note that the DIR itself will not be added to SUBDIRS

--- a/src/mumble/CMakeLists.txt
+++ b/src/mumble/CMakeLists.txt
@@ -416,9 +416,15 @@ else()
 	endif()
 endif()
 
+# This is used to invalidate the saved widget state if a change in the source is detected.
+get_numerical_file_hash("${CMAKE_CURRENT_SOURCE_DIR}/MainWindow.ui" MAINWINDOW_UI_HASH)
+
+message(STATUS "MAINWINDOW_UI_HASH: ${MAINWINDOW_UI_HASH}")
+
 target_compile_definitions(mumble_client_object_lib
 	PUBLIC
 		"MUMBLE"
+		"MUMBLE_MAINWINDOW_UI_HASH=${MAINWINDOW_UI_HASH}"
 		"QT_RESTRICTED_CAST_FROM_ASCII"
 )
 

--- a/src/mumble/MainWindow.cpp
+++ b/src/mumble/MainWindow.cpp
@@ -1389,7 +1389,6 @@ void MainWindow::storeState(const bool minimalView) {
 	} else {
 		Global::get().s.qbaMainWindowGeometry = saveGeometry();
 		Global::get().s.qbaMainWindowState    = saveState(stateVersion());
-		Global::get().s.qbaHeaderState        = qtvUsers->header()->saveState();
 	}
 }
 

--- a/src/mumble/MainWindow.h
+++ b/src/mumble/MainWindow.h
@@ -145,6 +145,9 @@ public:
 	void focusNextMainWidget();
 	QPair< QByteArray, QImage > openImageFile();
 
+	void loadState(bool minimalView);
+	void storeState(bool minimalView);
+
 	void updateChatBar();
 	void openTextMessageDialog(ClientUser *p);
 	void openUserLocalNicknameDialog(const ClientUser &p);
@@ -192,6 +195,8 @@ protected:
 	qt_unique_ptr< MenuLabel > m_localVolumeLabel;
 	qt_unique_ptr< UserLocalVolumeSlider > m_userLocalVolumeSlider;
 	qt_unique_ptr< ListenerVolumeSlider > m_listenerVolumeSlider;
+
+	static constexpr int stateVersion();
 
 	void createActions();
 	void setupGui();

--- a/src/mumble/OverlayClient.cpp
+++ b/src/mumble/OverlayClient.cpp
@@ -206,14 +206,7 @@ void OverlayClient::showGui() {
 	bWasVisible = !Global::get().mw->isHidden();
 
 	if (bWasVisible) {
-		if (Global::get().s.bMinimalView) {
-			Global::get().s.qbaMinimalViewGeometry = Global::get().mw->saveGeometry();
-			Global::get().s.qbaMinimalViewState    = Global::get().mw->saveState();
-		} else {
-			Global::get().s.qbaMainWindowGeometry = Global::get().mw->saveGeometry();
-			Global::get().s.qbaMainWindowState    = Global::get().mw->saveState();
-			Global::get().s.qbaHeaderState        = Global::get().mw->qtvUsers->header()->saveState();
-		}
+		Global::get().mw->storeState(Global::get().s.bMinimalView);
 	}
 
 	{
@@ -315,13 +308,7 @@ void OverlayClient::hideGui() {
 	}
 
 	if (bWasVisible) {
-		if (Global::get().s.bMinimalView && !Global::get().s.qbaMinimalViewGeometry.isNull()) {
-			Global::get().mw->restoreGeometry(Global::get().s.qbaMinimalViewGeometry);
-			Global::get().mw->restoreState(Global::get().s.qbaMinimalViewState);
-		} else if (!Global::get().s.bMinimalView && !Global::get().s.qbaMainWindowGeometry.isNull()) {
-			Global::get().mw->restoreGeometry(Global::get().s.qbaMainWindowGeometry);
-			Global::get().mw->restoreState(Global::get().s.qbaMainWindowState);
-		}
+		Global::get().mw->loadState(Global::get().s.bMinimalView);
 	}
 
 #ifdef Q_OS_MAC

--- a/src/mumble/Settings.cpp
+++ b/src/mumble/Settings.cpp
@@ -964,7 +964,6 @@ void Settings::legacyLoad(const QString &path) {
 	LOAD(qbaMinimalViewState, "ui/minimalviewstate");
 	LOAD(qbaConfigGeometry, "ui/ConfigGeometry");
 	LOADENUM(wlWindowLayout, "ui/WindowLayout");
-	LOAD(qbaHeaderState, "ui/header");
 	LOAD(qsUsername, "ui/username");
 	LOAD(qsLastServer, "ui/server");
 	LOADENUM(ssFilter, "ui/serverfilter");

--- a/src/mumble/Settings.h
+++ b/src/mumble/Settings.h
@@ -403,7 +403,6 @@ struct Settings {
 	QByteArray qbaMainWindowState        = {};
 	QByteArray qbaMinimalViewGeometry    = {};
 	QByteArray qbaMinimalViewState       = {};
-	QByteArray qbaHeaderState            = {};
 	QByteArray qbaConfigGeometry         = {};
 	WindowLayout wlWindowLayout          = LayoutClassic;
 	ChannelExpand ceExpand               = ChannelsWithUsers;

--- a/src/mumble/SettingsMacros.h
+++ b/src/mumble/SettingsMacros.h
@@ -158,7 +158,6 @@
 	PROCESS(ui, WINDOW_STATE_MINIMAL_VIEW_KEY, qbaMinimalViewState)              \
 	PROCESS(ui, CONFIG_GEOMETRY_KEY, qbaConfigGeometry)                          \
 	PROCESS(ui, WINDOW_LAYOUT_KEY, wlWindowLayout)                               \
-	PROCESS(ui, OVERLAY_HEADER_STATE, qbaHeaderState)                            \
 	PROCESS(ui, SERVER_FILTER_MODE_KEY, ssFilter)                                \
 	PROCESS(ui, HIDE_IN_TRAY_KEY, bHideInTray)                                   \
 	PROCESS(ui, DISPLAY_TALKING_STATE_IN_TRAY_KEY, bStateInTray)                 \


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `1.5.x`:
 - [Merge PR #6584: FIX(client): Specify version when loading/saving MainWindow state](https://github.com/mumble-voip/mumble/pull/6584)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)