### PR TITLE
FIX(client): Prevent ServerHandler from making main thread hang

### DIFF
--- a/src/mumble/MainWindow.cpp
+++ b/src/mumble/MainWindow.cpp
@@ -1227,8 +1227,12 @@ static void recreateServerHandler() {
 	if (sh && sh->isRunning()) {
 		Global::get().mw->on_qaServerDisconnect_triggered();
 		sh->disconnect();
-		sh->wait();
-		QCoreApplication::instance()->processEvents();
+
+		while (!sh->wait(1000)) {
+			Global::get().l->log(Log::Information,
+								 QObject::tr("Waiting for previous connection to fully terminate..."));
+			QCoreApplication::instance()->processEvents();
+		}
 	}
 
 	Global::get().sh.reset();

--- a/src/mumble/ServerHandler.cpp
+++ b/src/mumble/ServerHandler.cpp
@@ -403,6 +403,10 @@ void ServerHandler::run() {
 		}
 	}
 
+	if (m_connectionAborted) {
+		return;
+	}
+
 	QList< ServerAddress > targetAddresses(qlAddresses);
 	bool shouldTryNextTargetServer = true;
 	do {
@@ -695,6 +699,7 @@ void ServerHandler::disconnect() {
 	ServerHandlerMessageEvent *shme =
 		new ServerHandlerMessageEvent(qbaBuffer, Mumble::Protocol::TCPMessageType::Ping, false);
 	QApplication::postEvent(this, shme);
+	m_connectionAborted = true;
 }
 
 void ServerHandler::serverConnectionClosed(QAbstractSocket::SocketError err, const QString &reason) {

--- a/src/mumble/ServerHandler.h
+++ b/src/mumble/ServerHandler.h
@@ -65,6 +65,8 @@ private:
 	static QMutex nextConnectionIDMutex;
 	static int nextConnectionID;
 
+	bool m_connectionAborted = false;
+
 protected:
 	QString qsHostName;
 	QString qsUserName;


### PR DESCRIPTION
When ServerHandler::run is resolving a DNS entry for a server and the user chooses to establish a new connection, the main thread would hang - on Global::get().sh->wait() - while waiting for ServerHandler to destroy itself, which it never does.

This commit introduces a flag to indicate that the ServerHandler was terminated by the user (e.g. connecting to a different server or hitting the disconnect button). After the DNS record is resolved the flag is checked and ServerHandler::run is aborted early, "fixing" the hang.

"fixing" in quotation marks, because the main thread still has to wait until the DNS query is resolved before ServerHandler terminates. To make this a little bit better, this commit replaces the wait() with a wait(1000) and a user facing log message that indicates to the user that we are waiting on the connection.