### PR TITLE
FIX(server): Reintroduce the evaluation of bRememberChan

### DIFF
--- a/src/murmur/Messages.cpp
+++ b/src/murmur/Messages.cpp
@@ -298,7 +298,7 @@ void Server::msgAuthenticate(ServerUser *uSource, MumbleProto::Authenticate &msg
 	}
 
 	Channel *lc = nullptr;
-	if (uSource->iId >= 0) {
+	if (uSource->iId >= 0 && Meta::mp->bRememberChan) {
 		unsigned int lastChannelID = m_dbWrapper.getLastChannelID(iServerNum, static_cast< unsigned int >(uSource->iId),
 																  static_cast< unsigned int >(iRememberChanDuration),
 																  tUptime.elapsed< std::chrono::seconds >());


### PR DESCRIPTION
Before 2907d6dd39d1ea3ac364cca06af70c9e75754030, the ``ServerDB`` abstraction contained a check for ``bRememberChan``. This check was omitted when switching to the new ``DBWrapper`` abstraction.
This lead to ``rememberchannel`` being effectively ``true`` in all cases.

This commit re-introduces the check for ``bRememberChan``, this time to ``Messages.cpp`` where it makes more sense.