### PR TITLE
FIX(client): Filter and drop excessive analog input events

### DIFF
--- a/src/mumble/GlobalShortcut_win.cpp
+++ b/src/mumble/GlobalShortcut_win.cpp
@@ -311,7 +311,7 @@ QList< Shortcut > GlobalShortcutWin::migrateSettings(const QList< Shortcut > &ol
 }
 
 GlobalShortcutWin::GlobalShortcutWin()
-	: m_msgQueue(64)
+	: m_msgQueue(GlobalShortcutWin::QUEUE_CAPACITY)
 #ifdef USE_XBOXINPUT
 	  ,
 	  m_xinputDevices(0), m_xinputLastPacket()
@@ -424,6 +424,48 @@ void GlobalShortcutWin::run() {
 	} while (!isInterruptionRequested());
 }
 
+bool GlobalShortcutWin::isRateLimited(HANDLE device) {
+	if (m_throttleThreshold[device] > 0) {
+		m_throttleCounter[device]++;
+
+		if (m_throttleCounter[device] < m_throttleThreshold[device]) {
+			// Only let every throttleThreshold-th event through
+			return true;
+		}
+
+		m_throttleCounter[device] = 0;
+
+		if (m_msgQueue.size() < GlobalShortcutWin::QUEUE_CAPACITY / 2) {
+			// Queue is half empty, relax threshold
+			m_throttleThreshold[device]--;
+			if (m_throttleThreshold[device] == 0) {
+				qInfo() << "GlobalShortcutWin: Throttle threshold disabled for device " << device;
+			}
+		}
+	}
+
+	return false;
+}
+
+void GlobalShortcutWin::tryPlaceEvent(HANDLE device, bool rawhid, std::unique_ptr< MsgRaw > &&event) {
+	const bool enqueued = m_msgQueue.try_emplace(std::move(event));
+	if (!enqueued) {
+		qWarning() << "GlobalShortcutWin: Failed to enqueue input event - queue full?";
+
+		if (rawhid) {
+			// Cap m_throttle at 8192 to prevent excessive event dropping while still protecting the queue
+			// 8192 = 2^13 feels like a good upper limit
+			m_throttleThreshold[device] = std::min(static_cast< unsigned int >(8192), m_throttleThreshold[device] + 1);
+			if (m_throttleThreshold[device] == 1) {
+				qInfo() << "GlobalShortcutWin: Throttle threshold enabled for device " << device;
+			}
+
+			qInfo() << "GlobalShortcutWin: New throttle threshold for device " << device << " is "
+					<< m_throttleThreshold[device];
+		}
+	}
+}
+
 void GlobalShortcutWin::injectRawInputMessage(HRAWINPUT handle) {
 	UINT size = 0;
 	if (GetRawInputData(handle, RID_INPUT, nullptr, &size, sizeof(RAWINPUTHEADER)) != 0) {
@@ -439,7 +481,7 @@ void GlobalShortcutWin::injectRawInputMessage(HRAWINPUT handle) {
 	switch (input->header.dwType) {
 		case RIM_TYPEMOUSE: {
 			const RAWMOUSE &mouse = input->data.mouse;
-			m_msgQueue.emplace(std::make_unique< MsgMouse >(mouse.usButtonFlags));
+			tryPlaceEvent(input->header.hDevice, false, std::make_unique< MsgMouse >(mouse.usButtonFlags));
 			break;
 		}
 		case RIM_TYPEKEYBOARD: {
@@ -455,13 +497,28 @@ void GlobalShortcutWin::injectRawInputMessage(HRAWINPUT handle) {
 				return;
 			}
 
-			m_msgQueue.emplace(std::make_unique< MsgKeyboard >(keyboard.Flags, keyboard.MakeCode, keyboard.VKey));
+			tryPlaceEvent(input->header.hDevice, false,
+						  std::make_unique< MsgKeyboard >(keyboard.Flags, keyboard.MakeCode, keyboard.VKey));
 			break;
 		}
 		case RIM_TYPEHID: {
 			const RAWHID &hid = input->data.hid;
 			MsgHid::RawReports reports(hid.bRawData, hid.dwSizeHid * hid.dwCount);
-			m_msgQueue.emplace(std::make_unique< MsgHid >(input->header.hDevice, reports, hid.dwSizeHid));
+
+			if (reports.empty()) {
+				break;
+			}
+
+			// We have had the problem that certain analog input devices (joysticks, wheels) would
+			// overwhelm our input event queue with messages and freeze Mumble as a whole. Therefore
+			// we have to implement rate-limiting for analog input events, while keyboard and mouse
+			// inputs are fine. See: https://github.com/mumble-voip/mumble/issues/6696
+			if (isRateLimited(input->header.hDevice)) {
+				break;
+			}
+
+			tryPlaceEvent(input->header.hDevice, true,
+						  std::make_unique< MsgHid >(input->header.hDevice, reports, hid.dwSizeHid));
 			break;
 		}
 		default:

--- a/src/mumble/GlobalShortcut_win.h
+++ b/src/mumble/GlobalShortcut_win.h
@@ -29,6 +29,8 @@ class GlobalShortcutWin : public GlobalShortcutEngine {
 	Q_DISABLE_COPY(GlobalShortcutWin)
 
 public:
+	static constexpr size_t QUEUE_CAPACITY = 64;
+
 	static void registerMetaTypes();
 
 	/// @param oldShortcuts List of shortcuts to migrate.
@@ -136,6 +138,13 @@ protected:
 	DeviceMap::iterator addDevice(const HANDLE deviceHandle);
 
 	static std::string utf16To8(const std::wstring &wstr);
+
+private:
+	std::map< HANDLE, unsigned int > m_throttleThreshold;
+	std::map< HANDLE, unsigned int > m_throttleCounter;
+
+	bool isRateLimited(HANDLE device);
+	void tryPlaceEvent(HANDLE device, bool rawhid, std::unique_ptr< MsgRaw > &&event);
 };
 
 #endif


### PR DESCRIPTION
Previously, we would add all input events to a fixed-size blocking Queue on Windows.
This lead to the problem where analog input devices which create a lot of events would fill up that blocking queue quickly, stalling the main thread and UI.

This commit replaces the "emplace" call for the queue with "try_emplace" dropping anything that would exceed the limit of the queue.

Furthermore, this commit adds a throttle mechanism. If we fail to place an event in the queue, we increase a threshold value. The threshold value determines how many intermediate events will be unconditionally dropped before we accept a new event from an input device (excluding mouse or keyboard). If the queue becomes less full, the threshold value will decrease again - hopefully balancing the processing of the queue.

supersedes #6839