### PR TITLE
FIX(client): Fix DNS resolver in ConnectDialog

### DIFF
--- a/src/mumble/ConnectDialog.h
+++ b/src/mumble/ConnectDialog.h
@@ -247,7 +247,7 @@ protected:
 	bool bAutoConnect;
 
 	Timer tPing;
-	Timer tCurrent, tHover, tRestart;
+	Timer tCurrent, tHover, tRestart, tResolverBuffer;
 	QUdpSocket *qusSocket4;
 	QUdpSocket *qusSocket6;
 	QTimer *qtPingTick;
@@ -256,7 +256,7 @@ protected:
 	ServerItem *siAutoConnect;
 
 	QList< UnresolvedServerAddress > qlDNSLookup;
-	QSet< UnresolvedServerAddress > qsDNSActive;
+	QSet< UnresolvedServerAddress > qsDNSActive, qlDNSLookupBuffer;
 	QHash< UnresolvedServerAddress, QSet< ServerItem * > > qhDNSWait;
 	QHash< UnresolvedServerAddress, QList< ServerAddress > > qhDNSCache;
 


### PR DESCRIPTION
In c80ece5bb46165d62020efa7264513afecd93b19 the foreach macros were
replaced with regular cpp for-each loops.
In the case of the ConnectDialog, this lead to a concurrent modification
of the list of unresolved DNS lookups.

Additionally, the ConnectDialog would not handle unresolvable hostnames
gracefully. This was essentially only affecting servers on the favorite
list, because servers on the public list are required to have functional
DNS entries.

This commit fixes both problems by introducing a set for recently queried
hostnames, eliminating the need to concurrently modify qlDNSLookup, as well
as adding a timer such that unresolvable hostnames are only retried after a  
full second.