### PR TITLE
Backport "Merge PR #7025: MAINT(osx): Allow bundling without overlay" to 1.5.x

### DIFF
--- a/macx/scripts/osxdist.py
+++ b/macx/scripts/osxdist.py
@@ -359,7 +359,7 @@ def package_server():
 		print('Failed to build Murmur XIP package')
 		sys.exit(1)
 
-	absrelease = os.path.join(os.getcwd(), 'options.binary_dir')
+	absrelease = os.path.join(os.getcwd(), options.binary_dir)
 
 	p = Popen(('tar', '-cjpf', name+'.tar.bz2', name), cwd=absrelease)
 	retval = p.wait()


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `1.5.x`:
 - [Merge PR #7025: MAINT(osx): Allow bundling without overlay](https://github.com/mumble-voip/mumble/pull/7025)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)