### PR TITLE
FIX(cmake): Don't set WORKING_DIRECTORY for ExternalProject_Add()

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -168,10 +168,6 @@ set(CMAKE_INTERPROCEDURAL_OPTIMIZATION_DEBUG OFF)
 
 add_subdirectory(${3RDPARTY_DIR}/utfcpp)
 
-if(client OR server)
-	add_subdirectory(src)
-endif()
-
 if(g15 AND WIN32)
 	add_subdirectory("helpers/g15helper")
 endif()
@@ -197,6 +193,10 @@ endif()
 
 if(plugins AND client)
 	add_subdirectory(plugins)
+endif()
+
+if(client OR server)
+	add_subdirectory(src)
 endif()
 
 add_subdirectory(auxiliary_files)

--- a/helpers/g15helper/CMakeLists.txt
+++ b/helpers/g15helper/CMakeLists.txt
@@ -12,8 +12,6 @@ set(G15HELPER_PLIST "${CMAKE_BINARY_DIR}/g15helper.plist")
 configure_file("${CMAKE_CURRENT_SOURCE_DIR}/g15helper.plist.in" "${G15HELPER_PLIST}")
 configure_file("${CMAKE_CURRENT_SOURCE_DIR}/g15helper.rc.in" "${G15HELPER_RC}")
 
-get_target_property(MUMBLE_SOURCE_DIR mumble SOURCE_DIR)
-
 add_executable(g15-helper WIN32
 	"${CMAKE_SOURCE_DIR}/auxiliary_files/mumble.appcompat.manifest"
 	"${G15HELPER_RC}"

--- a/overlay/CMakeLists.txt
+++ b/overlay/CMakeLists.txt
@@ -172,7 +172,6 @@ if(64_BIT AND MSVC)
 				"-Dversion=${PROJECT_VERSION}"
 				${CMAKE_SOURCE_DIR}/overlay
 			CMAKE_GENERATOR_PLATFORM "Win32"
-			WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/overlay/overlay_xcompile-prefix
 			INSTALL_COMMAND ""
 		)
 	else()
@@ -194,7 +193,6 @@ if(64_BIT AND MSVC)
 				"-Dsymbols=${symbols}"
 				"-Dversion=${PROJECT_VERSION}"
 				${CMAKE_SOURCE_DIR}/overlay
-			WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/overlay/overlay_xcompile-prefix
 			INSTALL_COMMAND ""
 		)
 	endif()

--- a/plugins/CMakeLists.txt
+++ b/plugins/CMakeLists.txt
@@ -9,6 +9,7 @@ if(retracted-plugins)
 	message(STATUS "Including retracted plugins")
 endif()
 
+add_custom_target(plugins ALL)
 
 set(AVAILABLE_PLUGINS "")
 
@@ -123,5 +124,5 @@ foreach(CURRENT_PLUGIN IN LISTS AVAILABLE_PLUGINS)
 		install(TARGETS ${CURRENT_PLUGIN} LIBRARY DESTINATION "${MUMBLE_INSTALL_PLUGINDIR}" COMPONENT mumble_client)
 	endif()
 
-	add_dependencies(mumble ${CURRENT_PLUGIN})
+	add_dependencies(plugins ${CURRENT_PLUGIN})
 endforeach()

--- a/src/mumble/CMakeLists.txt
+++ b/src/mumble/CMakeLists.txt
@@ -887,15 +887,23 @@ if(overlay)
 				"Overlay_win.cpp"
 				"Overlay_win.h"
 		)
+
+		add_dependencies(mumble overlay)
 	else()
 		if(APPLE)
 			target_sources(mumble_client_object_lib PRIVATE "Overlay_macx.mm")
 		else()
 			target_sources(mumble_client_object_lib PRIVATE "Overlay_unix.cpp")
 		endif()
+
+		add_dependencies(mumble overlay_gl)
 	endif()
 
 	target_compile_definitions(mumble_client_object_lib PUBLIC "USE_OVERLAY")
+endif()
+
+if(plugins)
+	add_dependencies(mumble plugins)
 endif()
 
 if(xboxinput)
@@ -926,6 +934,7 @@ if(g15)
 				"G15LCDEngine_helper.h"
 		)
 	target_include_directories(mumble_client_object_lib PUBLIC "${CMAKE_SOURCE_DIR}/helpers")
+	add_dependencies(mumble g15-helper)
 	else()
 		find_library(LIB_G15DAEMON_CLIENT "g15daemon_client")
 		if(LIB_G15DAEMON_CLIENT-NOTFOUND)


### PR DESCRIPTION
This is a workaround for a bug that appeared in a recent version of CMake.

`WORKING_DIRECTORY` prepends the specified path to a list instead of using it directly, resulting in:

`cd /D D:\a\1\b\overlay\overlay_xcompile-prefix;D:\a\1\b\overlay\overlay_xcompile-prefix\src\overlay_xcompile-build`

For reference, this causes the build to fail on Windows with the following error:

"The filename, directory name, or volume label syntax is incorrect."

This commit simply removes the parameter from the `ExternalProject_Add()` call, since the default working directory is perfectly fine.
