### PR TITLE
Backport "Merge PR #6728: FIX(Client): bug with talking UI options" to 1.5.x

### DIFF
--- a/src/mumble/LookConfig.cpp
+++ b/src/mumble/LookConfig.cpp
@@ -299,7 +299,7 @@ void LookConfig::themeDirectoryChanged() {
 }
 
 void LookConfig::on_qcbAbbreviateChannelNames_stateChanged(int state) {
-	bool abbreviateNames = state == Qt::Checked;
+	bool abbreviateNames = (state == Qt::Checked) || (state == Qt::PartiallyChecked);
 
 	// Only enable the abbreviation related settings if abbreviation is actually enabled
 	qcbAbbreviateCurrentChannel->setEnabled(abbreviateNames);


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `1.5.x`:
 - [Merge PR #6728: FIX(Client): bug with talking UI options](https://github.com/mumble-voip/mumble/pull/6728)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)