### PR TITLE
Backport "Merge PR #6742: FIX(mac): Set CFBundleShortVersionString" to 1.5.x

### DIFF
--- a/macx/scripts/osxdist.py
+++ b/macx/scripts/osxdist.py
@@ -162,6 +162,7 @@ class AppBundle(object):
 			print(' * Changing version in Info.plist')
 			p = self.infoplist
 			p['CFBundleVersion'] = self.version
+			p['CFBundleShortVersionString'] = self.version
 			plistlib.dump(p, open(self.infopath, "wb"))
 
 	def set_min_macosx_version(self, version):


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `1.5.x`:
 - [Merge PR #6742: FIX(mac): Set CFBundleShortVersionString](https://github.com/mumble-voip/mumble/pull/6742)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)