### PR TITLE
Do not build database backends by default when compiling the client

### DIFF
--- a/docs/dev/build-instructions/build_linux.md
+++ b/docs/dev/build-instructions/build_linux.md
@@ -160,6 +160,14 @@ For all available build options, have a look [here](cmake_options.md).
 E.g. if you only want to build the server, use `cmake -Dclient=OFF ..`.
 
 
+## Database backends
+
+When compiling the Mumble server, backends for postgresql and mysql are enabled and compiled by default.
+These require additional development headers to be installed on the system.
+
+Alternatively, you can disable those backends using the respective [CMake options](cmake_options.md).
+
+
 ## Building
 
 By default cmake will create Makefiles if run on Linux, so in order to build, you can simply run `make` in the build directory. If you want to

--- a/docs/dev/build-instructions/cmake_options.md
+++ b/docs/dev/build-instructions/cmake_options.md
@@ -117,12 +117,12 @@ Set \"uiAccess=true\", required for global shortcuts to work with privileged app
 ### enable-mysql
 
 Whether or not to enable the MySQL database backend
-(Default: ON)
+(Default: ${server})
 
 ### enable-postgresql
 
 Whether or not to enable the PostgreSQL database backend
-(Default: ON)
+(Default: ${server})
 
 ### enable-sqlite
 

--- a/src/database/CMakeLists.txt
+++ b/src/database/CMakeLists.txt
@@ -6,8 +6,8 @@
 option(bundled-soci "Build the included version of SOCI instead of looking for one on the system" ON)
 
 option(enable-sqlite "Whether or not to enable the SQLite database backend" ON)
-option(enable-mysql "Whether or not to enable the MySQL database backend" ON)
-option(enable-postgresql "Whether or not to enable the PostgreSQL database backend" ON)
+option(enable-mysql "Whether or not to enable the MySQL database backend" ${server})
+option(enable-postgresql "Whether or not to enable the PostgreSQL database backend" ${server})
 
 add_library(mumble_database STATIC
 	"Backend.cpp"


### PR DESCRIPTION
* Changes db backend CMake vars to default to ``${server}``
* Updates build documentation for Linux