### PR TITLE
Backport "Merge PR #6916: FIX(server): Make msgQueryUsers perform a permission check" to 1.5.x

### DIFF
--- a/src/murmur/Messages.cpp
+++ b/src/murmur/Messages.cpp
@@ -1972,6 +1972,19 @@ void Server::msgQueryUsers(ServerUser *uSource, MumbleProto::QueryUsers &msg) {
 
 	MSG_SETUP(ServerUser::Authenticated);
 
+	// User needs Write permission on at least one channel in the tree
+	bool hasWritePermission = false;
+	for (Channel *chan : qhChannels) {
+		if (hasPermission(uSource, chan, ChanACL::Write)) {
+			hasWritePermission = true;
+			break;
+		}
+	}
+
+	if (!hasWritePermission) {
+		return;
+	}
+
 	MumbleProto::QueryUsers reply;
 
 	for (int i = 0; i < msg.ids_size(); ++i) {


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `1.5.x`:
 - [Merge PR #6916: FIX(server): Make msgQueryUsers perform a permission check](https://github.com/mumble-voip/mumble/pull/6916)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)