### PR TITLE
FIX(server): Make msgQueryUsers perform a permission check

### DIFF
--- a/src/murmur/Messages.cpp
+++ b/src/murmur/Messages.cpp
@@ -2016,6 +2016,19 @@ void Server::msgQueryUsers(ServerUser *uSource, MumbleProto::QueryUsers &msg) {
 
 	MSG_SETUP(ServerUser::Authenticated);
 
+	// User needs Write permission on at least one channel in the tree
+	bool hasWritePermission = false;
+	for (Channel *chan : qhChannels) {
+		if (hasPermission(uSource, chan, ChanACL::Write)) {
+			hasWritePermission = true;
+			break;
+		}
+	}
+
+	if (!hasWritePermission) {
+		return;
+	}
+
 	MumbleProto::QueryUsers reply;
 
 	for (int i = 0; i < msg.ids_size(); ++i) {


### PR DESCRIPTION
The QueryUsers protocol is used to fill the ACLEditor with usernames. It relates registered user ids with registered user names, even if the target user is offline.

Since its inception, msgQueryUsers did not check for any permissions when replying to user requests. So in theory, any fully unpriviledged user could get the entire registered user list if they knew what they were doing.

This commit adds a check so that the server only responds to msgQueryUsers if the requesting user has the Write ACL in any channel on the server.

Note: Being able to create and then creating a temporary channel is enough to satisfy this condition.

Fixes #3394
