### PR TITLE
FIX(client): Crash in PipeWire when the main thread is null

### DIFF
--- a/src/mumble/PipeWire.cpp
+++ b/src/mumble/PipeWire.cpp
@@ -292,7 +292,7 @@ void PipeWireEngine::start() {
 }
 
 void PipeWireEngine::stop() {
-	if (m_loop) {
+	if (m_thread) {
 		pws->pw_thread_loop_stop(m_thread);
 	}
 }


### PR DESCRIPTION
The main thread fails to create under certain circumstances, see:

https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1091358
https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1107868