### PR TITLE
Update mumble_ol.rc.in

### DIFF
--- a/overlay_winx64/mumble_ol.rc.in
+++ b/overlay_winx64/mumble_ol.rc.in
@@ -1,49 +1,86 @@
-// Copyright 2005-2020 The Mumble Developers. All rights reserved.
-// Use of this source code is governed by a BSD-style license
-// that can be found in the LICENSE file at the root of the
-// Mumble source tree or at <https://www.mumble.info/LICENSE>.
+///////////////////////////////////////////////////////////////////////////////
+// Mumble Version Resource Script
+// 
+// Copyright (C) 2005-2020 The Mumble Developers
+//
+// This file is governed by a BSD-style license that can be found in the
+// LICENSE file at the root of the Mumble source tree or at
+// <https://www.mumble.info/LICENSE>.
+//
+// Description:
+//   This resource script sets up the version information for the Mumble DLL.
+//   It uses compile-time macros and placeholders to populate major/minor/patch
+//   version fields, as well as debug, snapshot, and release metadata.
+//
+// Note:
+//   - @PROJECT_VERSION@, @PROJECT_VERSION_MAJOR@, etc., are placeholders
+//     typically replaced at build time (e.g. CMake, qmake, or another build
+//     system).
+//   - The blocks below define Windows-specific version information.
+//
+///////////////////////////////////////////////////////////////////////////////
 
 #include <winver.h>
 
+///////////////////////////////////////////////////////////////////////////////
+// Define preprocessor macros for debug/release flags
+///////////////////////////////////////////////////////////////////////////////
+
 #ifndef DEBUG
-#define VER_DEBUG                   0L
+#  define VER_DEBUG 0L
 #else
-#define VER_DEBUG                   VS_FF_DEBUG
+#  define VER_DEBUG VS_FF_DEBUG
 #endif
 
 #ifdef SNAPSHOT_BUILD
-#define	VER_RELEASE	VS_FF_SPECIALBUILD|VS_FF_PRERELEASE
+#  define VER_RELEASE (VS_FF_SPECIALBUILD | VS_FF_PRERELEASE)
 #else
-#define VER_RELEASE 0L
+#  define VER_RELEASE 0L
 #endif
 
+///////////////////////////////////////////////////////////////////////////////
+// Version resource block
+///////////////////////////////////////////////////////////////////////////////
 VS_VERSION_INFO VERSIONINFO
-	FILEVERSION     @PROJECT_VERSION_MAJOR@,@PROJECT_VERSION_MINOR@,@PROJECT_VERSION_PATCH@
-	PRODUCTVERSION  @PROJECT_VERSION_MAJOR@,@PROJECT_VERSION_MINOR@,@PROJECT_VERSION_PATCH@
-	FILEFLAGSMASK   VS_FFI_FILEFLAGSMASK
-	FILEFLAGS       (VER_DEBUG|VER_RELEASE)
-	FILEOS          VOS_NT_WINDOWS32
-	FILETYPE        VFT_DLL
-	FILESUBTYPE     0L
-	BEGIN
-		BLOCK "StringFileInfo"
-		BEGIN
-			BLOCK "040904E4"
-			BEGIN
-				VALUE "CompanyName", "The Mumble Developers"
-				VALUE "FileDescription", "Mumble - Low-latency VoIP client"
-				VALUE "FileVersion", "@PROJECT_VERSION@"
-				VALUE "ProductVersion", "@PROJECT_VERSION@"
-				VALUE "LegalCopyright", "Copyright (c) 2005-@MUMBLE_BUILD_YEAR@ The Mumble Developers"
-				VALUE "OriginalFilename", "mumble_ol_x64.dll"
-				VALUE "ProductName", "Mumble"
+ FILEVERSION     @PROJECT_VERSION_MAJOR@,@PROJECT_VERSION_MINOR@,@PROJECT_VERSION_PATCH@
+ PRODUCTVERSION  @PROJECT_VERSION_MAJOR@,@PROJECT_VERSION_MINOR@,@PROJECT_VERSION_PATCH@
+
+ // File flags for Windows
+ FILEFLAGSMASK   VS_FFI_FILEFLAGSMASK
+ FILEFLAGS       (VER_DEBUG | VER_RELEASE)
+
+ // Indicate this build is for Windows (VOS_NT_WINDOWS32)
+ FILEOS          VOS_NT_WINDOWS32
+ // VFT_DLL means this resource is for a DLL file
+ FILETYPE        VFT_DLL
+ // FILESUBTYPE is 0 by default
+ FILESUBTYPE     0L
+
+BEGIN
+    // "StringFileInfo" block
+    BLOCK "StringFileInfo"
+    BEGIN
+        // Typical LCID (language code identifier) for US English with CP 1252
+        BLOCK "040904E4"
+        BEGIN
+            // Basic string fields describing this file
+            VALUE "CompanyName", "The Mumble Developers"
+            VALUE "FileDescription", "Mumble - Low-latency VoIP client"
+            VALUE "FileVersion", "@PROJECT_VERSION@"
+            VALUE "ProductVersion", "@PROJECT_VERSION@"
+            VALUE "LegalCopyright", "Copyright (c) 2005-@MUMBLE_BUILD_YEAR@ The Mumble Developers"
+            VALUE "OriginalFilename", "mumble_ol_x64.dll"
+            VALUE "ProductName", "Mumble"
+
 #ifdef SNAPSHOT_BUILD
-				VALUE "SpecialBuild", "Snapshot development release"
+            VALUE "SpecialBuild", "Snapshot development release"
 #endif
-			END
-		END
-		BLOCK "VarFileInfo"
-		BEGIN
-			VALUE "Translation", 0x409, 1252
-		END
-	END
+        END
+    END
+
+    // "VarFileInfo" block to store language/character-set info
+    BLOCK "VarFileInfo"
+    BEGIN
+        VALUE "Translation", 0x0409, 1252
+    END
+END


### PR DESCRIPTION
Below is a refined and fully commented version of the Win32 resource script you provided. The original snippet appears to define version information for a DLL or executable (in this case, a Mumble DLL). I’ve retained the same logical structure while clarifying the preprocessor macros, version fields, and resource block layout. This version is designed for better maintainability and readability, while preserving functionality.

Explanation of Notable Elements
Include and Macro Definitions
We include <winver.h> for standard Windows versioning macros (VS_FF_DEBUG, VS_FF_PRERELEASE, etc.). We also define:

VER_DEBUG — used when the DEBUG macro is set.
VER_RELEASE — used when SNAPSHOT_BUILD is defined or not. VERSIONINFO Block

FILEVERSION and PRODUCTVERSION are set via placeholders (e.g., @PROJECT_VERSION_MAJOR@). Typically, your build system (like CMake, qmake, etc.) replaces these macros at compile time with actual integer version numbers. FILEFLAGS merges debug and release flags.
FILEOS, FILETYPE, and FILESUBTYPE define the OS and whether the resource is for a .exe or .dll. BEGIN / END Blocks
Within the resource, the “StringFileInfo” block contains string key-value pairs (e.g., CompanyName, ProductName, etc.). The “VarFileInfo” block stores numeric data specifying the language ID (0x0409 is U.S. English) and the code page (1252 is Latin-1).

Conditional Fields

SNAPSHOT_BUILD triggers the SpecialBuild string.
DEBUG triggers the debug flags in version info.
Comments
Additional commentary clarifies the Windows version resource structure, the placeholders, and the reason for the macros. This helps future maintainers quickly see the purpose of each section.

Please adjust the placeholder macros (like @PROJECT_VERSION_MAJOR@) to fit your actual build environment. This script typically goes in a .rc file that is compiled by the Windows resource compiler.


### Checks

- [ ] My commits follow the [commit guidelines](https://github.com/mumble-voip/mumble/blob/master/COMMIT_GUIDELINES.md)

