### PR TITLE
FEAT(client,images): Add animated image support to tooltips on the user view

### DIFF
--- a/src/mumble/CustomElements.cpp
+++ b/src/mumble/CustomElements.cpp
@@ -247,10 +247,14 @@ void LogTextBrowser::keyPressEvent(QKeyEvent *keyEvt) {
 			return setScrollY(logInternalHeight);
 		case Qt::Key_Return:
 		case Qt::Key_Enter:
-			customItemFocusIndex += itemFocusIndex == lastItemIndex ? -lastItemIndex : 1;
+			if (lastItemIndex != -1) {
+				customItemFocusIndex += itemFocusIndex == lastItemIndex ? -lastItemIndex : 1;
+			}
 			break;
 		case Qt::Key_Backspace:
-			customItemFocusIndex += itemFocusIndex < 1 ? lastItemIndex + (itemFocusIndex == -1 ? 1 : 0) : -1;
+			if (lastItemIndex != -1) {
+				customItemFocusIndex += itemFocusIndex < 1 ? lastItemIndex + (itemFocusIndex == -1 ? 1 : 0) : -1;
+			}
 			break;
 		case Qt::Key_Escape:
 			customItemFocusIndex = -1;
@@ -263,7 +267,7 @@ void LogTextBrowser::keyPressEvent(QKeyEvent *keyEvt) {
 	}
 	bool isItemSelectionChanged = customItemFocusIndex != itemFocusIndex;
 
-	QObject *item = customItems.at(customItemFocusIndex);
+	QObject *item = customItems[customItemFocusIndex];
 	switch (qvariant_cast< Log::TextObjectType >(item->property("objectType"))) {
 		case Log::TextObjectType::Animation: {
 			QMovie *animation = qobject_cast< QMovie * >(item);
@@ -288,7 +292,7 @@ void LogTextBrowser::keyReleaseEvent(QKeyEvent *keyEvt) {
 	customItemFocusIndex = !isItemFocusIndex ? -1 : isItemFocusIndexTooHigh ? lastCustomItemIndex : itemFocusIndex;
 	queuedNumericInput.clear();
 	if (isItemFocusIndex && customItemFocusIndex != -1) {
-		QObject *item = customItems.at(customItemFocusIndex);
+		QObject *item = customItems[customItemFocusIndex];
 		return scrollItemIntoView(item->property("posAndSize").toRect());
 	}
 	update();

--- a/src/mumble/CustomElements.cpp
+++ b/src/mumble/CustomElements.cpp
@@ -421,7 +421,7 @@ void LogTextBrowser::keyPressEvent(QKeyEvent *keyEvt) {
 	int docHeight                   = verticalScrollBar()->maximum();
 	auto customObjects              = qvariant_cast< QList< QObject * > >(doc.property("customObjects"));
 
-	int lastIndex  = customObjects.size() - 1;
+	int lastIndex  = static_cast< int >(customObjects.size() - 1);
 	int focusIndex = doc.property("customObjectFocusIndex").toInt();
 	int scrollStep = 15;
 	if (modifiers.testFlag(Qt::ControlModifier)) {
@@ -504,7 +504,7 @@ void LogTextBrowser::keyReleaseEvent(QKeyEvent *keyEvt) {
 
 	QTextDocument *doc = document();
 	auto customObjects = qvariant_cast< QList< QObject * > >(doc->property("customObjects"));
-	int lastIndex      = customObjects.size() - 1;
+	int lastIndex      = static_cast< int >(customObjects.size() - 1);
 	bool isFocusIndex;
 	int inputFocusIndex      = queuedNumericInput.toInt(&isFocusIndex);
 	bool isFocusIndexTooHigh = !isFocusIndex || inputFocusIndex > lastIndex;
@@ -1953,7 +1953,7 @@ void ImageAnimationTextObject::toggleVideoControls() {
 
 void ImageAnimationTextObject::addVideoControlsSwitch(QMenu &menu) {
 	QString firstWord = areVideoControlsShown ? tr("Hide") : tr("Show");
-	menu.addAction(tr("%1 Video Controls").arg(firstWord), this, [this]() { toggleVideoControls(); });
+	menu.addAction(tr("%1 Video Controls").arg(firstWord), this, &ImageAnimationTextObject::toggleVideoControls);
 }
 
 bool ImageAnimationTextObject::mousePress(const QPoint &mouseDocPos, const Qt::MouseButton &button, QMovie &animation) {

--- a/src/mumble/CustomElements.cpp
+++ b/src/mumble/CustomElements.cpp
@@ -210,7 +210,7 @@ void LogTextBrowser::wheelEvent(QWheelEvent *wheelEvt) {
 	if (obj != nullptr) {
 		switch (qvariant_cast< Log::TextObjectType >(obj->property("objectType"))) {
 			case Log::TextObjectType::Animation: {
-				QMovie *animation = qobject_cast< QMovie * >(obj);
+				QMovie *animation    = qobject_cast< QMovie * >(obj);
 				isCustomScrollAction = AnimationTextObject::scroll(animation, mouseDocPos, isScrollingUp);
 				break;
 			}
@@ -568,7 +568,7 @@ bool ChatbarTextEdit::emitPastedImage(const QImage &image, const QString &filePa
 	qsizetype fileExtStartIndex = filePath.lastIndexOf('.') + 1;
 	QString fileExt             = (fileExtStartIndex != 0 ? filePath.sliced(fileExtStartIndex) : "").toLower();
 
-	Log::TextObjectType txtObjType = Log::findTxtObjType(fileExt);
+	Log::TextObjectType txtObjType = Log::findTextObjectType(fileExt);
 	if (txtObjType == Log::TextObjectType::Animation) {
 		QFile file(filePath);
 		if (!file.open(QIODevice::ReadOnly)) {
@@ -1587,10 +1587,10 @@ bool AnimationTextObject::scroll(QMovie *animation, const QPoint &mouseDocPos, b
 			isCustomScrollAction = true;
 			switch (videoControl) {
 				case VideoUtils::VideoControl::View:
-				    changeFrameByTime(animation, 1000);
-				    break;
+					changeFrameByTime(animation, 1000);
+					break;
 				default:
-				    isCustomScrollAction = false;
+					isCustomScrollAction = false;
 					break;
 			}
 		}
@@ -1611,17 +1611,17 @@ bool AnimationTextObject::scroll(QMovie *animation, const QPoint &mouseDocPos, b
 				changeSpeed(animation, -5);
 				break;
 			default:
-			    isCustomScrollAction = false;
+				isCustomScrollAction = false;
 				break;
 		}
 		if (!isCustomScrollAction && isFullScreen && areVideoControlsOnFullScreen) {
 			isCustomScrollAction = true;
 			switch (videoControl) {
 				case VideoUtils::VideoControl::View:
-				    changeFrameByTime(animation, -1000);
-				    break;
+					changeFrameByTime(animation, -1000);
+					break;
 				default:
-				    isCustomScrollAction = false;
+					isCustomScrollAction = false;
 					break;
 			}
 		}

--- a/src/mumble/CustomElements.cpp
+++ b/src/mumble/CustomElements.cpp
@@ -323,17 +323,18 @@ void LogTextBrowser::scrollAreaIntoView(const QTextDocument &doc, const QRect &r
 
 QObject *LogTextBrowser::customObjectAt(const QTextDocument &doc, const QPoint &pos) {
 	QTextFormat fmt = doc.documentLayout()->formatAt(pos);
+	return customObjectOfFormat(fmt, pos);
+}
+
+QObject *LogTextBrowser::customObjectOfFormat(const QTextFormat &fmt, const QPoint &pos) {
 	if (!fmt.hasProperty(1)) {
 		return nullptr;
 	}
 	auto *obj  = qvariant_cast< QObject * >(fmt.property(1));
 	QRect rect = obj->property("posAndSize").toRect();
-	// Ensure the selection was within the text object's vertical space,
-	// such as if an inline animated image is not as tall as the content before it:
-	if (!VideoUtils::isInBoundsOnAxis(pos.y(), rect.y(), rect.height())) {
-		return nullptr;
-	}
-	return obj;
+	// Ensure the selection was within the text object's vertical space, such as if an
+	// inline animated image is not as tall as the content next to it on the same line:
+	return VideoUtils::isInBoundsOnAxis(pos.y(), rect.y(), rect.height()) ? obj : nullptr;
 }
 
 void LogTextBrowser::update(const QTextDocument &doc, const QRect &rect) {

--- a/src/mumble/CustomElements.cpp
+++ b/src/mumble/CustomElements.cpp
@@ -18,17 +18,80 @@
 #include <QtGui/QClipboard>
 #include <QtGui/QContextMenuEvent>
 #include <QtGui/QKeyEvent>
+#include <QtGui/QMovie>
+#include <QtGui/QPainter>
+#include <QtGui/QPainterPath>
 #include <QtWidgets/QScrollBar>
 
 LogTextBrowser::LogTextBrowser(QWidget *p) : QTextBrowser(p) {
 }
 
-int LogTextBrowser::getLogScroll() {
+void LogTextBrowser::update() {
+	document()->documentLayout()->update(QRect(getScrollX(), getScrollY(), width(), height()));
+}
+
+int LogTextBrowser::getScrollX() {
+	return horizontalScrollBar()->value();
+}
+
+int LogTextBrowser::getScrollY() {
 	return verticalScrollBar()->value();
 }
 
-void LogTextBrowser::setLogScroll(int scroll_pos) {
+void LogTextBrowser::setScrollX(int scroll_pos) {
+	horizontalScrollBar()->setValue(scroll_pos);
+}
+
+void LogTextBrowser::setScrollY(int scroll_pos) {
 	verticalScrollBar()->setValue(scroll_pos);
+}
+
+void LogTextBrowser::changeScrollX(int change) {
+	QScrollBar *scrollBar = horizontalScrollBar();
+	scrollBar->setValue(scrollBar->value() + change);
+}
+
+void LogTextBrowser::changeScrollY(int change) {
+	QScrollBar *scrollBar = verticalScrollBar();
+	scrollBar->setValue(scrollBar->value() + change);
+}
+
+void LogTextBrowser::scrollItemIntoView(QRect rect) {
+	QRect logRect(getScrollX(), getScrollY(), width(), height());
+	int rectXWithWidth     = rect.x() + rect.width();
+	int logRectXWithWidth  = logRect.x() + logRect.width();
+	int rectYWithHeight    = rect.y() + rect.height();
+	int logRectYWithHeight = logRect.y() + logRect.height();
+
+	bool isItemToTheRight  = rectXWithWidth > logRectXWithWidth;
+	bool isItemToTheLeft   = rect.x() < logRect.x();
+	bool isItemBelow       = rectYWithHeight > logRectYWithHeight;
+	bool isItemAbove       = rect.y() < logRect.y();
+	bool isItemAtAllInView = rect.x() < logRectXWithWidth && rectXWithWidth > logRect.x()
+							 && rect.y() < logRectYWithHeight && rectYWithHeight > logRect.y();
+
+	int offset          = 20;
+	bool isWithinWidth  = rect.width() <= logRect.width() - offset;
+	bool isWithinHeight = rect.height() <= logRect.height() - offset;
+	// Scroll to the item if it fits the log window and is at all out of view. Otherwise only
+	// scroll to the item if it is entirely out of view. Both ways scroll just far enough, with the set offset as
+	// margin, to show the item at the bottom or top of the log window if the previous position was above or below the
+	// item respectively. If the item does not fit the log window then scroll as far as the start or end of the item is
+	// still in view if the previous position was entirely above or below the item respectively. The same principles
+	// apply horizontally, where below is to the right and above is to the left:
+	if ((isWithinWidth && (isItemToTheRight || isItemToTheLeft)) || !isItemAtAllInView) {
+		setScrollX((isWithinWidth && isItemToTheRight) || (!isWithinWidth && isItemToTheLeft)
+					   ? rectXWithWidth - logRect.width() + offset
+					   : rect.x() - offset);
+	}
+	if ((isWithinHeight && (isItemBelow || isItemAbove)) || !isItemAtAllInView) {
+		setScrollY((isWithinHeight && isItemBelow) || (!isWithinHeight && isItemAbove)
+					   ? rectYWithHeight - logRect.height() + offset
+					   : rect.y() - offset);
+	}
+	if (getScrollX() == logRect.x() && getScrollY() == logRect.y()) {
+		update();
+	}
 }
 
 bool LogTextBrowser::isScrolledToBottom() {
@@ -36,6 +99,105 @@ bool LogTextBrowser::isScrolledToBottom() {
 	return scrollBar->value() == scrollBar->maximum();
 }
 
+void LogTextBrowser::mousePressEvent(QMouseEvent *qme) {
+	QPoint mouseDocPos                     = qme->pos();
+	Qt::MouseButton mouseButton            = qme->button();
+	QAbstractTextDocumentLayout *docLayout = document()->documentLayout();
+	// Set the vertical axis of the position to include the scrollable area above it:
+	mouseDocPos.setY(mouseDocPos.y() + getScrollY());
+
+	AnimationTextObject::mousePress(docLayout, mouseDocPos, mouseButton);
+}
+
+void LogTextBrowser::keyPressEvent(QKeyEvent *qke) {
+	Qt::Key key                     = static_cast< Qt::Key >(qke->key());
+	Qt::KeyboardModifiers modifiers = QApplication::keyboardModifiers();
+	int logWindowHeight             = height();
+	int logInternalHeight           = verticalScrollBar()->maximum();
+
+	int lastItemIndex  = lastCustomInteractiveItemIndex;
+	int itemFocusIndex = customInteractiveItemFocusIndex;
+	int scrollStep     = 15;
+	if (modifiers.testFlag(Qt::ControlModifier)) {
+		switch (key) {
+			case Qt::Key_A:
+				return selectAll();
+			case Qt::Key_C:
+				return copy();
+			case Qt::Key_0:
+				return queuedNumericInput.push_back('0');
+			case Qt::Key_1:
+				return queuedNumericInput.push_back('1');
+			case Qt::Key_2:
+				return queuedNumericInput.push_back('2');
+			case Qt::Key_3:
+				return queuedNumericInput.push_back('3');
+			case Qt::Key_4:
+				return queuedNumericInput.push_back('4');
+			case Qt::Key_5:
+				return queuedNumericInput.push_back('5');
+			case Qt::Key_6:
+				return queuedNumericInput.push_back('6');
+			case Qt::Key_7:
+				return queuedNumericInput.push_back('7');
+			case Qt::Key_8:
+				return queuedNumericInput.push_back('8');
+			case Qt::Key_9:
+				return queuedNumericInput.push_back('9');
+			default:
+				break;
+		}
+	}
+	switch (key) {
+		case Qt::Key_Down:
+			return changeScrollY(scrollStep);
+		case Qt::Key_Up:
+			return changeScrollY(-scrollStep);
+		case Qt::Key_Right:
+			return changeScrollX(15);
+		case Qt::Key_Left:
+			return changeScrollX(-15);
+		case Qt::Key_PageDown:
+			return changeScrollY(logWindowHeight);
+		case Qt::Key_PageUp:
+			return changeScrollY(-logWindowHeight);
+		case Qt::Key_Home:
+			return setScrollY(0);
+		case Qt::Key_End:
+			return setScrollY(logInternalHeight);
+		case Qt::Key_Return:
+		case Qt::Key_Enter:
+			customInteractiveItemFocusIndex += itemFocusIndex == lastItemIndex ? -lastItemIndex : 1;
+			break;
+		case Qt::Key_Backspace:
+			customInteractiveItemFocusIndex += itemFocusIndex < 1 ? lastItemIndex + (itemFocusIndex == -1 ? 1 : 0) : -1;
+			break;
+		case Qt::Key_Escape:
+			customInteractiveItemFocusIndex = -1;
+			return update();
+		default:
+			break;
+	}
+	bool isItemSelectionChanged = customInteractiveItemFocusIndex != itemFocusIndex;
+
+	AnimationTextObject::keyPress(this, isItemSelectionChanged, key);
+}
+
+void LogTextBrowser::keyReleaseEvent(QKeyEvent *qke) {
+	Qt::Key key = static_cast< Qt::Key >(qke->key());
+	if (queuedNumericInput.length() > 0 && key == Qt::Key_Control) {
+		int lastItemIndex            = lastCustomInteractiveItemIndex;
+		int itemFocusIndex           = queuedNumericInput.toInt();
+		bool isItemFocusIndexTooHigh = itemFocusIndex > lastItemIndex;
+
+		customInteractiveItemFocusIndex = isItemFocusIndexTooHigh ? -1 : itemFocusIndex;
+		queuedNumericInput.clear();
+		if (isItemFocusIndexTooHigh) {
+			return update();
+		}
+		AnimationTextObject::keyPress(this, true, key);
+	}
+}
 
 void ChatbarTextEdit::focusInEvent(QFocusEvent *qfe) {
 	inFocus(true);
@@ -206,7 +368,7 @@ bool ChatbarTextEdit::sendImagesFromMimeData(const QMimeData *source) {
 
 					if (image.isNull())
 						continue;
-					if (emitPastedImage(image)) {
+					if (emitPastedImage(image, path)) {
 						++count;
 					} else {
 						Global::get().l->log(Log::Information, tr("Unable to send image %1: too large.").arg(path));
@@ -222,7 +384,20 @@ bool ChatbarTextEdit::sendImagesFromMimeData(const QMimeData *source) {
 	return false;
 }
 
-bool ChatbarTextEdit::emitPastedImage(QImage image) {
+bool ChatbarTextEdit::emitPastedImage(QImage image, QString filePath) {
+	if (filePath.endsWith(".gif")) {
+		QFile file(filePath);
+		if (file.open(QIODevice::ReadOnly)) {
+			QByteArray animationBa(file.readAll());
+			file.close();
+			QString base64ImageData = qvariant_cast< QString >(animationBa.toBase64());
+			emit pastedImage("<br /><img src=\"data:image/GIF;base64," + base64ImageData + "\" />");
+		} else {
+			Global::get().l->log(Log::Information, tr("Unable to read animated image file: %1").arg(filePath));
+		}
+		return true;
+	}
+
 	QString processedImage = Log::imageToImg(image, static_cast< int >(Global::get().uiImageLength));
 	if (processedImage.length() > 0) {
 		QString imgHtml = QLatin1String("<br />") + processedImage;
@@ -231,6 +406,761 @@ bool ChatbarTextEdit::emitPastedImage(QImage image) {
 	}
 	return false;
 }
+
+
+bool AnimationTextObject::areVideoControlsOn = false;
+
+QString AnimationTextObject::loopModeToString(LoopMode mode) {
+	switch (mode) {
+		case Unchanged:
+			return "Unchanged";
+		case Loop:
+			return "Loop";
+		case NoLoop:
+			return "No loop";
+		default:
+			return "Undefined";
+	}
+}
+
+void AnimationTextObject::updateVideoControls(QObject *propertyHolder) {
+	QRect rect              = propertyHolder->property("posAndSize").toRect();
+	int videoControlsHeight = videoBarHeight + underVideoBarHeight;
+	int videoControlsY      = rect.y() + rect.height() - videoControlsHeight;
+	QRect videoControlsRect(rect.x(), videoControlsY, rect.width(), videoControlsHeight);
+
+	emit Global::get().mw->qteLog->document()->documentLayout()->update(videoControlsRect);
+}
+
+void AnimationTextObject::setFrame(QMovie *animation, int frameIndex) {
+	int lastFrameIndex       = animation->property("lastFrameIndex").toInt();
+	bool isFrameIndexTooLow  = frameIndex < 0;
+	bool isFrameIndexTooHigh = frameIndex > lastFrameIndex;
+	if (isFrameIndexTooLow || isFrameIndexTooHigh) {
+		frameIndex = isFrameIndexTooLow ? 0 : lastFrameIndex;
+	}
+	if (animation->cacheMode() == QMovie::CacheAll) {
+		animation->jumpToFrame(frameIndex);
+		return;
+	}
+
+	bool wasRunning = animation->state() == QMovie::Running;
+	if (!wasRunning) {
+		animation->setPaused(false);
+	}
+	bool isStartTried = false;
+	// Can only load the target frame by traversing
+	// in sequential order when the frames are not cached:
+	while (animation->currentFrameNumber() != frameIndex) {
+		if (!animation->jumpToNextFrame()) {
+			// Continue traversing animations that either are stopped or do stop after one or more iterations:
+			if (animation->state() == QMovie::NotRunning && !isStartTried) {
+				animation->start();
+				isStartTried = true;
+				continue;
+			}
+			break;
+		}
+	}
+	if (!wasRunning) {
+		animation->setPaused(true);
+	}
+}
+
+void AnimationTextObject::setFrameByProportion(QMovie *animation, double proportion) {
+	int msPassedAtProportion = (int) round(proportion * getTotalTime(animation));
+	setFrameByTime(animation, msPassedAtProportion);
+}
+
+void AnimationTextObject::setFrameByTime(QMovie *animation, int milliseconds) {
+	int totalMs            = getTotalTime(animation);
+	bool isTimeAfterEnd    = milliseconds > totalMs;
+	bool isTimeBeforeStart = milliseconds < 0;
+	if (isTimeAfterEnd || isTimeBeforeStart) {
+		milliseconds = isTimeAfterEnd ? totalMs : 0;
+	}
+	QList< QVariant > frameDelays = animation->property("frameDelays").toList();
+	qsizetype frameDelayAmount    = frameDelays.length();
+	int msUntilCurrentFrame       = 0;
+
+	int frameIndex = 0;
+	for (int i = 0; i < frameDelayAmount; ++i) {
+		int delay = frameDelays[i].toInt();
+		msUntilCurrentFrame += delay;
+		if (milliseconds <= msUntilCurrentFrame) {
+			bool isNextFrame            = i + 1 < frameDelayAmount;
+			int currentFrameDifference  = msUntilCurrentFrame - milliseconds;
+			int previousFrameDifference = currentFrameDifference - delay;
+			int nextFrameDifference =
+				isNextFrame ? msUntilCurrentFrame + frameDelays[i + 1].toInt() - milliseconds : -1;
+
+			bool isPreviousFrameCloser = abs(previousFrameDifference) < currentFrameDifference;
+			bool isNextFrameCloser     = isNextFrame ? abs(nextFrameDifference) < currentFrameDifference : false;
+			// The first delay has passed by the second frame and so on,
+			// hence the index is greater by 1 for the frame of the full delay:
+			frameIndex = i + 1 + (isPreviousFrameCloser ? -1 : isNextFrameCloser ? 1 : 0);
+			break;
+		}
+	}
+	setFrame(animation, frameIndex);
+}
+
+void AnimationTextObject::togglePause(QMovie *animation) {
+	int lastFrameIndex            = animation->property("lastFrameIndex").toInt();
+	QMovie::MovieState state      = animation->state();
+	bool wasStoppedOrNeverStarted = state == QMovie::NotRunning;
+	if (animation->speed() < 0) {
+		int frameIndex           = animation->currentFrameNumber();
+		int frameIndexToSwitchTo = wasStoppedOrNeverStarted && frameIndex == 0 ? lastFrameIndex : frameIndex;
+		if (wasStoppedOrNeverStarted) {
+			animation->start();
+			animation->setPaused(true);
+			setFrame(animation, frameIndexToSwitchTo);
+		}
+		bool wasPlayingInReverse = animation->property("isPlayingInReverse").toBool();
+		animation->setProperty("isPlayingInReverse", !wasPlayingInReverse);
+		if (wasPlayingInReverse) {
+			emit animation->stateChanged(state);
+		} else {
+			emit animation->frameChanged(frameIndexToSwitchTo);
+		}
+	} else if (wasStoppedOrNeverStarted) {
+		animation->start();
+		// Ensure the animation starts on the first attempt to do so:
+		animation->setPaused(false);
+	} else {
+		animation->setPaused(state != QMovie::Paused);
+	}
+}
+
+void AnimationTextObject::toggleCache(QMovie *animation) {
+	int lastFrameIndex               = animation->property("lastFrameIndex").toInt();
+	bool wasCached                   = animation->cacheMode() == QMovie::CacheAll;
+	QMovie::CacheMode cacheModeToSet = wasCached ? QMovie::CacheNone : QMovie::CacheAll;
+	QMovie::MovieState state         = animation->state();
+	bool wasPaused                   = state == QMovie::Paused;
+	bool wasRunning                  = state == QMovie::Running;
+
+	int previousFrame = animation->currentFrameNumber();
+	// Turning caching on or off requires reloading the animation, which is done via `setDevice`,
+	// otherwise it will not play properly or dispose of the cache when it is not to be used:
+	animation->stop();
+	QIODevice *device = animation->device();
+	// Prepare the animation to be loaded when starting for the first time:
+	device->reset();
+	animation->setDevice(device);
+	animation->setCacheMode(cacheModeToSet);
+	animation->start();
+
+	// Restore the state of the animation playback to what it was before reloading it
+	// but ensure it can be resumed when caching is off by pausing it if it is not at the start or end:
+	setFrame(animation, previousFrame);
+	if (wasPaused || (!wasRunning && previousFrame != 0 && previousFrame != lastFrameIndex)) {
+		animation->setPaused(true);
+	} else if (!wasRunning) {
+		animation->stop();
+	}
+	updateVideoControls(animation);
+}
+
+void AnimationTextObject::stopPlayback(QMovie *animation) {
+	animation->stop();
+	animation->setProperty("isPlayingInReverse", false);
+}
+
+void AnimationTextObject::resetPlayback(QMovie *animation) {
+	// Show the first frame that the animation would continue from if started again
+	// without caching anyway, indicating that the animation was stopped instead of paused:
+	setFrame(animation, 0);
+	stopPlayback(animation);
+}
+
+void AnimationTextObject::setSpeed(QMovie *animation, int percentage) {
+	// Pausing the animation should only be done via the play state to avoid confusion:
+	if (percentage == 0) {
+		return;
+	}
+	animation->setSpeed(percentage);
+	updateVideoControls(animation);
+	// `QMovie` does not itself support reverse playback but this can be and is implemented using it:
+	bool wasPlayingInReverse = animation->property("isPlayingInReverse").toBool();
+	bool wasRunning          = animation->state() == QMovie::Running || wasPlayingInReverse;
+	if (percentage < 0) {
+		if (wasPlayingInReverse) {
+			return;
+		}
+		animation->setPaused(true);
+		animation->setProperty("isPlayingInReverse", wasRunning);
+		if (wasRunning) {
+			// Trigger the signal `frameChanged` where the handler also supports reverse playback:
+			emit animation->frameChanged(animation->currentFrameNumber());
+		}
+	} else if (wasPlayingInReverse) {
+		animation->setProperty("isPlayingInReverse", false);
+		animation->setPaused(!wasRunning);
+	}
+}
+
+void AnimationTextObject::changeLoopMode(QMovie *animation, int steps) {
+	LoopMode loopMode     = qvariant_cast< LoopMode >(animation->property("LoopMode"));
+	int loopModeChangedTo = loopMode + steps;
+	int loopModeResult =
+		loopModeChangedTo > NoLoop ? 0 : loopModeChangedTo < 0 ? static_cast< int >(NoLoop) : loopModeChangedTo;
+	animation->setProperty("LoopMode", static_cast< LoopMode >(loopModeResult));
+	updateVideoControls(animation);
+}
+
+void AnimationTextObject::changeFrame(QMovie *animation, int amount) {
+	int lastFrameIndex       = animation->property("lastFrameIndex").toInt();
+	int frameIndex           = animation->currentFrameNumber() + amount;
+	int amountOfTimesGreater = (int) abs(floor(frameIndex / (double) lastFrameIndex));
+
+	int lastFrameIndexScaledToInput = lastFrameIndex * amountOfTimesGreater;
+	int frameIndexWrappedBackward   = lastFrameIndexScaledToInput + 1 + frameIndex;
+	int frameIndexWrappedForward    = frameIndex - 1 - lastFrameIndexScaledToInput;
+	setFrame(animation, frameIndex < 0 ? frameIndexWrappedBackward
+									   : frameIndex > lastFrameIndex ? frameIndexWrappedForward : frameIndex);
+}
+
+void AnimationTextObject::changeFrameByTime(QMovie *animation, int milliseconds) {
+	setFrameByTime(animation, getCurrentTime(animation, animation->currentFrameNumber()) + milliseconds);
+}
+
+void AnimationTextObject::changeSpeed(QMovie *animation, int percentageStep) {
+	int speed          = animation->speed();
+	int nextPercentage = speed + percentageStep;
+	setSpeed(animation, speed + percentageStep * (nextPercentage != 0 ? 1 : 2));
+}
+
+int AnimationTextObject::getTotalTime(QObject *propertyHolder) {
+	return propertyHolder->property("totalMs").toInt();
+}
+
+int AnimationTextObject::getCurrentTime(QObject *propertyHolder, int frameIndex) {
+	int lastFrameIndex            = propertyHolder->property("lastFrameIndex").toInt();
+	QList< QVariant > frameDelays = propertyHolder->property("frameDelays").toList();
+	int msUntilCurrentFrame       = 0;
+	// Determine the time until the current frame or the time until the end of the last frame
+	// if on the last frame, so as to show a clear time for the start and end:
+	for (int i = 0; i < (frameIndex == lastFrameIndex ? frameDelays.length() : frameIndex); ++i) {
+		msUntilCurrentFrame += frameDelays[i].toInt();
+	}
+	return msUntilCurrentFrame;
+}
+
+bool AnimationTextObject::isInBoundsOnAxis(QPoint pos, bool yInsteadOfX, int start, int length) {
+	int posOnAxis = yInsteadOfX ? pos.y() : pos.x();
+	return posOnAxis >= start && posOnAxis <= start + length;
+}
+
+bool AnimationTextObject::isInBounds(QPoint pos, QRect bounds) {
+	return isInBoundsOnAxis(pos, false, bounds.x(), bounds.width())
+		   && isInBoundsOnAxis(pos, true, bounds.y(), bounds.height());
+}
+
+int AnimationTextObject::getOffset(int offset, int start, int length) {
+	return start + offset + (offset < 0 ? length : 0);
+}
+
+void AnimationTextObject::drawVideoControls(QPainter *painter, QObject *propertyHolder, QPixmap frame, bool wasPaused,
+											bool wasCached, int frameIndex, int speedPercentage) {
+	QRect rect              = propertyHolder->property("posAndSize").toRect();
+	int videoControlsHeight = videoBarHeight + underVideoBarHeight;
+	QSize viewSizeMin(rect.width(), rect.height() - videoControlsHeight);
+	auto getOffsetX     = [rect](int offset) { return rect.x() + offset + (offset < 0 ? rect.width() : 0); };
+	int cacheX          = getOffsetX(cacheOffsetX);
+	int loopModeX       = getOffsetX(loopModeOffsetX);
+	int frameTraversalX = getOffsetX(frameTraversalOffsetX);
+	int speedX          = getOffsetX(speedOffsetX);
+
+	int videoBarX                = rect.x();
+	int videoBarY                = rect.y() + rect.height() - videoControlsHeight;
+	int underVideoBarY           = videoBarY + videoBarHeight;
+	int underVideoBarWithMarginY = underVideoBarY + 14;
+
+	auto convertUnit = [](int integer, int exponent, int decimalAmount = 0) -> double {
+		bool noDecimals              = decimalAmount == 0;
+		int exponentForDecimalAmount = exponent < 0 ? exponent + decimalAmount : exponent - decimalAmount;
+
+		double product = integer * pow(10, exponentForDecimalAmount);
+		return noDecimals ? product : round(product) / (double) pow(10, decimalAmount);
+	};
+	auto padDecimals = [](QString numberStr, int decimalAmount) -> QString {
+		qsizetype decimalMarkIndex     = numberStr.lastIndexOf('.');
+		bool isDecimal                 = decimalMarkIndex != -1 && decimalMarkIndex < numberStr.length() - 1;
+		qsizetype currentDecimalAmount = isDecimal ? numberStr.sliced(decimalMarkIndex + 1).length() : 0;
+		qsizetype decimalFillerAmount  = decimalAmount - currentDecimalAmount;
+
+		QString decimalFillers = QString('0').repeated(decimalFillerAmount);
+		return decimalFillerAmount > 0 ? numberStr.append((!isDecimal ? "." : "") + decimalFillers) : numberStr;
+	};
+	auto padNumber = [](QString numberStr, int digitAmount) -> QString {
+		qsizetype numberLength                = numberStr.length();
+		qsizetype decimalMarkIndex            = numberStr.lastIndexOf('.');
+		qsizetype decimalsIncludingMarkLength = decimalMarkIndex != -1 ? numberLength - decimalMarkIndex : 0;
+		return numberStr.rightJustified(digitAmount + decimalsIncludingMarkLength, '0');
+	};
+	auto formatTime = [padDecimals, padNumber](double seconds, double totalSeconds = 0) -> QString {
+		auto getTimeNumbers = [](double seconds) -> QList< double > {
+			auto floorDivision   = [](double dividend, double divisor = 60) { return (int) floor(dividend / divisor); };
+			int minutes          = floorDivision(seconds);
+			int hours            = floorDivision(minutes);
+			int remainingMinutes = std::max(minutes - hours * 60, 0);
+			double remainingSeconds = std::max< double >(seconds - minutes * 60, 0);
+			return QList< double >({ remainingSeconds, (double) remainingMinutes, (double) hours });
+		};
+		auto getDigitAmount = [](int number) -> int {
+			int digitAmount = 0;
+			do {
+				number /= 10;
+				++digitAmount;
+			} while (number != 0);
+			return digitAmount;
+		};
+
+		QList< double > timeNumbers      = getTimeNumbers(seconds);
+		QList< double > totalTimeNumbers = totalSeconds == 0 ? timeNumbers : getTimeNumbers(totalSeconds);
+		int timeNumberAmount             = (int) timeNumbers.length();
+		int decimalAmount                = 1;
+
+		int lastTimeNumberIndex = 0;
+		for (int i = timeNumberAmount - 1; i >= 0; --i) {
+			if (totalTimeNumbers[i] > 0) {
+				lastTimeNumberIndex = i;
+				break;
+			}
+		}
+
+		QString timeStr;
+		for (int i = 0; i < timeNumberAmount; ++i) {
+			double number         = timeNumbers[i];
+			bool isSeconds        = i == 0;
+			bool isLastNumber     = i == lastTimeNumberIndex;
+			bool hasAnotherNumber = i < lastTimeNumberIndex;
+			if (number == 0 && !hasAnotherNumber && !isLastNumber) {
+				break;
+			}
+			QString numberStr = QString::number(number);
+			if (hasAnotherNumber || isLastNumber) {
+				int digitAmount = isLastNumber ? getDigitAmount((int) totalTimeNumbers[i]) : 2;
+				numberStr       = padNumber(numberStr, digitAmount);
+			}
+			timeStr.prepend(isSeconds ? padDecimals(numberStr, decimalAmount) : numberStr.append(":"));
+		}
+		return timeStr;
+	};
+
+	QList< QVariant > frameDelays = propertyHolder->property("frameDelays").toList();
+	int totalMs                   = getTotalTime(propertyHolder);
+	int msUntilCurrentFrame       = getCurrentTime(propertyHolder, frameIndex);
+	// Convert to seconds rounded to one decimal:
+	double totalS   = convertUnit(totalMs, -3, 1);
+	double currentS = convertUnit(msUntilCurrentFrame, -3, 1);
+
+	painter->drawPixmap(QRect(rect.topLeft(), viewSizeMin), frame);
+	painter->fillRect(videoBarX, videoBarY, viewSizeMin.width(), videoControlsHeight, QBrush(QColor(50, 50, 50, 180)));
+
+	double videoBarProgress = msUntilCurrentFrame / (double) totalMs;
+	QBrush videoBarBrush(QColor(0, 0, 200));
+	painter->fillRect(videoBarX, videoBarY, viewSizeMin.width(), 4, QBrush(QColor(90, 90, 90, 180)));
+	painter->fillRect(videoBarX, videoBarY, (int) round(viewSizeMin.width() * videoBarProgress), 4, videoBarBrush);
+
+	painter->setPen(QColor(149, 165, 166));
+	QString speedStr = padDecimals(QString::number(convertUnit(speedPercentage, -2)), 2);
+	QPoint speedPos(speedX, underVideoBarWithMarginY);
+	painter->drawText(speedPos, speedStr);
+	// Draw the plus "+":
+	painter->drawLine(speedPos.x() - 9, speedPos.y() - 11, speedPos.x() - 9, speedPos.y() - 3);
+	painter->drawLine(speedPos.x() - 13, speedPos.y() - 7, speedPos.x() - 5, speedPos.y() - 7);
+	// Draw the minus "-":
+	painter->drawLine(speedPos.x() - 13, speedPos.y() + 2, speedPos.x() - 5, speedPos.y() + 2);
+	// Draw the circle "o":
+	painter->drawEllipse(speedPos.x() - 26, speedPos.y() - 6, 6, 6);
+
+	QPoint frameTraversalPos(frameTraversalX, underVideoBarWithMarginY);
+	painter->drawText(frameTraversalPos, "<  >");
+
+	LoopMode loopMode           = qvariant_cast< LoopMode >(propertyHolder->property("LoopMode"));
+	QString loopModeStr         = loopModeToString(loopMode);
+	QFont font                  = painter->font();
+	qsizetype loopModeStrLength = loopModeStr.length();
+	int loopModeStrOffset       = loopModeStrLength > 7 ? 12 : loopModeStrLength > 4 ? 5 : 0;
+	double fontSizeSmall        = 0.7;
+	font.setPointSize((int) round(font.pointSize() * fontSizeSmall));
+	painter->setFont(font);
+	painter->drawText(QPointF(loopModeX, underVideoBarY + 8), "mode:");
+	painter->drawText(QPointF(loopModeX - (double) loopModeStrOffset, underVideoBarY + 17), loopModeStr);
+
+	QString cachedStr = QString::fromStdString(wasCached ? "on" : "off");
+	painter->drawText(QPointF(cacheX, underVideoBarY + 8), "cache:");
+	painter->drawText(QPointF(cacheX + 5, underVideoBarY + 17), cachedStr);
+	font.setPointSize((int) round(font.pointSize() / fontSizeSmall));
+	painter->setFont(font);
+
+	QString totalTimeStr   = formatTime(totalS);
+	QString currentTimeStr = formatTime(currentS, totalS);
+	painter->drawText(QPoint(videoBarX + 20, underVideoBarWithMarginY),
+					  tr("%1 / %2").arg(currentTimeStr).arg(totalTimeStr));
+
+	QPointF iconTopPos(videoBarX + 2, underVideoBarY + 2);
+	if (wasPaused) {
+		// Add a play-icon, which is a right-pointing triangle, like this "▶":
+		QPolygonF polygon(
+			{ iconTopPos, QPointF(videoBarX + 15, underVideoBarY + 10), QPointF(videoBarX + 2, underVideoBarY + 18) });
+		QPainterPath path;
+		path.addPolygon(polygon);
+		painter->fillPath(path, QBrush(Qt::white));
+	} else {
+		// Add a pause-icon, which is two vertical rectangles next to each other, like this "||":
+		QSize pauseBarSize(4, 16);
+		QBrush brush(Qt::white);
+		painter->fillRect(QRect(iconTopPos.toPoint(), pauseBarSize), brush);
+		painter->fillRect(QRect(QPoint(videoBarX + 11, underVideoBarY + 2), pauseBarSize), brush);
+	}
+}
+
+AnimationTextObject::VideoController AnimationTextObject::mousePressVideoControls(QObject *propertyHolder,
+																				  QPoint mouseDocPos) {
+	QRect rect              = propertyHolder->property("posAndSize").toRect();
+	int videoControlsHeight = videoBarHeight + underVideoBarHeight;
+	QSize viewSizeMin(rect.width(), rect.height() - videoControlsHeight);
+	auto getOffsetX     = [rect](int offset) { return rect.x() + offset + (offset < 0 ? rect.width() : 0); };
+	int cacheX          = getOffsetX(cacheOffsetX);
+	int loopModeX       = getOffsetX(loopModeOffsetX);
+	int frameTraversalX = getOffsetX(frameTraversalOffsetX);
+	int speedX          = getOffsetX(speedOffsetX);
+
+	auto isThisInBoundsOnAxis = [mouseDocPos](bool yInsteadOfX, int start, int length) {
+		return isInBoundsOnAxis(mouseDocPos, yInsteadOfX, start, length);
+	};
+	auto isThisInBounds = [mouseDocPos](QRect bounds) { return isInBounds(mouseDocPos, bounds); };
+	int videoControlsY  = rect.y() + rect.height() - videoControlsHeight;
+	int underVideoBarY  = videoControlsY + videoBarHeight;
+
+	QRect viewRect(rect.topLeft(), viewSizeMin);
+	QRect playPauseRect(rect.x(), underVideoBarY, 15, underVideoBarHeight);
+
+	QRect cacheRect(cacheX, underVideoBarY, 25, underVideoBarHeight);
+	QRect loopModeRect(loopModeX, underVideoBarY, 24, underVideoBarHeight);
+
+	int frameTraversalWidth = 12;
+	QRect framePreviousRect(frameTraversalX, underVideoBarY, frameTraversalWidth, underVideoBarHeight);
+	QRect frameNextRect(frameTraversalX + frameTraversalWidth + 2, underVideoBarY, frameTraversalWidth,
+						underVideoBarHeight);
+
+	int speedWidth       = 9;
+	int speedMinusHeight = 9;
+	int speedPlusHeight  = 11;
+	QRect speedResetRect(speedX - 28, underVideoBarY, speedWidth, underVideoBarHeight);
+	QRect speedMinusRect(speedX - 14, underVideoBarY + speedPlusHeight, speedWidth, speedMinusHeight);
+	QRect speedPlusRect(speedX - 14, underVideoBarY, speedWidth, speedPlusHeight);
+
+	if (!isThisInBoundsOnAxis(false, viewRect.x(), viewRect.width()))
+		return None;
+	if (isThisInBoundsOnAxis(true, viewRect.y(), viewRect.height()))
+		return View;
+	if (isThisInBoundsOnAxis(true, videoControlsY, videoBarHeight))
+		return VideoBar;
+	if (isThisInBounds(playPauseRect))
+		return PlayPause;
+	if (isThisInBounds(cacheRect))
+		return CacheSwitch;
+	if (isThisInBounds(loopModeRect))
+		return LoopSwitch;
+	if (isThisInBounds(framePreviousRect))
+		return PreviousFrame;
+	if (isThisInBounds(frameNextRect))
+		return NextFrame;
+	if (isThisInBounds(speedResetRect))
+		return ResetSpeed;
+	if (isThisInBounds(speedMinusRect))
+		return DecreaseSpeed;
+	if (isThisInBounds(speedPlusRect))
+		return IncreaseSpeed;
+	return None;
+}
+
+void AnimationTextObject::mousePress(QAbstractTextDocumentLayout *docLayout, QPoint mouseDocPos,
+									 Qt::MouseButton mouseButton) {
+	QTextFormat baseFmt = docLayout->formatAt(mouseDocPos);
+	if (!baseFmt.isCharFormat() || baseFmt.objectType() != Log::Animation) {
+		return;
+	}
+	QMovie *animation = qvariant_cast< QMovie * >(baseFmt.toCharFormat().property(1));
+	QRect rect        = animation->property("posAndSize").toRect();
+	// Ensure the selection was within the text object's vertical space,
+	// such as if an inline image is not as tall as the content before it:
+	if (!isInBoundsOnAxis(mouseDocPos, true, rect.y(), rect.height())) {
+		return;
+	}
+
+	auto setFrameByVideoBarSelection = [animation, mouseDocPos, rect]() {
+		double videoBarPercentage = (mouseDocPos.x() - rect.x()) / (double) rect.width();
+		setFrameByProportion(animation, videoBarPercentage);
+	};
+	bool isLeftMouseButtonPressed   = mouseButton == Qt::LeftButton;
+	bool isMiddleMouseButtonPressed = mouseButton == Qt::MiddleButton;
+	if (areVideoControlsOn) {
+		VideoController videoController = mousePressVideoControls(animation, mouseDocPos);
+		if (isLeftMouseButtonPressed) {
+			switch (videoController) {
+				case VideoBar:
+					return setFrameByVideoBarSelection();
+				case View:
+				case PlayPause:
+					return togglePause(animation);
+				case CacheSwitch:
+					return toggleCache(animation);
+				case LoopSwitch:
+					return changeLoopMode(animation, 1);
+				case PreviousFrame:
+					return changeFrame(animation, -1);
+				case NextFrame:
+					return changeFrame(animation, 1);
+				case ResetSpeed:
+					return setSpeed(animation, 100);
+				case DecreaseSpeed:
+					return changeSpeed(animation, -10);
+				case IncreaseSpeed:
+					return changeSpeed(animation, 10);
+				default:
+					return;
+			}
+		} else if (isMiddleMouseButtonPressed) {
+			switch (videoController) {
+				case View:
+				case PlayPause:
+					return resetPlayback(animation);
+				case LoopSwitch:
+					return changeLoopMode(animation, -1);
+				case PreviousFrame:
+					return changeFrame(animation, -5);
+				case NextFrame:
+					return changeFrame(animation, 5);
+				case DecreaseSpeed:
+					return changeSpeed(animation, -50);
+				case IncreaseSpeed:
+					return changeSpeed(animation, 50);
+				default:
+					return;
+			}
+		}
+		return;
+	}
+	if (isLeftMouseButtonPressed) {
+		togglePause(animation);
+	} else if (isMiddleMouseButtonPressed) {
+		resetPlayback(animation);
+	}
+	// Right mouse button shows the context menu for the text object,
+	// which is handled where the custom context menu for the log is.
+}
+
+void AnimationTextObject::keyPress(LogTextBrowser *log, bool isItemSelectionChanged, Qt::Key key) {
+	bool isItemAtIndex        = false;
+	int itemIndex             = log->customInteractiveItemFocusIndex;
+	QMovie *animation         = nullptr;
+	QList< QTextFormat > fmts = log->document()->allFormats();
+	for (auto fmt : fmts) {
+		if (fmt.objectType() != Log::Animation) {
+			continue;
+		}
+		animation     = qvariant_cast< QMovie * >(fmt.property(1));
+		isItemAtIndex = itemIndex == animation->property("customInteractiveItemIndex").toInt();
+		if (isItemAtIndex) {
+			break;
+		}
+	}
+	if (!isItemAtIndex) {
+		return;
+	}
+
+	bool isKeyBoundToAction         = true;
+	Qt::KeyboardModifiers modifiers = QApplication::keyboardModifiers();
+	if (modifiers.testFlag(Qt::NoModifier) || modifiers.testFlag(Qt::KeypadModifier)) {
+		switch (key) {
+			case Qt::Key_Space:
+			case Qt::Key_K:
+				togglePause(animation);
+				break;
+			case Qt::Key_Q:
+				resetPlayback(animation);
+				break;
+			case Qt::Key_V:
+				areVideoControlsOn = !areVideoControlsOn;
+				break;
+			case Qt::Key_C:
+				toggleCache(animation);
+				break;
+			case Qt::Key_O:
+				changeLoopMode(animation, -1);
+				break;
+			case Qt::Key_L:
+				changeLoopMode(animation, 1);
+				break;
+			case Qt::Key_Comma:
+				changeFrame(animation, -1);
+				break;
+			case Qt::Key_Period:
+				changeFrame(animation, 1);
+				break;
+			case Qt::Key_N:
+				changeFrame(animation, -5);
+				break;
+			case Qt::Key_M:
+				changeFrame(animation, 5);
+				break;
+			case Qt::Key_H:
+				changeFrameByTime(animation, -1000);
+				break;
+			case Qt::Key_J:
+				changeFrameByTime(animation, 1000);
+				break;
+			case Qt::Key_F:
+				changeFrameByTime(animation, -5000);
+				break;
+			case Qt::Key_G:
+				changeFrameByTime(animation, 5000);
+				break;
+			case Qt::Key_S:
+			case Qt::Key_Minus:
+				changeSpeed(animation, -5);
+				break;
+			case Qt::Key_D:
+			case Qt::Key_Plus:
+				changeSpeed(animation, 5);
+				break;
+			case Qt::Key_W:
+				changeSpeed(animation, -25);
+				break;
+			case Qt::Key_E:
+				changeSpeed(animation, 25);
+				break;
+			case Qt::Key_R:
+				setSpeed(animation, 100);
+				break;
+			case Qt::Key_0:
+				setFrameByProportion(animation, 0);
+				break;
+			case Qt::Key_1:
+				setFrameByProportion(animation, 0.1);
+				break;
+			case Qt::Key_2:
+				setFrameByProportion(animation, 0.2);
+				break;
+			case Qt::Key_3:
+				setFrameByProportion(animation, 0.3);
+				break;
+			case Qt::Key_4:
+				setFrameByProportion(animation, 0.4);
+				break;
+			case Qt::Key_5:
+				setFrameByProportion(animation, 0.5);
+				break;
+			case Qt::Key_6:
+				setFrameByProportion(animation, 0.6);
+				break;
+			case Qt::Key_7:
+				setFrameByProportion(animation, 0.7);
+				break;
+			case Qt::Key_8:
+				setFrameByProportion(animation, 0.8);
+				break;
+			case Qt::Key_9:
+				setFrameByProportion(animation, 0.9);
+				break;
+			default:
+				isKeyBoundToAction = false;
+				break;
+		}
+	} else {
+		isKeyBoundToAction = false;
+	}
+	if (isKeyBoundToAction || isItemSelectionChanged) {
+		log->scrollItemIntoView(animation->property("posAndSize").toRect());
+	}
+}
+
+void AnimationTextObject::drawCenteredPlayIcon(QPainter *painter, QRect rect) {
+	int centerX = (int) round(rect.x() + rect.width() / (double) 2);
+	int centerY = (int) round(rect.y() + rect.height() / (double) 2);
+	// Add a play-icon, which is a right-pointing triangle, like this "▶":
+	QPolygonF polygon(
+		{ QPointF(centerX - 8, centerY - 10), QPointF(centerX + 12, centerY), QPointF(centerX - 8, centerY + 10) });
+	QPainterPath path;
+	QPen thinBlackPen(Qt::black, 0.25);
+	path.addPolygon(polygon);
+	painter->fillPath(path, QBrush(Qt::white));
+	// Add outline contrast to the triangle:
+	painter->strokePath(path, thinBlackPen);
+
+	auto drawCenteredCircle = [painter, centerX, centerY](int diameter) {
+		int radius = diameter / 2;
+		painter->drawEllipse(centerX - radius, centerY - radius, diameter, diameter);
+	};
+	// Add a ring around the triangle:
+	painter->setPen(QPen(Qt::white, 2));
+	drawCenteredCircle(40);
+	// Add outline contrast to the ring:
+	painter->setPen(thinBlackPen);
+	drawCenteredCircle(36);
+	drawCenteredCircle(44);
+}
+
+void AnimationTextObject::updatePropertyRect(QObject *propertyHolder, QRect rect) {
+	QVariant propertyPosAndSize = propertyHolder->property("posAndSize");
+	QRect propertyRect          = propertyPosAndSize.isValid() ? propertyPosAndSize.toRect() : QRect();
+	// Update the property for the position and size of the animation if it has not been set before,
+	// if its width changes when video controls are switched on or off,
+	// if its vertical position changes, such as if content above it has its height altered by text wrapping,
+	// or if its horizontal position changes, such as if the window resizes when the animation is centered
+	// and dependent on available blank space:
+	if (propertyRect.width() != rect.width() || propertyRect.y() != rect.y() || propertyRect.x() != rect.x()) {
+		propertyHolder->setProperty("posAndSize", QVariant(rect));
+	}
+}
+
+AnimationTextObject::AnimationTextObject() : QObject() {
+}
+
+QSizeF AnimationTextObject::intrinsicSize(QTextDocument *, int, const QTextFormat &fmt) {
+	QMovie *animation = qvariant_cast< QMovie * >(fmt.property(1));
+	QSize size        = animation->currentPixmap().size();
+	if (areVideoControlsOn) {
+		int videoControlsHeight = videoBarHeight + underVideoBarHeight;
+		int viewWidthMin        = size.width() - videoControlsHeight;
+		size.setWidth(viewWidthMin);
+	}
+	return QSizeF(size);
+}
+
+void AnimationTextObject::drawObject(QPainter *painter, const QRectF &rectF, QTextDocument *doc, int,
+									 const QTextFormat &fmt) {
+	LogTextBrowser *log = qobject_cast< LogTextBrowser * >(doc->parent());
+	QMovie *animation   = qvariant_cast< QMovie * >(fmt.property(1));
+	QRect rect          = rectF.toRect();
+	QPixmap frame       = animation->currentPixmap();
+	bool wasRunning     = animation->state() == QMovie::Running || animation->property("isPlayingInReverse").toBool();
+	updatePropertyRect(animation, rect);
+
+	painter->setRenderHint(QPainter::Antialiasing);
+	if (log->customInteractiveItemFocusIndex == animation->property("customInteractiveItemIndex").toInt()) {
+		painter->setPen(QPen(QColor(50, 50, 200), 2));
+		painter->drawRect(QRect(rect.x() - 1, rect.y() - 1, rect.width() + 2, rect.height() + 2));
+	}
+	if (areVideoControlsOn) {
+		bool wasCached      = animation->cacheMode() == QMovie::CacheAll;
+		int frameIndex      = animation->currentFrameNumber();
+		int speedPercentage = animation->speed();
+		drawVideoControls(painter, animation, frame, !wasRunning, wasCached, frameIndex, speedPercentage);
+		return;
+	}
+	painter->drawPixmap(rect, frame);
+	if (!wasRunning) {
+		drawCenteredPlayIcon(painter, rect);
+	}
+}
+
 
 bool ChatbarTextEdit::event(QEvent *evt) {
 	if (evt->type() == QEvent::ShortcutOverride) {

--- a/src/mumble/CustomElements.cpp
+++ b/src/mumble/CustomElements.cpp
@@ -1159,10 +1159,10 @@ QObject *AnimationTextObject::createAnimation(const QByteArray &animationBa, Log
 						animation->state() == QMovie::Running || animation->property("isPlayingInReverse").toBool();
 					return currentFrameIndex == targetFrameIndex && wasRunning;
 				};
-				auto isRunningAtFrameWithNoLoop = [&getLoopMode, &isRunningAtFrame](int targetFrameIndex) {
+				auto isRunningAtFrameWithNoLoop = [getLoopMode, isRunningAtFrame](int targetFrameIndex) {
 					return isRunningAtFrame(targetFrameIndex) && getLoopMode() == LoopMode::NoLoop;
 				};
-				auto stopAtEndOfThisFrame = [&animation, &isRunningAtFrameWithNoLoop, &calcFrameDelay, &frameIndex]() {
+				auto stopAtEndOfThisFrame = [&animation, &isRunningAtFrameWithNoLoop, &frameIndex, &calcFrameDelay]() {
 					int delay = calcFrameDelay(frameIndex);
 					QTimer::singleShot(delay, Qt::PreciseTimer, animation,
 									   [animation, isRunningAtFrameWithNoLoop, frameIndex]() {
@@ -1179,8 +1179,7 @@ QObject *AnimationTextObject::createAnimation(const QByteArray &animationBa, Log
 						return;
 					}
 					if (isRunningAtFrameWithNoLoop(0)) {
-						stopAtEndOfThisFrame();
-						return;
+						return stopAtEndOfThisFrame();
 					}
 					int precedingFrameIndex = frameIndex <= 0 ? lastFrameIndex : frameIndex - 1;
 					int precedingFrameDelay = calcFrameDelay(precedingFrameIndex);

--- a/src/mumble/CustomElements.cpp
+++ b/src/mumble/CustomElements.cpp
@@ -483,7 +483,7 @@ bool ChatbarTextEdit::sendImagesFromMimeData(const QMimeData *source) {
 
 bool ChatbarTextEdit::emitPastedImage(QImage image, QString filePath) {
 	qsizetype fileExtStartIndex = filePath.lastIndexOf('.') + 1;
-	QString fileExt             = (fileExtStartIndex != 0 ? filePath.sliced(fileExtStartIndex) : "").toUpper();
+	QString fileExt             = (fileExtStartIndex != 0 ? filePath.sliced(fileExtStartIndex) : "").toLower();
 
 	Log::TextObjectType txtObjType = Log::findTxtObjType(fileExt);
 	if (txtObjType == Log::TextObjectType::Animation) {

--- a/src/mumble/CustomElements.cpp
+++ b/src/mumble/CustomElements.cpp
@@ -1775,15 +1775,10 @@ void ImageAnimationTextObject::setFrameByProportion(QMovie *animation, double pr
 }
 
 void ImageAnimationTextObject::changeFrame(QMovie *animation, int amount) {
-	int lastFrameIndex       = animation->property("lastFrameIndex").toInt();
-	int frameIndex           = animation->currentFrameNumber() + amount;
-	int amountOfTimesGreater = (int) abs(floor(frameIndex / (double) lastFrameIndex));
-
-	int lastFrameIndexScaledToInput = lastFrameIndex * amountOfTimesGreater;
-	int frameIndexWrappedBackward   = lastFrameIndexScaledToInput + 1 + frameIndex;
-	int frameIndexWrappedForward    = frameIndex - 1 - lastFrameIndexScaledToInput;
-	setFrame(animation, frameIndex < 0 ? frameIndexWrappedBackward
-									   : frameIndex > lastFrameIndex ? frameIndexWrappedForward : frameIndex);
+	int lastFrameIndex   = animation->property("lastFrameIndex").toInt();
+	int frameIndex       = animation->currentFrameNumber() + amount;
+	int frameIndexResult = frameIndex > lastFrameIndex ? lastFrameIndex : frameIndex < 0 ? 0 : frameIndex;
+	setFrame(animation, frameIndexResult);
 }
 
 void ImageAnimationTextObject::changeFrameByTime(QMovie *animation, int milliseconds) {

--- a/src/mumble/CustomElements.cpp
+++ b/src/mumble/CustomElements.cpp
@@ -1950,6 +1950,11 @@ void ImageAnimationTextObject::toggleVideoControls() {
 	LogTextBrowser::reflow(*qobject_cast< QTextDocument * >(parent()));
 }
 
+void ImageAnimationTextObject::addVideoControlsSwitch(QMenu &menu) {
+	QString firstWord = areVideoControlsShown ? tr("Hide") : tr("Show");
+	menu.addAction(tr("%1 Video Controls").arg(firstWord), this, [this]() { toggleVideoControls(); });
+}
+
 bool ImageAnimationTextObject::mousePress(const QPoint &mouseDocPos, const Qt::MouseButton &button, QMovie &animation) {
 	return mousePress(animation, mouseDocPos, button, areVideoControlsShown);
 }

--- a/src/mumble/CustomElements.h
+++ b/src/mumble/CustomElements.h
@@ -40,7 +40,7 @@ public:
 	void toggleFullScreen(QWidget *widget);
 	void highlightSelectedObject(QPainter *painter, const QRect &rect, QObject *propertyHolder);
 	QObject *customObjectAt(const QPoint &pos);
-	/// Removes the content of the client's log, deletes the objects used by text objects
+	/// Removes the content of the client's log, deletes the objects used by custom text objects
 	/// and clears the counter for custom objects as well as their focus index.
 	void clear();
 	void repaint(const QRect &rect = QRect());

--- a/src/mumble/CustomElements.h
+++ b/src/mumble/CustomElements.h
@@ -156,7 +156,7 @@ public:
 	static void setAttributesWidthAndHeight(QObject *propertyHolder, QSize &size);
 };
 
-class AnimationTextObject : public QObject, public QTextObjectInterface {
+class ImageAnimationTextObject : public QObject, public QTextObjectInterface {
 	Q_OBJECT
 	Q_INTERFACES(QTextObjectInterface)
 
@@ -167,10 +167,10 @@ protected:
 
 public:
 	static bool areVideoControlsOn;
-	AnimationTextObject();
-	static QObject *createAnimation(const QByteArray &animationBa, LogTextBrowser *parentLog,
-									bool &isAnimationCheckOnly);
-	static QObject *createAnimation(const QByteArray &animationBa, LogTextBrowser *parentLog);
+	ImageAnimationTextObject();
+	static QObject *createImageAnimation(const QByteArray &animationBa, LogTextBrowser *parentLog,
+										 bool &isAnimationCheckOnly);
+	static QObject *createImageAnimation(const QByteArray &animationBa, LogTextBrowser *parentLog);
 	static void mousePress(QMovie *animation, const QPoint &mouseDocPos, const Qt::MouseButton &button);
 	static bool scroll(QMovie *animation, const QPoint &mouseDocPos, bool isScrollingUp);
 	static void keyPress(QMovie *animation, const Qt::Key &key, bool isObjectSelectionChanged = false);
@@ -201,7 +201,7 @@ public:
 	static void changeLoopMode(QMovie *animation, int steps);
 };
 
-class FullScreenAnimation : public QLabel {
+class FullScreenImageAnimation : public QLabel {
 	Q_OBJECT
 
 protected:
@@ -212,7 +212,7 @@ protected:
 	void paintEvent(QPaintEvent *) Q_DECL_OVERRIDE;
 
 public:
-	FullScreenAnimation(QMovie *animation, LogTextBrowser *parent = nullptr);
+	FullScreenImageAnimation(QMovie *animation, LogTextBrowser *parent = nullptr);
 };
 
 class DockTitleBar : public QLabel {

--- a/src/mumble/CustomElements.h
+++ b/src/mumble/CustomElements.h
@@ -169,12 +169,12 @@ public:
 
 	static void updateVideoControls(QObject *propertyHolder, QWidget *area = nullptr);
 	static void updatePropertyRect(QObject *propertyHolder, const QRect &rect);
-	static QSizeF calcIntrinsicSize(const QSize &size, bool areVideoControlsOn);
+	static QSizeF calcIntrinsicSize(const QSize &size, bool areVideoControlsShown);
 	static void setPropertyFullScreen(QObject *propertyHolder, bool on);
 	static void setAttributesWidthAndHeight(QObject *propertyHolder, QSize &size);
 };
 
-class ImageAnimationTextObject : public QObject, QTextObjectInterface {
+class ImageAnimationTextObject : public QObject, public QTextObjectInterface {
 	Q_OBJECT
 	Q_INTERFACES(QTextObjectInterface)
 
@@ -184,20 +184,20 @@ protected:
 					const QTextFormat &fmt) Q_DECL_OVERRIDE;
 
 public:
-	static bool areVideoControlsOn;
-	ImageAnimationTextObject(QTextDocument *parentDoc = nullptr);
+	bool areVideoControlsShown = false;
+	ImageAnimationTextObject(QTextDocument *parentDoc);
 	static QObject *createImageAnimation(const QByteArray &animationBa, QTextDocument *parentDoc,
 										 bool &isAnimationCheckOnly);
 	static QObject *createImageAnimation(const QByteArray &animationBa, QTextDocument *parentDoc);
-	static bool mousePress(QMovie *animation, const QPoint &mouseDocPos, const Qt::MouseButton &button);
-	static bool scroll(QMovie *animation, const QPoint &mouseDocPos, bool isScrollingUp);
+	static bool mousePress(QMovie *animation, const QPoint &mouseDocPos, const Qt::MouseButton &button,
+						   bool areVideoControlsShown = false);
+	static bool scroll(QMovie *animation, const QPoint &mouseDocPos, bool isScrollingUp,
+					   bool areVideoControlsShown = false);
 	static bool keyPress(QMovie *animation, const Qt::Key &key, bool isObjectSelectionChanged = false);
 
 	enum class LoopMode { Unchanged, Loop, NoLoop };
 	static QString loopModeToString(LoopMode mode);
 
-	static void toggleVideoControls(QTextDocument *doc);
-	static void toggleVideoControlsFullScreen(QObject *propertyHolder);
 	static int getTotalTime(QObject *propertyHolder);
 	static int getCurrentTime(QObject *propertyHolder, int frameIndex);
 	static void setFrame(QMovie *animation, int frameIndex);
@@ -217,6 +217,11 @@ public:
 	static void changeSpeed(QMovie *animation, int percentageStep);
 	static void setLoopMode(QMovie *animation, LoopMode mode);
 	static void changeLoopMode(QMovie *animation, int steps);
+	static void toggleVideoControlsFullScreen(QObject *propertyHolder);
+
+	void toggleVideoControls();
+	bool mousePress(const QPoint &mouseDocPos, const Qt::MouseButton &button, QMovie *animation);
+	bool scroll(const QPoint &mouseDocPos, bool isScrollingUp, QMovie *animation);
 };
 
 class FullScreenImageAnimation : public QLabel {

--- a/src/mumble/CustomElements.h
+++ b/src/mumble/CustomElements.h
@@ -32,32 +32,34 @@ protected:
 public:
 	LogTextBrowser(QWidget *p = nullptr);
 
-	static void registerCustomTextObjects(QTextDocument *doc);
-	static void highlightSelectedObject(QTextDocument *doc, QPainter *painter, const QRect &rect,
-										QObject *propertyHolder);
+	static void registerCustomTextObjects(QTextDocument &doc);
+	static void highlightSelectedObject(const QTextDocument &doc, QPainter &painter, const QRect &rect,
+										const QObject &propertyHolder);
 	static QRect calcRectScaledToScreen(const QSize &size);
 	static bool isWidgetInFullScreen();
 	static void toggleFullScreen(QWidget *widget = nullptr);
 
-	static bool mousePressCustomTextObjects(QTextDocument *doc, QMouseEvent *mouseEvt);
-	static bool scrollCustomTextObjects(QTextDocument *doc, QWheelEvent *wheelEvt);
-	static bool keyPressCustomTextObjects(QTextDocument *doc, QKeyEvent *keyEvt, bool isObjSelectionChanged);
-	static QString addedCustomTextObjectsToHtml(const QString &html, QTextCursor *tc, bool isLimitedToSelection = true);
+	static bool mousePressCustomTextObjects(const QTextDocument &doc, const QMouseEvent &mouseEvt);
+	static bool scrollCustomTextObjects(const QTextDocument &doc, const QWheelEvent &wheelEvt);
+	static bool keyPressCustomTextObjects(const QTextDocument &doc, const QKeyEvent &keyEvt,
+										  bool isObjSelectionChanged);
+	static QString addedCustomTextObjectsToHtml(const QString &html, const QTextCursor &tc,
+												bool isLimitedToSelection = true);
 
-	static void clear(QTextDocument *doc, std::function< void() > baseClear = nullptr);
-	static int getScrollX(QTextDocument *doc);
-	static int getScrollY(QTextDocument *doc);
-	static QPoint getScrollPos(QTextDocument *doc);
-	static QRect getDocumentViewRect(QTextDocument *doc);
-	static void setScrollX(QTextDocument *doc, int scrollPos);
-	static void setScrollY(QTextDocument *doc, int scrollPos);
-	static void changeScrollX(QTextDocument *doc, int change);
-	static void changeScrollY(QTextDocument *doc, int change);
-	static bool isScrolledToBottom(QTextDocument *doc);
-	static void scrollAreaIntoView(QTextDocument *doc, const QRect &rect);
-	static QObject *customObjectAt(QTextDocument *doc, const QPoint &pos);
-	static void update(QTextDocument *doc, const QRect &rect = QRect());
-	static void reflow(QTextDocument *doc);
+	static void clear(QTextDocument &doc, std::function< void() > baseClear = nullptr);
+	static int getScrollX(const QTextDocument &doc);
+	static int getScrollY(const QTextDocument &doc);
+	static QPoint getScrollPos(const QTextDocument &doc);
+	static QRect getDocumentViewRect(const QTextDocument &doc);
+	static void setScrollX(const QTextDocument &doc, int scrollPos);
+	static void setScrollY(const QTextDocument &doc, int scrollPos);
+	static void changeScrollX(const QTextDocument &doc, int change);
+	static void changeScrollY(const QTextDocument &doc, int change);
+	static bool isScrolledToBottom(const QTextDocument &doc);
+	static void scrollAreaIntoView(const QTextDocument &doc, const QRect &rect);
+	static QObject *customObjectAt(const QTextDocument &doc, const QPoint &pos);
+	static void update(const QTextDocument &doc, const QRect &rect = QRect());
+	static void reflow(QTextDocument &doc);
 
 	void clear();
 	int getScrollX();
@@ -157,21 +159,23 @@ public:
 	static bool isInBoundsOnAxis(int posOnAxis, int start, int length);
 	static bool isInBounds(const QPoint &pos, const QRect &bounds);
 	static int calcPosOnAxisFromOffset(int offset, int start, int length);
-	static QRect calcVideoControlsRect(QObject *propertyHolder);
+	static QRect calcVideoControlsRect(const QObject &propertyHolder);
 
 	static VideoControl videoControlAt(const QPoint &pos, const QRect &rect);
 	static double videoBarProportionAt(const QPoint &pos, const QRect &rect);
-	static void drawVideoControls(QPainter *painter, const QRect &rect, QObject *propertyHolder, double opacity = 1);
-	static void drawCenteredPlayIcon(QPainter *painter, const QRect &rect);
-	static void addVideoControlsTransition(QObject *propertyHolder, QWidget *area, bool isIdleCursorHidden = true);
-	static void startOrHoldVideoControlsTransition(QObject *propertyHolder, const QPoint &hoveredPos = QPoint(),
+	static void drawVideoControls(QPainter &painter, const QRect &rect, const QObject &propertyHolder,
+								  double opacity = 1);
+	static void drawCenteredPlayIcon(QPainter &painter, const QRect &rect);
+	static void addVideoControlsTransition(QObject &propertyHolder, QWidget &area, bool isIdleCursorHidden = true);
+	static void startOrHoldVideoControlsTransition(QObject &propertyHolder, const QPoint &hoveredPos = QPoint(),
 												   QWidget *cursorArea = nullptr);
 
-	static void updateVideoControls(QObject *propertyHolder, QWidget *area = nullptr);
-	static void updatePropertyRect(QObject *propertyHolder, const QRect &rect);
+	static void updateVideoControls(const QObject &propertyHolder, QWidget *area = nullptr,
+									const QMargins &margins = QMargins());
+	static void updatePropertyRect(QObject &propertyHolder, const QRect &rect);
 	static QSizeF calcIntrinsicSize(const QSize &size, bool areVideoControlsShown);
-	static void setPropertyFullScreen(QObject *propertyHolder, bool on);
-	static void setAttributesWidthAndHeight(QObject *propertyHolder, QSize &size);
+	static void setPropertyFullScreen(QObject &propertyHolder, bool isShown);
+	static void setAttributesWidthAndHeight(const QObject &propertyHolder, QSize &size);
 };
 
 class ImageAnimationTextObject : public QObject, public QTextObjectInterface {
@@ -179,49 +183,51 @@ class ImageAnimationTextObject : public QObject, public QTextObjectInterface {
 	Q_INTERFACES(QTextObjectInterface)
 
 protected:
+	static QObject *createImageAnimation(bool &isAnimationCheckOnly, const QByteArray &animationBa,
+										 QTextDocument *parentDoc = nullptr);
 	QSizeF intrinsicSize(QTextDocument *doc, int charPos, const QTextFormat &fmt) Q_DECL_OVERRIDE;
-	void drawObject(QPainter *painter, const QRectF &rectF, QTextDocument *doc, int charPos,
+	void drawObject(QPainter *painterPtr, const QRectF &rectF, QTextDocument *doc, int charPos,
 					const QTextFormat &fmt) Q_DECL_OVERRIDE;
 
 public:
 	bool areVideoControlsShown = false;
-	ImageAnimationTextObject(QTextDocument *parentDoc);
-	static QObject *createImageAnimation(const QByteArray &animationBa, QTextDocument *parentDoc,
-										 bool &isAnimationCheckOnly);
-	static QObject *createImageAnimation(const QByteArray &animationBa, QTextDocument *parentDoc);
-	static bool mousePress(QMovie *animation, const QPoint &mouseDocPos, const Qt::MouseButton &button,
+	ImageAnimationTextObject(QTextDocument &parentDoc);
+	static QObject *createImageAnimation(const QByteArray &animationBa, QTextDocument &parentDoc);
+	static bool testImageAnimation(const QByteArray &animationBa);
+
+	static bool mousePress(QMovie &animation, const QPoint &mouseDocPos, const Qt::MouseButton &button,
 						   bool areVideoControlsShown = false);
-	static bool scroll(QMovie *animation, const QPoint &mouseDocPos, bool isScrollingUp,
+	static bool scroll(QMovie &animation, const QPoint &mouseDocPos, bool isScrollingUp,
 					   bool areVideoControlsShown = false);
-	static bool keyPress(QMovie *animation, const Qt::Key &key, bool isObjectSelectionChanged = false);
+	static bool keyPress(QMovie &animation, const Qt::Key &key, bool isObjectSelectionChanged = false);
 
 	enum class LoopMode { Unchanged, Loop, NoLoop };
 	static QString loopModeToString(LoopMode mode);
 
-	static int getTotalTime(QObject *propertyHolder);
-	static int getCurrentTime(QObject *propertyHolder, int frameIndex);
-	static void setFrame(QMovie *animation, int frameIndex);
-	static void setFrameByTime(QMovie *animation, int milliseconds);
-	static void setFrameByProportion(QMovie *animation, double proportion);
-	static void changeFrame(QMovie *animation, int amount);
-	static void changeFrameByTime(QMovie *animation, int milliseconds);
-	static void togglePause(QMovie *animation);
-	static void toggleCache(QMovie *animation);
-	static void toggleFullScreen(QMovie *animation);
+	static int getTotalTime(const QObject &propertyHolder);
+	static int getCurrentTime(const QObject &propertyHolder, int frameIndex);
+	static void setFrame(QMovie &animation, int frameIndex);
+	static void setFrameByTime(QMovie &animation, int milliseconds);
+	static void setFrameByProportion(QMovie &animation, double proportion);
+	static void changeFrame(QMovie &animation, int amount);
+	static void changeFrameByTime(QMovie &animation, int milliseconds);
+	static void togglePause(QMovie &animation);
+	static void toggleCache(QMovie &animation);
+	static void toggleFullScreen(QMovie &animation);
 	static void escapeFullScreen();
-	static void stopPlayback(QMovie *animation);
-	static void resetPlayback(QMovie *animation);
-	static void setSpeed(QMovie *animation, int percentage);
-	static void resetSpeed(QMovie *animation);
-	static void invertSpeed(QMovie *animation);
-	static void changeSpeed(QMovie *animation, int percentageStep);
-	static void setLoopMode(QMovie *animation, LoopMode mode);
-	static void changeLoopMode(QMovie *animation, int steps);
-	static void toggleVideoControlsFullScreen(QObject *propertyHolder);
+	static void stopPlayback(QMovie &animation);
+	static void resetPlayback(QMovie &animation);
+	static void setSpeed(QMovie &animation, int percentage);
+	static void resetSpeed(QMovie &animation);
+	static void invertSpeed(QMovie &animation);
+	static void changeSpeed(QMovie &animation, int percentageStep);
+	static void setLoopMode(QMovie &animation, LoopMode mode);
+	static void changeLoopMode(QMovie &animation, int steps);
+	static void toggleVideoControlsFullScreen(QObject &propertyHolder);
 
 	void toggleVideoControls();
-	bool mousePress(const QPoint &mouseDocPos, const Qt::MouseButton &button, QMovie *animation);
-	bool scroll(const QPoint &mouseDocPos, bool isScrollingUp, QMovie *animation);
+	bool mousePress(const QPoint &mouseDocPos, const Qt::MouseButton &button, QMovie &animation);
+	bool scroll(const QPoint &mouseDocPos, bool isScrollingUp, QMovie &animation);
 };
 
 class FullScreenImageAnimation : public QLabel {
@@ -235,7 +241,7 @@ protected:
 	void paintEvent(QPaintEvent *) Q_DECL_OVERRIDE;
 
 public:
-	FullScreenImageAnimation(QMovie *animation, QWidget *parentWidget = nullptr);
+	FullScreenImageAnimation(QMovie &animation, QWidget *parentWidget = nullptr);
 };
 
 class DockTitleBar : public QLabel {

--- a/src/mumble/CustomElements.h
+++ b/src/mumble/CustomElements.h
@@ -24,6 +24,7 @@ protected:
 	QWidget *widgetInFullScreen;
 	QString queuedNumericInput;
 	void mousePressEvent(QMouseEvent *) Q_DECL_OVERRIDE;
+	void wheelEvent(QWheelEvent *) Q_DECL_OVERRIDE;
 	void keyPressEvent(QKeyEvent *) Q_DECL_OVERRIDE;
 	void keyReleaseEvent(QKeyEvent *) Q_DECL_OVERRIDE;
 	QMimeData *createMimeDataFromSelection() const Q_DECL_OVERRIDE;
@@ -38,6 +39,7 @@ public:
 	bool isWidgetInFullScreen();
 	void toggleFullScreen(QWidget *widget);
 	void highlightSelectedObject(QPainter *painter, const QRect &rect, QObject *propertyHolder);
+	QObject *customObjectAt(const QPoint &pos);
 	/// Removes the content of the client's log, deletes the objects used by text objects
 	/// and clears the counter for custom objects as well as their focus index.
 	void clear();
@@ -170,6 +172,7 @@ public:
 									bool &isAnimationCheckOnly);
 	static QObject *createAnimation(const QByteArray &animationBa, LogTextBrowser *parentLog);
 	static void mousePress(QMovie *animation, const QPoint &mouseDocPos, const Qt::MouseButton &button);
+	static bool scroll(QMovie *animation, const QPoint &mouseDocPos, bool isScrollingUp);
 	static void keyPress(QMovie *animation, const Qt::Key &key, bool isObjectSelectionChanged = false);
 
 	enum class LoopMode { Unchanged, Loop, NoLoop };
@@ -204,6 +207,7 @@ class FullScreenAnimation : public QLabel {
 protected:
 	void mousePressEvent(QMouseEvent *) Q_DECL_OVERRIDE;
 	void mouseMoveEvent(QMouseEvent *) Q_DECL_OVERRIDE;
+	void wheelEvent(QWheelEvent *) Q_DECL_OVERRIDE;
 	void keyPressEvent(QKeyEvent *) Q_DECL_OVERRIDE;
 	void paintEvent(QPaintEvent *) Q_DECL_OVERRIDE;
 

--- a/src/mumble/CustomElements.h
+++ b/src/mumble/CustomElements.h
@@ -7,20 +7,38 @@
 #define MUMBLE_MUMBLE_CUSTOMELEMENTS_H_
 
 #include <QtCore/QObject>
+#include <QtGui/QMovie>
+#include <QtGui/QTextObjectInterface>
 #include <QtWidgets/QLabel>
 #include <QtWidgets/QTextBrowser>
 #include <QtWidgets/QTextEdit>
+
+Q_DECLARE_METATYPE(QMovie *)
 
 class LogTextBrowser : public QTextBrowser {
 private:
 	Q_OBJECT
 	Q_DISABLE_COPY(LogTextBrowser)
 
+protected:
+	QString queuedNumericInput;
+	void mousePressEvent(QMouseEvent *) Q_DECL_OVERRIDE;
+	void keyPressEvent(QKeyEvent *) Q_DECL_OVERRIDE;
+	void keyReleaseEvent(QKeyEvent *) Q_DECL_OVERRIDE;
+
 public:
+	int lastCustomInteractiveItemIndex  = -1;
+	int customInteractiveItemFocusIndex = -1;
 	LogTextBrowser(QWidget *p = nullptr);
 
-	int getLogScroll();
-	void setLogScroll(int scroll_pos);
+	void update();
+	int getScrollX();
+	int getScrollY();
+	void setScrollX(int scroll_pos);
+	void setScrollY(int scroll_pos);
+	void changeScrollX(int change);
+	void changeScrollY(int change);
+	void scrollItemIntoView(QRect rect);
 	bool isScrolledToBottom();
 };
 
@@ -52,7 +70,7 @@ protected:
 	bool canInsertFromMimeData(const QMimeData *source) const Q_DECL_OVERRIDE;
 	void insertFromMimeData(const QMimeData *source) Q_DECL_OVERRIDE;
 	bool sendImagesFromMimeData(const QMimeData *source);
-	bool emitPastedImage(QImage image);
+	bool emitPastedImage(QImage image, QString filePath = "");
 
 public:
 	void setDefaultText(const QString &, bool = false);
@@ -74,6 +92,71 @@ public slots:
 
 public:
 	ChatbarTextEdit(QWidget *p = nullptr);
+};
+
+class AnimationTextObject : public QObject, public QTextObjectInterface {
+	Q_OBJECT
+	Q_INTERFACES(QTextObjectInterface)
+
+protected:
+	static const int videoBarHeight        = 4;
+	static const int underVideoBarHeight   = 20;
+	static const int cacheOffsetX          = -170;
+	static const int loopModeOffsetX       = -130;
+	static const int frameTraversalOffsetX = -90;
+	static const int speedOffsetX          = -30;
+	QSizeF intrinsicSize(QTextDocument *doc, int posInDoc, const QTextFormat &fmt) Q_DECL_OVERRIDE;
+	void drawObject(QPainter *painter, const QRectF &rectF, QTextDocument *doc, int posInDoc,
+					const QTextFormat &fmt) Q_DECL_OVERRIDE;
+
+public:
+	static bool areVideoControlsOn;
+	AnimationTextObject();
+	static void mousePress(QAbstractTextDocumentLayout *docLayout, QPoint mouseDocPos, Qt::MouseButton button);
+	static void keyPress(LogTextBrowser *log, bool isItemSelectionChanged, Qt::Key key);
+
+	enum VideoController {
+		VideoBar,
+		View,
+		PlayPause,
+		CacheSwitch,
+		LoopSwitch,
+		PreviousFrame,
+		NextFrame,
+		ResetSpeed,
+		DecreaseSpeed,
+		IncreaseSpeed,
+		None
+	};
+	enum LoopMode { Unchanged, Loop, NoLoop };
+	static QString loopModeToString(LoopMode mode);
+
+	static void updateVideoControls(QObject *propertyHolder);
+	static int getTotalTime(QObject *propertyHolder);
+	static int getCurrentTime(QObject *propertyHolder, int frameIndex);
+	static void setFrame(QMovie *animation, int frameIndex);
+	static void setFrameByTime(QMovie *animation, int milliseconds);
+	static void setFrameByProportion(QMovie *animation, double proportion);
+	static void togglePause(QMovie *animation);
+	static void toggleCache(QMovie *animation);
+	static void stopPlayback(QMovie *animation);
+	static void resetPlayback(QMovie *animation);
+	static void setSpeed(QMovie *animation, int percentage);
+	static void changeLoopMode(QMovie *animation, int steps);
+	static void changeFrame(QMovie *animation, int amount);
+	static void changeFrameByTime(QMovie *animation, int milliseconds);
+	static void changeSpeed(QMovie *animation, int percentageStep);
+
+	static bool isInBoundsOnAxis(QPoint pos, bool yInsteadOfX, int start, int length);
+	static bool isInBounds(QPoint pos, QRect bounds);
+	static int getOffset(int offset, int start, int length);
+	static void setRectAndVideoControlPositioning(QObject *propertyHolder, QRect rect);
+	static VideoController mousePressVideoControls(QObject *propertyHolder, QPoint mouseDocPos);
+	static void drawVideoControls(QPainter *painter, QObject *propertyHolder, QPixmap frame, bool wasPaused,
+								  bool wasCached, int frameIndex, int speedPercentage);
+
+	static void updatePropertyRect(QObject *propertyHolder, QRect rect);
+	static void drawCenteredPlayIcon(QPainter *painter, QRect rect);
 };
 
 class DockTitleBar : public QLabel {

--- a/src/mumble/CustomElements.h
+++ b/src/mumble/CustomElements.h
@@ -226,6 +226,7 @@ public:
 	static void toggleVideoControlsFullScreen(QObject &propertyHolder);
 
 	void toggleVideoControls();
+	void addVideoControlsSwitch(QMenu &menu);
 	bool mousePress(const QPoint &mouseDocPos, const Qt::MouseButton &button, QMovie &animation);
 	bool scroll(const QPoint &mouseDocPos, bool isScrollingUp, QMovie &animation);
 };

--- a/src/mumble/CustomElements.h
+++ b/src/mumble/CustomElements.h
@@ -58,6 +58,7 @@ public:
 	static bool isScrolledToBottom(const QTextDocument &doc);
 	static void scrollAreaIntoView(const QTextDocument &doc, const QRect &rect);
 	static QObject *customObjectAt(const QTextDocument &doc, const QPoint &pos);
+	static QObject *customObjectOfFormat(const QTextFormat &fmt, const QPoint &pos);
 	static void update(const QTextDocument &doc, const QRect &rect = QRect());
 	static void reflow(QTextDocument &doc);
 

--- a/src/mumble/CustomElements.h
+++ b/src/mumble/CustomElements.h
@@ -26,6 +26,7 @@ protected:
 	void mousePressEvent(QMouseEvent *) Q_DECL_OVERRIDE;
 	void keyPressEvent(QKeyEvent *) Q_DECL_OVERRIDE;
 	void keyReleaseEvent(QKeyEvent *) Q_DECL_OVERRIDE;
+	QMimeData *createMimeDataFromSelection() const Q_DECL_OVERRIDE;
 
 public:
 	int lastCustomObjectIndex  = -1;
@@ -158,8 +159,8 @@ class AnimationTextObject : public QObject, public QTextObjectInterface {
 	Q_INTERFACES(QTextObjectInterface)
 
 protected:
-	QSizeF intrinsicSize(QTextDocument *doc, int charPosInDoc, const QTextFormat &fmt) Q_DECL_OVERRIDE;
-	void drawObject(QPainter *painter, const QRectF &rectF, QTextDocument *doc, int charPosInDoc,
+	QSizeF intrinsicSize(QTextDocument *doc, int charPos, const QTextFormat &fmt) Q_DECL_OVERRIDE;
+	void drawObject(QPainter *painter, const QRectF &rectF, QTextDocument *doc, int charPos,
 					const QTextFormat &fmt) Q_DECL_OVERRIDE;
 
 public:

--- a/src/mumble/CustomElements.h
+++ b/src/mumble/CustomElements.h
@@ -28,19 +28,20 @@ protected:
 	void keyReleaseEvent(QKeyEvent *) Q_DECL_OVERRIDE;
 
 public:
-	int lastCustomItemIndex  = -1;
-	int customItemFocusIndex = -1;
-	QList< QObject * > customItems;
+	int lastCustomObjectIndex  = -1;
+	int customObjectFocusIndex = -1;
+	QList< QObject * > customObjects;
 	LogTextBrowser(QWidget *p = nullptr);
 
 	static QRect calcRectScaledToScreen(const QSize &size);
 	bool isWidgetInFullScreen();
 	void toggleFullScreen(QWidget *widget);
-	void highlightSelectedItem(QPainter *painter, const QRect &rect, QObject *propertyHolder);
+	void highlightSelectedObject(QPainter *painter, const QRect &rect, QObject *propertyHolder);
 	/// Removes the content of the client's log, deletes the objects used by text objects
-	/// and clears the counter for custom interactive items as well as their focus index.
+	/// and clears the counter for custom objects as well as their focus index.
 	void clear();
-	void update(const QRect &rect = QRect());
+	void repaint(const QRect &rect = QRect());
+	void reflow();
 	int getScrollX();
 	int getScrollY();
 	QPoint getScrollPos();
@@ -49,7 +50,7 @@ public:
 	void setScrollY(int scrollPos);
 	void changeScrollX(int change);
 	void changeScrollY(int change);
-	void scrollItemIntoView(const QRect &rect);
+	void scrollObjectIntoView(const QRect &rect);
 	bool isScrolledToBottom();
 };
 
@@ -81,7 +82,7 @@ protected:
 	bool canInsertFromMimeData(const QMimeData *source) const Q_DECL_OVERRIDE;
 	void insertFromMimeData(const QMimeData *source) Q_DECL_OVERRIDE;
 	bool sendImagesFromMimeData(const QMimeData *source);
-	bool emitPastedImage(QImage image, QString filePath = "");
+	bool emitPastedImage(const QImage &image, const QString &filePath = "");
 
 public:
 	void setDefaultText(const QString &, bool = false);
@@ -146,8 +147,9 @@ public:
 												   QWidget *cursorArea = nullptr);
 
 	static void updateVideoControls(QObject *propertyHolder, QWidget *area = nullptr);
-	static bool updatePropertyRect(QObject *propertyHolder, const QRect &rect);
-	static QSizeF calcIntrinsicSize(QObject *propertyHolder, const QSize &size, bool areVideoControlsOn);
+	static void updatePropertyRect(QObject *propertyHolder, const QRect &rect);
+	static QSizeF calcIntrinsicSize(const QSize &size, bool areVideoControlsOn);
+	static void setPropertyFullScreen(QObject *propertyHolder, bool on);
 	static void setAttributesWidthAndHeight(QObject *propertyHolder, QSize &size);
 };
 
@@ -163,15 +165,16 @@ protected:
 public:
 	static bool areVideoControlsOn;
 	AnimationTextObject();
-	static QObject *createAnimation(const QByteArray &animationBa, LogTextBrowser *parent, bool &isAnimationCheckOnly);
-	static QObject *createAnimation(const QByteArray &animationBa, LogTextBrowser *parent);
+	static QObject *createAnimation(const QByteArray &animationBa, LogTextBrowser *parentLog,
+									bool &isAnimationCheckOnly);
+	static QObject *createAnimation(const QByteArray &animationBa, LogTextBrowser *parentLog);
 	static void mousePress(QMovie *animation, const QPoint &mouseDocPos, const Qt::MouseButton &button);
-	static void keyPress(QMovie *animation, const Qt::Key &key, bool isItemSelectionChanged = false);
+	static void keyPress(QMovie *animation, const Qt::Key &key, bool isObjectSelectionChanged = false);
 
 	enum class LoopMode { Unchanged, Loop, NoLoop };
 	static QString loopModeToString(LoopMode mode);
 
-	static void toggleVideoControls();
+	static void toggleVideoControls(LogTextBrowser *log);
 	static void toggleVideoControlsFullScreen(QObject *propertyHolder);
 	static int getTotalTime(QObject *propertyHolder);
 	static int getCurrentTime(QObject *propertyHolder, int frameIndex);

--- a/src/mumble/Log.cpp
+++ b/src/mumble/Log.cpp
@@ -841,13 +841,13 @@ bool Log::htmlWithCustomTextObjects(const QString &html, QTextCursor *tc) {
 		int objType         = static_cast< int >(type);
 		fmt.setObjectType(objType);
 		fmt.setProperty(1, QVariant::fromValue(obj));
-		fmt.setProperty(2, fileExt);
 		if (width > 0) {
 			obj->setProperty("overrideWidth", width);
 		}
 		if (height > 0) {
 			obj->setProperty("overrideHeight", height);
 		}
+		obj->setProperty("fileExtension", fileExt);
 		obj->setProperty("objectType", objType);
 		obj->setProperty("customItemIndex", ++log->lastCustomItemIndex);
 		log->customItems.append(obj);

--- a/src/mumble/Log.cpp
+++ b/src/mumble/Log.cpp
@@ -674,8 +674,8 @@ bool Log::isFileExt(const QByteArray &ext, const QByteArray &header) {
 	} else if (ext == "xpm" && headerLength > 5) {
 		objExt = header.sliced(3, 3);
 	} else if (ext == "svg" || ext == "svgz") {
-		return header.contains("<svg ") || header.contains("<svg\n")
-		       || header.contains("<svg\r\n") || header.contains("<svg\r");
+		return header.contains("<svg ") || header.contains("<svg\n") || header.contains("<svg\r\n")
+			   || header.contains("<svg\r");
 	} else if ((isExtIco || isExtCur) && headerLength > 2) {
 		int imageType = static_cast< int >(header[2]);
 		return (isExtIco && imageType == 1) || (isExtCur && imageType == 2);
@@ -694,8 +694,8 @@ QString Log::findFileExt(const QByteArray &header) {
 
 Log::TextObjectType Log::findTxtObjType(const QString &fileExt) {
 	TextObjectType txtObjType{};
-	for (auto i = txtObjTypeToFileExtsMap.cbegin(); i != txtObjTypeToFileExtsMap.cend(); ++i) {
-		if (i.value().contains(fileExt, Qt::CaseInsensitive)) {
+	for (auto i = txtObjTypeToFileExtsFuncMap.cbegin(); i != txtObjTypeToFileExtsFuncMap.cend(); ++i) {
+		if (i.value()().contains(fileExt.toUtf8())) {
 			txtObjType = i.key();
 			break;
 		}
@@ -706,11 +706,11 @@ Log::TextObjectType Log::findTxtObjType(const QString &fileExt) {
 std::tuple< Log::TextObjectType, QString > Log::findTxtObjTypeAndFileExt(const QByteArray &header) {
 	std::tuple< TextObjectType, QString > txtObjTypeAndFileExt{ TextObjectType::NoCustomObject, "" };
 	bool isCompatibleExt = false;
-	for (auto i = txtObjTypeToFileExtsMap.cbegin(); i != txtObjTypeToFileExtsMap.cend(); ++i) {
-		for (const QString &ext : i.value()) {
-			isCompatibleExt = isFileExt(ext.toUtf8(), header);
+	for (auto i = txtObjTypeToFileExtsFuncMap.cbegin(); i != txtObjTypeToFileExtsFuncMap.cend(); ++i) {
+		for (const QByteArray &ext : i.value()()) {
+			isCompatibleExt = isFileExt(ext, header);
 			if (isCompatibleExt) {
-				txtObjTypeAndFileExt = { i.key(), ext };
+				txtObjTypeAndFileExt = { i.key(), QString::fromUtf8(ext) };
 				break;
 			}
 		}

--- a/src/mumble/Log.cpp
+++ b/src/mumble/Log.cpp
@@ -847,11 +847,14 @@ bool Log::htmlWithCustomTextObjects(const QString &html, QTextCursor *tc) {
 		if (height > 0) {
 			obj->setProperty("overrideHeight", height);
 		}
+		obj->setProperty("characterPos", tc->position());
 		obj->setProperty("fileExtension", fileExt);
 		obj->setProperty("objectType", objType);
 		obj->setProperty("customObjectIndex", ++log->lastCustomObjectIndex);
 		log->customObjects.append(obj);
 
+		// Set marker (zero-width space) for custom text object used when copying from selection at least:
+		tc->insertHtml("&#8203;");
 		tc->insertText(QString(QChar::ObjectReplacementCharacter), fmt);
 	} while (true);
 	if (isAnyCustomTxtObj) {

--- a/src/mumble/Log.cpp
+++ b/src/mumble/Log.cpp
@@ -849,8 +849,8 @@ bool Log::htmlWithCustomTextObjects(const QString &html, QTextCursor *tc) {
 		}
 		obj->setProperty("fileExtension", fileExt);
 		obj->setProperty("objectType", objType);
-		obj->setProperty("customItemIndex", ++log->lastCustomItemIndex);
-		log->customItems.append(obj);
+		obj->setProperty("customObjectIndex", ++log->lastCustomObjectIndex);
+		log->customObjects.append(obj);
 
 		tc->insertText(QString(QChar::ObjectReplacementCharacter), fmt);
 	} while (true);

--- a/src/mumble/Log.cpp
+++ b/src/mumble/Log.cpp
@@ -810,7 +810,7 @@ bool Log::writeHtmlWithCustomTextObjects(const QString &html, QTextCursor *tc) {
 		return txtObj;
 	};
 
-	QTextDocument *doc     = tc->document();
+	QTextDocument &doc     = *tc->document();
 	bool isAnyCustomTxtObj = false;
 	// Track the end of the previous custom text object and thereby where to move the start of the search to
 	// as well as what HTML is between the currently processed custom text object and the previous one:
@@ -852,13 +852,13 @@ bool Log::writeHtmlWithCustomTextObjects(const QString &html, QTextCursor *tc) {
 		obj->setProperty("characterPos", tc->position());
 		obj->setProperty("fileExtension", fileExt);
 		obj->setProperty("objectType", objType);
-		QVariant customObjectsProperty = doc->property("customObjects");
+		QVariant customObjectsProperty = doc.property("customObjects");
 		auto customObjects             = customObjectsProperty.isValid()
 								 ? qvariant_cast< QList< QObject * > >(customObjectsProperty)
 								 : QList< QObject * >();
 		obj->setProperty("customObjectIndex", customObjects.size());
 		customObjects.append(obj);
-		doc->setProperty("customObjects", QVariant::fromValue(customObjects));
+		doc.setProperty("customObjects", QVariant::fromValue(customObjects));
 
 		// Set marker (zero-width space) for custom text object used when copying from selection at least:
 		tc->insertHtml("&#8203;");
@@ -871,9 +871,9 @@ bool Log::writeHtmlWithCustomTextObjects(const QString &html, QTextCursor *tc) {
 	return isAnyCustomTxtObj;
 }
 
-QString Log::setHtml(const QString &html, QTextCursor *tc, std::function< void() > baseClear) {
-	LogTextBrowser::clear(tc->document(), baseClear);
-	return writeHtml(html, tc);
+QString Log::setHtml(const QString &html, QTextCursor &tc, std::function< void() > baseClear) {
+	LogTextBrowser::clear(*tc.document(), baseClear);
+	return writeHtml(html, &tc);
 }
 
 QString Log::writeHtml(const QString &html, QTextCursor *tc) {

--- a/src/mumble/Log.cpp
+++ b/src/mumble/Log.cpp
@@ -797,9 +797,14 @@ bool Log::writeHtmlWithCustomTextObjects(const QString &html, QTextCursor *tc) {
 			auto [type, fileExt] = findTextObjectTypeAndFileExtension(header);
 			isCompatibleExt      = type != TextObjectType::NoCustomObject;
 			if (isCompatibleExt) {
-				QString base64      = html.sliced(base64StartIndex, base64Size);
-				QByteArray txtObjBa = QByteArray::fromBase64(qvariant_cast< QByteArray >(base64));
-				txtObj              = { type, txtObjBa, fileExt, imgStartIndex, imgEndIndex, width, height };
+				QByteArray base64 = qvariant_cast< QByteArray >(html.sliced(base64StartIndex, base64Size));
+				QByteArray ba;
+				bool isPercentEncoded = base64.contains('%');
+				if (isPercentEncoded) {
+					ba = QByteArray::fromPercentEncoding(base64);
+				}
+				ba     = QByteArray::fromBase64(isPercentEncoded ? ba : base64);
+				txtObj = { type, ba, fileExt, imgStartIndex, imgEndIndex, width, height };
 			}
 		} while (!isCompatibleExt && imgStartIndex != -1);
 		return txtObj;

--- a/src/mumble/Log.cpp
+++ b/src/mumble/Log.cpp
@@ -415,6 +415,9 @@ QVector< LogMessage > Log::qvDeferredLogs;
 Log::Log(QObject *p) : QObject(p) {
 	qRegisterMetaType< Log::MsgType >();
 
+	QAbstractTextDocumentLayout *docLayout = Global::get().mw->qteLog->document()->documentLayout();
+	docLayout->registerHandler(Animation, new AnimationTextObject());
+
 #ifndef USE_NO_TTS
 	tts = new TextToSpeech(this);
 	tts->setVolume(Global::get().s.iTTSVolume);
@@ -636,6 +639,206 @@ QString Log::imageToImg(QImage img, int maxSize) {
 	return QString();
 }
 
+bool Log::htmlWithAnimations(const QString &html, QTextCursor *tc) {
+	bool isAnyAnimation = false;
+
+	qsizetype htmlEndIndex = html.length() - 1;
+	auto searchForAnimationHeader =
+		[html, htmlEndIndex](qsizetype previousImgEndIndex) -> std::tuple< bool, qsizetype, qsizetype > {
+		bool isCompatibleHeader;
+		qsizetype imgStartIndex = -1;
+		qsizetype base64StartIndex;
+		do {
+			imgStartIndex    = html.indexOf("<img", (imgStartIndex == -1 ? previousImgEndIndex : imgStartIndex) + 1);
+			base64StartIndex = html.indexOf(',', imgStartIndex) + 1;
+			// Get the relevant part of the header through decoding the first 4
+			// characters where each character is 6 bits in base64 encoding
+			// and each decoded character is 1 byte, with 3 bytes consisting of 24 bits:
+			QString imageFirstThreeBytes =
+				base64StartIndex > 0 && htmlEndIndex > base64StartIndex + 2 ? qvariant_cast< QString >(
+					QByteArray::fromBase64(qvariant_cast< QByteArray >(html.sliced(base64StartIndex, 4))))
+																			: "";
+			isCompatibleHeader = imageFirstThreeBytes == "GIF";
+		} while (!isCompatibleHeader && imgStartIndex != -1);
+		return std::make_tuple(isCompatibleHeader, imgStartIndex, base64StartIndex);
+	};
+	auto getIndexOfDoubleOrSingleQuote = [html](qsizetype startIndex) -> qsizetype {
+		qsizetype index = html.indexOf('\"', startIndex);
+		if (index == -1) {
+			index = html.indexOf('\'', startIndex);
+		}
+		return index;
+	};
+
+	// Track if there are more animations to insert after the current one:
+	bool isAnotherAnimation;
+	// Track the end of the previous animation and thereby where to move forward the start of the search to
+	// as well as what HTML precedes the currently processed animation but succeeds the previous animation:
+	qsizetype previousImgEndIndex = -1;
+	do {
+		qsizetype imgStartIndex;
+		qsizetype base64StartIndex;
+		std::tie(isAnotherAnimation, imgStartIndex, base64StartIndex) = searchForAnimationHeader(previousImgEndIndex);
+		qsizetype base64EndIndex = getIndexOfDoubleOrSingleQuote(base64StartIndex) - 1;
+		qsizetype imgEndIndex    = html.indexOf('>', base64EndIndex);
+		bool isImgEndIndex       = imgEndIndex != -1;
+		if (!isAnotherAnimation || base64EndIndex == -2 || !isImgEndIndex) {
+			previousImgEndIndex = isImgEndIndex ? imgEndIndex : -2;
+			continue;
+		}
+		qsizetype base64Size    = base64EndIndex - base64StartIndex + 1;
+		QString animationBase64 = html.sliced(base64StartIndex, base64Size);
+		QByteArray animationBa  = QByteArray::fromBase64(qvariant_cast< QByteArray >(animationBase64));
+
+		QMovie *animation = new QMovie();
+		QBuffer *buffer   = new QBuffer(animation);
+		buffer->setData(animationBa);
+		buffer->open(QIODevice::ReadOnly);
+		animation->setDevice(buffer);
+		if (!animation->isValid()) {
+			delete animation;
+			previousImgEndIndex = imgEndIndex;
+			continue;
+		}
+		animation->setProperty("LoopMode", QVariant::fromValue(AnimationTextObject::Unchanged));
+		// Track when the animation is playing in reverse instead of using the in-built play-controls which do not
+		// support it:
+		animation->setProperty("isPlayingInReverse", false);
+		// Block further signals during sequential traversal until reaching the preceding frame:
+		animation->setProperty("isTraversingFrames", false);
+		// Load and start the animation but stop or pause it after this when it should not play by default:
+		animation->start();
+
+		int frameCount     = animation->frameCount();
+		int frameCountTest = 0;
+		int totalMs        = 0;
+		QList< QVariant > frameDelays;
+		// Test how many frames there are by index in case the animation format does not support `frameCount`.
+		// Also determine the total play time used for the video controls by gathering the time from each frame.
+		// The current time is determined by a list of the time between frames since each delay until the next
+		// frame may vary:
+		while (animation->jumpToFrame(++frameCountTest)) {
+			int delay = animation->nextFrameDelay();
+			frameDelays.append(QVariant(delay));
+			totalMs += delay;
+		}
+		if (frameCount == 0) {
+			frameCount = frameCountTest;
+		}
+		int lastFrameIndex = frameCount - 1;
+		animation->setProperty("lastFrameIndex", QVariant(lastFrameIndex));
+		animation->setProperty("totalMs", QVariant(totalMs));
+		animation->setProperty("frameDelays", frameDelays);
+		animation->jumpToFrame(0);
+		animation->stop();
+
+		LogTextBrowser *log                    = Global::get().mw->qteLog;
+		QAbstractTextDocumentLayout *docLayout = log->document()->documentLayout();
+		animation->setProperty("customInteractiveItemIndex", ++log->lastCustomInteractiveItemIndex);
+
+		qsizetype frameDelayAmount = frameDelays.length();
+		auto refresh               = [animation, docLayout]() {
+            QRect rect = animation->property("posAndSize").toRect();
+            emit docLayout->update(rect);
+		};
+		auto getLoopMode = [animation]() {
+			return qvariant_cast< AnimationTextObject::LoopMode >(animation->property("LoopMode"));
+		};
+		// Refresh the image on change:
+		connect(animation, &QMovie::updated, refresh);
+		// Refresh the image once more when the animation is paused or stopped:
+		connect(animation, &QMovie::stateChanged, [refresh](QMovie::MovieState currentState) {
+			if (currentState != QMovie::Running) {
+				refresh();
+			}
+		});
+		// Start the animation again when it finishes if the loop mode is `Loop`:
+		connect(animation, &QMovie::finished, [animation, getLoopMode]() {
+			if (getLoopMode() == AnimationTextObject::Loop) {
+				animation->start();
+			}
+		});
+		// Stop the animation at the end of the last frame if the loop mode is `NoLoop` and
+		// play the animation in reverse if the property for it is `true`:
+		connect(
+			animation, &QMovie::frameChanged,
+			[animation, getLoopMode, frameDelays, frameDelayAmount, lastFrameIndex](int frameIndex) {
+				auto getFrameDelay = [animation, frameDelays, frameDelayAmount](int targetFrameIndex) -> int {
+					double speed                 = abs(animation->speed() / (double) 100);
+					bool isIndexInBoundsForDelay = targetFrameIndex >= 0 && targetFrameIndex < frameDelayAmount;
+					return (int) round(
+						frameDelays[isIndexInBoundsForDelay ? targetFrameIndex : frameDelayAmount - 1].toInt() / speed);
+				};
+				auto isAtFrameAndRunning = [animation](int targetFrameIndex) -> bool {
+					int currentFrameIndex = animation->currentFrameNumber();
+					bool wasRunning =
+						animation->state() == QMovie::Running || animation->property("isPlayingInReverse").toBool();
+					return currentFrameIndex == targetFrameIndex && wasRunning;
+				};
+				auto isAtFrameAndRunningWithNoLoop = [getLoopMode, isAtFrameAndRunning](int targetFrameIndex) {
+					return isAtFrameAndRunning(targetFrameIndex) && getLoopMode() == AnimationTextObject::NoLoop;
+				};
+				auto stopAtEndOfCurrentFrame = [animation, isAtFrameAndRunningWithNoLoop, getFrameDelay, frameIndex]() {
+					int delay = getFrameDelay(frameIndex);
+					QTimer::singleShot(delay, Qt::PreciseTimer, animation,
+									   [animation, isAtFrameAndRunningWithNoLoop, frameIndex]() {
+										   if (!isAtFrameAndRunningWithNoLoop(frameIndex)) {
+											   return;
+										   }
+										   AnimationTextObject::setFrame(animation, frameIndex);
+										   AnimationTextObject::stopPlayback(animation);
+									   });
+				};
+
+				if (animation->property("isPlayingInReverse").toBool()) {
+					if (animation->property("isTraversingFrames").toBool()) {
+						return;
+					}
+					if (isAtFrameAndRunningWithNoLoop(0)) {
+						stopAtEndOfCurrentFrame();
+						return;
+					}
+					int precedingFrameIndex = frameIndex <= 0 ? lastFrameIndex : frameIndex - 1;
+					int precedingFrameDelay = getFrameDelay(precedingFrameIndex);
+					QTimer::singleShot(precedingFrameDelay, Qt::PreciseTimer, animation,
+									   [animation, isAtFrameAndRunning, frameIndex, precedingFrameIndex]() {
+										   if (!isAtFrameAndRunning(frameIndex)) {
+											   return;
+										   }
+										   bool wasCached = animation->cacheMode() == QMovie::CacheAll;
+										   if (!wasCached) {
+											   animation->setProperty("isTraversingFrames", true);
+										   }
+										   AnimationTextObject::setFrame(animation, precedingFrameIndex);
+										   if (!wasCached) {
+											   animation->setProperty("isTraversingFrames", false);
+											   emit animation->frameChanged(precedingFrameIndex);
+										   }
+									   });
+				} else if (isAtFrameAndRunningWithNoLoop(lastFrameIndex)) {
+					stopAtEndOfCurrentFrame();
+				}
+			});
+
+		QTextCharFormat fmt = Global::get().mw->qteLog->currentCharFormat();
+		fmt.setObjectType(Animation);
+		fmt.setProperty(1, QVariant::fromValue(animation));
+
+		isAnotherAnimation            = std::get< 0 >(searchForAnimationHeader(imgEndIndex));
+		qsizetype htmlBeforeImgLength = imgStartIndex - 1 - previousImgEndIndex;
+		QString htmlBeforeImg =
+			imgStartIndex - 1 > previousImgEndIndex ? html.sliced(previousImgEndIndex + 1, htmlBeforeImgLength) : "";
+		QString htmlAfterImg = !isAnotherAnimation && imgEndIndex < htmlEndIndex ? html.sliced(imgEndIndex + 1) : "";
+		tc->insertHtml(htmlBeforeImg);
+		tc->insertText(QString(QChar::ObjectReplacementCharacter), fmt);
+		tc->insertHtml(htmlAfterImg);
+
+		previousImgEndIndex = imgEndIndex;
+		isAnyAnimation      = true;
+	} while (isAnotherAnimation);
+	return isAnyAnimation;
+}
+
 QString Log::validHtml(const QString &html, QTextCursor *tc) {
 	LogDocument qtd;
 
@@ -650,7 +853,11 @@ QString Log::validHtml(const QString &html, QTextCursor *tc) {
 	// allowing our validation checks for things such as
 	// data URL images to run.
 	(void) qtd.documentLayout();
-	qtd.setHtml(html);
+	// Parse and insert animated image files along with the rest of the HTML
+	// if a tag, a header and valid data for any is detected, otherwise log the HTML as usual:
+	if (!tc || !htmlWithAnimations(html, tc)) {
+		qtd.setHtml(html);
+	}
 
 	QStringList qslAllowed = allowedSchemes();
 	for (QTextBlock qtb = qtd.begin(); qtb != qtd.end(); qtb = qtb.next()) {
@@ -747,7 +954,7 @@ void Log::log(MsgType mt, const QString &console, const QString &terse, bool own
 		qttf.setBottomMargin(msgMargin);
 
 		LogTextBrowser *tlog     = Global::get().mw->qteLog;
-		const int oldscrollvalue = tlog->getLogScroll();
+		const int oldscrollvalue = tlog->getScrollY();
 		// Restore the previous scroll position after inserting a new message
 		// if the message was not sent by the user AND the chat log is not
 		// scrolled all the way down.
@@ -806,7 +1013,7 @@ void Log::log(MsgType mt, const QString &console, const QString &terse, bool own
 		tc.setBlockFormat(bf);
 
 		if (restoreScroll) {
-			tlog->setLogScroll(oldscrollvalue);
+			tlog->setScrollY(oldscrollvalue);
 		}
 	}
 

--- a/src/mumble/Log.cpp
+++ b/src/mumble/Log.cpp
@@ -416,7 +416,7 @@ Log::Log(QObject *p) : QObject(p) {
 	qRegisterMetaType< MsgType >();
 
 	QAbstractTextDocumentLayout *docLayout = Global::get().mw->qteLog->document()->documentLayout();
-	docLayout->registerHandler(static_cast< int >(TextObjectType::Animation), new AnimationTextObject());
+	docLayout->registerHandler(static_cast< int >(TextObjectType::ImageAnimation), new ImageAnimationTextObject());
 
 #ifndef USE_NO_TTS
 	tts = new TextToSpeech(this);
@@ -822,8 +822,8 @@ bool Log::htmlWithCustomTextObjects(const QString &html, QTextCursor *tc) {
 		LogTextBrowser *log = Global::get().mw->qteLog;
 		QObject *obj        = nullptr;
 		switch (type) {
-			case TextObjectType::Animation:
-				obj = AnimationTextObject::createAnimation(ba, log);
+			case TextObjectType::ImageAnimation:
+				obj = ImageAnimationTextObject::createImageAnimation(ba, log);
 				break;
 			case TextObjectType::NoCustomObject:
 				break;

--- a/src/mumble/Log.cpp
+++ b/src/mumble/Log.cpp
@@ -642,8 +642,11 @@ bool Log::isFileExt(const QByteArray &ext, const QByteArray &header) {
 			QByteArray extLower = ext.toLower();
 			return objExt == extLower || objExt == extLower.replace(3, 1, "s");
 		}
-	} else if ((ext == "PNG" || ext == "MNG") && headerSize > 3) {
+	} else if ((ext == "PNG" || ext == "APNG" || ext == "MNG") && headerSize > 3) {
 		objExt = header.sliced(1, 3);
+		if (ext.startsWith('A')) {
+			return ext.endsWith(objExt);
+		}
 	}
 	return objExt == ext;
 }

--- a/src/mumble/Log.cpp
+++ b/src/mumble/Log.cpp
@@ -634,7 +634,7 @@ QString Log::imageToImg(QImage img, int maxSize, const QByteArray &format) {
 	return QString();
 }
 
-bool Log::isFileExt(const QByteArray &ext, const QByteArray &header) {
+bool Log::isFileExtension(const QByteArray &ext, const QByteArray &header) {
 	qsizetype headerLength = header.size();
 	QByteArray objExt;
 	bool isExtAvif = ext == "avif";
@@ -689,16 +689,16 @@ bool Log::isFileExt(const QByteArray &ext, const QByteArray &header) {
 	return objExt.toLower() == ext;
 }
 
-QString Log::findFileExt(const QByteArray &header) {
+QString Log::findFileExtension(const QByteArray &header) {
 	for (const QByteArray &ext : QImageReader::supportedImageFormats()) {
-		if (isFileExt(ext, header)) {
+		if (isFileExtension(ext, header)) {
 			return QString::fromUtf8(ext);
 		}
 	}
 	return QLatin1String();
 }
 
-Log::TextObjectType Log::findTxtObjType(const QString &fileExt) {
+Log::TextObjectType Log::findTextObjectType(const QString &fileExt) {
 	TextObjectType txtObjType{};
 	for (auto i = txtObjTypeToFileExtsFuncMap.cbegin(); i != txtObjTypeToFileExtsFuncMap.cend(); ++i) {
 		if (i.value()().contains(fileExt.toUtf8())) {
@@ -709,12 +709,12 @@ Log::TextObjectType Log::findTxtObjType(const QString &fileExt) {
 	return txtObjType;
 }
 
-std::tuple< Log::TextObjectType, QString > Log::findTxtObjTypeAndFileExt(const QByteArray &header) {
+std::tuple< Log::TextObjectType, QString > Log::findTextObjectTypeAndFileExtension(const QByteArray &header) {
 	std::tuple< TextObjectType, QString > txtObjTypeAndFileExt{ TextObjectType::NoCustomObject, "" };
 	bool isCompatibleExt = false;
 	for (auto i = txtObjTypeToFileExtsFuncMap.cbegin(); i != txtObjTypeToFileExtsFuncMap.cend(); ++i) {
 		for (const QByteArray &ext : i.value()()) {
-			isCompatibleExt = isFileExt(ext, header);
+			isCompatibleExt = isFileExtension(ext, header);
 			if (isCompatibleExt) {
 				txtObjTypeAndFileExt = { i.key(), QString::fromUtf8(ext) };
 				break;
@@ -769,7 +769,7 @@ bool Log::htmlWithCustomTextObjects(const QString &html, QTextCursor *tc) {
 		}
 		return { startIndex, endIndex };
 	};
-	auto findTxtObjData = [&html, &findQuoteRange](const qsizetype &previousImgEndIndex) -> TextObject {
+	auto findTextObjectData = [&html, &findQuoteRange](const qsizetype &previousImgEndIndex) -> TextObject {
 		TextObject txtObj;
 		qsizetype imgStartIndex;
 		qsizetype imgEndIndex = previousImgEndIndex;
@@ -797,7 +797,7 @@ bool Log::htmlWithCustomTextObjects(const QString &html, QTextCursor *tc) {
 			qsizetype base64Size = srcEndIndex - base64StartIndex + 1;
 			QString base64Header = html.sliced(base64StartIndex, std::min((qsizetype) 16, base64Size));
 			QByteArray header    = QByteArray::fromBase64(qvariant_cast< QByteArray >(base64Header));
-			auto [type, fileExt] = findTxtObjTypeAndFileExt(header);
+			auto [type, fileExt] = findTextObjectTypeAndFileExtension(header);
 			isCompatibleExt      = type != TextObjectType::NoCustomObject;
 			if (isCompatibleExt) {
 				QString base64      = html.sliced(base64StartIndex, base64Size);
@@ -813,7 +813,7 @@ bool Log::htmlWithCustomTextObjects(const QString &html, QTextCursor *tc) {
 	// as well as what HTML is between the currently processed custom text object and the previous one:
 	qsizetype previousImgEndIndex = -1;
 	do {
-		auto [type, ba, fileExt, imgStartIndex, imgEndIndex, width, height] = findTxtObjData(previousImgEndIndex);
+		auto [type, ba, fileExt, imgStartIndex, imgEndIndex, width, height] = findTextObjectData(previousImgEndIndex);
 		if (type == TextObjectType::NoCustomObject) {
 			break;
 		}

--- a/src/mumble/Log.h
+++ b/src/mumble/Log.h
@@ -139,7 +139,7 @@ protected:
 #endif
 	unsigned int uiLastId;
 	QDate qdDate;
-	static bool htmlWithCustomTextObjects(const QString &html, QTextCursor *tc);
+	static bool writeHtmlWithCustomTextObjects(const QString &html, QTextCursor *tc);
 	static const QStringList allowedSchemes();
 	void postNotification(MsgType mt, const QString &plain);
 	void postQtNotification(MsgType mt, const QString &plain);
@@ -149,7 +149,8 @@ public:
 	QString msgName(MsgType t) const;
 	void setIgnore(MsgType t, int ignore = 1 << 30);
 	void clearIgnore();
-	static QString validHtml(const QString &html, QTextCursor *tc = nullptr);
+	static QString setHtml(const QString &html, QTextCursor *tc, std::function< void() > baseClear = nullptr);
+	static QString writeHtml(const QString &html, QTextCursor *tc = nullptr);
 	static QString imageToImg(const QByteArray &format, const QByteArray &image);
 	static QString imageToImg(QImage img, int maxSize = 0, const QByteArray &format = "jpg");
 	static bool isFileExtension(const QByteArray &ext, const QByteArray &header);

--- a/src/mumble/Log.h
+++ b/src/mumble/Log.h
@@ -121,7 +121,7 @@ public:
 
 	enum class TextObjectType { NoCustomObject, Animation = QTextFormat::UserObject };
 	inline static const QHash< TextObjectType, QStringList > txtObjTypeToFileExtsMap = {
-		{ TextObjectType::Animation, { "GIF", "WEBP", "PNG", "MNG", "AVIF" } }
+		{ TextObjectType::Animation, { "GIF", "PNG", "APNG", "MNG", "WEBP", "AVIF" } }
 	};
 
 protected:

--- a/src/mumble/Log.h
+++ b/src/mumble/Log.h
@@ -152,10 +152,10 @@ public:
 	static QString validHtml(const QString &html, QTextCursor *tc = nullptr);
 	static QString imageToImg(const QByteArray &format, const QByteArray &image);
 	static QString imageToImg(QImage img, int maxSize = 0, const QByteArray &format = "jpg");
-	static bool isFileExt(const QByteArray &ext, const QByteArray &header);
-	static QString findFileExt(const QByteArray &header);
-	static TextObjectType findTxtObjType(const QString &fileExt);
-	static std::tuple< TextObjectType, QString > findTxtObjTypeAndFileExt(const QByteArray &header);
+	static bool isFileExtension(const QByteArray &ext, const QByteArray &header);
+	static QString findFileExtension(const QByteArray &header);
+	static TextObjectType findTextObjectType(const QString &fileExt);
+	static std::tuple< TextObjectType, QString > findTextObjectTypeAndFileExtension(const QByteArray &header);
 	static QString msgColor(const QString &text, LogColorType t);
 	static QString formatClientUser(ClientUser *cu, LogColorType t, const QString &displayName = QString());
 	static QString formatChannel(::Channel *c);

--- a/src/mumble/Log.h
+++ b/src/mumble/Log.h
@@ -120,9 +120,9 @@ public:
 	// versions.
 	static const MsgType msgOrder[];
 
-	enum class TextObjectType { NoCustomObject, Animation = QTextFormat::UserObject };
+	enum class TextObjectType { NoCustomObject, ImageAnimation = QTextFormat::UserObject };
 	inline static const QHash< TextObjectType, std::function< QList< QByteArray >() > > txtObjTypeToFileExtsFuncMap = {
-		{ TextObjectType::Animation, QMovie::supportedFormats }
+		{ TextObjectType::ImageAnimation, QMovie::supportedFormats }
 	};
 
 protected:

--- a/src/mumble/Log.h
+++ b/src/mumble/Log.h
@@ -119,6 +119,8 @@ public:
 	// versions.
 	static const MsgType msgOrder[];
 
+	enum TextObjectType { Animation = QTextFormat::UserObject };
+
 protected:
 	/// Mutex for qvDeferredLogs
 	static QMutex qmDeferredLogs;
@@ -134,6 +136,9 @@ protected:
 	unsigned int uiLastId;
 	QDate qdDate;
 	static const QStringList allowedSchemes();
+	void postNotification(MsgType mt, const QString &plain);
+	void postQtNotification(MsgType mt, const QString &plain);
+	static bool htmlWithAnimations(const QString &html, QTextCursor *tc);
 
 public:
 	Log(QObject *p = nullptr);

--- a/src/mumble/Log.h
+++ b/src/mumble/Log.h
@@ -151,7 +151,7 @@ public:
 	void clearIgnore();
 	static QString validHtml(const QString &html, QTextCursor *tc = nullptr);
 	static QString imageToImg(const QByteArray &format, const QByteArray &image);
-	static QString imageToImg(QImage img, int maxSize = 0, const QByteArray &format = "png");
+	static QString imageToImg(QImage img, int maxSize = 0, const QByteArray &format = "jpg");
 	static bool isFileExt(const QByteArray &ext, const QByteArray &header);
 	static QString findFileExt(const QByteArray &header);
 	static TextObjectType findTxtObjType(const QString &fileExt);

--- a/src/mumble/Log.h
+++ b/src/mumble/Log.h
@@ -149,7 +149,7 @@ public:
 	QString msgName(MsgType t) const;
 	void setIgnore(MsgType t, int ignore = 1 << 30);
 	void clearIgnore();
-	static QString setHtml(const QString &html, QTextCursor *tc, std::function< void() > baseClear = nullptr);
+	static QString setHtml(const QString &html, QTextCursor &tc, std::function< void() > baseClear = nullptr);
 	static QString writeHtml(const QString &html, QTextCursor *tc = nullptr);
 	static QString imageToImg(const QByteArray &format, const QByteArray &image);
 	static QString imageToImg(QImage img, int maxSize = 0, const QByteArray &format = "jpg");

--- a/src/mumble/Log.h
+++ b/src/mumble/Log.h
@@ -119,7 +119,10 @@ public:
 	// versions.
 	static const MsgType msgOrder[];
 
-	enum TextObjectType { Animation = QTextFormat::UserObject };
+	enum class TextObjectType { NoCustomObject, Animation = QTextFormat::UserObject };
+	inline static const QHash< TextObjectType, QStringList > txtObjTypeToFileExtsMap = {
+		{ TextObjectType::Animation, { "GIF", "WEBP", "PNG", "MNG", "AVIF" } }
+	};
 
 protected:
 	/// Mutex for qvDeferredLogs
@@ -135,10 +138,10 @@ protected:
 #endif
 	unsigned int uiLastId;
 	QDate qdDate;
+	static bool htmlWithCustomTextObjects(const QString &html, QTextCursor *tc);
 	static const QStringList allowedSchemes();
 	void postNotification(MsgType mt, const QString &plain);
 	void postQtNotification(MsgType mt, const QString &plain);
-	static bool htmlWithAnimations(const QString &html, QTextCursor *tc);
 
 public:
 	Log(QObject *p = nullptr);
@@ -147,7 +150,10 @@ public:
 	void clearIgnore();
 	static QString validHtml(const QString &html, QTextCursor *tc = nullptr);
 	static QString imageToImg(const QByteArray &format, const QByteArray &image);
-	static QString imageToImg(QImage img, int maxSize = 0);
+	static QString imageToImg(QImage img, int maxSize = 0, const QByteArray &format = "PNG");
+	static bool isFileExt(const QByteArray &ext, const QByteArray &header);
+	static std::tuple< TextObjectType, QString > findTxtObjTypeAndFileExt(const QByteArray &header);
+	static TextObjectType findTxtObjType(const QString &fileExt);
 	static QString msgColor(const QString &text, LogColorType t);
 	static QString formatClientUser(ClientUser *cu, LogColorType t, const QString &displayName = QString());
 	static QString formatChannel(::Channel *c);

--- a/src/mumble/Log.h
+++ b/src/mumble/Log.h
@@ -152,8 +152,9 @@ public:
 	static QString imageToImg(const QByteArray &format, const QByteArray &image);
 	static QString imageToImg(QImage img, int maxSize = 0, const QByteArray &format = "PNG");
 	static bool isFileExt(const QByteArray &ext, const QByteArray &header);
-	static std::tuple< TextObjectType, QString > findTxtObjTypeAndFileExt(const QByteArray &header);
+	static QString findFileExt(const QByteArray &header);
 	static TextObjectType findTxtObjType(const QString &fileExt);
+	static std::tuple< TextObjectType, QString > findTxtObjTypeAndFileExt(const QByteArray &header);
 	static QString msgColor(const QString &text, LogColorType t);
 	static QString formatClientUser(ClientUser *cu, LogColorType t, const QString &displayName = QString());
 	static QString formatChannel(::Channel *c);

--- a/src/mumble/Log.h
+++ b/src/mumble/Log.h
@@ -121,7 +121,7 @@ public:
 
 	enum class TextObjectType { NoCustomObject, Animation = QTextFormat::UserObject };
 	inline static const QHash< TextObjectType, QStringList > txtObjTypeToFileExtsMap = {
-		{ TextObjectType::Animation, { "GIF", "PNG", "APNG", "MNG", "WEBP", "AVIF" } }
+		{ TextObjectType::Animation, { "gif", "png", "apng", "mng", "webp", "avif" } }
 	};
 
 protected:
@@ -150,7 +150,7 @@ public:
 	void clearIgnore();
 	static QString validHtml(const QString &html, QTextCursor *tc = nullptr);
 	static QString imageToImg(const QByteArray &format, const QByteArray &image);
-	static QString imageToImg(QImage img, int maxSize = 0, const QByteArray &format = "PNG");
+	static QString imageToImg(QImage img, int maxSize = 0, const QByteArray &format = "png");
 	static bool isFileExt(const QByteArray &ext, const QByteArray &header);
 	static QString findFileExt(const QByteArray &header);
 	static TextObjectType findTxtObjType(const QString &fileExt);

--- a/src/mumble/Log.h
+++ b/src/mumble/Log.h
@@ -10,6 +10,7 @@
 #include <QtCore/QDate>
 #include <QtCore/QMutex>
 #include <QtCore/QVector>
+#include <QtGui/QMovie>
 #include <QtGui/QTextCursor>
 #include <QtGui/QTextDocument>
 
@@ -120,8 +121,8 @@ public:
 	static const MsgType msgOrder[];
 
 	enum class TextObjectType { NoCustomObject, Animation = QTextFormat::UserObject };
-	inline static const QHash< TextObjectType, QStringList > txtObjTypeToFileExtsMap = {
-		{ TextObjectType::Animation, { "gif", "png", "apng", "mng", "webp", "avif" } }
+	inline static const QHash< TextObjectType, std::function< QList< QByteArray >() > > txtObjTypeToFileExtsFuncMap = {
+		{ TextObjectType::Animation, QMovie::supportedFormats }
 	};
 
 protected:

--- a/src/mumble/MainWindow.cpp
+++ b/src/mumble/MainWindow.cpp
@@ -1023,7 +1023,7 @@ void MainWindow::on_qteLog_customContextMenuRequested(const QPoint &mpos) {
 	QMenu *menu   = qteLog->createStandardContextMenu(docPos);
 
 	QTextFormat fmt  = qteLog->document()->documentLayout()->formatAt(docPos);
-	bool isAnimation = fmt.objectType() == static_cast< int >(Log::TextObjectType::Animation);
+	bool isAnimation = fmt.objectType() == static_cast< int >(Log::TextObjectType::ImageAnimation);
 	if (fmt.isImageFormat() || isAnimation) {
 		menu->addSeparator();
 		menu->addAction(tr("Save Image As..."), this, &MainWindow::saveImageAs);
@@ -1031,9 +1031,9 @@ void MainWindow::on_qteLog_customContextMenuRequested(const QPoint &mpos) {
 		saveImageTextObject = fmt;
 	}
 	if (isAnimation) {
-		QString firstWord = AnimationTextObject::areVideoControlsOn ? tr("Hide") : tr("Show");
+		QString firstWord = ImageAnimationTextObject::areVideoControlsOn ? tr("Hide") : tr("Show");
 		menu->addAction(tr("%1 Video Controls").arg(firstWord), qteLog,
-						[&log = qteLog]() { AnimationTextObject::toggleVideoControls(log); });
+						[&log = qteLog]() { ImageAnimationTextObject::toggleVideoControls(log); });
 	}
 
 	menu->addSeparator();
@@ -1043,7 +1043,7 @@ void MainWindow::on_qteLog_customContextMenuRequested(const QPoint &mpos) {
 }
 
 void MainWindow::saveImageAs() {
-	bool isAnimation     = saveImageTextObject.objectType() == static_cast< int >(Log::TextObjectType::Animation);
+	bool isAnimation     = saveImageTextObject.objectType() == static_cast< int >(Log::TextObjectType::ImageAnimation);
 	QMovie *animation    = isAnimation ? qvariant_cast< QMovie * >(saveImageTextObject.property(1)) : nullptr;
 	QString fileExt      = isAnimation ? animation->property("fileExtension").toString() : "jpg";
 	QString now          = QDateTime::currentDateTime().toString("yyyy-MM-dd-HHmmss");

--- a/src/mumble/MainWindow.cpp
+++ b/src/mumble/MainWindow.cpp
@@ -1026,7 +1026,8 @@ void MainWindow::on_qteLog_customContextMenuRequested(const QPoint &mpos) {
 	QAbstractTextDocumentLayout *docLayout = doc->documentLayout();
 	QTextFormat fmt                        = docLayout->formatAt(docPos);
 	int objType                            = fmt.objectType();
-	bool isAnimation                       = objType == static_cast< int >(Log::TextObjectType::ImageAnimation);
+	bool isCustomObj                       = LogTextBrowser::customObjectOfFormat(fmt, docPos) != nullptr;
+	bool isAnimation = isCustomObj && objType == static_cast< int >(Log::TextObjectType::ImageAnimation);
 	if (fmt.isImageFormat() || isAnimation) {
 		menu->addSeparator();
 		menu->addAction(tr("Save Image As..."), this, &MainWindow::saveImageAs);
@@ -1034,7 +1035,7 @@ void MainWindow::on_qteLog_customContextMenuRequested(const QPoint &mpos) {
 		saveImageTextObject = fmt;
 	}
 	if (isAnimation) {
-		((ImageAnimationTextObject *)docLayout->handlerForObject(objType))->addVideoControlsSwitch(*menu);
+		((ImageAnimationTextObject *) docLayout->handlerForObject(objType))->addVideoControlsSwitch(*menu);
 	}
 
 	menu->addSeparator();

--- a/src/mumble/MainWindow.cpp
+++ b/src/mumble/MainWindow.cpp
@@ -1031,12 +1031,13 @@ void MainWindow::on_qteLog_customContextMenuRequested(const QPoint &mpos) {
 		saveImageTextObject = fmt;
 	}
 	if (isAnimation) {
-		QString actionFirstWord = AnimationTextObject::areVideoControlsOn ? "Hide" : "Show";
-		menu->addAction(tr("%1 Video Controls").arg(actionFirstWord), this, &AnimationTextObject::toggleVideoControls);
+		QString firstWord = AnimationTextObject::areVideoControlsOn ? tr("Hide") : tr("Show");
+		menu->addAction(tr("%1 Video Controls").arg(firstWord), qteLog,
+						[&log = qteLog]() { AnimationTextObject::toggleVideoControls(log); });
 	}
 
 	menu->addSeparator();
-	menu->addAction("Clear", qteLog, &LogTextBrowser::clear);
+	menu->addAction(tr("Clear"), qteLog, &LogTextBrowser::clear);
 	menu->exec(qteLog->mapToGlobal(mpos));
 	delete menu;
 }
@@ -1048,7 +1049,7 @@ void MainWindow::saveImageAs() {
 	QString now          = QDateTime::currentDateTime().toString("yyyy-MM-dd-HHmmss");
 	QString defaultFname = QLatin1String("Mumble-%1.%2").arg(now, fileExt);
 
-	QByteArray fileExtBa = fileExt.toUtf8();
+	QByteArray fileExtBa                           = fileExt.toUtf8();
 	QList< QByteArray > writeSupportedImageFormats = QImageWriter::supportedImageFormats();
 	if (isAnimation && !writeSupportedImageFormats.contains(fileExtBa)) {
 		writeSupportedImageFormats.append(fileExtBa);

--- a/src/mumble/MainWindow.cpp
+++ b/src/mumble/MainWindow.cpp
@@ -1039,7 +1039,7 @@ void MainWindow::on_qteLog_customContextMenuRequested(const QPoint &mpos) {
 	}
 
 	menu->addSeparator();
-	menu->addAction(tr("Clear"), qteLog, qOverload< void >(&LogTextBrowser::clear));
+	menu->addAction(tr("Clear"), qteLog, static_cast< void (LogTextBrowser::*)(void) >(&LogTextBrowser::clear));
 	menu->exec(qteLog->mapToGlobal(mpos));
 	delete menu;
 }

--- a/src/mumble/MainWindow.cpp
+++ b/src/mumble/MainWindow.cpp
@@ -1034,11 +1034,7 @@ void MainWindow::on_qteLog_customContextMenuRequested(const QPoint &mpos) {
 		saveImageTextObject = fmt;
 	}
 	if (isAnimation) {
-		QTextObjectInterface *objHandler = docLayout->handlerForObject(objType);
-		auto animationHandler            = (ImageAnimationTextObject *) objHandler;
-		QString firstWord                = animationHandler->areVideoControlsShown ? tr("Hide") : tr("Show");
-		menu->addAction(tr("%1 Video Controls").arg(firstWord), doc,
-						[animationHandler]() { animationHandler->toggleVideoControls(); });
+		((ImageAnimationTextObject *)docLayout->handlerForObject(objType))->addVideoControlsSwitch(*menu);
 	}
 
 	menu->addSeparator();

--- a/src/mumble/MainWindow.cpp
+++ b/src/mumble/MainWindow.cpp
@@ -1022,9 +1022,11 @@ void MainWindow::on_qteLog_customContextMenuRequested(const QPoint &mpos) {
 	QPoint docPos = mpos + contentPosition;
 	QMenu *menu   = qteLog->createStandardContextMenu(docPos);
 
-	QTextDocument *doc = qteLog->document();
-	QTextFormat fmt    = doc->documentLayout()->formatAt(docPos);
-	bool isAnimation   = fmt.objectType() == static_cast< int >(Log::TextObjectType::ImageAnimation);
+	QTextDocument *doc                     = qteLog->document();
+	QAbstractTextDocumentLayout *docLayout = doc->documentLayout();
+	QTextFormat fmt                        = docLayout->formatAt(docPos);
+	int objType                            = fmt.objectType();
+	bool isAnimation                       = objType == static_cast< int >(Log::TextObjectType::ImageAnimation);
 	if (fmt.isImageFormat() || isAnimation) {
 		menu->addSeparator();
 		menu->addAction(tr("Save Image As..."), this, &MainWindow::saveImageAs);
@@ -1032,9 +1034,11 @@ void MainWindow::on_qteLog_customContextMenuRequested(const QPoint &mpos) {
 		saveImageTextObject = fmt;
 	}
 	if (isAnimation) {
-		QString firstWord = ImageAnimationTextObject::areVideoControlsOn ? tr("Hide") : tr("Show");
+		QTextObjectInterface *objHandler = docLayout->handlerForObject(objType);
+		auto animationHandler            = (ImageAnimationTextObject *) objHandler;
+		QString firstWord                = animationHandler->areVideoControlsShown ? tr("Hide") : tr("Show");
 		menu->addAction(tr("%1 Video Controls").arg(firstWord), doc,
-						[doc]() { ImageAnimationTextObject::toggleVideoControls(doc); });
+						[animationHandler]() { animationHandler->toggleVideoControls(); });
 	}
 
 	menu->addSeparator();

--- a/src/mumble/MainWindow.cpp
+++ b/src/mumble/MainWindow.cpp
@@ -1042,7 +1042,7 @@ void MainWindow::on_qteLog_customContextMenuRequested(const QPoint &mpos) {
 
 void MainWindow::saveImageAs() {
 	bool isAnimation = saveImageTextObject.objectType() == static_cast< int >(Log::TextObjectType::Animation);
-	QString fileExt  = isAnimation ? saveImageTextObject.property(2).toString().toLower() : "jpg";
+	QString fileExt  = isAnimation ? saveImageTextObject.property(2).toString() : "jpg";
 	QDateTime now    = QDateTime::currentDateTime();
 	QString defaultFname =
 		QString::fromLatin1("Mumble-%1.%2").arg(now.toString(QString::fromLatin1("yyyy-MM-dd-HHmmss")), fileExt);
@@ -1085,7 +1085,7 @@ void MainWindow::saveImageAs() {
 	if (!ok) {
 		// In case fname did not contain a file extension, try saving with an
 		// explicit format.
-		ok = img.save(fname, "PNG");
+		ok = img.save(fname, "png");
 	}
 
 	updateImagePath(fname);

--- a/src/mumble/MainWindow.cpp
+++ b/src/mumble/MainWindow.cpp
@@ -1022,8 +1022,9 @@ void MainWindow::on_qteLog_customContextMenuRequested(const QPoint &mpos) {
 	QPoint docPos = mpos + contentPosition;
 	QMenu *menu   = qteLog->createStandardContextMenu(docPos);
 
-	QTextFormat fmt  = qteLog->document()->documentLayout()->formatAt(docPos);
-	bool isAnimation = fmt.objectType() == static_cast< int >(Log::TextObjectType::ImageAnimation);
+	QTextDocument *doc = qteLog->document();
+	QTextFormat fmt    = doc->documentLayout()->formatAt(docPos);
+	bool isAnimation   = fmt.objectType() == static_cast< int >(Log::TextObjectType::ImageAnimation);
 	if (fmt.isImageFormat() || isAnimation) {
 		menu->addSeparator();
 		menu->addAction(tr("Save Image As..."), this, &MainWindow::saveImageAs);
@@ -1032,12 +1033,12 @@ void MainWindow::on_qteLog_customContextMenuRequested(const QPoint &mpos) {
 	}
 	if (isAnimation) {
 		QString firstWord = ImageAnimationTextObject::areVideoControlsOn ? tr("Hide") : tr("Show");
-		menu->addAction(tr("%1 Video Controls").arg(firstWord), qteLog,
-						[&log = qteLog]() { ImageAnimationTextObject::toggleVideoControls(log); });
+		menu->addAction(tr("%1 Video Controls").arg(firstWord), doc,
+						[doc]() { ImageAnimationTextObject::toggleVideoControls(doc); });
 	}
 
 	menu->addSeparator();
-	menu->addAction(tr("Clear"), qteLog, &LogTextBrowser::clear);
+	menu->addAction(tr("Clear"), qteLog, qOverload< void >(&LogTextBrowser::clear));
 	menu->exec(qteLog->mapToGlobal(mpos));
 	delete menu;
 }

--- a/src/mumble/MainWindow.cpp
+++ b/src/mumble/MainWindow.cpp
@@ -68,6 +68,7 @@
 #endif
 
 #include <QAccessible>
+#include <QtCore/QSaveFile>
 #include <QtCore/QStandardPaths>
 #include <QtCore/QUrlQuery>
 #include <QtGui/QClipboard>
@@ -1033,38 +1034,80 @@ void MainWindow::on_qteLog_customContextMenuRequested(const QPoint &mpos) {
 		cursor.movePosition(QTextCursor::NextCharacter);
 		fmt = cursor.charFormat();
 	}
-	if (cursor.charFormat().isImageFormat()) {
+	bool isAnimation = fmt.objectType() == Log::Animation;
+	if (fmt.isImageFormat() || isAnimation) {
 		menu->addSeparator();
 		menu->addAction(tr("Save Image As..."), this, SLOT(saveImageAs(void)));
 
 		qtcSaveImageCursor = cursor;
 	}
+	if (isAnimation) {
+		bool areVideoControlsOn = AnimationTextObject::areVideoControlsOn;
+		QString actionFirstWord = areVideoControlsOn ? "Hide" : "Show";
+		menu->addAction(tr("%1 Video Controls").arg(actionFirstWord), this, SLOT(toggleVideoControls(void)));
+	}
 
 	menu->addSeparator();
-	menu->addAction(tr("Clear"), qteLog, SLOT(clear(void)));
+	menu->addAction(tr("Clear"), this, SLOT(clearDocument(void)));
 	menu->exec(qteLog->mapToGlobal(mpos));
 	delete menu;
 }
 
+void MainWindow::clearDocument() {
+	QList< QTextFormat > fmts = qteLog->document()->allFormats();
+	for (auto fmt : fmts) {
+		if (fmt.objectType() == Log::Animation) {
+			QMovie *animation = qvariant_cast< QMovie * >(fmt.property(1));
+			AnimationTextObject::stopPlayback(animation);
+			animation->deleteLater();
+		}
+	}
+	qteLog->clear();
+}
+
+void MainWindow::toggleVideoControls() {
+	AnimationTextObject::areVideoControlsOn = !AnimationTextObject::areVideoControlsOn;
+}
+
 void MainWindow::saveImageAs() {
-	QDateTime now = QDateTime::currentDateTime();
-	QString defaultFname =
-		QString::fromLatin1("Mumble-%1.jpg").arg(now.toString(QString::fromLatin1("yyyy-MM-dd-HHmmss")));
+	QTextCharFormat fmt   = qtcSaveImageCursor.charFormat();
+	bool isAnimation      = fmt.objectType() == Log::Animation;
+	QString fileExtension = isAnimation ? "gif" : "jpg";
+	QDateTime now         = QDateTime::currentDateTime();
+	QString defaultFname  = QString::fromLatin1("Mumble-%1.%2")
+							   .arg(now.toString(QString::fromLatin1("yyyy-MM-dd-HHmmss")))
+							   .arg(fileExtension);
 
 	QString fname = QFileDialog::getSaveFileName(this, tr("Save Image File"), getImagePath(defaultFname),
-												 tr("Images (*.png *.jpg *.jpeg)"));
+												 tr("Images (*.png *.jpg *.jpeg *.gif)"));
 	if (fname.isNull()) {
 		return;
 	}
 
-	QString resName = qtcSaveImageCursor.charFormat().toImageFormat().name();
-	QVariant res    = qteLog->document()->resource(QTextDocument::ImageResource, resName);
-	QImage img      = res.value< QImage >();
-	bool ok         = img.save(fname);
-	if (!ok) {
-		// In case fname did not contain a file extension, try saving with an
-		// explicit format.
-		ok = img.save(fname, "PNG");
+	bool ok = false;
+	if (isAnimation) {
+		QMovie *animation  = qvariant_cast< QMovie * >(fmt.property(1));
+		QIODevice *device  = animation->device();
+		qint64 previousPos = device->pos();
+		if (device->reset()) {
+			QByteArray fileData = device->readAll();
+			QSaveFile saveFile(fname);
+			if (saveFile.open(QIODevice::WriteOnly)) {
+				saveFile.write(fileData);
+				ok = saveFile.commit();
+			}
+		}
+		device->seek(previousPos);
+	} else {
+		QString resName = fmt.toImageFormat().name();
+		QVariant res    = qteLog->document()->resource(QTextDocument::ImageResource, resName);
+		QImage img      = res.value< QImage >();
+		ok              = img.save(fname);
+		if (!ok) {
+			// In case fname did not contain a file extension, try saving with an
+			// explicit format.
+			ok = img.save(fname, "PNG");
+		}
 	}
 
 	updateImagePath(fname);
@@ -3902,8 +3945,8 @@ void MainWindow::context_triggered() {
 QPair< QByteArray, QImage > MainWindow::openImageFile() {
 	QPair< QByteArray, QImage > retval;
 
-	QString fname =
-		QFileDialog::getOpenFileName(this, tr("Choose image file"), getImagePath(), tr("Images (*.png *.jpg *.jpeg)"));
+	QString fname = QFileDialog::getOpenFileName(this, tr("Choose image file"), getImagePath(),
+												 tr("Images (*.png *.jpg *.jpeg *.gif)"));
 
 	if (fname.isNull())
 		return retval;

--- a/src/mumble/MainWindow.h
+++ b/src/mumble/MainWindow.h
@@ -379,6 +379,10 @@ public slots:
 	void onResetAudio();
 	void showRaiseWindow();
 	void on_qaFilterToggle_triggered();
+	/// Removes the content of the client's log and deletes the objects used by text objects.
+	void clearDocument();
+	/// Alternates between showing and hiding video controls for animated images.
+	void toggleVideoControls();
 	/// Opens a save dialog for the image referenced by qtcSaveImageCursor.
 	void saveImageAs();
 	/// Returns the path to the user's image directory, optionally with a

--- a/src/mumble/MainWindow.h
+++ b/src/mumble/MainWindow.h
@@ -130,9 +130,9 @@ public:
 	/// Restart the client after shutdown
 	bool restartOnQuit;
 
-	/// Contains the cursor whose position is immediately before the image to
-	/// save when activating the "Save Image As..." context menu item.
-	QTextCursor qtcSaveImageCursor;
+	/// Contains the text object of the image to save
+	/// when activating the "Save Image As..." context menu item.
+	QTextFormat saveImageTextObject;
 
 	QPointer< Channel > cContextChannel;
 	QPointer< ClientUser > cuContextUser;
@@ -379,10 +379,6 @@ public slots:
 	void onResetAudio();
 	void showRaiseWindow();
 	void on_qaFilterToggle_triggered();
-	/// Removes the content of the client's log and deletes the objects used by text objects.
-	void clearDocument();
-	/// Alternates between showing and hiding video controls for animated images.
-	void toggleVideoControls();
 	/// Opens a save dialog for the image referenced by qtcSaveImageCursor.
 	void saveImageAs();
 	/// Returns the path to the user's image directory, optionally with a

--- a/src/mumble/UserModel.cpp
+++ b/src/mumble/UserModel.cpp
@@ -682,7 +682,7 @@ QVariant UserModel::otherRoles(const QModelIndex &idx, int role) const {
 								}
 							}
 							const_cast< UserModel * >(this)->seenComment(idx);
-							QString base = Log::validHtml(p->qsComment);
+							QString base = Log::writeHtml(p->qsComment);
 							if (!qsImage.isEmpty())
 								return QString::fromLatin1(
 										   "<table><tr><td valign=\"top\">%1</td><td>%2</td></tr></table>")
@@ -706,7 +706,7 @@ QVariant UserModel::otherRoles(const QModelIndex &idx, int role) const {
 							}
 
 							const_cast< UserModel * >(this)->seenComment(idx);
-							return Log::validHtml(c->qsDesc);
+							return Log::writeHtml(c->qsDesc);
 						}
 					}
 				} break;

--- a/src/mumble/UserView.h
+++ b/src/mumble/UserView.h
@@ -8,10 +8,23 @@
 
 #include <QtCore/QtGlobal>
 #include <QtWidgets/QStyledItemDelegate>
+#include <QtWidgets/QTextEdit>
 #include <QtWidgets/QTreeView>
 
 #include "QtUtils.h"
 #include "Timer.h"
+
+class RichTooltip : public QTextEdit {
+private:
+	Q_OBJECT
+
+public:
+	RichTooltip(QWidget &parentWidget);
+	QSize getDocumentSize();
+	void show(const QString &text, const QPoint &pos, bool isAnimated = true);
+	void move(const QPoint &pos, bool isVisible = true);
+	void destruct(bool isAnimated = true);
+};
 
 class UserDelegate : public QStyledItemDelegate {
 private:
@@ -21,8 +34,10 @@ private:
 	int m_iconTotalDimension;
 	int m_iconIconPadding;
 	int m_iconIconDimension;
+	quintptr previousItemId = 0;
 
 public:
+	RichTooltip *richTooltip = nullptr;
 	UserDelegate(QObject *parent);
 	void paint(QPainter *painter, const QStyleOptionViewItem &option, const QModelIndex &index) const Q_DECL_OVERRIDE;
 	void adjustIcons(int iconTotalDimension, int iconIconPadding, int iconIconDimension);

--- a/src/mumble/mumble_ar.ts
+++ b/src/mumble/mumble_ar.ts
@@ -2963,15 +2963,19 @@ Are you sure you wish to replace your certificate?
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Unable to send image: too large.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Unable to send image %1: too large.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>This server does not allow sending images.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Unable to send image</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>too large</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>cannot read file</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -3865,6 +3869,21 @@ Without this option enabled, using Mumble&apos;s global shortcuts in privileged 
     </message>
     <message>
         <source>Mouse</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>ImageAnimationTextObject</name>
+    <message>
+        <source>Hide</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>%1 Video Controls</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -5464,10 +5483,6 @@ Otherwise abort and check your certificate and username.</source>
     </message>
     <message>
         <source>Wrong server password for unregistered user account, please try again.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Images (*.png *.jpg *.jpeg)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -7083,6 +7098,22 @@ Valid options are:
     </message>
     <message>
         <source>This decreases the attenuation of channel listeners by 10 percents points</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Icons</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Cursors</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Animated Cursors</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Images (*.png *.jpg *.jpeg *.gif)</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/mumble/mumble_bg.ts
+++ b/src/mumble/mumble_bg.ts
@@ -2960,15 +2960,19 @@ Are you sure you wish to replace your certificate?
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Unable to send image: too large.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Unable to send image %1: too large.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>This server does not allow sending images.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Unable to send image</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>too large</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>cannot read file</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -3862,6 +3866,21 @@ Without this option enabled, using Mumble&apos;s global shortcuts in privileged 
     </message>
     <message>
         <source>Mouse</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>ImageAnimationTextObject</name>
+    <message>
+        <source>Hide</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>%1 Video Controls</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -5462,10 +5481,6 @@ Otherwise abort and check your certificate and username.</source>
     <message>
         <source>Wrong server password for unregistered user account, please try again.</source>
         <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Images (*.png *.jpg *.jpeg)</source>
-        <translation>Изображения (*.png *.jpg *.jpeg)</translation>
     </message>
     <message>
         <source>C&amp;onfigure</source>
@@ -7080,6 +7095,22 @@ Valid options are:
     </message>
     <message>
         <source>This decreases the attenuation of channel listeners by 10 percents points</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Icons</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Cursors</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Animated Cursors</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Images (*.png *.jpg *.jpeg *.gif)</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/mumble/mumble_br.ts
+++ b/src/mumble/mumble_br.ts
@@ -2959,15 +2959,19 @@ Are you sure you wish to replace your certificate?
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Unable to send image: too large.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Unable to send image %1: too large.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>This server does not allow sending images.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Unable to send image</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>too large</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>cannot read file</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -3862,6 +3866,21 @@ Without this option enabled, using Mumble&apos;s global shortcuts in privileged 
     <message>
         <source>Mouse</source>
         <translation>Logodenn</translation>
+    </message>
+</context>
+<context>
+    <name>ImageAnimationTextObject</name>
+    <message>
+        <source>Hide</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>%1 Video Controls</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -5460,10 +5479,6 @@ Otherwise abort and check your certificate and username.</source>
     </message>
     <message>
         <source>Wrong server password for unregistered user account, please try again.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Images (*.png *.jpg *.jpeg)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -7079,6 +7094,22 @@ Valid options are:
     </message>
     <message>
         <source>This decreases the attenuation of channel listeners by 10 percents points</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Icons</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Cursors</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Animated Cursors</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Images (*.png *.jpg *.jpeg *.gif)</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/mumble/mumble_ca.ts
+++ b/src/mumble/mumble_ca.ts
@@ -3000,16 +3000,20 @@ Esteu segur que vols substituir el vostre certificat?
         <translation>&lt;center&gt;Escriviu aquí el missatge del xat&lt;/center&gt;</translation>
     </message>
     <message>
-        <source>Unable to send image: too large.</source>
-        <translation>No es pot enviar la imatge: és massa gran.</translation>
-    </message>
-    <message>
-        <source>Unable to send image %1: too large.</source>
-        <translation>No es pot enviar la imatge %1: és massa gran.</translation>
-    </message>
-    <message>
         <source>This server does not allow sending images.</source>
         <translation>Aquest servidor no permet enviar imatges.</translation>
+    </message>
+    <message>
+        <source>Unable to send image</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>too large</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>cannot read file</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -3914,6 +3918,21 @@ Sense aquesta opció activada, l&apos;ús de les dreceres globals del Mumble en 
     <message>
         <source>Mouse</source>
         <translation>Ratolí</translation>
+    </message>
+</context>
+<context>
+    <name>ImageAnimationTextObject</name>
+    <message>
+        <source>Hide</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>%1 Video Controls</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -5525,10 +5544,6 @@ Altrament avorta i comproveu el vostre certificat i nom d&apos;usuari.</translat
     <message>
         <source>Wrong server password for unregistered user account, please try again.</source>
         <translation>Contrasenya de servidor incorrecte per a un compte d&apos;usuari no registrat, si us plau proveu de nou.</translation>
-    </message>
-    <message>
-        <source>Images (*.png *.jpg *.jpeg)</source>
-        <translation>Imatges (*.png *.jpg *.jpeg)</translation>
     </message>
     <message>
         <source>C&amp;onfigure</source>
@@ -7173,6 +7188,22 @@ Valid options are:
     </message>
     <message>
         <source>This decreases the attenuation of channel listeners by 10 percents points</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Icons</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Cursors</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Animated Cursors</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Images (*.png *.jpg *.jpeg *.gif)</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/mumble/mumble_cs.ts
+++ b/src/mumble/mumble_cs.ts
@@ -3001,15 +3001,19 @@ Jste si jisti, že chcete certifikát nahradit?
         <translation>&lt;center&gt;Zde zadejte chatovou zprávu&lt;/center&gt;</translation>
     </message>
     <message>
-        <source>Unable to send image: too large.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Unable to send image %1: too large.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>This server does not allow sending images.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Unable to send image</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>too large</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>cannot read file</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -3908,6 +3912,21 @@ Without this option enabled, using Mumble&apos;s global shortcuts in privileged 
     </message>
     <message>
         <source>Mouse</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>ImageAnimationTextObject</name>
+    <message>
+        <source>Hide</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>%1 Video Controls</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -5518,10 +5537,6 @@ Jinak přerušte a zkontrolujte Váš certifikát a uživatelské jméno.</trans
     <message>
         <source>Wrong server password for unregistered user account, please try again.</source>
         <translation>Špatné heslo serveru pro účet neregistrovaného uživatele, prosím zkuste znovu.</translation>
-    </message>
-    <message>
-        <source>Images (*.png *.jpg *.jpeg)</source>
-        <translation>Obrázky (*.png *.jpg *.jpeg)</translation>
     </message>
     <message>
         <source>C&amp;onfigure</source>
@@ -7141,6 +7156,22 @@ Valid options are:
     </message>
     <message>
         <source>This decreases the attenuation of channel listeners by 10 percents points</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Icons</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Cursors</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Animated Cursors</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Images (*.png *.jpg *.jpeg *.gif)</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/mumble/mumble_cy.ts
+++ b/src/mumble/mumble_cy.ts
@@ -2963,15 +2963,19 @@ Are you sure you wish to replace your certificate?
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Unable to send image: too large.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Unable to send image %1: too large.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>This server does not allow sending images.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Unable to send image</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>too large</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>cannot read file</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -3865,6 +3869,21 @@ Without this option enabled, using Mumble&apos;s global shortcuts in privileged 
     </message>
     <message>
         <source>Mouse</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>ImageAnimationTextObject</name>
+    <message>
+        <source>Hide</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>%1 Video Controls</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -5464,10 +5483,6 @@ Otherwise abort and check your certificate and username.</source>
     </message>
     <message>
         <source>Wrong server password for unregistered user account, please try again.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Images (*.png *.jpg *.jpeg)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -7083,6 +7098,22 @@ Valid options are:
     </message>
     <message>
         <source>This decreases the attenuation of channel listeners by 10 percents points</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Icons</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Cursors</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Animated Cursors</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Images (*.png *.jpg *.jpeg *.gif)</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/mumble/mumble_da.ts
+++ b/src/mumble/mumble_da.ts
@@ -3000,15 +3000,19 @@ Er du sikker på du vil erstatte dit certifikat?
         <translation>&lt;center&gt;Skriv chatbesked hér&lt;/center&gt;</translation>
     </message>
     <message>
-        <source>Unable to send image: too large.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Unable to send image %1: too large.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>This server does not allow sending images.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Unable to send image</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>too large</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>cannot read file</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -3907,6 +3911,21 @@ Without this option enabled, using Mumble&apos;s global shortcuts in privileged 
     </message>
     <message>
         <source>Mouse</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>ImageAnimationTextObject</name>
+    <message>
+        <source>Hide</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>%1 Video Controls</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -5515,10 +5534,6 @@ Otherwise abort and check your certificate and username.</source>
     <message>
         <source>Wrong server password for unregistered user account, please try again.</source>
         <translation>Forkert serveradgangskode for uregistreret brugerkonto, prøv venligst igen.</translation>
-    </message>
-    <message>
-        <source>Images (*.png *.jpg *.jpeg)</source>
-        <translation>Billeder (*.png *.jpg *.jpeg)</translation>
     </message>
     <message>
         <source>C&amp;onfigure</source>
@@ -7136,6 +7151,22 @@ Valid options are:
     </message>
     <message>
         <source>This decreases the attenuation of channel listeners by 10 percents points</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Icons</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Cursors</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Animated Cursors</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Images (*.png *.jpg *.jpeg *.gif)</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/mumble/mumble_de.ts
+++ b/src/mumble/mumble_de.ts
@@ -3000,16 +3000,20 @@ Sind Sie sicher, dass Sie Ihr Zertifikat ersetzen möchten?
         <translation>&lt;center&gt;Textnachricht hier eingeben&lt;/center&gt;</translation>
     </message>
     <message>
-        <source>Unable to send image: too large.</source>
-        <translation>Bild konnte nicht gesendet werden: Maximale Größe überschritten.</translation>
-    </message>
-    <message>
-        <source>Unable to send image %1: too large.</source>
-        <translation>Bild %1 konnte nicht gesendet werden: Maximale Größe überschritten.</translation>
-    </message>
-    <message>
         <source>This server does not allow sending images.</source>
         <translation>Dieser Server erlaubt das Senden von Bildern nicht.</translation>
+    </message>
+    <message>
+        <source>Unable to send image</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>too large</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>cannot read file</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -3914,6 +3918,21 @@ Ohne diese Option funktioniert die Verwendung der globalen Tastaturkürzel von M
     <message>
         <source>Mouse</source>
         <translation>Maus</translation>
+    </message>
+</context>
+<context>
+    <name>ImageAnimationTextObject</name>
+    <message>
+        <source>Hide</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>%1 Video Controls</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -5525,10 +5544,6 @@ Falls nicht, brechen Sie ab und überprüfen Sie Ihr Zertifikat und Ihren Benutz
     <message>
         <source>Wrong server password for unregistered user account, please try again.</source>
         <translation>Falsches Serverpasswort für unregistrierte Benutzer. Bitte versuchen Sie es noch einmal.</translation>
-    </message>
-    <message>
-        <source>Images (*.png *.jpg *.jpeg)</source>
-        <translation>Bilder (*.png *.jpg *.jpeg)</translation>
     </message>
     <message>
         <source>C&amp;onfigure</source>
@@ -7234,6 +7249,22 @@ Verfügbare Optionen sind:
     </message>
     <message>
         <source>This decreases the attenuation of channel listeners by 10 percents points</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Icons</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Cursors</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Animated Cursors</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Images (*.png *.jpg *.jpeg *.gif)</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/mumble/mumble_el.ts
+++ b/src/mumble/mumble_el.ts
@@ -3000,16 +3000,20 @@ Are you sure you wish to replace your certificate?
         <translation>&lt;center&gt;Πληκτρολογήστε εδώ το μήνυμα συνομιλίας&lt;/center&gt;</translation>
     </message>
     <message>
-        <source>Unable to send image: too large.</source>
-        <translation>Αδυναμία αποστολής εικόνας: μεγάλο μέγεθος.</translation>
-    </message>
-    <message>
-        <source>Unable to send image %1: too large.</source>
-        <translation>Αδυναμία αποστολής εικόνας %1: μεγάλο μέγεθος.</translation>
-    </message>
-    <message>
         <source>This server does not allow sending images.</source>
         <translation>Αυτός ο διακομιστής δεν επιτρέπει αποστολή εικόνων.</translation>
+    </message>
+    <message>
+        <source>Unable to send image</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>too large</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>cannot read file</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -3914,6 +3918,21 @@ Without this option enabled, using Mumble&apos;s global shortcuts in privileged 
     <message>
         <source>Mouse</source>
         <translation>Ποντίκι</translation>
+    </message>
+</context>
+<context>
+    <name>ImageAnimationTextObject</name>
+    <message>
+        <source>Hide</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>%1 Video Controls</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -5525,10 +5544,6 @@ Otherwise abort and check your certificate and username.</source>
     <message>
         <source>Wrong server password for unregistered user account, please try again.</source>
         <translation>Λάθος κωδικός πρόσβασης διακομιστή για μη εγγραμμένο λογαριασμό χρήστη, δοκιμάστε ξανά.</translation>
-    </message>
-    <message>
-        <source>Images (*.png *.jpg *.jpeg)</source>
-        <translation>Εικόνες (*.png *.jpg *.jpeg)</translation>
     </message>
     <message>
         <source>C&amp;onfigure</source>
@@ -7173,6 +7188,22 @@ Valid options are:
     </message>
     <message>
         <source>This decreases the attenuation of channel listeners by 10 percents points</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Icons</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Cursors</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Animated Cursors</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Images (*.png *.jpg *.jpeg *.gif)</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/mumble/mumble_en.ts
+++ b/src/mumble/mumble_en.ts
@@ -2958,15 +2958,19 @@ Are you sure you wish to replace your certificate?
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Unable to send image: too large.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Unable to send image %1: too large.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>This server does not allow sending images.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Unable to send image</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>too large</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>cannot read file</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -3860,6 +3864,21 @@ Without this option enabled, using Mumble&apos;s global shortcuts in privileged 
     </message>
     <message>
         <source>Mouse</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>ImageAnimationTextObject</name>
+    <message>
+        <source>Hide</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>%1 Video Controls</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -5459,10 +5478,6 @@ Otherwise abort and check your certificate and username.</source>
     </message>
     <message>
         <source>Wrong server password for unregistered user account, please try again.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Images (*.png *.jpg *.jpeg)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -7078,6 +7093,22 @@ Valid options are:
     </message>
     <message>
         <source>This decreases the attenuation of channel listeners by 10 percents points</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Icons</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Cursors</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Animated Cursors</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Images (*.png *.jpg *.jpeg *.gif)</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/mumble/mumble_en_GB.ts
+++ b/src/mumble/mumble_en_GB.ts
@@ -3000,16 +3000,20 @@ Are you sure you wish to replace your certificate?
         <translation>&lt;center&gt;Type chat message here&lt;/center&gt;</translation>
     </message>
     <message>
-        <source>Unable to send image: too large.</source>
-        <translation>Unable to send image: too large.</translation>
-    </message>
-    <message>
-        <source>Unable to send image %1: too large.</source>
-        <translation>Unable to send image %1: too large.</translation>
-    </message>
-    <message>
         <source>This server does not allow sending images.</source>
         <translation>This server does not allow sending images.</translation>
+    </message>
+    <message>
+        <source>Unable to send image</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>too large</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>cannot read file</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -3910,6 +3914,21 @@ Without this option enabled, using Mumble&apos;s global shortcuts in privileged 
     </message>
     <message>
         <source>Mouse</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>ImageAnimationTextObject</name>
+    <message>
+        <source>Hide</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>%1 Video Controls</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -5513,10 +5532,6 @@ Otherwise abort and check your certificate and username.</source>
     </message>
     <message>
         <source>Wrong server password for unregistered user account, please try again.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Images (*.png *.jpg *.jpeg)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -7132,6 +7147,22 @@ Valid options are:
     </message>
     <message>
         <source>This decreases the attenuation of channel listeners by 10 percents points</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Icons</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Cursors</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Animated Cursors</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Images (*.png *.jpg *.jpeg *.gif)</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/mumble/mumble_eo.ts
+++ b/src/mumble/mumble_eo.ts
@@ -2967,15 +2967,19 @@ Are you sure you wish to replace your certificate?
         <translation>&lt;center&gt;Tajpu babilmesaĝon ĉi tie&lt;/center&gt;</translation>
     </message>
     <message>
-        <source>Unable to send image: too large.</source>
-        <translation>Nekapabla sendi bildon: tro granda.</translation>
-    </message>
-    <message>
-        <source>Unable to send image %1: too large.</source>
+        <source>This server does not allow sending images.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>This server does not allow sending images.</source>
+        <source>Unable to send image</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>too large</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>cannot read file</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -3871,6 +3875,21 @@ Without this option enabled, using Mumble&apos;s global shortcuts in privileged 
     </message>
     <message>
         <source>Mouse</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>ImageAnimationTextObject</name>
+    <message>
+        <source>Hide</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>%1 Video Controls</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -5472,10 +5491,6 @@ Otherwise abort and check your certificate and username.</source>
     <message>
         <source>Wrong server password for unregistered user account, please try again.</source>
         <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Images (*.png *.jpg *.jpeg)</source>
-        <translation>Bildoj (*.png *.jpg *.jpeg)</translation>
     </message>
     <message>
         <source>C&amp;onfigure</source>
@@ -7091,6 +7106,22 @@ Valid options are:
     </message>
     <message>
         <source>This decreases the attenuation of channel listeners by 10 percents points</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Icons</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Cursors</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Animated Cursors</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Images (*.png *.jpg *.jpeg *.gif)</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/mumble/mumble_es.ts
+++ b/src/mumble/mumble_es.ts
@@ -3000,16 +3000,20 @@ Are you sure you wish to replace your certificate?
         <translation>&lt;center&gt;Escriba aquí el mensaje de conversación&lt;/center&gt;</translation>
     </message>
     <message>
-        <source>Unable to send image: too large.</source>
-        <translation>No es posible enviar la imagen: es muy grande.</translation>
-    </message>
-    <message>
-        <source>Unable to send image %1: too large.</source>
-        <translation>No es posible enviar la imagen %1: es muy grande.</translation>
-    </message>
-    <message>
         <source>This server does not allow sending images.</source>
         <translation>Este servidor no permite enviar imágenes.</translation>
+    </message>
+    <message>
+        <source>Unable to send image</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>too large</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>cannot read file</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -3915,6 +3919,21 @@ Sin esta opción habilitada, los métodos abreviados globales de Mumble en aplic
     <message>
         <source>Mouse</source>
         <translation>Ratón</translation>
+    </message>
+</context>
+<context>
+    <name>ImageAnimationTextObject</name>
+    <message>
+        <source>Hide</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>%1 Video Controls</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -5526,10 +5545,6 @@ De lo contrario, aborte y compruebe su certificado y nombre de usuario.</transla
     <message>
         <source>Wrong server password for unregistered user account, please try again.</source>
         <translation>Contraseña del servidor incorrecta para cuenta de usuario no registrada, por favor, inténtelo de nuevo.</translation>
-    </message>
-    <message>
-        <source>Images (*.png *.jpg *.jpeg)</source>
-        <translation>Imágenes (*.png *.jpg *.jpeg)</translation>
     </message>
     <message>
         <source>C&amp;onfigure</source>
@@ -7174,6 +7189,22 @@ Valid options are:
     </message>
     <message>
         <source>This decreases the attenuation of channel listeners by 10 percents points</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Icons</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Cursors</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Animated Cursors</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Images (*.png *.jpg *.jpeg *.gif)</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/mumble/mumble_et.ts
+++ b/src/mumble/mumble_et.ts
@@ -2960,15 +2960,19 @@ Are you sure you wish to replace your certificate?
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Unable to send image: too large.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Unable to send image %1: too large.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>This server does not allow sending images.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Unable to send image</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>too large</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>cannot read file</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -3862,6 +3866,21 @@ Without this option enabled, using Mumble&apos;s global shortcuts in privileged 
     </message>
     <message>
         <source>Mouse</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>ImageAnimationTextObject</name>
+    <message>
+        <source>Hide</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>%1 Video Controls</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -5461,10 +5480,6 @@ Otherwise abort and check your certificate and username.</source>
     </message>
     <message>
         <source>Wrong server password for unregistered user account, please try again.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Images (*.png *.jpg *.jpeg)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -7080,6 +7095,22 @@ Valid options are:
     </message>
     <message>
         <source>This decreases the attenuation of channel listeners by 10 percents points</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Icons</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Cursors</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Animated Cursors</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Images (*.png *.jpg *.jpeg *.gif)</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/mumble/mumble_eu.ts
+++ b/src/mumble/mumble_eu.ts
@@ -2970,15 +2970,19 @@ adierazten du.</translation>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Unable to send image: too large.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Unable to send image %1: too large.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>This server does not allow sending images.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Unable to send image</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>too large</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>cannot read file</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -3879,6 +3883,21 @@ Without this option enabled, using Mumble&apos;s global shortcuts in privileged 
     <message>
         <source>Mouse</source>
         <translation>Xagua</translation>
+    </message>
+</context>
+<context>
+    <name>ImageAnimationTextObject</name>
+    <message>
+        <source>Hide</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>%1 Video Controls</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -5479,10 +5498,6 @@ Otherwise abort and check your certificate and username.</source>
     <message>
         <source>Wrong server password for unregistered user account, please try again.</source>
         <translation>Zerbitzariko pasahitz okerra erregistratu gabeko erabiltzaile konturako, mesedez saiatu berriz.</translation>
-    </message>
-    <message>
-        <source>Images (*.png *.jpg *.jpeg)</source>
-        <translation>Irudiak (*.png *.jpg *.jpeg)</translation>
     </message>
     <message>
         <source>C&amp;onfigure</source>
@@ -7100,6 +7115,22 @@ Valid options are:
     </message>
     <message>
         <source>This decreases the attenuation of channel listeners by 10 percents points</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Icons</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Cursors</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Animated Cursors</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Images (*.png *.jpg *.jpeg *.gif)</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/mumble/mumble_fa_IR.ts
+++ b/src/mumble/mumble_fa_IR.ts
@@ -2960,15 +2960,19 @@ Are you sure you wish to replace your certificate?
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Unable to send image: too large.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Unable to send image %1: too large.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>This server does not allow sending images.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Unable to send image</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>too large</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>cannot read file</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -3862,6 +3866,21 @@ Without this option enabled, using Mumble&apos;s global shortcuts in privileged 
     </message>
     <message>
         <source>Mouse</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>ImageAnimationTextObject</name>
+    <message>
+        <source>Hide</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>%1 Video Controls</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -5461,10 +5480,6 @@ Otherwise abort and check your certificate and username.</source>
     </message>
     <message>
         <source>Wrong server password for unregistered user account, please try again.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Images (*.png *.jpg *.jpeg)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -7080,6 +7095,22 @@ Valid options are:
     </message>
     <message>
         <source>This decreases the attenuation of channel listeners by 10 percents points</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Icons</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Cursors</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Animated Cursors</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Images (*.png *.jpg *.jpeg *.gif)</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/mumble/mumble_fi.ts
+++ b/src/mumble/mumble_fi.ts
@@ -3000,16 +3000,20 @@ Haluatko varmasti korvata varmenteen?
         <translation>&lt;center&gt;Kirjoita viesti tähän&lt;/center&gt;</translation>
     </message>
     <message>
-        <source>Unable to send image: too large.</source>
-        <translation>Ei voida lähettää kuvaa: liian suuri.</translation>
-    </message>
-    <message>
-        <source>Unable to send image %1: too large.</source>
-        <translation>Ei voida lähettää kuvaa %1: liian suuri.</translation>
-    </message>
-    <message>
         <source>This server does not allow sending images.</source>
         <translation>Tämä palvelin ei salli kuvien lähettämistä.</translation>
+    </message>
+    <message>
+        <source>Unable to send image</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>too large</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>cannot read file</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -3914,6 +3918,21 @@ Ilman tätä asetusta järjestelmänlaajuiset pikanäppäimet eivät toimi kysei
     <message>
         <source>Mouse</source>
         <translation>Hiiri</translation>
+    </message>
+</context>
+<context>
+    <name>ImageAnimationTextObject</name>
+    <message>
+        <source>Hide</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>%1 Video Controls</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -5525,10 +5544,6 @@ Muutoin keskeytä ja tarkista varmenteesi sekä käyttäjänimesi.</translation>
     <message>
         <source>Wrong server password for unregistered user account, please try again.</source>
         <translation>Väärä palvelin salasana rekisteröimättömällä käyttäjätilillä, ole hyvä ja yritä uudelleen.</translation>
-    </message>
-    <message>
-        <source>Images (*.png *.jpg *.jpeg)</source>
-        <translation>Kuvat (*.png *.jpg *.jpeg)</translation>
     </message>
     <message>
         <source>C&amp;onfigure</source>
@@ -7236,6 +7251,22 @@ Kelvolliset vaihtoehdot ovat :
     </message>
     <message>
         <source>This decreases the attenuation of channel listeners by 10 percents points</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Icons</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Cursors</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Animated Cursors</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Images (*.png *.jpg *.jpeg *.gif)</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/mumble/mumble_fr.ts
+++ b/src/mumble/mumble_fr.ts
@@ -3000,16 +3000,20 @@ Are you sure you wish to replace your certificate?
         <translation>&lt;center&gt;Saisir un message ici&lt;/center&gt;</translation>
     </message>
     <message>
-        <source>Unable to send image: too large.</source>
-        <translation>Impossible d&apos;envoyer l&apos;image : trop lourde.</translation>
-    </message>
-    <message>
-        <source>Unable to send image %1: too large.</source>
-        <translation>Impossible d&apos;envoyer l&apos;image %1 : trop lourde.</translation>
-    </message>
-    <message>
         <source>This server does not allow sending images.</source>
         <translation>Ce serveur n&apos;autorise pas l&apos;envoi d&apos;image.</translation>
+    </message>
+    <message>
+        <source>Unable to send image</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>too large</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>cannot read file</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -3914,6 +3918,21 @@ Sans cette option, l&apos;utilisation des raccourcis globaux de Mumble dans les 
     <message>
         <source>Mouse</source>
         <translation>Souris</translation>
+    </message>
+</context>
+<context>
+    <name>ImageAnimationTextObject</name>
+    <message>
+        <source>Hide</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>%1 Video Controls</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -5525,10 +5544,6 @@ veuillez réessayer. Sinon annulez et vérifiez votre certificat et nom d&apos;u
     <message>
         <source>Wrong server password for unregistered user account, please try again.</source>
         <translation>Mauvais mot de passe de serveur pour un utilisateur non enregistré, veuillez essayer à nouveau.</translation>
-    </message>
-    <message>
-        <source>Images (*.png *.jpg *.jpeg)</source>
-        <translation>Images (*.png *.jpg *.jpeg)</translation>
     </message>
     <message>
         <source>C&amp;onfigure</source>
@@ -7235,6 +7250,22 @@ Les options valides sont&#xa0;:
     </message>
     <message>
         <source>This decreases the attenuation of channel listeners by 10 percents points</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Icons</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Cursors</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Animated Cursors</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Images (*.png *.jpg *.jpeg *.gif)</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/mumble/mumble_gl.ts
+++ b/src/mumble/mumble_gl.ts
@@ -2961,15 +2961,19 @@ Are you sure you wish to replace your certificate?
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Unable to send image: too large.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Unable to send image %1: too large.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>This server does not allow sending images.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Unable to send image</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>too large</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>cannot read file</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -3863,6 +3867,21 @@ Without this option enabled, using Mumble&apos;s global shortcuts in privileged 
     </message>
     <message>
         <source>Mouse</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>ImageAnimationTextObject</name>
+    <message>
+        <source>Hide</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>%1 Video Controls</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -5462,10 +5481,6 @@ Otherwise abort and check your certificate and username.</source>
     </message>
     <message>
         <source>Wrong server password for unregistered user account, please try again.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Images (*.png *.jpg *.jpeg)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -7081,6 +7096,22 @@ Valid options are:
     </message>
     <message>
         <source>This decreases the attenuation of channel listeners by 10 percents points</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Icons</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Cursors</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Animated Cursors</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Images (*.png *.jpg *.jpeg *.gif)</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/mumble/mumble_he.ts
+++ b/src/mumble/mumble_he.ts
@@ -2998,15 +2998,19 @@ Are you sure you wish to replace your certificate?
         <translation>&lt;center&gt;הקלד הודעת שיחה כאן&lt;/center&gt;</translation>
     </message>
     <message>
-        <source>Unable to send image: too large.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Unable to send image %1: too large.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>This server does not allow sending images.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Unable to send image</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>too large</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>cannot read file</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -3905,6 +3909,21 @@ Without this option enabled, using Mumble&apos;s global shortcuts in privileged 
     </message>
     <message>
         <source>Mouse</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>ImageAnimationTextObject</name>
+    <message>
+        <source>Hide</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>%1 Video Controls</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -5513,10 +5532,6 @@ Otherwise abort and check your certificate and username.</source>
     <message>
         <source>Wrong server password for unregistered user account, please try again.</source>
         <translation>&lt;p dir=&quot;RTL&quot;&gt;הסיסמה שהזנתם אינה נכונה, אנא נסו שנית.&lt;/p&gt;</translation>
-    </message>
-    <message>
-        <source>Images (*.png *.jpg *.jpeg)</source>
-        <translation>תמונות (‎*.png *.jpg *.jpeg)</translation>
     </message>
     <message>
         <source>C&amp;onfigure</source>
@@ -7133,6 +7148,22 @@ Valid options are:
     </message>
     <message>
         <source>This decreases the attenuation of channel listeners by 10 percents points</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Icons</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Cursors</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Animated Cursors</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Images (*.png *.jpg *.jpeg *.gif)</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/mumble/mumble_hi.ts
+++ b/src/mumble/mumble_hi.ts
@@ -2940,15 +2940,19 @@ Are you sure you wish to replace your certificate?
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Unable to send image: too large.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Unable to send image %1: too large.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>This server does not allow sending images.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Unable to send image</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>too large</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>cannot read file</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -3836,6 +3840,21 @@ Without this option enabled, using Mumble&apos;s global shortcuts in privileged 
     </message>
     <message>
         <source>Mouse</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>ImageAnimationTextObject</name>
+    <message>
+        <source>Hide</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>%1 Video Controls</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -5884,10 +5903,6 @@ Valid actions are:
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Images (*.png *.jpg *.jpeg)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Could not save image: %1</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7042,6 +7057,22 @@ Valid options are:
     </message>
     <message>
         <source>This decreases the attenuation of channel listeners by 10 percents points</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Icons</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Cursors</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Animated Cursors</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Images (*.png *.jpg *.jpeg *.gif)</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/mumble/mumble_hu.ts
+++ b/src/mumble/mumble_hu.ts
@@ -2989,16 +2989,20 @@ Biztos abban, hogy le akarja cserélni a tanúsítványát?
         <translation>&lt;center&gt;Üzenet írása...&lt;/center&gt;</translation>
     </message>
     <message>
-        <source>Unable to send image: too large.</source>
-        <translation>Kép küldése sikertelen: a képfájl túl nagy.</translation>
-    </message>
-    <message>
-        <source>Unable to send image %1: too large.</source>
-        <translation>%1 küldése sikertelen: a képfájl túl nagy.</translation>
-    </message>
-    <message>
         <source>This server does not allow sending images.</source>
         <translation>A kiszolgáló nem támogatja képfájlok küldését.</translation>
+    </message>
+    <message>
+        <source>Unable to send image</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>too large</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>cannot read file</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -3902,6 +3906,21 @@ Ha ez a beállítás nincs bejelölve az adott játék nem fogja engedni, hogy a
     <message>
         <source>Mouse</source>
         <translation>Egér</translation>
+    </message>
+</context>
+<context>
+    <name>ImageAnimationTextObject</name>
+    <message>
+        <source>Hide</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>%1 Video Controls</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -5511,10 +5530,6 @@ Ha nem ön az, ellenőrizze a felhasználónevét és a tanúsítványt!</transl
     <message>
         <source>Wrong server password for unregistered user account, please try again.</source>
         <translation>A nem regisztrált felhasználói jelszó hibás, próbálja újra.</translation>
-    </message>
-    <message>
-        <source>Images (*.png *.jpg *.jpeg)</source>
-        <translation>Képfájl (*.png *.jpg *.jpeg)</translation>
     </message>
     <message>
         <source>C&amp;onfigure</source>
@@ -7131,6 +7146,22 @@ Valid options are:
     </message>
     <message>
         <source>This decreases the attenuation of channel listeners by 10 percents points</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Icons</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Cursors</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Animated Cursors</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Images (*.png *.jpg *.jpeg *.gif)</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/mumble/mumble_it.ts
+++ b/src/mumble/mumble_it.ts
@@ -3000,16 +3000,20 @@ Sei sicuro di voler sostituire il tuo certificato?
         <translation>&lt;center&gt;Inserisci qui il messaggio&lt;/center&gt;</translation>
     </message>
     <message>
-        <source>Unable to send image: too large.</source>
-        <translation>Impossibile inviare immagine: dimensione troppo grande.</translation>
-    </message>
-    <message>
-        <source>Unable to send image %1: too large.</source>
-        <translation>Impossibile inviare immagine %1: dimensione troppo grande.</translation>
-    </message>
-    <message>
         <source>This server does not allow sending images.</source>
         <translation>Il server non permette l&apos;invio di immagini.</translation>
+    </message>
+    <message>
+        <source>Unable to send image</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>too large</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>cannot read file</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -3914,6 +3918,21 @@ Senza questa opzione abilitata, le scorciatoie globali di Mumble non funzioneran
     <message>
         <source>Mouse</source>
         <translation>Mouse</translation>
+    </message>
+</context>
+<context>
+    <name>ImageAnimationTextObject</name>
+    <message>
+        <source>Hide</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>%1 Video Controls</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -5525,10 +5544,6 @@ Altrimenti annulla e controlla il tuo certificato ed il nome utente.</translatio
     <message>
         <source>Wrong server password for unregistered user account, please try again.</source>
         <translation>Password errata per un account non registrato, prova di nuovo.</translation>
-    </message>
-    <message>
-        <source>Images (*.png *.jpg *.jpeg)</source>
-        <translation>Immagini (*.png *.jpg *.jpeg)</translation>
     </message>
     <message>
         <source>C&amp;onfigure</source>
@@ -7173,6 +7188,22 @@ Valid options are:
     </message>
     <message>
         <source>This decreases the attenuation of channel listeners by 10 percents points</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Icons</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Cursors</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Animated Cursors</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Images (*.png *.jpg *.jpeg *.gif)</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/mumble/mumble_ja.ts
+++ b/src/mumble/mumble_ja.ts
@@ -2995,16 +2995,20 @@ Are you sure you wish to replace your certificate?
         <translation>&lt;center&gt;ここにメッセージを入力&lt;/center&gt;</translation>
     </message>
     <message>
-        <source>Unable to send image: too large.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Unable to send image %1: too large.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>This server does not allow sending images.</source>
         <translation>このサーバーでは画像を送信できません。</translation>
+    </message>
+    <message>
+        <source>Unable to send image</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>too large</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>cannot read file</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -3909,6 +3913,21 @@ Without this option enabled, using Mumble&apos;s global shortcuts in privileged 
     </message>
 </context>
 <context>
+    <name>ImageAnimationTextObject</name>
+    <message>
+        <source>Hide</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>%1 Video Controls</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>JackAudioSystem</name>
     <message>
         <source>Hardware Ports</source>
@@ -4436,7 +4455,7 @@ The setting only applies for new messages, the already shown ones will retain th
     </message>
     <message>
         <source> %</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished"> %</translation>
     </message>
     <message>
         <source>Notification sound volume adjustment</source>
@@ -4889,7 +4908,7 @@ The setting only applies for new messages, the already shown ones will retain th
     </message>
     <message>
         <source>Search</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">検索</translation>
     </message>
     <message>
         <source>The action to perform when a user is activated (via double-click or enter) in the search dialog.</source>
@@ -5512,10 +5531,6 @@ Otherwise abort and check your certificate and username.</source>
     <message>
         <source>Wrong server password for unregistered user account, please try again.</source>
         <translation>未登録ユーザのパスワードが違います。再度試してください。</translation>
-    </message>
-    <message>
-        <source>Images (*.png *.jpg *.jpeg)</source>
-        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>C&amp;onfigure</source>
@@ -6844,7 +6859,7 @@ Valid actions are:
     </message>
     <message>
         <source>Yes</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">はい</translation>
     </message>
     <message>
         <source>No</source>
@@ -7131,6 +7146,22 @@ Valid options are:
     </message>
     <message>
         <source>This decreases the attenuation of channel listeners by 10 percents points</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Icons</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Cursors</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Animated Cursors</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Images (*.png *.jpg *.jpeg *.gif)</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -8064,7 +8095,7 @@ To upgrade these files to their latest versions, click the button below.</source
     </message>
     <message>
         <source>Enable</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">有効</translation>
     </message>
     <message>
         <source>PA</source>
@@ -8771,7 +8802,7 @@ See &lt;a href=&quot;https://github.com/mumble-voip/mumble&quot;&gt;the project 
     <name>SearchDialog</name>
     <message>
         <source>Search</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">検索</translation>
     </message>
     <message>
         <source>Enter search String...</source>

--- a/src/mumble/mumble_ko.ts
+++ b/src/mumble/mumble_ko.ts
@@ -2999,16 +2999,20 @@ Are you sure you wish to replace your certificate?
         <translation>&lt;center&gt;여기에 채팅 메시지 입력&lt;/center&gt;</translation>
     </message>
     <message>
-        <source>Unable to send image: too large.</source>
-        <translation>이미지를 보낼 수 없음: 너무 큽니다.</translation>
-    </message>
-    <message>
-        <source>Unable to send image %1: too large.</source>
-        <translation>%1 이미지를 보낼 수 없음: 너무 큽니다.</translation>
-    </message>
-    <message>
         <source>This server does not allow sending images.</source>
         <translation>이 서버는 이미지 보내기를 허용하지 않습니다.</translation>
+    </message>
+    <message>
+        <source>Unable to send image</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>too large</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>cannot read file</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -3913,6 +3917,21 @@ Without this option enabled, using Mumble&apos;s global shortcuts in privileged 
     <message>
         <source>Mouse</source>
         <translation>마우스</translation>
+    </message>
+</context>
+<context>
+    <name>ImageAnimationTextObject</name>
+    <message>
+        <source>Hide</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>%1 Video Controls</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -5524,10 +5543,6 @@ Otherwise abort and check your certificate and username.</source>
     <message>
         <source>Wrong server password for unregistered user account, please try again.</source>
         <translation>등록되지 않은 유저 계정의 서버 비밀번호가 잘못되었습니다. 다시 시도하세요.</translation>
-    </message>
-    <message>
-        <source>Images (*.png *.jpg *.jpeg)</source>
-        <translation>이미지 (*.png *.jpg *.jpeg)</translation>
     </message>
     <message>
         <source>C&amp;onfigure</source>
@@ -7172,6 +7187,22 @@ Valid options are:
     </message>
     <message>
         <source>This decreases the attenuation of channel listeners by 10 percents points</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Icons</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Cursors</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Animated Cursors</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Images (*.png *.jpg *.jpeg *.gif)</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/mumble/mumble_lt.ts
+++ b/src/mumble/mumble_lt.ts
@@ -2991,15 +2991,19 @@ Ar tikrai norite pakeisti savo liudijimą?
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Unable to send image: too large.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Unable to send image %1: too large.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>This server does not allow sending images.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Unable to send image</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>too large</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>cannot read file</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -3894,6 +3898,21 @@ Without this option enabled, using Mumble&apos;s global shortcuts in privileged 
     <message>
         <source>Mouse</source>
         <translation>Pelė</translation>
+    </message>
+</context>
+<context>
+    <name>ImageAnimationTextObject</name>
+    <message>
+        <source>Hide</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>%1 Video Controls</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -5494,10 +5513,6 @@ Otherwise abort and check your certificate and username.</source>
     <message>
         <source>Wrong server password for unregistered user account, please try again.</source>
         <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Images (*.png *.jpg *.jpeg)</source>
-        <translation>Paveikslai (*.png *.jpg *.jpeg)</translation>
     </message>
     <message>
         <source>C&amp;onfigure</source>
@@ -7114,6 +7129,22 @@ Valid options are:
     </message>
     <message>
         <source>This decreases the attenuation of channel listeners by 10 percents points</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Icons</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Cursors</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Animated Cursors</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Images (*.png *.jpg *.jpeg *.gif)</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/mumble/mumble_nl.ts
+++ b/src/mumble/mumble_nl.ts
@@ -3000,16 +3000,20 @@ Weet je zeker dat je jouw certificaat wilt vervangen?
         <translation>&lt;center&gt;Schrijf chatbericht hier&lt;/center&gt;</translation>
     </message>
     <message>
-        <source>Unable to send image: too large.</source>
-        <translation>Kon afbeelding niet versturen: te groot.</translation>
-    </message>
-    <message>
-        <source>Unable to send image %1: too large.</source>
-        <translation>Kon afbeelding %1 niet versturen: te groot.</translation>
-    </message>
-    <message>
         <source>This server does not allow sending images.</source>
         <translation>Deze server laat het versturen van afbeeldingen niet toe.</translation>
+    </message>
+    <message>
+        <source>Unable to send image</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>too large</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>cannot read file</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -3914,6 +3918,21 @@ Als deze optie is uitgeschakeld, werken Mumble&apos;s globale sneltoetsen niet i
     <message>
         <source>Mouse</source>
         <translation>Muis</translation>
+    </message>
+</context>
+<context>
+    <name>ImageAnimationTextObject</name>
+    <message>
+        <source>Hide</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>%1 Video Controls</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -5525,10 +5544,6 @@ Indien niet, gelieve te annuleren en beide opnieuw te controleren.</translation>
     <message>
         <source>Wrong server password for unregistered user account, please try again.</source>
         <translation>Verkeerd server-wachtwoord voor ongeregistreerde account, gelieve opnieuw te proberen.</translation>
-    </message>
-    <message>
-        <source>Images (*.png *.jpg *.jpeg)</source>
-        <translation>Afbeeldingen (*.png *.jpg *.jpeg)</translation>
     </message>
     <message>
         <source>C&amp;onfigure</source>
@@ -7173,6 +7188,22 @@ Valid options are:
     </message>
     <message>
         <source>This decreases the attenuation of channel listeners by 10 percents points</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Icons</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Cursors</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Animated Cursors</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Images (*.png *.jpg *.jpeg *.gif)</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/mumble/mumble_no.ts
+++ b/src/mumble/mumble_no.ts
@@ -3014,16 +3014,20 @@ Er du sikker på at du vil erstatte ditt sertifikat?
         <translation>&lt;center&gt;Skriv inn sludremelding her&lt;/center&gt;</translation>
     </message>
     <message>
-        <source>Unable to send image: too large.</source>
-        <translation type="unfinished">Bildet er for stort til å bli sendt</translation>
-    </message>
-    <message>
-        <source>Unable to send image %1: too large.</source>
-        <translation type="unfinished">Kunne ikke sende «%1»-bildet siden det var for stort.</translation>
-    </message>
-    <message>
         <source>This server does not allow sending images.</source>
         <translation>Tjeneren tillater ikke bildeforsendelse.</translation>
+    </message>
+    <message>
+        <source>Unable to send image</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>too large</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>cannot read file</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -3928,6 +3932,21 @@ Uten dette påskrudd kan du ikke bruke Mumble-snarveier i priviligerte programme
     <message>
         <source>Mouse</source>
         <translation>Mus</translation>
+    </message>
+</context>
+<context>
+    <name>ImageAnimationTextObject</name>
+    <message>
+        <source>Hide</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>%1 Video Controls</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -5540,10 +5559,6 @@ Ellers avbryt alt og sjekk ditt sertifikat og brukernavn.</translation>
     <message>
         <source>Wrong server password for unregistered user account, please try again.</source>
         <translation>Feil tjenerpassord for uregistrert brukerkonto, prøv igjen.</translation>
-    </message>
-    <message>
-        <source>Images (*.png *.jpg *.jpeg)</source>
-        <translation>Bilder (*.png *.jpg *.jpeg)</translation>
     </message>
     <message>
         <source>C&amp;onfigure</source>
@@ -7188,6 +7203,22 @@ Valid options are:
     </message>
     <message>
         <source>This decreases the attenuation of channel listeners by 10 percents points</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Icons</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Cursors</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Animated Cursors</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Images (*.png *.jpg *.jpeg *.gif)</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/mumble/mumble_oc.ts
+++ b/src/mumble/mumble_oc.ts
@@ -2960,15 +2960,19 @@ Are you sure you wish to replace your certificate?
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Unable to send image: too large.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Unable to send image %1: too large.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>This server does not allow sending images.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Unable to send image</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>too large</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>cannot read file</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -3863,6 +3867,21 @@ Without this option enabled, using Mumble&apos;s global shortcuts in privileged 
     <message>
         <source>Mouse</source>
         <translation>Mirga</translation>
+    </message>
+</context>
+<context>
+    <name>ImageAnimationTextObject</name>
+    <message>
+        <source>Hide</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>%1 Video Controls</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -5462,10 +5481,6 @@ Otherwise abort and check your certificate and username.</source>
     <message>
         <source>Wrong server password for unregistered user account, please try again.</source>
         <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Images (*.png *.jpg *.jpeg)</source>
-        <translation>Imatges (*.png *.jpg *.jpeg)</translation>
     </message>
     <message>
         <source>C&amp;onfigure</source>
@@ -7080,6 +7095,22 @@ Valid options are:
     </message>
     <message>
         <source>This decreases the attenuation of channel listeners by 10 percents points</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Icons</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Cursors</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Animated Cursors</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Images (*.png *.jpg *.jpeg *.gif)</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/mumble/mumble_pl.ts
+++ b/src/mumble/mumble_pl.ts
@@ -3001,16 +3001,20 @@ Czy na pewno chcesz zastąpić swój bieżący certyfikat?
         <translation>&lt;center&gt;Wpisz tutaj wiadomość&lt;/center&gt;</translation>
     </message>
     <message>
-        <source>Unable to send image: too large.</source>
-        <translation>Nie można wysłać obrazu: zbyt duży.</translation>
-    </message>
-    <message>
-        <source>Unable to send image %1: too large.</source>
-        <translation>Nie można wysłać obrazu %1: zbyt duży.</translation>
-    </message>
-    <message>
         <source>This server does not allow sending images.</source>
         <translation>Ten serwer nie pozwala na wysyłanie obrazów.</translation>
+    </message>
+    <message>
+        <source>Unable to send image</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>too large</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>cannot read file</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -3915,6 +3919,21 @@ Bez tej opcji korzystanie z globalnych skrótów Mumble w aplikacjach uprzywilej
     <message>
         <source>Mouse</source>
         <translation>Mysz</translation>
+    </message>
+</context>
+<context>
+    <name>ImageAnimationTextObject</name>
+    <message>
+        <source>Hide</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>%1 Video Controls</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -5526,10 +5545,6 @@ W przeciwnym razie proszę przerwać i sprawdzić swój certyfikat oraz nazwę u
     <message>
         <source>Wrong server password for unregistered user account, please try again.</source>
         <translation>Podałeś złe hasło dla niezarejestrowanych użytkowników, spróbuj jeszcze raz.</translation>
-    </message>
-    <message>
-        <source>Images (*.png *.jpg *.jpeg)</source>
-        <translation>Obrazy (*.png *.jpg *.jpeg)</translation>
     </message>
     <message>
         <source>C&amp;onfigure</source>
@@ -7237,6 +7252,22 @@ Prawidłowe opcje to:
     <message>
         <source>This decreases the attenuation of channel listeners by 10 percents points</source>
         <translation>Zmniejsza to tłumienie słuchaczy kanału o 10 punktów procentowych</translation>
+    </message>
+    <message>
+        <source>Icons</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Cursors</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Animated Cursors</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Images (*.png *.jpg *.jpeg *.gif)</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/src/mumble/mumble_pt_BR.ts
+++ b/src/mumble/mumble_pt_BR.ts
@@ -2236,11 +2236,11 @@ Fale alto, como quando você está incomodado ou animado. Diminua o volume no pa
     </message>
     <message>
         <source>Audio input system</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">Sistema de entrada de áudio</translation>
     </message>
     <message>
         <source>Audio input device</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">Dispositivo de entrada de áudio</translation>
     </message>
     <message>
         <source>Select audio output device</source>
@@ -3000,16 +3000,20 @@ Você tem certeza de que quer substituir o seu certificado?
         <translation>&lt;center&gt;Digite a mensagem aqui&lt;/center&gt;</translation>
     </message>
     <message>
-        <source>Unable to send image: too large.</source>
-        <translation>Impossível enviar imagem: grande demais.</translation>
-    </message>
-    <message>
-        <source>Unable to send image %1: too large.</source>
-        <translation>Impossível enviar imagem %1: grande demais.</translation>
-    </message>
-    <message>
         <source>This server does not allow sending images.</source>
         <translation>Este servidor não permite o envio de imagens.</translation>
+    </message>
+    <message>
+        <source>Unable to send image</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>too large</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>cannot read file</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -3914,6 +3918,21 @@ Sem essa opção ativada, usar os atalhos globais do Mumble em aplicações priv
     <message>
         <source>Mouse</source>
         <translation>Mouse</translation>
+    </message>
+</context>
+<context>
+    <name>ImageAnimationTextObject</name>
+    <message>
+        <source>Hide</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>%1 Video Controls</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -5525,10 +5544,6 @@ Caso contrário, aborte e verifique seu certificado e nome de usuário.</transla
     <message>
         <source>Wrong server password for unregistered user account, please try again.</source>
         <translation>Senha de servidor incorreta para conta de usuário não registrada, por favor tente novamente.</translation>
-    </message>
-    <message>
-        <source>Images (*.png *.jpg *.jpeg)</source>
-        <translation>Imagens (*.png *.jpg *.jpeg)</translation>
     </message>
     <message>
         <source>C&amp;onfigure</source>
@@ -7173,6 +7188,22 @@ Valid options are:
     </message>
     <message>
         <source>This decreases the attenuation of channel listeners by 10 percents points</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Icons</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Cursors</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Animated Cursors</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Images (*.png *.jpg *.jpeg *.gif)</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/mumble/mumble_pt_PT.ts
+++ b/src/mumble/mumble_pt_PT.ts
@@ -3000,16 +3000,20 @@ Tem certeza de que quer substituir o seu certificado?
         <translation>&lt;center&gt;Escreva a mensagem aqui&lt;/center&gt;</translation>
     </message>
     <message>
-        <source>Unable to send image: too large.</source>
-        <translation>Impossível enviar imagem: grande demais.</translation>
-    </message>
-    <message>
-        <source>Unable to send image %1: too large.</source>
-        <translation>Impossível enviar imagem %1: grande demais.</translation>
-    </message>
-    <message>
         <source>This server does not allow sending images.</source>
         <translation>Este servidor não permite o envio de imagens.</translation>
+    </message>
+    <message>
+        <source>Unable to send image</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>too large</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>cannot read file</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -3914,6 +3918,21 @@ Sem essa opção ativada, usar os atalhos globais do Mumble em aplicações priv
     <message>
         <source>Mouse</source>
         <translation>Mouse</translation>
+    </message>
+</context>
+<context>
+    <name>ImageAnimationTextObject</name>
+    <message>
+        <source>Hide</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>%1 Video Controls</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -5526,10 +5545,6 @@ o seu certificado e nome de utilizador.</translation>
     <message>
         <source>Wrong server password for unregistered user account, please try again.</source>
         <translation>Palavra-passe de servidor errada para conta de utilizador não registado, por favor tente novamente.</translation>
-    </message>
-    <message>
-        <source>Images (*.png *.jpg *.jpeg)</source>
-        <translation>Imagens (*.png *.jpg *.jpeg)</translation>
     </message>
     <message>
         <source>C&amp;onfigure</source>
@@ -7174,6 +7189,22 @@ Valid options are:
     </message>
     <message>
         <source>This decreases the attenuation of channel listeners by 10 percents points</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Icons</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Cursors</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Animated Cursors</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Images (*.png *.jpg *.jpeg *.gif)</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/mumble/mumble_ro.ts
+++ b/src/mumble/mumble_ro.ts
@@ -2968,15 +2968,19 @@ Are you sure you wish to replace your certificate?
         <translation>&lt;center&gt;Scrie mesajul pe chat&lt;/center&gt;</translation>
     </message>
     <message>
-        <source>Unable to send image: too large.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Unable to send image %1: too large.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>This server does not allow sending images.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Unable to send image</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>too large</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>cannot read file</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -3870,6 +3874,21 @@ Without this option enabled, using Mumble&apos;s global shortcuts in privileged 
     </message>
     <message>
         <source>Mouse</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>ImageAnimationTextObject</name>
+    <message>
+        <source>Hide</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>%1 Video Controls</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -5469,10 +5488,6 @@ Otherwise abort and check your certificate and username.</source>
     </message>
     <message>
         <source>Wrong server password for unregistered user account, please try again.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Images (*.png *.jpg *.jpeg)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -7088,6 +7103,22 @@ Valid options are:
     </message>
     <message>
         <source>This decreases the attenuation of channel listeners by 10 percents points</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Icons</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Cursors</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Animated Cursors</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Images (*.png *.jpg *.jpeg *.gif)</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/mumble/mumble_ru.ts
+++ b/src/mumble/mumble_ru.ts
@@ -3001,16 +3001,20 @@ Are you sure you wish to replace your certificate?
         <translation>&lt;center&gt;Напишите здесь сообщение в чат&lt;/center&gt;</translation>
     </message>
     <message>
-        <source>Unable to send image: too large.</source>
-        <translation>Невозможно отправить изображение: слишком большой размер.</translation>
-    </message>
-    <message>
-        <source>Unable to send image %1: too large.</source>
-        <translation>Невозможно отправить изображение %1: слишком большой размер.</translation>
-    </message>
-    <message>
         <source>This server does not allow sending images.</source>
         <translation>Этот сервер не позволяет отправлять изображения.</translation>
+    </message>
+    <message>
+        <source>Unable to send image</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>too large</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>cannot read file</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -3915,6 +3919,21 @@ Without this option enabled, using Mumble&apos;s global shortcuts in privileged 
     <message>
         <source>Mouse</source>
         <translation>Мышь</translation>
+    </message>
+</context>
+<context>
+    <name>ImageAnimationTextObject</name>
+    <message>
+        <source>Hide</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>%1 Video Controls</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -5526,10 +5545,6 @@ Otherwise abort and check your certificate and username.</source>
     <message>
         <source>Wrong server password for unregistered user account, please try again.</source>
         <translation>Неверный пароль для подключения к серверу. Попробуйте еще раз.</translation>
-    </message>
-    <message>
-        <source>Images (*.png *.jpg *.jpeg)</source>
-        <translation>Изображения (*.png *.jpg *.jpeg)</translation>
     </message>
     <message>
         <source>C&amp;onfigure</source>
@@ -7176,6 +7191,22 @@ Valid options are:
         <source>This decreases the attenuation of channel listeners by 10 percents points</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Icons</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Cursors</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Animated Cursors</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Images (*.png *.jpg *.jpeg *.gif)</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>Manual</name>
@@ -7265,7 +7296,7 @@ Valid options are:
     </message>
     <message>
         <source>Graphical positional audio simulation view</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">Графическое представление позиционного моделирования звука</translation>
     </message>
     <message>
         <source>This visually represents the positional audio configuration that is currently being used</source>

--- a/src/mumble/mumble_si.ts
+++ b/src/mumble/mumble_si.ts
@@ -2940,15 +2940,19 @@ Are you sure you wish to replace your certificate?
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Unable to send image: too large.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Unable to send image %1: too large.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>This server does not allow sending images.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Unable to send image</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>too large</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>cannot read file</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -3836,6 +3840,21 @@ Without this option enabled, using Mumble&apos;s global shortcuts in privileged 
     </message>
     <message>
         <source>Mouse</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>ImageAnimationTextObject</name>
+    <message>
+        <source>Hide</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>%1 Video Controls</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -5802,10 +5821,6 @@ Valid actions are:
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Images (*.png *.jpg *.jpeg)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Could not save image: %1</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7042,6 +7057,22 @@ Valid options are:
     </message>
     <message>
         <source>This decreases the attenuation of channel listeners by 10 percents points</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Icons</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Cursors</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Animated Cursors</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Images (*.png *.jpg *.jpeg *.gif)</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/mumble/mumble_sk.ts
+++ b/src/mumble/mumble_sk.ts
@@ -2944,15 +2944,19 @@ Are you sure you wish to replace your certificate?
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Unable to send image: too large.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Unable to send image %1: too large.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>This server does not allow sending images.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Unable to send image</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>too large</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>cannot read file</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -3840,6 +3844,21 @@ Without this option enabled, using Mumble&apos;s global shortcuts in privileged 
     </message>
     <message>
         <source>Mouse</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>ImageAnimationTextObject</name>
+    <message>
+        <source>Hide</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>%1 Video Controls</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -5862,10 +5881,6 @@ Valid actions are:
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Images (*.png *.jpg *.jpeg)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Could not save image: %1</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7046,6 +7061,22 @@ Valid options are:
     </message>
     <message>
         <source>This decreases the attenuation of channel listeners by 10 percents points</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Icons</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Cursors</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Animated Cursors</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Images (*.png *.jpg *.jpeg *.gif)</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/mumble/mumble_sq.ts
+++ b/src/mumble/mumble_sq.ts
@@ -2233,7 +2233,7 @@ Mumble is under continuous development, and the development team wants to focus 
     </message>
     <message>
         <source>Push to talk</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">Push</translation>
     </message>
     <message>
         <source>Use the &quot;push to talk shortcut&quot; button to assign a key</source>
@@ -2942,15 +2942,19 @@ Are you sure you wish to replace your certificate?
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Unable to send image: too large.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Unable to send image %1: too large.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>This server does not allow sending images.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Unable to send image</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>too large</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>cannot read file</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -3711,7 +3715,7 @@ Without this option enabled, using Mumble&apos;s global shortcuts in privileged 
     </message>
     <message>
         <source>Unassigned</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">%{name} rihapi raportimin %{target}</translation>
     </message>
     <message>
         <source>checked</source>
@@ -3839,6 +3843,21 @@ Without this option enabled, using Mumble&apos;s global shortcuts in privileged 
     <message>
         <source>Mouse</source>
         <translation>Mi</translation>
+    </message>
+</context>
+<context>
+    <name>ImageAnimationTextObject</name>
+    <message>
+        <source>Hide</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>%1 Video Controls</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -5823,10 +5842,6 @@ Valid actions are:
         <translation>Ruaje listë si një kartelë</translation>
     </message>
     <message>
-        <source>Images (*.png *.jpg *.jpeg)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Could not save image: %1</source>
         <translation>S’u ruajtën dot widget-et vijuese: %s.</translation>
     </message>
@@ -7048,6 +7063,22 @@ Valid options are:
     </message>
     <message>
         <source>This decreases the attenuation of channel listeners by 10 percents points</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Icons</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Cursors</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Animated Cursors</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Images (*.png *.jpg *.jpeg *.gif)</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/mumble/mumble_sv.ts
+++ b/src/mumble/mumble_sv.ts
@@ -3000,16 +3000,20 @@ Are you sure you wish to replace your certificate?
         <translation>&lt;center&gt;Skriv chattmeddelande här&lt;/center&gt;</translation>
     </message>
     <message>
-        <source>Unable to send image: too large.</source>
-        <translation>Det gick inte att skicka bilden: för stor.</translation>
-    </message>
-    <message>
-        <source>Unable to send image %1: too large.</source>
-        <translation>Det gick inte att skicka bilden %1: för stor.</translation>
-    </message>
-    <message>
         <source>This server does not allow sending images.</source>
         <translation>Denna server tillåter inte att bilder skickas.</translation>
+    </message>
+    <message>
+        <source>Unable to send image</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>too large</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>cannot read file</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -3914,6 +3918,21 @@ Om det här alternativet inte är aktiverat fungerar det inte att använda Mumbl
     <message>
         <source>Mouse</source>
         <translation>Mus</translation>
+    </message>
+</context>
+<context>
+    <name>ImageAnimationTextObject</name>
+    <message>
+        <source>Hide</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>%1 Video Controls</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -5525,10 +5544,6 @@ Om inte, avbryt och kontrollera ditt certifikat eller användarnamn.</translatio
     <message>
         <source>Wrong server password for unregistered user account, please try again.</source>
         <translation>Felaktigt serverlösenord för oregistrerat användarkonto, försök igen.</translation>
-    </message>
-    <message>
-        <source>Images (*.png *.jpg *.jpeg)</source>
-        <translation>Bilder (*.png *.jpg *.jpeg)</translation>
     </message>
     <message>
         <source>C&amp;onfigure</source>
@@ -7173,6 +7188,22 @@ Valid options are:
     </message>
     <message>
         <source>This decreases the attenuation of channel listeners by 10 percents points</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Icons</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Cursors</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Animated Cursors</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Images (*.png *.jpg *.jpeg *.gif)</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/mumble/mumble_te.ts
+++ b/src/mumble/mumble_te.ts
@@ -2971,15 +2971,19 @@ Are you sure you wish to replace your certificate?
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Unable to send image: too large.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Unable to send image %1: too large.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>This server does not allow sending images.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Unable to send image</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>too large</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>cannot read file</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -3873,6 +3877,21 @@ Without this option enabled, using Mumble&apos;s global shortcuts in privileged 
     </message>
     <message>
         <source>Mouse</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>ImageAnimationTextObject</name>
+    <message>
+        <source>Hide</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>%1 Video Controls</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -5472,10 +5491,6 @@ Otherwise abort and check your certificate and username.</source>
     </message>
     <message>
         <source>Wrong server password for unregistered user account, please try again.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Images (*.png *.jpg *.jpeg)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -7091,6 +7106,22 @@ Valid options are:
     </message>
     <message>
         <source>This decreases the attenuation of channel listeners by 10 percents points</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Icons</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Cursors</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Animated Cursors</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Images (*.png *.jpg *.jpeg *.gif)</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/mumble/mumble_th.ts
+++ b/src/mumble/mumble_th.ts
@@ -2958,15 +2958,19 @@ Are you sure you wish to replace your certificate?
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Unable to send image: too large.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Unable to send image %1: too large.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>This server does not allow sending images.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Unable to send image</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>too large</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>cannot read file</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -3860,6 +3864,21 @@ Without this option enabled, using Mumble&apos;s global shortcuts in privileged 
     </message>
     <message>
         <source>Mouse</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>ImageAnimationTextObject</name>
+    <message>
+        <source>Hide</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>%1 Video Controls</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -5459,10 +5478,6 @@ Otherwise abort and check your certificate and username.</source>
     </message>
     <message>
         <source>Wrong server password for unregistered user account, please try again.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Images (*.png *.jpg *.jpeg)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -7078,6 +7093,22 @@ Valid options are:
     </message>
     <message>
         <source>This decreases the attenuation of channel listeners by 10 percents points</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Icons</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Cursors</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Animated Cursors</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Images (*.png *.jpg *.jpeg *.gif)</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/mumble/mumble_tr.ts
+++ b/src/mumble/mumble_tr.ts
@@ -2999,16 +2999,20 @@ Sertifikanızı değiştirmek istediğinize emin misiniz?
         <translation>&lt;center&gt;Sohbet mesajını buraya yazınız&lt;/center&gt;</translation>
     </message>
     <message>
-        <source>Unable to send image: too large.</source>
-        <translation>Görüntü gönderilememiyor: çok büyük.</translation>
-    </message>
-    <message>
-        <source>Unable to send image %1: too large.</source>
-        <translation>%1 görüntüsü gönderilememiyor: çok büyük.</translation>
-    </message>
-    <message>
         <source>This server does not allow sending images.</source>
         <translation>Bu sunucu görüntü göndermeye izin vermiyor.</translation>
+    </message>
+    <message>
+        <source>Unable to send image</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>too large</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>cannot read file</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -3913,6 +3917,21 @@ Bu seçenek seçilmediyse, yetkili programlarda Mumble&apos;ın genel kısayolla
     <message>
         <source>Mouse</source>
         <translation>Fare</translation>
+    </message>
+</context>
+<context>
+    <name>ImageAnimationTextObject</name>
+    <message>
+        <source>Hide</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>%1 Video Controls</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -5524,10 +5543,6 @@ deneyiniz. Yoksa iptal edip parolanızı kontrol ediniz.</translation>
     <message>
         <source>Wrong server password for unregistered user account, please try again.</source>
         <translation>Kaydedilmemiş kullanıcı oturumu için yanlış sunucu parolası, tekrar deneyiniz.</translation>
-    </message>
-    <message>
-        <source>Images (*.png *.jpg *.jpeg)</source>
-        <translation>Resimler (*.png *.jpg *.jpeg)</translation>
     </message>
     <message>
         <source>C&amp;onfigure</source>
@@ -7234,6 +7249,22 @@ Geçerli seçenekler şunlardır:
     </message>
     <message>
         <source>This decreases the attenuation of channel listeners by 10 percents points</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Icons</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Cursors</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Animated Cursors</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Images (*.png *.jpg *.jpeg *.gif)</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/mumble/mumble_uk.ts
+++ b/src/mumble/mumble_uk.ts
@@ -3001,16 +3001,20 @@ Are you sure you wish to replace your certificate?
         <translation>&lt;center&gt;Введіть тут повідомлення чату&lt;/center&gt;</translation>
     </message>
     <message>
-        <source>Unable to send image: too large.</source>
-        <translation>Неможливо надіслати зображення: завелике.</translation>
-    </message>
-    <message>
-        <source>Unable to send image %1: too large.</source>
-        <translation>Неможливо надіслати зображення %1: завелике.</translation>
-    </message>
-    <message>
         <source>This server does not allow sending images.</source>
         <translation>Цей сервер не дозволяє надсилати зображення.</translation>
+    </message>
+    <message>
+        <source>Unable to send image</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>too large</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>cannot read file</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -3915,6 +3919,21 @@ Without this option enabled, using Mumble&apos;s global shortcuts in privileged 
     <message>
         <source>Mouse</source>
         <translation>миша</translation>
+    </message>
+</context>
+<context>
+    <name>ImageAnimationTextObject</name>
+    <message>
+        <source>Hide</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>%1 Video Controls</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -5526,10 +5545,6 @@ Otherwise abort and check your certificate and username.</source>
     <message>
         <source>Wrong server password for unregistered user account, please try again.</source>
         <translation>Неправильний пароль сервера для незареєстрованого облікового запису користувача, спробуйте ще раз.</translation>
-    </message>
-    <message>
-        <source>Images (*.png *.jpg *.jpeg)</source>
-        <translation>Зображення (*.png *.jpg *.jpeg)</translation>
     </message>
     <message>
         <source>C&amp;onfigure</source>
@@ -7237,6 +7252,22 @@ mumble://[&lt;ім&apos;я користувача&gt;[:&lt;пароль&gt;]@]&l
     <message>
         <source>This decreases the attenuation of channel listeners by 10 percents points</source>
         <translation>Це зменшує затухання прослуховувачів каналу на 10 відсоткових пунктів</translation>
+    </message>
+    <message>
+        <source>Icons</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Cursors</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Animated Cursors</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Images (*.png *.jpg *.jpeg *.gif)</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/src/mumble/mumble_zh_CN.ts
+++ b/src/mumble/mumble_zh_CN.ts
@@ -2999,16 +2999,20 @@ Are you sure you wish to replace your certificate?
         <translation>&lt;center&gt;在这里输入聊天消息&lt;/center&gt;</translation>
     </message>
     <message>
-        <source>Unable to send image: too large.</source>
-        <translation>无法发送图片：图片过大。</translation>
-    </message>
-    <message>
-        <source>Unable to send image %1: too large.</source>
-        <translation>无法发送图片 %1：图片过大。</translation>
-    </message>
-    <message>
         <source>This server does not allow sending images.</source>
         <translation>当前服务器不允许发送图片。</translation>
+    </message>
+    <message>
+        <source>Unable to send image</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>too large</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>cannot read file</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -3913,6 +3917,21 @@ Without this option enabled, using Mumble&apos;s global shortcuts in privileged 
     <message>
         <source>Mouse</source>
         <translation>鼠标</translation>
+    </message>
+</context>
+<context>
+    <name>ImageAnimationTextObject</name>
+    <message>
+        <source>Hide</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>%1 Video Controls</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -5524,10 +5543,6 @@ Otherwise abort and check your certificate and username.</source>
     <message>
         <source>Wrong server password for unregistered user account, please try again.</source>
         <translation>未注册用户输入的密码错误，请重试。</translation>
-    </message>
-    <message>
-        <source>Images (*.png *.jpg *.jpeg)</source>
-        <translation>图片文件 (*.png *.jpg *.jpeg)</translation>
     </message>
     <message>
         <source>C&amp;onfigure</source>
@@ -7232,6 +7247,22 @@ mumble://[&lt;用户名&gt;[:&lt;密码&gt;]@]&lt;主机名&gt;[:&lt;端口&gt;]
     <message>
         <source>This decreases the attenuation of channel listeners by 10 percents points</source>
         <translation>这会将频道监听者衰减减小百分之 10</translation>
+    </message>
+    <message>
+        <source>Icons</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Cursors</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Animated Cursors</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Images (*.png *.jpg *.jpeg *.gif)</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/src/mumble/mumble_zh_HK.ts
+++ b/src/mumble/mumble_zh_HK.ts
@@ -2958,15 +2958,19 @@ Are you sure you wish to replace your certificate?
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Unable to send image: too large.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Unable to send image %1: too large.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>This server does not allow sending images.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Unable to send image</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>too large</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>cannot read file</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -3860,6 +3864,21 @@ Without this option enabled, using Mumble&apos;s global shortcuts in privileged 
     </message>
     <message>
         <source>Mouse</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>ImageAnimationTextObject</name>
+    <message>
+        <source>Hide</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>%1 Video Controls</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -5462,10 +5481,6 @@ Otherwise abort and check your certificate and username.</source>
     <message>
         <source>Wrong server password for unregistered user account, please try again.</source>
         <translation>伺服器密碼錯誤，請重試。</translation>
-    </message>
-    <message>
-        <source>Images (*.png *.jpg *.jpeg)</source>
-        <translation>圖片 (*.png *.jpg *.jpeg)</translation>
     </message>
     <message>
         <source>C&amp;onfigure</source>
@@ -7083,6 +7098,22 @@ Valid options are:
     </message>
     <message>
         <source>This decreases the attenuation of channel listeners by 10 percents points</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Icons</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Cursors</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Animated Cursors</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Images (*.png *.jpg *.jpeg *.gif)</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/mumble/mumble_zh_TW.ts
+++ b/src/mumble/mumble_zh_TW.ts
@@ -2979,15 +2979,19 @@ Are you sure you wish to replace your certificate?
         <translation>&lt;center&gt;在此輸入訊息&lt;/center&gt;</translation>
     </message>
     <message>
-        <source>Unable to send image: too large.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Unable to send image %1: too large.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>This server does not allow sending images.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Unable to send image</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>too large</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>cannot read file</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -3886,6 +3890,21 @@ Without this option enabled, using Mumble&apos;s global shortcuts in privileged 
     </message>
     <message>
         <source>Mouse</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>ImageAnimationTextObject</name>
+    <message>
+        <source>Hide</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>%1 Video Controls</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -5492,10 +5511,6 @@ Otherwise abort and check your certificate and username.</source>
     <message>
         <source>Wrong server password for unregistered user account, please try again.</source>
         <translation>未註冊使用者的伺服器密碼錯誤，請重試。</translation>
-    </message>
-    <message>
-        <source>Images (*.png *.jpg *.jpeg)</source>
-        <translation>圖片 (*.png *.jpg *.jpeg)</translation>
     </message>
     <message>
         <source>C&amp;onfigure</source>
@@ -7110,6 +7125,22 @@ Valid options are:
     </message>
     <message>
         <source>This decreases the attenuation of channel listeners by 10 percents points</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Icons</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Cursors</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Animated Cursors</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Images (*.png *.jpg *.jpeg *.gif)</source>
         <translation type="unfinished"></translation>
     </message>
 </context>


### PR DESCRIPTION
The UI was here changed to support animated images in tooltips on users and channels, enabling this to be viewed in comments and avatars when hovered.


### Checks

- [x] My commits follow the [commit guidelines](https://github.com/mumble-voip/mumble/blob/master/COMMIT_GUIDELINES.md)

