### PR TITLE
FEAT(Client): Added Channel "View Description" Context Menu Functionality

### DIFF
--- a/src/mumble/MainWindow.h
+++ b/src/mumble/MainWindow.h
@@ -283,6 +283,7 @@ public slots:
 	void on_qaChannelHide_triggered();
 	void on_qaChannelPin_triggered();
 	void on_qaChannelCopyURL_triggered();
+	void on_qaView_Channel_Description_triggered();
 	void on_qaAudioReset_triggered();
 	void on_qaAudioMute_triggered();
 	void on_qaAudioDeaf_triggered();


### PR DESCRIPTION
Previously, there was no context menu option to view channel descriptions in a new window when right clicking on a channel. This functionality is already present for viewing a user's comment, so it was a necessary feature for application consistency and user experience.

Now, when right clicking on a channel, there will be a new option named "View Description", and when clicked, a new window will pop up with the channel's description inside of it. Contents of the window can be copy and pasted, and the window itself is resizable.

Implements #6525