### PR TITLE
FIX(client): a typo in a sanitizing regex

### DIFF
--- a/src/mumble/VoiceRecorder.cpp
+++ b/src/mumble/VoiceRecorder.cpp
@@ -69,7 +69,7 @@ QString VoiceRecorder::sanitizeFilenameOrPathComponent(const QString &str) const
 
 	// Prepend reserved filenames CON, PRN, AUX, NUL, COM1, COM2, COM3, COM4, COM5, COM6, COM7, COM8, COM9, LPT1, LPT2,
 	// LPT3, LPT4, LPT5, LPT6, LPT7, LPT8, and LPT9
-	res = res.replace(QRegularExpression(QLatin1String("^((CON|PRN|AUX|NUL|COM[1-9]|LPT1[1-9])(\\.|$))"),
+	res = res.replace(QRegularExpression(QLatin1String("^((CON|PRN|AUX|NUL|COM[1-9]|LPT[1-9])(\\.|$))"),
 										 QRegularExpression::CaseInsensitiveOption),
 					  QLatin1String("_\\1"));
 


### PR DESCRIPTION
### Checks

- [x] My commits follow the [commit guidelines](https://github.com/mumble-voip/mumble/blob/master/COMMIT_GUIDELINES.md)

