### PR TITLE
Backport "Merge PR #6841: FIX(client): Add more key events to local volume adjustment slider" to 1.5.x

### DIFF
--- a/src/mumble/VolumeSliderWidgetAction.cpp
+++ b/src/mumble/VolumeSliderWidgetAction.cpp
@@ -24,8 +24,9 @@ VolumeSliderWidgetAction::VolumeSliderWidgetAction(QWidget *parent)
 	m_label->setStyleSheet("QLabel { margin-left: 0px; padding: 0px; }");
 	m_volumeSlider->setStyleSheet("QSlider { margin-right: 0px; }");
 
-	KeyEventObserver *keyEventFilter =
-		new KeyEventObserver(this, QEvent::KeyRelease, false, { Qt::Key_Left, Qt::Key_Right });
+	KeyEventObserver *keyEventFilter = new KeyEventObserver(
+		this, QEvent::KeyRelease, false,
+		{ Qt::Key_Left, Qt::Key_Right, Qt::Key_Home, Qt::Key_End, Qt::Key_PageUp, Qt::Key_PageDown });
 	m_volumeSlider->installEventFilter(keyEventFilter);
 
 	// The list of wheel events observed seems odd at first. We have to check for multiple


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `1.5.x`:
 - [Merge PR #6841: FIX(client): Add more key events to local volume adjustment slider](https://github.com/mumble-voip/mumble/pull/6841)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)