### PR TITLE
feat(proto): add a UDP variant of `Authenticate`

### DIFF
--- a/docs/dev/network-protocol/README.md
+++ b/docs/dev/network-protocol/README.md
@@ -1,8 +1,8 @@
 # Mumble Network Protocol Documentation
 
 The Mumble Network Protocol documentation is meant to be a reference for the
-Mumble VoIP 1.2.X server-client communication protocol. It reflects the state of
-the protocol implemented in the Mumble 1.2.8 client and might be outdated by the
+Mumble VoIP 1.5.X server-client communication protocol. It reflects the state of
+the protocol implemented in the Mumble 1.5.857 client and might be outdated by the
 time you are reading this.
 
 For up to date message type and message structure information

--- a/src/Mumble.proto
+++ b/src/Mumble.proto
@@ -603,6 +603,8 @@ message ServerConfig {
 	optional uint32 max_users = 6;
 	// Whether using Mumble's recording feature is allowed on the server
 	optional bool recording_allowed = 7;
+	// How often the client should send UDP pings to the server in milliseconds
+	optional uint32 udp_ping_interval = 8;
 }
 
 // Sent by the server to inform the clients of suggested client configuration

--- a/src/MumbleUDP.proto
+++ b/src/MumbleUDP.proto
@@ -83,3 +83,15 @@ message Ping {
 	// The maximum bandwidth each user is allowed to use for sending audio to the server
 	uint32 max_bandwidth_per_user = 6;
 }
+
+/**
+ * Authentication message for telling the server that the specified `session_id` wants to authenticate for UDP, the server
+ * will echo back the same packet if it managed to decrypt the packet, the client can then start sending UDP voice packets.
+ */
+message Authenticate {
+	// The session the client is trying to authenticate for.
+	uint32 session_id = 1;
+
+	// An encrypted audio buffer that the server will have to decrypt to verify that the specified session is who they say they are.
+	Audio buffer = 2;
+}


### PR DESCRIPTION
The current flow for connection handling of mumble client puts a bunch of un-needed strain on the server as we have to go through the entire list of UDP sockets that aren't yet authenticated.

This instead allows us to send a partially unencrypted packet with a `session_id` that the calling client is trying to authenticate for, and an encrypted Audio packet that the server will use to verify that they are actually the client.


### Checks

- [ ] My commits follow the [commit guidelines](https://github.com/mumble-voip/mumble/blob/master/COMMIT_GUIDELINES.md)

