### PR TITLE
Fix image link in docs

### DIFF
--- a/docs/dev/network-protocol/protocol_stack_tcp.md
+++ b/docs/dev/network-protocol/protocol_stack_tcp.md
@@ -5,7 +5,7 @@ uses Google's Protocol Buffers[^1] with simple prefixing to
 distinguish the different kinds of packets sent through a TLSv1
 encrypted connection. This makes the protocol very easily expandable.
 
-![resources/mumble_packet.png](Mumble packet)
+![Mumble packet](resources/mumble_packet.png)
 
 The prefix consists out of the two bytes defining the type of the packet
 in the payload and 4 bytes stating the length of the payload in bytes


### PR DESCRIPTION
Quick fix for docs image of a TCP packet

![Screenshot 2025-04-03 at 11 21 17 AM](https://github.com/user-attachments/assets/25ca0e41-614d-463e-a972-0de042b9b3ea)

### Checks

- [x] My commits follow the [commit guidelines](https://github.com/mumble-voip/mumble/blob/master/COMMIT_GUIDELINES.md)

