### PR TITLE
TYPE(FEAT): ToggleFullScreen Shortcut

### DIFF
--- a/src/mumble/GlobalShortcutTypes.h
+++ b/src/mumble/GlobalShortcutTypes.h
@@ -63,6 +63,7 @@ enum Type {
 	ListenerAttenuationUp,
 	ListenerAttenuationDown,
 	AdaptivePush,
+	ToggleFullScreen,
 };
 
 // A few assertions meant to catch, if anyone inserts a new value in-between instead of appending

--- a/src/mumble/MainWindow.cpp
+++ b/src/mumble/MainWindow.cpp
@@ -454,6 +454,11 @@ void MainWindow::createActions() {
 	gsAdaptivePush->qsToolTip = tr("When using the push-to-talk transmission mode, this will act as the push-to-talk "
 								   "action. Otherwise, it will act as a push-to-mute action.",
 								   "Global Shortcut");
+
+	gsToggleFullScreen = new GlobalShortcut(this, GlobalShortcutType::ToggleFullScreen,
+												 tr("ToggleFullScreen", "Global Shortcut"));
+	gsToggleFullScreen->setObjectName("gsToggleFullScreen");
+	gsToggleFullScreen->qsWhatsThis = tr("This will toggle FullScreen on/off");
 }
 
 void MainWindow::setupGui() {

--- a/src/mumble/MainWindow.h
+++ b/src/mumble/MainWindow.h
@@ -115,6 +115,7 @@ public:
 	GlobalShortcut *gsMoveBack;
 	GlobalShortcut *gsCycleListenerAttenuationMode, *gsListenerAttenuationUp, *gsListenerAttenuationDown;
 	GlobalShortcut *gsAdaptivePush;
+	GlobalShortcut *gsToggleFullScreen;
 
 	DockTitleBar *dtbLogDockTitle, *dtbChatDockTitle;
 


### PR DESCRIPTION
These changes were made to implement a toggle Fullscreen button.

Toggle Fullscreen Button.


### Checks

- [x] My commits follow the [commit guidelines](https://github.com/mumble-voip/mumble/blob/master/COMMIT_GUIDELINES.md)

