### PR TITLE
FIX(client, macos): Add conversion on TextToSpeech setVolume:volume

### DIFF
--- a/src/mumble/TextToSpeech_macx.mm
+++ b/src/mumble/TextToSpeech_macx.mm
@@ -135,7 +135,7 @@ void TextToSpeechPrivate::say(const QString &text) {
 void TextToSpeechPrivate::setVolume(int volume) {
 	// Check for setVolume: availability. It's only available on 10.5+.
 	if ([[m_synthesizerHelper synthesizer] respondsToSelector:@selector(setVolume:)]) {
-		[[m_synthesizerHelper synthesizer] setVolume:volume / 100.0f];
+		[[m_synthesizerHelper synthesizer] setVolume:(float)volume / 100.0f];
 	}
 }
 


### PR DESCRIPTION
When attempting to compile mumble using LLVM on MacOS, the TextToSppech_macx.mm fails to compile due to an implicit conversion on settings the volume.

```
/Users/max/Projects/CLionProjects/mumble/src/mumble/TextToSpeech_macx.mm:138:48: error: implicit conversion from 'int' to 'float' may lose precision [-Werror,-Wimplicit-int-float-conversion]
138 | [[m_synthesizerHelper synthesizer] setVolume:volume / 100.0f];
    |                                              ^~~~~~ ~
```

This change adds the conversion from int to float.


### Checks

- [x] My commits follow the [commit guidelines](https://github.com/mumble-voip/mumble/blob/master/COMMIT_GUIDELINES.md)