### PR TITLE
DOCS(man): Update Mumble manpage to add two new RPC commands

### DIFF
--- a/auxiliary_files/man_files/mumble.1
+++ b/auxiliary_files/man_files/mumble.1
@@ -89,6 +89,10 @@ Deafen self
 Undeafen self
 .IP \fBtoggledeaf\fR
 Toggle self-deafen status
+.IP \fBstarttalking\fR
+Start talking
+.IP \fBstoptalking\fR
+Stop talking
 .RE
 .SH SEE ALSO
 .BR mumble\-overlay (1),


### PR DESCRIPTION
From: https://sources.debian.org/src/mumble/1.5.735-4/debian/patches/15-update-mumble-manpage.diff/

Closes #6802