### PR TITLE
DOCS: Mention differences in documentation across branches

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,10 @@ information on how this works and how these have to be created in the [plugin do
 
 For information on how to build Mumble, check out [the dedicated documentation](docs/dev/build-instructions/README.md).
 
+Make sure to switch to the appropriate branch in this repository to get the correct build documentation. The current ``master`` branch contains
+the unstable code for a future release of Mumble. If you want to build an already released stable version of Mumble, e.g. ``1.5.735``, select the
+corresponding branch, e.g. ``1.5.x``, in the dropdown menu above. Alternatively, use the documentation in the respective release tarball.
+
 
 ## Reporting issues
 

--- a/docs/dev/build-instructions/README.md
+++ b/docs/dev/build-instructions/README.md
@@ -1,5 +1,8 @@
 ﻿# Build Mumble
 
+This documentation is version-specific. The current ``master`` branch contains the unstable code for a future release of Mumble.
+If you want to build an already released stable version of Mumble, use the respective branch.
+
 A fundamental dependency for building Mumble is [git](https://git-scm.com/), so make sure you have it installed. If you are new to git, make sure to
 checkout [this guide](https://guides.github.com/introduction/git-handbook/) on git's basics in order to be able to follow the given instructions.
 


### PR DESCRIPTION
We should specify that the build documentation will change over time and the correct branch needs to be selected for any given version.

Fixes #6658

Ping @roughnecks 