### PR TITLE
FIX(mac): Set CFBundleShortVersionString

### DIFF
--- a/macx/scripts/osxdist.py
+++ b/macx/scripts/osxdist.py
@@ -162,6 +162,7 @@ class AppBundle(object):
 			print(' * Changing version in Info.plist')
 			p = self.infoplist
 			p['CFBundleVersion'] = self.version
+			p['CFBundleShortVersionString'] = self.version
 			plistlib.dump(p, open(self.infopath, "wb"))
 
 	def set_min_macosx_version(self, version):


### PR DESCRIPTION
This fixes #6741

The CFBundleVersion is used as a technical identifier by the system, while the CFBundleShortVersionString is used as a user visible value throughout the system. Most notably in the Finder where it defines the user visible version.

See:
- Apples Documentation about CFBundleVersion https://developer.apple.com/documentation/bundleresources/information-property-list/cfbundleversion
- Apples Documentation about CFBundleShortVersionString https://developer.apple.com/documentation/bundleresources/information-property-list/cfbundleshortversionstring


### Checks

- [x] My commits follow the [commit guidelines](https://github.com/mumble-voip/mumble/blob/master/COMMIT_GUIDELINES.md)

