### PR TITLE
Fix build with unbundled GSL

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -221,14 +221,16 @@ target_link_libraries(shared PUBLIC Tracy::TracyClient)
 if(bundled-gsl)
 	add_subdirectory("${3RDPARTY_DIR}/gsl" "${CMAKE_CURRENT_BINARY_DIR}/gsl" EXCLUDE_FROM_ALL)
 
-	target_link_libraries(shared PUBLIC GSL)
+	add_library(MSGSL::MSGSL ALIAS GSL)
+	target_link_libraries(shared PUBLIC MSGSL::MSGSL)
 else()
 	# First try to locate via GSL's native cmake support (via a *Config.cmake file that should have been installed alongside
 	# GSL since version 3)
 	find_pkg("Microsoft.GSL")
 
 	if (TARGET Microsoft.GSL::GSL)
-		target_link_libraries(shared PUBLIC Microsoft.GSL::GSL)
+		add_library(MSGSL::MSGSL ALIAS Microsoft.GSL::GSL)
+		target_link_libraries(shared PUBLIC MSGSL::MSGSL)
 	else()
 		# If the above failed, it could mean that there is an installation of GSL < v3.0 on this system, which does not yet
 		# provide cmake support for finding it. Thus, we have to use our custom Find-script.

--- a/src/murmur/database/CMakeLists.txt
+++ b/src/murmur/database/CMakeLists.txt
@@ -37,7 +37,7 @@ set_property(TARGET mumble_server_database PROPERTY INTERPROCEDURAL_OPTIMIZATION
 # We require boost::algorithm::lower_hex which was introduced in Boost v1.62.0
 find_pkg(Boost 1.62.0 REQUIRED)
 
-target_link_libraries(mumble_server_database PUBLIC mumble_database GSL Boost::headers)
+target_link_libraries(mumble_server_database PUBLIC mumble_database MSGSL::MSGSL Boost::headers)
 
 target_include_directories(mumble_server_database
 	PUBLIC


### PR DESCRIPTION
The GSL library can be found under multiple names depending on whether it is bundled and whether it is found via its CMake package files. This can cause build failures in certain setups. Fix these build errors by unifying the name of the GSL library as `MSGSL::MSGSL`.

### Checks

- [x] My commits follow the [commit guidelines](https://github.com/mumble-voip/mumble/blob/master/COMMIT_GUIDELINES.md)

