### PR TITLE
Backport "Merge PR #6747: FIX(client): Prevent local muted users from triggering attenuation"

### DIFF
--- a/src/mumble/AudioOutput.cpp
+++ b/src/mumble/AudioOutput.cpp
@@ -449,14 +449,18 @@ bool AudioOutput::mix(void *outbuff, unsigned int frameCount) {
 	// Get the users that are currently talking (and are thus serving as an audio source)
 	QMultiHash< const ClientUser *, AudioOutputBuffer * >::const_iterator it = qmOutputs.constBegin();
 	while (it != qmOutputs.constEnd()) {
+		const ClientUser *user    = it.key();
 		AudioOutputBuffer *buffer = it.value();
+
 		if (!buffer->prepareSampleBuffer(frameCount)) {
 			qlDel.append(buffer);
-		} else {
+		} else if (!user) {
+			// Audio samples
+			qlMix.append(buffer);
+		} else if (!user->bLocalMute) {
 			qlMix.append(buffer);
 
-			const ClientUser *user = it.key();
-			if (user && user->bPrioritySpeaker) {
+			if (user->bPrioritySpeaker) {
 				prioritySpeakerActive = true;
 			}
 		}


### PR DESCRIPTION
Manual backport of #6747
