### PR TITLE
DOCS: Use new CLI argument names throughout 

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ Start Menu, from which you can start Mumble.
 Double-click the icon to start ``mumble-server``. There will be a small icon on your
 taskbar from which you can view the log.
 
-To set the superuser password, run ``mumble-server`` with the parameters `-supw <password>`.
+To set the superuser password, run ``mumble-server`` with the parameters `--set-su-pw <password>`.
 
 
 ## MacOS
@@ -105,20 +105,20 @@ additional steps are necessary.
 and go to wherever you installed Mumble. Run ``mumble-server`` as
 
 ```
-mumble-server [-supw <password>] [-ini <inifile>] [-fg] [v]
+mumble-server [--set-su-pw <password>] [--ini <inifile>] [--foreground] [--verbose]
 
--supw   Set a new password for the user SuperUser, which is hardcoded to
-        bypass ACLs. Keep this password safe. Until you set a password,
-        the SuperUser is disabled. If you use this option, mumble-server will
-        set the password in the database and then exit.
+--set-su-pw     Set a new password for the user SuperUser, which is hardcoded to
+                bypass ACLs. Keep this password safe. Until you set a password,
+                the SuperUser is disabled. If you use this option, mumble-server will
+                set the password in the database and then exit.
 
--ini    Use an inifile other than mumble-server.ini, use this to run several instances
-        of mumble-server from the same directory. Make sure each instance is using
-        a separate database.
+--ini           Use an inifile other than mumble-server.ini, use this to run several instances
+                of mumble-server from the same directory. Make sure each instance is using
+                a separate database.
 
--fg     Run in the foreground, logging to standard output.
+--foreground    Run in the foreground, logging to standard output.
 
--v      More verbose logging.
+--verbose       More verbose logging.
 ```
 
 #### Docker image

--- a/auxiliary_files/config_files/mumble-server.service.in
+++ b/auxiliary_files/config_files/mumble-server.service.in
@@ -7,7 +7,7 @@ Wants=network-online.target
 [Service]
 AmbientCapabilities=CAP_NET_BIND_SERVICE
 CapabilityBoundingSet=CAP_NET_BIND_SERVICE
-ExecStart=@MUMBLE_INSTALL_ABS_EXECUTABLEDIR@/@MUMBLE_SERVER_BINARY_NAME@ -ini @MUMBLE_INSTALL_ABS_SYSCONFDIR@/mumble-server.ini -fg
+ExecStart=@MUMBLE_INSTALL_ABS_EXECUTABLEDIR@/@MUMBLE_SERVER_BINARY_NAME@ --ini @MUMBLE_INSTALL_ABS_SYSCONFDIR@/mumble-server.ini --foreground
 ExecReload=kill -s SIGUSR1 $MAINPID
 Group=_mumble-server
 LockPersonality=yes

--- a/auxiliary_files/man_files/mumble-server.1
+++ b/auxiliary_files/man_files/mumble-server.1
@@ -3,31 +3,31 @@
 mumble\-server - VoIP server.
 .SH SYNOPSIS
 .B mumble\-server
-[\fB-ini \fIinifile\fR] [\fB-fg\fR] [\fB-v\fR]
+[\fB\-\-ini \fIinifile\fR] [\fB\-\-foreground\fR] [\fB\-\-verbose\fR]
 .br
-.B mumble\-server \-supw\fR \fIpassword\fR [\fIserverid\fR]
+.B mumble\-server \-\-set-su-pw\fR \fIpassword\fR [\fIserverid\fR]
 .br
-.B mumble\-server \-readsupw\fR [\fIserverid\fR]
+.B mumble\-server \-\-read-su-pw\fR [\fIserverid\fR]
 .br
-.B mumble\-server \-disablesu\fR [\fIserverid\fR]
+.B mumble\-server \-\-disable-su\fR [\fIserverid\fR]
 .br
-.B mumble\-server \-limits
+.B mumble\-server \-\-limits
 .br
-.B mumble\-server \-wipessl
+.B mumble\-server \-\-wipe-ssl
 .br
-.B mumble\-server \-wipelogs
+.B mumble\-server \-\-wipe-logs
 .br
-.B mumble\-server \-loggroups
+.B mumble\-server \-\-log-groups
 .br
-.B mumble\-server \-logacls
+.B mumble\-server \-\-log-acls
 .br
-.B mumble\-server \-license
+.B mumble\-server \-\-license
 .br
-.B mumble\-server \-authors
+.B mumble\-server \-\-authors
 .br
-.B mumble\-server \-third\-party\-licenses
+.B mumble\-server \-\-third\-party\-licenses
 .br
-.B mumble\-server \-version\fR|\fB\-\-version
+.B mumble\-server \-\-version\fR|\fB\-\-version
 .br
 .B mumble\-server \-h\fR|\fB\-help\fR|\fB\-\-help
 .SH DESCRIPTION
@@ -38,61 +38,61 @@ application.
 .B \-h, \-help, \-\-help
 Show a summary of the options.
 .TP
-.B \-ini \fIinifile
+.B \-\-ini \fIinifile
 Specify which ini file to use. Without this option, mumble\-server will search for
 a murmur.ini file and will fall back to builtin defaults if one isn't found.
 .TP
-.B \-fg
+.B \-\-foreground
 Run in the foreground (do not fork).
 .TP
-.B \-v
+.B \-\-verbose
 Verbose mode, slightly more information is logged.
 .TP
-.B \-supw \fIpassword\fR [\fIserverid\fR]
+.B \-\-set\-su\-pw \fIpassword\fR [\fIserverid\fR]
 This sets the SuperUser password for a server. SuperUser is a special account
 (similar to root) which bypasses all access controls. This command may be used
 while the server is running. Optionally takes a \fIserverid\fR representing the
 virtual server to set the password for.
 .TP
-.B \-readsupw\fR\ [\fIserverid\fR]
+.B \-\-read-su-pw\fR\ [\fIserverid\fR]
 Reads SuperUser password from stdin. Optionally takes a \fIserverid\fR
 representing the virtual server to set the password for.
 .TP
-.B \-disablesu\fR\ [\fIserverid\fR]
+.B \-\-disable-su\fR\ [\fIserverid\fR]
 Disables the SuperUser account. Optionally takes a \fIserverid\fR representing
 the virtual server to disable the SuperUser account on.
 
 Disabling the SuperUser account makes it impossible to log in as SuperUser
 until a new password is set. You can set a new SuperUser password with the
-\-supw parameter.
+\-\-set\-su\-pw parameter.
 .TP
-.B \-limits
+.B \-\-limits
 Tests and shows how many file descriptors and threads can be created. The
 purpose of this option is to test how many clients the server can handle. The
 server will exit after this test.
 .TP
-.B \-wipessl
+.B \-\-wipe-ssl
 Remove SSL certificates from database.
 .TP
-.B \-wipelogs
+.B \-\-wipe-logs
 Remove all log entries from database.
 .TP
-.B \-loggroups
+.B \-\-log-groups
 Turns on logging for group changes for all servers.
 .TP
-.B \-logacls
+.B \-\-log-acls
 Turns on logging for ACL changes for all servers.
 .TP
-.B \-license
+.B \-\-license
 Show mumble\-server's license.
 .TP
-.B \-authors
+.B \-\-authors
 Show mumble\-server's authors.
 .TP
-.B \-third\-party\-licenses
+.B \-\-third\-party\-licenses
 Show licenses for third-party software used by mumble\-server.
 .TP
-.B \-version, \-\-version
+.B \-\-version
 Show version information.
 .SH SIGNALS
 .TP

--- a/auxiliary_files/mumble-server.ini
+++ b/auxiliary_files/mumble-server.ini
@@ -74,7 +74,7 @@ icesecretwrite=
 ;logfile=mumble-server.log
 
 ; If set, the server will write its process ID to this file
-; when running in daemon mode (when the -fg flag is not
+; when running in daemon mode (when the --foreground flag is not
 ; specified on the command line). Only available on
 ; Unix-like systems.
 ;pidfile=

--- a/auxiliary_files/run_scripts/mumble-server-user-wrapper.in
+++ b/auxiliary_files/run_scripts/mumble-server-user-wrapper.in
@@ -43,7 +43,7 @@ while getopts "sid:p:k" flag; do
 done
 
 if [ $DO_KILL == 1 ]; then
-	if pkill -U $UID -u $EUID -o -x -f "@MUMBLE_INSTALL_ABS_EXECUTABLEDIR@/@MUMBLE_SERVER_BINARY_NAME@ -ini $DIR/mumble-server.ini"; then
+	if pkill -U $UID -u $EUID -o -x -f "@MUMBLE_INSTALL_ABS_EXECUTABLEDIR@/@MUMBLE_SERVER_BINARY_NAME@ --ini $DIR/mumble-server.ini"; then
 		echo "Termination signal sent"
 	else
 		echo "Mumble server process not found; not terminated"
@@ -81,11 +81,11 @@ fi
 
 if [ "X$SETPW" != "X" ]; then
 	echo "Setting superuser password to \"$SETPW\""
-	@MUMBLE_INSTALL_ABS_EXECUTABLEDIR@/@MUMBLE_SERVER_BINARY_NAME@ -ini $DIR/mumble-server.ini -supw $SETPW
+	@MUMBLE_INSTALL_ABS_EXECUTABLEDIR@/@MUMBLE_SERVER_BINARY_NAME@ --ini $DIR/mumble-server.ini --set-su-pw $SETPW
 	exit 0
 fi
 
-PID=$(pgrep -U $UID -u $EUID -o -x -f "@MUMBLE_INSTALL_ABS_EXECUTABLEDIR@/@MUMBLE_SERVER_BINARY_NAME@ -ini $DIR/mumble-server.ini")
+PID=$(pgrep -U $UID -u $EUID -o -x -f "@MUMBLE_INSTALL_ABS_EXECUTABLEDIR@/@MUMBLE_SERVER_BINARY_NAME@ --ini $DIR/mumble-server.ini")
 
 if [ $DO_STATUS == 1 ]; then
 	if [ "X$PID" != "X" ]; then
@@ -103,4 +103,4 @@ if [ "X$PID" != "X" ]; then
 fi
 
 echo "Starting Mumble server"
-exec @MUMBLE_INSTALL_ABS_EXECUTABLEDIR@/@MUMBLE_SERVER_BINARY_NAME@ -ini $DIR/mumble-server.ini
+exec @MUMBLE_INSTALL_ABS_EXECUTABLEDIR@/@MUMBLE_SERVER_BINARY_NAME@ --ini $DIR/mumble-server.ini

--- a/docs/additional-readmes/README.static.linux
+++ b/docs/additional-readmes/README.static.linux
@@ -23,7 +23,7 @@ Running Murmur
 In this build of Murmur, the binary is called 'murmur.x86'. To get Murmur
 up and running, simply execute the following command at your shell:
 
- $ ./murmur.x86 -fg -ini murmur.ini
+ $ ./murmur.x86 --foreground --ini murmur.ini
 
 This will spawn a foregrounded (Murmur will, by default, run in daemon mode,
 which means it will launch itself as a background process on your system).
@@ -98,16 +98,16 @@ Additional Murmur Options
 The above instructions use a very bare-bones approach to running Murmur.
 Several other command line options are available. These are listed below:
 
-murmur.x86 [-supw <password>] [-ini <inifile>] [-fg] [v]
+murmur.x86 [--set-su-pw <password>] [--ini <inifile>] [--foreground] [--verbose]
 
--supw   Set new password for the user SuperUser, which is hardcoded to
-        bypass ACLs. Keep this password safe. If you use this option,
-        Murmur will set the password in the database and then exit.
+--set-su-pw         Set new password for the user SuperUser, which is hardcoded to
+                    bypass ACLs. Keep this password safe. If you use this option,
+                    Murmur will set the password in the database and then exit.
 
--ini    Use an ini file other than murmur.ini, use this to run several
-        instances of Murmur from the same directory. Make sure each
-        instance is using a separate database. (Specified in the ini file.)
+--ini               Use an ini file other than murmur.ini, use this to run several
+                    instances of Murmur from the same directory. Make sure each
+                    instance is using a separate database. (Specified in the ini file.)
 
--fg     Run in the foreground, logging to standard output.
+--foreground        Run in the foreground, logging to standard output.
 
--v      More verbose logging.
+--verbose           More verbose logging.

--- a/docs/additional-readmes/README.static.osx
+++ b/docs/additional-readmes/README.static.osx
@@ -21,7 +21,7 @@ Running Murmur
 In this build of Murmur, the binary is called 'murmurd'. To get Murmur
 up and running, simply execute the following command at your shell:
 
- $ ./murmurd -fg -ini murmur.ini
+ $ ./murmurd --foreground --ini murmur.ini
 
 This will spawn a foregrounded (Murmur will, by default, run in daemon mode,
 which means it will launch itself as a background process on your system).
@@ -96,16 +96,16 @@ Additional Murmur Options
 The above instructions use a very bare-bones approach to running Murmur.
 Several other command line options are available. These are listed below:
 
-murmurd [-supw <password>] [-ini <inifile>] [-fg] [v]
+murmurd [--set-su-pw <password>] [--ini <inifile>] [--foreground] [--verbose]
 
--supw   Set new password for the user SuperUser, which is hardcoded to
-        bypass ACLs. Keep this password safe. If you use this option,
-        Murmur will set the password in the database and then exit.
+--set-su-pw         Set new password for the user SuperUser, which is hardcoded to
+                    bypass ACLs. Keep this password safe. If you use this option,
+                    Murmur will set the password in the database and then exit.
 
--ini    Use an ini file other than murmur.ini, use this to run several
-        instances of Murmur from the same directory. Make sure each
-        instance is using a separate database. (Specified in the ini file.)
+--ini               Use an ini file other than murmur.ini, use this to run several
+                    instances of Murmur from the same directory. Make sure each
+                    instance is using a separate database. (Specified in the ini file.)
 
--fg     Run in the foreground, logging to standard output.
+--foreground        Run in the foreground, logging to standard output.
 
--v      More verbose logging.
+--verbose           More verbose logging.

--- a/docs/dev/Profiling.md
+++ b/docs/dev/Profiling.md
@@ -30,4 +30,4 @@ profiling data out through the network, while Mumble is running.
 
 - Profiling should generally be done in `Release` mode in order to obtain reasonable data
 - If you are having issues connecting your Tracy _server_ to the Mumble server, you should not let it fork. The default behavior in release
-  mode is to fork, but you can change that by using the `-fg` parameter when starting the server.
+  mode is to fork, but you can change that by using the `--foreground` parameter when starting the server.


### PR DESCRIPTION
### Checks

- [x] Updated all documentation and scripts to match the correct flag or option 
#6962 