### PR TITLE
FEAT(client): Add toggleable transparency state for talking ui

### DIFF
--- a/src/mumble/GlobalShortcutTypes.h
+++ b/src/mumble/GlobalShortcutTypes.h
@@ -63,6 +63,7 @@ enum Type {
 	ListenerAttenuationUp,
 	ListenerAttenuationDown,
 	AdaptivePush,
+	ToggleTalkingUITransparency,
 };
 
 // A few assertions meant to catch, if anyone inserts a new value in-between instead of appending

--- a/src/mumble/LookConfig.cpp
+++ b/src/mumble/LookConfig.cpp
@@ -262,6 +262,7 @@ void LookConfig::load(const Settings &r) {
 	qsbPrefixCharCount->setValue(r.iTalkingUI_PrefixCharCount);
 	qsbPostfixCharCount->setValue(r.iTalkingUI_PostfixCharCount);
 	qleAbbreviationReplacement->setText(r.qsTalkingUI_AbbreviationReplacement);
+	qsbTransparencyLevel->setValue(r.iTalkingUI_TransparencyLevel);
 	if (r.talkingUI_BackgroundColor.has_value()) {
 		talkinguiBackgroundSet(*r.talkingUI_BackgroundColor);
 	} else {
@@ -353,6 +354,7 @@ void LookConfig::save() const {
 	s.iTalkingUI_PostfixCharCount         = qsbPostfixCharCount->value();
 	s.qsTalkingUI_AbbreviationReplacement = qleAbbreviationReplacement->text();
 	s.talkingUI_BackgroundColor           = selectedBackgroundColor;
+	s.iTalkingUI_TransparencyLevel        = qsbTransparencyLevel->value();
 
 	s.qsHierarchyChannelSeparator = qleChannelSeparator->text();
 
@@ -430,4 +432,15 @@ void LookConfig::on_qcbUsersAlwaysVisible_stateChanged(int state) {
 	qcbLocalUserVisible->setEnabled(!usersAlwaysVisible);
 	// Only enable the user visibility timeout settings when all users are not always visible
 	qsbSilentUserLifetime->setEnabled(!usersAlwaysVisible);
+}
+
+void LookConfig::on_qcbTalkingUITransparent_stateChanged(int state) {
+	// Handle transparency checkbox state change
+	qsbTransparencyLevel->setEnabled(state == Qt::Checked);
+}
+
+void LookConfig::on_qsbTransparencyLevel_valueChanged(int value) {
+	// Handle transparency level change
+	Q_UNUSED(value);
+	// You can add preview logic here if needed
 }

--- a/src/mumble/LookConfig.h
+++ b/src/mumble/LookConfig.h
@@ -46,6 +46,9 @@ public slots:
 	void on_qcbAbbreviateChannelNames_stateChanged(int state);
 	void on_qcbUsersAlwaysVisible_stateChanged(int state);
 	void qbBackgroundColor_clicked();
+	void on_qcbTalkingUITransparent_stateChanged(int state);
+	void on_qsbTransparencyLevel_valueChanged(int value);
+
 
 private:
 	/// Reload themes combobox and select given configuredStyle in it

--- a/src/mumble/LookConfig.ui
+++ b/src/mumble/LookConfig.ui
@@ -621,6 +621,23 @@
         </property>
        </widget>
       </item>
+      <item row="13" column="2">
+       <widget class="QSpinBox" name="qsbTransparencyLevel">
+        <property name="minimum">
+         <number>0</number>
+        </property>
+        <property name="maximum">
+         <number>255</number>
+        </property>
+    
+        <property name="toolTip">
+         <string>Transparency level of the TalkingUI. </string>
+        </property>
+        <property name="accessibleName">
+         <string>Transparency level</string>
+        </property>
+       </widget>
+      </item>
       <item row="8" column="0" colspan="2">
        <widget class="QLabel" name="qlMaxNameLength">
         <property name="toolTip">
@@ -674,6 +691,19 @@
         </property>
         <property name="buddy">
          <cstring>qbBackgroundColor</cstring>
+        </property>
+       </widget>
+      </item>
+      <item row="13" column="0">
+       <widget class="QLabel" name="qlTransparencyLevel">
+        <property name="toolTip">
+         <string>Transparency level of the TalkingUI.</string>
+        </property>
+        <property name="text">
+         <string>Transparency Level</string>
+        </property>
+        <property name="buddy">
+         <cstring>qsbTransparencyLevel</cstring>
         </property>
        </widget>
       </item>
@@ -1316,6 +1346,7 @@
   <tabstop>qbClearBackgroundColor</tabstop>
   <tabstop>qleChannelSeparator</tabstop>
   <tabstop>qbBackgroundColor</tabstop>
+  <tabstop>qsbTransparencyLevel</tabstop>
  </tabstops>
  <resources/>
  <connections/>

--- a/src/mumble/MainWindow.cpp
+++ b/src/mumble/MainWindow.cpp
@@ -453,6 +453,11 @@ void MainWindow::createActions() {
 	gsAdaptivePush->qsToolTip = tr("When using the push-to-talk transmission mode, this will act as the push-to-talk "
 								   "action. Otherwise, it will act as a push-to-mute action.",
 								   "Global Shortcut");
+
+	gsToggleTalkingUITransparency = new GlobalShortcut(this, GlobalShortcutType::ToggleTalkingUITransparency,
+													   tr("Toggle TalkingUI Transparency", "Global Shortcut"));
+	gsToggleTalkingUITransparency->setObjectName("gsToggleTalkingUITransparency");
+	gsToggleTalkingUITransparency->qsToolTip = tr("Toggle transparency of the TalkingUI", "Global Shortcut");
 }
 
 void MainWindow::setupGui() {
@@ -3810,6 +3815,15 @@ void MainWindow::on_qaTalkingUIToggle_triggered() {
 	Global::get().talkingUI->setVisible(!Global::get().talkingUI->isVisible());
 
 	Global::get().s.bShowTalkingUI = Global::get().talkingUI->isVisible();
+}
+
+void MainWindow::on_gsToggleTalkingUITransparency_triggered(bool down,QVariant) {
+    if (down){
+
+        if (Global::get().talkingUI) {
+            Global::get().talkingUI->toggleTransparency();
+        }
+    }
 }
 
 /**

--- a/src/mumble/MainWindow.h
+++ b/src/mumble/MainWindow.h
@@ -113,6 +113,7 @@ public:
 	GlobalShortcut *gsMoveBack;
 	GlobalShortcut *gsCycleListenerAttenuationMode, *gsListenerAttenuationUp, *gsListenerAttenuationDown;
 	GlobalShortcut *gsAdaptivePush;
+	GlobalShortcut *gsToggleTalkingUITransparency;
 
 	DockTitleBar *dtbLogDockTitle, *dtbChatDockTitle;
 
@@ -355,6 +356,7 @@ public slots:
 	void on_gsListenerAttenuationUp_triggered(bool, QVariant);
 	void on_gsListenerAttenuationDown_triggered(bool, QVariant);
 	void on_gsAdaptivePush_triggered(bool, QVariant);
+	void on_gsToggleTalkingUITransparency_triggered(bool, QVariant);
 
 	void on_Reconnect_timeout();
 	void on_qaTalkingUIToggle_triggered();

--- a/src/mumble/Settings.cpp
+++ b/src/mumble/Settings.cpp
@@ -1006,6 +1006,7 @@ void Settings::legacyLoad(const QString &path) {
 	LOAD(iTalkingUI_PrefixCharCount, "ui/talkingUI_PrefixCharCount");
 	LOAD(iTalkingUI_PostfixCharCount, "ui/talkingUI_PostfixCharCount");
 	LOAD(qsTalkingUI_AbbreviationReplacement, "ui/talkingUI_AbbreviationReplacement");
+	LOAD(iTalkingUI_TransparencyLevel, "ui/talkingUI_TransparencyLevel");
 
 	// Load the old setting first in case it is set and then load the actual setting
 	LOAD(qsHierarchyChannelSeparator, "ui/talkingUI_ChannelSeparator");

--- a/src/mumble/Settings.h
+++ b/src/mumble/Settings.h
@@ -395,6 +395,7 @@ struct Settings {
 	int iTalkingUI_PostfixCharCount                   = 2;
 	QString qsTalkingUI_AbbreviationReplacement       = QStringLiteral("...");
 	std::optional< QColor > talkingUI_BackgroundColor = std::nullopt;
+	int iTalkingUI_TransparencyLevel                  = 255;
 
 	QString qsHierarchyChannelSeparator = QStringLiteral("/");
 

--- a/src/mumble/SettingsKeys.h
+++ b/src/mumble/SettingsKeys.h
@@ -243,6 +243,7 @@ const SettingsKey TALKINGUI_NAME_PREFIX_COUNT_KEY          = { "name_prefix_coun
 const SettingsKey TALKINGUI_NAME_POSTFIX_COUNT_KEY         = { "name_postfix_count" };
 const SettingsKey TALKINGUI_ABBREVIATION_REPLACEMENT_KEY   = { "abbreviation_replacement" };
 const SettingsKey TALKINGUI_BACKGROUND_COLOR_KEY           = { "background_color" };
+const SettingsKey TALKINGUI_TRANSPARENCY_LEVEL_KEY         = { "transparency_level" };
 
 // Channel hierarchy
 const SettingsKey CHANNEL_NAME_SEPARATOR_KEY = { "channel_name_separator" };

--- a/src/mumble/SettingsMacros.h
+++ b/src/mumble/SettingsMacros.h
@@ -210,7 +210,8 @@
 	PROCESS(talkingui, TALKINGUI_NAME_PREFIX_COUNT_KEY, iTalkingUI_PrefixCharCount)                   \
 	PROCESS(talkingui, TALKINGUI_NAME_POSTFIX_COUNT_KEY, iTalkingUI_PostfixCharCount)                 \
 	PROCESS(talkingui, TALKINGUI_ABBREVIATION_REPLACEMENT_KEY, qsTalkingUI_AbbreviationReplacement)   \
-	PROCESS(talkingui, TALKINGUI_BACKGROUND_COLOR_KEY, talkingUI_BackgroundColor)
+	PROCESS(talkingui, TALKINGUI_BACKGROUND_COLOR_KEY, talkingUI_BackgroundColor)                     \
+	PROCESS(talkingui, TALKINGUI_TRANSPARENCY_LEVEL_KEY, iTalkingUI_TransparencyLevel)
 
 
 #define CHANNEL_HIERARCHY_SETTINGS PROCESS(channel_hierarchy, CHANNEL_NAME_SEPARATOR_KEY, qsHierarchyChannelSeparator)

--- a/src/mumble/TalkingUI.cpp
+++ b/src/mumble/TalkingUI.cpp
@@ -33,6 +33,10 @@
 #include <algorithm>
 #include <cassert>
 
+#ifdef Q_OS_WIN
+#include <windows.h>
+#endif
+
 TalkingUI::TalkingUI(QWidget *parent) : QWidget(parent), m_containers(), m_currentSelection(nullptr) {
 	setupUI();
 }
@@ -231,6 +235,10 @@ void TalkingUI::setupUI() {
 	// that due to it taking valuable screen space so that the title can't be displayed
 	// properly and as the TalkingUI doesn't provide context help anyways, this is not a big loss.
 	setWindowFlags(windowFlags() & ~Qt::WindowContextHelpButtonHint);
+
+
+    setAttribute(Qt::WA_TranslucentBackground, true);
+
 
 	if (Global::get().s.talkingUI_BackgroundColor.has_value()) {
 		setBackgroundColor(*Global::get().s.talkingUI_BackgroundColor);
@@ -896,10 +904,133 @@ void TalkingUI::on_channelListenerLocalVolumeAdjustmentChanged(unsigned int chan
 
 void TalkingUI::setBackgroundColor(QColor backgroundColor) {
 	if (backgroundColor.isValid()) {
-		setStyleSheet(QString("background-color: %1;").arg(backgroundColor.name()));
+		setStyleSheet(QString("background-color: rgba(%1, %2, %3, 4);")
+			.arg(backgroundColor.red())
+			.arg(backgroundColor.green())
+			.arg(backgroundColor.blue())
+			.arg(backgroundColor.alpha()));
 	}
 }
 
 void TalkingUI::clearBackgroundColor() {
 	setStyleSheet("");
+}
+
+void TalkingUI::updateTransparency() {
+	if (!this->isVisible()) {
+		return;
+	}
+	
+	int transparency = Global::get().s.iTalkingUI_TransparencyLevel;
+	double opacity = transparency / 255.0;
+	
+	hide();
+	setWindowFlags(windowFlags()|Qt::FramelessWindowHint);
+    // this is what we would like to do but it seems to have side effects when used with Qt:FramlessWindowHint
+    //setAttribute(Qt::WA_transparentForMouseEvents, true);
+	setWindowOpacity(opacity);
+	
+#ifdef Q_OS_WIN
+	HWND hwnd = (HWND)winId();
+	LONG_PTR exStyle = GetWindowLongPtr(hwnd, GWL_EXSTYLE);
+	SetWindowLongPtr(hwnd, GWL_EXSTYLE, exStyle | WS_EX_TRANSPARENT | WS_EX_LAYERED);
+#endif
+	
+	show();
+}
+
+void TalkingUI::clearTransparency() {
+	if (!this->isVisible()) {
+		return;
+	}
+	
+	hide();
+	setWindowFlags(windowFlags() & ~Qt::FramelessWindowHint);
+    // this is what we would like to do but it seems to have side effects when used with Qt:FramlessWindowHint
+    //setAttribute(Qt::WA_transparentForMouseEvents, false);
+	setWindowOpacity(1.0);
+	
+#ifdef Q_OS_WIN
+	// Remove mouse transparency
+	HWND hwnd = (HWND)winId();
+	LONG_PTR exStyle = GetWindowLongPtr(hwnd, GWL_EXSTYLE);
+	SetWindowLongPtr(hwnd, GWL_EXSTYLE, exStyle & ~WS_EX_TRANSPARENT);
+#endif
+	
+	show();
+}
+
+void TalkingUI::toggleTransparency() {
+	if (!this->isVisible()) {
+		return;
+	}
+	
+	bool hasTransparency = windowOpacity() < 1.0;
+	
+	if (hasTransparency) {
+		clearTransparency();
+	} else {
+		updateTransparency();
+	}
+}
+
+void TalkingUI::paintEvent(QPaintEvent *event) {
+    QPainter painter(this);
+
+    bool isTransparent = windowOpacity() < 1.0;
+    if (isTransparent) {
+        painter.setCompositionMode(QPainter::CompositionMode_Clear);
+        painter.fillRect(rect(), Qt::transparent);
+        painter.setCompositionMode(QPainter::CompositionMode_SourceOver);
+        
+        // Only paint background where there's content
+        int transparency = Global::get().s.iTalkingUI_TransparencyLevel;
+        if (Global::get().s.talkingUI_BackgroundColor.has_value()) {
+            QColor bgColor = *Global::get().s.talkingUI_BackgroundColor;
+            // Paint background for text and icon content only
+            for (QLabel *label : findChildren<QLabel*>()) {
+                if (label->isVisible()) {
+                    QPoint labelPos = label->mapTo(this, QPoint(0, 0));
+                    
+                    if (!label->pixmap().isNull()) {
+                        QRect pixmapRect = QRect(labelPos, label->size());
+                        painter.fillRect(pixmapRect, QColor(bgColor.red(),bgColor.green(),bgColor.blue(),transparency));
+
+                    } else if (!label->text().isEmpty()) {
+                        QFontMetrics fm(label->font());
+                        QRect textRect = fm.boundingRect(label->text().trimmed());
+                        textRect.moveTopLeft(labelPos);
+                        painter.fillRect(textRect, QColor(bgColor.red(),bgColor.green(),bgColor.blue(),transparency));
+                    }
+                }
+            }
+            for (QGroupBox *groupBox : findChildren<QGroupBox*>()) {
+                if (groupBox->isVisible() && !groupBox->title().isEmpty()) {
+                    QStyleOptionGroupBox option;
+                    option.initFrom(groupBox);
+                    // it seems initFrom is not filling it properly, we need the following
+                    option.text = groupBox->title();
+                    option.textAlignment = groupBox->alignment();
+                    option.rect = groupBox->rect();
+                    option.subControls = QStyle::SC_GroupBoxLabel;
+
+                    QRect titleRect = groupBox->style()->subControlRect(
+                        QStyle::CC_GroupBox, &option, QStyle::SC_GroupBoxLabel, groupBox);
+                    
+                    QRect mappedRect = QRect(groupBox->mapTo(this, titleRect.topLeft()), titleRect.size());
+                    // add padding 2  pixel
+                    mappedRect.adjust(-2, -2, 2, 2);
+                    painter.fillRect(mappedRect, QColor(bgColor.red(), bgColor.green(), bgColor.blue(), transparency));
+                }
+            }
+        }
+    } else {
+        if (Global::get().s.talkingUI_BackgroundColor.has_value()) {
+            painter.fillRect(rect(), *Global::get().s.talkingUI_BackgroundColor);
+        } else {
+            painter.fillRect(rect(), QColor(255,255,255,255));
+        }
+    }
+
+    QWidget::paintEvent(event);
 }

--- a/src/mumble/TalkingUI.h
+++ b/src/mumble/TalkingUI.h
@@ -121,6 +121,11 @@ public:
 	QSize sizeHint() const Q_DECL_OVERRIDE;
 	QSize minimumSizeHint() const Q_DECL_OVERRIDE;
 
+	void updateTransparency();
+	void clearTransparency();
+	void toggleTransparency();
+    void paintEvent(QPaintEvent *event) Q_DECL_OVERRIDE;
+
 public slots:
 	void on_talkingStateChanged();
 	void on_mainWindowSelectionChanged(const QModelIndex &current, const QModelIndex &previous);


### PR DESCRIPTION
### Checks

- [X] My commits follow the [commit guidelines](https://github.com/mumble-voip/mumble/blob/master/COMMIT_GUIDELINES.md)

# Feature description
This implements list of changes so that "Talking UI" can act more like an actual overlay. The changes are: 

* Settings/UI changes to able to set short cut key to "trigger transparency"
* UI changes to settings for Transparency Level setting
* When transparency short cut key is triggered it intends to do the following. However currently, not everything is working as intended and only windows has full intention working.
    * Remove windows decorations (title bar and close button) (cross platform working)
    * Set transparency to the value set in settings UI (cross platform working)
    * Set the UI transparent to mouse events (clickthrough) (only working on windows). The code as it stands on other platforms will be able to click while in transparent mode.
    * If background color is set in settings UI, only the content will be set to background. This aims to achieve a minimal look to reduce visual clutter (cross platform working).

See this video on how it should look. https://www.youtube.com/watch?v=FyiMCaXfKvg
