### PR TITLE
Backport "Merge PR #6859: Fix Write and Traverse ACL permission regressions" to 1.5.x

### DIFF
--- a/src/ACL.cpp
+++ b/src/ACL.cpp
@@ -168,20 +168,23 @@ QFlags< ChanACL::Perm > ChanACL::effectivePermissions(ServerUser *p, Channel *ch
 			// If the user tries to enter C, we need to deny Traverse, because the user
 			// should already be blocked from traversing A. But "apply" will be false,
 			// as the "normal" ACL inheritence rules do not apply here.
-			// Therefore, we need applyDenyTraverse which will be true, if any channel
+			// Therefore, we need applyTraverse which will be true, if any channel
 			// from root to the reference channel denies Traverse without necessarily
 			// handing it down.
-			bool applyDenyTraverse = applyInherited || acl->bApplyHere;
+			bool applyTraverse = applyInherited || acl->bApplyHere;
 
 			if (matchUser || matchGroup) {
 				// The "traverse" and "write" booleans do not grant or deny anything here.
 				// We merely check, if we are missing traverse AND write in this
 				// channel and therefore abort without any permissions later on.
-				if (apply && (acl->pAllow & Traverse)) {
-					traverse = true;
-				}
-				if (applyDenyTraverse && (acl->pDeny & Traverse)) {
-					traverse = false;
+				if (applyTraverse) {
+					if (acl->pAllow & Traverse) {
+						traverse = true;
+					}
+
+					if (acl->pDeny & Traverse) {
+						traverse = false;
+					}
 				}
 
 				write = apply && (acl->pAllow & Write) && !(acl->pDeny & Write);

--- a/src/ACL.cpp
+++ b/src/ACL.cpp
@@ -187,7 +187,15 @@ QFlags< ChanACL::Perm > ChanACL::effectivePermissions(ServerUser *p, Channel *ch
 					}
 				}
 
-				write = apply && (acl->pAllow & Write) && !(acl->pDeny & Write);
+				if (apply) {
+					if (acl->pAllow & Write) {
+						write = true;
+					}
+
+					if (acl->pDeny & Write) {
+						write = false;
+					}
+				}
 
 				// These permissions are only grantable from the root channel
 				// as they affect the users globally. For example: You can not


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `1.5.x`:
 - [Merge PR #6859: Fix Write and Traverse ACL permission regressions](https://github.com/mumble-voip/mumble/pull/6859)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)