### PR TITLE
Backport "Merge PR #6896: FIX(client, macos): Add conversion on TextToSpeech setVolume:volume" to 1.5.x

### DIFF
--- a/src/mumble/TextToSpeech_macx.mm
+++ b/src/mumble/TextToSpeech_macx.mm
@@ -135,7 +135,7 @@ void TextToSpeechPrivate::say(const QString &text) {
 void TextToSpeechPrivate::setVolume(int volume) {
 	// Check for setVolume: availability. It's only available on 10.5+.
 	if ([[m_synthesizerHelper synthesizer] respondsToSelector:@selector(setVolume:)]) {
-		[[m_synthesizerHelper synthesizer] setVolume:volume / 100.0f];
+		[[m_synthesizerHelper synthesizer] setVolume:(float)volume / 100.0f];
 	}
 }
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `1.5.x`:
 - [Merge PR #6896: FIX(client, macos): Add conversion on TextToSpeech setVolume:volume](https://github.com/mumble-voip/mumble/pull/6896)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)