### PR TITLE
FIX(client): Update chat bar if selected channel target state is modified

### DIFF
--- a/src/mumble/MainWindow.cpp
+++ b/src/mumble/MainWindow.cpp
@@ -2582,9 +2582,13 @@ void MainWindow::userStateChanged() {
 	}
 }
 
-void MainWindow::on_channelStateChanged(Channel *channel) {
+void MainWindow::on_channelStateChanged(Channel *channel, bool forceUpdateTree) {
 	if (channel == pmModel->getChannel(qtvUsers->currentIndex())) {
 		updateChatBar();
+	}
+
+	if (forceUpdateTree) {
+		pmModel->forceVisualUpdate();
 	}
 }
 

--- a/src/mumble/MainWindow.cpp
+++ b/src/mumble/MainWindow.cpp
@@ -198,6 +198,8 @@ MainWindow::MainWindow(QWidget *p)
 	// This will, for example, make sure the correct status tray icon is used on connect.
 	QObject::connect(this, &MainWindow::serverSynchronized, this, &MainWindow::userStateChanged);
 
+	QObject::connect(this, &MainWindow::channelStateChanged, this, &MainWindow::on_channelStateChanged);
+
 	QAccessible::installFactory(AccessibleSlider::semanticSliderFactory);
 }
 
@@ -2577,6 +2579,12 @@ void MainWindow::userStateChanged() {
 			Global::get().bAttenuateOthers              = false;
 			Global::get().prioritySpeakerActiveOverride = false;
 			break;
+	}
+}
+
+void MainWindow::on_channelStateChanged(Channel *channel) {
+	if (channel == pmModel->getChannel(qtvUsers->currentIndex())) {
+		updateChatBar();
 	}
 }
 

--- a/src/mumble/MainWindow.h
+++ b/src/mumble/MainWindow.h
@@ -358,6 +358,7 @@ public slots:
 	/// Handles state changes like talking mode changes and mute/unmute
 	/// or priority speaker flag changes for the gui user
 	void userStateChanged();
+	void on_channelStateChanged(Channel *channel);
 	void destroyUserInformation();
 	void sendChatbarMessage(QString msg);
 	void sendChatbarText(QString msg, bool plainText = false);
@@ -402,6 +403,10 @@ signals:
 
 	/// Signal emitted when the local user changes their talking status either actively or passively
 	void talkingStatusChanged();
+
+	/// Signal when channel state has been changed
+	void channelStateChanged(Channel *channel);
+
 	/// Signal emitted when the connection was terminated and all cleanup code has been run
 	void disconnectedFromServer();
 

--- a/src/mumble/MainWindow.h
+++ b/src/mumble/MainWindow.h
@@ -358,7 +358,7 @@ public slots:
 	/// Handles state changes like talking mode changes and mute/unmute
 	/// or priority speaker flag changes for the gui user
 	void userStateChanged();
-	void on_channelStateChanged(Channel *channel);
+	void on_channelStateChanged(Channel *channel, bool forceUpdateTree);
 	void destroyUserInformation();
 	void sendChatbarMessage(QString msg);
 	void sendChatbarText(QString msg, bool plainText = false);
@@ -405,7 +405,7 @@ signals:
 	void talkingStatusChanged();
 
 	/// Signal when channel state has been changed
-	void channelStateChanged(Channel *channel);
+	void channelStateChanged(Channel *channel, bool forceUpdateTree);
 
 	/// Signal emitted when the connection was terminated and all cleanup code has been run
 	void disconnectedFromServer();

--- a/src/mumble/Messages.cpp
+++ b/src/mumble/Messages.cpp
@@ -974,6 +974,8 @@ void MainWindow::msgChannelState(const MumbleProto::ChannelState &msg) {
 	if (updateUI) {
 		this->pmModel->forceVisualUpdate();
 	}
+
+	emit channelStateChanged(c);
 }
 
 void MainWindow::msgChannelRemove(const MumbleProto::ChannelRemove &msg) {

--- a/src/mumble/Messages.cpp
+++ b/src/mumble/Messages.cpp
@@ -959,23 +959,19 @@ void MainWindow::msgChannelState(const MumbleProto::ChannelState &msg) {
 		c->uiMaxUsers = msg.max_users();
 	}
 
-	bool updateUI = false;
+	bool forceUpdateTree = false;
 
 	if (msg.has_is_enter_restricted()) {
 		c->hasEnterRestrictions.store(msg.is_enter_restricted());
-		updateUI = true;
+		forceUpdateTree = true;
 	}
 
 	if (msg.has_can_enter()) {
 		c->localUserCanEnter.store(msg.can_enter());
-		updateUI = true;
+		forceUpdateTree = true;
 	}
 
-	if (updateUI) {
-		this->pmModel->forceVisualUpdate();
-	}
-
-	emit channelStateChanged(c);
+	emit channelStateChanged(c, forceUpdateTree);
 }
 
 void MainWindow::msgChannelRemove(const MumbleProto::ChannelRemove &msg) {


### PR DESCRIPTION
**FIX(client): Update chat bar if selected channel target state is modified**

Previously, the chat bar would not update its text when a selected target
channel was modified.

This commit adds a signal slot to the channel state modified message
and updates the chat bar accordingly.

Fixes #1884

**REFAC(client): Move forced visual update from Messages.cpp to channelState slot**