### PR TITLE
FIX(client): Add more key events to local volume adjustment slider

### DIFF
--- a/src/mumble/VolumeSliderWidgetAction.cpp
+++ b/src/mumble/VolumeSliderWidgetAction.cpp
@@ -24,8 +24,9 @@ VolumeSliderWidgetAction::VolumeSliderWidgetAction(QWidget *parent)
 	m_label->setStyleSheet("QLabel { margin-left: 0px; padding: 0px; }");
 	m_volumeSlider->setStyleSheet("QSlider { margin-right: 0px; }");
 
-	KeyEventObserver *keyEventFilter =
-		new KeyEventObserver(this, QEvent::KeyRelease, false, { Qt::Key_Left, Qt::Key_Right });
+	KeyEventObserver *keyEventFilter = new KeyEventObserver(
+		this, QEvent::KeyRelease, false,
+		{ Qt::Key_Left, Qt::Key_Right, Qt::Key_Home, Qt::Key_End, Qt::Key_PageUp, Qt::Key_PageDown });
 	m_volumeSlider->installEventFilter(keyEventFilter);
 
 	// The list of wheel events observed seems odd at first. We have to check for multiple


### PR DESCRIPTION
I went through the entire application looking for places where KP_BEGIN or KP_END would cause trouble for keyboard navigation and screen readers.

This is the only place that I found. I suspect that other reports of apparent bugs were caused by buggy versions of Orca which have since been fixed and are out of our control.

Closes #6479 