### PR TITLE
FIX(client): Properly handle ServerHandler states

### DIFF
--- a/src/mumble/MainWindow.cpp
+++ b/src/mumble/MainWindow.cpp
@@ -1232,8 +1232,9 @@ static void recreateServerHandler() {
 	}
 
 	Global::get().sh.reset();
-	while (sh && sh.use_count() > 1)
+	while (sh && sh.use_count() > 1) {
 		QThread::yieldCurrentThread();
+	}
 	sh.reset();
 
 	sh = ServerHandlerPtr(new ServerHandler());

--- a/src/mumble/ServerHandler.h
+++ b/src/mumble/ServerHandler.h
@@ -53,6 +53,19 @@ public:
 	ServerHandlerMessageEvent(const QByteArray &msg, Mumble::Protocol::TCPMessageType type, bool flush = false);
 };
 
+enum class ServerHandlerState {
+	Idle,
+	DNSQuery,
+	DNSResolved,
+	DNSFailed,
+	AwaitingConnection,
+	TLSHandshake,
+	ConnectionEstablished,
+	Disconnecting,
+	ConnectionOver,
+	Aborted
+};
+
 using ConnectionPtr = std::shared_ptr< Connection >;
 
 class ServerHandler : public QThread {
@@ -64,6 +77,11 @@ private:
 
 	static QMutex nextConnectionIDMutex;
 	static int nextConnectionID;
+
+	bool isAborted();
+	void changeState(ServerHandlerState state);
+
+	ServerHandlerState m_state = ServerHandlerState::Idle;
 
 protected:
 	QString qsHostName;
@@ -194,6 +212,7 @@ signals:
 	void disconnected(QAbstractSocket::SocketError, QString reason);
 	void connected();
 	void pingRequested();
+	void abortRequested();
 protected slots:
 	void message(Mumble::Protocol::TCPMessageType type, const QByteArray &);
 	void serverConnectionConnected();
@@ -205,6 +224,7 @@ protected slots:
 	void hostnameResolved();
 private slots:
 	void sendPingInternal();
+	void abortConnection();
 public slots:
 	void sendPing();
 };


### PR DESCRIPTION
So, the fundamental idea of the ServerHandler is that it will do various tasks upon connecting to a server until the connection is terminated. To do this, the ServerHandler uses Qt's event system and a separate thread as to not interfere with the main thread.
If the connection is being closed, the ServerHandler is supposed to die as well. The MainWindow will create a new ServerHandler upon a new connection.

In detail, the ServerHandler extends the QThread class and is started by the MainWindow. The run() method of the ServerHandler is overloaded with a long setup method which 1) does the DNS resolving of hostnames 2) sets up the connection to the server and the events such that server messages are being processed correctly, and 3) is closing and destroying the connection objects after a session is done.

The ServerHandler mostly uses signals, slots and Qt events to communicate asynchronously. One crucial point is that it calls exec() twice, to suspend it's own thread until some event calls exit(). The exec() is used to wait for the DNS resolver, and the second exec() is used to wait for the connection to be terminated either by the user or the remote server.

Now unfortunately, two problems are present here:

1) It was never considered what happens, if the resolving of the DNS query took extremly long and for some reason an exit() was fired. For example, when the user aborts the connection during that time using the disconnect button. In this case, the first exec() would terminate with an exit() that was meant for the second exec(), keeping the ServerHandler in the second event loop indefinitely. Since the main thread was actively waiting for the SeverHandler thread to terminate, Mumble as a whole would hang.

2) There was some thought put into handling a forced disconnect by the user with the customEvent system. However, this hacky solution was not working for a connection with a broken state. It would only work for fully established connections.

This commit introduces an auxilliary state enum which keeps track of connection state. It replaces the hacky custom event with a signal and slot mechanism that relaibly sets the state to "aborted" and sending out exit(0) for the waiting exec(). And introduces a check to make sure the thread properly terminates, if it is aborted during DNS resolve time.