### PR TITLE
FIX(server): Prevent server startup when providing empty certificate files

### DIFF
--- a/src/murmur/Meta.cpp
+++ b/src/murmur/Meta.cpp
@@ -466,12 +466,14 @@ bool MetaParams::loadSSLSettings() {
 	}
 
 	QByteArray crt, key;
+	bool certSpecified = false;
 
 	if (!qsSSLCert.isEmpty()) {
 		QFile pem(qsSSLCert);
 		if (pem.open(QIODevice::ReadOnly)) {
 			crt = pem.readAll();
 			pem.close();
+			certSpecified = true;
 		} else {
 			qCritical("MetaParams: Failed to read %s", qPrintable(qsSSLCert));
 			return false;
@@ -482,13 +484,14 @@ bool MetaParams::loadSSLSettings() {
 		if (pem.open(QIODevice::ReadOnly)) {
 			key = pem.readAll();
 			pem.close();
+			certSpecified = true;
 		} else {
 			qCritical("MetaParams: Failed to read %s", qPrintable(qsSSLKey));
 			return false;
 		}
 	}
 
-	if (!key.isEmpty() || !crt.isEmpty()) {
+	if (certSpecified) {
 		if (!key.isEmpty()) {
 			tmpKey = Server::privateKeyFromPEM(key, qbaPassPhrase);
 		}


### PR DESCRIPTION
Ok, so I tried to reproduce #1014, but the only thing that seems to not be caught by the current ``loadSSLSettings`` routine, is providing an existing, but **empty** certificate file.
I also tried:
* Specifying a non-existent file
* Specifying an existing but invalid file
* Specifying a file with no read permissions

All of these lead to ``loadSSLSettings`` returning false and mumble-server exiting early. I also checked the code paths for reloading SSL settings etc. and it does not seem to be the case that we hit the self-signed certificate generation without a prior properly error-handled call to ``loadSSLSettings``. So I guess #1014 was mostly fixed already after all.

The previous iteration of the ``loadSSLSettings`` method would skip the block of actually loading any user-provided certificate or key files if the provided file existed, but were empty. This would lead to self-signed certificates being generated despite a certificate/key path being present.

This commit replaces the check to make sure SSL parameter loading fails when the provided file is empty.

Fixes #1014