### PR TITLE
Backport "Merge PR #6865: CI(appveyor): Upload .exe artifacts instead of .msi" to 1.5.x

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -39,7 +39,7 @@ build_script:
   - cmd: .ci/build_windows.bat
 
 after_build:
-  - cmd: cd "%MUMBLE_BUILD_DIRECTORY%" && 7z a binaries.zip *.exe *.dll *.pdb plugins/*.dll plugins/*.pdb installer/client/*client*.msi installer/server/*server*.msi
+  - cmd: cd "%MUMBLE_BUILD_DIRECTORY%" && 7z a binaries.zip *.exe *.dll *.pdb plugins/*.dll plugins/*.pdb installer/client/*client*.exe installer/server/*server*.exe
 
 artifacts:
   - path: 'build/binaries.zip'


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `1.5.x`:
 - [Merge PR #6865: CI(appveyor): Upload .exe artifacts instead of .msi](https://github.com/mumble-voip/mumble/pull/6865)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)