### PR TITLE
Backport "FIX(server): Prevent server startup when providing empty certificate files (#6750)" to 1.5.x

### DIFF
--- a/src/murmur/Meta.cpp
+++ b/src/murmur/Meta.cpp
@@ -479,12 +479,14 @@ bool MetaParams::loadSSLSettings() {
 	}
 
 	QByteArray crt, key;
+	bool certSpecified = false;
 
 	if (!qsSSLCert.isEmpty()) {
 		QFile pem(qsSSLCert);
 		if (pem.open(QIODevice::ReadOnly)) {
 			crt = pem.readAll();
 			pem.close();
+			certSpecified = true;
 		} else {
 			qCritical("MetaParams: Failed to read %s", qPrintable(qsSSLCert));
 			return false;
@@ -495,13 +497,14 @@ bool MetaParams::loadSSLSettings() {
 		if (pem.open(QIODevice::ReadOnly)) {
 			key = pem.readAll();
 			pem.close();
+			certSpecified = true;
 		} else {
 			qCritical("MetaParams: Failed to read %s", qPrintable(qsSSLKey));
 			return false;
 		}
 	}
 
-	if (!key.isEmpty() || !crt.isEmpty()) {
+	if (certSpecified) {
 		if (!key.isEmpty()) {
 			tmpKey = Server::privateKeyFromPEM(key, qbaPassPhrase);
 		}


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `1.5.x`:
 - [FIX(server): Prevent server startup when providing empty certificate files (#6750)](https://github.com/mumble-voip/mumble/pull/6750)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)