### PR TITLE
FEAT(client,images): Add animated GIF support

### DIFF
--- a/src/mumble/CustomElements.cpp
+++ b/src/mumble/CustomElements.cpp
@@ -18,17 +18,80 @@
 #include <QtGui/QClipboard>
 #include <QtGui/QContextMenuEvent>
 #include <QtGui/QKeyEvent>
+#include <QtGui/QMovie>
+#include <QtGui/QPainter>
+#include <QtGui/QPainterPath>
 #include <QtWidgets/QScrollBar>
 
 LogTextBrowser::LogTextBrowser(QWidget *p) : QTextBrowser(p) {
 }
 
-int LogTextBrowser::getLogScroll() {
+void LogTextBrowser::update() {
+	document()->documentLayout()->update(QRect(getScrollX(), getScrollY(), width(), height()));
+}
+
+int LogTextBrowser::getScrollX() {
+	return horizontalScrollBar()->value();
+}
+
+int LogTextBrowser::getScrollY() {
 	return verticalScrollBar()->value();
 }
 
-void LogTextBrowser::setLogScroll(int scroll_pos) {
+void LogTextBrowser::setScrollX(int scroll_pos) {
+	horizontalScrollBar()->setValue(scroll_pos);
+}
+
+void LogTextBrowser::setScrollY(int scroll_pos) {
 	verticalScrollBar()->setValue(scroll_pos);
+}
+
+void LogTextBrowser::changeScrollX(int change) {
+	QScrollBar *scrollBar = horizontalScrollBar();
+	scrollBar->setValue(scrollBar->value() + change);
+}
+
+void LogTextBrowser::changeScrollY(int change) {
+	QScrollBar *scrollBar = verticalScrollBar();
+	scrollBar->setValue(scrollBar->value() + change);
+}
+
+void LogTextBrowser::scrollItemIntoView(QRect rect) {
+	QRect logRect(getScrollX(), getScrollY(), width(), height());
+	int rectXWithWidth     = rect.x() + rect.width();
+	int logRectXWithWidth  = logRect.x() + logRect.width();
+	int rectYWithHeight    = rect.y() + rect.height();
+	int logRectYWithHeight = logRect.y() + logRect.height();
+
+	bool isItemToTheRight  = rectXWithWidth > logRectXWithWidth;
+	bool isItemToTheLeft   = rect.x() < logRect.x();
+	bool isItemBelow       = rectYWithHeight > logRectYWithHeight;
+	bool isItemAbove       = rect.y() < logRect.y();
+	bool isItemAtAllInView = rect.x() < logRectXWithWidth && rectXWithWidth > logRect.x()
+							 && rect.y() < logRectYWithHeight && rectYWithHeight > logRect.y();
+
+	int offset          = 20;
+	bool isWithinWidth  = rect.width() <= logRect.width() - offset;
+	bool isWithinHeight = rect.height() <= logRect.height() - offset;
+	// Scroll to the item if it fits the log window and is at all out of view. Otherwise only
+	// scroll to the item if it is entirely out of view. Both ways scroll just far enough, with the set offset as
+	// margin, to show the item at the bottom or top of the log window if the previous position was above or below the
+	// item respectively. If the item does not fit the log window then scroll as far as the start or end of the item is
+	// still in view if the previous position was entirely above or below the item respectively. The same principles
+	// apply horizontally, where below is to the right and above is to the left:
+	if ((isWithinWidth && (isItemToTheRight || isItemToTheLeft)) || !isItemAtAllInView) {
+		setScrollX((isWithinWidth && isItemToTheRight) || (!isWithinWidth && isItemToTheLeft)
+					   ? rectXWithWidth - logRect.width() + offset
+					   : rect.x() - offset);
+	}
+	if ((isWithinHeight && (isItemBelow || isItemAbove)) || !isItemAtAllInView) {
+		setScrollY((isWithinHeight && isItemBelow) || (!isWithinHeight && isItemAbove)
+					   ? rectYWithHeight - logRect.height() + offset
+					   : rect.y() - offset);
+	}
+	if (getScrollX() == logRect.x() && getScrollY() == logRect.y()) {
+		update();
+	}
 }
 
 bool LogTextBrowser::isScrolledToBottom() {
@@ -36,6 +99,105 @@ bool LogTextBrowser::isScrolledToBottom() {
 	return scrollBar->value() == scrollBar->maximum();
 }
 
+void LogTextBrowser::mousePressEvent(QMouseEvent *qme) {
+	QPoint mouseDocPos                     = qme->pos();
+	Qt::MouseButton mouseButton            = qme->button();
+	QAbstractTextDocumentLayout *docLayout = document()->documentLayout();
+	// Set the vertical axis of the position to include the scrollable area above it:
+	mouseDocPos.setY(mouseDocPos.y() + getScrollY());
+
+	AnimationTextObject::mousePress(docLayout, mouseDocPos, mouseButton);
+}
+
+void LogTextBrowser::keyPressEvent(QKeyEvent *qke) {
+	Qt::Key key                     = static_cast< Qt::Key >(qke->key());
+	Qt::KeyboardModifiers modifiers = QApplication::keyboardModifiers();
+	int logWindowHeight             = height();
+	int logInternalHeight           = verticalScrollBar()->maximum();
+
+	int lastItemIndex  = lastCustomInteractiveItemIndex;
+	int itemFocusIndex = customInteractiveItemFocusIndex;
+	int scrollStep     = 15;
+	if (modifiers.testFlag(Qt::ControlModifier)) {
+		switch (key) {
+			case Qt::Key_A:
+				return selectAll();
+			case Qt::Key_C:
+				return copy();
+			case Qt::Key_0:
+				return queuedNumericInput.push_back('0');
+			case Qt::Key_1:
+				return queuedNumericInput.push_back('1');
+			case Qt::Key_2:
+				return queuedNumericInput.push_back('2');
+			case Qt::Key_3:
+				return queuedNumericInput.push_back('3');
+			case Qt::Key_4:
+				return queuedNumericInput.push_back('4');
+			case Qt::Key_5:
+				return queuedNumericInput.push_back('5');
+			case Qt::Key_6:
+				return queuedNumericInput.push_back('6');
+			case Qt::Key_7:
+				return queuedNumericInput.push_back('7');
+			case Qt::Key_8:
+				return queuedNumericInput.push_back('8');
+			case Qt::Key_9:
+				return queuedNumericInput.push_back('9');
+			default:
+				break;
+		}
+	}
+	switch (key) {
+		case Qt::Key_Down:
+			return changeScrollY(scrollStep);
+		case Qt::Key_Up:
+			return changeScrollY(-scrollStep);
+		case Qt::Key_Right:
+			return changeScrollX(15);
+		case Qt::Key_Left:
+			return changeScrollX(-15);
+		case Qt::Key_PageDown:
+			return changeScrollY(logWindowHeight);
+		case Qt::Key_PageUp:
+			return changeScrollY(-logWindowHeight);
+		case Qt::Key_Home:
+			return setScrollY(0);
+		case Qt::Key_End:
+			return setScrollY(logInternalHeight);
+		case Qt::Key_Return:
+		case Qt::Key_Enter:
+			customInteractiveItemFocusIndex += itemFocusIndex == lastItemIndex ? -lastItemIndex : 1;
+			break;
+		case Qt::Key_Backspace:
+			customInteractiveItemFocusIndex += itemFocusIndex < 1 ? lastItemIndex + (itemFocusIndex == -1 ? 1 : 0) : -1;
+			break;
+		case Qt::Key_Escape:
+			customInteractiveItemFocusIndex = -1;
+			return update();
+		default:
+			break;
+	}
+	bool isItemSelectionChanged = customInteractiveItemFocusIndex != itemFocusIndex;
+
+	AnimationTextObject::keyPress(this, isItemSelectionChanged, key);
+}
+
+void LogTextBrowser::keyReleaseEvent(QKeyEvent *qke) {
+	Qt::Key key = static_cast< Qt::Key >(qke->key());
+	if (queuedNumericInput.length() > 0 && key == Qt::Key_Control) {
+		int lastItemIndex            = lastCustomInteractiveItemIndex;
+		int itemFocusIndex           = queuedNumericInput.toInt();
+		bool isItemFocusIndexTooHigh = itemFocusIndex > lastItemIndex;
+
+		customInteractiveItemFocusIndex = isItemFocusIndexTooHigh ? -1 : itemFocusIndex;
+		queuedNumericInput.clear();
+		if (isItemFocusIndexTooHigh) {
+			return update();
+		}
+		AnimationTextObject::keyPress(this, true, key);
+	}
+}
 
 void ChatbarTextEdit::focusInEvent(QFocusEvent *qfe) {
 	inFocus(true);
@@ -201,7 +363,7 @@ bool ChatbarTextEdit::sendImagesFromMimeData(const QMimeData *source) {
 
 					if (image.isNull())
 						continue;
-					if (emitPastedImage(image)) {
+					if (emitPastedImage(image, path)) {
 						++count;
 					} else {
 						Global::get().l->log(Log::Information, tr("Unable to send image %1: too large.").arg(path));
@@ -217,7 +379,20 @@ bool ChatbarTextEdit::sendImagesFromMimeData(const QMimeData *source) {
 	return false;
 }
 
-bool ChatbarTextEdit::emitPastedImage(QImage image) {
+bool ChatbarTextEdit::emitPastedImage(QImage image, QString filePath) {
+	if (filePath.endsWith(".gif")) {
+		QFile file(filePath);
+		if (file.open(QIODevice::ReadOnly)) {
+			QByteArray animationBa(file.readAll());
+			file.close();
+			QString base64ImageData = qvariant_cast< QString >(animationBa.toBase64());
+			emit pastedImage("<br /><img src=\"data:image/GIF;base64," + base64ImageData + "\" />");
+		} else {
+			Global::get().l->log(Log::Information, tr("Unable to read animated image file: %1").arg(filePath));
+		}
+		return true;
+	}
+
 	QString processedImage = Log::imageToImg(image, static_cast< int >(Global::get().uiImageLength));
 	if (processedImage.length() > 0) {
 		QString imgHtml = QLatin1String("<br />") + processedImage;
@@ -226,6 +401,761 @@ bool ChatbarTextEdit::emitPastedImage(QImage image) {
 	}
 	return false;
 }
+
+
+bool AnimationTextObject::areVideoControlsOn = false;
+
+QString AnimationTextObject::loopModeToString(LoopMode mode) {
+	switch (mode) {
+		case Unchanged:
+			return "Unchanged";
+		case Loop:
+			return "Loop";
+		case NoLoop:
+			return "No loop";
+		default:
+			return "Undefined";
+	}
+}
+
+void AnimationTextObject::updateVideoControls(QObject *propertyHolder) {
+	QRect rect              = propertyHolder->property("posAndSize").toRect();
+	int videoControlsHeight = videoBarHeight + underVideoBarHeight;
+	int videoControlsY      = rect.y() + rect.height() - videoControlsHeight;
+	QRect videoControlsRect(rect.x(), videoControlsY, rect.width(), videoControlsHeight);
+
+	emit Global::get().mw->qteLog->document()->documentLayout()->update(videoControlsRect);
+}
+
+void AnimationTextObject::setFrame(QMovie *animation, int frameIndex) {
+	int lastFrameIndex       = animation->property("lastFrameIndex").toInt();
+	bool isFrameIndexTooLow  = frameIndex < 0;
+	bool isFrameIndexTooHigh = frameIndex > lastFrameIndex;
+	if (isFrameIndexTooLow || isFrameIndexTooHigh) {
+		frameIndex = isFrameIndexTooLow ? 0 : lastFrameIndex;
+	}
+	if (animation->cacheMode() == QMovie::CacheAll) {
+		animation->jumpToFrame(frameIndex);
+		return;
+	}
+
+	bool wasRunning = animation->state() == QMovie::Running;
+	if (!wasRunning) {
+		animation->setPaused(false);
+	}
+	bool isStartTried = false;
+	// Can only load the target frame by traversing
+	// in sequential order when the frames are not cached:
+	while (animation->currentFrameNumber() != frameIndex) {
+		if (!animation->jumpToNextFrame()) {
+			// Continue traversing animations that either are stopped or do stop after one or more iterations:
+			if (animation->state() == QMovie::NotRunning && !isStartTried) {
+				animation->start();
+				isStartTried = true;
+				continue;
+			}
+			break;
+		}
+	}
+	if (!wasRunning) {
+		animation->setPaused(true);
+	}
+}
+
+void AnimationTextObject::setFrameByProportion(QMovie *animation, double proportion) {
+	int msPassedAtProportion = (int) round(proportion * getTotalTime(animation));
+	setFrameByTime(animation, msPassedAtProportion);
+}
+
+void AnimationTextObject::setFrameByTime(QMovie *animation, int milliseconds) {
+	int totalMs            = getTotalTime(animation);
+	bool isTimeAfterEnd    = milliseconds > totalMs;
+	bool isTimeBeforeStart = milliseconds < 0;
+	if (isTimeAfterEnd || isTimeBeforeStart) {
+		milliseconds = isTimeAfterEnd ? totalMs : 0;
+	}
+	QList< QVariant > frameDelays = animation->property("frameDelays").toList();
+	qsizetype frameDelayAmount    = frameDelays.length();
+	int msUntilCurrentFrame       = 0;
+
+	int frameIndex = 0;
+	for (int i = 0; i < frameDelayAmount; ++i) {
+		int delay = frameDelays[i].toInt();
+		msUntilCurrentFrame += delay;
+		if (milliseconds <= msUntilCurrentFrame) {
+			bool isNextFrame            = i + 1 < frameDelayAmount;
+			int currentFrameDifference  = msUntilCurrentFrame - milliseconds;
+			int previousFrameDifference = currentFrameDifference - delay;
+			int nextFrameDifference =
+				isNextFrame ? msUntilCurrentFrame + frameDelays[i + 1].toInt() - milliseconds : -1;
+
+			bool isPreviousFrameCloser = abs(previousFrameDifference) < currentFrameDifference;
+			bool isNextFrameCloser     = isNextFrame ? abs(nextFrameDifference) < currentFrameDifference : false;
+			// The first delay has passed by the second frame and so on,
+			// hence the index is greater by 1 for the frame of the full delay:
+			frameIndex = i + 1 + (isPreviousFrameCloser ? -1 : isNextFrameCloser ? 1 : 0);
+			break;
+		}
+	}
+	setFrame(animation, frameIndex);
+}
+
+void AnimationTextObject::togglePause(QMovie *animation) {
+	int lastFrameIndex            = animation->property("lastFrameIndex").toInt();
+	QMovie::MovieState state      = animation->state();
+	bool wasStoppedOrNeverStarted = state == QMovie::NotRunning;
+	if (animation->speed() < 0) {
+		int frameIndex           = animation->currentFrameNumber();
+		int frameIndexToSwitchTo = wasStoppedOrNeverStarted && frameIndex == 0 ? lastFrameIndex : frameIndex;
+		if (wasStoppedOrNeverStarted) {
+			animation->start();
+			animation->setPaused(true);
+			setFrame(animation, frameIndexToSwitchTo);
+		}
+		bool wasPlayingInReverse = animation->property("isPlayingInReverse").toBool();
+		animation->setProperty("isPlayingInReverse", !wasPlayingInReverse);
+		if (wasPlayingInReverse) {
+			emit animation->stateChanged(state);
+		} else {
+			emit animation->frameChanged(frameIndexToSwitchTo);
+		}
+	} else if (wasStoppedOrNeverStarted) {
+		animation->start();
+		// Ensure the animation starts on the first attempt to do so:
+		animation->setPaused(false);
+	} else {
+		animation->setPaused(state != QMovie::Paused);
+	}
+}
+
+void AnimationTextObject::toggleCache(QMovie *animation) {
+	int lastFrameIndex               = animation->property("lastFrameIndex").toInt();
+	bool wasCached                   = animation->cacheMode() == QMovie::CacheAll;
+	QMovie::CacheMode cacheModeToSet = wasCached ? QMovie::CacheNone : QMovie::CacheAll;
+	QMovie::MovieState state         = animation->state();
+	bool wasPaused                   = state == QMovie::Paused;
+	bool wasRunning                  = state == QMovie::Running;
+
+	int previousFrame = animation->currentFrameNumber();
+	// Turning caching on or off requires reloading the animation, which is done via `setDevice`,
+	// otherwise it will not play properly or dispose of the cache when it is not to be used:
+	animation->stop();
+	QIODevice *device = animation->device();
+	// Prepare the animation to be loaded when starting for the first time:
+	device->reset();
+	animation->setDevice(device);
+	animation->setCacheMode(cacheModeToSet);
+	animation->start();
+
+	// Restore the state of the animation playback to what it was before reloading it
+	// but ensure it can be resumed when caching is off by pausing it if it is not at the start or end:
+	setFrame(animation, previousFrame);
+	if (wasPaused || (!wasRunning && previousFrame != 0 && previousFrame != lastFrameIndex)) {
+		animation->setPaused(true);
+	} else if (!wasRunning) {
+		animation->stop();
+	}
+	updateVideoControls(animation);
+}
+
+void AnimationTextObject::stopPlayback(QMovie *animation) {
+	animation->stop();
+	animation->setProperty("isPlayingInReverse", false);
+}
+
+void AnimationTextObject::resetPlayback(QMovie *animation) {
+	// Show the first frame that the animation would continue from if started again
+	// without caching anyway, indicating that the animation was stopped instead of paused:
+	setFrame(animation, 0);
+	stopPlayback(animation);
+}
+
+void AnimationTextObject::setSpeed(QMovie *animation, int percentage) {
+	// Pausing the animation should only be done via the play state to avoid confusion:
+	if (percentage == 0) {
+		return;
+	}
+	animation->setSpeed(percentage);
+	updateVideoControls(animation);
+	// `QMovie` does not itself support reverse playback but this can be and is implemented using it:
+	bool wasPlayingInReverse = animation->property("isPlayingInReverse").toBool();
+	bool wasRunning          = animation->state() == QMovie::Running || wasPlayingInReverse;
+	if (percentage < 0) {
+		if (wasPlayingInReverse) {
+			return;
+		}
+		animation->setPaused(true);
+		animation->setProperty("isPlayingInReverse", wasRunning);
+		if (wasRunning) {
+			// Trigger the signal `frameChanged` where the handler also supports reverse playback:
+			emit animation->frameChanged(animation->currentFrameNumber());
+		}
+	} else if (wasPlayingInReverse) {
+		animation->setProperty("isPlayingInReverse", false);
+		animation->setPaused(!wasRunning);
+	}
+}
+
+void AnimationTextObject::changeLoopMode(QMovie *animation, int steps) {
+	LoopMode loopMode     = qvariant_cast< LoopMode >(animation->property("LoopMode"));
+	int loopModeChangedTo = loopMode + steps;
+	int loopModeResult =
+		loopModeChangedTo > NoLoop ? 0 : loopModeChangedTo < 0 ? static_cast< int >(NoLoop) : loopModeChangedTo;
+	animation->setProperty("LoopMode", static_cast< LoopMode >(loopModeResult));
+	updateVideoControls(animation);
+}
+
+void AnimationTextObject::changeFrame(QMovie *animation, int amount) {
+	int lastFrameIndex       = animation->property("lastFrameIndex").toInt();
+	int frameIndex           = animation->currentFrameNumber() + amount;
+	int amountOfTimesGreater = (int) abs(floor(frameIndex / (double) lastFrameIndex));
+
+	int lastFrameIndexScaledToInput = lastFrameIndex * amountOfTimesGreater;
+	int frameIndexWrappedBackward   = lastFrameIndexScaledToInput + 1 + frameIndex;
+	int frameIndexWrappedForward    = frameIndex - 1 - lastFrameIndexScaledToInput;
+	setFrame(animation, frameIndex < 0 ? frameIndexWrappedBackward
+									   : frameIndex > lastFrameIndex ? frameIndexWrappedForward : frameIndex);
+}
+
+void AnimationTextObject::changeFrameByTime(QMovie *animation, int milliseconds) {
+	setFrameByTime(animation, getCurrentTime(animation, animation->currentFrameNumber()) + milliseconds);
+}
+
+void AnimationTextObject::changeSpeed(QMovie *animation, int percentageStep) {
+	int speed          = animation->speed();
+	int nextPercentage = speed + percentageStep;
+	setSpeed(animation, speed + percentageStep * (nextPercentage != 0 ? 1 : 2));
+}
+
+int AnimationTextObject::getTotalTime(QObject *propertyHolder) {
+	return propertyHolder->property("totalMs").toInt();
+}
+
+int AnimationTextObject::getCurrentTime(QObject *propertyHolder, int frameIndex) {
+	int lastFrameIndex            = propertyHolder->property("lastFrameIndex").toInt();
+	QList< QVariant > frameDelays = propertyHolder->property("frameDelays").toList();
+	int msUntilCurrentFrame       = 0;
+	// Determine the time until the current frame or the time until the end of the last frame
+	// if on the last frame, so as to show a clear time for the start and end:
+	for (int i = 0; i < (frameIndex == lastFrameIndex ? frameDelays.length() : frameIndex); ++i) {
+		msUntilCurrentFrame += frameDelays[i].toInt();
+	}
+	return msUntilCurrentFrame;
+}
+
+bool AnimationTextObject::isInBoundsOnAxis(QPoint pos, bool yInsteadOfX, int start, int length) {
+	int posOnAxis = yInsteadOfX ? pos.y() : pos.x();
+	return posOnAxis >= start && posOnAxis <= start + length;
+}
+
+bool AnimationTextObject::isInBounds(QPoint pos, QRect bounds) {
+	return isInBoundsOnAxis(pos, false, bounds.x(), bounds.width())
+		   && isInBoundsOnAxis(pos, true, bounds.y(), bounds.height());
+}
+
+int AnimationTextObject::getOffset(int offset, int start, int length) {
+	return start + offset + (offset < 0 ? length : 0);
+}
+
+void AnimationTextObject::drawVideoControls(QPainter *painter, QObject *propertyHolder, QPixmap frame, bool wasPaused,
+											bool wasCached, int frameIndex, int speedPercentage) {
+	QRect rect              = propertyHolder->property("posAndSize").toRect();
+	int videoControlsHeight = videoBarHeight + underVideoBarHeight;
+	QSize viewSizeMin(rect.width(), rect.height() - videoControlsHeight);
+	auto getOffsetX     = [rect](int offset) { return rect.x() + offset + (offset < 0 ? rect.width() : 0); };
+	int cacheX          = getOffsetX(cacheOffsetX);
+	int loopModeX       = getOffsetX(loopModeOffsetX);
+	int frameTraversalX = getOffsetX(frameTraversalOffsetX);
+	int speedX          = getOffsetX(speedOffsetX);
+
+	int videoBarX                = rect.x();
+	int videoBarY                = rect.y() + rect.height() - videoControlsHeight;
+	int underVideoBarY           = videoBarY + videoBarHeight;
+	int underVideoBarWithMarginY = underVideoBarY + 14;
+
+	auto convertUnit = [](int integer, int exponent, int decimalAmount = 0) -> double {
+		bool noDecimals              = decimalAmount == 0;
+		int exponentForDecimalAmount = exponent < 0 ? exponent + decimalAmount : exponent - decimalAmount;
+
+		double product = integer * pow(10, exponentForDecimalAmount);
+		return noDecimals ? product : round(product) / (double) pow(10, decimalAmount);
+	};
+	auto padDecimals = [](QString numberStr, int decimalAmount) -> QString {
+		qsizetype decimalMarkIndex     = numberStr.lastIndexOf('.');
+		bool isDecimal                 = decimalMarkIndex != -1 && decimalMarkIndex < numberStr.length() - 1;
+		qsizetype currentDecimalAmount = isDecimal ? numberStr.sliced(decimalMarkIndex + 1).length() : 0;
+		qsizetype decimalFillerAmount  = decimalAmount - currentDecimalAmount;
+
+		QString decimalFillers = QString('0').repeated(decimalFillerAmount);
+		return decimalFillerAmount > 0 ? numberStr.append((!isDecimal ? "." : "") + decimalFillers) : numberStr;
+	};
+	auto padNumber = [](QString numberStr, int digitAmount) -> QString {
+		qsizetype numberLength                = numberStr.length();
+		qsizetype decimalMarkIndex            = numberStr.lastIndexOf('.');
+		qsizetype decimalsIncludingMarkLength = decimalMarkIndex != -1 ? numberLength - decimalMarkIndex : 0;
+		return numberStr.rightJustified(digitAmount + decimalsIncludingMarkLength, '0');
+	};
+	auto formatTime = [padDecimals, padNumber](double seconds, double totalSeconds = 0) -> QString {
+		auto getTimeNumbers = [](double seconds) -> QList< double > {
+			auto floorDivision   = [](double dividend, double divisor = 60) { return (int) floor(dividend / divisor); };
+			int minutes          = floorDivision(seconds);
+			int hours            = floorDivision(minutes);
+			int remainingMinutes = std::max(minutes - hours * 60, 0);
+			double remainingSeconds = std::max< double >(seconds - minutes * 60, 0);
+			return QList< double >({ remainingSeconds, (double) remainingMinutes, (double) hours });
+		};
+		auto getDigitAmount = [](int number) -> int {
+			int digitAmount = 0;
+			do {
+				number /= 10;
+				++digitAmount;
+			} while (number != 0);
+			return digitAmount;
+		};
+
+		QList< double > timeNumbers      = getTimeNumbers(seconds);
+		QList< double > totalTimeNumbers = totalSeconds == 0 ? timeNumbers : getTimeNumbers(totalSeconds);
+		int timeNumberAmount             = (int) timeNumbers.length();
+		int decimalAmount                = 1;
+
+		int lastTimeNumberIndex = 0;
+		for (int i = timeNumberAmount - 1; i >= 0; --i) {
+			if (totalTimeNumbers[i] > 0) {
+				lastTimeNumberIndex = i;
+				break;
+			}
+		}
+
+		QString timeStr;
+		for (int i = 0; i < timeNumberAmount; ++i) {
+			double number         = timeNumbers[i];
+			bool isSeconds        = i == 0;
+			bool isLastNumber     = i == lastTimeNumberIndex;
+			bool hasAnotherNumber = i < lastTimeNumberIndex;
+			if (number == 0 && !hasAnotherNumber && !isLastNumber) {
+				break;
+			}
+			QString numberStr = QString::number(number);
+			if (hasAnotherNumber || isLastNumber) {
+				int digitAmount = isLastNumber ? getDigitAmount((int) totalTimeNumbers[i]) : 2;
+				numberStr       = padNumber(numberStr, digitAmount);
+			}
+			timeStr.prepend(isSeconds ? padDecimals(numberStr, decimalAmount) : numberStr.append(":"));
+		}
+		return timeStr;
+	};
+
+	QList< QVariant > frameDelays = propertyHolder->property("frameDelays").toList();
+	int totalMs                   = getTotalTime(propertyHolder);
+	int msUntilCurrentFrame       = getCurrentTime(propertyHolder, frameIndex);
+	// Convert to seconds rounded to one decimal:
+	double totalS   = convertUnit(totalMs, -3, 1);
+	double currentS = convertUnit(msUntilCurrentFrame, -3, 1);
+
+	painter->drawPixmap(QRect(rect.topLeft(), viewSizeMin), frame);
+	painter->fillRect(videoBarX, videoBarY, viewSizeMin.width(), videoControlsHeight, QBrush(QColor(50, 50, 50, 180)));
+
+	double videoBarProgress = msUntilCurrentFrame / (double) totalMs;
+	QBrush videoBarBrush(QColor(0, 0, 200));
+	painter->fillRect(videoBarX, videoBarY, viewSizeMin.width(), 4, QBrush(QColor(90, 90, 90, 180)));
+	painter->fillRect(videoBarX, videoBarY, (int) round(viewSizeMin.width() * videoBarProgress), 4, videoBarBrush);
+
+	painter->setPen(QColor(149, 165, 166));
+	QString speedStr = padDecimals(QString::number(convertUnit(speedPercentage, -2)), 2);
+	QPoint speedPos(speedX, underVideoBarWithMarginY);
+	painter->drawText(speedPos, speedStr);
+	// Draw the plus "+":
+	painter->drawLine(speedPos.x() - 9, speedPos.y() - 11, speedPos.x() - 9, speedPos.y() - 3);
+	painter->drawLine(speedPos.x() - 13, speedPos.y() - 7, speedPos.x() - 5, speedPos.y() - 7);
+	// Draw the minus "-":
+	painter->drawLine(speedPos.x() - 13, speedPos.y() + 2, speedPos.x() - 5, speedPos.y() + 2);
+	// Draw the circle "o":
+	painter->drawEllipse(speedPos.x() - 26, speedPos.y() - 6, 6, 6);
+
+	QPoint frameTraversalPos(frameTraversalX, underVideoBarWithMarginY);
+	painter->drawText(frameTraversalPos, "<  >");
+
+	LoopMode loopMode           = qvariant_cast< LoopMode >(propertyHolder->property("LoopMode"));
+	QString loopModeStr         = loopModeToString(loopMode);
+	QFont font                  = painter->font();
+	qsizetype loopModeStrLength = loopModeStr.length();
+	int loopModeStrOffset       = loopModeStrLength > 7 ? 12 : loopModeStrLength > 4 ? 5 : 0;
+	double fontSizeSmall        = 0.7;
+	font.setPointSize((int) round(font.pointSize() * fontSizeSmall));
+	painter->setFont(font);
+	painter->drawText(QPointF(loopModeX, underVideoBarY + 8), "mode:");
+	painter->drawText(QPointF(loopModeX - (double) loopModeStrOffset, underVideoBarY + 17), loopModeStr);
+
+	QString cachedStr = QString::fromStdString(wasCached ? "on" : "off");
+	painter->drawText(QPointF(cacheX, underVideoBarY + 8), "cache:");
+	painter->drawText(QPointF(cacheX + 5, underVideoBarY + 17), cachedStr);
+	font.setPointSize((int) round(font.pointSize() / fontSizeSmall));
+	painter->setFont(font);
+
+	QString totalTimeStr   = formatTime(totalS);
+	QString currentTimeStr = formatTime(currentS, totalS);
+	painter->drawText(QPoint(videoBarX + 20, underVideoBarWithMarginY),
+					  tr("%1 / %2").arg(currentTimeStr).arg(totalTimeStr));
+
+	QPointF iconTopPos(videoBarX + 2, underVideoBarY + 2);
+	if (wasPaused) {
+		// Add a play-icon, which is a right-pointing triangle, like this "▶":
+		QPolygonF polygon(
+			{ iconTopPos, QPointF(videoBarX + 15, underVideoBarY + 10), QPointF(videoBarX + 2, underVideoBarY + 18) });
+		QPainterPath path;
+		path.addPolygon(polygon);
+		painter->fillPath(path, QBrush(Qt::white));
+	} else {
+		// Add a pause-icon, which is two vertical rectangles next to each other, like this "||":
+		QSize pauseBarSize(4, 16);
+		QBrush brush(Qt::white);
+		painter->fillRect(QRect(iconTopPos.toPoint(), pauseBarSize), brush);
+		painter->fillRect(QRect(QPoint(videoBarX + 11, underVideoBarY + 2), pauseBarSize), brush);
+	}
+}
+
+AnimationTextObject::VideoController AnimationTextObject::mousePressVideoControls(QObject *propertyHolder,
+																				  QPoint mouseDocPos) {
+	QRect rect              = propertyHolder->property("posAndSize").toRect();
+	int videoControlsHeight = videoBarHeight + underVideoBarHeight;
+	QSize viewSizeMin(rect.width(), rect.height() - videoControlsHeight);
+	auto getOffsetX     = [rect](int offset) { return rect.x() + offset + (offset < 0 ? rect.width() : 0); };
+	int cacheX          = getOffsetX(cacheOffsetX);
+	int loopModeX       = getOffsetX(loopModeOffsetX);
+	int frameTraversalX = getOffsetX(frameTraversalOffsetX);
+	int speedX          = getOffsetX(speedOffsetX);
+
+	auto isThisInBoundsOnAxis = [mouseDocPos](bool yInsteadOfX, int start, int length) {
+		return isInBoundsOnAxis(mouseDocPos, yInsteadOfX, start, length);
+	};
+	auto isThisInBounds = [mouseDocPos](QRect bounds) { return isInBounds(mouseDocPos, bounds); };
+	int videoControlsY  = rect.y() + rect.height() - videoControlsHeight;
+	int underVideoBarY  = videoControlsY + videoBarHeight;
+
+	QRect viewRect(rect.topLeft(), viewSizeMin);
+	QRect playPauseRect(rect.x(), underVideoBarY, 15, underVideoBarHeight);
+
+	QRect cacheRect(cacheX, underVideoBarY, 25, underVideoBarHeight);
+	QRect loopModeRect(loopModeX, underVideoBarY, 24, underVideoBarHeight);
+
+	int frameTraversalWidth = 12;
+	QRect framePreviousRect(frameTraversalX, underVideoBarY, frameTraversalWidth, underVideoBarHeight);
+	QRect frameNextRect(frameTraversalX + frameTraversalWidth + 2, underVideoBarY, frameTraversalWidth,
+						underVideoBarHeight);
+
+	int speedWidth       = 9;
+	int speedMinusHeight = 9;
+	int speedPlusHeight  = 11;
+	QRect speedResetRect(speedX - 28, underVideoBarY, speedWidth, underVideoBarHeight);
+	QRect speedMinusRect(speedX - 14, underVideoBarY + speedPlusHeight, speedWidth, speedMinusHeight);
+	QRect speedPlusRect(speedX - 14, underVideoBarY, speedWidth, speedPlusHeight);
+
+	if (!isThisInBoundsOnAxis(false, viewRect.x(), viewRect.width()))
+		return None;
+	if (isThisInBoundsOnAxis(true, viewRect.y(), viewRect.height()))
+		return View;
+	if (isThisInBoundsOnAxis(true, videoControlsY, videoBarHeight))
+		return VideoBar;
+	if (isThisInBounds(playPauseRect))
+		return PlayPause;
+	if (isThisInBounds(cacheRect))
+		return CacheSwitch;
+	if (isThisInBounds(loopModeRect))
+		return LoopSwitch;
+	if (isThisInBounds(framePreviousRect))
+		return PreviousFrame;
+	if (isThisInBounds(frameNextRect))
+		return NextFrame;
+	if (isThisInBounds(speedResetRect))
+		return ResetSpeed;
+	if (isThisInBounds(speedMinusRect))
+		return DecreaseSpeed;
+	if (isThisInBounds(speedPlusRect))
+		return IncreaseSpeed;
+	return None;
+}
+
+void AnimationTextObject::mousePress(QAbstractTextDocumentLayout *docLayout, QPoint mouseDocPos,
+									 Qt::MouseButton mouseButton) {
+	QTextFormat baseFmt = docLayout->formatAt(mouseDocPos);
+	if (!baseFmt.isCharFormat() || baseFmt.objectType() != Log::Animation) {
+		return;
+	}
+	QMovie *animation = qvariant_cast< QMovie * >(baseFmt.toCharFormat().property(1));
+	QRect rect        = animation->property("posAndSize").toRect();
+	// Ensure the selection was within the text object's vertical space,
+	// such as if an inline image is not as tall as the content before it:
+	if (!isInBoundsOnAxis(mouseDocPos, true, rect.y(), rect.height())) {
+		return;
+	}
+
+	auto setFrameByVideoBarSelection = [animation, mouseDocPos, rect]() {
+		double videoBarPercentage = (mouseDocPos.x() - rect.x()) / (double) rect.width();
+		setFrameByProportion(animation, videoBarPercentage);
+	};
+	bool isLeftMouseButtonPressed   = mouseButton == Qt::LeftButton;
+	bool isMiddleMouseButtonPressed = mouseButton == Qt::MiddleButton;
+	if (areVideoControlsOn) {
+		VideoController videoController = mousePressVideoControls(animation, mouseDocPos);
+		if (isLeftMouseButtonPressed) {
+			switch (videoController) {
+				case VideoBar:
+					return setFrameByVideoBarSelection();
+				case View:
+				case PlayPause:
+					return togglePause(animation);
+				case CacheSwitch:
+					return toggleCache(animation);
+				case LoopSwitch:
+					return changeLoopMode(animation, 1);
+				case PreviousFrame:
+					return changeFrame(animation, -1);
+				case NextFrame:
+					return changeFrame(animation, 1);
+				case ResetSpeed:
+					return setSpeed(animation, 100);
+				case DecreaseSpeed:
+					return changeSpeed(animation, -10);
+				case IncreaseSpeed:
+					return changeSpeed(animation, 10);
+				default:
+					return;
+			}
+		} else if (isMiddleMouseButtonPressed) {
+			switch (videoController) {
+				case View:
+				case PlayPause:
+					return resetPlayback(animation);
+				case LoopSwitch:
+					return changeLoopMode(animation, -1);
+				case PreviousFrame:
+					return changeFrame(animation, -5);
+				case NextFrame:
+					return changeFrame(animation, 5);
+				case DecreaseSpeed:
+					return changeSpeed(animation, -50);
+				case IncreaseSpeed:
+					return changeSpeed(animation, 50);
+				default:
+					return;
+			}
+		}
+		return;
+	}
+	if (isLeftMouseButtonPressed) {
+		togglePause(animation);
+	} else if (isMiddleMouseButtonPressed) {
+		resetPlayback(animation);
+	}
+	// Right mouse button shows the context menu for the text object,
+	// which is handled where the custom context menu for the log is.
+}
+
+void AnimationTextObject::keyPress(LogTextBrowser *log, bool isItemSelectionChanged, Qt::Key key) {
+	bool isItemAtIndex        = false;
+	int itemIndex             = log->customInteractiveItemFocusIndex;
+	QMovie *animation         = nullptr;
+	QList< QTextFormat > fmts = log->document()->allFormats();
+	for (auto fmt : fmts) {
+		if (fmt.objectType() != Log::Animation) {
+			continue;
+		}
+		animation     = qvariant_cast< QMovie * >(fmt.property(1));
+		isItemAtIndex = itemIndex == animation->property("customInteractiveItemIndex").toInt();
+		if (isItemAtIndex) {
+			break;
+		}
+	}
+	if (!isItemAtIndex) {
+		return;
+	}
+
+	bool isKeyBoundToAction         = true;
+	Qt::KeyboardModifiers modifiers = QApplication::keyboardModifiers();
+	if (modifiers.testFlag(Qt::NoModifier) || modifiers.testFlag(Qt::KeypadModifier)) {
+		switch (key) {
+			case Qt::Key_Space:
+			case Qt::Key_K:
+				togglePause(animation);
+				break;
+			case Qt::Key_Q:
+				resetPlayback(animation);
+				break;
+			case Qt::Key_V:
+				areVideoControlsOn = !areVideoControlsOn;
+				break;
+			case Qt::Key_C:
+				toggleCache(animation);
+				break;
+			case Qt::Key_O:
+				changeLoopMode(animation, -1);
+				break;
+			case Qt::Key_L:
+				changeLoopMode(animation, 1);
+				break;
+			case Qt::Key_Comma:
+				changeFrame(animation, -1);
+				break;
+			case Qt::Key_Period:
+				changeFrame(animation, 1);
+				break;
+			case Qt::Key_N:
+				changeFrame(animation, -5);
+				break;
+			case Qt::Key_M:
+				changeFrame(animation, 5);
+				break;
+			case Qt::Key_H:
+				changeFrameByTime(animation, -1000);
+				break;
+			case Qt::Key_J:
+				changeFrameByTime(animation, 1000);
+				break;
+			case Qt::Key_F:
+				changeFrameByTime(animation, -5000);
+				break;
+			case Qt::Key_G:
+				changeFrameByTime(animation, 5000);
+				break;
+			case Qt::Key_S:
+			case Qt::Key_Minus:
+				changeSpeed(animation, -5);
+				break;
+			case Qt::Key_D:
+			case Qt::Key_Plus:
+				changeSpeed(animation, 5);
+				break;
+			case Qt::Key_W:
+				changeSpeed(animation, -25);
+				break;
+			case Qt::Key_E:
+				changeSpeed(animation, 25);
+				break;
+			case Qt::Key_R:
+				setSpeed(animation, 100);
+				break;
+			case Qt::Key_0:
+				setFrameByProportion(animation, 0);
+				break;
+			case Qt::Key_1:
+				setFrameByProportion(animation, 0.1);
+				break;
+			case Qt::Key_2:
+				setFrameByProportion(animation, 0.2);
+				break;
+			case Qt::Key_3:
+				setFrameByProportion(animation, 0.3);
+				break;
+			case Qt::Key_4:
+				setFrameByProportion(animation, 0.4);
+				break;
+			case Qt::Key_5:
+				setFrameByProportion(animation, 0.5);
+				break;
+			case Qt::Key_6:
+				setFrameByProportion(animation, 0.6);
+				break;
+			case Qt::Key_7:
+				setFrameByProportion(animation, 0.7);
+				break;
+			case Qt::Key_8:
+				setFrameByProportion(animation, 0.8);
+				break;
+			case Qt::Key_9:
+				setFrameByProportion(animation, 0.9);
+				break;
+			default:
+				isKeyBoundToAction = false;
+				break;
+		}
+	} else {
+		isKeyBoundToAction = false;
+	}
+	if (isKeyBoundToAction || isItemSelectionChanged) {
+		log->scrollItemIntoView(animation->property("posAndSize").toRect());
+	}
+}
+
+void AnimationTextObject::drawCenteredPlayIcon(QPainter *painter, QRect rect) {
+	int centerX = (int) round(rect.x() + rect.width() / (double) 2);
+	int centerY = (int) round(rect.y() + rect.height() / (double) 2);
+	// Add a play-icon, which is a right-pointing triangle, like this "▶":
+	QPolygonF polygon(
+		{ QPointF(centerX - 8, centerY - 10), QPointF(centerX + 12, centerY), QPointF(centerX - 8, centerY + 10) });
+	QPainterPath path;
+	QPen thinBlackPen(Qt::black, 0.25);
+	path.addPolygon(polygon);
+	painter->fillPath(path, QBrush(Qt::white));
+	// Add outline contrast to the triangle:
+	painter->strokePath(path, thinBlackPen);
+
+	auto drawCenteredCircle = [painter, centerX, centerY](int diameter) {
+		int radius = diameter / 2;
+		painter->drawEllipse(centerX - radius, centerY - radius, diameter, diameter);
+	};
+	// Add a ring around the triangle:
+	painter->setPen(QPen(Qt::white, 2));
+	drawCenteredCircle(40);
+	// Add outline contrast to the ring:
+	painter->setPen(thinBlackPen);
+	drawCenteredCircle(36);
+	drawCenteredCircle(44);
+}
+
+void AnimationTextObject::updatePropertyRect(QObject *propertyHolder, QRect rect) {
+	QVariant propertyPosAndSize = propertyHolder->property("posAndSize");
+	QRect propertyRect          = propertyPosAndSize.isValid() ? propertyPosAndSize.toRect() : QRect();
+	// Update the property for the position and size of the animation if it has not been set before,
+	// if its width changes when video controls are switched on or off,
+	// if its vertical position changes, such as if content above it has its height altered by text wrapping,
+	// or if its horizontal position changes, such as if the window resizes when the animation is centered
+	// and dependent on available blank space:
+	if (propertyRect.width() != rect.width() || propertyRect.y() != rect.y() || propertyRect.x() != rect.x()) {
+		propertyHolder->setProperty("posAndSize", QVariant(rect));
+	}
+}
+
+AnimationTextObject::AnimationTextObject() : QObject() {
+}
+
+QSizeF AnimationTextObject::intrinsicSize(QTextDocument *, int, const QTextFormat &fmt) {
+	QMovie *animation = qvariant_cast< QMovie * >(fmt.property(1));
+	QSize size        = animation->currentPixmap().size();
+	if (areVideoControlsOn) {
+		int videoControlsHeight = videoBarHeight + underVideoBarHeight;
+		int viewWidthMin        = size.width() - videoControlsHeight;
+		size.setWidth(viewWidthMin);
+	}
+	return QSizeF(size);
+}
+
+void AnimationTextObject::drawObject(QPainter *painter, const QRectF &rectF, QTextDocument *doc, int,
+									 const QTextFormat &fmt) {
+	LogTextBrowser *log = qobject_cast< LogTextBrowser * >(doc->parent());
+	QMovie *animation   = qvariant_cast< QMovie * >(fmt.property(1));
+	QRect rect          = rectF.toRect();
+	QPixmap frame       = animation->currentPixmap();
+	bool wasRunning     = animation->state() == QMovie::Running || animation->property("isPlayingInReverse").toBool();
+	updatePropertyRect(animation, rect);
+
+	painter->setRenderHint(QPainter::Antialiasing);
+	if (log->customInteractiveItemFocusIndex == animation->property("customInteractiveItemIndex").toInt()) {
+		painter->setPen(QPen(QColor(50, 50, 200), 2));
+		painter->drawRect(QRect(rect.x() - 1, rect.y() - 1, rect.width() + 2, rect.height() + 2));
+	}
+	if (areVideoControlsOn) {
+		bool wasCached      = animation->cacheMode() == QMovie::CacheAll;
+		int frameIndex      = animation->currentFrameNumber();
+		int speedPercentage = animation->speed();
+		drawVideoControls(painter, animation, frame, !wasRunning, wasCached, frameIndex, speedPercentage);
+		return;
+	}
+	painter->drawPixmap(rect, frame);
+	if (!wasRunning) {
+		drawCenteredPlayIcon(painter, rect);
+	}
+}
+
 
 bool ChatbarTextEdit::event(QEvent *evt) {
 	if (evt->type() == QEvent::ShortcutOverride) {

--- a/src/mumble/Log.h
+++ b/src/mumble/Log.h
@@ -118,6 +118,8 @@ public:
 	// versions.
 	static const MsgType msgOrder[];
 
+	enum TextObjectType { Animation = QTextFormat::UserObject };
+
 protected:
 	/// Mutex for qvDeferredLogs
 	static QMutex qmDeferredLogs;
@@ -135,6 +137,7 @@ protected:
 	static const QStringList allowedSchemes();
 	void postNotification(MsgType mt, const QString &plain);
 	void postQtNotification(MsgType mt, const QString &plain);
+	static bool htmlWithAnimations(const QString &html, QTextCursor *tc);
 
 public:
 	Log(QObject *p = nullptr);

--- a/src/mumble/MainWindow.h
+++ b/src/mumble/MainWindow.h
@@ -372,6 +372,10 @@ public slots:
 	void onResetAudio();
 	void showRaiseWindow();
 	void on_qaFilterToggle_triggered();
+	/// Removes the content of the client's log and deletes the objects used by text objects.
+	void clearDocument();
+	/// Alternates between showing and hiding video controls for animated images.
+	void toggleVideoControls();
 	/// Opens a save dialog for the image referenced by qtcSaveImageCursor.
 	void saveImageAs();
 	/// Returns the path to the user's image directory, optionally with a

--- a/src/mumble/mumble_ar.ts
+++ b/src/mumble/mumble_ar.ts
@@ -703,6 +703,13 @@ This value allows you to set the maximum number of users allowed in the channel.
     </message>
 </context>
 <context>
+    <name>AnimationTextObject</name>
+    <message>
+        <source>%1 / %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>AudioInput</name>
     <message>
         <source>Interface</source>
@@ -2956,6 +2963,10 @@ Are you sure you wish to replace your certificate?
     </message>
     <message>
         <source>This server does not allow sending images.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Unable to read animated image file: %1</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -5423,10 +5434,6 @@ Otherwise abort and check your certificate and username.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Images (*.png *.jpg *.jpeg)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>C&amp;onfigure</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7013,6 +7020,14 @@ Valid options are:
     </message>
     <message>
         <source>This could be caused by one of the following scenarios:&lt;ul&gt;&lt;li&gt;Your client and the server use different encryption standards. This could be because you are using a very old client or the server you are connecting to is very old. In the first case, you should update your client and in the second case you should contact the server administrator so that they can update their server.&lt;/li&gt;&lt;li&gt;Either your client or the server is using an old operating system that doesn&apos;t provide up-to-date encryption methods. In this case you should consider updating your OS or contacting the server admin so that they can update theirs.&lt;/li&gt;&lt;li&gt;The server you are connecting to isn&apos;t actually a Mumble server. Please ensure that the used server address really belongs to a Mumble server and not e.g. to a game server.&lt;/li&gt;&lt;li&gt;The port you are connecting to does not belong to a Mumble server but instead is bound to a completely unrelated process on the server-side. Please double-check you have used the correct port.&lt;/li&gt;&lt;/ul&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>%1 Video Controls</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Images (*.png *.jpg *.jpeg *.gif)</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/mumble/mumble_bg.ts
+++ b/src/mumble/mumble_bg.ts
@@ -704,6 +704,13 @@ This value allows you to set the maximum number of users allowed in the channel.
     </message>
 </context>
 <context>
+    <name>AnimationTextObject</name>
+    <message>
+        <source>%1 / %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>AudioInput</name>
     <message>
         <source>Interface</source>
@@ -2953,6 +2960,10 @@ Are you sure you wish to replace your certificate?
     </message>
     <message>
         <source>This server does not allow sending images.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Unable to read animated image file: %1</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -5420,10 +5431,6 @@ Otherwise abort and check your certificate and username.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Images (*.png *.jpg *.jpeg)</source>
-        <translation>Изображения (*.png *.jpg *.jpeg)</translation>
-    </message>
-    <message>
         <source>C&amp;onfigure</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7010,6 +7017,14 @@ Valid options are:
     </message>
     <message>
         <source>This could be caused by one of the following scenarios:&lt;ul&gt;&lt;li&gt;Your client and the server use different encryption standards. This could be because you are using a very old client or the server you are connecting to is very old. In the first case, you should update your client and in the second case you should contact the server administrator so that they can update their server.&lt;/li&gt;&lt;li&gt;Either your client or the server is using an old operating system that doesn&apos;t provide up-to-date encryption methods. In this case you should consider updating your OS or contacting the server admin so that they can update theirs.&lt;/li&gt;&lt;li&gt;The server you are connecting to isn&apos;t actually a Mumble server. Please ensure that the used server address really belongs to a Mumble server and not e.g. to a game server.&lt;/li&gt;&lt;li&gt;The port you are connecting to does not belong to a Mumble server but instead is bound to a completely unrelated process on the server-side. Please double-check you have used the correct port.&lt;/li&gt;&lt;/ul&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>%1 Video Controls</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Images (*.png *.jpg *.jpeg *.gif)</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/mumble/mumble_br.ts
+++ b/src/mumble/mumble_br.ts
@@ -703,6 +703,13 @@ This value allows you to set the maximum number of users allowed in the channel.
     </message>
 </context>
 <context>
+    <name>AnimationTextObject</name>
+    <message>
+        <source>%1 / %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>AudioInput</name>
     <message>
         <source>Interface</source>
@@ -2952,6 +2959,10 @@ Are you sure you wish to replace your certificate?
     </message>
     <message>
         <source>This server does not allow sending images.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Unable to read animated image file: %1</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -5419,10 +5430,6 @@ Otherwise abort and check your certificate and username.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Images (*.png *.jpg *.jpeg)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>C&amp;onfigure</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7009,6 +7016,14 @@ Valid options are:
     </message>
     <message>
         <source>This could be caused by one of the following scenarios:&lt;ul&gt;&lt;li&gt;Your client and the server use different encryption standards. This could be because you are using a very old client or the server you are connecting to is very old. In the first case, you should update your client and in the second case you should contact the server administrator so that they can update their server.&lt;/li&gt;&lt;li&gt;Either your client or the server is using an old operating system that doesn&apos;t provide up-to-date encryption methods. In this case you should consider updating your OS or contacting the server admin so that they can update theirs.&lt;/li&gt;&lt;li&gt;The server you are connecting to isn&apos;t actually a Mumble server. Please ensure that the used server address really belongs to a Mumble server and not e.g. to a game server.&lt;/li&gt;&lt;li&gt;The port you are connecting to does not belong to a Mumble server but instead is bound to a completely unrelated process on the server-side. Please double-check you have used the correct port.&lt;/li&gt;&lt;/ul&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>%1 Video Controls</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Images (*.png *.jpg *.jpeg *.gif)</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/mumble/mumble_ca.ts
+++ b/src/mumble/mumble_ca.ts
@@ -711,6 +711,13 @@ Aquest valor us permet establir el nombre màxim d&apos;usuaris permesos al cana
     </message>
 </context>
 <context>
+    <name>AnimationTextObject</name>
+    <message>
+        <source>%1 / %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>AudioInput</name>
     <message>
         <source>Interface</source>
@@ -2994,6 +3001,10 @@ Esteu segur que vols substituir el vostre certificat?
     <message>
         <source>This server does not allow sending images.</source>
         <translation>Aquest servidor no permet enviar imatges.</translation>
+    </message>
+    <message>
+        <source>Unable to read animated image file: %1</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -5483,10 +5494,6 @@ Altrament avorta i comproveu el vostre certificat i nom d&apos;usuari.</translat
         <translation>Contrasenya de servidor incorrecte per a un compte d&apos;usuari no registrat, si us plau proveu de nou.</translation>
     </message>
     <message>
-        <source>Images (*.png *.jpg *.jpeg)</source>
-        <translation>Imatges (*.png *.jpg *.jpeg)</translation>
-    </message>
-    <message>
         <source>C&amp;onfigure</source>
         <translation>C&amp;onfigura</translation>
     </message>
@@ -7164,6 +7171,14 @@ Les opcions vàlides són:
     <message>
         <source>This could be caused by one of the following scenarios:&lt;ul&gt;&lt;li&gt;Your client and the server use different encryption standards. This could be because you are using a very old client or the server you are connecting to is very old. In the first case, you should update your client and in the second case you should contact the server administrator so that they can update their server.&lt;/li&gt;&lt;li&gt;Either your client or the server is using an old operating system that doesn&apos;t provide up-to-date encryption methods. In this case you should consider updating your OS or contacting the server admin so that they can update theirs.&lt;/li&gt;&lt;li&gt;The server you are connecting to isn&apos;t actually a Mumble server. Please ensure that the used server address really belongs to a Mumble server and not e.g. to a game server.&lt;/li&gt;&lt;li&gt;The port you are connecting to does not belong to a Mumble server but instead is bound to a completely unrelated process on the server-side. Please double-check you have used the correct port.&lt;/li&gt;&lt;/ul&gt;</source>
         <translation>La causa pot ser una de les següents:&lt;ul&gt;&lt;li&gt;El vostre client i el servidor fan servir estàndards d&apos;encriptació diferents. Potser el vostre client o el servidor són molt antics. En el primer cas, hauríeu d&apos;actualitzar el vostre client i en el segon cas hauríeu de contactar l&apos;administrador del servidor per que l&apos;actualitzi.&lt;/li&gt;&lt;li&gt;O bé el vostre client o el servidor estan utilitzant un sistema operatiu antic que no proporciona mètodes d&apos;encriptació actuals. En aquest cas hauríeu de considerar actualitzar el vostre sistema o contactar l&apos;administrador del servidor per que actualitzi el seu.&lt;/li&gt;&lt;li&gt;El servidor al que esteu connectat a no és de fet un Mumble servidor. Si us plau assegureu-vos que l&apos;adreça del servidor que utilitzeu correspon realment a un servidor Mumble, i no, per exemple, a un servidor de joc.&lt;/li&gt;&lt;li&gt;El port al que esteu connectat no pertany a un servidor Mumble servidor si no que està lligat a un procés sense cap relació amb el servidor lateral. Comproveu si us plau que utilitzeu el port correcte.&lt;/li&gt;&lt;/ul&gt;</translation>
+    </message>
+    <message>
+        <source>%1 Video Controls</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Images (*.png *.jpg *.jpeg *.gif)</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/src/mumble/mumble_cs.ts
+++ b/src/mumble/mumble_cs.ts
@@ -711,6 +711,13 @@ Tato hodnota Vám umožňuje nastavit maximální počet povolených uživatelů
     </message>
 </context>
 <context>
+    <name>AnimationTextObject</name>
+    <message>
+        <source>%1 / %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>AudioInput</name>
     <message>
         <source>Interface</source>
@@ -2994,6 +3001,10 @@ Jste si jisti, že chcete certifikát nahradit?
     </message>
     <message>
         <source>This server does not allow sending images.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Unable to read animated image file: %1</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -5476,10 +5487,6 @@ Jinak přerušte a zkontrolujte Váš certifikát a uživatelské jméno.</trans
         <translation>Špatné heslo serveru pro účet neregistrovaného uživatele, prosím zkuste znovu.</translation>
     </message>
     <message>
-        <source>Images (*.png *.jpg *.jpeg)</source>
-        <translation>Obrázky (*.png *.jpg *.jpeg)</translation>
-    </message>
-    <message>
         <source>C&amp;onfigure</source>
         <translation>&amp;Nastavit</translation>
     </message>
@@ -7069,6 +7076,14 @@ Valid options are:
     </message>
     <message>
         <source>This could be caused by one of the following scenarios:&lt;ul&gt;&lt;li&gt;Your client and the server use different encryption standards. This could be because you are using a very old client or the server you are connecting to is very old. In the first case, you should update your client and in the second case you should contact the server administrator so that they can update their server.&lt;/li&gt;&lt;li&gt;Either your client or the server is using an old operating system that doesn&apos;t provide up-to-date encryption methods. In this case you should consider updating your OS or contacting the server admin so that they can update theirs.&lt;/li&gt;&lt;li&gt;The server you are connecting to isn&apos;t actually a Mumble server. Please ensure that the used server address really belongs to a Mumble server and not e.g. to a game server.&lt;/li&gt;&lt;li&gt;The port you are connecting to does not belong to a Mumble server but instead is bound to a completely unrelated process on the server-side. Please double-check you have used the correct port.&lt;/li&gt;&lt;/ul&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>%1 Video Controls</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Images (*.png *.jpg *.jpeg *.gif)</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/mumble/mumble_cy.ts
+++ b/src/mumble/mumble_cy.ts
@@ -704,6 +704,13 @@ This value allows you to set the maximum number of users allowed in the channel.
     </message>
 </context>
 <context>
+    <name>AnimationTextObject</name>
+    <message>
+        <source>%1 / %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>AudioInput</name>
     <message>
         <source>Interface</source>
@@ -2956,6 +2963,10 @@ Are you sure you wish to replace your certificate?
     </message>
     <message>
         <source>This server does not allow sending images.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Unable to read animated image file: %1</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -5423,10 +5434,6 @@ Otherwise abort and check your certificate and username.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Images (*.png *.jpg *.jpeg)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>C&amp;onfigure</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7013,6 +7020,14 @@ Valid options are:
     </message>
     <message>
         <source>This could be caused by one of the following scenarios:&lt;ul&gt;&lt;li&gt;Your client and the server use different encryption standards. This could be because you are using a very old client or the server you are connecting to is very old. In the first case, you should update your client and in the second case you should contact the server administrator so that they can update their server.&lt;/li&gt;&lt;li&gt;Either your client or the server is using an old operating system that doesn&apos;t provide up-to-date encryption methods. In this case you should consider updating your OS or contacting the server admin so that they can update theirs.&lt;/li&gt;&lt;li&gt;The server you are connecting to isn&apos;t actually a Mumble server. Please ensure that the used server address really belongs to a Mumble server and not e.g. to a game server.&lt;/li&gt;&lt;li&gt;The port you are connecting to does not belong to a Mumble server but instead is bound to a completely unrelated process on the server-side. Please double-check you have used the correct port.&lt;/li&gt;&lt;/ul&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>%1 Video Controls</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Images (*.png *.jpg *.jpeg *.gif)</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/mumble/mumble_da.ts
+++ b/src/mumble/mumble_da.ts
@@ -710,6 +710,13 @@ This value allows you to set the maximum number of users allowed in the channel.
     </message>
 </context>
 <context>
+    <name>AnimationTextObject</name>
+    <message>
+        <source>%1 / %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>AudioInput</name>
     <message>
         <source>Interface</source>
@@ -2992,6 +2999,10 @@ Er du sikker på du vil erstatte dit certifikat?
     </message>
     <message>
         <source>This server does not allow sending images.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Unable to read animated image file: %1</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -5472,10 +5483,6 @@ Otherwise abort and check your certificate and username.</source>
         <translation>Forkert serveradgangskode for uregistreret brugerkonto, prøv venligst igen.</translation>
     </message>
     <message>
-        <source>Images (*.png *.jpg *.jpeg)</source>
-        <translation>Billeder (*.png *.jpg *.jpeg)</translation>
-    </message>
-    <message>
         <source>C&amp;onfigure</source>
         <translation>K&amp;onfigurér</translation>
     </message>
@@ -7065,6 +7072,14 @@ Valid options are:
     </message>
     <message>
         <source>This could be caused by one of the following scenarios:&lt;ul&gt;&lt;li&gt;Your client and the server use different encryption standards. This could be because you are using a very old client or the server you are connecting to is very old. In the first case, you should update your client and in the second case you should contact the server administrator so that they can update their server.&lt;/li&gt;&lt;li&gt;Either your client or the server is using an old operating system that doesn&apos;t provide up-to-date encryption methods. In this case you should consider updating your OS or contacting the server admin so that they can update theirs.&lt;/li&gt;&lt;li&gt;The server you are connecting to isn&apos;t actually a Mumble server. Please ensure that the used server address really belongs to a Mumble server and not e.g. to a game server.&lt;/li&gt;&lt;li&gt;The port you are connecting to does not belong to a Mumble server but instead is bound to a completely unrelated process on the server-side. Please double-check you have used the correct port.&lt;/li&gt;&lt;/ul&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>%1 Video Controls</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Images (*.png *.jpg *.jpeg *.gif)</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/mumble/mumble_de.ts
+++ b/src/mumble/mumble_de.ts
@@ -711,6 +711,13 @@ Dieser Wert erlaubt das Einstellen der maximal im Kanal erlaubten Benutzeranzahl
     </message>
 </context>
 <context>
+    <name>AnimationTextObject</name>
+    <message>
+        <source>%1 / %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>AudioInput</name>
     <message>
         <source>Interface</source>
@@ -2994,6 +3001,10 @@ Sind Sie sicher, dass Sie Ihr Zertifikat ersetzen möchten?
     <message>
         <source>This server does not allow sending images.</source>
         <translation>Dieser Server erlaubt das Senden von Bildern nicht.</translation>
+    </message>
+    <message>
+        <source>Unable to read animated image file: %1</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -5483,10 +5494,6 @@ Falls nicht, brechen Sie ab und überprüfen Sie Ihr Zertifikat und Ihren Benutz
         <translation>Falsches Serverpasswort für unregistrierte Benutzer. Bitte versuchen Sie es noch einmal.</translation>
     </message>
     <message>
-        <source>Images (*.png *.jpg *.jpeg)</source>
-        <translation>Bilder (*.png *.jpg *.jpeg)</translation>
-    </message>
-    <message>
         <source>C&amp;onfigure</source>
         <translation>K&amp;onfiguration</translation>
     </message>
@@ -7156,6 +7163,14 @@ Gültige Optionen sind:
     </message>
     <message>
         <source>This could be caused by one of the following scenarios:&lt;ul&gt;&lt;li&gt;Your client and the server use different encryption standards. This could be because you are using a very old client or the server you are connecting to is very old. In the first case, you should update your client and in the second case you should contact the server administrator so that they can update their server.&lt;/li&gt;&lt;li&gt;Either your client or the server is using an old operating system that doesn&apos;t provide up-to-date encryption methods. In this case you should consider updating your OS or contacting the server admin so that they can update theirs.&lt;/li&gt;&lt;li&gt;The server you are connecting to isn&apos;t actually a Mumble server. Please ensure that the used server address really belongs to a Mumble server and not e.g. to a game server.&lt;/li&gt;&lt;li&gt;The port you are connecting to does not belong to a Mumble server but instead is bound to a completely unrelated process on the server-side. Please double-check you have used the correct port.&lt;/li&gt;&lt;/ul&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>%1 Video Controls</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Images (*.png *.jpg *.jpeg *.gif)</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/mumble/mumble_el.ts
+++ b/src/mumble/mumble_el.ts
@@ -711,6 +711,13 @@ This value allows you to set the maximum number of users allowed in the channel.
     </message>
 </context>
 <context>
+    <name>AnimationTextObject</name>
+    <message>
+        <source>%1 / %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>AudioInput</name>
     <message>
         <source>Interface</source>
@@ -2994,6 +3001,10 @@ Are you sure you wish to replace your certificate?
     <message>
         <source>This server does not allow sending images.</source>
         <translation>Αυτός ο διακομιστής δεν επιτρέπει αποστολή εικόνων.</translation>
+    </message>
+    <message>
+        <source>Unable to read animated image file: %1</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -5483,10 +5494,6 @@ Otherwise abort and check your certificate and username.</source>
         <translation>Λάθος κωδικός πρόσβασης διακομιστή για μη εγγραμμένο λογαριασμό χρήστη, δοκιμάστε ξανά.</translation>
     </message>
     <message>
-        <source>Images (*.png *.jpg *.jpeg)</source>
-        <translation>Εικόνες (*.png *.jpg *.jpeg)</translation>
-    </message>
-    <message>
         <source>C&amp;onfigure</source>
         <translation>Δ&amp;ιαμόρφωση</translation>
     </message>
@@ -7163,6 +7170,14 @@ mumble://[&lt;username&gt;[:&lt;password&gt;]@]&lt;host&gt;[:&lt;port&gt;][/&lt;
     </message>
     <message>
         <source>This could be caused by one of the following scenarios:&lt;ul&gt;&lt;li&gt;Your client and the server use different encryption standards. This could be because you are using a very old client or the server you are connecting to is very old. In the first case, you should update your client and in the second case you should contact the server administrator so that they can update their server.&lt;/li&gt;&lt;li&gt;Either your client or the server is using an old operating system that doesn&apos;t provide up-to-date encryption methods. In this case you should consider updating your OS or contacting the server admin so that they can update theirs.&lt;/li&gt;&lt;li&gt;The server you are connecting to isn&apos;t actually a Mumble server. Please ensure that the used server address really belongs to a Mumble server and not e.g. to a game server.&lt;/li&gt;&lt;li&gt;The port you are connecting to does not belong to a Mumble server but instead is bound to a completely unrelated process on the server-side. Please double-check you have used the correct port.&lt;/li&gt;&lt;/ul&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>%1 Video Controls</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Images (*.png *.jpg *.jpeg *.gif)</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/mumble/mumble_en.ts
+++ b/src/mumble/mumble_en.ts
@@ -703,6 +703,13 @@ This value allows you to set the maximum number of users allowed in the channel.
     </message>
 </context>
 <context>
+    <name>AnimationTextObject</name>
+    <message>
+        <source>%1 / %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>AudioInput</name>
     <message>
         <source>Interface</source>
@@ -2951,6 +2958,10 @@ Are you sure you wish to replace your certificate?
     </message>
     <message>
         <source>This server does not allow sending images.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Unable to read animated image file: %1</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -5418,10 +5429,6 @@ Otherwise abort and check your certificate and username.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Images (*.png *.jpg *.jpeg)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>C&amp;onfigure</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7008,6 +7015,14 @@ Valid options are:
     </message>
     <message>
         <source>This could be caused by one of the following scenarios:&lt;ul&gt;&lt;li&gt;Your client and the server use different encryption standards. This could be because you are using a very old client or the server you are connecting to is very old. In the first case, you should update your client and in the second case you should contact the server administrator so that they can update their server.&lt;/li&gt;&lt;li&gt;Either your client or the server is using an old operating system that doesn&apos;t provide up-to-date encryption methods. In this case you should consider updating your OS or contacting the server admin so that they can update theirs.&lt;/li&gt;&lt;li&gt;The server you are connecting to isn&apos;t actually a Mumble server. Please ensure that the used server address really belongs to a Mumble server and not e.g. to a game server.&lt;/li&gt;&lt;li&gt;The port you are connecting to does not belong to a Mumble server but instead is bound to a completely unrelated process on the server-side. Please double-check you have used the correct port.&lt;/li&gt;&lt;/ul&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>%1 Video Controls</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Images (*.png *.jpg *.jpeg *.gif)</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/mumble/mumble_en_GB.ts
+++ b/src/mumble/mumble_en_GB.ts
@@ -711,6 +711,13 @@ This value allows you to set the maximum number of users allowed in the channel.
     </message>
 </context>
 <context>
+    <name>AnimationTextObject</name>
+    <message>
+        <source>%1 / %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>AudioInput</name>
     <message>
         <source>Interface</source>
@@ -1677,7 +1684,7 @@ This value allows you to set the maximum number of users allowed in the channel.
     </message>
     <message>
         <source>milliseconds</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">milliseconds</translation>
     </message>
     <message>
         <source>meters</source>
@@ -2232,11 +2239,11 @@ Speak loudly as if you are annoyed or excited. Decrease the volume in the sound 
     </message>
     <message>
         <source>Audio output system</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">Audio output system</translation>
     </message>
     <message>
         <source>Audio output device</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">Audio output device</translation>
     </message>
     <message>
         <source>The Mumble positional audio system enables users to link the relative position of their voice to third party applications such as games.</source>
@@ -2252,7 +2259,7 @@ Speak loudly as if you are annoyed or excited. Decrease the volume in the sound 
     </message>
     <message>
         <source>Speech is dynamically amplified by at most this amount</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">Speech is dynamically amplified by at most this amount</translation>
     </message>
     <message>
         <source>Voice activity detection level</source>
@@ -2994,6 +3001,10 @@ Are you sure you wish to replace your certificate?
     <message>
         <source>This server does not allow sending images.</source>
         <translation>This server does not allow sending images.</translation>
+    </message>
+    <message>
+        <source>Unable to read animated image file: %1</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -4494,7 +4505,7 @@ This setting only applies to new messages; existing messages keep the previous t
     </message>
     <message>
         <source>decibels</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">decibels</translation>
     </message>
 </context>
 <context>
@@ -5469,10 +5480,6 @@ Otherwise abort and check your certificate and username.</source>
     </message>
     <message>
         <source>Wrong server password for unregistered user account, please try again.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Images (*.png *.jpg *.jpeg)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -7062,6 +7069,14 @@ Valid options are:
     </message>
     <message>
         <source>This could be caused by one of the following scenarios:&lt;ul&gt;&lt;li&gt;Your client and the server use different encryption standards. This could be because you are using a very old client or the server you are connecting to is very old. In the first case, you should update your client and in the second case you should contact the server administrator so that they can update their server.&lt;/li&gt;&lt;li&gt;Either your client or the server is using an old operating system that doesn&apos;t provide up-to-date encryption methods. In this case you should consider updating your OS or contacting the server admin so that they can update theirs.&lt;/li&gt;&lt;li&gt;The server you are connecting to isn&apos;t actually a Mumble server. Please ensure that the used server address really belongs to a Mumble server and not e.g. to a game server.&lt;/li&gt;&lt;li&gt;The port you are connecting to does not belong to a Mumble server but instead is bound to a completely unrelated process on the server-side. Please double-check you have used the correct port.&lt;/li&gt;&lt;/ul&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>%1 Video Controls</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Images (*.png *.jpg *.jpeg *.gif)</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/mumble/mumble_eo.ts
+++ b/src/mumble/mumble_eo.ts
@@ -711,6 +711,13 @@ This value allows you to set the maximum number of users allowed in the channel.
     </message>
 </context>
 <context>
+    <name>AnimationTextObject</name>
+    <message>
+        <source>%1 / %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>AudioInput</name>
     <message>
         <source>Interface</source>
@@ -2960,6 +2967,10 @@ Are you sure you wish to replace your certificate?
     </message>
     <message>
         <source>This server does not allow sending images.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Unable to read animated image file: %1</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -5430,10 +5441,6 @@ Otherwise abort and check your certificate and username.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Images (*.png *.jpg *.jpeg)</source>
-        <translation>Bildoj (*.png *.jpg *.jpeg)</translation>
-    </message>
-    <message>
         <source>C&amp;onfigure</source>
         <translation>Ag&amp;ordi</translation>
     </message>
@@ -7021,6 +7028,14 @@ Valid options are:
     </message>
     <message>
         <source>This could be caused by one of the following scenarios:&lt;ul&gt;&lt;li&gt;Your client and the server use different encryption standards. This could be because you are using a very old client or the server you are connecting to is very old. In the first case, you should update your client and in the second case you should contact the server administrator so that they can update their server.&lt;/li&gt;&lt;li&gt;Either your client or the server is using an old operating system that doesn&apos;t provide up-to-date encryption methods. In this case you should consider updating your OS or contacting the server admin so that they can update theirs.&lt;/li&gt;&lt;li&gt;The server you are connecting to isn&apos;t actually a Mumble server. Please ensure that the used server address really belongs to a Mumble server and not e.g. to a game server.&lt;/li&gt;&lt;li&gt;The port you are connecting to does not belong to a Mumble server but instead is bound to a completely unrelated process on the server-side. Please double-check you have used the correct port.&lt;/li&gt;&lt;/ul&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>%1 Video Controls</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Images (*.png *.jpg *.jpeg *.gif)</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/mumble/mumble_es.ts
+++ b/src/mumble/mumble_es.ts
@@ -711,6 +711,13 @@ Este valor permite fijar el número máximo de usuarios permitidos en el canal. 
     </message>
 </context>
 <context>
+    <name>AnimationTextObject</name>
+    <message>
+        <source>%1 / %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>AudioInput</name>
     <message>
         <source>Interface</source>
@@ -2994,6 +3001,10 @@ Are you sure you wish to replace your certificate?
     <message>
         <source>This server does not allow sending images.</source>
         <translation>Este servidor no permite enviar imágenes.</translation>
+    </message>
+    <message>
+        <source>Unable to read animated image file: %1</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -5484,10 +5495,6 @@ De lo contrario, aborte y compruebe su certificado y nombre de usuario.</transla
         <translation>Contraseña del servidor incorrecta para cuenta de usuario no registrada, por favor, inténtelo de nuevo.</translation>
     </message>
     <message>
-        <source>Images (*.png *.jpg *.jpeg)</source>
-        <translation>Imágenes (*.png *.jpg *.jpeg)</translation>
-    </message>
-    <message>
         <source>C&amp;onfigure</source>
         <translation>C&amp;onfigurar</translation>
     </message>
@@ -7165,6 +7172,14 @@ Las opciones válidas son:
     <message>
         <source>This could be caused by one of the following scenarios:&lt;ul&gt;&lt;li&gt;Your client and the server use different encryption standards. This could be because you are using a very old client or the server you are connecting to is very old. In the first case, you should update your client and in the second case you should contact the server administrator so that they can update their server.&lt;/li&gt;&lt;li&gt;Either your client or the server is using an old operating system that doesn&apos;t provide up-to-date encryption methods. In this case you should consider updating your OS or contacting the server admin so that they can update theirs.&lt;/li&gt;&lt;li&gt;The server you are connecting to isn&apos;t actually a Mumble server. Please ensure that the used server address really belongs to a Mumble server and not e.g. to a game server.&lt;/li&gt;&lt;li&gt;The port you are connecting to does not belong to a Mumble server but instead is bound to a completely unrelated process on the server-side. Please double-check you have used the correct port.&lt;/li&gt;&lt;/ul&gt;</source>
         <translation>Esto podría deberse a uno de los siguientes escenarios:&lt;ul&gt;&lt;li&gt;El cliente y el servidor usan estándares de cifrado diferentes. Esto puede deberse a que está utilizando un cliente muy antiguo o el servidor al que se está conectando es muy antiguo. En el primer caso, debe actualizar su cliente y en el segundo caso debe ponerse en contacto con el administrador del servidor para que pueda actualizar su servidor.&lt;/li&gt;&lt;li&gt;El cliente o el servidor utilizan un sistema operativo antiguo que no proporciona métodos de cifrado actualizados. En este caso, debe considerar actualizar su sistema operativo o ponerse en contacto con el administrador del servidor para que pueda actualizar el suyo.&lt;/li&gt;&lt;li&gt;El servidor al que te estás conectando no es en realidad un servidor Mumble. Asegúrese de que la dirección del servidor utilizada pertenezca realmente a un servidor de Mumble y no, por ejemplo, a un servidor de juegos.&lt;/li&gt;&lt;li&gt;El puerto al que se está conectando no pertenece a un servidor Mumble, sino que está vinculado a un proceso completamente no relacionado en el lado del servidor. Por favor, compruebe dos veces que ha utilizado el puerto correcto. &lt;/li&gt;&lt;/ul&gt;</translation>
+    </message>
+    <message>
+        <source>%1 Video Controls</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Images (*.png *.jpg *.jpeg *.gif)</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/src/mumble/mumble_et.ts
+++ b/src/mumble/mumble_et.ts
@@ -704,6 +704,13 @@ This value allows you to set the maximum number of users allowed in the channel.
     </message>
 </context>
 <context>
+    <name>AnimationTextObject</name>
+    <message>
+        <source>%1 / %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>AudioInput</name>
     <message>
         <source>Interface</source>
@@ -2953,6 +2960,10 @@ Are you sure you wish to replace your certificate?
     </message>
     <message>
         <source>This server does not allow sending images.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Unable to read animated image file: %1</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -5420,10 +5431,6 @@ Otherwise abort and check your certificate and username.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Images (*.png *.jpg *.jpeg)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>C&amp;onfigure</source>
         <translation>&amp;Seadista</translation>
     </message>
@@ -7010,6 +7017,14 @@ Valid options are:
     </message>
     <message>
         <source>This could be caused by one of the following scenarios:&lt;ul&gt;&lt;li&gt;Your client and the server use different encryption standards. This could be because you are using a very old client or the server you are connecting to is very old. In the first case, you should update your client and in the second case you should contact the server administrator so that they can update their server.&lt;/li&gt;&lt;li&gt;Either your client or the server is using an old operating system that doesn&apos;t provide up-to-date encryption methods. In this case you should consider updating your OS or contacting the server admin so that they can update theirs.&lt;/li&gt;&lt;li&gt;The server you are connecting to isn&apos;t actually a Mumble server. Please ensure that the used server address really belongs to a Mumble server and not e.g. to a game server.&lt;/li&gt;&lt;li&gt;The port you are connecting to does not belong to a Mumble server but instead is bound to a completely unrelated process on the server-side. Please double-check you have used the correct port.&lt;/li&gt;&lt;/ul&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>%1 Video Controls</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Images (*.png *.jpg *.jpeg *.gif)</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/mumble/mumble_eu.ts
+++ b/src/mumble/mumble_eu.ts
@@ -713,6 +713,13 @@ This value allows you to set the maximum number of users allowed in the channel.
     </message>
 </context>
 <context>
+    <name>AnimationTextObject</name>
+    <message>
+        <source>%1 / %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>AudioInput</name>
     <message>
         <source>Interface</source>
@@ -2963,6 +2970,10 @@ adierazten du.</translation>
     </message>
     <message>
         <source>This server does not allow sending images.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Unable to read animated image file: %1</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -5437,10 +5448,6 @@ Otherwise abort and check your certificate and username.</source>
         <translation>Zerbitzariko pasahitz okerra erregistratu gabeko erabiltzaile konturako, mesedez saiatu berriz.</translation>
     </message>
     <message>
-        <source>Images (*.png *.jpg *.jpeg)</source>
-        <translation>Irudiak (*.png *.jpg *.jpeg)</translation>
-    </message>
-    <message>
         <source>C&amp;onfigure</source>
         <translation>Ezarpenak</translation>
     </message>
@@ -7030,6 +7037,14 @@ Valid options are:
     </message>
     <message>
         <source>This could be caused by one of the following scenarios:&lt;ul&gt;&lt;li&gt;Your client and the server use different encryption standards. This could be because you are using a very old client or the server you are connecting to is very old. In the first case, you should update your client and in the second case you should contact the server administrator so that they can update their server.&lt;/li&gt;&lt;li&gt;Either your client or the server is using an old operating system that doesn&apos;t provide up-to-date encryption methods. In this case you should consider updating your OS or contacting the server admin so that they can update theirs.&lt;/li&gt;&lt;li&gt;The server you are connecting to isn&apos;t actually a Mumble server. Please ensure that the used server address really belongs to a Mumble server and not e.g. to a game server.&lt;/li&gt;&lt;li&gt;The port you are connecting to does not belong to a Mumble server but instead is bound to a completely unrelated process on the server-side. Please double-check you have used the correct port.&lt;/li&gt;&lt;/ul&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>%1 Video Controls</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Images (*.png *.jpg *.jpeg *.gif)</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/mumble/mumble_fa_IR.ts
+++ b/src/mumble/mumble_fa_IR.ts
@@ -705,6 +705,13 @@ This value allows you to set the maximum number of users allowed in the channel.
     </message>
 </context>
 <context>
+    <name>AnimationTextObject</name>
+    <message>
+        <source>%1 / %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>AudioInput</name>
     <message>
         <source>Interface</source>
@@ -2953,6 +2960,10 @@ Are you sure you wish to replace your certificate?
     </message>
     <message>
         <source>This server does not allow sending images.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Unable to read animated image file: %1</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -5420,10 +5431,6 @@ Otherwise abort and check your certificate and username.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Images (*.png *.jpg *.jpeg)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>C&amp;onfigure</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7010,6 +7017,14 @@ Valid options are:
     </message>
     <message>
         <source>This could be caused by one of the following scenarios:&lt;ul&gt;&lt;li&gt;Your client and the server use different encryption standards. This could be because you are using a very old client or the server you are connecting to is very old. In the first case, you should update your client and in the second case you should contact the server administrator so that they can update their server.&lt;/li&gt;&lt;li&gt;Either your client or the server is using an old operating system that doesn&apos;t provide up-to-date encryption methods. In this case you should consider updating your OS or contacting the server admin so that they can update theirs.&lt;/li&gt;&lt;li&gt;The server you are connecting to isn&apos;t actually a Mumble server. Please ensure that the used server address really belongs to a Mumble server and not e.g. to a game server.&lt;/li&gt;&lt;li&gt;The port you are connecting to does not belong to a Mumble server but instead is bound to a completely unrelated process on the server-side. Please double-check you have used the correct port.&lt;/li&gt;&lt;/ul&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>%1 Video Controls</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Images (*.png *.jpg *.jpeg *.gif)</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/mumble/mumble_fi.ts
+++ b/src/mumble/mumble_fi.ts
@@ -711,6 +711,13 @@ Tämän numeron ollessa suurempi kuin nolla kanava sallii enintään numeron suu
     </message>
 </context>
 <context>
+    <name>AnimationTextObject</name>
+    <message>
+        <source>%1 / %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>AudioInput</name>
     <message>
         <source>Interface</source>
@@ -2994,6 +3001,10 @@ Haluatko varmasti korvata varmenteen?
     <message>
         <source>This server does not allow sending images.</source>
         <translation>Tämä palvelin ei salli kuvien lähettämistä.</translation>
+    </message>
+    <message>
+        <source>Unable to read animated image file: %1</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -5483,10 +5494,6 @@ Muutoin keskeytä ja tarkista varmenteesi sekä käyttäjänimesi.</translation>
         <translation>Väärä palvelin salasana rekisteröimättömällä käyttäjätilillä, ole hyvä ja yritä uudelleen.</translation>
     </message>
     <message>
-        <source>Images (*.png *.jpg *.jpeg)</source>
-        <translation>Kuvat (*.png *.jpg *.jpeg)</translation>
-    </message>
-    <message>
         <source>C&amp;onfigure</source>
         <translation>K&amp;onfiguroi</translation>
     </message>
@@ -7163,6 +7170,14 @@ Hyväksytyt valinnat ovat
     <message>
         <source>This could be caused by one of the following scenarios:&lt;ul&gt;&lt;li&gt;Your client and the server use different encryption standards. This could be because you are using a very old client or the server you are connecting to is very old. In the first case, you should update your client and in the second case you should contact the server administrator so that they can update their server.&lt;/li&gt;&lt;li&gt;Either your client or the server is using an old operating system that doesn&apos;t provide up-to-date encryption methods. In this case you should consider updating your OS or contacting the server admin so that they can update theirs.&lt;/li&gt;&lt;li&gt;The server you are connecting to isn&apos;t actually a Mumble server. Please ensure that the used server address really belongs to a Mumble server and not e.g. to a game server.&lt;/li&gt;&lt;li&gt;The port you are connecting to does not belong to a Mumble server but instead is bound to a completely unrelated process on the server-side. Please double-check you have used the correct port.&lt;/li&gt;&lt;/ul&gt;</source>
         <translation>Tämä voi johtua jostakin seuraavista tilanteista:&lt;ul&gt;&lt;li&gt;Asiakkaasi ja palvelin käyttävät erilaisia salausstandardeja. Tämä voi johtua siitä, että käytät erittäin vanhaa asiakasta tai palvelin, johon muodostat yhteyden, on hyvin vanha. Ensimmäisessä tapauksessa sinun tulee päivittää asiakasohjelmasi ja toisessa tapauksessa ottaa yhteyttä palvelimen järjestelmänvalvojaan, jotta hän voi päivittää palvelimensa.&lt;/li&gt;&lt;li&gt;Joko asiakkaasi tai palvelin käyttää vanhaa käyttöjärjestelmää, joka ei tarjoa ajan tasalla olevia salausmenetelmiä. Tässä tapauksessa sinun kannattaa harkita käyttöjärjestelmän päivittämistä tai ottaa yhteyttä palvelimen järjestelmänvalvojaan, jotta he voivat päivittää omansa.&lt;/li&gt;&lt;li&gt;Palvelin, johon muodostat yhteyden, ei ole itse asiassa Mumble-palvelin. Varmista, että käytetty palvelinosoite todella kuuluu Mumble-palvelimelle eikä esim. pelipalvelimelle.&lt;/li&gt;&lt;li&gt;Portti, johon muodostat yhteyden, ei kuulu Mumble-palvelimelle, vaan se on sidottu täysin asiaankuulumattomaan palvelinpuolen prosessiin. Tarkista, että olet käyttänyt oikeaa porttia.&lt;/li&gt;&lt;/ul&gt;</translation>
+    </message>
+    <message>
+        <source>%1 Video Controls</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Images (*.png *.jpg *.jpeg *.gif)</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/src/mumble/mumble_fr.ts
+++ b/src/mumble/mumble_fr.ts
@@ -711,6 +711,13 @@ Cette valeur vous permet de définir un nombre maximum d&apos;utilisateurs autor
     </message>
 </context>
 <context>
+    <name>AnimationTextObject</name>
+    <message>
+        <source>%1 / %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>AudioInput</name>
     <message>
         <source>Interface</source>
@@ -2994,6 +3001,10 @@ Are you sure you wish to replace your certificate?
     <message>
         <source>This server does not allow sending images.</source>
         <translation>Ce serveur n&apos;autorise pas l&apos;envoi d&apos;image.</translation>
+    </message>
+    <message>
+        <source>Unable to read animated image file: %1</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -5483,10 +5494,6 @@ veuillez réessayer. Sinon annulez et vérifiez votre certificat et nom d&apos;u
         <translation>Mauvais mot de passe de serveur pour un utilisateur non enregistré, veuillez essayer à nouveau.</translation>
     </message>
     <message>
-        <source>Images (*.png *.jpg *.jpeg)</source>
-        <translation>Images (*.png *.jpg *.jpeg)</translation>
-    </message>
-    <message>
         <source>C&amp;onfigure</source>
         <translation>C&amp;onfigurer</translation>
     </message>
@@ -7170,6 +7177,14 @@ Les options valides sont :
     </message>
     <message>
         <source>This could be caused by one of the following scenarios:&lt;ul&gt;&lt;li&gt;Your client and the server use different encryption standards. This could be because you are using a very old client or the server you are connecting to is very old. In the first case, you should update your client and in the second case you should contact the server administrator so that they can update their server.&lt;/li&gt;&lt;li&gt;Either your client or the server is using an old operating system that doesn&apos;t provide up-to-date encryption methods. In this case you should consider updating your OS or contacting the server admin so that they can update theirs.&lt;/li&gt;&lt;li&gt;The server you are connecting to isn&apos;t actually a Mumble server. Please ensure that the used server address really belongs to a Mumble server and not e.g. to a game server.&lt;/li&gt;&lt;li&gt;The port you are connecting to does not belong to a Mumble server but instead is bound to a completely unrelated process on the server-side. Please double-check you have used the correct port.&lt;/li&gt;&lt;/ul&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>%1 Video Controls</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Images (*.png *.jpg *.jpeg *.gif)</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/mumble/mumble_gl.ts
+++ b/src/mumble/mumble_gl.ts
@@ -705,6 +705,13 @@ This value allows you to set the maximum number of users allowed in the channel.
     </message>
 </context>
 <context>
+    <name>AnimationTextObject</name>
+    <message>
+        <source>%1 / %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>AudioInput</name>
     <message>
         <source>Interface</source>
@@ -2954,6 +2961,10 @@ Are you sure you wish to replace your certificate?
     </message>
     <message>
         <source>This server does not allow sending images.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Unable to read animated image file: %1</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -5421,10 +5432,6 @@ Otherwise abort and check your certificate and username.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Images (*.png *.jpg *.jpeg)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>C&amp;onfigure</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7011,6 +7018,14 @@ Valid options are:
     </message>
     <message>
         <source>This could be caused by one of the following scenarios:&lt;ul&gt;&lt;li&gt;Your client and the server use different encryption standards. This could be because you are using a very old client or the server you are connecting to is very old. In the first case, you should update your client and in the second case you should contact the server administrator so that they can update their server.&lt;/li&gt;&lt;li&gt;Either your client or the server is using an old operating system that doesn&apos;t provide up-to-date encryption methods. In this case you should consider updating your OS or contacting the server admin so that they can update theirs.&lt;/li&gt;&lt;li&gt;The server you are connecting to isn&apos;t actually a Mumble server. Please ensure that the used server address really belongs to a Mumble server and not e.g. to a game server.&lt;/li&gt;&lt;li&gt;The port you are connecting to does not belong to a Mumble server but instead is bound to a completely unrelated process on the server-side. Please double-check you have used the correct port.&lt;/li&gt;&lt;/ul&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>%1 Video Controls</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Images (*.png *.jpg *.jpeg *.gif)</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/mumble/mumble_he.ts
+++ b/src/mumble/mumble_he.ts
@@ -712,6 +712,13 @@ This value allows you to set the maximum number of users allowed in the channel.
     </message>
 </context>
 <context>
+    <name>AnimationTextObject</name>
+    <message>
+        <source>%1 / %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>AudioInput</name>
     <message>
         <source>Interface</source>
@@ -2990,6 +2997,10 @@ Are you sure you wish to replace your certificate?
     </message>
     <message>
         <source>This server does not allow sending images.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Unable to read animated image file: %1</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -5469,10 +5480,6 @@ Otherwise abort and check your certificate and username.</source>
         <translation>&lt;p dir=&quot;RTL&quot;&gt;הסיסמה שהזנתם אינה נכונה, אנא נסו שנית.&lt;/p&gt;</translation>
     </message>
     <message>
-        <source>Images (*.png *.jpg *.jpeg)</source>
-        <translation>תמונות (‎*.png *.jpg *.jpeg)</translation>
-    </message>
-    <message>
         <source>C&amp;onfigure</source>
         <translation>&amp;תצורה</translation>
     </message>
@@ -7061,6 +7068,14 @@ Valid options are:
     </message>
     <message>
         <source>This could be caused by one of the following scenarios:&lt;ul&gt;&lt;li&gt;Your client and the server use different encryption standards. This could be because you are using a very old client or the server you are connecting to is very old. In the first case, you should update your client and in the second case you should contact the server administrator so that they can update their server.&lt;/li&gt;&lt;li&gt;Either your client or the server is using an old operating system that doesn&apos;t provide up-to-date encryption methods. In this case you should consider updating your OS or contacting the server admin so that they can update theirs.&lt;/li&gt;&lt;li&gt;The server you are connecting to isn&apos;t actually a Mumble server. Please ensure that the used server address really belongs to a Mumble server and not e.g. to a game server.&lt;/li&gt;&lt;li&gt;The port you are connecting to does not belong to a Mumble server but instead is bound to a completely unrelated process on the server-side. Please double-check you have used the correct port.&lt;/li&gt;&lt;/ul&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>%1 Video Controls</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Images (*.png *.jpg *.jpeg *.gif)</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/mumble/mumble_hi.ts
+++ b/src/mumble/mumble_hi.ts
@@ -699,6 +699,13 @@ Contains the list of members inherited by the current channel. Uncheck &lt;i&gt;
     </message>
 </context>
 <context>
+    <name>AnimationTextObject</name>
+    <message>
+        <source>%1 / %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>AudioInput</name>
     <message>
         <source>Audio input</source>
@@ -2933,6 +2940,10 @@ Are you sure you wish to replace your certificate?
     </message>
     <message>
         <source>This server does not allow sending images.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Unable to read animated image file: %1</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -5860,10 +5871,6 @@ Valid actions are:
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Images (*.png *.jpg *.jpeg)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Could not save image: %1</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6972,6 +6979,14 @@ Valid options are:
     </message>
     <message>
         <source>This could be caused by one of the following scenarios:&lt;ul&gt;&lt;li&gt;Your client and the server use different encryption standards. This could be because you are using a very old client or the server you are connecting to is very old. In the first case, you should update your client and in the second case you should contact the server administrator so that they can update their server.&lt;/li&gt;&lt;li&gt;Either your client or the server is using an old operating system that doesn&apos;t provide up-to-date encryption methods. In this case you should consider updating your OS or contacting the server admin so that they can update theirs.&lt;/li&gt;&lt;li&gt;The server you are connecting to isn&apos;t actually a Mumble server. Please ensure that the used server address really belongs to a Mumble server and not e.g. to a game server.&lt;/li&gt;&lt;li&gt;The port you are connecting to does not belong to a Mumble server but instead is bound to a completely unrelated process on the server-side. Please double-check you have used the correct port.&lt;/li&gt;&lt;/ul&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>%1 Video Controls</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Images (*.png *.jpg *.jpeg *.gif)</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/mumble/mumble_hu.ts
+++ b/src/mumble/mumble_hu.ts
@@ -707,6 +707,13 @@ This value allows you to set the maximum number of users allowed in the channel.
     </message>
 </context>
 <context>
+    <name>AnimationTextObject</name>
+    <message>
+        <source>%1 / %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>AudioInput</name>
     <message>
         <source>Interface</source>
@@ -2983,6 +2990,10 @@ Biztos abban, hogy le akarja cserélni a tanúsítványát?
     <message>
         <source>This server does not allow sending images.</source>
         <translation>A kiszolgáló nem támogatja képfájlok küldését.</translation>
+    </message>
+    <message>
+        <source>Unable to read animated image file: %1</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -5469,10 +5480,6 @@ Ha nem ön az, ellenőrizze a felhasználónevét és a tanúsítványt!</transl
         <translation>A nem regisztrált felhasználói jelszó hibás, próbálja újra.</translation>
     </message>
     <message>
-        <source>Images (*.png *.jpg *.jpeg)</source>
-        <translation>Képfájl (*.png *.jpg *.jpeg)</translation>
-    </message>
-    <message>
         <source>C&amp;onfigure</source>
         <translation>&amp;Beállítások</translation>
     </message>
@@ -7061,6 +7068,14 @@ Valid options are:
     </message>
     <message>
         <source>This could be caused by one of the following scenarios:&lt;ul&gt;&lt;li&gt;Your client and the server use different encryption standards. This could be because you are using a very old client or the server you are connecting to is very old. In the first case, you should update your client and in the second case you should contact the server administrator so that they can update their server.&lt;/li&gt;&lt;li&gt;Either your client or the server is using an old operating system that doesn&apos;t provide up-to-date encryption methods. In this case you should consider updating your OS or contacting the server admin so that they can update theirs.&lt;/li&gt;&lt;li&gt;The server you are connecting to isn&apos;t actually a Mumble server. Please ensure that the used server address really belongs to a Mumble server and not e.g. to a game server.&lt;/li&gt;&lt;li&gt;The port you are connecting to does not belong to a Mumble server but instead is bound to a completely unrelated process on the server-side. Please double-check you have used the correct port.&lt;/li&gt;&lt;/ul&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>%1 Video Controls</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Images (*.png *.jpg *.jpeg *.gif)</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/mumble/mumble_it.ts
+++ b/src/mumble/mumble_it.ts
@@ -711,6 +711,13 @@ Questo valore ti permette di impostare il numero massimo di utenti consentiti ne
     </message>
 </context>
 <context>
+    <name>AnimationTextObject</name>
+    <message>
+        <source>%1 / %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>AudioInput</name>
     <message>
         <source>Interface</source>
@@ -2994,6 +3001,10 @@ Sei sicuro di voler sostituire il tuo certificato?
     <message>
         <source>This server does not allow sending images.</source>
         <translation>Il server non permette l&apos;invio di immagini.</translation>
+    </message>
+    <message>
+        <source>Unable to read animated image file: %1</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -5483,10 +5494,6 @@ Altrimenti annulla e controlla il tuo certificato ed il nome utente.</translatio
         <translation>Password errata per un account non registrato, prova di nuovo.</translation>
     </message>
     <message>
-        <source>Images (*.png *.jpg *.jpeg)</source>
-        <translation>Immagini (*.png *.jpg *.jpeg)</translation>
-    </message>
-    <message>
         <source>C&amp;onfigure</source>
         <translation>&amp;Impostazioni</translation>
     </message>
@@ -7103,6 +7110,14 @@ Valid options are:
     </message>
     <message>
         <source>This could be caused by one of the following scenarios:&lt;ul&gt;&lt;li&gt;Your client and the server use different encryption standards. This could be because you are using a very old client or the server you are connecting to is very old. In the first case, you should update your client and in the second case you should contact the server administrator so that they can update their server.&lt;/li&gt;&lt;li&gt;Either your client or the server is using an old operating system that doesn&apos;t provide up-to-date encryption methods. In this case you should consider updating your OS or contacting the server admin so that they can update theirs.&lt;/li&gt;&lt;li&gt;The server you are connecting to isn&apos;t actually a Mumble server. Please ensure that the used server address really belongs to a Mumble server and not e.g. to a game server.&lt;/li&gt;&lt;li&gt;The port you are connecting to does not belong to a Mumble server but instead is bound to a completely unrelated process on the server-side. Please double-check you have used the correct port.&lt;/li&gt;&lt;/ul&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>%1 Video Controls</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Images (*.png *.jpg *.jpeg *.gif)</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/mumble/mumble_ja.ts
+++ b/src/mumble/mumble_ja.ts
@@ -712,6 +712,13 @@ This value allows you to set the maximum number of users allowed in the channel.
     </message>
 </context>
 <context>
+    <name>AnimationTextObject</name>
+    <message>
+        <source>%1 / %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>AudioInput</name>
     <message>
         <source>Interface</source>
@@ -2988,6 +2995,10 @@ Are you sure you wish to replace your certificate?
     </message>
     <message>
         <source>This server does not allow sending images.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Unable to read animated image file: %1</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -5468,10 +5479,6 @@ Otherwise abort and check your certificate and username.</source>
         <translation>未登録ユーザのパスワードが違います。再度試してください。</translation>
     </message>
     <message>
-        <source>Images (*.png *.jpg *.jpeg)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>C&amp;onfigure</source>
         <translation>設定(&amp;O)</translation>
     </message>
@@ -7059,6 +7066,14 @@ Valid options are:
     </message>
     <message>
         <source>This could be caused by one of the following scenarios:&lt;ul&gt;&lt;li&gt;Your client and the server use different encryption standards. This could be because you are using a very old client or the server you are connecting to is very old. In the first case, you should update your client and in the second case you should contact the server administrator so that they can update their server.&lt;/li&gt;&lt;li&gt;Either your client or the server is using an old operating system that doesn&apos;t provide up-to-date encryption methods. In this case you should consider updating your OS or contacting the server admin so that they can update theirs.&lt;/li&gt;&lt;li&gt;The server you are connecting to isn&apos;t actually a Mumble server. Please ensure that the used server address really belongs to a Mumble server and not e.g. to a game server.&lt;/li&gt;&lt;li&gt;The port you are connecting to does not belong to a Mumble server but instead is bound to a completely unrelated process on the server-side. Please double-check you have used the correct port.&lt;/li&gt;&lt;/ul&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>%1 Video Controls</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Images (*.png *.jpg *.jpeg *.gif)</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/mumble/mumble_ko.ts
+++ b/src/mumble/mumble_ko.ts
@@ -711,6 +711,13 @@ This value allows you to set the maximum number of users allowed in the channel.
     </message>
 </context>
 <context>
+    <name>AnimationTextObject</name>
+    <message>
+        <source>%1 / %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>AudioInput</name>
     <message>
         <source>Interface</source>
@@ -2993,6 +3000,10 @@ Are you sure you wish to replace your certificate?
     <message>
         <source>This server does not allow sending images.</source>
         <translation>이 서버는 이미지 보내기를 허용하지 않습니다.</translation>
+    </message>
+    <message>
+        <source>Unable to read animated image file: %1</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -5482,10 +5493,6 @@ Otherwise abort and check your certificate and username.</source>
         <translation>등록되지 않은 유저 계정의 서버 비밀번호가 잘못되었습니다. 다시 시도하세요.</translation>
     </message>
     <message>
-        <source>Images (*.png *.jpg *.jpeg)</source>
-        <translation>이미지 (*.png *.jpg *.jpeg)</translation>
-    </message>
-    <message>
         <source>C&amp;onfigure</source>
         <translation>구성(&amp;O)</translation>
     </message>
@@ -7102,6 +7109,14 @@ Valid options are:
     </message>
     <message>
         <source>This could be caused by one of the following scenarios:&lt;ul&gt;&lt;li&gt;Your client and the server use different encryption standards. This could be because you are using a very old client or the server you are connecting to is very old. In the first case, you should update your client and in the second case you should contact the server administrator so that they can update their server.&lt;/li&gt;&lt;li&gt;Either your client or the server is using an old operating system that doesn&apos;t provide up-to-date encryption methods. In this case you should consider updating your OS or contacting the server admin so that they can update theirs.&lt;/li&gt;&lt;li&gt;The server you are connecting to isn&apos;t actually a Mumble server. Please ensure that the used server address really belongs to a Mumble server and not e.g. to a game server.&lt;/li&gt;&lt;li&gt;The port you are connecting to does not belong to a Mumble server but instead is bound to a completely unrelated process on the server-side. Please double-check you have used the correct port.&lt;/li&gt;&lt;/ul&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>%1 Video Controls</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Images (*.png *.jpg *.jpeg *.gif)</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/mumble/mumble_lt.ts
+++ b/src/mumble/mumble_lt.ts
@@ -707,6 +707,13 @@ This value allows you to set the maximum number of users allowed in the channel.
     </message>
 </context>
 <context>
+    <name>AnimationTextObject</name>
+    <message>
+        <source>%1 / %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>AudioInput</name>
     <message>
         <source>Interface</source>
@@ -2984,6 +2991,10 @@ Ar tikrai norite pakeisti savo liudijimą?
     </message>
     <message>
         <source>This server does not allow sending images.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Unable to read animated image file: %1</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -5452,10 +5463,6 @@ Otherwise abort and check your certificate and username.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Images (*.png *.jpg *.jpeg)</source>
-        <translation>Paveikslai (*.png *.jpg *.jpeg)</translation>
-    </message>
-    <message>
         <source>C&amp;onfigure</source>
         <translation>K&amp;onfigūruoti</translation>
     </message>
@@ -7044,6 +7051,14 @@ Valid options are:
     </message>
     <message>
         <source>This could be caused by one of the following scenarios:&lt;ul&gt;&lt;li&gt;Your client and the server use different encryption standards. This could be because you are using a very old client or the server you are connecting to is very old. In the first case, you should update your client and in the second case you should contact the server administrator so that they can update their server.&lt;/li&gt;&lt;li&gt;Either your client or the server is using an old operating system that doesn&apos;t provide up-to-date encryption methods. In this case you should consider updating your OS or contacting the server admin so that they can update theirs.&lt;/li&gt;&lt;li&gt;The server you are connecting to isn&apos;t actually a Mumble server. Please ensure that the used server address really belongs to a Mumble server and not e.g. to a game server.&lt;/li&gt;&lt;li&gt;The port you are connecting to does not belong to a Mumble server but instead is bound to a completely unrelated process on the server-side. Please double-check you have used the correct port.&lt;/li&gt;&lt;/ul&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>%1 Video Controls</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Images (*.png *.jpg *.jpeg *.gif)</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/mumble/mumble_nl.ts
+++ b/src/mumble/mumble_nl.ts
@@ -711,6 +711,13 @@ Deze waarde laat je toe om een maximum aantal gebruikers in te stellen voor het 
     </message>
 </context>
 <context>
+    <name>AnimationTextObject</name>
+    <message>
+        <source>%1 / %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>AudioInput</name>
     <message>
         <source>Interface</source>
@@ -2994,6 +3001,10 @@ Weet je zeker dat je jouw certificaat wilt vervangen?
     <message>
         <source>This server does not allow sending images.</source>
         <translation>Deze server laat het versturen van afbeeldingen niet toe.</translation>
+    </message>
+    <message>
+        <source>Unable to read animated image file: %1</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -5483,10 +5494,6 @@ Indien niet, gelieve te annuleren en beide opnieuw te controleren.</translation>
         <translation>Verkeerd server-wachtwoord voor ongeregistreerde account, gelieve opnieuw te proberen.</translation>
     </message>
     <message>
-        <source>Images (*.png *.jpg *.jpeg)</source>
-        <translation>Afbeeldingen (*.png *.jpg *.jpeg)</translation>
-    </message>
-    <message>
         <source>C&amp;onfigure</source>
         <translation>C&amp;onfigureer</translation>
     </message>
@@ -7103,6 +7110,14 @@ Valid options are:
     </message>
     <message>
         <source>This could be caused by one of the following scenarios:&lt;ul&gt;&lt;li&gt;Your client and the server use different encryption standards. This could be because you are using a very old client or the server you are connecting to is very old. In the first case, you should update your client and in the second case you should contact the server administrator so that they can update their server.&lt;/li&gt;&lt;li&gt;Either your client or the server is using an old operating system that doesn&apos;t provide up-to-date encryption methods. In this case you should consider updating your OS or contacting the server admin so that they can update theirs.&lt;/li&gt;&lt;li&gt;The server you are connecting to isn&apos;t actually a Mumble server. Please ensure that the used server address really belongs to a Mumble server and not e.g. to a game server.&lt;/li&gt;&lt;li&gt;The port you are connecting to does not belong to a Mumble server but instead is bound to a completely unrelated process on the server-side. Please double-check you have used the correct port.&lt;/li&gt;&lt;/ul&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>%1 Video Controls</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Images (*.png *.jpg *.jpeg *.gif)</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/mumble/mumble_no.ts
+++ b/src/mumble/mumble_no.ts
@@ -711,6 +711,13 @@ Denne verdien gjør at du setter maksimalt antall brukere tillatt i kanalen. Hvi
     </message>
 </context>
 <context>
+    <name>AnimationTextObject</name>
+    <message>
+        <source>%1 / %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>AudioInput</name>
     <message>
         <source>Interface</source>
@@ -3008,6 +3015,10 @@ Er du sikker på at du vil erstatte ditt sertifikat?
     <message>
         <source>This server does not allow sending images.</source>
         <translation>Tjeneren tillater ikke bildeforsendelse.</translation>
+    </message>
+    <message>
+        <source>Unable to read animated image file: %1</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -5498,10 +5509,6 @@ Ellers avbryt alt og sjekk ditt sertifikat og brukernavn.</translation>
         <translation>Feil tjenerpassord for uregistrert brukerkonto, prøv igjen.</translation>
     </message>
     <message>
-        <source>Images (*.png *.jpg *.jpeg)</source>
-        <translation>Bilder (*.png *.jpg *.jpeg)</translation>
-    </message>
-    <message>
         <source>C&amp;onfigure</source>
         <translation>&amp;Sett opp</translation>
     </message>
@@ -7118,6 +7125,14 @@ Valid options are:
     </message>
     <message>
         <source>This could be caused by one of the following scenarios:&lt;ul&gt;&lt;li&gt;Your client and the server use different encryption standards. This could be because you are using a very old client or the server you are connecting to is very old. In the first case, you should update your client and in the second case you should contact the server administrator so that they can update their server.&lt;/li&gt;&lt;li&gt;Either your client or the server is using an old operating system that doesn&apos;t provide up-to-date encryption methods. In this case you should consider updating your OS or contacting the server admin so that they can update theirs.&lt;/li&gt;&lt;li&gt;The server you are connecting to isn&apos;t actually a Mumble server. Please ensure that the used server address really belongs to a Mumble server and not e.g. to a game server.&lt;/li&gt;&lt;li&gt;The port you are connecting to does not belong to a Mumble server but instead is bound to a completely unrelated process on the server-side. Please double-check you have used the correct port.&lt;/li&gt;&lt;/ul&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>%1 Video Controls</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Images (*.png *.jpg *.jpeg *.gif)</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/mumble/mumble_oc.ts
+++ b/src/mumble/mumble_oc.ts
@@ -704,6 +704,13 @@ This value allows you to set the maximum number of users allowed in the channel.
     </message>
 </context>
 <context>
+    <name>AnimationTextObject</name>
+    <message>
+        <source>%1 / %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>AudioInput</name>
     <message>
         <source>Interface</source>
@@ -2953,6 +2960,10 @@ Are you sure you wish to replace your certificate?
     </message>
     <message>
         <source>This server does not allow sending images.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Unable to read animated image file: %1</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -5420,10 +5431,6 @@ Otherwise abort and check your certificate and username.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Images (*.png *.jpg *.jpeg)</source>
-        <translation>Imatges (*.png *.jpg *.jpeg)</translation>
-    </message>
-    <message>
         <source>C&amp;onfigure</source>
         <translation>C&amp;onfigurar</translation>
     </message>
@@ -7010,6 +7017,14 @@ Valid options are:
     </message>
     <message>
         <source>This could be caused by one of the following scenarios:&lt;ul&gt;&lt;li&gt;Your client and the server use different encryption standards. This could be because you are using a very old client or the server you are connecting to is very old. In the first case, you should update your client and in the second case you should contact the server administrator so that they can update their server.&lt;/li&gt;&lt;li&gt;Either your client or the server is using an old operating system that doesn&apos;t provide up-to-date encryption methods. In this case you should consider updating your OS or contacting the server admin so that they can update theirs.&lt;/li&gt;&lt;li&gt;The server you are connecting to isn&apos;t actually a Mumble server. Please ensure that the used server address really belongs to a Mumble server and not e.g. to a game server.&lt;/li&gt;&lt;li&gt;The port you are connecting to does not belong to a Mumble server but instead is bound to a completely unrelated process on the server-side. Please double-check you have used the correct port.&lt;/li&gt;&lt;/ul&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>%1 Video Controls</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Images (*.png *.jpg *.jpeg *.gif)</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/mumble/mumble_pl.ts
+++ b/src/mumble/mumble_pl.ts
@@ -711,6 +711,13 @@ Określa maksymalną dozwoloną liczbę użytkowników na tym kanale. Jeżeli wa
     </message>
 </context>
 <context>
+    <name>AnimationTextObject</name>
+    <message>
+        <source>%1 / %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>AudioInput</name>
     <message>
         <source>Interface</source>
@@ -2995,6 +3002,10 @@ Czy na pewno chcesz zastąpić swój bieżący certyfikat?
     <message>
         <source>This server does not allow sending images.</source>
         <translation>Ten serwer nie pozwala na wysyłanie obrazów.</translation>
+    </message>
+    <message>
+        <source>Unable to read animated image file: %1</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -5484,10 +5495,6 @@ W przeciwnym razie proszę przerwać i sprawdzić swój certyfikat oraz nazwę u
         <translation>Podałeś złe hasło dla niezarejestrowanych użytkowników, spróbuj jeszcze raz.</translation>
     </message>
     <message>
-        <source>Images (*.png *.jpg *.jpeg)</source>
-        <translation>Obrazy (*.png *.jpg *.jpeg)</translation>
-    </message>
-    <message>
         <source>C&amp;onfigure</source>
         <translation>&amp;Opcje</translation>
     </message>
@@ -7165,6 +7172,14 @@ Prawidłowe opcje to:
     <message>
         <source>This could be caused by one of the following scenarios:&lt;ul&gt;&lt;li&gt;Your client and the server use different encryption standards. This could be because you are using a very old client or the server you are connecting to is very old. In the first case, you should update your client and in the second case you should contact the server administrator so that they can update their server.&lt;/li&gt;&lt;li&gt;Either your client or the server is using an old operating system that doesn&apos;t provide up-to-date encryption methods. In this case you should consider updating your OS or contacting the server admin so that they can update theirs.&lt;/li&gt;&lt;li&gt;The server you are connecting to isn&apos;t actually a Mumble server. Please ensure that the used server address really belongs to a Mumble server and not e.g. to a game server.&lt;/li&gt;&lt;li&gt;The port you are connecting to does not belong to a Mumble server but instead is bound to a completely unrelated process on the server-side. Please double-check you have used the correct port.&lt;/li&gt;&lt;/ul&gt;</source>
         <translation>Może to być spowodowane jednym z następujących scenariuszy:&lt;ul&gt;&lt;li&gt;Twój klient i serwer używają różnych standardów szyfrowania. Może to być spowodowane tym, że używasz bardzo starego klienta lub serwer, z którym się łączysz, jest bardzo stary. W pierwszym przypadku należy zaktualizować swojego klienta, a w drugim przypadku należy skontaktować się z administratorem serwera, aby mógł zaktualizować swój serwer.&lt;/li&gt;&lt;li&gt;Twój klient lub serwer używa starego systemu operacyjnego, który nie zapewnia aktualnych metod szyfrowania. W takim przypadku należy rozważyć aktualizację swojego systemu operacyjnego lub skontaktować się z administratorem serwera, aby mógł zaktualizować swój.&lt;/li&gt;&lt;li&gt;Serwer, z którym się łączysz, nie jest w rzeczywistości serwerem Mumble. Upewnij się, że używany adres serwera rzeczywiście należy do serwera Mumble, a nie np. do serwera gier.&lt;/li&gt;&lt;li&gt;Port, z którym się łączysz, nie należy do serwera Mumble, ale jest powiązany z zupełnie niezwiązanym procesem po stronie serwera. Sprawdź dokładnie, czy używasz prawidłowego portu.&lt;/li&gt;&lt;/ul&gt;</translation>
+    </message>
+    <message>
+        <source>%1 Video Controls</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Images (*.png *.jpg *.jpeg *.gif)</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/src/mumble/mumble_pt_BR.ts
+++ b/src/mumble/mumble_pt_BR.ts
@@ -711,6 +711,13 @@ Este valor permite que você especifique o número máximo de usuários permitid
     </message>
 </context>
 <context>
+    <name>AnimationTextObject</name>
+    <message>
+        <source>%1 / %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>AudioInput</name>
     <message>
         <source>Interface</source>
@@ -2994,6 +3001,10 @@ Você tem certeza de que quer substituir o seu certificado?
     <message>
         <source>This server does not allow sending images.</source>
         <translation>Este servidor não permite o envio de imagens.</translation>
+    </message>
+    <message>
+        <source>Unable to read animated image file: %1</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -5483,10 +5494,6 @@ Caso contrário, aborte e verifique seu certificado e nome de usuário.</transla
         <translation>Senha de servidor incorreta para conta de usuário não registrada, por favor tente novamente.</translation>
     </message>
     <message>
-        <source>Images (*.png *.jpg *.jpeg)</source>
-        <translation>Imagens (*.png *.jpg *.jpeg)</translation>
-    </message>
-    <message>
         <source>C&amp;onfigure</source>
         <translation>C&amp;onfigurar</translation>
     </message>
@@ -7103,6 +7110,14 @@ Valid options are:
     </message>
     <message>
         <source>This could be caused by one of the following scenarios:&lt;ul&gt;&lt;li&gt;Your client and the server use different encryption standards. This could be because you are using a very old client or the server you are connecting to is very old. In the first case, you should update your client and in the second case you should contact the server administrator so that they can update their server.&lt;/li&gt;&lt;li&gt;Either your client or the server is using an old operating system that doesn&apos;t provide up-to-date encryption methods. In this case you should consider updating your OS or contacting the server admin so that they can update theirs.&lt;/li&gt;&lt;li&gt;The server you are connecting to isn&apos;t actually a Mumble server. Please ensure that the used server address really belongs to a Mumble server and not e.g. to a game server.&lt;/li&gt;&lt;li&gt;The port you are connecting to does not belong to a Mumble server but instead is bound to a completely unrelated process on the server-side. Please double-check you have used the correct port.&lt;/li&gt;&lt;/ul&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>%1 Video Controls</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Images (*.png *.jpg *.jpeg *.gif)</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/mumble/mumble_pt_PT.ts
+++ b/src/mumble/mumble_pt_PT.ts
@@ -711,6 +711,13 @@ Este valor permite definir o número máximo de utilizadores permitido no canal.
     </message>
 </context>
 <context>
+    <name>AnimationTextObject</name>
+    <message>
+        <source>%1 / %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>AudioInput</name>
     <message>
         <source>Interface</source>
@@ -2994,6 +3001,10 @@ Tem certeza de que quer substituir o seu certificado?
     <message>
         <source>This server does not allow sending images.</source>
         <translation>Este servidor não permite o envio de imagens.</translation>
+    </message>
+    <message>
+        <source>Unable to read animated image file: %1</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -5484,10 +5495,6 @@ o seu certificado e nome de utilizador.</translation>
         <translation>Palavra-passe de servidor errada para conta de utilizador não registado, por favor tente novamente.</translation>
     </message>
     <message>
-        <source>Images (*.png *.jpg *.jpeg)</source>
-        <translation>Imagens (*.png *.jpg *.jpeg)</translation>
-    </message>
-    <message>
         <source>C&amp;onfigure</source>
         <translation>C&amp;onfigurar</translation>
     </message>
@@ -7104,6 +7111,14 @@ Valid options are:
     </message>
     <message>
         <source>This could be caused by one of the following scenarios:&lt;ul&gt;&lt;li&gt;Your client and the server use different encryption standards. This could be because you are using a very old client or the server you are connecting to is very old. In the first case, you should update your client and in the second case you should contact the server administrator so that they can update their server.&lt;/li&gt;&lt;li&gt;Either your client or the server is using an old operating system that doesn&apos;t provide up-to-date encryption methods. In this case you should consider updating your OS or contacting the server admin so that they can update theirs.&lt;/li&gt;&lt;li&gt;The server you are connecting to isn&apos;t actually a Mumble server. Please ensure that the used server address really belongs to a Mumble server and not e.g. to a game server.&lt;/li&gt;&lt;li&gt;The port you are connecting to does not belong to a Mumble server but instead is bound to a completely unrelated process on the server-side. Please double-check you have used the correct port.&lt;/li&gt;&lt;/ul&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>%1 Video Controls</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Images (*.png *.jpg *.jpeg *.gif)</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/mumble/mumble_ro.ts
+++ b/src/mumble/mumble_ro.ts
@@ -711,6 +711,13 @@ Această valoare vă permite să setați numărul maxim de utilizatori permis î
     </message>
 </context>
 <context>
+    <name>AnimationTextObject</name>
+    <message>
+        <source>%1 / %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>AudioInput</name>
     <message>
         <source>Interface</source>
@@ -2961,6 +2968,10 @@ Are you sure you wish to replace your certificate?
     </message>
     <message>
         <source>This server does not allow sending images.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Unable to read animated image file: %1</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -5428,10 +5439,6 @@ Otherwise abort and check your certificate and username.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Images (*.png *.jpg *.jpeg)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>C&amp;onfigure</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7018,6 +7025,14 @@ Valid options are:
     </message>
     <message>
         <source>This could be caused by one of the following scenarios:&lt;ul&gt;&lt;li&gt;Your client and the server use different encryption standards. This could be because you are using a very old client or the server you are connecting to is very old. In the first case, you should update your client and in the second case you should contact the server administrator so that they can update their server.&lt;/li&gt;&lt;li&gt;Either your client or the server is using an old operating system that doesn&apos;t provide up-to-date encryption methods. In this case you should consider updating your OS or contacting the server admin so that they can update theirs.&lt;/li&gt;&lt;li&gt;The server you are connecting to isn&apos;t actually a Mumble server. Please ensure that the used server address really belongs to a Mumble server and not e.g. to a game server.&lt;/li&gt;&lt;li&gt;The port you are connecting to does not belong to a Mumble server but instead is bound to a completely unrelated process on the server-side. Please double-check you have used the correct port.&lt;/li&gt;&lt;/ul&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>%1 Video Controls</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Images (*.png *.jpg *.jpeg *.gif)</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/mumble/mumble_ru.ts
+++ b/src/mumble/mumble_ru.ts
@@ -711,6 +711,13 @@ This value allows you to set the maximum number of users allowed in the channel.
     </message>
 </context>
 <context>
+    <name>AnimationTextObject</name>
+    <message>
+        <source>%1 / %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>AudioInput</name>
     <message>
         <source>Interface</source>
@@ -2995,6 +3002,10 @@ Are you sure you wish to replace your certificate?
     <message>
         <source>This server does not allow sending images.</source>
         <translation>Этот сервер не позволяет отправлять изображения.</translation>
+    </message>
+    <message>
+        <source>Unable to read animated image file: %1</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -5484,10 +5495,6 @@ Otherwise abort and check your certificate and username.</source>
         <translation>Неверный пароль для подключения к серверу. Попробуйте еще раз.</translation>
     </message>
     <message>
-        <source>Images (*.png *.jpg *.jpeg)</source>
-        <translation>Изображения (*.png *.jpg *.jpeg)</translation>
-    </message>
-    <message>
         <source>C&amp;onfigure</source>
         <translation>Н&amp;астройки</translation>
     </message>
@@ -7164,6 +7171,14 @@ mumble://[&lt;имя пользователя&gt;[:&lt;пароль&gt;]@]&lt;х
     </message>
     <message>
         <source>This could be caused by one of the following scenarios:&lt;ul&gt;&lt;li&gt;Your client and the server use different encryption standards. This could be because you are using a very old client or the server you are connecting to is very old. In the first case, you should update your client and in the second case you should contact the server administrator so that they can update their server.&lt;/li&gt;&lt;li&gt;Either your client or the server is using an old operating system that doesn&apos;t provide up-to-date encryption methods. In this case you should consider updating your OS or contacting the server admin so that they can update theirs.&lt;/li&gt;&lt;li&gt;The server you are connecting to isn&apos;t actually a Mumble server. Please ensure that the used server address really belongs to a Mumble server and not e.g. to a game server.&lt;/li&gt;&lt;li&gt;The port you are connecting to does not belong to a Mumble server but instead is bound to a completely unrelated process on the server-side. Please double-check you have used the correct port.&lt;/li&gt;&lt;/ul&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>%1 Video Controls</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Images (*.png *.jpg *.jpeg *.gif)</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/mumble/mumble_si.ts
+++ b/src/mumble/mumble_si.ts
@@ -699,6 +699,13 @@ Contains the list of members inherited by the current channel. Uncheck &lt;i&gt;
     </message>
 </context>
 <context>
+    <name>AnimationTextObject</name>
+    <message>
+        <source>%1 / %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>AudioInput</name>
     <message>
         <source>Audio input</source>
@@ -2933,6 +2940,10 @@ Are you sure you wish to replace your certificate?
     </message>
     <message>
         <source>This server does not allow sending images.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Unable to read animated image file: %1</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -5778,10 +5789,6 @@ Valid actions are:
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Images (*.png *.jpg *.jpeg)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Could not save image: %1</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6972,6 +6979,14 @@ Valid options are:
     </message>
     <message>
         <source>This could be caused by one of the following scenarios:&lt;ul&gt;&lt;li&gt;Your client and the server use different encryption standards. This could be because you are using a very old client or the server you are connecting to is very old. In the first case, you should update your client and in the second case you should contact the server administrator so that they can update their server.&lt;/li&gt;&lt;li&gt;Either your client or the server is using an old operating system that doesn&apos;t provide up-to-date encryption methods. In this case you should consider updating your OS or contacting the server admin so that they can update theirs.&lt;/li&gt;&lt;li&gt;The server you are connecting to isn&apos;t actually a Mumble server. Please ensure that the used server address really belongs to a Mumble server and not e.g. to a game server.&lt;/li&gt;&lt;li&gt;The port you are connecting to does not belong to a Mumble server but instead is bound to a completely unrelated process on the server-side. Please double-check you have used the correct port.&lt;/li&gt;&lt;/ul&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>%1 Video Controls</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Images (*.png *.jpg *.jpeg *.gif)</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/mumble/mumble_sk.ts
+++ b/src/mumble/mumble_sk.ts
@@ -702,6 +702,13 @@ Contains the list of members inherited by the current channel. Uncheck &lt;i&gt;
     </message>
 </context>
 <context>
+    <name>AnimationTextObject</name>
+    <message>
+        <source>%1 / %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>AudioInput</name>
     <message>
         <source>Audio input</source>
@@ -2937,6 +2944,10 @@ Are you sure you wish to replace your certificate?
     </message>
     <message>
         <source>This server does not allow sending images.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Unable to read animated image file: %1</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -5838,10 +5849,6 @@ Valid actions are:
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Images (*.png *.jpg *.jpeg)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Could not save image: %1</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6976,6 +6983,14 @@ Valid options are:
     </message>
     <message>
         <source>This could be caused by one of the following scenarios:&lt;ul&gt;&lt;li&gt;Your client and the server use different encryption standards. This could be because you are using a very old client or the server you are connecting to is very old. In the first case, you should update your client and in the second case you should contact the server administrator so that they can update their server.&lt;/li&gt;&lt;li&gt;Either your client or the server is using an old operating system that doesn&apos;t provide up-to-date encryption methods. In this case you should consider updating your OS or contacting the server admin so that they can update theirs.&lt;/li&gt;&lt;li&gt;The server you are connecting to isn&apos;t actually a Mumble server. Please ensure that the used server address really belongs to a Mumble server and not e.g. to a game server.&lt;/li&gt;&lt;li&gt;The port you are connecting to does not belong to a Mumble server but instead is bound to a completely unrelated process on the server-side. Please double-check you have used the correct port.&lt;/li&gt;&lt;/ul&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>%1 Video Controls</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Images (*.png *.jpg *.jpeg *.gif)</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/mumble/mumble_sq.ts
+++ b/src/mumble/mumble_sq.ts
@@ -701,6 +701,13 @@ Contains the list of members inherited by the current channel. Uncheck &lt;i&gt;
     </message>
 </context>
 <context>
+    <name>AnimationTextObject</name>
+    <message>
+        <source>%1 / %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>AudioInput</name>
     <message>
         <source>Audio input</source>
@@ -2935,6 +2942,10 @@ Are you sure you wish to replace your certificate?
     </message>
     <message>
         <source>This server does not allow sending images.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Unable to read animated image file: %1</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -5795,10 +5806,6 @@ Valid actions are:
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Images (*.png *.jpg *.jpeg)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Could not save image: %1</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6974,6 +6981,14 @@ Valid options are:
     </message>
     <message>
         <source>This could be caused by one of the following scenarios:&lt;ul&gt;&lt;li&gt;Your client and the server use different encryption standards. This could be because you are using a very old client or the server you are connecting to is very old. In the first case, you should update your client and in the second case you should contact the server administrator so that they can update their server.&lt;/li&gt;&lt;li&gt;Either your client or the server is using an old operating system that doesn&apos;t provide up-to-date encryption methods. In this case you should consider updating your OS or contacting the server admin so that they can update theirs.&lt;/li&gt;&lt;li&gt;The server you are connecting to isn&apos;t actually a Mumble server. Please ensure that the used server address really belongs to a Mumble server and not e.g. to a game server.&lt;/li&gt;&lt;li&gt;The port you are connecting to does not belong to a Mumble server but instead is bound to a completely unrelated process on the server-side. Please double-check you have used the correct port.&lt;/li&gt;&lt;/ul&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>%1 Video Controls</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Images (*.png *.jpg *.jpeg *.gif)</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/mumble/mumble_sv.ts
+++ b/src/mumble/mumble_sv.ts
@@ -711,6 +711,13 @@ Det värdet tillåter dig att ställa in ett maximalt antal av användare som ä
     </message>
 </context>
 <context>
+    <name>AnimationTextObject</name>
+    <message>
+        <source>%1 / %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>AudioInput</name>
     <message>
         <source>Interface</source>
@@ -2994,6 +3001,10 @@ Are you sure you wish to replace your certificate?
     <message>
         <source>This server does not allow sending images.</source>
         <translation>Denna server tillåter inte att bilder skickas.</translation>
+    </message>
+    <message>
+        <source>Unable to read animated image file: %1</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -5483,10 +5494,6 @@ Om inte, avbryt och kontrollera ditt certifikat eller användarnamn.</translatio
         <translation>Felaktigt serverlösenord för oregistrerat användarkonto, försök igen.</translation>
     </message>
     <message>
-        <source>Images (*.png *.jpg *.jpeg)</source>
-        <translation>Bilder (*.png *.jpg *.jpeg)</translation>
-    </message>
-    <message>
         <source>C&amp;onfigure</source>
         <translation>K&amp;onfigurera</translation>
     </message>
@@ -7162,6 +7169,14 @@ Giltiga värden för options är:
     </message>
     <message>
         <source>This could be caused by one of the following scenarios:&lt;ul&gt;&lt;li&gt;Your client and the server use different encryption standards. This could be because you are using a very old client or the server you are connecting to is very old. In the first case, you should update your client and in the second case you should contact the server administrator so that they can update their server.&lt;/li&gt;&lt;li&gt;Either your client or the server is using an old operating system that doesn&apos;t provide up-to-date encryption methods. In this case you should consider updating your OS or contacting the server admin so that they can update theirs.&lt;/li&gt;&lt;li&gt;The server you are connecting to isn&apos;t actually a Mumble server. Please ensure that the used server address really belongs to a Mumble server and not e.g. to a game server.&lt;/li&gt;&lt;li&gt;The port you are connecting to does not belong to a Mumble server but instead is bound to a completely unrelated process on the server-side. Please double-check you have used the correct port.&lt;/li&gt;&lt;/ul&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>%1 Video Controls</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Images (*.png *.jpg *.jpeg *.gif)</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/mumble/mumble_te.ts
+++ b/src/mumble/mumble_te.ts
@@ -709,6 +709,13 @@ This value allows you to set the maximum number of users allowed in the channel.
     </message>
 </context>
 <context>
+    <name>AnimationTextObject</name>
+    <message>
+        <source>%1 / %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>AudioInput</name>
     <message>
         <source>Interface</source>
@@ -2964,6 +2971,10 @@ Are you sure you wish to replace your certificate?
     </message>
     <message>
         <source>This server does not allow sending images.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Unable to read animated image file: %1</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -5431,10 +5442,6 @@ Otherwise abort and check your certificate and username.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Images (*.png *.jpg *.jpeg)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>C&amp;onfigure</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7021,6 +7028,14 @@ Valid options are:
     </message>
     <message>
         <source>This could be caused by one of the following scenarios:&lt;ul&gt;&lt;li&gt;Your client and the server use different encryption standards. This could be because you are using a very old client or the server you are connecting to is very old. In the first case, you should update your client and in the second case you should contact the server administrator so that they can update their server.&lt;/li&gt;&lt;li&gt;Either your client or the server is using an old operating system that doesn&apos;t provide up-to-date encryption methods. In this case you should consider updating your OS or contacting the server admin so that they can update theirs.&lt;/li&gt;&lt;li&gt;The server you are connecting to isn&apos;t actually a Mumble server. Please ensure that the used server address really belongs to a Mumble server and not e.g. to a game server.&lt;/li&gt;&lt;li&gt;The port you are connecting to does not belong to a Mumble server but instead is bound to a completely unrelated process on the server-side. Please double-check you have used the correct port.&lt;/li&gt;&lt;/ul&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>%1 Video Controls</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Images (*.png *.jpg *.jpeg *.gif)</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/mumble/mumble_th.ts
+++ b/src/mumble/mumble_th.ts
@@ -703,6 +703,13 @@ This value allows you to set the maximum number of users allowed in the channel.
     </message>
 </context>
 <context>
+    <name>AnimationTextObject</name>
+    <message>
+        <source>%1 / %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>AudioInput</name>
     <message>
         <source>Interface</source>
@@ -2951,6 +2958,10 @@ Are you sure you wish to replace your certificate?
     </message>
     <message>
         <source>This server does not allow sending images.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Unable to read animated image file: %1</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -5418,10 +5429,6 @@ Otherwise abort and check your certificate and username.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Images (*.png *.jpg *.jpeg)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>C&amp;onfigure</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7008,6 +7015,14 @@ Valid options are:
     </message>
     <message>
         <source>This could be caused by one of the following scenarios:&lt;ul&gt;&lt;li&gt;Your client and the server use different encryption standards. This could be because you are using a very old client or the server you are connecting to is very old. In the first case, you should update your client and in the second case you should contact the server administrator so that they can update their server.&lt;/li&gt;&lt;li&gt;Either your client or the server is using an old operating system that doesn&apos;t provide up-to-date encryption methods. In this case you should consider updating your OS or contacting the server admin so that they can update theirs.&lt;/li&gt;&lt;li&gt;The server you are connecting to isn&apos;t actually a Mumble server. Please ensure that the used server address really belongs to a Mumble server and not e.g. to a game server.&lt;/li&gt;&lt;li&gt;The port you are connecting to does not belong to a Mumble server but instead is bound to a completely unrelated process on the server-side. Please double-check you have used the correct port.&lt;/li&gt;&lt;/ul&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>%1 Video Controls</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Images (*.png *.jpg *.jpeg *.gif)</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/mumble/mumble_tr.ts
+++ b/src/mumble/mumble_tr.ts
@@ -711,6 +711,13 @@ Bu değer kanalda izin verilen azami kullanıcı sayısını ayarlamanıza izin 
     </message>
 </context>
 <context>
+    <name>AnimationTextObject</name>
+    <message>
+        <source>%1 / %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>AudioInput</name>
     <message>
         <source>Interface</source>
@@ -2993,6 +3000,10 @@ Sertifikanızı değiştirmek istediğinize emin misiniz?
     <message>
         <source>This server does not allow sending images.</source>
         <translation>Bu sunucu görüntü göndermeye izin vermiyor.</translation>
+    </message>
+    <message>
+        <source>Unable to read animated image file: %1</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -5482,10 +5493,6 @@ deneyiniz. Yoksa iptal edip parolanızı kontrol ediniz.</translation>
         <translation>Kaydedilmemiş kullanıcı oturumu için yanlış sunucu parolası, tekrar deneyiniz.</translation>
     </message>
     <message>
-        <source>Images (*.png *.jpg *.jpeg)</source>
-        <translation>Resimler (*.png *.jpg *.jpeg)</translation>
-    </message>
-    <message>
         <source>C&amp;onfigure</source>
         <translation>&amp;Yapılandır</translation>
     </message>
@@ -7165,6 +7172,14 @@ Geçerli seçenekler şunlardır:
     <message>
         <source>This could be caused by one of the following scenarios:&lt;ul&gt;&lt;li&gt;Your client and the server use different encryption standards. This could be because you are using a very old client or the server you are connecting to is very old. In the first case, you should update your client and in the second case you should contact the server administrator so that they can update their server.&lt;/li&gt;&lt;li&gt;Either your client or the server is using an old operating system that doesn&apos;t provide up-to-date encryption methods. In this case you should consider updating your OS or contacting the server admin so that they can update theirs.&lt;/li&gt;&lt;li&gt;The server you are connecting to isn&apos;t actually a Mumble server. Please ensure that the used server address really belongs to a Mumble server and not e.g. to a game server.&lt;/li&gt;&lt;li&gt;The port you are connecting to does not belong to a Mumble server but instead is bound to a completely unrelated process on the server-side. Please double-check you have used the correct port.&lt;/li&gt;&lt;/ul&gt;</source>
         <translation>Bunun nedeni şu durumlardan biri olabilir:&lt;ul&gt;&lt;li&gt;İstemciniz ve sunucunuz farklı şifreleme standartları kullanmaktadır. Bunun nedeni çok eski bir istemci kullanıyor olmanız veya bağlandığınız sunucunun çok eski olması olabilir. İlk durumda, istemcinizi güncellemelisiniz ve ikinci durumda sunucularını güncelleyebilmeleri için sunucu yöneticisiyle iletişime geçmelisiniz.&lt;/li&gt;&lt;li&gt;Ya istemciniz ya da sunucunuz güncel şifreleme yöntemleri sağlamayan eski bir işletim sistemi kullanıyordur. Bu durumda işletim sisteminizi güncellemeyi düşünmeli ya da sunucu yöneticisiyle iletişime geçerek kendi işletim sistemlerini güncellemelerini sağlamalısınız.&lt;/li&gt;&lt;li&gt;Bağlandığınız sunucu aslında bir Mumble sunucusu değil. Lütfen kullanılan sunucu adresinin gerçekten bir Mumble sunucusuna ait olduğundan ve örneğin bir oyun sunucusuna ait olmadığından emin olun.&lt;/li&gt;&lt;li&gt;Bağlandığınız bağlantı noktası bir Mumble sunucusuna ait değil, bunun yerine sunucu tarafında tamamen ilgisiz bir işleme bağlı. Lütfen doğru bağlantı noktasını kullandığınızı iki kez gözden geçirin.&lt;/li&gt;&lt;/ul&gt;</translation>
+    </message>
+    <message>
+        <source>%1 Video Controls</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Images (*.png *.jpg *.jpeg *.gif)</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/src/mumble/mumble_uk.ts
+++ b/src/mumble/mumble_uk.ts
@@ -711,6 +711,13 @@ This value allows you to set the maximum number of users allowed in the channel.
     </message>
 </context>
 <context>
+    <name>AnimationTextObject</name>
+    <message>
+        <source>%1 / %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>AudioInput</name>
     <message>
         <source>Interface</source>
@@ -2961,6 +2968,10 @@ Are you sure you wish to replace your certificate?
     </message>
     <message>
         <source>This server does not allow sending images.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Unable to read animated image file: %1</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -5428,10 +5439,6 @@ Otherwise abort and check your certificate and username.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Images (*.png *.jpg *.jpeg)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>C&amp;onfigure</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7018,6 +7025,14 @@ Valid options are:
     </message>
     <message>
         <source>This could be caused by one of the following scenarios:&lt;ul&gt;&lt;li&gt;Your client and the server use different encryption standards. This could be because you are using a very old client or the server you are connecting to is very old. In the first case, you should update your client and in the second case you should contact the server administrator so that they can update their server.&lt;/li&gt;&lt;li&gt;Either your client or the server is using an old operating system that doesn&apos;t provide up-to-date encryption methods. In this case you should consider updating your OS or contacting the server admin so that they can update theirs.&lt;/li&gt;&lt;li&gt;The server you are connecting to isn&apos;t actually a Mumble server. Please ensure that the used server address really belongs to a Mumble server and not e.g. to a game server.&lt;/li&gt;&lt;li&gt;The port you are connecting to does not belong to a Mumble server but instead is bound to a completely unrelated process on the server-side. Please double-check you have used the correct port.&lt;/li&gt;&lt;/ul&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>%1 Video Controls</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Images (*.png *.jpg *.jpeg *.gif)</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/mumble/mumble_zh_CN.ts
+++ b/src/mumble/mumble_zh_CN.ts
@@ -711,6 +711,13 @@ This value allows you to set the maximum number of users allowed in the channel.
     </message>
 </context>
 <context>
+    <name>AnimationTextObject</name>
+    <message>
+        <source>%1 / %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>AudioInput</name>
     <message>
         <source>Interface</source>
@@ -2993,6 +3000,10 @@ Are you sure you wish to replace your certificate?
     <message>
         <source>This server does not allow sending images.</source>
         <translation>当前服务器不允许发送图片。</translation>
+    </message>
+    <message>
+        <source>Unable to read animated image file: %1</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -5482,10 +5493,6 @@ Otherwise abort and check your certificate and username.</source>
         <translation>未注册用户输入的密码错误，请重试。</translation>
     </message>
     <message>
-        <source>Images (*.png *.jpg *.jpeg)</source>
-        <translation>图片文件 (*.png *.jpg *.jpeg)</translation>
-    </message>
-    <message>
         <source>C&amp;onfigure</source>
         <translation>配置(&amp;O)</translation>
     </message>
@@ -7163,6 +7170,14 @@ mumble://[&lt;用户名&gt;[:&lt;密码&gt;]@]&lt;主机名&gt;[:&lt;端口&gt;]
     <message>
         <source>This could be caused by one of the following scenarios:&lt;ul&gt;&lt;li&gt;Your client and the server use different encryption standards. This could be because you are using a very old client or the server you are connecting to is very old. In the first case, you should update your client and in the second case you should contact the server administrator so that they can update their server.&lt;/li&gt;&lt;li&gt;Either your client or the server is using an old operating system that doesn&apos;t provide up-to-date encryption methods. In this case you should consider updating your OS or contacting the server admin so that they can update theirs.&lt;/li&gt;&lt;li&gt;The server you are connecting to isn&apos;t actually a Mumble server. Please ensure that the used server address really belongs to a Mumble server and not e.g. to a game server.&lt;/li&gt;&lt;li&gt;The port you are connecting to does not belong to a Mumble server but instead is bound to a completely unrelated process on the server-side. Please double-check you have used the correct port.&lt;/li&gt;&lt;/ul&gt;</source>
         <translation>这可能由下列情形之一导致：&lt;ul&gt;&lt;li&gt;客户端和服务器使用不同的加密标准。这可能是因为客户端版本太旧或者要连接到的服务器版本太旧。如果是第一种情况，则应该更新客户端。如果是第二种情况，则应该联系服务器管理员更新服务器。&lt;/li&gt;&lt;li&gt;客户端或服务器使用的旧版操作系统未提供足够新的加密方法。在这种情况下，您应该考虑更新操作系统，或联系服务器管理员更新服务器的操作系统。&lt;/li&gt;&lt;li&gt;您正在连接的服务器不是 Mumble 服务器。请确保所用的服务器地址确实属于 Mumble 服务器而不是游戏服务器等。&lt;/li&gt;&lt;li&gt;您正在连接的端口不属于 Mumble 服务器，而是绑定到服务端一个完全无关的进程。请再次确认您使用的是正确的端口。&lt;/li&gt;&lt;/ul&gt;</translation>
+    </message>
+    <message>
+        <source>%1 Video Controls</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Images (*.png *.jpg *.jpeg *.gif)</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/src/mumble/mumble_zh_HK.ts
+++ b/src/mumble/mumble_zh_HK.ts
@@ -703,6 +703,13 @@ This value allows you to set the maximum number of users allowed in the channel.
     </message>
 </context>
 <context>
+    <name>AnimationTextObject</name>
+    <message>
+        <source>%1 / %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>AudioInput</name>
     <message>
         <source>Interface</source>
@@ -2951,6 +2958,10 @@ Are you sure you wish to replace your certificate?
     </message>
     <message>
         <source>This server does not allow sending images.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Unable to read animated image file: %1</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -5420,10 +5431,6 @@ Otherwise abort and check your certificate and username.</source>
         <translation>伺服器密碼錯誤，請重試。</translation>
     </message>
     <message>
-        <source>Images (*.png *.jpg *.jpeg)</source>
-        <translation>圖片 (*.png *.jpg *.jpeg)</translation>
-    </message>
-    <message>
         <source>C&amp;onfigure</source>
         <translation>&amp;設定</translation>
     </message>
@@ -7013,6 +7020,14 @@ Valid options are:
     </message>
     <message>
         <source>This could be caused by one of the following scenarios:&lt;ul&gt;&lt;li&gt;Your client and the server use different encryption standards. This could be because you are using a very old client or the server you are connecting to is very old. In the first case, you should update your client and in the second case you should contact the server administrator so that they can update their server.&lt;/li&gt;&lt;li&gt;Either your client or the server is using an old operating system that doesn&apos;t provide up-to-date encryption methods. In this case you should consider updating your OS or contacting the server admin so that they can update theirs.&lt;/li&gt;&lt;li&gt;The server you are connecting to isn&apos;t actually a Mumble server. Please ensure that the used server address really belongs to a Mumble server and not e.g. to a game server.&lt;/li&gt;&lt;li&gt;The port you are connecting to does not belong to a Mumble server but instead is bound to a completely unrelated process on the server-side. Please double-check you have used the correct port.&lt;/li&gt;&lt;/ul&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>%1 Video Controls</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Images (*.png *.jpg *.jpeg *.gif)</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/mumble/mumble_zh_TW.ts
+++ b/src/mumble/mumble_zh_TW.ts
@@ -706,6 +706,13 @@ This value allows you to set the maximum number of users allowed in the channel.
     </message>
 </context>
 <context>
+    <name>AnimationTextObject</name>
+    <message>
+        <source>%1 / %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>AudioInput</name>
     <message>
         <source>Interface</source>
@@ -2969,6 +2976,10 @@ Are you sure you wish to replace your certificate?
     </message>
     <message>
         <source>This server does not allow sending images.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Unable to read animated image file: %1</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -5447,10 +5458,6 @@ Otherwise abort and check your certificate and username.</source>
         <translation>未註冊使用者的伺服器密碼錯誤，請重試。</translation>
     </message>
     <message>
-        <source>Images (*.png *.jpg *.jpeg)</source>
-        <translation>圖片 (*.png *.jpg *.jpeg)</translation>
-    </message>
-    <message>
         <source>C&amp;onfigure</source>
         <translation>設定(&amp;C)</translation>
     </message>
@@ -7037,6 +7044,14 @@ Valid options are:
     </message>
     <message>
         <source>This could be caused by one of the following scenarios:&lt;ul&gt;&lt;li&gt;Your client and the server use different encryption standards. This could be because you are using a very old client or the server you are connecting to is very old. In the first case, you should update your client and in the second case you should contact the server administrator so that they can update their server.&lt;/li&gt;&lt;li&gt;Either your client or the server is using an old operating system that doesn&apos;t provide up-to-date encryption methods. In this case you should consider updating your OS or contacting the server admin so that they can update theirs.&lt;/li&gt;&lt;li&gt;The server you are connecting to isn&apos;t actually a Mumble server. Please ensure that the used server address really belongs to a Mumble server and not e.g. to a game server.&lt;/li&gt;&lt;li&gt;The port you are connecting to does not belong to a Mumble server but instead is bound to a completely unrelated process on the server-side. Please double-check you have used the correct port.&lt;/li&gt;&lt;/ul&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>%1 Video Controls</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Images (*.png *.jpg *.jpeg *.gif)</source>
         <translation type="unfinished"></translation>
     </message>
 </context>


### PR DESCRIPTION
The way images are handled for the `gif` file format when pasting and receiving one in the chat was here changed to support playing the animation. By default they do not play but whenever an animation is not running this is indicated by a play-icon, thereby differentiating them from still images on a glance. Whether the animation is paused is toggled by left-clicking it and reset by middle-clicking it. Saving a `gif` image file from log is also supported just as it is for other image file formats.

Additionally, one can also toggle video controls for animations via the log context menu on them. This enables the following features:

- Jumping to any point of the animation via the video bar
- Viewing the current time and total time of the animation
- Switching caching of all frames on or off
- Switching loop mode between "Unchanged", "Loop" and "No loop"
- Traversing frame-by-frame backwards or forward
- Changing and resetting the playback speed

Alternatively, animations can be controlled via keybindings as follows:

- ENTER - Select the next animation
- BACKSPACE - Select the previous animation
- CTRL+0-9 - Select animation by the index entered
- ESCAPE - Deselect animation
- SPACE/K - Play/pause
- Q - Reset playback
- V - Show/hide video controls
- C - Turn caching of all frames on/off
- O - Switch to the previous loop mode
- L - Switch to the next loop mode
- , - Jump to the preceding frame
- . - Jump to the next frame
- N - Jump 5 frames backwards
- M - Jump 5 frames forward
- H - Jump 1 second backwards
- J - Jump 1 second forward
- F - Jump 5 seconds backwards
- G - Jump 5 seconds forward
- 0-9 - Jump to 0-90% of the animation
- -/S - Decrease playback speed by 5%
- +/D - Increase playback speed by 5%
- W - Decrease playback speed by 25%
- E - Increase playback speed by 25%
- R - Reset playback speed

To turn on caching most notably boosts performance when jumping to frames that are sequentially far apart due to `QMovie` only being able to switch frame in order from start to end and around when caching is off, though it usually plays fine regardless except for when playing in reverse in an animation with many frames. Reverse playback is also implemented here, so when decreasing the speed to less than zero it will play at that speed in reverse as expected, taking a speed-step that's twice as big if the speed would otherwise become zero so that the animation only pauses when it's not playing. As for loop mode, "Unchanged" is to use the in-built setting in the `gif` image file for how many times it is to repeat, whereas "Loop" and "No loop" override this behavior accordingly.

The main limitation is the character limit on text messages for images. Currently this is usually set to 128 KB, which is very small for a `gif` image file and on top of this requires the data to be 33% smaller before being sent in base64 encoding. This limit should be at least ten times larger in order to fit many `gif` image files, or this should apply to another limit specifically for animations. Other than that, the functionality for pasting images from the clipboard itself, instead of by a file path from it, could not be implemented for `gif` image files due to not being able to get compatible formatted data from the MIME data received.

Here are workarounds that can be applied to these limitations:

- Configure the server to increase or disable the limit on image message length
- Save copied `gif` images to file and then copy and paste those files

Lastly, if settings were to be added to this feature, then here are some suggestions for those settings:

- Play animations by default
- Show video controls by default
- Cache all frames by default
- Specify the default loop mode
- Specify the default playback speed

### Checks

- [X] My commits follow the [commit guidelines](https://github.com/mumble-voip/mumble/blob/master/COMMIT_GUIDELINES.md)

