### PR TITLE
CHANGE: increase iMaxImageMessageLength and mumble-server.ini to 1MB …

### DIFF
--- a/auxiliary_files/mumble-server.ini
+++ b/auxiliary_files/mumble-server.ini
@@ -200,7 +200,7 @@ allowping=true
 ;textmessagelength=5000
 
 ; Maximum length of text messages in characters, with image data. 0 for no limit.
-;imagemessagelength=131072
+;imagemessagelength=1048576
 
 ; Allow clients to use HTML in messages, user comments and channel descriptions?
 ;allowhtml=true

--- a/src/murmur/Meta.cpp
+++ b/src/murmur/Meta.cpp
@@ -69,7 +69,7 @@ MetaParams::MetaParams() {
 	iMaxListenersPerChannel    = -1;
 	iMaxListenerProxiesPerUser = -1;
 	iMaxTextMessageLength      = 5000;
-	iMaxImageMessageLength     = 131072;
+	iMaxImageMessageLength     = 1048576;
 	legacyPasswordHash         = false;
 	kdfIterations              = -1;
 	bAllowHTML                 = true;


### PR DESCRIPTION
…The default value for  in the server configuration has been increesed to 1MB to handle higher image sizes.closes #6993


### Checks

- [ ] My commits follow the [commit guidelines](https://github.com/mumble-voip/mumble/blob/master/COMMIT_GUIDELINES.md)

