### PR TITLE
DOCS(server): Add Documentation key to mumble-server unit

### DIFF
--- a/auxiliary_files/config_files/mumble-server.service.in
+++ b/auxiliary_files/config_files/mumble-server.service.in
@@ -1,5 +1,6 @@
 [Unit]
 Description=Mumble server
+Documentation=man:mumble-server(1)
 After=network.target
 Wants=network-online.target
 


### PR DESCRIPTION
Make it easy to view the man page by documenting it in its service unit file. Then it can be viewed via `systemctl help mumble-server.service`.


### Checks

- [x] My commits follow the [commit guidelines](https://github.com/mumble-voip/mumble/blob/master/COMMIT_GUIDELINES.md)

