### PR TITLE
FIX(client): Multiple minor Fixes for pasting Images in Chat

### DIFF
--- a/src/mumble/CustomElements.h
+++ b/src/mumble/CustomElements.h
@@ -49,6 +49,7 @@ protected:
 	QSize minimumSizeHint() const Q_DECL_OVERRIDE;
 	QSize sizeHint() const Q_DECL_OVERRIDE;
 	void resizeEvent(QResizeEvent *e) Q_DECL_OVERRIDE;
+	bool canInsertFromMimeData(const QMimeData *source) const Q_DECL_OVERRIDE;
 	void insertFromMimeData(const QMimeData *source) Q_DECL_OVERRIDE;
 	bool sendImagesFromMimeData(const QMimeData *source);
 	bool emitPastedImage(QImage image);

--- a/src/mumble/RichTextEditor.cpp
+++ b/src/mumble/RichTextEditor.cpp
@@ -238,28 +238,18 @@ void RichTextEditor::on_qaLink_triggered() {
 }
 
 void RichTextEditor::on_qaImage_triggered() {
-	QPair< QByteArray, QImage > choice = Global::get().mw->openImageFile();
-
-	QByteArray &qba = choice.first;
-
-	if (qba.isEmpty())
+	QImage img = Global::get().mw->openImageFile().second;
+	if (img.isNull()) {
 		return;
-
-	if ((Global::get().uiImageLength > 0)
-		&& (static_cast< unsigned int >(qba.length()) > Global::get().uiImageLength)) {
+	}
+	QString processedImage = Log::imageToImg(img, static_cast< int >(Global::get().uiImageLength));
+	if (processedImage.length() > 0) {
+		qteRichText->insertHtml(processedImage);
+	} else {
 		QMessageBox::warning(this, tr("Failed to load image"),
 							 tr("Image file too large to embed in document. Please use images smaller than %1 kB.")
 								 .arg(Global::get().uiImageLength / 1024));
-		return;
 	}
-
-	QBuffer qb(&qba);
-	qb.open(QIODevice::ReadOnly);
-
-	QByteArray format = QImageReader::imageFormat(&qb);
-	qb.close();
-
-	qteRichText->insertHtml(Log::imageToImg(format, qba));
 }
 
 void RichTextEditor::onCurrentChanged(int index) {

--- a/src/mumble/RichTextEditor.cpp
+++ b/src/mumble/RichTextEditor.cpp
@@ -85,7 +85,7 @@ void RichTextHtmlEdit::insertFromMimeData(const QMimeData *source) {
 
 	if (source->hasImage()) {
 		QImage img   = qvariant_cast< QImage >(source->imageData());
-		QString html = Log::imageToImg(img);
+		QString html = Log::imageToImg(img, static_cast< int >(Global::get().uiImageLength));
 		if (!html.isEmpty())
 			insertHtml(html);
 		return;


### PR DESCRIPTION
This PR fixes three minor issues with copy and pasting images:

1. When pasting/dragging images to the chat was added in 3d2a196, limiting the size of images pasted in the RichTextEditor was removed.
I was used to send images via the RichTextEditor from old mumble versions (1.3.4 and earlier) and was very confused why sending images via that editor in newer versions would show `Denied: Text message too long.` errors. I guess the limit was removed by accident. This commit re-enables the limit to correctly reduce the size of limit exceeding images again.
2. Previously, images inserted using the GUI-Button in the RichTextEditor were rejected when they exceeded the size limit.
(The button, which opens a file dialog to choose an image.)
With this PR images will be resized and converted to 'jpeg' format like images pasted in the chat bar.
3. The "Paste" option in the context menu of the Chatbar will be enabled when an image is in the clipboard
Also removes the Paste & Send option in this case, because images are always send immediately.
Fixes that no additional empty message is sent when the Paste & Send shortcut (Ctrl+Shift+V) is used with an image in the clipboard.