### PR TITLE
Backport "Merge PR #6879: MAINT: Update Check-CRLF action" to 1.5.x

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -29,7 +29,7 @@ jobs:
       shell: bash
 
     - name: Check line endings
-      uses: erclu/check-crlf@v1
+      uses: erclu/check-crlf@master
       with:
           exclude: '3rdparty/'
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `1.5.x`:
 - [Merge PR #6879: MAINT: Update Check-CRLF action](https://github.com/mumble-voip/mumble/pull/6879)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)