### PR TITLE
Backport "Merge PR #6832: FIX(client): Shortcut data not being saved" to 1.5.x

### DIFF
--- a/src/mumble/Settings.h
+++ b/src/mumble/Settings.h
@@ -579,4 +579,10 @@ private:
 	QString findSettingsLocation(bool legacy = false, bool *foundExistingFile = nullptr) const;
 };
 
+QDataStream &operator<<(QDataStream &qds, const ChannelTarget &target);
+QDataStream &operator>>(QDataStream &qds, ChannelTarget &target);
+
+QDataStream &operator<<(QDataStream &qds, const ShortcutTarget &st);
+QDataStream &operator>>(QDataStream &qds, ShortcutTarget &st);
+
 #endif // MUMBLE_MUMBLE_SETTINGS_H_


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `1.5.x`:
 - [Merge PR #6832: FIX(client): Shortcut data not being saved](https://github.com/mumble-voip/mumble/pull/6832)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)