### PR TITLE
CI: Fix release dispatch workflow

### DIFF
--- a/.github/workflows/release_dispatch.yml
+++ b/.github/workflows/release_dispatch.yml
@@ -3,15 +3,17 @@ name: Dispatch new release
 on:
     release:
         types: [ published ]
+    workflow_dispatch:
 
 jobs:
     dispatch:
         runs-on: ubuntu-latest
         steps:
             - name: "Dispatch release to mumble-docker repo"
-              uses: peter-evans/repository-dispatch@v3
+              uses: peter-evans/repository-dispatch@v4
               with:
                   token: ${{ secrets.DOCKER_REPO_ACCCESS_TOKEN }}
+                  repository: mumble-voip/mumble-docker
                   event-type: new_release
-                  client_payload: >
+                  client-payload: >
                       { "tag": "${{ github.event.release.tag_name }}", "is_latest": "${{ github.event.release.commitish == 'master' }}" }


### PR DESCRIPTION
- Upgrade the action to v4
- Use the correct attribute name in the YAML (using a "dash": `-`)
- Add missing `repository`, you will need to set this to `mumble-voip/mumble-docker`
- You will need to validate yourself that you create a **CLASSIC** personal access token with `repo` **scope** and added it to THIS repository secrets of this repo called `DOCKER_REPO_ACCCESS_TOKEN`

### Checks

- [x] My commits follow the [commit guidelines](https://github.com/mumble-voip/mumble/blob/master/COMMIT_GUIDELINES.md)

Related: https://github.com/mumble-voip/mumble-docker/issues/63

