### PR TITLE
CHANGE(client): Changed client-side max image width and height

### DIFF
--- a/src/mumble/Log.cpp
+++ b/src/mumble/Log.cpp
@@ -607,8 +607,8 @@ QString Log::imageToImg(const QByteArray &format, const QByteArray &image) {
 }
 
 QString Log::imageToImg(QImage img, int maxSize) {
-	constexpr int MAX_WIDTH  = 600;
-	constexpr int MAX_HEIGHT = 400;
+	constexpr int MAX_WIDTH  = 1600;
+	constexpr int MAX_HEIGHT = 1000;
 
 	if ((img.width() > MAX_WIDTH) || (img.height() > MAX_HEIGHT)) {
 		img = img.scaled(MAX_WIDTH, MAX_HEIGHT, Qt::KeepAspectRatio, Qt::SmoothTransformation);


### PR DESCRIPTION
Expanded on change from 420x270 to 800x600 in #5029.  Small image details such as text are illegible on 600x400 images. 3000x2000 is just an example that keeps the 3:2 aspect ratio but it is a bit excessive, though I believe that the limit shouldn't be lower than 1440p due to the prevalence of higher resolution screens. 

This is a band-aid solution until/if proper file management is implemented, but for the meantime it should make image support a lot more useful.
