### PR TITLE
FIX(server): Correctly apply register URL

### DIFF
--- a/src/murmur/Server.cpp
+++ b/src/murmur/Server.cpp
@@ -442,7 +442,7 @@ void Server::readParams() {
 	m_dbWrapper.getConfigurationTo(iServerNum, "registerhostname", qsRegHost);
 	m_dbWrapper.getConfigurationTo(iServerNum, "registerlocation", qsRegLocation);
 
-	QString registerURL;
+	QString registerURL = qurlRegWeb.toString();
 	m_dbWrapper.getConfigurationTo(iServerNum, "registerurl", registerURL);
 	qurlRegWeb = QUrl(std::move(registerURL));
 


### PR DESCRIPTION
Since 2907d6dd39d1ea3ac364cca06af70c9e75754030 the register URL was not loaded correctly from config.
This is due to the fact that the third argument of `getConfigurationTo` not only serves as the output of the function, but also as the default value. The new implementation was constructing an empty string for the return value, but not filling in the default value (the URL read from config), leading to the config value being dropped in all cases.

This commit initializes the return value correctly with the URL read from config.

Fixes #6826
