### PR TITLE
Documentation Updates

### DIFF
--- a/auxiliary_files/mumble-server.ini
+++ b/auxiliary_files/mumble-server.ini
@@ -10,6 +10,8 @@
 ;     * Make sure to escape special characters like '\' or '"' correctly
 ;        NOT variable = """ BUT variable = "\""
 ;        NOT regex = \w* BUT regex = \\w*
+; * Any property that may be different on a per-user basis will require the
+;   user to be registered to apply.
 
 ; When using SQLite: Path to database. If blank, will search for
 ;   mumble-server.sqlite in default locations or create it if not found.

--- a/docs/dev/build-instructions/README.md
+++ b/docs/dev/build-instructions/README.md
@@ -12,6 +12,25 @@ The first step in building Mumble is to clone this repository and all the submod
 
 _Tip:_ You can also [build a specific version or commit](faq.md#build-a-specific-version-or-commit) of Mumble.
 
+
+## Using the BUILD_NUMBER variable
+
+We are currently using a [versioning scheme](https://www.mumble.info/blog/new-versioning-scheme/) that monotonically increases
+the "build" or "patch" component of the version string. This build number is specified via cmake as a variable e.g. ``-DBUILD_NUMBER=123``.
+Since we are exposing the complete version string in the Mumble UI as well as over the network protocol, it would be nice if the ``BUILD_NUMBER``
+variable is set correctly when building the binaries. This is especially relevant for **distribution package maintainers**.
+If not specified, the version string will end in ``.0``. This is also fine and not break anything, but it will be harder for
+us to determine the version of Mumble in bug reports and usage statistics.
+
+There exists a mapping between commit hash and ``BUILD_NUMBER``. If a ``BUILD_NUMBER`` exists for a given commit, it can be
+retrieved from our website by requesting ``https://mumble.info/get-build-number?commit=<commit_hash>&version=<mumble_version>``
+where ``<mumble_version>`` refers to the major and minor version of Mumble you are building e.g. ``1.6``. If there is no ``BUILD_NUMBER``
+for a given commit, feel free to fallback to ``0``. There is also a [Python script](/scripts/mumble-build-number.py) which can be used
+to perform this HTTP request automatically.
+
+
+## Specific Instructions
+
 In order to actually build Mumble, you can follow one of the following instruction sets:
 - [Build on Windows](build_windows.md)
 - [Build on Linux](build_linux.md)

--- a/docs/dev/build-instructions/build_macos.md
+++ b/docs/dev/build-instructions/build_macos.md
@@ -13,7 +13,7 @@ Once homebrew is installed, you can run the following command to install all req
 brew update && brew install \
   cmake \
   pkg-config \
-  qt5 \
+  qt6 \
   boost \
   libogg \
   libvorbis \

--- a/scripts/updatetranslations.py
+++ b/scripts/updatetranslations.py
@@ -11,7 +11,7 @@
 # * lupdate to update translation strings
 # * Commit the resulting translation file
 #
-# Requires qt5 ; sudo apt-get install libqt5-dev
+# Requires Qt "lupdate" binary; check build requirements
 
 import os, glob, logging, sys, subprocess, re
 import argparse

--- a/scripts/updatetranslations.py
+++ b/scripts/updatetranslations.py
@@ -23,7 +23,7 @@ def FindLupdate(vcpkg_triplet: Optional[str] = None) -> Optional[str]:
     if which('lupdate') is not None:
         return 'lupdate'
     if vcpkg_triplet is not None:
-        vcpkgbin = os.path.join(os.path.expanduser('~'), 'vcpkg', 'installed', vcpkg_triplet, 'tools', 'qt5', 'bin')
+        vcpkgbin = os.path.join(os.path.expanduser('~'), 'vcpkg', 'installed', vcpkg_triplet, 'tools', 'qt6', 'bin')
         logging.debug('Looking for lupdate in %s…', vcpkgbin)
         return which('lupdate', path=vcpkgbin)
     return None


### PR DESCRIPTION
* ``qt5`` -> ``qt6`` in build_macos (Thanks @maxer137 )
* Mention and explain ``BUILD_NUMBER`` in build_linux
* Remove specific Qt version in updatetranslations.py documentation
* Bump qt5 -> qt6 in updatetranslations.py code
* ``rememberchannel`` only applies to registered users