### PR TITLE
MAINT: Support certificate reload via systemd service

### DIFF
--- a/auxiliary_files/config_files/mumble-server.service.in
+++ b/auxiliary_files/config_files/mumble-server.service.in
@@ -8,6 +8,7 @@ Wants=network-online.target
 AmbientCapabilities=CAP_NET_BIND_SERVICE
 CapabilityBoundingSet=CAP_NET_BIND_SERVICE
 ExecStart=@MUMBLE_INSTALL_ABS_EXECUTABLEDIR@/@MUMBLE_SERVER_BINARY_NAME@ -ini @MUMBLE_INSTALL_ABS_SYSCONFDIR@/mumble-server.ini -fg
+ExecReload=kill -s SIGUSR1 $MAINPID
 Group=_mumble-server
 LockPersonality=yes
 MemoryDenyWriteExecute=yes


### PR DESCRIPTION
This allows certs to be reloaded with `systemctl reload mumble-server` without relying on legacy methods like getting the PID from a PID file.

See https://github.com/mumble-voip/mumble/pull/2850


### Checks

- [ ] My commits follow the [commit guidelines](https://github.com/mumble-voip/mumble/blob/master/COMMIT_GUIDELINES.md)

