### PR TITLE
MAINT(ci): Update to macOS 14 on Azure Pipelines

### DIFF
--- a/.ci/azure-pipelines/main-pr.yml
+++ b/.ci/azure-pipelines/main-pr.yml
@@ -43,7 +43,7 @@ jobs:
     workspace:
       clean: all
     pool:
-      vmImage: 'macOS-12'
+      vmImage: 'macOS-14'
     variables:
       MUMBLE_ENVIRONMENT_VERSION: 'mumble_env.x64-osx-release.2024-08-17.9ad0398d8'
       MUMBLE_ENVIRONMENT_TRIPLET: 'x64-osx-release'

--- a/.ci/azure-pipelines/main.yml
+++ b/.ci/azure-pipelines/main.yml
@@ -41,7 +41,7 @@ jobs:
     workspace:
       clean: all
     pool:
-      vmImage: 'macOS-12'
+      vmImage: 'macOS-14'
     variables:
       MUMBLE_ENVIRONMENT_VERSION: 'mumble_env.x64-osx-release.2024-08-17.9ad0398d8'
       MUMBLE_ENVIRONMENT_TRIPLET: 'x64-osx-release'


### PR DESCRIPTION
The macOS 12 image has been removed.

https://learn.microsoft.com/en-us/azure/devops/pipelines/agents/hosted?view=azure-devops&tabs=yaml#software

We skip version 13 since we always run the latest macOS on our own builder anyway.