### PR TITLE
Backport "Merge PR #6825: CHANGE(client): Changed client-side max image width and height" to 1.5.x

### DIFF
--- a/src/mumble/Log.cpp
+++ b/src/mumble/Log.cpp
@@ -605,8 +605,8 @@ QString Log::imageToImg(const QByteArray &format, const QByteArray &image) {
 }
 
 QString Log::imageToImg(QImage img, int maxSize) {
-	constexpr int MAX_WIDTH  = 600;
-	constexpr int MAX_HEIGHT = 400;
+	constexpr int MAX_WIDTH  = 1600;
+	constexpr int MAX_HEIGHT = 1000;
 
 	if ((img.width() > MAX_WIDTH) || (img.height() > MAX_HEIGHT)) {
 		img = img.scaled(MAX_WIDTH, MAX_HEIGHT, Qt::KeepAspectRatio, Qt::SmoothTransformation);


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `1.5.x`:
 - [Merge PR #6825: CHANGE(client): Changed client-side max image width and height](https://github.com/mumble-voip/mumble/pull/6825)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)