### PR TITLE
Backport "Merge PR #6703: MAINT(ci): Update to macOS 14 on Azure Pipelines" to 1.5.x

### DIFF
--- a/.ci/azure-pipelines/main-pr.yml
+++ b/.ci/azure-pipelines/main-pr.yml
@@ -43,7 +43,7 @@ jobs:
     workspace:
       clean: all
     pool:
-      vmImage: 'macOS-12'
+      vmImage: 'macOS-14'
     variables:
       MUMBLE_ENVIRONMENT_VERSION: 'mumble_env.x64-osx-release.2023-12-31.6a3ce9c65'
       MUMBLE_ENVIRONMENT_TRIPLET: 'x64-osx-release'

--- a/.ci/azure-pipelines/main.yml
+++ b/.ci/azure-pipelines/main.yml
@@ -41,7 +41,7 @@ jobs:
     workspace:
       clean: all
     pool:
-      vmImage: 'macOS-12'
+      vmImage: 'macOS-14'
     variables:
       MUMBLE_ENVIRONMENT_VERSION: 'mumble_env.x64-osx-release.2023-12-31.6a3ce9c65'
       MUMBLE_ENVIRONMENT_TRIPLET: 'x64-osx-release'


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `1.5.x`:
 - [Merge PR #6703: MAINT(ci): Update to macOS 14 on Azure Pipelines](https://github.com/mumble-voip/mumble/pull/6703)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)