### PR TITLE
Backport "Merge PR #6723: CI(cirrus): Update to FreeBSD 14.2" to 1.5.x

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -3,7 +3,7 @@
 # that can be found in the LICENSE file at the root of the
 # Mumble source tree or at <https://www.mumble.info/LICENSE>.
 freebsd_instance:
-  image_family: freebsd-14-0
+  image_family: freebsd-14-2
 
 freebsd_task:
   pkg_script:


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `1.5.x`:
 - [Merge PR #6723: CI(cirrus): Update to FreeBSD 14.2](https://github.com/mumble-voip/mumble/pull/6723)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)