### PR TITLE
Backport "Merge PR #6637: DOCS(server): Add Documentation key to mumble-server unit" to 1.5.x

### DIFF
--- a/auxiliary_files/config_files/mumble-server.service.in
+++ b/auxiliary_files/config_files/mumble-server.service.in
@@ -1,5 +1,6 @@
 [Unit]
 Description=Mumble server
+Documentation=man:mumble-server(1)
 After=network.target
 Wants=network-online.target
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `1.5.x`:
 - [Merge PR #6637: DOCS(server): Add Documentation key to mumble-server unit](https://github.com/mumble-voip/mumble/pull/6637)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)