### PR TITLE
MAINT: Update Check-CRLF action

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -29,7 +29,7 @@ jobs:
       shell: bash
 
     - name: Check line endings
-      uses: erclu/check-crlf@v1
+      uses: erclu/check-crlf@master
       with:
           exclude: '3rdparty/'
 


### PR DESCRIPTION
The old action was depending on a now-unsupported Docker image. The fix for that has been merged into master but the tagged release hasn't been updated (yet). Hence, we just fetch from master.


### Checks

- [x] My commits follow the [commit guidelines](https://github.com/mumble-voip/mumble/blob/master/COMMIT_GUIDELINES.md)

