### PR TITLE
FEAT(installer): Bundle C++ redistributables

### DIFF
--- a/.ci/azure-pipelines/release_windows.bat
+++ b/.ci/azure-pipelines/release_windows.bat
@@ -17,9 +17,9 @@ if errorlevel 1 (
 	exit /b %errorlevel%
 )
 
-copy installer\client\mumble_client*.msi %BUILD_ARTIFACTSTAGINGDIRECTORY%
+copy installer\client\mumble_client*.exe %BUILD_ARTIFACTSTAGINGDIRECTORY%
 
-copy installer\server\mumble_server*.msi %BUILD_ARTIFACTSTAGINGDIRECTORY%
+copy installer\server\mumble_server*.exe %BUILD_ARTIFACTSTAGINGDIRECTORY%
 
 7z a PDBs.7z *.pdb plugins\*.pdb
 copy PDBs.7z %BUILD_ARTIFACTSTAGINGDIRECTORY%

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -196,7 +196,27 @@ if(plugins AND client)
 endif()
 
 if (packaging AND WIN32)
-	set(VC_REDIST_URL "https://download.visualstudio.microsoft.com/download/pr/285b28c7-3cf9-47fb-9be8-01cf5323a8df/8F9FB1B3CFE6E5092CF1225ECD6659DAB7CE50B8BF935CB79BFEDE1F3C895240/VC_redist.x64.exe")
+	execute_process(COMMAND
+		powershell -Command "
+			$response = Invoke-WebRequest \
+					-Uri 'https://aka.ms/vs/17/release/vc_redist.x64.exe' \
+					-Method Head \
+					-MaximumRedirection 0 \
+					-ErrorAction SilentlyContinue
+			$response.Headers.Location"
+		OUTPUT_VARIABLE VC_REDIST_URL
+	)
+	string(STRIP ${VC_REDIST_URL} VC_REDIST_URL)
+
+	file(DOWNLOAD ${VC_REDIST_URL} ${CMAKE_BINARY_DIR}/installer/VC_redist.x64.exe)
+
+	execute_process(COMMAND
+		powershell -Command "
+			$exe = (Get-Item -path '${CMAKE_BINARY_DIR}/installer/VC_redist.x64.exe')
+			$exe.VersionInfo.ProductVersion"
+		OUTPUT_VARIABLE VC_REDIST_VERSION
+	)
+	string(STRIP ${VC_REDIST_VERSION} VC_REDIST_VERSION)
 endif()
 
 if(client OR server)
@@ -225,8 +245,6 @@ if(packaging)
 				${CMAKE_BINARY_DIR}/installer
 		)
 
-		file(DOWNLOAD ${VC_REDIST_URL} ${CMAKE_BINARY_DIR}/installer/VC_redist.x64.exe)
-		
 		file(COPY 
 			${CMAKE_SOURCE_DIR}/icons/mumble.ico
 			${CMAKE_SOURCE_DIR}/icons/murmur.ico

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -195,6 +195,10 @@ if(plugins AND client)
 	add_subdirectory(plugins)
 endif()
 
+if (packaging AND WIN32)
+	set(VC_REDIST_URL "https://download.visualstudio.microsoft.com/download/pr/285b28c7-3cf9-47fb-9be8-01cf5323a8df/8F9FB1B3CFE6E5092CF1225ECD6659DAB7CE50B8BF935CB79BFEDE1F3C895240/VC_redist.x64.exe")
+endif()
+
 if(client OR server)
 	add_subdirectory(src)
 endif()
@@ -217,10 +221,11 @@ if(packaging)
 			${CMAKE_SOURCE_DIR}/installer/bannrbmp.bmp
 			${CMAKE_SOURCE_DIR}/installer/dlgbmp.bmp
 			${CMAKE_SOURCE_DIR}/installer/Theme.xml
-			${CMAKE_SOURCE_DIR}/installer/VC_redist.x64.exe
 			DESTINATION
 				${CMAKE_BINARY_DIR}/installer
 		)
+
+		file(DOWNLOAD ${VC_REDIST_URL} ${CMAKE_BINARY_DIR}/installer/VC_redist.x64.exe)
 		
 		file(COPY 
 			${CMAKE_SOURCE_DIR}/icons/mumble.ico

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -216,6 +216,8 @@ if(packaging)
 		file(COPY
 			${CMAKE_SOURCE_DIR}/installer/bannrbmp.bmp
 			${CMAKE_SOURCE_DIR}/installer/dlgbmp.bmp
+			${CMAKE_SOURCE_DIR}/installer/Theme.xml
+			${CMAKE_SOURCE_DIR}/installer/VC_redist.x64.exe
 			DESTINATION
 				${CMAKE_BINARY_DIR}/installer
 		)

--- a/installer/ClientInstaller.cs
+++ b/installer/ClientInstaller.cs
@@ -201,7 +201,6 @@ class BuildInstaller
 	public static void Main(string[] args) {
 		string version = "";
 		string arch = "";
-		string vcRedistUrl = "";
 		string vcRedistRequired = "";
 		bool isAllLangs = false;
 		Features features = new Features();
@@ -217,10 +216,6 @@ class BuildInstaller
 
 			if (args[i] == "--all-languages") {
 				isAllLangs = true;
-			}
-
-			if (args[i] == "--vc-redist-url") {
-				vcRedistUrl = args[i + 1];
 			}
 
 			if (args[i] == "--vc-redist-required") {
@@ -248,7 +243,7 @@ class BuildInstaller
 			            ? clInstaller.BuildMultilanguageMsi()
 			            : clInstaller.BuildMsi();
 
-			clInstaller.BundleMsi(msiPath, vcRedistUrl, vcRedistRequired)
+			clInstaller.BundleMsi(msiPath, vcRedistRequired)
 			           .Build(msiPath.PathChangeExtension(".exe"));
 		} else {
 			Console.WriteLine("ERROR - Values for arch or version are null or incorrect!");

--- a/installer/ClientInstaller.cs
+++ b/installer/ClientInstaller.cs
@@ -201,6 +201,7 @@ class BuildInstaller
 	public static void Main(string[] args) {
 		string version = "";
 		string arch = "";
+		string vcRedistUrl = "";
 		bool isAllLangs = false;
 		Features features = new Features();
 
@@ -215,6 +216,10 @@ class BuildInstaller
 
 			if (args[i] == "--all-languages") {
 				isAllLangs = true;
+			}
+
+			if (args[i] == "--vc-redist-url") {
+				vcRedistUrl = args[i + 1];
 			}
 
 			if (args[i] == "--g15") {
@@ -238,7 +243,7 @@ class BuildInstaller
 			            ? clInstaller.BuildMultilanguageMsi()
 			            : clInstaller.BuildMsi();
 
-			clInstaller.BundleMsi(msiPath)
+			clInstaller.BundleMsi(msiPath, vcRedistUrl)
 			           .Build(msiPath.PathChangeExtension(".exe"));
 		} else {
 			Console.WriteLine("ERROR - Values for arch or version are null or incorrect!");

--- a/installer/ClientInstaller.cs
+++ b/installer/ClientInstaller.cs
@@ -202,6 +202,7 @@ class BuildInstaller
 		string version = "";
 		string arch = "";
 		string vcRedistUrl = "";
+		string vcRedistRequired = "";
 		bool isAllLangs = false;
 		Features features = new Features();
 
@@ -220,6 +221,10 @@ class BuildInstaller
 
 			if (args[i] == "--vc-redist-url") {
 				vcRedistUrl = args[i + 1];
+			}
+
+			if (args[i] == "--vc-redist-required") {
+				vcRedistRequired = args[i + 1];
 			}
 
 			if (args[i] == "--g15") {
@@ -243,7 +248,7 @@ class BuildInstaller
 			            ? clInstaller.BuildMultilanguageMsi()
 			            : clInstaller.BuildMsi();
 
-			clInstaller.BundleMsi(msiPath, vcRedistUrl)
+			clInstaller.BundleMsi(msiPath, vcRedistUrl, vcRedistRequired)
 			           .Build(msiPath.PathChangeExtension(".exe"));
 		} else {
 			Console.WriteLine("ERROR - Values for arch or version are null or incorrect!");

--- a/installer/ClientInstaller.cs
+++ b/installer/ClientInstaller.cs
@@ -11,8 +11,11 @@ using System.Linq;
 using System.Text.RegularExpressions;
 using System.Windows.Forms;
 using Microsoft.Deployment.WindowsInstaller;
+using System.Xml;
+using System.Xml.Linq;
 using System.Collections.Generic;
 using WixSharp;
+using WixSharp.Bootstrapper;
 using WixSharp.CommonTasks;
 
 public struct Features {
@@ -231,11 +234,12 @@ class BuildInstaller
 			var clInstaller = new ClientInstaller(version, arch, features);
 			clInstaller.Version = new Version(version);
 
-			if (isAllLangs) {
-				clInstaller.BuildMultilanguageMsi();
-			} else {
-				clInstaller.BuildMsi();
-			}
+			var msiPath = isAllLangs
+			            ? clInstaller.BuildMultilanguageMsi()
+			            : clInstaller.BuildMsi();
+
+			clInstaller.BundleMsi(msiPath)
+			           .Build(msiPath.PathChangeExtension(".exe"));
 		} else {
 			Console.WriteLine("ERROR - Values for arch or version are null or incorrect!");
 			Environment.ExitCode = 0xA0; // Bad argument

--- a/installer/MumbleInstall.cs
+++ b/installer/MumbleInstall.cs
@@ -31,7 +31,7 @@ public class MumbleInstall : Project {
 		this.Properties = new Property[] { allUsersProp };
 	}
 
-	public Bundle BundleMsi(string msiPath, string vcRedistUrl, string vcRedistRequired) {
+	public Bundle BundleMsi(string msiPath, string vcRedistRequired) {
 		var bootstrapper = new Bundle(
 				this.Name,
 				new MsiPackage(msiPath)
@@ -40,24 +40,14 @@ public class MumbleInstall : Project {
 				{
 					Id = "VCREDIST_EXE",
 					Name = "VC_redist.x64.exe",
-					/* The SourceFile is required used by wix to generate a RemotePayload object for
-					 * this ExePackage. It inludes a sha1 hash of the SourceFile in the installer we
-					 * build to validate the download at install time on the user's machine. */
 					SourceFile = @"..\VC_redist.x64.exe",
 					DisplayName = "Microsoft Visual C++ 2015-2022 Redistributable (x64)",
-					DownloadUrl = vcRedistUrl,
 					/* This condition being true should mean that it is already installed. */
 					DetectCondition = "VCREDIST_INSTALLED >= VCREDIST_REQUIRED",
 					InstallCommand = "/install /quiet /norestart /ChainingPackage \"[WixBundleName]\"",
-					/* I don't think this has anything to do with compression.
-					 * A true value means the exe is "embedded", false means its "external".
-					 * Since this is a download, it is not embedded in the bundle. */
-					Compressed = false,
-					/* By default, if the installer does not have an internet connection, the download
-					 * will fail and the entire install will fail. Setting Vital to false means that
-					 * the install for the redistributables can fail silently and Mumble's install
-					 * will continue. */
-					Vital = false,
+					/* A true value means the exe is "embedded", false means its downloaded at install time 
+					 * using the URL at the `DownloadUrl` property on this object. */
+					Compressed = true,
 					/* Permanent just means it won't uninstall this when uninstalling Mumble.
 					 * This will still show up in Add/Remove Programs and can be removed there,
 					 * even when Permanent is true. */

--- a/installer/MumbleInstall.cs
+++ b/installer/MumbleInstall.cs
@@ -4,7 +4,12 @@
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.
 
 using System;
+using System.Xml;
+using System.Xml.Linq;
+using System.Collections.Generic;
 using WixSharp;
+using WixSharp.Bootstrapper;
+using WixSharp.CommonTasks;
 
 // base class with info across installers
 public class MumbleInstall : Project {
@@ -23,5 +28,71 @@ public class MumbleInstall : Project {
 		this.ControlPanelInfo.ProductIcon = @"..\icons\mumble.ico";
 		this.ControlPanelInfo.UrlInfoAbout = "https://mumble.info";
 		this.Properties = new Property[] { allUsersProp };
+	}
+
+	public Bundle BundleMsi(string msiPath) {
+		var bootstrapper = new Bundle(
+				this.Name,
+				new MsiPackage(msiPath)
+				{ },
+				new ExePackage()
+				{
+					Id = "VCREDIST_EXE",
+					Name = "VC_redist.x64.exe",
+					SourceFile = @"..\VC_redist.x64.exe",
+					DisplayName = "Microsoft Visual C++ 2015-2022 Redistributable (x64)",
+					/* I couldn't find a page from Microsoft that lists permalinks to particular versions
+					 * of the redistributables. I could only find a link that redirects you to a link for
+					 * the latest redistributable version. The page is at [1] and the link is [2].
+					 *
+					 * The VC_redist.x64.exe downloaded from the `DownloadUrl` value below should be
+					 * placed in the build/installer/client folder, since WixSharp will use the file
+					 * to include a hash in the installer to verify the download at the time of install.
+					 *
+					 * The URL in DownloadUrl is for version 14.42.34438.0
+					 *
+					 * [1] https://learn.microsoft.com/en-us/cpp/windows/latest-supported-vc-redist?view=msvc-170#latest-microsoft-visual-c-redistributable-version
+					 * [2] https://aka.ms/vs/17/release/vc_redist.x64.exe */
+					DownloadUrl = "https://download.visualstudio.microsoft.com/download/pr/285b28c7-3cf9-47fb-9be8-01cf5323a8df/8F9FB1B3CFE6E5092CF1225ECD6659DAB7CE50B8BF935CB79BFEDE1F3C895240/VC_redist.x64.exe",
+					/* This condition being true should mean that it is already installed. */
+					DetectCondition = "VCREDIST_INSTALLED >= VCREDIST_REQUIRED",
+					InstallCommand = "/install /quiet /norestart /ChainingPackage \"[WixBundleName]\"",
+					/* I don't think this has anything to do with compression.
+					 * A true value means the exe is "embedded", false means its "external".
+					 * Since this is a download, it is not embedded in the bundle. */
+					Compressed = false,
+					/* By default, if the installer does not have an internet connection, the download
+					 * will fail and the entire install will fail. Setting Vital to false means that
+					 * if the install for the redistributables can fail silently and Mumble's install
+					 * will continue. */
+					Vital = false,
+					/* Permanent just means it won't uninstall this when uninstalling Mumble.
+					 * This will still show up in Add/Remove Programs and can be removed there,
+					 * even when Permanent is true. */
+					Permanent = true,
+				});
+		bootstrapper.Variables = new[] {
+				new Variable("VCREDIST_REQUIRED", "14.0.0.0")
+				{ Type = WixSharp.VariableType.version }
+				};
+		// Visual C++ 14 2015-2022 Redistributable (x64)
+		bootstrapper.AddWixFragment(
+				"Wix/Bundle",
+				new UtilProductSearch
+				{
+					UpgradeCode = "{36F68A90-239C-34DF-B58C-64B30153CE35}",
+					Variable = "VCREDIST_INSTALLED"
+				});
+
+		bootstrapper.SetVersionFromFile(msiPath);
+		bootstrapper.UpgradeCode = this.UpgradeCode ?? Guid.Empty;
+		/* The options UI allows specifying an alternate install path,
+		 * SuppressOptionsUI hides the button for that screen. */
+		bootstrapper.Application.SuppressOptionsUI = true;
+		bootstrapper.Application.LicensePath = @"..\..\licenses\Mumble.rtf";
+		bootstrapper.Application.LogoFile = @"..\dlgbmp.bmp";
+		bootstrapper.Application.ThemeFile = @"..\Theme.xml";
+		bootstrapper.Include(WixExtension.Util);
+		return bootstrapper;
 	}
 }

--- a/installer/MumbleInstall.cs
+++ b/installer/MumbleInstall.cs
@@ -31,7 +31,7 @@ public class MumbleInstall : Project {
 		this.Properties = new Property[] { allUsersProp };
 	}
 
-	public Bundle BundleMsi(string msiPath, string vcRedistUrl) {
+	public Bundle BundleMsi(string msiPath, string vcRedistUrl, string vcRedistRequired) {
 		var bootstrapper = new Bundle(
 				this.Name,
 				new MsiPackage(msiPath)
@@ -64,7 +64,9 @@ public class MumbleInstall : Project {
 					Permanent = true,
 				});
 		bootstrapper.Variables = new[] {
-				new Variable("VCREDIST_REQUIRED", "14.0.0.0")
+				/* Version.ToString() is here to validating the input when the installer is built.
+				 * Otherwise, the installer can fail silently at runtime and that'harder to debug. */
+				new Variable("VCREDIST_REQUIRED", new Version(vcRedistRequired).ToString())
 				{ Type = WixSharp.VariableType.version }
 				};
 		// Visual C++ 14 2015-2022 Redistributable (x64)

--- a/installer/ServerInstaller.cs
+++ b/installer/ServerInstaller.cs
@@ -85,6 +85,7 @@ class BuildInstaller
 	public static void Main(string[] args) {
 		string version = "";
 		string arch = "";
+		string vcRedistUrl = "";
 		bool isAllLangs = false;
 
 		for (int i = 0; i < args.Length; i++) {
@@ -99,6 +100,10 @@ class BuildInstaller
 			if (args[i] == "--all-languages") {
 				isAllLangs = true;
 			}
+
+			if (args[i] == "--vc-redist-url") {
+				vcRedistUrl = args[i + 1];
+			}
 		}
 
 		if (version != null && arch != null) {
@@ -109,7 +114,7 @@ class BuildInstaller
 			            ? srvInstaller.BuildMultilanguageMsi()
 			            : srvInstaller.BuildMsi();
 
-			srvInstaller.BundleMsi(msiPath)
+			srvInstaller.BundleMsi(msiPath, vcRedistUrl)
 			            .Build(msiPath.PathChangeExtension(".exe"));
 
 		} else {

--- a/installer/ServerInstaller.cs
+++ b/installer/ServerInstaller.cs
@@ -105,11 +105,13 @@ class BuildInstaller
 			var srvInstaller = new ServerInstaller(version, arch);
 			srvInstaller.Version = new Version(version);
 
-			if (isAllLangs) {
-				srvInstaller.BuildMultilanguageMsi();
-			} else {
-				srvInstaller.BuildMsi();
-			}
+			var msiPath = isAllLangs
+			            ? srvInstaller.BuildMultilanguageMsi()
+			            : srvInstaller.BuildMsi();
+
+			srvInstaller.BundleMsi(msiPath)
+			            .Build(msiPath.PathChangeExtension(".exe"));
+
 		} else {
 			Console.WriteLine("ERROR - Values for arch or version are null or incorrect!");
 			Environment.ExitCode = 0xA0; // Bad argument

--- a/installer/ServerInstaller.cs
+++ b/installer/ServerInstaller.cs
@@ -86,6 +86,7 @@ class BuildInstaller
 		string version = "";
 		string arch = "";
 		string vcRedistUrl = "";
+		string vcRedistRequired = "";
 		bool isAllLangs = false;
 
 		for (int i = 0; i < args.Length; i++) {
@@ -104,6 +105,10 @@ class BuildInstaller
 			if (args[i] == "--vc-redist-url") {
 				vcRedistUrl = args[i + 1];
 			}
+
+			if (args[i] == "--vc-redist-required") {
+				vcRedistRequired = args[i + 1];
+			}
 		}
 
 		if (version != null && arch != null) {
@@ -114,7 +119,7 @@ class BuildInstaller
 			            ? srvInstaller.BuildMultilanguageMsi()
 			            : srvInstaller.BuildMsi();
 
-			srvInstaller.BundleMsi(msiPath, vcRedistUrl)
+			srvInstaller.BundleMsi(msiPath, vcRedistUrl, vcRedistRequired)
 			            .Build(msiPath.PathChangeExtension(".exe"));
 
 		} else {

--- a/installer/ServerInstaller.cs
+++ b/installer/ServerInstaller.cs
@@ -85,7 +85,6 @@ class BuildInstaller
 	public static void Main(string[] args) {
 		string version = "";
 		string arch = "";
-		string vcRedistUrl = "";
 		string vcRedistRequired = "";
 		bool isAllLangs = false;
 
@@ -102,10 +101,6 @@ class BuildInstaller
 				isAllLangs = true;
 			}
 
-			if (args[i] == "--vc-redist-url") {
-				vcRedistUrl = args[i + 1];
-			}
-
 			if (args[i] == "--vc-redist-required") {
 				vcRedistRequired = args[i + 1];
 			}
@@ -119,7 +114,7 @@ class BuildInstaller
 			            ? srvInstaller.BuildMultilanguageMsi()
 			            : srvInstaller.BuildMsi();
 
-			srvInstaller.BundleMsi(msiPath, vcRedistUrl, vcRedistRequired)
+			srvInstaller.BundleMsi(msiPath, vcRedistRequired)
 			            .Build(msiPath.PathChangeExtension(".exe"));
 
 		} else {

--- a/installer/Theme.xml
+++ b/installer/Theme.xml
@@ -1,0 +1,82 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Copyright (c) .NET Foundation and contributors. All rights reserved. Licensed under the Microsoft Reciprocal License. See LICENSE.TXT file in the project root for full license information. -->
+
+<!-- modified RtfLargeTheme -->
+<Theme xmlns="http://wixtoolset.org/schemas/thmutil/2010">
+  <Window Width="680" Height="420" HexStyle="100a0000" FontId="0">#(loc.Caption)</Window>
+    <Font Id="0" Height="-12" Weight="500" Foreground="000000" Background="FFFFFF">Segoe UI</Font>
+    <Font Id="1" Height="-24" Weight="500" Foreground="000000">Segoe UI</Font>
+    <Font Id="2" Height="-22" Weight="500" Foreground="666666">Segoe UI</Font>
+    <Font Id="3" Height="-12" Weight="500" Foreground="000000" Background="FFFFFF">Segoe UI</Font>
+    <Font Id="4" Height="-12" Weight="500" Foreground="ff0000" Background="FFFFFF" Underline="yes">Segoe UI</Font>
+
+    <Image X="0" Y="0" Width="164" Height="312" ImageFile="logo.png" Visible="yes"/>
+    <Text X="177" Y="11" Width="-11" Height="64" FontId="1" Visible="yes" DisablePrefix="yes">#(loc.Title)</Text>
+
+    <Page Name="Help">
+        <Text X="177" Y="80" Width="-11" Height="30" FontId="2" DisablePrefix="yes">#(loc.HelpHeader)</Text>
+        <Text X="177" Y="112" Width="-11" Height="-35" FontId="3" DisablePrefix="yes">#(loc.HelpText)</Text>
+        <Button Name="HelpCancelButton" X="-11" Y="-11" Width="75" Height="23" TabStop="yes" FontId="0">#(loc.HelpCloseButton)</Button>
+    </Page>
+    <Page Name="Install">
+        <Richedit Name="EulaRichedit" X="177" Y="64" Width="-12" Height="-76" TabStop="yes" FontId="0" />
+        <Text Name="InstallVersion" X="177" Y="-41" Width="210" Height="17" FontId="3" DisablePrefix="yes" HideWhenDisabled="yes">#(loc.InstallVersion)</Text>
+        <Checkbox Name="EulaAcceptCheckbox" X="-11" Y="-41" Width="260" Height="17" TabStop="yes" FontId="3" HideWhenDisabled="yes">#(loc.InstallAcceptCheckbox)</Checkbox>
+        <Button Name="OptionsButton" X="-171" Y="-11" Width="75" Height="23" TabStop="yes" FontId="0" HideWhenDisabled="yes">#(loc.InstallOptionsButton)</Button>
+        <Button Name="InstallButton" X="-91" Y="-11" Width="75" Height="23" TabStop="yes" FontId="0">#(loc.InstallInstallButton)</Button>
+        <Button Name="WelcomeCancelButton" X="-11" Y="-11" Width="75" Height="23" TabStop="yes" FontId="0">#(loc.InstallCloseButton)</Button>
+    </Page>
+    <Page Name="Options">
+        <Text X="177" Y="80" Width="-11" Height="30" FontId="2" DisablePrefix="yes">#(loc.OptionsHeader)</Text>
+        <Text X="177" Y="121" Width="-11" Height="17" FontId="3" DisablePrefix="yes">#(loc.OptionsLocationLabel)</Text>
+        <Editbox Name="FolderEditbox" X="177" Y="143" Width="-91" Height="21" TabStop="yes" FontId="3" FileSystemAutoComplete="yes" />
+        <Button Name="BrowseButton" X="-11" Y="142" Width="75" Height="23" TabStop="yes" FontId="3">#(loc.OptionsBrowseButton)</Button>
+        <Button Name="OptionsOkButton" X="-91" Y="-11" Width="75" Height="23" TabStop="yes" FontId="0">#(loc.OptionsOkButton)</Button>
+        <Button Name="OptionsCancelButton" X="-11" Y="-11" Width="75" Height="23" TabStop="yes" FontId="0">#(loc.OptionsCancelButton)</Button>
+    </Page>
+    <Page Name="FilesInUse">
+      <Text X="177" Y="80" Width="-11" Height="30" FontId="2" DisablePrefix="yes">#(loc.FilesInUseHeader)</Text>
+      <Text X="177" Y="121" Width="-11" Height="34" FontId="3" DisablePrefix="yes">#(loc.FilesInUseLabel)</Text>
+      <Text Name="FilesInUseText" X="177" Y="150" Width="-11" Height="-86" FontId="3" DisablePrefix="yes" HexStyle="0x0000000C">A</Text>
+
+      <Button Name="FilesInUseCloseRadioButton" X="177" Y="-60" Width="-11" Height="23" TabStop="yes" FontId="0" HideWhenDisabled="yes" HexStyle="0x000009">#(loc.FilesInUseCloseRadioButton)</Button>
+      <Button Name="FilesInUseDontCloseRadioButton" X="177" Y="-40" Width="-11" Height="23" TabStop="yes" FontId="0" HideWhenDisabled="yes" HexStyle="0x000009">#(loc.FilesInUseDontCloseRadioButton)</Button>
+
+      <Button Name="FilesInUseOkButton" X="-91" Y="-11" Width="75" Height="23" TabStop="yes" FontId="0" HideWhenDisabled="yes">#(loc.FilesInUseOkButton)</Button>
+      <Button Name="FilesInUseCancelButton" X="-11" Y="-11" Width="75" Height="23" TabStop="yes" FontId="0">#(loc.FilesInUseCancelButton)</Button>
+    </Page>
+    <Page Name="Progress">
+        <Text X="177" Y="80" Width="-11" Height="30" FontId="2" DisablePrefix="yes">#(loc.ProgressHeader)</Text>
+        <Text X="177" Y="121" Width="70" Height="17" FontId="3" DisablePrefix="yes">#(loc.ProgressLabel)</Text>
+        <Text Name="OverallProgressPackageText" X="177" Y="121" Width="-11" Height="17" FontId="3" DisablePrefix="yes">#(loc.OverallProgressPackageText)</Text>
+        <Progressbar Name="OverallCalculatedProgressbar" X="177" Y="143" Width="-11" Height="15" />
+        <Button Name="ProgressCancelButton" X="-11" Y="-11" Width="75" Height="23" TabStop="yes" FontId="0">#(loc.ProgressCancelButton)</Button>
+    </Page>
+    <Page Name="Modify">
+        <Text X="177" Y="80" Width="-11" Height="30" FontId="2" DisablePrefix="yes">#(loc.ModifyHeader)</Text>
+        <Button Name="RepairButton" X="-171" Y="-11" Width="75" Height="23" TabStop="yes" FontId="0" HideWhenDisabled="yes">#(loc.ModifyRepairButton)</Button>
+        <Button Name="UninstallButton" X="-91" Y="-11" Width="75" Height="23" TabStop="yes" FontId="0">#(loc.ModifyUninstallButton)</Button>
+        <Button Name="ModifyCancelButton" X="-11" Y="-11" Width="75" Height="23" TabStop="yes" FontId="0">#(loc.ModifyCloseButton)</Button>
+    </Page>
+    <Page Name="Success">
+        <Text Name="SuccessHeader" X="177" Y="80"  Width="-11" Height="30" FontId="2" HideWhenDisabled="yes" DisablePrefix="yes">#(loc.SuccessHeader)</Text>
+        <Text Name="SuccessInstallHeader" X="177" Y="80" Width="-11" Height="30" FontId="2" HideWhenDisabled="yes" DisablePrefix="yes">#(loc.SuccessInstallHeader)</Text>
+        <Text Name="SuccessRepairHeader" X="177" Y="80" Width="-11" Height="30" FontId="2" HideWhenDisabled="yes" DisablePrefix="yes">#(loc.SuccessRepairHeader)</Text> 	
+        <Text Name="SuccessUninstallHeader" X="177" Y="80" Width="-11" Height="30" FontId="2" HideWhenDisabled="yes" DisablePrefix="yes">#(loc.SuccessUninstallHeader)</Text> 
+        <Button Name="LaunchButton" X="-91" Y="-11" Width="75" Height="23" TabStop="yes" FontId="0" HideWhenDisabled="yes">#(loc.SuccessLaunchButton)</Button>
+        <Text Name="SuccessRestartText" X="-11" Y="-51" Width="400" Height="34" FontId="3" HideWhenDisabled="yes" DisablePrefix="yes">#(loc.SuccessRestartText)</Text>
+        <Button Name="SuccessRestartButton" X="-91" Y="-11" Width="75" Height="23" TabStop="yes" FontId="0" HideWhenDisabled="yes">#(loc.SuccessRestartButton)</Button>
+        <Button Name="SuccessCancelButton" X="-11" Y="-11" Width="75" Height="23" TabStop="yes" FontId="0">#(loc.SuccessCloseButton)</Button>
+    </Page>
+    <Page Name="Failure">
+        <Text Name="FailureHeader" X="177" Y="80" Width="-11" Height="30" FontId="2" HideWhenDisabled="yes" DisablePrefix="yes">#(loc.FailureHeader)</Text>
+        <Text Name="FailureInstallHeader" X="177" Y="80" Width="-11" Height="30" FontId="2" HideWhenDisabled="yes" DisablePrefix="yes">#(loc.FailureInstallHeader)</Text>
+        <Text Name="FailureUninstallHeader" X="177" Y="80" Width="-11" Height="30" FontId="2" HideWhenDisabled="yes" DisablePrefix="yes">#(loc.FailureUninstallHeader)</Text>
+        <Text Name="FailureRepairHeader" X="177" Y="80" Width="-11" Height="30" FontId="2" HideWhenDisabled="yes" DisablePrefix="yes">#(loc.FailureRepairHeader)</Text>		
+        <Hypertext Name="FailureLogFileLink" X="177" Y="121" Width="-11" Height="42" FontId="3" TabStop="yes" HideWhenDisabled="yes">#(loc.FailureHyperlinkLogText)</Hypertext>
+        <Hypertext Name="FailureMessageText" X="22" Y="163" Width="-11" Height="51" FontId="3" TabStop="yes" HideWhenDisabled="yes" />
+        <Text Name="FailureRestartText" X="-11" Y="-51" Width="400" Height="34" FontId="3" HideWhenDisabled="yes" DisablePrefix="yes">#(loc.FailureRestartText)</Text>
+        <Button Name="FailureRestartButton" X="-91" Y="-11" Width="75" Height="23" TabStop="yes" FontId="0" HideWhenDisabled="yes">#(loc.FailureRestartButton)</Button>
+        <Button Name="FailureCloseButton" X="-11" Y="-11" Width="75" Height="23" TabStop="yes" FontId="0">#(loc.FailureCloseButton)</Button>
+    </Page>
+</Theme>

--- a/src/mumble/CMakeLists.txt
+++ b/src/mumble/CMakeLists.txt
@@ -1182,6 +1182,7 @@ if(packaging AND WIN32)
 		"--version" ${PROJECT_VERSION}
 		"--arch" "${MUMBLE_TARGET_ARCH}"
 		"--vc-redist-url" "${VC_REDIST_URL}"
+		"--vc-redist-required" "${VC_REDIST_VERSION}"
 	)
 
 	if(overlay)

--- a/src/mumble/CMakeLists.txt
+++ b/src/mumble/CMakeLists.txt
@@ -1181,7 +1181,6 @@ if(packaging AND WIN32)
 	list(APPEND installer_vars
 		"--version" ${PROJECT_VERSION}
 		"--arch" "${MUMBLE_TARGET_ARCH}"
-		"--vc-redist-url" "${VC_REDIST_URL}"
 		"--vc-redist-required" "${VC_REDIST_VERSION}"
 	)
 

--- a/src/mumble/CMakeLists.txt
+++ b/src/mumble/CMakeLists.txt
@@ -1181,6 +1181,7 @@ if(packaging AND WIN32)
 	list(APPEND installer_vars
 		"--version" ${PROJECT_VERSION}
 		"--arch" "${MUMBLE_TARGET_ARCH}"
+		"--vc-redist-url" "${VC_REDIST_URL}"
 	)
 
 	if(overlay)

--- a/src/murmur/CMakeLists.txt
+++ b/src/murmur/CMakeLists.txt
@@ -294,7 +294,6 @@ if(packaging)
 		list(APPEND installer_vars
 			"--version" ${PROJECT_VERSION}
 			"--arch" ${MUMBLE_TARGET_ARCH}
-			"--vc-redist-url" "${VC_REDIST_URL}"
 			"--vc-redist-required" "${VC_REDIST_VERSION}"
 		)
 

--- a/src/murmur/CMakeLists.txt
+++ b/src/murmur/CMakeLists.txt
@@ -294,6 +294,7 @@ if(packaging)
 		list(APPEND installer_vars
 			"--version" ${PROJECT_VERSION}
 			"--arch" ${MUMBLE_TARGET_ARCH}
+			"--vc-redist-url" "${VC_REDIST_URL}"
 		)
 
 		file(COPY

--- a/src/murmur/CMakeLists.txt
+++ b/src/murmur/CMakeLists.txt
@@ -295,6 +295,7 @@ if(packaging)
 			"--version" ${PROJECT_VERSION}
 			"--arch" ${MUMBLE_TARGET_ARCH}
 			"--vc-redist-url" "${VC_REDIST_URL}"
+			"--vc-redist-required" "${VC_REDIST_VERSION}"
 		)
 
 		file(COPY


### PR DESCRIPTION
After building each server and client msi, the installer script creates an exe bundle that includes a step to download and install the visual c++ redistributables.

re #5549 

This commit needs the redistrituables installer downloaded to `installer/VC_redist.x64.exe`. It includes a change in cmake to copy the file from there to the build directory. The wixsharp installer building stuff needs `VC_redist.x64.exe` when building the bundle, even though the file isn't embedded in the resulting exe.

I presume you would rather configure cmake download `VC_redist.x64.exe` or something instead of adding it to version control, so I didn't commit it.

I left some comments in the C# code to try to explain what is going on with the installer and how the Wix stuff works. Let me know if you have any other questions.

The way the bundle works in this commit is that it hides the UI from the .msi installer and just displays is own UI in its place. So the license and logo are copied in to the bundle UI and it ends up resembling the .msi a bit. Here's a screenshot of what to expect.

![image](https://github.com/user-attachments/assets/8112ac47-0b25-4ebf-9950-47fcc9ff355f)

### Checks

- [X] My commits follow the [commit guidelines](https://github.com/mumble-voip/mumble/blob/master/COMMIT_GUIDELINES.md)

