### PR TITLE
DOCS(build_linux): Update Debian B-D: pkg-config -> pkgconf

### DIFF
--- a/docs/dev/build-instructions/build_linux.md
+++ b/docs/dev/build-instructions/build_linux.md
@@ -13,7 +13,7 @@ In order to install the needed dependencies on Ubuntu, you have to run the follo
 sudo apt install \
   build-essential \
   cmake \
-  pkg-config \
+  pkgconf \
   qt6-base-dev \
   qt6-tools-dev \
   qt6-tools-dev-tools \


### PR DESCRIPTION
Since Debian Bookworm the pkg-config package is a transitional package to pkgconf, so update the build dependency install instructions to point to its target.


### Checks

- [x] My commits follow the [commit guidelines](https://github.com/mumble-voip/mumble/blob/master/COMMIT_GUIDELINES.md)

