### PR TITLE
FIX(Client): register const void *

### DIFF
--- a/src/mumble/AudioOutput.cpp
+++ b/src/mumble/AudioOutput.cpp
@@ -31,7 +31,7 @@ QMap< QString, AudioOutputRegistrar * > *AudioOutputRegistrar::qmNew;
 QString AudioOutputRegistrar::current = QString();
 
 AudioOutputRegistrar::AudioOutputRegistrar(const QString &n, int p) : name(n), priority(p) {
-	qRegisterMetaType< AudioOutputBuffer * >("AudioOutputBuffer *");
+	qRegisterMetaType< const void * >("const void *");
 
 	if (!qmNew)
 		qmNew = new QMap< QString, AudioOutputRegistrar * >();


### PR DESCRIPTION
Added metatype registration of const void * 
previously audio output wasn't working correctly due to forgotten registration in ca87877

Closes #6735

