### PR TITLE
FIX(server): Restore CLI flag --help output for mumble-server

### DIFF
--- a/src/mumble/main.cpp
+++ b/src/mumble/main.cpp
@@ -213,6 +213,7 @@ extern HWND mumble_mw_hwnd;
 
 
 struct CLIOptions {
+	int exitCode                  = 0;
 	bool allowMultiple            = false;
 	bool suppressIdentity         = false;
 	bool rpcMode                  = false;
@@ -364,7 +365,8 @@ CLIOptions parseCLI(int argc, char **argv) {
 		} else {
 			qInfo("%s", info_stream.str().c_str());
 		}
-		options.quit = true;
+		options.quit     = true;
+		options.exitCode = e.get_exit_code();
 	}
 
 	return options;
@@ -405,7 +407,7 @@ int main(int argc, char **argv) {
 	CLIOptions options = parseCLI(argc, argv);
 
 	if (options.quit) {
-		return 0;
+		return options.exitCode;
 	}
 
 	// This argument has to be parsed first, since it's value is needed to create the global struct,

--- a/src/murmur/main.cpp
+++ b/src/murmur/main.cpp
@@ -193,6 +193,7 @@ void cleanup(int signum) {
 }
 
 struct CLIOptions {
+	int exitCode = 0;
 	bool quit    = false;
 	std::optional< std::string > iniFile;
 	std::optional< std::string > dbDumpPath;
@@ -315,6 +316,8 @@ CLIOptions parseCLI(int argc, char **argv) {
 			std::cout << info_stream.str();
 		}
 
+		options.quit     = true;
+		options.exitCode = e.get_exit_code();
 	}
 
 	return options;
@@ -376,7 +379,7 @@ int main(int argc, char **argv) {
 #endif
 		CLIOptions cli_options = parseCLI(argc, argv);
 		if (cli_options.quit)
-			return 0;
+			return cli_options.exitCode;
 
 		if (cli_options.printLicense) {
 #ifdef Q_OS_WIN


### PR DESCRIPTION

Commit restores output from the `--help` and `-h` command when calling `mumble-server` by passing the help text from CLI11 to stdout.

Previously the `--help` was being swallowed by internal logger, since Mumble’s startup wraps CLI11 inside its own Murmur initializing logic that was detaching from the console.

So effectively the `--help` flag was being triggered and parsed but not displayed on user output terminal.

Closes #6934 