### PR TITLE
Backport "Merge PR #6744: MAINT: Support certificate reload via systemd service" to 1.5.x

### DIFF
--- a/auxiliary_files/config_files/mumble-server.service.in
+++ b/auxiliary_files/config_files/mumble-server.service.in
@@ -8,6 +8,7 @@ Wants=network-online.target
 AmbientCapabilities=CAP_NET_BIND_SERVICE
 CapabilityBoundingSet=CAP_NET_BIND_SERVICE
 ExecStart=@MUMBLE_INSTALL_ABS_EXECUTABLEDIR@/@MUMBLE_SERVER_BINARY_NAME@ -ini @MUMBLE_INSTALL_ABS_SYSCONFDIR@/mumble-server.ini -fg
+ExecReload=kill -s SIGUSR1 $MAINPID
 Group=_mumble-server
 LockPersonality=yes
 MemoryDenyWriteExecute=yes


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `1.5.x`:
 - [Merge PR #6744: MAINT: Support certificate reload via systemd service](https://github.com/mumble-voip/mumble/pull/6744)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)