### PR TITLE
Backport "FIX(client): Fix Windows Unicode paths when using raw file streams #6635" to 1.5.x

### DIFF
--- a/src/QtUtils.cpp
+++ b/src/QtUtils.cpp
@@ -7,6 +7,8 @@
 #include <QStringList>
 #include <QUrl>
 
+#include <boost/filesystem.hpp>
+
 namespace Mumble {
 namespace QtUtils {
 	void deleteQObject(QObject *object) { object->deleteLater(); }
@@ -23,6 +25,17 @@ namespace QtUtils {
 		return QString();
 	}
 
+	boost::filesystem::path qstring_to_path(const QString &input) {
+		// Path handling uses wide character encoding on Windows.
+		// When converting from QStrings, we need to take that
+		// into account, otherwise raw file operations will fail when
+		// the path contains Unicode characters.
+#ifdef Q_OS_WIN
+		return boost::filesystem::path(input.toStdWString());
+#else
+		return boost::filesystem::path(input.toUtf8());
+#endif
+	}
 
 } // namespace QtUtils
 } // namespace Mumble

--- a/src/QtUtils.h
+++ b/src/QtUtils.h
@@ -9,6 +9,8 @@
 #include <QCryptographicHash>
 #include <QString>
 
+#include <boost/filesystem.hpp>
+
 #include <memory>
 
 class QObject;
@@ -33,6 +35,11 @@ namespace QtUtils {
 	 * given list. If the list is empty an empty String is returned.
 	 */
 	QString decode_first_utf8_qssl_string(const QStringList &list);
+
+	/**
+	 * Creates a platform agnostic path from a QString
+	 */
+	boost::filesystem::path qstring_to_path(const QString &input);
 
 } // namespace QtUtils
 } // namespace Mumble

--- a/src/mumble/PluginInstaller.cpp
+++ b/src/mumble/PluginInstaller.cpp
@@ -6,6 +6,7 @@
 #include "PluginInstaller.h"
 #include "PluginManager.h"
 #include "PluginManifest.h"
+#include "QtUtils.h"
 #include "Global.h"
 
 #include <QMessageBox>
@@ -18,8 +19,9 @@
 #include <QtGui/QIcon>
 
 #include <exception>
-#include <fstream>
 #include <string>
+
+#include <boost/filesystem/fstream.hpp>
 
 #include <Poco/Exception.h>
 #include <Poco/FileStream.h>
@@ -124,7 +126,8 @@ void PluginInstaller::init() {
 
 			zipInput.clear();
 			Poco::Zip::ZipInputStream zipin(zipInput, pluginIt->second);
-			std::ofstream out(tmpPluginPath.toStdString(), std::ios::out | std::ios::binary);
+			boost::filesystem::ofstream out(Mumble::QtUtils::qstring_to_path(tmpPluginPath),
+											std::ios::out | std::ios::binary);
 			Poco::StreamCopier::copyStream(zipin, out);
 
 			m_pluginSource = QFileInfo(tmpPluginPath);


### PR DESCRIPTION
From #6635