### PR TITLE
Backport "Merge PR #6775: BUILD(overlay): Fix building with GCC 15" to 1.5.x

### DIFF
--- a/overlay_gl/overlay.c
+++ b/overlay_gl/overlay.c
@@ -14,6 +14,7 @@
 #include <pwd.h>
 #include <semaphore.h>
 #include <stdarg.h>
+#include <stdbool.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -37,9 +38,6 @@
 
 #	include <link.h>
 
-typedef unsigned char bool;
-#	define true 1
-#	define false 0
 #elif defined(TARGET_MAC)
 #	include <AGL/agl.h>
 #	include <Carbon/Carbon.h>


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `1.5.x`:
 - [Merge PR #6775: BUILD(overlay): Fix building with GCC 15](https://github.com/mumble-voip/mumble/pull/6775)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)