### PR TITLE
Added Auto Theme detection and setting in LookConfig

### DIFF
--- a/src/mumble/LookConfig.h
+++ b/src/mumble/LookConfig.h
@@ -27,6 +27,7 @@ public:
 	virtual QIcon icon() const Q_DECL_OVERRIDE;
 
 public slots:
+	void on_qcbAutoTheme_stateChanged(int state);
 	void accept() const Q_DECL_OVERRIDE;
 	void save() const Q_DECL_OVERRIDE;
 	void load(const Settings &r) Q_DECL_OVERRIDE;

--- a/src/mumble/LookConfig.ui
+++ b/src/mumble/LookConfig.ui
@@ -152,7 +152,7 @@
    <item row="6" column="1">
     <spacer name="horizontalSpacer">
      <property name="orientation">
-      <enum>Qt::Horizontal</enum>
+      <enum>Qt::Orientation::Horizontal</enum>
      </property>
      <property name="sizeHint" stdset="0">
       <size>
@@ -165,7 +165,7 @@
    <item row="6" column="0">
     <spacer name="verticalSpacer_2">
      <property name="orientation">
-      <enum>Qt::Vertical</enum>
+      <enum>Qt::Orientation::Vertical</enum>
      </property>
      <property name="sizeHint" stdset="0">
       <size>
@@ -283,7 +283,7 @@
       <item row="1" column="2">
        <spacer name="horizontalSpacer_4">
         <property name="orientation">
-         <enum>Qt::Horizontal</enum>
+         <enum>Qt::Orientation::Horizontal</enum>
         </property>
         <property name="sizeHint" stdset="0">
          <size>
@@ -325,7 +325,7 @@
       <item row="1" column="4">
        <spacer name="horizontalSpacer_5">
         <property name="orientation">
-         <enum>Qt::Horizontal</enum>
+         <enum>Qt::Orientation::Horizontal</enum>
         </property>
         <property name="sizeHint" stdset="0">
          <size>
@@ -338,7 +338,7 @@
       <item row="1" column="0">
        <spacer name="horizontalSpacer_2">
         <property name="orientation">
-         <enum>Qt::Horizontal</enum>
+         <enum>Qt::Orientation::Horizontal</enum>
         </property>
         <property name="sizeHint" stdset="0">
          <size>
@@ -351,7 +351,7 @@
       <item row="1" column="8">
        <spacer name="horizontalSpacer_3">
         <property name="orientation">
-         <enum>Qt::Horizontal</enum>
+         <enum>Qt::Orientation::Horizontal</enum>
         </property>
         <property name="sizeHint" stdset="0">
          <size>
@@ -364,7 +364,7 @@
       <item row="1" column="6">
        <spacer name="horizontalSpacer_6">
         <property name="orientation">
-         <enum>Qt::Horizontal</enum>
+         <enum>Qt::Orientation::Horizontal</enum>
         </property>
         <property name="sizeHint" stdset="0">
          <size>
@@ -845,107 +845,6 @@
      </layout>
     </widget>
    </item>
-   <item row="1" column="0" rowspan="2">
-    <widget class="QGroupBox" name="qgbLookFeel">
-     <property name="title">
-      <string>Look and Feel</string>
-     </property>
-     <layout class="QGridLayout" name="gridLayout">
-      <item row="3" column="0" colspan="2">
-       <widget class="MUComboBox" name="qcbLanguage">
-        <property name="toolTip">
-         <string>Language to use (requires restart)</string>
-        </property>
-        <property name="whatsThis">
-         <string>&lt;b&gt;This sets which language Mumble should use.&lt;/b&gt;&lt;br /&gt;You have to restart Mumble to use the new language.</string>
-        </property>
-        <property name="accessibleName">
-         <string>Language</string>
-        </property>
-       </widget>
-      </item>
-      <item row="0" column="0">
-       <widget class="QLabel" name="qliTheme">
-        <property name="text">
-         <string>Theme</string>
-        </property>
-        <property name="buddy">
-         <cstring>qcbTheme</cstring>
-        </property>
-       </widget>
-      </item>
-      <item row="1" column="0" colspan="2">
-       <widget class="MUComboBox" name="qcbTheme">
-        <property name="sizePolicy">
-         <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-          <horstretch>0</horstretch>
-          <verstretch>0</verstretch>
-         </sizepolicy>
-        </property>
-        <property name="toolTip">
-         <string>Theme to use to style the user interface</string>
-        </property>
-        <property name="whatsThis">
-         <string>&lt;b&gt;Configures which theme the Mumble user interface should be styled with&lt;/b&gt;&lt;br /&gt;Mumble will pick up themes from certain directories and display them in this list. The one you select will be used to customize the visual appearance of Mumble. This includes colors, icons and more.</string>
-        </property>
-        <property name="accessibleName">
-         <string>Mumble theme</string>
-        </property>
-       </widget>
-      </item>
-      <item row="5" column="0" colspan="2">
-       <widget class="QCheckBox" name="qcbShowTransmitModeComboBox">
-        <property name="text">
-         <string>Show transmit mode dropdown in toolbar</string>
-        </property>
-       </widget>
-      </item>
-      <item row="4" column="0" colspan="2">
-       <widget class="QCheckBox" name="qcbHighContrast">
-        <property name="toolTip">
-         <string>Apply some high contrast optimizations for visually impaired users</string>
-        </property>
-        <property name="text">
-         <string>Optimize for high contrast</string>
-        </property>
-       </widget>
-      </item>
-      <item row="6" column="0">
-       <spacer name="verticalSpacer">
-        <property name="orientation">
-         <enum>Qt::Vertical</enum>
-        </property>
-        <property name="sizeHint" stdset="0">
-         <size>
-          <width>20</width>
-          <height>40</height>
-         </size>
-        </property>
-       </spacer>
-      </item>
-      <item row="2" column="0">
-       <widget class="QLabel" name="qliLanguage">
-        <property name="text">
-         <string>Language</string>
-        </property>
-        <property name="buddy">
-         <cstring>qcbLanguage</cstring>
-        </property>
-       </widget>
-      </item>
-      <item row="0" column="1">
-       <widget class="QLabel" name="qlThemesDirectory">
-        <property name="text">
-         <string/>
-        </property>
-        <property name="alignment">
-         <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-        </property>
-       </widget>
-      </item>
-     </layout>
-    </widget>
-   </item>
    <item row="3" column="0">
     <widget class="QGroupBox" name="qgbSearch">
      <property name="title">
@@ -1013,7 +912,7 @@
       <item row="2" column="0">
        <spacer name="verticalSpacer_3">
         <property name="orientation">
-         <enum>Qt::Vertical</enum>
+         <enum>Qt::Orientation::Vertical</enum>
         </property>
         <property name="sizeHint" stdset="0">
          <size>
@@ -1022,6 +921,114 @@
          </size>
         </property>
        </spacer>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item row="1" column="0" rowspan="2">
+    <widget class="QGroupBox" name="qgbLookFeel">
+     <property name="title">
+      <string>Look and Feel</string>
+     </property>
+     <layout class="QGridLayout" name="gridLayout">
+      <item row="0" column="1">
+       <widget class="QLabel" name="qlThemesDirectory">
+        <property name="text">
+         <string/>
+        </property>
+        <property name="alignment">
+         <set>Qt::AlignmentFlag::AlignRight|Qt::AlignmentFlag::AlignTrailing|Qt::AlignmentFlag::AlignVCenter</set>
+        </property>
+       </widget>
+      </item>
+      <item row="6" column="0" colspan="2">
+       <widget class="QCheckBox" name="qcbShowTransmitModeComboBox">
+        <property name="text">
+         <string>Show transmit mode dropdown in toolbar</string>
+        </property>
+       </widget>
+      </item>
+      <item row="5" column="0" colspan="2">
+       <widget class="QCheckBox" name="qcbHighContrast">
+        <property name="toolTip">
+         <string>Apply some high contrast optimizations for visually impaired users</string>
+        </property>
+        <property name="text">
+         <string>Optimize for high contrast</string>
+        </property>
+       </widget>
+      </item>
+      <item row="4" column="0" colspan="2">
+       <widget class="MUComboBox" name="qcbLanguage">
+        <property name="toolTip">
+         <string>Language to use (requires restart)</string>
+        </property>
+        <property name="whatsThis">
+         <string>&lt;b&gt;This sets which language Mumble should use.&lt;/b&gt;&lt;br /&gt;You have to restart Mumble to use the new language.</string>
+        </property>
+        <property name="accessibleName">
+         <string>Language</string>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="0" colspan="2">
+       <widget class="MUComboBox" name="qcbTheme">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="toolTip">
+         <string>Theme to use to style the user interface</string>
+        </property>
+        <property name="whatsThis">
+         <string>&lt;b&gt;Configures which theme the Mumble user interface should be styled with&lt;/b&gt;&lt;br /&gt;Mumble will pick up themes from certain directories and display them in this list. The one you select will be used to customize the visual appearance of Mumble. This includes colors, icons and more.</string>
+        </property>
+        <property name="accessibleName">
+         <string>Mumble theme</string>
+        </property>
+       </widget>
+      </item>
+      <item row="7" column="0">
+       <spacer name="verticalSpacer">
+        <property name="orientation">
+         <enum>Qt::Orientation::Vertical</enum>
+        </property>
+        <property name="sizeHint" stdset="0">
+         <size>
+          <width>20</width>
+          <height>40</height>
+         </size>
+        </property>
+       </spacer>
+      </item>
+      <item row="0" column="0">
+       <widget class="QLabel" name="qliTheme">
+        <property name="text">
+         <string>Theme</string>
+        </property>
+        <property name="buddy">
+         <cstring>qcbTheme</cstring>
+        </property>
+       </widget>
+      </item>
+      <item row="3" column="0">
+       <widget class="QLabel" name="qliLanguage">
+        <property name="text">
+         <string>Language</string>
+        </property>
+        <property name="buddy">
+         <cstring>qcbLanguage</cstring>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="0">
+       <widget class="QCheckBox" name="qcbAutoTheme">
+        <property name="text">
+         <string>Choose theme based on OS</string>
+        </property>
+       </widget>
       </item>
      </layout>
     </widget>

--- a/src/mumble/Settings.h
+++ b/src/mumble/Settings.h
@@ -219,6 +219,7 @@ struct Settings {
 	quint64 uiDoublePush     = 0;
 	quint64 pttHold          = 0;
 
+	bool bAutoTheme = false; // Store the state of the auto theme checkbox
 	bool audioCueEnabledPTT = true;
 	bool audioCueEnabledVAD = false;
 	QString qsTxAudioCueOn  = cqsDefaultPushClickOn;
@@ -397,6 +398,8 @@ struct Settings {
 	QString themeName = QStringLiteral("Mumble");
 	/// Name of the style to use from theme. @see Themes
 	QString themeStyleName = QStringLiteral("Lite");
+
+	bool bAutoTheme; // Whether to automatically switch to the system theme
 
 	QByteArray qbaMainWindowGeometry     = {};
 	QByteArray qbaMainWindowState        = {};

--- a/src/mumble/Themes.cpp
+++ b/src/mumble/Themes.cpp
@@ -30,6 +30,19 @@ boost::optional< ThemeInfo::StyleInfo > Themes::getConfiguredStyle(const Setting
 	return *styleIt;
 }
 
+void Themes::setSystemTheme() {
+    // Check if the system is using dark mode
+    bool isDarkMode = QGuiApplication::styleHints()->colorScheme() == Qt::ColorScheme::Dark;
+
+    QString detectedTheme = isDarkMode ? "DarkTheme" : "LightTheme";
+
+    if (styles.contains(detectedTheme)) {
+        defaultStyle = detectedTheme;
+    } else {
+        qWarning() << "System theme" << detectedTheme << "not found, using default theme";
+    }
+}
+
 void Themes::setConfiguredStyle(Settings &settings, boost::optional< ThemeInfo::StyleInfo > style, bool &outChanged) {
 	if (style) {
 		if (settings.themeName != style->themeName || settings.themeStyleName != style->name) {

--- a/src/mumble/Themes.h
+++ b/src/mumble/Themes.h
@@ -33,6 +33,9 @@ public:
 
 	/// Return a theme name to theme map
 	static ThemeMap getThemes();
+	
+	// Add this function to detect & apply system theme
+	static void setSystemTheme(); 
 
 	/// Returns the per user themes directory
 	static QDir getUserThemesDirectory();


### PR DESCRIPTION
This PR adds an "auto" theme option to Mumble, allowing the user to automatically adjust the theme of the app based on the system's color scheme. Compatible with Qt 6.5+ but still works on Qt 5.15 as well.


- [ ] My commits follow the [commit guidelines](https://github.com/mumble-voip/mumble/blob/master/COMMIT_GUIDELINES.md)

