### PR TITLE
BUILD: Add option to prevent use of compile time timestamps

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,9 +17,6 @@ if ("${BUILD_NUMBER}" STREQUAL "")
 	endif()
 endif()
 
-# Get compilation year
-string(TIMESTAMP MUMBLE_BUILD_YEAR "%Y")
-
 project(mumble
 	VERSION "1.6.${BUILD_NUMBER}"
 	DESCRIPTION "Open source, low-latency, high quality voice chat."
@@ -59,6 +56,7 @@ option(optimize "Build a heavily optimized version, specific to the machine it's
 option(static "Build static binaries." OFF)
 option(symbols "Build binaries in a way that allows easier debugging." OFF)
 option(warnings-as-errors "All warnings are treated as errors." ON)
+option(use-timestamps "Allow using compile-time timestamps" ON)
 
 option(client "Build the client (Mumble)" ON)
 option(server "Build the server (Murmur)" ON)
@@ -143,6 +141,12 @@ else()
 	message(FATAL_ERROR "Unable to determine target OS")
 endif()
 
+# Get compilation year
+if (use-timestamps)
+	string(TIMESTAMP MUMBLE_BUILD_YEAR "%Y")
+else()
+	set(MUMBLE_BUILD_YEAR "now")
+endif()
 
 # Make the build year accessible as a macro
 add_compile_definitions(MUMBLE_BUILD_YEAR=${MUMBLE_BUILD_YEAR})

--- a/auxiliary_files/CMakeLists.txt
+++ b/auxiliary_files/CMakeLists.txt
@@ -8,7 +8,11 @@ include(pkg-utils)
 
 if(NOT BUILD_RELEASE_DATE)
 	# If BUILD_RELEASE_DATE has not been set, default to time of build
-	string(TIMESTAMP BUILD_RELEASE_DATE "%Y-%m-%d" UTC)
+	if(use-timestamps)
+		string(TIMESTAMP BUILD_RELEASE_DATE "%Y-%m-%d" UTC)
+	else()
+		set(BUILD_RELEASE_DATE "1970-01-01")
+	endif()
 endif()
 
 if(overlay)

--- a/docs/dev/build-instructions/cmake_options.md
+++ b/docs/dev/build-instructions/cmake_options.md
@@ -299,6 +299,11 @@ Check for updates by default.
 Try to query install paths from pkgconf - this is incompatible to using CMAKE_INSTALL_PREFIX
 (Default: OFF)
 
+### use-timestamps
+
+Allow using compile-time timestamps
+(Default: ON)
+
 ### warnings-as-errors
 
 All warnings are treated as errors.


### PR DESCRIPTION
Add a compile time option to prevent the use of TIMESTAMP during the build process.
This is mostly useful for reproducible builds.