### PR TITLE
Backport "Merge PR #6809: DOCS(man): Update Mumble manpage to add two new RPC commands" to 1.5.x

### DIFF
--- a/auxiliary_files/man_files/mumble.1
+++ b/auxiliary_files/man_files/mumble.1
@@ -89,6 +89,10 @@ Deafen self
 Undeafen self
 .IP \fBtoggledeaf\fR
 Toggle self-deafen status
+.IP \fBstarttalking\fR
+Start talking
+.IP \fBstoptalking\fR
+Stop talking
 .RE
 .SH SEE ALSO
 .BR mumble\-overlay (1),


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `1.5.x`:
 - [Merge PR #6809: DOCS(man): Update Mumble manpage to add two new RPC commands](https://github.com/mumble-voip/mumble/pull/6809)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)