### PR TITLE
FIX(client): Crash when closing connect dialog

### DIFF
--- a/src/mumble/ConnectDialog.cpp
+++ b/src/mumble/ConnectDialog.cpp
@@ -346,6 +346,11 @@ ServerItem::~ServerItem() {
 
 	// This is just for cleanup when exiting the dialog, it won't stop pending DNS for the children.
 	for (ServerItem *si : qlChildren) {
+		assert(si->siParent == this);
+		// Prevent children from self-removing from qlChildren, causing concurrent modification which messes up our loop
+		// iterations
+		si->siParent = nullptr;
+
 		delete si;
 	}
 }


### PR DESCRIPTION
Using the foreach macro (almost certainly) used to create a copy of qlChildren for iterating over it. Hence, the behavior of children that self-remove themselves from qlChildren of their parent doesn't affect the iteration.
However, with the standard range-based for loop, no copy is created. Hence, children self-removing themselves from the list cause concurrent modifications that mess with iterations. This commit ensures that children won't self-remove during the iterations.

Fixes #6895


### Checks

- [x] My commits follow the [commit guidelines](https://github.com/mumble-voip/mumble/blob/master/COMMIT_GUIDELINES.md)

