### PR TITLE
CI(appveyor): Workaround for FXC failing to run with error C0000139

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -25,6 +25,10 @@ environment:
     - MUMBLE_ENVIRONMENT_TRIPLET: 'x64-windows-static-md-release'
       MUMBLE_ENVIRONMENT_VERSION: 'mumble_env.x64-windows-static-md-release.2023-12-31.6a3ce9c65'
 
+init:
+  # https://github.com/appveyor/ci/issues/3937
+  - cmd: del /s /q "%ProgramFiles(x86)%\Windows Kits\10\bin\d3dcompiler_47.dll"
+
 install:
   - ps: .ci/install-environment_windows.ps1
 


### PR DESCRIPTION
This adds a fix for the appveyor CI pipeline to the 1.5.x branch.

from @davidebeatrici:

The Effect-Compiler Tool ("fxc.exe") seems to have only two direct dependencies:

- kernel32.dll
- D3DCompiler_47.dll

Both libraries are shipped with Windows, but the SDK provides a variant of the latter along with the executable. Turns out that variant is causing FXC to fail to launch with the following error:

"The procedure entry point __CxxFrameHandler4 could not be located in the dynamic link library C:\Program Files (x86)\Windows Kits\10\bin\10.0.26100.0\x64\D3DCOMPILER_47.dll."

It's unclear when exactly the issue started happening and why. We just know it was never encountered until this week, when triggering a new official release (last one was in May).

The workaround is simple: we delete any instances of the problematic DLL in the SDK folder(s) so that the working one that is shipped with the operating system is picked up.
