### PR TITLE
CI(appveyor): Upload .exe artifacts instead of .msi

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -35,7 +35,7 @@ build_script:
   - cmd: .ci/build_windows.bat
 
 after_build:
-  - cmd: cd "%MUMBLE_BUILD_DIRECTORY%" && 7z a binaries.zip *.exe *.dll *.pdb plugins/*.dll plugins/*.pdb installer/client/*client*.msi installer/server/*server*.msi
+  - cmd: cd "%MUMBLE_BUILD_DIRECTORY%" && 7z a binaries.zip *.exe *.dll *.pdb plugins/*.dll plugins/*.pdb installer/client/*client*.exe installer/server/*server*.exe
 
 artifacts:
   - path: 'build/binaries.zip'


### PR DESCRIPTION
Due to PR #6789 we are now bundling the C++ redistributables ourselves. That means we will need to upload and distribute the new .exe files instead of the old .msi (which are included in the .exe files)
