### PR TITLE
FEAT(client, MacOS): Set application appearance based on Theme

### DIFF
--- a/src/mumble/CMakeLists.txt
+++ b/src/mumble/CMakeLists.txt
@@ -691,6 +691,7 @@ else()
 			PRIVATE
 				"AppNap.h"
 				"AppNap.mm"
+				"ThemeSwitch_macx.mm"
 				"GlobalShortcut_macx.h"
 				"GlobalShortcut_macx.mm"
 				"os_macx.mm"
@@ -1118,6 +1119,7 @@ if(${CMAKE_VERSION} VERSION_GREATER_EQUAL "3.16.0")
 		# Prevent objective C files from being included in unity builds as that causes issues
 		set_source_files_properties(
 			"AppNap.mm"
+			"ThemeSwitch_macx.mm"
 			"GlobalShortcut_macx.mm"
 			"os_macx.mm"
 			"TextToSpeech_macx.mm"

--- a/src/mumble/ThemeSwitch_macx.mm
+++ b/src/mumble/ThemeSwitch_macx.mm
@@ -1,0 +1,28 @@
+#import <Cocoa/Cocoa.h>
+
+static NSString *currentAppAppearance = nil;
+
+void setDarkAppearance()
+{
+    NSAppearance *darkAppearance = [NSAppearance appearanceNamed:NSAppearanceNameDarkAqua];
+    [NSApp setAppearance:darkAppearance];
+}
+
+void setLightAppearance()
+{
+    NSAppearance *lightAppearance = [NSAppearance appearanceNamed:NSAppearanceNameAqua];
+    [NSApp setAppearance:lightAppearance];
+}
+
+// Revert to system behavior
+// When resseting the appearance, we need to check if the system isn't already on the nil appearance
+// If not checked, mumble will fall into a loop of trying to apply the theme, calling resetAppearance,
+// then sending an event to change the theme. Creating a loop.
+void resetAppearanceToSystem() {
+    dispatch_async(dispatch_get_main_queue(), ^{
+        if (NSApp.appearance != nil) {
+            currentAppAppearance = nil;
+            [NSApp setAppearance:nil];
+        }
+    });
+}

--- a/src/mumble/Themes.cpp
+++ b/src/mumble/Themes.cpp
@@ -17,6 +17,13 @@
 
 #include <optional>
 
+#ifdef Q_OS_MAC
+// declared in ThemeSwitch_macx.mm
+extern void setLightAppearance();
+extern void setDarkAppearance();
+extern void resetAppearanceToSystem();
+#endif
+
 std::optional< ThemeInfo::StyleInfo > Themes::getThemeStyle(const Settings &settings, bool darkMode) {
 	QString themeStyleName = darkMode ? settings.themeDarkStyleName : settings.themeStyleName;
 	QString themeName      = darkMode ? settings.themeDarkName : settings.themeName;
@@ -100,6 +107,20 @@ bool Themes::applyConfigured() {
 	qWarning() << "Theme:" << style->themeName;
 	qWarning() << "Style:" << style->name;
 	qWarning() << "--> qss:" << qssFile.absoluteFilePath();
+
+#ifdef Q_OS_MAC
+	switch (Global::get().s.styleType) {
+		case StyleType::Light:
+			setLightAppearance();
+			break;
+		case StyleType::Dark:
+			setDarkAppearance();
+			break;
+		case StyleType::Auto:
+			resetAppearanceToSystem();
+			break;
+	}
+#endif
 
 	QFile file(qssFile.absoluteFilePath());
 	if (!file.open(QFile::ReadOnly)) {


### PR DESCRIPTION
This commit allows the MacOS `NSApplication` Appearance to be set depending on the theme. This sets the application bar to the right color depending on if the Light or Dark appearance is chosen.

This fixes the issue described in [a comment under PR #6877](https://github.com/mumble-voip/mumble/pull/6877#issuecomment-3146561982)
## Behaviour before change:
<img width="1274" height="491" alt="Screenshot 2025-08-10 at 12 07 41" src="https://github.com/user-attachments/assets/e4fb2134-e154-45d4-8bf7-24715fcedd8a" />

When the themes are opposite, System has "Light" appearance and mumble has "Dark" appearance and vice versa, the application header and other parts of Mumble will display the incorrect colors inherinted from the system appearance.

## Behaviour after change
<img width="1036" height="487" alt="Screenshot 2025-08-10 at 12 06 15" src="https://github.com/user-attachments/assets/0d7d8dd9-d5e6-4519-aa71-aab24a8ae480" />

When the appearance is set to "Light" or "Dark", Mumble will set it's NSApplication NSAppearance to the correct style to ensure the colors of the theme are correct.

---
### What to test
Since I do not have access to Linux or Windows build systems, testing that Mumble builds correctly on these systems should ensure this change doesn't break the build config.


### Checks

- [x] My commits follow the [commit guidelines](https://github.com/mumble-voip/mumble/blob/master/COMMIT_GUIDELINES.md)

