### PR TITLE
SSL Certificate Hot-Reload for Mumble Server

### DIFF
--- a/src/murmur/Server.cpp
+++ b/src/murmur/Server.cpp
@@ -135,8 +135,8 @@ Server::Server(unsigned int snum, const ::mumble::db::ConnectionParameter &conne
 		int tcpsock   = static_cast< int >(ss->socketDescriptor());
 		socklen_t len = sizeof(addr);
 #else
-		SOCKET tcpsock        = ss->socketDescriptor();
-		int len               = sizeof(addr);
+		SOCKET tcpsock = ss->socketDescriptor();
+		int len        = sizeof(addr);
 #endif
 		memset(&addr, 0, sizeof(addr));
 		getsockname(tcpsock, reinterpret_cast< struct sockaddr * >(&addr), &len);
@@ -254,6 +254,7 @@ Server::Server(unsigned int snum, const ::mumble::db::ConnectionParameter &conne
 			initZeroconf();
 #endif
 		initRegister();
+		initCertMonitoring();
 	}
 }
 
@@ -733,8 +734,8 @@ void Server::udpActivated(int socket) {
 	int fromlen = static_cast< int >(sizeof(from));
 	SOCKET sock = static_cast< SOCKET >(socket);
 	len         = ::recvfrom(sock, reinterpret_cast< char * >(m_udpDecoder.getBuffer().data()),
-                     static_cast< int >(m_udpDecoder.getBuffer().size()), 0,
-                     reinterpret_cast< struct sockaddr * >(&from), &fromlen);
+							 static_cast< int >(m_udpDecoder.getBuffer().size()), 0,
+							 reinterpret_cast< struct sockaddr * >(&from), &fromlen);
 #endif
 
 	std::span< Mumble::Protocol::byte > inputData(&m_udpDecoder.getBuffer()[0], static_cast< std::size_t >(len));
@@ -752,13 +753,13 @@ void Server::udpActivated(int socket) {
 			::sendmsg(sock, &msg, 0);
 #else
 #	ifdef Q_OS_WIN
-            using size_type = int;
+			using size_type = int;
 #	else
 			using size_type = std::size_t;
 #	endif
-            ::sendto(sock, reinterpret_cast< const char * >(encodedPing.data()),
-                     static_cast< size_type >(encodedPing.size()), 0, reinterpret_cast< struct sockaddr * >(&from),
-                     fromlen);
+			::sendto(sock, reinterpret_cast< const char * >(encodedPing.data()),
+					 static_cast< size_type >(encodedPing.size()), 0, reinterpret_cast< struct sockaddr * >(&from),
+					 fromlen);
 #endif
 		}
 	}
@@ -1068,7 +1069,7 @@ void Server::sendMessage(ServerUser &u, const unsigned char *data, int len, QByt
 #else
 		std::vector< char > bufVec;
 		bufVec.resize(static_cast< std::size_t >(len + 4));
-		char *buffer    = bufVec.data();
+		char *buffer = bufVec.data();
 #endif
 		{
 			QMutexLocker wl(&u.qmCrypt);
@@ -1669,9 +1670,9 @@ void Server::connectionClosed(QAbstractSocket::SocketError err, const QString &r
 		qhUsers.remove(u->uiSession);
 		qhHostUsers[u->haAddress].remove(u);
 
-		quint16 port = (u->saiUdpAddress.ss_family == AF_INET6)
-						   ? (reinterpret_cast< sockaddr_in6 * >(&u->saiUdpAddress)->sin6_port)
-						   : (reinterpret_cast< sockaddr_in * >(&u->saiUdpAddress)->sin_port);
+		quint16 port                             = (u->saiUdpAddress.ss_family == AF_INET6)
+													   ? (reinterpret_cast< sockaddr_in6 * >(&u->saiUdpAddress)->sin6_port)
+													   : (reinterpret_cast< sockaddr_in * >(&u->saiUdpAddress)->sin_port);
 		const QPair< HostAddress, quint16 > &key = QPair< HostAddress, quint16 >(u->haAddress, port);
 		qhPeerUsers.remove(key);
 

--- a/src/murmur/Server.h
+++ b/src/murmur/Server.h
@@ -210,6 +210,10 @@ public:
 	QTimer qtTick;
 	void initRegister();
 
+	// Certificate monitoring, implementation in Cert.cpp
+	QTimer qtCertCheck;
+	void initCertMonitoring();
+
 	WhisperTargetCache createWhisperTargetCacheFor(ServerUser &speaker, const WhisperTarget &target);
 
 private:
@@ -223,6 +227,7 @@ public slots:
 	void regSslError(const QList< QSslError > &);
 	void finished();
 	void update();
+	void checkCertExpiry();
 
 	// Certificate stuff, implemented partially in Cert.cpp
 public:
@@ -233,6 +238,7 @@ public:
 	/// If no valid private key is found, a null QSslKey is returned.
 	static QSslKey privateKeyFromPEM(const QByteArray &buf, const QByteArray &pass = QByteArray());
 	void initializeCert();
+	bool reloadCertFromDisk();
 	const QString getDigest() const;
 
 public slots:


### PR DESCRIPTION
Currently, when SSL certificates expire or are renewed (like with Let's Encrypt auto-renewal that expire every few months), the Mumble server requires a full restart to pick up the new certificates. This causes service interruption and disconnects all connected users. A friend of mine runs a HUGE (small) mumble server and was annoyed by this. I've worked on a QT project before (GQRX) so somewhat familiar with how this should go.

The server will check every hour for a new certificate with QTimer, and will try to reload from the configured ssl file paths in murmur.ini if we are within a week of expiry.

This just works for file based certificates for now, so not database stored certs but that would be an obvious fleshing out of this. The cert checking activity is logged, idk if this is too aggressive for you guys.

- Added qtCertCheck timer and initCertMonitoring() to Server class
- Added checkCertExpiry() slot that runs hourly checks
- Added reloadCertFromDisk() method that calls Meta::loadSSLSettings()
- Only reloads when bUsingMetaCert flag is true (file-based certs)
- Validates new certificate before accepting
- Logs success/failure with certificate expiry information

I tested this with some self signed test certs, and had some test code to shorten the expiry checking (not in this commit) - started with a certificate expiring in a day, triggering our check for a replacement. I replaced the cert on the disk with a new 90-day expiry one, and the next check detected the change and reloaded the certs successfully. So no restart or connection drops needed, new connects will use the new cert.

Build configuration used for testing (I didn't want to install all the dependancies): `cmake -Dserver=ON -Dclient=OFF -Denable-mysql=OFF -Denable-postgresql=OFF -Dzeroconf=OFF -Dice=OFF`

User-Visible Changes
- Server logs certificate expiry checks hourly (only visible when cert is expiring soon)
- When certificate expires within 7 days: logs reload attempt and result
- New connections automatically use refreshed certificates after successful reload
- Existing connections remain unaffected

Future Enhancements
- Could be extended to support database-stored certificates
- Check interval and expiry threshold could be made configurable


### Checks

- [x] My commits follow the [commit guidelines](https://github.com/mumble-voip/mumble/blob/master/COMMIT_GUIDELINES.md)

Just a note here: I did use Claude Code for a lot of this, making sure I complied with the commit guidelines and the development guide, so if the formatting or structure seems unusually polished for a first-time contributor, that's why. I can write CPP just fine on my own (cope :sob: ), I'm just 10x faster with this tool, and 100x faster with getting familiar with a codebase. Happy to adjust anything that doesn't fit the project's style or conventions, but I did use clang-format and supervised the demon machine throughout the entire thing. Tested compilation on master before making any edits, made my edits, tested compilation, added some test code and swapped out certs (as described above) compiled and tested again, removed the test code to force it to trigger without waiting a few hours, and compiled and tested again, removed the test code, compiled and well, here we are.

Speaking of, changes to spacing of server.cpp is just from clang-format.

Thanks!