### PR TITLE
FIX(build): fix build with unbundled SOCI

### DIFF
--- a/src/database/CMakeLists.txt
+++ b/src/database/CMakeLists.txt
@@ -74,7 +74,7 @@ else()
 		list(APPEND components "PostgreSQL")
 	endif()
 
-	find_pkg("Soci" 4.1.0 COMPONENTS ${components} REQUIRED)
+	find_package("Soci" 4.1.0 COMPONENTS ${components} CONFIG REQUIRED)
 endif()
 
 target_link_libraries(mumble_database PUBLIC SOCI::soci)


### PR DESCRIPTION
When multiple database backends are enabled, our `find_pkg()` macro cannot be used because SOCI's package internally creates the `soci_interface` library each time it is called which causes a conflict for each enabled backend:

```
-- Found SOCI: /usr/lib64/cmake/soci-4.1.2/soci-config.cmake (found version "4.1.2") found components: Core, PostgreSQL, SQLite3
-- Soci component found: SQLite3 | Version: 4.1.2
CMake Error at /usr/lib64/cmake/soci-4.1.2/soci-config.cmake:179 (add_library):
  add_library cannot create target "soci_interface" because another target
  with the same name already exists.  The existing target is an interface
  library created in source directory
  "/var/tmp/portage/net-voip/murmur-9999/work/murmur-9999/src/database".  See
  documentation for policy CMP0002 for more details.
Call Stack (most recent call first):
  cmake/pkg-utils.cmake:77 (find_package)
  src/database/CMakeLists.txt:77 (find_pkg)

CMake Error at /usr/lib64/cmake/soci-4.1.2/soci-config.cmake:185 (add_library):
  add_library cannot create ALIAS target "SOCI::soci" because another target
  with the same name already exists.
Call Stack (most recent call first):
  cmake/pkg-utils.cmake:77 (find_package)
  src/database/CMakeLists.txt:77 (find_pkg)

-- Found SOCI: /usr/lib64/cmake/soci-4.1.2/soci-config.cmake (found version "4.1.2") found components: Core, PostgreSQL, SQLite3
-- Soci component found: PostgreSQL | Version: 4.1.2
[...]
```

### Checks

- [x] My commits follow the [commit guidelines](https://github.com/mumble-voip/mumble/blob/master/COMMIT_GUIDELINES.md)

