### PR TITLE
FEAT(client,avatars): Add avatar icons to user view

### DIFF
--- a/src/mumble/MainWindow.cpp
+++ b/src/mumble/MainWindow.cpp
@@ -2127,6 +2127,7 @@ void MainWindow::on_qaUserTextureReset_triggered() {
 		QMessageBox::No);
 	if (ret == QMessageBox::Yes) {
 		Global::get().sh->setUserTexture(session, QByteArray());
+		qtvUsers->triggerUpdate();
 	}
 }
 
@@ -4108,6 +4109,7 @@ void MainWindow::changeServerTexture() {
 
 void MainWindow::removeServerTexture() {
 	Global::get().sh->setUserTexture(Global::get().uiSession, QByteArray());
+	qtvUsers->triggerUpdate();
 }
 
 void MainWindow::selfRegister() {

--- a/src/mumble/UserModel.cpp
+++ b/src/mumble/UserModel.cpp
@@ -286,7 +286,7 @@ UserModel::~UserModel() {
 QString UserModel::mergeIconsToImg(const QList< QPair< QIcon, QRect > > &iconsWithRect, const QSize &fullSize,
 								   const QString &format) {
 	QImage image = QImage(fullSize, QImage::Format_ARGB32);
-	image.fill(QColor(0, 0, 0, 0));
+	image.fill(Qt::transparent);
 	QPainter painter(&image);
 	painter.setRenderHint(QPainter::Antialiasing);
 	for (auto [icon, rect] : iconsWithRect) {

--- a/src/mumble/UserModel.cpp
+++ b/src/mumble/UserModel.cpp
@@ -235,13 +235,17 @@ QString ModelItem::hash() const {
 }
 
 UserModel::UserModel(QObject *p) : QAbstractItemModel(p) {
-	qiTalkingOff      = QIcon(QLatin1String("skin:talking_off.svg"));
-	qiTalkingOn       = QIcon(QLatin1String("skin:talking_on.svg"));
-	qiTalkingMuted    = QIcon(QLatin1String("skin:talking_muted.svg"));
-	qiTalkingShout    = QIcon(QLatin1String("skin:talking_alt.svg"));
-	qiTalkingWhisper  = QIcon(QLatin1String("skin:talking_whisper.svg"));
-	qiPrioritySpeaker = QIcon(QLatin1String("skin:priority_speaker.svg"));
-	qiRecording       = QIcon(QLatin1String("skin:actions/media-record.svg"));
+	qiTalkingOff           = QIcon(QLatin1String("skin:talking_off.svg"));
+	qiTalkingOn            = QIcon(QLatin1String("skin:talking_on.svg"));
+	qiTalkingMuted         = QIcon(QLatin1String("skin:talking_muted.svg"));
+	qiTalkingShout         = QIcon(QLatin1String("skin:talking_alt.svg"));
+	qiTalkingWhisper       = QIcon(QLatin1String("skin:talking_whisper.svg"));
+	qiPrioritySpeaker      = QIcon(QLatin1String("skin:priority_speaker.svg"));
+	qiCustomTalkingOn      = QIcon(QLatin1String("skin:custom_talking_on.svg"));
+	qiCustomTalkingMuted   = QIcon(QLatin1String("skin:custom_talking_muted.svg"));
+	qiCustomTalkingShout   = QIcon(QLatin1String("skin:custom_talking_alt.svg"));
+	qiCustomTalkingWhisper = QIcon(QLatin1String("skin:custom_talking_whisper.svg"));
+	qiRecording            = QIcon(QLatin1String("skin:actions/media-record.svg"));
 	qiMutedPushToMute.addFile(QLatin1String("skin:muted_pushtomute.svg"));
 	qiMutedSelf       = QIcon(QLatin1String("skin:muted_self.svg"));
 	qiMutedServer     = QIcon(QLatin1String("skin:muted_server.svg"));
@@ -438,29 +442,29 @@ QVariant UserModel::data(const QModelIndex &idx, int role) const {
 				if (idx.column() == 0) {
 					if (item->isListener) {
 						return qiEar;
-					} else {
-						// Select the talking-state symbol to display
-						if (p == pSelf && p->bSelfMute) {
-							// This is a workaround for a bug that can lead to the user having muted him/herself but
-							// the talking icon is stuck at qiTalkingOn for some reason.
-							// Until someone figures out how to fix the root of the problem, we'll have this workaround
-							// to cure the symptoms of the bug.
-							return qiTalkingOff;
-						}
+					}
+					// Select the talking-state symbol to display
+					if (p == pSelf && p->bSelfMute) {
+						// This is a workaround for a bug that can lead to the user having muted him/herself but
+						// the talking icon is stuck at qiTalkingOn for some reason.
+						// Until someone figures out how to fix the root of the problem, we'll have this workaround
+						// to cure the symptoms of the bug.
+						return qiTalkingOff;
+					}
 
-						switch (p->tsState) {
-							case Settings::Talking:
-								return qiTalkingOn;
-							case Settings::MutedTalking:
-								return qiTalkingMuted;
-							case Settings::Whispering:
-								return qiTalkingWhisper;
-							case Settings::Shouting:
-								return qiTalkingShout;
-							case Settings::Passive:
-							default:
-								return qiTalkingOff;
-						}
+					bool isUserProvidedAvatar = !p->qbaTextureHash.isEmpty() && !p->qbaTexture.isEmpty();
+					switch (p->tsState) {
+						case Settings::Talking:
+							return isUserProvidedAvatar ? qiCustomTalkingOn : qiTalkingOn;
+						case Settings::MutedTalking:
+							return isUserProvidedAvatar ? qiCustomTalkingMuted : qiTalkingMuted;
+						case Settings::Whispering:
+							return isUserProvidedAvatar ? qiCustomTalkingWhisper : qiTalkingWhisper;
+						case Settings::Shouting:
+							return isUserProvidedAvatar ? qiCustomTalkingShout : qiTalkingShout;
+						case Settings::Passive:
+						default:
+							return qiTalkingOff;
 					}
 				}
 				break;

--- a/src/mumble/UserModel.h
+++ b/src/mumble/UserModel.h
@@ -108,6 +108,9 @@ public:
 	UserModel(QObject *parent = 0);
 	~UserModel() Q_DECL_OVERRIDE;
 
+	static QString mergeIconsToImg(const QList< QPair< QIcon, QRect > > &iconsWithRect, const QSize &fullSize,
+								   const QString &format = "png");
+
 	QModelIndex index(ClientUser *, int column = 0) const;
 	QModelIndex index(Channel *, int column = 0) const;
 	QModelIndex index(ModelItem *) const;

--- a/src/mumble/UserModel.h
+++ b/src/mumble/UserModel.h
@@ -71,6 +71,7 @@ private:
 	Q_DISABLE_COPY(UserModel)
 protected:
 	QIcon qiTalkingOn, qiTalkingMuted, qiTalkingWhisper, qiTalkingShout, qiTalkingOff;
+	QIcon qiCustomTalkingOn, qiCustomTalkingMuted, qiCustomTalkingWhisper, qiCustomTalkingShout;
 	QIcon qiMutedPushToMute, qiMutedSelf, qiMutedServer, qiMutedLocal, qiIgnoredLocal, qiMutedSuppressed;
 	QIcon qiPrioritySpeaker;
 	QIcon qiRecording;

--- a/src/mumble/UserView.cpp
+++ b/src/mumble/UserView.cpp
@@ -88,9 +88,10 @@ void UserDelegate::paint(QPainter *painter, const QStyleOptionViewItem &option, 
 	// draw icon
 	ModelItem *item      = static_cast< ModelItem * >(index.internalPointer());
 	ClientUser *user     = item->pUser;
+	const QIcon &icon    = o.icon;
 	QRect decorationRect = style->subElementRect(QStyle::SE_ItemViewItemDecoration, &o, o.widget);
-	if (!drawAvatarIcon(*painter, decorationRect.adjusted(-3, 0, -3, 0), user, o.icon)) {
-		o.icon.paint(painter, decorationRect, o.decorationAlignment, iconMode, QIcon::On);
+	if (item->isListener || !drawAvatarIcon(*painter, decorationRect.adjusted(-3, 0, -3, 0), user, icon)) {
+		icon.paint(painter, decorationRect, o.decorationAlignment, iconMode, QIcon::On);
 	}
 
 	// draw text

--- a/src/mumble/UserView.cpp
+++ b/src/mumble/UserView.cpp
@@ -331,6 +331,15 @@ void UserView::updateChannel(const QModelIndex &idx) {
 	}
 }
 
+void UserView::triggerUpdate() {
+	QPalette previousPalette = palette();
+	QPalette palette;
+	palette.setColor(QPalette::WindowText, previousPalette.color(QPalette::WindowText).darker(101));
+	setPalette(palette);
+	QApplication::processEvents();
+	setPalette(previousPalette);
+}
+
 void UserView::dataChanged(const QModelIndex &topLeft, const QModelIndex &bottomRight, const QVector< int > &) {
 	UserModel *um = static_cast< UserModel * >(model());
 	int nRowCount = um->rowCount();

--- a/src/mumble/UserView.h
+++ b/src/mumble/UserView.h
@@ -25,7 +25,8 @@ private:
 
 public:
 	UserDelegate(QObject *parent);
-	static bool drawAvatarIcon(QPainter *painter, const QRect &rect, ClientUser *user);
+	static bool drawAvatarIcon(QPainter &painter, const QRect &rect, const ClientUser *user,
+							   const QIcon &talkIndicator);
 	void paint(QPainter *painter, const QStyleOptionViewItem &option, const QModelIndex &index) const Q_DECL_OVERRIDE;
 	void adjustIcons(int iconTotalDimension, int iconIconPadding, int iconIconDimension);
 

--- a/src/mumble/UserView.h
+++ b/src/mumble/UserView.h
@@ -50,6 +50,7 @@ protected:
 
 public:
 	UserView(QWidget *);
+	void triggerUpdate();
 	void keyboardSearch(const QString &search) Q_DECL_OVERRIDE;
 	void dataChanged(const QModelIndex &topLeft, const QModelIndex &bottomRight,
 					 const QVector< int > &roles = QVector< int >()) Q_DECL_OVERRIDE;

--- a/src/mumble/UserView.h
+++ b/src/mumble/UserView.h
@@ -10,6 +10,7 @@
 #include <QtWidgets/QStyledItemDelegate>
 #include <QtWidgets/QTreeView>
 
+#include "ClientUser.h"
 #include "QtUtils.h"
 #include "Timer.h"
 
@@ -24,6 +25,7 @@ private:
 
 public:
 	UserDelegate(QObject *parent);
+	static bool drawAvatarIcon(QPainter *painter, const QRect &rect, ClientUser *user);
 	void paint(QPainter *painter, const QStyleOptionViewItem &option, const QModelIndex &index) const Q_DECL_OVERRIDE;
 	void adjustIcons(int iconTotalDimension, int iconIconPadding, int iconIconDimension);
 

--- a/themes/Default/custom_talking_alt.svg
+++ b/themes/Default/custom_talking_alt.svg
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" width="512px" height="512px" viewBox="0 0 512 512">
+<circle stroke="#FBBC05" stroke-width="18" fill-opacity="0" opacity="0.8" cx="256" cy="256" r="150" />
+<path stroke="#FBBC05" stroke-width="44" fill-opacity="0" d="M80,110 A282,242 0 0 0 80,402
+                                                             M432,110 A282,242 0 0 1 432,402"
+/>
+</svg>

--- a/themes/Default/custom_talking_muted.svg
+++ b/themes/Default/custom_talking_muted.svg
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" width="512px" height="512px" viewBox="0 0 512 512">
+<circle stroke="#7a7a7a" stroke-width="18" fill-opacity="0" opacity="0.8" cx="256" cy="256" r="150" />
+<path stroke="#7a7a7a" stroke-width="44" fill-opacity="0" d="M80,110 A282,242 0 0 0 80,402
+                                                             M432,110 A282,242 0 0 1 432,402"
+/>
+</svg>

--- a/themes/Default/custom_talking_on.svg
+++ b/themes/Default/custom_talking_on.svg
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" width="512px" height="512px" viewBox="0 0 512 512">
+<circle stroke="#44A3F2" stroke-width="18" fill-opacity="0" opacity="0.8" cx="256" cy="256" r="150" />
+<path stroke="#44A3F2" stroke-width="44" fill-opacity="0" d="M80,110 A282,242 0 0 0 80,402
+                                                             M432,110 A282,242 0 0 1 432,402"
+/>
+</svg>

--- a/themes/Default/custom_talking_whisper.svg
+++ b/themes/Default/custom_talking_whisper.svg
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" width="512px" height="512px" viewBox="0 0 512 512">
+<circle stroke="#9B59B6" stroke-width="18" fill-opacity="0" opacity="0.8" cx="256" cy="256" r="150" />
+<path stroke="#9B59B6" stroke-width="44" fill-opacity="0" d="M80,110 A282,242 0 0 0 80,402
+                                                             M432,110 A282,242 0 0 1 432,402"
+/>
+</svg>

--- a/themes/DefaultTheme.qrc
+++ b/themes/DefaultTheme.qrc
@@ -55,6 +55,10 @@
     <file alias="talking_on.svg">Default/talking_on.svg</file>
     <file alias="talking_muted.svg">Default/talking_muted.svg</file>
     <file alias="talking_whisper.svg">Default/talking_whisper.svg</file>
+    <file alias="custom_talking_alt.svg">Default/custom_talking_alt.svg</file>
+    <file alias="custom_talking_on.svg">Default/custom_talking_on.svg</file>
+    <file alias="custom_talking_muted.svg">Default/custom_talking_muted.svg</file>
+    <file alias="custom_talking_whisper.svg">Default/custom_talking_whisper.svg</file>
     <file alias="theme.ini">Default/theme.ini</file>
     <file alias="actions/audio-input-microphone-muted.svg">Default/actions/audio-input-microphone-muted.svg</file>
     <file alias="actions/audio-input-microphone.svg">Default/actions/audio-input-microphone.svg</file>


### PR DESCRIPTION
The UI was here changed to use the avatar (if the user has one) as user icon in the user view instead of only showing it in a tooltip when a user is hovered and in the overlay.

This enables one to easier distinguish users as well as getting more use of each user's avatar in a way that would be expected. Below is an example showing the differences.

Without avatar:
![image](https://github.com/user-attachments/assets/fb04e0fa-afa0-45ea-9f4e-7edda48259de)
![image](https://github.com/user-attachments/assets/00e84c20-1cc4-4e72-9961-a1480cea73e0)

With avatar:
![image](https://github.com/user-attachments/assets/ac32a286-766c-497b-bc9e-25bd3b28b115)
![image](https://github.com/user-attachments/assets/48dd2d90-0ac7-4258-ad1a-23925261f6eb)


The "What's this?" message on users was also extended to include the custom avatar talk indicator as shown here:
![image](https://github.com/user-attachments/assets/91cdecef-3dd5-4626-80a1-8a40a2808fd6)


### Checks

- [x] My commits follow the [commit guidelines](https://github.com/mumble-voip/mumble/blob/master/COMMIT_GUIDELINES.md)

