### PR TITLE
CHANGE mumble-server.ini to increase imagemessagelength to 1MB

### DIFF
--- a/auxiliary_files/mumble-server.ini
+++ b/auxiliary_files/mumble-server.ini
@@ -200,7 +200,7 @@ allowping=true
 ;textmessagelength=5000
 
 ; Maximum length of text messages in characters, with image data. 0 for no limit.
-;imagemessagelength=131072
+;imagemessagelength=1048576
 
 ; Allow clients to use HTML in messages, user comments and channel descriptions?
 ;allowhtml=true


### PR DESCRIPTION
I increase imagemessagelength to 1MB for reasons to post pics.

issue: https://github.com/mumble-voip/mumble/issues/6993


### Checks

- [ ] My commits follow the [commit guidelines](https://github.com/mumble-voip/mumble/blob/master/COMMIT_GUIDELINES.md)

