### PR TITLE
WIP: FEAT(client): Add listen option to mumble URLs

### DIFF
--- a/src/mumble/MainWindow.cpp
+++ b/src/mumble/MainWindow.cpp
@@ -1280,6 +1280,7 @@ void MainWindow::openUrl(const QUrl &url) {
 	QString user        = url.userName();
 	QString pw          = url.password();
 	qsDesiredChannel    = url.path();
+	bDesiredListen      = query.hasQueryItem(QLatin1String("listen"));
 	QString name;
 
 	if (query.hasQueryItem(QLatin1String("title")))
@@ -1352,7 +1353,9 @@ void MainWindow::findDesiredChannel() {
 		}
 	}
 	if (found) {
-		if (chan != ClientUser::get(Global::get().uiSession)->cChannel) {
+		if (bDesiredListen) {
+			Global::get().sh->startListeningToChannel(chan->iId);
+		} else if (chan != ClientUser::get(Global::get().uiSession)->cChannel) {
 			Global::get().sh->joinChannel(Global::get().uiSession, chan->iId);
 		}
 		qtvUsers->setCurrentIndex(pmModel->index(chan));

--- a/src/mumble/MainWindow.h
+++ b/src/mumble/MainWindow.h
@@ -124,6 +124,7 @@ public:
 	MumbleProto::Reject_RejectType rtLast;
 	bool bRetryServer;
 	QString qsDesiredChannel;
+	bool bDesiredListen;
 
 	bool forceQuit;
 	/// Restart the client after shutdown


### PR DESCRIPTION
Implements #6850

I should probably update the usage message, too, but I've not yet fully wrapped my head around how to work with translations. I also need to check if there is other documentation that needs to be updated.

I deliberately allowed listening to the channel the user is currently in, does this justify a comment in the source code?

### Checks

- [x] My commits follow the [commit guidelines](https://github.com/mumble-voip/mumble/blob/master/COMMIT_GUIDELINES.md)

