### PR TITLE
FIX(client): Fix Windows Unicode paths when using raw file streams

### DIFF
--- a/src/QtUtils.cpp
+++ b/src/QtUtils.cpp
@@ -7,6 +7,8 @@
 #include <QStringList>
 #include <QUrl>
 
+#include <boost/filesystem.hpp>
+
 namespace Mumble {
 namespace QtUtils {
 	void deleteQObject(QObject *object) { object->deleteLater(); }
@@ -23,6 +25,17 @@ namespace QtUtils {
 		return QString();
 	}
 
+	boost::filesystem::path qstring_to_path(const QString &input) {
+		// Path handling uses wide character encoding on Windows.
+		// When converting from QStrings, we need to take that
+		// into account, otherwise raw file operations will fail when
+		// the path contains Unicode characters.
+#ifdef Q_OS_WIN
+		return boost::filesystem::path(input.toStdWString());
+#else
+		return boost::filesystem::path(input.toUtf8());
+#endif
+	}
 
 } // namespace QtUtils
 } // namespace Mumble

--- a/src/QtUtils.cpp
+++ b/src/QtUtils.cpp
@@ -7,7 +7,7 @@
 #include <QStringList>
 #include <QUrl>
 
-#include <boost/filesystem.hpp>
+#include <filesystem>
 
 namespace Mumble {
 namespace QtUtils {
@@ -25,15 +25,15 @@ namespace QtUtils {
 		return QString();
 	}
 
-	boost::filesystem::path qstring_to_path(const QString &input) {
+	std::filesystem::path qstring_to_path(const QString &input) {
 		// Path handling uses wide character encoding on Windows.
 		// When converting from QStrings, we need to take that
 		// into account, otherwise raw file operations will fail when
 		// the path contains Unicode characters.
 #ifdef Q_OS_WIN
-		return boost::filesystem::path(input.toStdWString());
+		return std::filesystem::path(input.toStdWString());
 #else
-		return boost::filesystem::path(input.toUtf8());
+		return std::filesystem::path(input.toUtf8().data());
 #endif
 	}
 

--- a/src/QtUtils.h
+++ b/src/QtUtils.h
@@ -10,6 +10,8 @@
 #include <QString>
 #include <QStringList>
 
+#include <boost/filesystem.hpp>
+
 #include <memory>
 
 class QObject;
@@ -33,6 +35,11 @@ namespace QtUtils {
 	 * given list. If the list is empty an empty String is returned.
 	 */
 	QString decode_first_utf8_qssl_string(const QStringList &list);
+
+	/**
+	 * Creates a platform agnostic path from a QString
+	 */
+	boost::filesystem::path qstring_to_path(const QString &input);
 
 } // namespace QtUtils
 } // namespace Mumble

--- a/src/QtUtils.h
+++ b/src/QtUtils.h
@@ -10,7 +10,7 @@
 #include <QString>
 #include <QStringList>
 
-#include <boost/filesystem.hpp>
+#include <filesystem>
 
 #include <memory>
 
@@ -39,7 +39,7 @@ namespace QtUtils {
 	/**
 	 * Creates a platform agnostic path from a QString
 	 */
-	boost::filesystem::path qstring_to_path(const QString &input);
+	std::filesystem::path qstring_to_path(const QString &input);
 
 } // namespace QtUtils
 } // namespace Mumble

--- a/src/mumble/PluginInstaller.cpp
+++ b/src/mumble/PluginInstaller.cpp
@@ -19,9 +19,8 @@
 #include <QtGui/QIcon>
 
 #include <exception>
+#include <fstream>
 #include <string>
-
-#include <boost/filesystem/fstream.hpp>
 
 #include <Poco/Exception.h>
 #include <Poco/FileStream.h>
@@ -129,8 +128,7 @@ void PluginInstaller::init() {
 
 			zipInput.clear();
 			Poco::Zip::ZipInputStream zipin(zipInput, pluginIt->second);
-			boost::filesystem::ofstream out(Mumble::QtUtils::qstring_to_path(tmpPluginPath),
-											std::ios::out | std::ios::binary);
+			std::ofstream out(Mumble::QtUtils::qstring_to_path(tmpPluginPath), std::ios::out | std::ios::binary);
 			Poco::StreamCopier::copyStream(zipin, out);
 
 			m_pluginSource = QFileInfo(tmpPluginPath);

--- a/src/mumble/PluginInstaller.cpp
+++ b/src/mumble/PluginInstaller.cpp
@@ -6,6 +6,7 @@
 #include "PluginInstaller.h"
 #include "PluginManager.h"
 #include "PluginManifest.h"
+#include "QtUtils.h"
 #include "Global.h"
 
 #include <QMessageBox>
@@ -18,8 +19,9 @@
 #include <QtGui/QIcon>
 
 #include <exception>
-#include <fstream>
 #include <string>
+
+#include <boost/filesystem/fstream.hpp>
 
 #include <Poco/Exception.h>
 #include <Poco/FileStream.h>
@@ -127,7 +129,8 @@ void PluginInstaller::init() {
 
 			zipInput.clear();
 			Poco::Zip::ZipInputStream zipin(zipInput, pluginIt->second);
-			std::ofstream out(tmpPluginPath.toStdString(), std::ios::out | std::ios::binary);
+			boost::filesystem::ofstream out(Mumble::QtUtils::qstring_to_path(tmpPluginPath),
+											std::ios::out | std::ios::binary);
 			Poco::StreamCopier::copyStream(zipin, out);
 
 			m_pluginSource = QFileInfo(tmpPluginPath);

--- a/src/mumble/Settings.cpp
+++ b/src/mumble/Settings.cpp
@@ -34,12 +34,12 @@
 #include <QStandardPaths>
 #include <QSystemTrayIcon>
 
-#include <boost/filesystem/fstream.hpp>
 #include <boost/typeof/typeof.hpp>
 
 #include <algorithm>
 #include <cassert>
 #include <cstring>
+#include <fstream>
 #include <limits>
 #include <memory>
 
@@ -156,7 +156,7 @@ void Settings::save(const QString &path) const {
 	QFile tmpFile(QString::fromLatin1("%1/mumble_settings.json.tmp")
 					  .arg(QStandardPaths::writableLocation(QStandardPaths::TempLocation)));
 
-	boost::filesystem::ofstream stream(Mumble::QtUtils::qstring_to_path(tmpFile.fileName()));
+	std::ofstream stream(Mumble::QtUtils::qstring_to_path(tmpFile.fileName()));
 	stream << settingsJSON.dump(4) << std::endl;
 	stream.close();
 
@@ -224,7 +224,7 @@ void Settings::load(const QString &path) {
 		settingsLocation = path;
 	}
 
-	boost::filesystem::ifstream stream(Mumble::QtUtils::qstring_to_path(path));
+	std::ifstream stream(Mumble::QtUtils::qstring_to_path(path));
 
 	nlohmann::json settingsJSON;
 	try {
@@ -613,13 +613,13 @@ void OverlaySettings::savePresets(const QString &filename) {
 	settingsJSON.erase(SettingsKeys::OVERLAY_LAUNCHERS_KEY);
 	settingsJSON.erase(SettingsKeys::OVERLAY_LAUNCHERS_EXCLUDE_KEY);
 
-	boost::filesystem::ofstream stream(Mumble::QtUtils::qstring_to_path(filename));
+	std::ofstream stream(Mumble::QtUtils::qstring_to_path(filename));
 
 	stream << settingsJSON.dump(4) << std::endl;
 }
 
 void OverlaySettings::load(const QString &filename) {
-	boost::filesystem::ifstream stream(Mumble::QtUtils::qstring_to_path(filename));
+	std::ifstream stream(Mumble::QtUtils::qstring_to_path(filename));
 
 	nlohmann::json settingsJSON;
 	try {

--- a/src/mumble/Settings.cpp
+++ b/src/mumble/Settings.cpp
@@ -10,6 +10,7 @@
 #include "EnvUtils.h"
 #include "JSONSerialization.h"
 #include "Log.h"
+#include "QtUtils.h"
 #include "SSL.h"
 #include "SettingsKeys.h"
 #include "SettingsMacros.h"
@@ -33,12 +34,12 @@
 #include <QStandardPaths>
 #include <QSystemTrayIcon>
 
+#include <boost/filesystem/fstream.hpp>
 #include <boost/typeof/typeof.hpp>
 
 #include <algorithm>
 #include <cassert>
 #include <cstring>
-#include <fstream>
 #include <limits>
 #include <memory>
 
@@ -155,11 +156,12 @@ void Settings::save(const QString &path) const {
 	QFile tmpFile(QString::fromLatin1("%1/mumble_settings.json.tmp")
 					  .arg(QStandardPaths::writableLocation(QStandardPaths::TempLocation)));
 
-	{
-		// The separate scope makes sure, the stream is closed again after the write has finished
-		std::ofstream stream(tmpFile.fileName().toUtf8());
+	boost::filesystem::ofstream stream(Mumble::QtUtils::qstring_to_path(tmpFile.fileName()));
+	stream << settingsJSON.dump(4) << std::endl;
+	stream.close();
 
-		stream << settingsJSON.dump(4) << std::endl;
+	if (stream.fail()) {
+		qWarning("Failed at writing temporary settings file: %s", qUtf8Printable(tmpFile.fileName()));
 	}
 
 	QFile targetFile(path);
@@ -222,7 +224,7 @@ void Settings::load(const QString &path) {
 		settingsLocation = path;
 	}
 
-	std::ifstream stream(path.toUtf8());
+	boost::filesystem::ifstream stream(Mumble::QtUtils::qstring_to_path(path));
 
 	nlohmann::json settingsJSON;
 	try {
@@ -611,13 +613,13 @@ void OverlaySettings::savePresets(const QString &filename) {
 	settingsJSON.erase(SettingsKeys::OVERLAY_LAUNCHERS_KEY);
 	settingsJSON.erase(SettingsKeys::OVERLAY_LAUNCHERS_EXCLUDE_KEY);
 
-	std::ofstream stream(filename.toUtf8());
+	boost::filesystem::ofstream stream(Mumble::QtUtils::qstring_to_path(filename));
 
 	stream << settingsJSON.dump(4) << std::endl;
 }
 
 void OverlaySettings::load(const QString &filename) {
-	std::ifstream stream(filename.toUtf8());
+	boost::filesystem::ifstream stream(Mumble::QtUtils::qstring_to_path(filename));
 
 	nlohmann::json settingsJSON;
 	try {


### PR DESCRIPTION
2 commits:

1) Use ``boost::filesystem::path`` and abstract the ``QString`` -> path conversion.
2) Replace ``boost::filesystem::path`` with ``std::filesystem::path`` (for 1.6.x and C++17)