### PR TITLE
FEAT(client): Resize images opened with UI-Button

### DIFF
--- a/src/mumble/RichTextEditor.cpp
+++ b/src/mumble/RichTextEditor.cpp
@@ -238,28 +238,15 @@ void RichTextEditor::on_qaLink_triggered() {
 }
 
 void RichTextEditor::on_qaImage_triggered() {
-	QPair< QByteArray, QImage > choice = Global::get().mw->openImageFile();
-
-	QByteArray &qba = choice.first;
-
-	if (qba.isEmpty())
-		return;
-
-	if ((Global::get().uiImageLength > 0)
-		&& (static_cast< unsigned int >(qba.length()) > Global::get().uiImageLength)) {
+	QImage img = Global::get().mw->openImageFile().second;
+	QString processedImage = Log::imageToImg(img, static_cast< int >(Global::get().uiImageLength));
+	if (processedImage.length() > 0) {
+		qteRichText->insertHtml(processedImage);
+	} else {
 		QMessageBox::warning(this, tr("Failed to load image"),
 							 tr("Image file too large to embed in document. Please use images smaller than %1 kB.")
 								 .arg(Global::get().uiImageLength / 1024));
-		return;
 	}
-
-	QBuffer qb(&qba);
-	qb.open(QIODevice::ReadOnly);
-
-	QByteArray format = QImageReader::imageFormat(&qb);
-	qb.close();
-
-	qteRichText->insertHtml(Log::imageToImg(format, qba));
 }
 
 void RichTextEditor::onCurrentChanged(int index) {


### PR DESCRIPTION
Previously, images inserted using the GUI-Button in the RichTextEditor were rejected when they exceeded the size limit.
(The button, which opens a file dialog to choose an image.)

With this PR images will be resized and converted to 'jpeg' format like images pasted in the chat bar. I strongly suggest to accept this together with #6790 to achieve a consistent behavior when inserting or pasting images in the Mumble chat.