### PR TITLE
MAINT(osx): Allow bundling without overlay

### DIFF
--- a/macx/scripts/osxdist.py
+++ b/macx/scripts/osxdist.py
@@ -359,7 +359,7 @@ def package_server():
 		print('Failed to build Murmur XIP package')
 		sys.exit(1)
 
-	absrelease = os.path.join(os.getcwd(), 'options.binary_dir')
+	absrelease = os.path.join(os.getcwd(), options.binary_dir)
 
 	p = Popen(('tar', '-cjpf', name+'.tar.bz2', name), cwd=absrelease)
 	retval = p.wait()


### PR DESCRIPTION
Fixes https://github.com/mumble-voip/mumble/issues/6816

### Checks

- [x] My commits follow the [commit guidelines](https://github.com/mumble-voip/mumble/blob/master/COMMIT_GUIDELINES.md)

