### PR TITLE
REFAC(client): Move argument parsing from main to ArgumentParser struct

### DIFF
--- a/src/mumble/ArgumentParser.cpp
+++ b/src/mumble/ArgumentParser.cpp
@@ -1,0 +1,191 @@
+#include "ArgumentParser.h"
+
+#include "ThemeInfo.h"
+#include <QDir>
+#include <QString>
+#include <QStringList>
+
+
+ArgumentParser::ArgumentParser(const QStringList &arguments) : args(arguments) {
+	parse();
+}
+
+std::optional< QString > ArgumentParser::getNextArg(int currentIndex) const {
+	if (currentIndex + 1 < args.count()) {
+		return args.at(currentIndex + 1);
+	}
+	return std::nullopt;
+}
+
+Arguments ArgumentParser::parse() {
+	Arguments result;
+	for (int i = 1; i < args.count(); ++i) {
+		const QString &arg = args.at(i);
+
+		result.help                        = result.help || isHelpArgument(arg);
+		result.version                     = result.version || isVersionArgument(arg);
+		result.allowMultiple               = result.allowMultiple || isAllowMultiple(arg);
+		result.suppressIdentity            = result.suppressIdentity || isSuppressIdentity(arg);
+		result.license                     = result.license || isLicense(arg);
+		result.authors                     = result.authors || isAuthors(arg);
+		result.thirdPartyLicenses          = result.thirdPartyLicenses || isThirdPartyLicenses(arg);
+		result.printEchocancelQueue        = result.printEchocancelQueue || isPrintEchocancelQueue(arg);
+		result.hidden                      = result.hidden || isHidden(arg);
+		result.printTranslationDirectories = result.printTranslationDirectories || isPrintTranslationDirectories(arg);
+
+		if (auto value = isJackName(arg, getNextArg(i))) {
+			result.jackName = *value;
+			++i;
+		}
+
+		if (auto value = isRpc(arg, getNextArg(i))) {
+			result.rpc = *value;
+			++i;
+		}
+
+		if (auto value = isWindowTitlePostFix(arg, getNextArg(i))) {
+			result.windowTitlePostFix = *value;
+			++i;
+		}
+
+		if (auto value = isLocale(arg, getNextArg(i))) {
+			result.locale = *value;
+			++i;
+		}
+		if (auto value = isTranslationDirectory(arg, getNextArg(i))) {
+			result.translationDirectory = *value;
+			++i;
+		}
+		if (auto value = isDefaultCertificateDirectory(arg, getNextArg(i))) {
+			result.defaultCertificateDirectory = *value;
+			++i;
+		}
+	}
+	return result;
+}
+
+
+bool ArgumentParser::isPrintTranslationDirectories(const QString &arg) const {
+	return arg == QLatin1String("--print-translation-dirs");
+}
+
+bool ArgumentParser::isHelpArgument(const QString &arg) const {
+	return (arg == QLatin1String("-h") || arg == QLatin1String("--help")
+#if defined(Q_OS_WIN)
+			|| arg == QLatin1String("/?")
+#endif
+	);
+}
+
+bool ArgumentParser::isVersionArgument(const QString &arg) const {
+	return arg == QLatin1String("--version");
+}
+
+bool ArgumentParser::isAllowMultiple(const QString &arg) const {
+	return arg == QLatin1String("-m") || arg == QLatin1String("--multiple");
+}
+
+bool ArgumentParser::isSuppressIdentity(const QString &arg) const {
+	return arg == QLatin1String("-n") || arg == QLatin1String("--noidentity");
+}
+
+bool ArgumentParser::isLicense(const QString &arg) const {
+	return arg == QLatin1String("-license") || arg == QLatin1String("--license");
+}
+
+bool ArgumentParser::isAuthors(const QString &arg) const {
+	return arg == QLatin1String("-authors") || arg == QLatin1String("--authors");
+}
+
+bool ArgumentParser::isThirdPartyLicenses(const QString &arg) const {
+	return arg == QLatin1String("-third-party-licenses") || arg == QLatin1String("--third-party-licenses");
+}
+
+bool ArgumentParser::isPrintEchocancelQueue(const QString &arg) const {
+	return arg == QLatin1String("--dump-input-streams");
+}
+
+bool ArgumentParser::isHidden(const QString &arg) const {
+	return arg == QLatin1String("--hidden");
+}
+
+std::optional< QString > ArgumentParser::isJackName(const QString &arg, const std::optional< QString > &value) const {
+	if (arg == QLatin1String("-jn") || arg == QLatin1String("--jackname")) {
+		if (value) {
+			return *value;
+		} else {
+			qCritical("Missing argument for --jackname!");
+		}
+	};
+	return std::nullopt;
+}
+
+std::optional< QString > ArgumentParser::isWindowTitlePostFix(const QString &arg,
+															  const std::optional< QString > &value) const {
+	if (arg == QLatin1String("--window-title-ext")) {
+		if (value) {
+			return *value;
+		} else {
+			qCritical("Missing argument for --window-title-ext!");
+		}
+	};
+	return std::nullopt;
+}
+
+
+std::optional< QString > ArgumentParser::isRpc(const QString &arg, const std::optional< QString > &value) const {
+	if (arg == QLatin1String("rpc")) {
+		if (value) {
+			return *value;
+		} else {
+			qCritical("Error: No RPC command specified");
+		}
+	};
+	return std::nullopt;
+}
+
+
+std::optional< QString > ArgumentParser::isLocale(const QString &arg, const std::optional< QString > &value) const {
+	if (arg == QLatin1String("--locale")) {
+		if (value) {
+			return *value;
+		} else {
+			qCritical("Missing argument for --locale!");
+		}
+	};
+	return std::nullopt;
+}
+
+std::optional< QString > ArgumentParser::isTranslationDirectory(const QString &arg,
+																const std::optional< QString > &value) const {
+	if (arg == QLatin1String("--translation-dir")) {
+		if (value) {
+			return *value;
+		} else {
+			qCritical("Missing argument for --translation-dir!");
+		}
+	};
+	return std::nullopt;
+}
+std::optional< QDir > ArgumentParser::isDefaultCertificateDirectory(const QString &arg,
+																	const std::optional< QString > &value) const {
+	if (arg == QLatin1String("--default-certificate-dir")) {
+		if (value) {
+			QDir qdCert = QDir(*value);
+			// I suppose we should really be checking whether the directory is writable here too,
+			// but there are some subtleties with doing that:
+			// (doc.qt.io/qt-5/qfile.html#platform-specific-issues)
+			// so we can just let things fail down below when this directory is used.
+			if (!qdCert.exists()) {
+				qCritical("Directory %s does not exist", qUtf8Printable(*value));
+			}
+		} else {
+			qCritical("Missing argument for --default-certificate-dir!");
+		}
+	};
+	return std::nullopt;
+}
+
+QStringList ArgumentParser::getArguments() const {
+	return args;
+}

--- a/src/mumble/ArgumentParser.h
+++ b/src/mumble/ArgumentParser.h
@@ -1,0 +1,57 @@
+// ArgumentParser.h
+#ifndef ARGUMENTPARSER_H
+#define ARGUMENTPARSER_H
+
+#include <QDir>
+#include <QStringList>
+
+struct Arguments {
+	bool help                        = false;
+	bool version                     = false;
+	bool allowMultiple               = false;
+	bool suppressIdentity            = false;
+	bool license                     = false;
+	bool authors                     = false;
+	bool thirdPartyLicenses          = false;
+	bool dumpInputStreams            = false;
+	bool printEchocancelQueue        = false;
+	bool hidden                      = false;
+	bool printTranslationDirectories = false;
+	std::optional< QString > windowTitlePostFix;
+	std::optional< QString > jackName;
+	std::optional< QString > rpc;
+	std::optional< QString > locale;
+	std::optional< QString > translationDirectory;
+	std::optional< QDir > defaultCertificateDirectory;
+};
+
+class ArgumentParser {
+public:
+	explicit ArgumentParser(const QStringList &arguments);
+	Arguments parse();
+
+private:
+	std::optional< QString > getNextArg(int currentIndex) const;
+	bool isHelpArgument(const QString &arg) const;
+	bool isVersionArgument(const QString &arg) const;
+	bool isAllowMultiple(const QString &arg) const;
+	bool isSuppressIdentity(const QString &arg) const;
+	bool isLicense(const QString &arg) const;
+	bool isAuthors(const QString &arg) const;
+	bool isThirdPartyLicenses(const QString &arg) const;
+	bool isDumpInputStreams(const QString &arg) const;
+	bool isPrintEchocancelQueue(const QString &arg) const;
+	bool isHidden(const QString &arg) const;
+	bool isPrintTranslationDirectories(const QString &arg) const;
+	std::optional< QString > isJackName(const QString &arg, const std::optional< QString > &value) const;
+	std::optional< QString > isWindowTitlePostFix(const QString &arg, const std::optional< QString > &value) const;
+	std::optional< QString > isRpc(const QString &arg, const std::optional< QString > &value) const;
+	std::optional< QString > isLocale(const QString &arg, const std::optional< QString > &value) const;
+	std::optional< QString > isTranslationDirectory(const QString &arg, const std::optional< QString > &value) const;
+	std::optional< QDir > isDefaultCertificateDirectory(const QString &arg,
+														const std::optional< QString > &value) const;
+	QStringList getArguments() const;
+	QStringList args;
+};
+
+#endif // ARGUMENTPARSER_H

--- a/src/mumble/CMakeLists.txt
+++ b/src/mumble/CMakeLists.txt
@@ -91,6 +91,8 @@ set(MUMBLE_SOURCES
 	"ACLEditor.ui"
 	"API_v_1_x_x.cpp"
 	"API.h"
+	"ArgumentParser.cpp"
+	"ArgumentParser.h"
 	"AudioConfigDialog.cpp"
 	"AudioConfigDialog.h"
 	"Audio.cpp"


### PR DESCRIPTION
When going over main.cpp, I noticed that much of the parsing for the arguments is done within `main()` itself.
I am interested in refactoring main to have fewer responsibilities.
By seperating the concerns of main we can setup to seperate which components can be delegated to `libmumble` in the future, and make it easier to write unit tests per component.

I've added this PR as draft as there are things this PR changes that break how mumble works currently, but I am interested in receiving feedback from other users.

Namely, I'm interested in how handling incorrect arguments should be done.

For example, currently, to check the rpc flag, if there's no RPC command, the application returns an error code:
```cpp
if (args.at(i) == QLatin1String("rpc")) {
    bRpcMode = true;
    if (args.count() - 1 > i) {
        rpcCommand = QString(args.at(i + 1));
    } else {
        QString rpcError = MainWindow::tr("Error: No RPC command specified");
#if defined(Q_OS_WIN)
        QMessageBox::information(nullptr, MainWindow::tr("RPC"), rpcError);
#else
        printf("%s\n", qPrintable(rpcError));
#endif
        return 1;
    }
}
```

Preferably, I'd make `ArgumentParser` use some kind of [`Expect`](https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2014/n4015.pdf) type to tell `main` that parsing the arguments failed to parse. Then let `main` handle how to respond to incorrect arguments, either returning, ignoring, or telling something else to the user. 
But Expect is a part of c++23, which we currently don't have access too.

We can also pass around the arguments of MainWindow and handle errors inside the `ArgumentParser`, but personally, I think that's quite the messy solution.