### PR TITLE
REFAC(client): Replace use of deprecated invalidateFilter()

### DIFF
--- a/src/mumble/UserEdit.cpp
+++ b/src/mumble/UserEdit.cpp
@@ -162,8 +162,15 @@ bool UserListFilterProxyModel::filterAcceptsRow(int source_row, const QModelInde
 }
 
 void UserListFilterProxyModel::setFilterMinimumInactiveDays(int minimumInactiveDays) {
+#if QT_VERSION >= QT_VERSION_CHECK(6, 10, 0)
+	beginFilterChange();
+#endif
 	m_minimumInactiveDays = minimumInactiveDays;
+#if QT_VERSION >= QT_VERSION_CHECK(6, 10, 0)
+	endFilterChange();
+#else
 	invalidateFilter();
+#endif
 }
 
 void UserListFilterProxyModel::removeRowsInSelection(const QItemSelection &selection) {


### PR DESCRIPTION
The function is deprecated since Qt 6.13 and the intended replacement are calls to beginFilterChange() and endFilterChange(). These functions exist since Qt 6.9 and 6.10 respectively. Hence, we switch to using the pair of functions if the used Qt version is 6.10 or newer.


### Checks

- [x] My commits follow the [commit guidelines](https://github.com/mumble-voip/mumble/blob/master/COMMIT_GUIDELINES.md)

