### PR TITLE
BUILD(cmake): Add option to disable use of DBus

### DIFF
--- a/docs/dev/build-instructions/cmake_options.md
+++ b/docs/dev/build-instructions/cmake_options.md
@@ -99,6 +99,11 @@ Whether to include the PostgreSQL database tests (requires special setup)
 Whether to include the SQLite database tests
 (Default: ON)
 
+### dbus
+
+Enable DBus support/interface
+(Default: ON)
+
 ### debug-dependency-search
 
 Prints extended information during the search for the needed dependencies

--- a/src/mumble/CMakeLists.txt
+++ b/src/mumble/CMakeLists.txt
@@ -51,6 +51,8 @@ elseif(UNIX)
 		option(speechd "Build support for Speech Dispatcher." ON)
 	endif()
 
+	option(dbus "Enable DBus support/interface" ON)
+
 	# scripts/generate_cmake_options_docs.py does not cope with duplicate option() lines,
 	# so single out common options into combined conditions.
 	# https://github.com/mumble-voip/mumble/issues/5488
@@ -835,7 +837,7 @@ if(NOT update)
 	target_compile_definitions(mumble_client_object_lib PUBLIC "NO_UPDATE_CHECK")
 endif()
 
-if(NOT WIN32 AND NOT APPLE)
+if(dbus AND (NOT WIN32 AND NOT APPLE))
 	find_pkg(Qt6 COMPONENTS DBus REQUIRED)
 
 	target_sources(mumble_client_object_lib


### PR DESCRIPTION
Fixes #7026


### Checks

- [x] My commits follow the [commit guidelines](https://github.com/mumble-voip/mumble/blob/master/COMMIT_GUIDELINES.md)

