### PR TITLE
CHANGE Meta.cpp to increase iMaxImageMessageLength to 1MB

### DIFF
--- a/src/murmur/Meta.cpp
+++ b/src/murmur/Meta.cpp
@@ -69,7 +69,7 @@ MetaParams::MetaParams() {
 	iMaxListenersPerChannel    = -1;
 	iMaxListenerProxiesPerUser = -1;
 	iMaxTextMessageLength      = 5000;
-	iMaxImageMessageLength     = 131072;
+	iMaxImageMessageLength     = 1048576;
 	legacyPasswordHash         = false;
 	kdfIterations              = -1;
 	bAllowHTML                 = true;


### PR DESCRIPTION
Made change to image size.

https://github.com/mumble-voip/mumble/issues/6993


### Checks

- [ ] My commits follow the [commit guidelines](https://github.com/mumble-voip/mumble/blob/master/COMMIT_GUIDELINES.md)

