### PR TITLE
FIX(macos): Update some of macOS obj-c code for 10.15 minimum

### DIFF
--- a/src/mumble/AppNap.mm
+++ b/src/mumble/AppNap.mm
@@ -7,16 +7,10 @@
 
 #include <Foundation/Foundation.h>
 
-#if MAC_OS_X_VERSION_MAX_ALLOWED >= 1070
 static bool appNapSuppressed = false;
-#endif
 
 void MUSuppressAppNap(bool suppress) {
-#if MAC_OS_X_VERSION_MAX_ALLOWED >= 1070
 	NSProcessInfo *processInfo = [NSProcessInfo processInfo];
-	if (![processInfo respondsToSelector:@selector(disableAutomaticTermination:)]) {
-		return;
-	}
 
 	if (suppress == appNapSuppressed) {
 		qWarning("AppNap: attempt to set AppNap suppression state to %s while already in that state.", suppress ? "true" : "false");
@@ -24,20 +18,19 @@ void MUSuppressAppNap(bool suppress) {
 	}
 
 	QString translatedReason = QApplication::tr("Mumble is currently connected to a server");
-	NSString *reason = const_cast<NSString *>(reinterpret_cast<const NSString *>(CFStringCreateWithCharacters(kCFAllocatorDefault, reinterpret_cast<const UniChar *>(translatedReason.unicode()), translatedReason.length())));
+	NSString *reason = [[NSString alloc] initWithCharacters:reinterpret_cast<const unichar *>(translatedReason.unicode())
+	                                                  length:static_cast<NSUInteger>(translatedReason.length())];
 
 	if (suppress) {
-		[[NSProcessInfo processInfo] disableAutomaticTermination:reason];
+		[processInfo disableAutomaticTermination:reason];
 		qWarning("AppNap: suppressed with reason: '%s'", qPrintable(translatedReason));
 	} else {
-		[[NSProcessInfo processInfo] enableAutomaticTermination:reason];
+		[processInfo enableAutomaticTermination:reason];
 		qWarning("AppNap: re-enabled, was suppressed with reason: '%s'", qPrintable(translatedReason));
 	}
 
 	appNapSuppressed = suppress;
 
 	[reason release];
-#else
-	Q_UNUSED(suppress);
-#endif
+
 }

--- a/src/mumble/CoreAudio.mm
+++ b/src/mumble/CoreAudio.mm
@@ -14,7 +14,7 @@
 #include "CoreAudio.h"
 
 // Ignore deprecation warnings for the whole file, for now.
-#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+
 
 
 namespace {
@@ -55,8 +55,7 @@ public:
 
 
 CFStringRef QStringToCFString(const QString &str) {
-	return CFStringCreateWithCharacters(kCFAllocatorDefault, reinterpret_cast< const UniChar * >(str.unicode()),
-	                                    str.length());
+	return CFStringCreateWithCharacters(kCFAllocatorDefault, reinterpret_cast<const UniChar *>(str.unicode()), str.length());
 }
 
 QString GetDeviceStringProperty(AudioObjectID device_id, AudioObjectPropertySelector property_selector) {
@@ -717,7 +716,7 @@ bool CoreAudioInput::initializeInputAU(AudioUnit au, AudioStreamBasicDescription
 	if (err != noErr) {
 		qWarning("CoreAudioInput: Unable to set preferred buffer size on device. Querying for device default.");
 		len = sizeof(UInt32);
-		CHECK_RETURN_FALSE(AudioDeviceGetProperty(inputDevId, 0, true, kAudioDevicePropertyBufferFrameSize, &len, &val),
+		CHECK_RETURN_FALSE(AudioObjectGetPropertyData(inputDevId, &propertyAddress, 0, nullptr, &len, &val),
 		                   "CoreAudioInput: Unable to query for device's buffer size.");
 
 		actualBufferLength = (int) val;

--- a/src/mumble/Overlay_macx.mm
+++ b/src/mumble/Overlay_macx.mm
@@ -318,6 +318,8 @@ bool OverlayConfig::needsUpgrade() {
 }
 
 static bool authExec(AuthorizationRef ref, const char **argv) {
+	Q_UNUSED(ref);
+	Q_UNUSED(argv);
 	OSStatus err = noErr;
 	int pid = 0, status = 0;
 

--- a/src/mumble/TextToSpeech_macx.mm
+++ b/src/mumble/TextToSpeech_macx.mm
@@ -133,10 +133,7 @@ void TextToSpeechPrivate::say(const QString &text) {
 }
 
 void TextToSpeechPrivate::setVolume(int volume) {
-	// Check for setVolume: availability. It's only available on 10.5+.
-	if ([[m_synthesizerHelper synthesizer] respondsToSelector:@selector(setVolume:)]) {
-		[[m_synthesizerHelper synthesizer] setVolume:(float)volume / 100.0f];
-	}
+	[[m_synthesizerHelper synthesizer] setVolume:(float)volume / 100.0f];
 }
 
 TextToSpeech::TextToSpeech(QObject *) {


### PR DESCRIPTION
Make the macOS code in obj-c with some changes to modernize

- Replace [dict objectForKey:] with modern subscripting syntax dict[key]
- Replace NSAutoreleasePool with `@autoreleasepool` blocks
- Replace deprecated AudioDeviceGetProperty with AudioObjectGetPropertyData
- Remove obsolete macOS version checks for < 10.15
- Remove dead 32-bit code (__LP64__ guards)
- Remove unnecessary respondsToSelector: checks for APIs available in 10.15+

- Fix potential crash in dumpEventTaps when process name is nil
- Fix memory leak in query_language by adding proper CFRelease calls
- Add defensive null checks in query_language for CFPreferencesCopyAppValue
- Fix unused variable warning in AppNap.mm
- Remove duplicate [reason release] call

- Remove deprecated API warning suppressions from CoreAudio.mm and Overlay_macx.mm
- Comment out deprecated AuthorizationExecuteWithPrivileges with migration note

### Checks

- [x] My commits follow the [commit guidelines](https://github.com/mumble-voip/mumble/blob/master/COMMIT_GUIDELINES.md)

