### PR TITLE
Backport "Merge PR #6790: FIX(client): Multiple minor Fixes for pasting Images in Chat" to 1.5.x

### DIFF
--- a/src/mumble/CustomElements.h
+++ b/src/mumble/CustomElements.h
@@ -49,6 +49,7 @@ protected:
 	QSize minimumSizeHint() const Q_DECL_OVERRIDE;
 	QSize sizeHint() const Q_DECL_OVERRIDE;
 	void resizeEvent(QResizeEvent *e) Q_DECL_OVERRIDE;
+	bool canInsertFromMimeData(const QMimeData *source) const Q_DECL_OVERRIDE;
 	void insertFromMimeData(const QMimeData *source) Q_DECL_OVERRIDE;
 	bool sendImagesFromMimeData(const QMimeData *source);
 	bool emitPastedImage(QImage image);

--- a/src/mumble/RichTextEditor.cpp
+++ b/src/mumble/RichTextEditor.cpp
@@ -84,7 +84,7 @@ void RichTextHtmlEdit::insertFromMimeData(const QMimeData *source) {
 
 	if (source->hasImage()) {
 		QImage img   = qvariant_cast< QImage >(source->imageData());
-		QString html = Log::imageToImg(img);
+		QString html = Log::imageToImg(img, static_cast< int >(Global::get().uiImageLength));
 		if (!html.isEmpty())
 			insertHtml(html);
 		return;

--- a/src/mumble/RichTextEditor.cpp
+++ b/src/mumble/RichTextEditor.cpp
@@ -237,28 +237,18 @@ void RichTextEditor::on_qaLink_triggered() {
 }
 
 void RichTextEditor::on_qaImage_triggered() {
-	QPair< QByteArray, QImage > choice = Global::get().mw->openImageFile();
-
-	QByteArray &qba = choice.first;
-
-	if (qba.isEmpty())
+	QImage img = Global::get().mw->openImageFile().second;
+	if (img.isNull()) {
 		return;
-
-	if ((Global::get().uiImageLength > 0)
-		&& (static_cast< unsigned int >(qba.length()) > Global::get().uiImageLength)) {
+	}
+	QString processedImage = Log::imageToImg(img, static_cast< int >(Global::get().uiImageLength));
+	if (processedImage.length() > 0) {
+		qteRichText->insertHtml(processedImage);
+	} else {
 		QMessageBox::warning(this, tr("Failed to load image"),
 							 tr("Image file too large to embed in document. Please use images smaller than %1 kB.")
 								 .arg(Global::get().uiImageLength / 1024));
-		return;
 	}
-
-	QBuffer qb(&qba);
-	qb.open(QIODevice::ReadOnly);
-
-	QByteArray format = QImageReader::imageFormat(&qb);
-	qb.close();
-
-	qteRichText->insertHtml(Log::imageToImg(format, qba));
 }
 
 void RichTextEditor::onCurrentChanged(int index) {


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `1.5.x`:
 - [Merge PR #6790: FIX(client): Multiple minor Fixes for pasting Images in Chat](https://github.com/mumble-voip/mumble/pull/6790)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)