### PR TITLE
REFAC(server): Add explicit casts to avoid conversion warnings

### DIFF
--- a/src/murmur/ServerUser.cpp
+++ b/src/murmur/ServerUser.cpp
@@ -176,7 +176,7 @@ bool LeakyBucket::ratelimit(int tokens) {
 	if (static_cast< qint64 >(m_currentTokens) < drainTokens) {
 		m_currentTokens = 0;
 	} else {
-		m_currentTokens -= drainTokens;
+		m_currentTokens -= static_cast< decltype(m_currentTokens) >(drainTokens);
 	}
 
 	// Now that the tokens have been updated to reflect the constant drain caused by
@@ -187,7 +187,7 @@ bool LeakyBucket::ratelimit(int tokens) {
 
 	// If the bucket is not overflowed, allow message and add tokens
 	if (!limit) {
-		m_currentTokens += tokens;
+		m_currentTokens += static_cast< decltype(m_currentTokens) >(tokens);
 	}
 
 	return limit;

--- a/src/murmur/ServerUser.h
+++ b/src/murmur/ServerUser.h
@@ -85,7 +85,7 @@ private:
 	/// (The capacity of the bucket)
 	unsigned int m_maxTokens;
 	/// The amount of tokens currently stored
-	/// (The amount of whater currently in the bucket)
+	/// (The amount of whatever currently is in the bucket)
 	long m_currentTokens;
 	/// A timer that is used to measure time intervals. It is essential
 	/// that this timer uses a monotonic clock (which is why QElapsedTimer is


### PR DESCRIPTION
Fixes https://github.com/mumble-voip/mumble/issues/6377 (hopefully for real, this time)

### Checks

- [x] My commits follow the [commit guidelines](https://github.com/mumble-voip/mumble/blob/master/COMMIT_GUIDELINES.md)

