### PR TITLE
FIX(client): Prevent local muted users from triggering attenuation

### DIFF
--- a/src/mumble/AudioOutput.cpp
+++ b/src/mumble/AudioOutput.cpp
@@ -442,12 +442,16 @@ void AudioOutput::prepareOutputBuffers(unsigned int frameCount, QList< AudioOutp
 	// Get the users that are currently talking (and are thus serving as an audio source)
 	auto it = qmOutputs.constBegin();
 	for (int i = 0; i < qmOutputs.count(); i++) {
+		const ClientUser *user    = it.key();
+		bool isSample             = user == nullptr;
 		AudioOutputBuffer *buffer = it.value();
+
 		if (!buffer->prepareSampleBuffer(frameCount)) {
 			qlDel.append(buffer);
-		} else {
+		} else if (isSample || !user->bLocalMute) {
 			qlMix.append(buffer);
 		}
+
 		++it;
 	}
 }
@@ -487,7 +491,7 @@ bool AudioOutput::mix(void *outbuff, unsigned int frameCount) {
 		QMultiHash< const ClientUser *, AudioOutputBuffer * >::const_iterator it = qmOutputs.constBegin();
 		while (it != qmOutputs.constEnd()) {
 			const ClientUser *user = it.key();
-			if (user && user->bPrioritySpeaker) {
+			if (user && user->bPrioritySpeaker && !user->bLocalMute) {
 				prioritySpeakerActive = true;
 			}
 			++it;

--- a/src/mumble/JackAudio.cpp
+++ b/src/mumble/JackAudio.cpp
@@ -1158,6 +1158,10 @@ void JackAudioOutput::prepareOutputBuffers(unsigned int frameCount, QList< Audio
 			continue;
 		}
 
+		if (user->bLocalMute) {
+			continue;
+		}
+
 		QString qsPortName = user->qsName;
 		qsPortName         = qsPortName.prepend("user_");
 		if (userPorts.find(qsPortName) == userPorts.end()) {


### PR DESCRIPTION
Previously, application attenuation and priority speaker attenuation would not consider local muted clients. In both situations local muted clients would still lower other clients or applications volume, despite not being played back.

This commit adds a check to the code where client voice is added to the mix data structure and prevents local muted clients (including priority speakers) to be considered in attenuation logic.

Fixes #6247 

Supersedes #6394