### PR TITLE
FIX(client): Exit ServerHandler event loop gracefully in certain conditions

### DIFF
--- a/src/mumble/ServerHandler.cpp
+++ b/src/mumble/ServerHandler.cpp
@@ -699,10 +699,16 @@ void ServerHandler::disconnect() {
 
 void ServerHandler::serverConnectionClosed(QAbstractSocket::SocketError err, const QString &reason) {
 	Connection *c = cConnection.get();
-	if (!c)
+	if (!c) {
+		exit(0);
 		return;
-	if (c->bDisconnectedEmitted)
+	}
+
+	if (c->bDisconnectedEmitted) {
+		exit(0);
 		return;
+	}
+
 	c->bDisconnectedEmitted = true;
 
 	AudioOutputPtr ao = Global::get().ao;


### PR DESCRIPTION
Without this, the MainWindow could, under certain conditions (unstable/slow connection), end up hanging indefinitely here:

https://github.com/mumble-voip/mumble/blob/3eac30797d37fa87caab818f41a7c6ac75a72cfe/src/mumble/MainWindow.cpp#L1234-L1237