### PR TITLE
Backport "Merge PR #6852: FIX(client): Crash in PipeWire when the main thread is null" to 1.5.x

### DIFF
--- a/src/mumble/PipeWire.cpp
+++ b/src/mumble/PipeWire.cpp
@@ -289,7 +289,7 @@ void PipeWireEngine::start() {
 }
 
 void PipeWireEngine::stop() {
-	if (m_loop) {
+	if (m_thread) {
 		pws->pw_thread_loop_stop(m_thread);
 	}
 }


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `1.5.x`:
 - [Merge PR #6852: FIX(client): Crash in PipeWire when the main thread is null](https://github.com/mumble-voip/mumble/pull/6852)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)