### PR TITLE
REFAC(plugin): Add constructors to UpdateEntry struct

### DIFF
--- a/src/mumble/PluginUpdater.cpp
+++ b/src/mumble/PluginUpdater.cpp
@@ -46,8 +46,7 @@ void PluginUpdater::checkForUpdates() {
 				QUrl updateURL = plugin->getUpdateDownloadURL();
 
 				if (updateURL.isValid() && !updateURL.isEmpty() && !updateURL.fileName().isEmpty()) {
-					UpdateEntry entry = { plugin->getID(), updateURL, updateURL.fileName(), 0 };
-					m_pluginsToUpdate << entry;
+					m_pluginsToUpdate.append(UpdateEntry(plugin->getID(), updateURL, updateURL.fileName()));
 				}
 			}
 
@@ -332,7 +331,7 @@ void PluginUpdater::on_updateDownloaded(QNetworkReply *reply) {
 			{
 				QMutexLocker l(&m_dataMutex);
 
-				m_pluginsToUpdate << entry;
+				m_pluginsToUpdate.append(entry);
 			}
 
 			// Post a new request for the file to the new URL

--- a/src/mumble/PluginUpdater.h
+++ b/src/mumble/PluginUpdater.h
@@ -8,6 +8,7 @@
 
 #include <QNetworkAccessManager>
 #include <QNetworkReply>
+#include <QString>
 #include <QtCore/QMutex>
 #include <QtCore/QUrl>
 #include <QtCore/QVector>
@@ -32,6 +33,10 @@ struct UpdateEntry {
 	QUrl updateURL;
 	QString fileName;
 	int redirects = 0;
+
+	UpdateEntry() = default;
+	explicit UpdateEntry(plugin_id_t id, const QUrl &url, const QString &name, int redirectCount = 0)
+		: pluginID(id), updateURL(url), fileName(name), redirects(redirectCount) {}
 };
 
 /// A class designed for managing plugin updates. At the same time this also represents


### PR DESCRIPTION
When building on MacOS with the clang compiler running strictly the lack of constructors becomes an error.

Implements: #6904


### Checks

- [x] My commits follow the [commit guidelines](https://github.com/mumble-voip/mumble/blob/master/COMMIT_GUIDELINES.md)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Simplified internal handling of plugin update entries during update checks.
  - Standardized filename derivation from update URLs for consistency.
  - Unified insertion method for queued plugin updates.

- **Chores**
  - Introduced explicit constructors to clarify initialization paths for update entries.

- **User Impact**
  - No visible UI changes. Plugin update processing is more consistent behind the scenes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->