### PR TITLE
CHANGE(server): Extended user stats now requires Ban ACL

### DIFF
--- a/src/murmur/Messages.cpp
+++ b/src/murmur/Messages.cpp
@@ -2246,7 +2246,7 @@ void Server::msgUserStats(ServerUser *uSource, MumbleProto::UserStats &msg) {
 	const BandwidthRecord &bwr            = pDstServerUser->bwr;
 	const QList< QSslCertificate > &certs = pDstServerUser->peerCertificateChain();
 
-	bool extend = (uSource == pDstServerUser) || hasPermission(uSource, qhChannels.value(0), ChanACL::Register);
+	bool extend = (uSource == pDstServerUser) || hasPermission(uSource, qhChannels.value(0), ChanACL::Ban);
 
 	if (!extend && !hasPermission(uSource, pDstServerUser->cChannel, ChanACL::Enter)) {
 		PERM_DENIED(uSource, pDstServerUser->cChannel, ChanACL::Enter);


### PR DESCRIPTION
Previously, the Register ACL was required to get extended user statistics (which includes used Mumble version, IP address etc.). However, the Register ACL was deemed to be a rather arbitrary choice for this. Instead, the Ban ACL was chosen as access to information such as packet loss, IP address and used Mumble version and OS seem much more relevant in the case of banning clients than it is for registering them.

Also, Ban permission is likely to be a better proxy for whether or not someone is a moderator/admin on a given server than Register privilege.

Fixes #6697


### Checks

- [x] My commits follow the [commit guidelines](https://github.com/mumble-voip/mumble/blob/master/COMMIT_GUIDELINES.md)

