### PR TITLE
DOCS(dev): Add network protocol outdated and up-to-date information

### DIFF
--- a/docs/dev/network-protocol/README.md
+++ b/docs/dev/network-protocol/README.md
@@ -5,6 +5,13 @@ Mumble VoIP 1.2.X server-client communication protocol. It reflects the state of
 the protocol implemented in the Mumble 1.2.8 client and might be outdated by the
 time you are reading this.
 
+For up to date message type and message structure information
+refer to the [`Mumble.proto`](https://github.com/mumble-voip/mumble/blob/master/src/Mumble.proto)
+and [`MumbleUDP.proto`](https://github.com/mumble-voip/mumble/blob/master/src/MumbleUDP.proto)
+protobuf definition files.
+
+This documentation is split into
+
 * [Overview](overview.md)
 * [Protocol Stack (TCP)](protocol_stack_tcp.md)
 * [Establishing a Connection](establishing_connection.md)

--- a/docs/dev/network-protocol/establishing_connection.md
+++ b/docs/dev/network-protocol/establishing_connection.md
@@ -23,6 +23,8 @@ its certificate and it is recommended that the client checks this.
 Once the TLS handshake is completed both sides should transmit their version
 information using the Version message. The message structure is described below.
 
+Note: This `Version` documentation is outdated. Please refer to the current proto definitions for up-to-date information.
+
 | Field        | Type     |
 | ------------ | -------- |
 | `version`    | `uint32` |

--- a/docs/dev/network-protocol/protocol_stack_tcp.md
+++ b/docs/dev/network-protocol/protocol_stack_tcp.md
@@ -42,7 +42,7 @@ If not mentioned otherwise all fields outside the protobuf encoding are big-endi
 | `24` | ServerConfig        |
 | `25` | SuggestConfig       |
 
-For raw representation of each packet type see the attached Mumble.proto [^2] file.
+For raw representation of each packet type see the [`Mumble.proto`](https://github.com/mumble-voip/mumble/blob/master/src/Mumble.proto)
+and [`MumbleUDP.proto`](https://github.com/mumble-voip/mumble/blob/master/src/MumbleUDP.proto) files.
 
 [^1]: <https://github.com/google/protobuf>
-[^2]: <https://raw.github.com/mumble-voip/mumble/master/src/Mumble.proto>


### PR DESCRIPTION
We migrated our network protocol documentation into this repository, but the documentation is outdated, documenting the state of 1.2.0.

Add a few notes/disclaimers and pointers to up-to-date information.

### Checks

- [x] My commits follow the [commit guidelines](https://github.com/mumble-voip/mumble/blob/master/COMMIT_GUIDELINES.md)

