### PR TITLE
CHANGE(client): Only display "muted"/"deafened" message from users in own channel

### DIFF
--- a/src/mumble/Messages.cpp
+++ b/src/mumble/Messages.cpp
@@ -550,22 +550,25 @@ void MainWindow::msgUserState(const MumbleProto::UserState &msg) {
 	}
 
 	if (msg.has_self_deaf() || msg.has_self_mute()) {
-		if (msg.has_self_mute())
+		if (msg.has_self_mute()) {
 			pDst->setSelfMute(msg.self_mute());
-		if (msg.has_self_deaf())
-			pDst->setSelfDeaf(msg.self_deaf());
+		}
 
-		if (pSelf && pDst != pSelf
-			&& ((pDst->cChannel == pSelf->cChannel) || pDst->cChannel->allLinks().contains(pSelf->cChannel))) {
-			if (pDst->bSelfMute && pDst->bSelfDeaf)
+		if (msg.has_self_deaf()) {
+			pDst->setSelfDeaf(msg.self_deaf());
+		}
+
+		if (pSelf && pDst != pSelf && pDst->cChannel == pSelf->cChannel) {
+			if (pDst->bSelfMute && pDst->bSelfDeaf) {
 				Global::get().l->log(Log::OtherSelfMute,
 									 tr("%1 is now muted and deafened.").arg(Log::formatClientUser(pDst, Log::Target)));
-			else if (pDst->bSelfMute)
+			} else if (pDst->bSelfMute) {
 				Global::get().l->log(Log::OtherSelfMute,
 									 tr("%1 is now muted.").arg(Log::formatClientUser(pDst, Log::Target)));
-			else
+			} else {
 				Global::get().l->log(Log::OtherSelfMute,
 									 tr("%1 is now unmuted.").arg(Log::formatClientUser(pDst, Log::Target)));
+			}
 		}
 	}
 


### PR DESCRIPTION
Since b83316ad Mumble has been displaying a "user is now muted/deafened" notification for users in all linked channels. While this is generally not a bad idea, this message is not checked against a speak permissions in the target channel.

In scenarios where a large number of users are in a certain channel but unable to speak in a linked channel, it is easy to imagine that those mute/deaf notifications might get overwhelming for the users in the linked channel.

We are currently not able to find a satisfying solution to check whether or not a certain user is able to speak in a certain channel on the client side. This is why this commit removes the mute/deaf notification for users in linked channels as we imagine that this use-case is more important than the current implementation.

Closes #3026
