### PR TITLE
Fix status icon alignment and TreeView item background (Qt6 regression)

### DIFF
--- a/src/mumble/UserView.cpp
+++ b/src/mumble/UserView.cpp
@@ -79,13 +79,14 @@ void UserDelegate::paint(QPainter *painter, const QStyleOptionViewItem &option, 
 						colorRole);
 
 	// draw icons to original rect
-	const QRect ps = QRect(option.rect.right() - (static_cast< int >(ql.size() * m_iconTotalDimension)),
-						   option.rect.y(), static_cast< int >(ql.size() * m_iconTotalDimension), option.rect.height());
+	const QRect ps     = QRect(option.rect.right() - (static_cast< int >(ql.size() * m_iconTotalDimension)),
+                           option.rect.y(), static_cast< int >(ql.size() * m_iconTotalDimension), option.rect.height());
+	const int iconPosY = (option.rect.height() / 2) - (m_iconIconDimension / 2);
 
 	for (int i = 0; i < ql.size(); ++i) {
 		QRect r = ps;
 		r.setSize(QSize(m_iconIconDimension, m_iconIconDimension));
-		r.translate(i * m_iconTotalDimension + m_iconIconPadding, m_iconIconPadding);
+		r.translate(i * m_iconTotalDimension + m_iconIconPadding, iconPosY);
 		QRect p = QStyle::alignedRect(option.direction, option.decorationAlignment, r.size(), r);
 		qvariant_cast< QIcon >(ql[i]).paint(painter, p, option.decorationAlignment, iconMode, QIcon::On);
 	}

--- a/themes/Default/Dark.qss
+++ b/themes/Default/Dark.qss
@@ -387,11 +387,11 @@ QTreeView::item:selected:active:only-one {
 }
 
 QTreeView::branch {
+  background-color: #191919;
   border-image: none;
   image: none;
-  margin-left: 3px;
-  margin-top: 1px;
   padding-left: 3px;
+  padding-top: 1px;
 }
 
 QTreeView::branch:has-children:closed {

--- a/themes/Default/Lite.qss
+++ b/themes/Default/Lite.qss
@@ -387,11 +387,11 @@ QTreeView::item:selected:active:only-one {
 }
 
 QTreeView::branch {
+  background-color: #FFF;
   border-image: none;
   image: none;
-  margin-left: 3px;
-  margin-top: 1px;
   padding-left: 3px;
+  padding-top: 1px;
 }
 
 QTreeView::branch:has-children:closed {

--- a/themes/Default/source/Imports/Base Theme.scss
+++ b/themes/Default/source/Imports/Base Theme.scss
@@ -438,11 +438,11 @@ QTreeView::item:selected:active:only-one
 
 QTreeView::branch
 {
+	background-color:$sub-bg;
 	border-image:none;
 	image:none;
-	margin-left:3px;
-	margin-top:1px;
 	padding-left:3px;
+	padding-top:1px;
 }
 
 QTreeView::branch:has-children:closed


### PR DESCRIPTION
Something changed in Qt6 and the QTreeView elements don't look like they used to in Qt5 (Mumble 1.5.x)
Notably:
* The row background somehow extends all the way to the left
* The icons are no longer aligned to the center of the item row

This MR addresses this. Tested in KDE Wayland

Before (broken):
![screen_before](https://github.com/user-attachments/assets/2a281fb8-b68c-4b96-abe8-da003827864a)

After (fixed):
![screen_after](https://github.com/user-attachments/assets/54bf5685-5ca9-4be3-9fda-cf806e1f28e5)
