### PR TITLE
FEAT(client): Allow not saving passwords

### DIFF
--- a/src/mumble/NetworkConfig.ui
+++ b/src/mumble/NetworkConfig.ui
@@ -84,10 +84,10 @@
          <string>Don't send certificate to server and don't save passwords. (Not saved).</string>
         </property>
         <property name="whatsThis">
-         <string>&lt;b&gt;This will suppress identity information from the client.&lt;/b&gt;&lt;p&gt;The client will not identify itself with a certificate, even if defined, and will not cache passwords for connections. This is primarily a test-option and is not saved.&lt;/p&gt;</string>
+         <string>&lt;b&gt;This will suppress identity information from the client.&lt;/b&gt;&lt;p&gt;The client will not identify itself with a certificate, even if defined. This is primarily a test-option and is not saved.&lt;/p&gt;</string>
         </property>
         <property name="text">
-         <string>Suppress certificate and password storage</string>
+         <string>Suppress certificate information</string>
         </property>
        </widget>
       </item>

--- a/src/mumble/widgets/FailedConnectionDialog.cpp
+++ b/src/mumble/widgets/FailedConnectionDialog.cpp
@@ -24,6 +24,18 @@ FailedConnectionDialog::FailedConnectionDialog(ConnectDetails details, Connectio
 	userPasswordInput->setText(m_details.password);
 	serverPasswordInput->setText(m_details.password);
 
+	qcbSavePassword->setChecked(!Global::get().s.bSuppressIdentity);
+
+	if (!Global::get().db->isFavorite(m_details.host, m_details.port)) {
+		qcbSavePassword->setEnabled(false);
+		qcbSavePassword->setChecked(false);
+		QString warning        = tr("Unavailable because the server is not saved in favorites");
+		QString currentText    = qcbSavePassword->text();
+		QString accessibleText = currentText + " — " + warning;
+		qcbSavePassword->setAccessibleName(accessibleText);
+		qcbSavePassword->setToolTip(warning);
+	}
+
 	connectSignals();
 
 	switch (type) {
@@ -69,7 +81,7 @@ void FailedConnectionDialog::connectSignals() {
 }
 
 void FailedConnectionDialog::initiateReconnect() {
-	if (Global::get().db->isFavorite(m_details.host, m_details.port)) {
+	if (Global::get().db->isFavorite(m_details.host, m_details.port) && qcbSavePassword->isChecked()) {
 		Global::get().db->setPassword(m_details.host, m_details.port, m_details.username, m_details.password);
 	}
 

--- a/src/mumble/widgets/FailedConnectionDialog.cpp
+++ b/src/mumble/widgets/FailedConnectionDialog.cpp
@@ -69,7 +69,7 @@ void FailedConnectionDialog::connectSignals() {
 }
 
 void FailedConnectionDialog::initiateReconnect() {
-	if (!Global::get().s.bSuppressIdentity) {
+	if (Global::get().db->isFavorite(m_details.host, m_details.port)) {
 		Global::get().db->setPassword(m_details.host, m_details.port, m_details.username, m_details.password);
 	}
 

--- a/src/mumble/widgets/FailedConnectionDialog.ui
+++ b/src/mumble/widgets/FailedConnectionDialog.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>409</width>
+    <width>424</width>
     <height>314</height>
    </rect>
   </property>
@@ -240,6 +240,30 @@
       </layout>
      </widget>
     </widget>
+   </item>
+   <item>
+    <layout class="QHBoxLayout" name="horizontalLayout_2">
+     <item>
+      <spacer name="horizontalSpacer_3">
+       <property name="orientation">
+        <enum>Qt::Orientation::Horizontal</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>0</width>
+         <height>0</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
+     <item>
+      <widget class="QCheckBox" name="qcbSavePassword">
+       <property name="text">
+        <string>Save settings on this device</string>
+       </property>
+      </widget>
+     </item>
+    </layout>
    </item>
    <item>
     <layout class="QHBoxLayout" name="horizontalLayout">


### PR DESCRIPTION
When asked for a password, the user has the option to save or not save the password to the device. 
Implements #1087 

### Checks

- [x] My commits follow the [commit guidelines](https://github.com/mumble-voip/mumble/blob/master/COMMIT_GUIDELINES.md)