### PR TITLE
FIX(tests): Reduce the amount of rounds in TestSSLLocks

### DIFF
--- a/src/tests/TestSSLLocks/TestSSLLocks.cpp
+++ b/src/tests/TestSSLLocks/TestSSLLocks.cpp
@@ -27,7 +27,7 @@ public:
 	void run() {
 		unsigned char buf[64];
 		while (m_running->loadRelaxed() == 1) {
-			for (int i = 0; i < 1024; i++) {
+			for (int i = 0; i < 64; i++) {
 				if (m_seed) {
 					RAND_seed(buf, sizeof(buf));
 				} else {


### PR DESCRIPTION
Without this patch, calling `RAND_seed` depleted the entropy pool and made the test block until sufficient entropy was added back into the pool. On network-less VMs there is little entropy, so this made it exceed the default Qt test timeout of 300s.

On my system, this changed runtime of `TestSSLLocks` from 495s to 32s (62s with 128 rounds).

This patch was done while working on reproducible builds for openSUSE.

Fixes #6818


### Checks

- [X] My commits follow the [commit guidelines](https://github.com/mumble-voip/mumble/blob/master/COMMIT_GUIDELINES.md)

