### PR TITLE
Backport "Merge PR #6777: FIX(client): Restart audio system when a WASAPI device we use reappears" to 1.5.x

### DIFF
--- a/src/mumble/WASAPINotificationClient.cpp
+++ b/src/mumble/WASAPINotificationClient.cpp
@@ -45,8 +45,14 @@ HRESULT STDMETHODCALLTYPE WASAPINotificationClient::OnPropertyValueChanged(LPCWS
 HRESULT STDMETHODCALLTYPE WASAPINotificationClient::OnDeviceAdded(LPCWSTR pwstrDeviceId) {
 	const QString device = QString::fromWCharArray(pwstrDeviceId);
 	qDebug() << "WASAPINotificationClient: Device added=" << device;
+
+	if (usedDevices.contains(device)) {
+		restartAudio();
+	}
+
 	return S_OK;
 }
+
 HRESULT STDMETHODCALLTYPE WASAPINotificationClient::OnDeviceRemoved(LPCWSTR pwstrDeviceId) {
 	const QString device = QString::fromWCharArray(pwstrDeviceId);
 	qDebug() << "WASAPINotificationClient: Device removed=" << device;

--- a/src/mumble/WASAPINotificationClient.cpp
+++ b/src/mumble/WASAPINotificationClient.cpp
@@ -15,8 +15,8 @@ HRESULT STDMETHODCALLTYPE WASAPINotificationClient::OnDefaultDeviceChanged(EData
 																		   LPCWSTR pwstrDefaultDevice) {
 	const QString device = QString::fromWCharArray(pwstrDefaultDevice);
 
-	qWarning() << "WASAPINotificationClient: Default device changed flow=" << flow << "role=" << role << "device"
-			   << device;
+	qDebug() << "WASAPINotificationClient: Default device changed flow=" << flow << "role=" << role << "device"
+			 << device;
 
 	QMutexLocker lock(&listsMutex);
 	if (!usedDefaultDevices.empty() && role == eCommunications) {
@@ -34,8 +34,8 @@ HRESULT STDMETHODCALLTYPE WASAPINotificationClient::OnPropertyValueChanged(LPCWS
 
 	QMutexLocker lock(&listsMutex);
 	if ((formatChanged || channelConfigChanged) && usedDevices.contains(device)) {
-		qWarning() << "WASAPINotificationClient: Property changed device=" << device
-				   << "formatChanged=" << formatChanged << "channelConfigChanged=" << channelConfigChanged;
+		qDebug() << "WASAPINotificationClient: Property changed device=" << device << "formatChanged=" << formatChanged
+				 << "channelConfigChanged=" << channelConfigChanged;
 
 		restartAudio();
 	}
@@ -44,19 +44,19 @@ HRESULT STDMETHODCALLTYPE WASAPINotificationClient::OnPropertyValueChanged(LPCWS
 
 HRESULT STDMETHODCALLTYPE WASAPINotificationClient::OnDeviceAdded(LPCWSTR pwstrDeviceId) {
 	const QString device = QString::fromWCharArray(pwstrDeviceId);
-	qWarning() << "WASAPINotificationClient: Device added=" << device;
+	qDebug() << "WASAPINotificationClient: Device added=" << device;
 	return S_OK;
 }
 HRESULT STDMETHODCALLTYPE WASAPINotificationClient::OnDeviceRemoved(LPCWSTR pwstrDeviceId) {
 	const QString device = QString::fromWCharArray(pwstrDeviceId);
-	qWarning() << "WASAPINotificationClient: Device removed=" << device;
+	qDebug() << "WASAPINotificationClient: Device removed=" << device;
 	return S_OK;
 }
 
 HRESULT STDMETHODCALLTYPE WASAPINotificationClient::OnDeviceStateChanged(LPCWSTR pwstrDeviceId, DWORD dwNewState) {
 	const QString device = QString::fromWCharArray(pwstrDeviceId);
 
-	qWarning() << "WASAPINotificationClient: Device state changed newState=" << dwNewState << "device=" << device;
+	qDebug() << "WASAPINotificationClient: Device state changed newState=" << dwNewState << "device=" << device;
 
 	return S_OK;
 }

--- a/src/mumble/WASAPINotificationClient.cpp
+++ b/src/mumble/WASAPINotificationClient.cpp
@@ -58,6 +58,15 @@ HRESULT STDMETHODCALLTYPE WASAPINotificationClient::OnDeviceStateChanged(LPCWSTR
 
 	qDebug() << "WASAPINotificationClient: Device state changed newState=" << dwNewState << "device=" << device;
 
+	switch (dwNewState) {
+		case DEVICE_STATE_ACTIVE:
+			return OnDeviceAdded(pwstrDeviceId);
+		case DEVICE_STATE_DISABLED:
+		case DEVICE_STATE_NOTPRESENT:
+		case DEVICE_STATE_UNPLUGGED:
+			return OnDeviceRemoved(pwstrDeviceId);
+	}
+
 	return S_OK;
 }
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `1.5.x`:
 - [Merge PR #6777: FIX(client): Restart audio system when a WASAPI device we use reappears](https://github.com/mumble-voip/mumble/pull/6777)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)