### PR TITLE
DOCS: Deletes a duplicated bundled-json CMake option

### DIFF
--- a/docs/dev/build-instructions/cmake_options.md
+++ b/docs/dev/build-instructions/cmake_options.md
@@ -44,11 +44,6 @@ Use the bundled GSL version instead of looking for one on the system
 Build the included version of nlohmann_json instead of looking for one on the system
 (Default: ON)
 
-### bundled-json
-
-Build the included version of nlohmann_json instead of looking for one on the system
-(Default: ON)
-
 ### bundled-rnnoise
 
 Build the included version of RNNoise instead of looking for one on the system.


### PR DESCRIPTION
### Checks

- [x] My commits follow the [commit guidelines](https://github.com/mumble-voip/mumble/blob/master/COMMIT_GUIDELINES.md)

