### PR TITLE
BUILD(overlay): Fix building with GCC 15

### DIFF
--- a/overlay_gl/overlay.c
+++ b/overlay_gl/overlay.c
@@ -14,6 +14,7 @@
 #include <pwd.h>
 #include <semaphore.h>
 #include <stdarg.h>
+#include <stdbool.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -37,9 +38,6 @@
 
 #	include <link.h>
 
-typedef unsigned char bool;
-#	define true 1
-#	define false 0
 #elif defined(TARGET_MAC)
 #	include <AGL/agl.h>
 #	include <Carbon/Carbon.h>


### PR DESCRIPTION
C23 added the bool keyword, which results in an error if you try to define an identifier named bool and then build with GCC 15.  We can use stdbool.h to define bool instead.

https://gcc.gnu.org/gcc-15/porting_to.html#c23-new-keywords

### Checks

- [x] My commits follow the [commit guidelines](https://github.com/mumble-voip/mumble/blob/master/COMMIT_GUIDELINES.md)

