### PR TITLE
 CI(freebsd): Disable Ice 

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -8,11 +8,11 @@ freebsd_instance:
 freebsd_task:
   pkg_script:
   - pkg update && pkg upgrade -y
-  - pkg install -y git ninja pkgconf cmake qt6-base qt6-svg qt6-tools boost-libs libsndfile protobuf ice37 avahi-libdns poco opus
+  - pkg install -y git ninja pkgconf cmake qt6-base qt6-svg qt6-tools boost-libs libsndfile protobuf avahi-libdns poco opus
   fetch_submodules_script: git submodule --quiet update --init --recursive
   build_script:
   - mkdir build && cd build
-  - cmake -G Ninja -DCMAKE_BUILD_TYPE=Release -DCMAKE_UNITY_BUILD=ON -Dtests=ON -Dsymbols=ON ..
+  - cmake -G Ninja -DCMAKE_BUILD_TYPE=Release -DCMAKE_UNITY_BUILD=ON -Dtests=ON -Dsymbols=ON -Dice=OFF ..
   - cmake --build .
   test_script:
   - cd build


### PR DESCRIPTION
It seems that the ZeroC Ice package has (temporarily) been removed from
the FreeBSD repositories. In order to prevent our FreeBSD from
constantly failing because of this, we disable the use of Ice instead.

### Checks

- [x] My commits follow the [commit guidelines](https://github.com/mumble-voip/mumble/blob/master/COMMIT_GUIDELINES.md)

