### PR TITLE
Improve handling of low volume settings

### DIFF
--- a/src/mumble/AudioOutputSpeech.cpp
+++ b/src/mumble/AudioOutputSpeech.cpp
@@ -474,7 +474,7 @@ bool AudioOutputSpeech::prepareSampleBuffer(unsigned int frameCount) {
 				break;
 		}
 
-		if (ts != Settings::Passive && p->bLocalMute) {
+		if (ts != Settings::Passive && (p->bLocalMute || p->volumeMute)) {
 			ts = Settings::MutedTalking;
 		}
 

--- a/src/mumble/ClientUser.cpp
+++ b/src/mumble/ClientUser.cpp
@@ -18,7 +18,8 @@ QReadWriteLock ClientUser::c_qrwlTalking;
 
 ClientUser::ClientUser(QObject *p)
 	: QObject(p), tsState(Settings::Passive), tLastTalkStateChange(false), bLocalIgnore(false), bLocalIgnoreTTS(false),
-	  bLocalMute(false), fPowerMin(0.0f), fPowerMax(0.0f), fAverageAvailable(0.0f), iFrames(0), iSequence(0) {
+	  bLocalMute(false), volumeMute(false), fPowerMin(0.0f), fPowerMax(0.0f), fAverageAvailable(0.0f), iFrames(0),
+	  iSequence(0) {
 }
 
 float ClientUser::getLocalVolumeAdjustments() const {

--- a/src/mumble/ClientUser.h
+++ b/src/mumble/ClientUser.h
@@ -28,6 +28,8 @@ public:
 	bool bLocalIgnore;
 	bool bLocalIgnoreTTS;
 	bool bLocalMute;
+	// Whether or not the user's effective output is inaudible due to volume settings, positional audio etc.
+	bool volumeMute;
 
 	float fPowerMin, fPowerMax;
 	float fAverageAvailable;


### PR DESCRIPTION
This MR contains two commits

**FIX(client): Do not abort processing sound data when master volume is low**

For many years the mix() method of AudioOutput contained an early return
when the settings master volume was close to 0.

Since the mix() method became more and more complex, this early return
has caused some logic to not work correctly in that situation.
Most notably, the user talking state icons are not being updated despite
clients talking and sending packets.

This commit removes the early return with the expectation of no side-effects
being discovered, since numerically the mix() method should handle
a volume of 0.0 gracefully anyway.

Fixes #6086

**FEAT(client): Display "talking muted" state when volume is low**

This commit adds a check for every user whether their individual volume,
which is composed of settings master volume and local volume adjustment,
is less than a certain threshold.
If so, the "talking muted" status icon is being displayed instead of
the regular talking status icon.

This should help indicate to users that their combination of settings
have made users (almost) inaudible, in effect similar to being "locally muted".