### PR TITLE
REFAC(db): Fix typo 'scheme' -> 'schema'

### DIFF
--- a/src/database/Database.h
+++ b/src/database/Database.h
@@ -40,7 +40,7 @@ namespace db {
 
 		virtual void init(const ConnectionParameter &parameter);
 
-		virtual unsigned int getSchemeVersion() const = 0;
+		virtual unsigned int getSchemaVersion() const = 0;
 
 		Backend getBackend() const;
 
@@ -103,10 +103,10 @@ namespace db {
 		/**
 		 * Initiates the migration of all tables currently contained in this database.
 		 *
-		 * @param fromSchemeVersion The scheme version to migrate from
-		 * @param toSchemeVersion The scheme version to migrate to
+		 * @param fromSchemaVersion The schema version to migrate from
+		 * @param toSchemaVersion The schema version to migrate to
 		 */
-		virtual void migrateTables(unsigned int fromSchemeVersion, unsigned int toSchemeVersion);
+		virtual void migrateTables(unsigned int fromSchemaVersion, unsigned int toSchemaVersion);
 
 		virtual void importMetaData(const nlohmann::json &json);
 		virtual nlohmann::json exportMetaData() const;

--- a/src/database/Index.cpp
+++ b/src/database/Index.cpp
@@ -66,7 +66,7 @@ namespace db {
 				// names in SQLite are global (instead of scoped per table)
 				return "SELECT 1 FROM sqlite_master WHERE type = 'index' AND name = '" + m_name + "'";
 			case Backend::PostgreSQL:
-				// Note: index names are global (for a given scheme), hence the table's name
+				// Note: index names are global (for a given schema), hence the table's name
 				// does not appear in the query
 				return "SELECT 1 FROM pg_indexes WHERE indexname = '" + m_name + "'";
 			case Backend::MySQL:

--- a/src/database/MetaTable.cpp
+++ b/src/database/MetaTable.cpp
@@ -35,13 +35,19 @@ namespace db {
 		setPrimaryKey(pk);
 	}
 
-	unsigned int MetaTable::getSchemeVersion() {
-		std::optional< std::string > strVersion = queryKey("scheme_version");
+	unsigned int MetaTable::getSchemaVersion() {
+		std::optional< std::string > strVersion = queryKey("schema_version");
+
+		if (!strVersion.has_value()) {
+			// Sometime before the first releases of 1.6, there was a typo in the name of the key
+			// Check that as well to retain compatibility with those versions
+			strVersion = queryKey("scheme_version");
+		}
 
 		return strVersion ? static_cast< unsigned int >(std::stoi(strVersion.value())) : 0;
 	}
 
-	void MetaTable::setSchemeVersion(unsigned int version) { setKey("scheme_version", std::to_string(version)); }
+	void MetaTable::setSchemaVersion(unsigned int version) { setKey("schema_version", std::to_string(version)); }
 
 	void MetaTable::setKey(const std::string &key, const std::string &value) {
 		try {
@@ -70,7 +76,7 @@ namespace db {
 			// emitted if these columns don't exist when using SQLite. The reason being that SQLite accepts strings
 			// wrapped in double quotes and hence reads the column names as strings.
 			// See https://sqlite.org/quirks.html#double_quoted_string_literals_are_accepted
-			// However, we rely on this throwing an error when querying the scheme version from Database::init.
+			// However, we rely on this throwing an error when querying the schema version from Database::init.
 			m_sql << "SELECT " << column::value << " FROM " << m_name << " WHERE " << column::key << " = :key",
 				soci::use(key), soci::into(value);
 
@@ -80,45 +86,45 @@ namespace db {
 		}
 	}
 
-	void MetaTable::migrate(unsigned int fromSchemeVersion, unsigned int toSchemeVersion) {
+	void MetaTable::migrate(unsigned int fromSchemaVersion, unsigned int toSchemaVersion) {
 		// Note: Always hard-code table and column names in this function in order to ensure that this
 		// migration path always stays the same regardless of whether the respective named constants change.
-		assert(fromSchemeVersion <= toSchemeVersion);
+		assert(fromSchemaVersion <= toSchemaVersion);
 
 		try {
-			if (fromSchemeVersion < 10) {
+			if (fromSchemaVersion < 10) {
 				// In v10 we renamed the columns "keystring" -> "meta_key" and "value" -> "meta_value"
 				// -> Import all data from the old table into the new one
 				m_sql << "INSERT INTO \"" << getName() << "\" (\"" << column::key << "\", \"" << column::value
 					  << "\") SELECT \"keystring\", \"value\" FROM \"meta" << Database::OLD_TABLE_SUFFIX << "\"";
 
-				// Furthermore, the schema version is no longer stored under "version" but under "scheme_version"
-				m_sql << "UPDATE \"" << getName() << "\" SET \"" << column::key << "\" = 'scheme_version' WHERE \""
+				// Furthermore, the schema version is no longer stored under "version" but under "schema_version"
+				m_sql << "UPDATE \"" << getName() << "\" SET \"" << column::key << "\" = 'schema_version' WHERE \""
 					  << column::key << "\" = 'version'";
 			} else {
 				// Use default implementation to handle migration without change of format
-				Table::migrate(fromSchemeVersion, toSchemeVersion);
+				Table::migrate(fromSchemaVersion, toSchemaVersion);
 			}
 		} catch (const soci::soci_error &) {
 			std::throw_with_nested(MigrationException(std::string("Failed at migrating table \"") + NAME
-													  + "\" from scheme version " + std::to_string(fromSchemeVersion)
-													  + " to " + std::to_string(toSchemeVersion)));
+													  + "\" from schema version " + std::to_string(fromSchemaVersion)
+													  + " to " + std::to_string(toSchemaVersion)));
 		}
 	}
 
-	unsigned int MetaTable::getSchemeVersionLegacy() {
+	unsigned int MetaTable::getSchemaVersionLegacy() {
 		try {
 			std::string value;
 			// Note: We are deliberately not wrapping the column names in double quotes as this prevents errors to be
 			// emitted if these columns don't exist when using SQLite. The reason being that SQLite accepts strings
 			// wrapped in double quotes and hence reads the column names as strings.
 			// See https://sqlite.org/quirks.html#double_quoted_string_literals_are_accepted
-			// However, we rely on this throwing an error when querying the scheme version from Database::init.
+			// However, we rely on this throwing an error when querying the schema version from Database::init.
 			m_sql << "SELECT value FROM meta WHERE keystring = 'version'", soci::into(value);
 
 			return m_sql.got_data() ? static_cast< unsigned int >(std::stoi(value)) : 0;
 		} catch (const soci::soci_error &e) {
-			throw AccessException(std::string("During legacy scheme version fetching: ") + e.what());
+			throw AccessException(std::string("During legacy schema version fetching: ") + e.what());
 		}
 	}
 

--- a/src/database/MetaTable.h
+++ b/src/database/MetaTable.h
@@ -29,16 +29,16 @@ namespace db {
 
 		MetaTable(soci::session &sql, Backend backend);
 
-		unsigned int getSchemeVersion();
-		void setSchemeVersion(unsigned int version);
+		unsigned int getSchemaVersion();
+		void setSchemaVersion(unsigned int version);
 
 		void setKey(const std::string &key, const std::string &value);
 		std::optional< std::string > queryKey(const std::string &key);
 
-		void migrate(unsigned int fromSchemeVersion, unsigned int toSchemeVersion) override;
+		void migrate(unsigned int fromSchemaVersion, unsigned int toSchemaVersion) override;
 
 	private:
-		unsigned int getSchemeVersionLegacy();
+		unsigned int getSchemaVersionLegacy();
 	};
 
 } // namespace db

--- a/src/database/Table.cpp
+++ b/src/database/Table.cpp
@@ -189,9 +189,9 @@ namespace db {
 		transaction.commit();
 	}
 
-	void Table::migrate(unsigned int fromSchemeVersion, unsigned int toSchemeVersion) {
-		(void) fromSchemeVersion;
-		(void) toSchemeVersion;
+	void Table::migrate(unsigned int fromSchemaVersion, unsigned int toSchemaVersion) {
+		(void) fromSchemaVersion;
+		(void) toSchemaVersion;
 		// The default implementation simply imports all data from the old table into the new one. The previously
 		// existing table will have been renamed to include the suffix Database::OLD_TABLE_SUFFIX. Other than that the
 		// table name and the columns in that table are assumed to be equal to those of the table represented by this
@@ -214,9 +214,9 @@ namespace db {
 		}
 	}
 
-	void Table::postMigrationAction(unsigned int fromSchemeVersion, unsigned int toSchemeVersion) {
-		(void) fromSchemeVersion;
-		(void) toSchemeVersion;
+	void Table::postMigrationAction(unsigned int fromSchemaVersion, unsigned int toSchemaVersion) {
+		(void) fromSchemaVersion;
+		(void) toSchemaVersion;
 	}
 
 	void Table::destroy() {

--- a/src/database/Table.h
+++ b/src/database/Table.h
@@ -45,18 +45,18 @@ namespace db {
 
 		virtual void create();
 		/**
-		 * Migrate this table to the new scheme version. Note that this function assumes that a transaction has already
+		 * Migrate this table to the new schema version. Note that this function assumes that a transaction has already
 		 * been started when this function is called. Note also that when this function is called, the original table
 		 * containing the legacy data has been renamed to have the suffix Database::OLD_TABLE_SUFFIX.
 		 *
-		 * @param fromSchemeVersion The scheme version of the existing DB
-		 * @param toSchemeVersion The scheme version to migrate to
+		 * @param fromSchemaVersion The schema version of the existing DB
+		 * @param toSchemaVersion The schema version to migrate to
 		 */
-		virtual void migrate(unsigned int fromSchemeVersion, unsigned int toSchemeVersion);
+		virtual void migrate(unsigned int fromSchemaVersion, unsigned int toSchemaVersion);
 		/**
 		 * Handler to be called once all tables have been successfully migrated.
 		 */
-		virtual void postMigrationAction(unsigned int fromSchemeVersion, unsigned int toScheme);
+		virtual void postMigrationAction(unsigned int fromSchemaVersion, unsigned int toSchemaVersion);
 		virtual void destroy();
 		virtual void clear();
 

--- a/src/murmur/database/ACLTable.cpp
+++ b/src/murmur/database/ACLTable.cpp
@@ -372,13 +372,13 @@ namespace server {
 			}
 		}
 
-		void ACLTable::migrate(unsigned int fromSchemeVersion, unsigned int toSchemeVersion) {
+		void ACLTable::migrate(unsigned int fromSchemaVersion, unsigned int toSchemaVersion) {
 			// Note: Always hard-code table and column names in this function in order to ensure that this
 			// migration path always stays the same regardless of whether the respective named constants change.
-			assert(fromSchemeVersion <= toSchemeVersion);
+			assert(fromSchemaVersion <= toSchemaVersion);
 
 			try {
-				if (fromSchemeVersion < 10) {
+				if (fromSchemaVersion < 10) {
 					// In v10 we renamed the table from "acl" to "access_control_lists" and the following columns have
 					// been renamed as well:
 					// "user_id" -> "affected_user_id"
@@ -505,16 +505,16 @@ namespace server {
 					}
 				} else {
 					// Use default implementation to handle migration without change of format
-					mdb::Table::migrate(fromSchemeVersion, toSchemeVersion);
+					mdb::Table::migrate(fromSchemaVersion, toSchemaVersion);
 				}
 			} catch (const soci::soci_error &) {
 				std::throw_with_nested(::mdb::MigrationException(
-					std::string("Failed at migrating table \"") + NAME + "\" from scheme version "
-					+ std::to_string(fromSchemeVersion) + " to " + std::to_string(toSchemeVersion)));
+					std::string("Failed at migrating table \"") + NAME + "\" from schema version "
+					+ std::to_string(fromSchemaVersion) + " to " + std::to_string(toSchemaVersion)));
 			} catch (const ::mdb::MigrationException &) {
 				std::throw_with_nested(::mdb::MigrationException(
-					std::string("Failed at migrating table \"") + NAME + "\" from scheme version "
-					+ std::to_string(fromSchemeVersion) + " to " + std::to_string(toSchemeVersion)));
+					std::string("Failed at migrating table \"") + NAME + "\" from schema version "
+					+ std::to_string(fromSchemaVersion) + " to " + std::to_string(toSchemaVersion)));
 			}
 		}
 

--- a/src/murmur/database/ACLTable.h
+++ b/src/murmur/database/ACLTable.h
@@ -67,7 +67,7 @@ namespace server {
 
 			std::size_t countOverallACLs(unsigned int serverID);
 
-			void migrate(unsigned int fromSchemeVersion, unsigned int toSchemeVersion) override;
+			void migrate(unsigned int fromSchemaVersion, unsigned int toSchemaVersion) override;
 		};
 
 	} // namespace db

--- a/src/murmur/database/BanTable.cpp
+++ b/src/murmur/database/BanTable.cpp
@@ -369,13 +369,13 @@ namespace server {
 			}
 		}
 
-		void BanTable::migrate(unsigned int fromSchemeVersion, unsigned int toSchemeVersion) {
+		void BanTable::migrate(unsigned int fromSchemaVersion, unsigned int toSchemaVersion) {
 			// Note: Always hard-code table and column names in this function in order to ensure that this
 			// migration path always stays the same regardless of whether the respective named constants change.
-			assert(fromSchemeVersion <= toSchemeVersion);
+			assert(fromSchemaVersion <= toSchemaVersion);
 
 			try {
-				if (fromSchemeVersion < 10) {
+				if (fromSchemaVersion < 10) {
 					// Before v4, we stored IPv4 addresses in the DB and there only were the fields server_id, base (the
 					// IPv4 address) and mask.
 					// In v10 the following columns have been renamed:
@@ -499,12 +499,12 @@ namespace server {
 					}
 				} else {
 					// Use default implementation to handle migration without change of format
-					mdb::Table::migrate(fromSchemeVersion, toSchemeVersion);
+					mdb::Table::migrate(fromSchemaVersion, toSchemaVersion);
 				}
 			} catch (const soci::soci_error &) {
 				std::throw_with_nested(::mdb::MigrationException(
-					std::string("Failed at migrating table \"") + NAME + "\" from scheme version "
-					+ std::to_string(fromSchemeVersion) + " to " + std::to_string(toSchemeVersion)));
+					std::string("Failed at migrating table \"") + NAME + "\" from schema version "
+					+ std::to_string(fromSchemaVersion) + " to " + std::to_string(toSchemaVersion)));
 			}
 		}
 

--- a/src/murmur/database/BanTable.h
+++ b/src/murmur/database/BanTable.h
@@ -63,7 +63,7 @@ namespace server {
 
 			void setBans(unsigned int serverID, const std::vector< DBBan > &bans);
 
-			void migrate(unsigned int fromSchemeVersion, unsigned int toSchemeVersion) override;
+			void migrate(unsigned int fromSchemaVersion, unsigned int toSchemaVersion) override;
 		};
 
 	} // namespace db

--- a/src/murmur/database/ChannelLinkTable.cpp
+++ b/src/murmur/database/ChannelLinkTable.cpp
@@ -206,13 +206,13 @@ namespace server {
 			}
 		}
 
-		void ChannelLinkTable::migrate(unsigned int fromSchemeVersion, unsigned int toSchemeVersion) {
+		void ChannelLinkTable::migrate(unsigned int fromSchemaVersion, unsigned int toSchemaVersion) {
 			// Note: Always hard-code old table and column names in this function in order to ensure that this
 			// migration path always stays the same regardless of whether the respective named constants change.
-			assert(fromSchemeVersion <= toSchemeVersion);
+			assert(fromSchemaVersion <= toSchemaVersion);
 
 			try {
-				if (fromSchemeVersion < 10) {
+				if (fromSchemaVersion < 10) {
 					// In v10 we renamed the columns "channel_id" -> "first_channel_id" and "link_id" ->
 					// "second_channel_id"
 					// -> Import all data from the old table into the new one
@@ -229,12 +229,12 @@ namespace server {
 					// clang-format on
 				} else {
 					// Use default implementation to handle migration without change of format
-					mdb::Table::migrate(fromSchemeVersion, toSchemeVersion);
+					mdb::Table::migrate(fromSchemaVersion, toSchemaVersion);
 				}
 			} catch (const soci::soci_error &) {
 				std::throw_with_nested(::mdb::MigrationException(
-					std::string("Failed at migrating table \"") + NAME + "\" from scheme version "
-					+ std::to_string(fromSchemeVersion) + " to " + std::to_string(toSchemeVersion)));
+					std::string("Failed at migrating table \"") + NAME + "\" from schema version "
+					+ std::to_string(fromSchemaVersion) + " to " + std::to_string(toSchemaVersion)));
 			}
 		}
 

--- a/src/murmur/database/ChannelLinkTable.h
+++ b/src/murmur/database/ChannelLinkTable.h
@@ -48,7 +48,7 @@ namespace server {
 
 			std::vector< DBChannelLink > getAllLinks(unsigned int serverID);
 
-			void migrate(unsigned int fromSchemeVersion, unsigned int toSchemeVersion) override;
+			void migrate(unsigned int fromSchemaVersion, unsigned int toSchemaVersion) override;
 		};
 
 	} // namespace db

--- a/src/murmur/database/ChannelListenerTable.cpp
+++ b/src/murmur/database/ChannelListenerTable.cpp
@@ -283,22 +283,22 @@ namespace server {
 			}
 		}
 
-		void ChannelListenerTable::migrate(unsigned int fromSchemeVersion, unsigned int toSchemeVersion) {
+		void ChannelListenerTable::migrate(unsigned int fromSchemaVersion, unsigned int toSchemaVersion) {
 			// Note: Always hard-code old table and column names in this function in order to ensure that this
 			// migration path always stays the same regardless of whether the respective named constants change.
-			assert(fromSchemeVersion <= toSchemeVersion);
+			assert(fromSchemaVersion <= toSchemaVersion);
 
 			try {
-				if (fromSchemeVersion < 9) {
+				if (fromSchemaVersion < 9) {
 					// The table only got introduced in v9
 				} else {
 					// Use default implementation to handle migration without change of format
-					mdb::Table::migrate(fromSchemeVersion, toSchemeVersion);
+					mdb::Table::migrate(fromSchemaVersion, toSchemaVersion);
 				}
 			} catch (const soci::soci_error &) {
 				std::throw_with_nested(::mdb::MigrationException(
-					std::string("Failed at migrating table \"") + NAME + "\" from scheme version "
-					+ std::to_string(fromSchemeVersion) + " to " + std::to_string(toSchemeVersion)));
+					std::string("Failed at migrating table \"") + NAME + "\" from schema version "
+					+ std::to_string(fromSchemaVersion) + " to " + std::to_string(toSchemaVersion)));
 			}
 		}
 

--- a/src/murmur/database/ChannelListenerTable.h
+++ b/src/murmur/database/ChannelListenerTable.h
@@ -61,7 +61,7 @@ namespace server {
 
 			std::vector< DBChannelListener > getListenersForChannel(unsigned int serverID, unsigned int channelID);
 
-			void migrate(unsigned int fromSchemeVersion, unsigned int toSchemeVersion) override;
+			void migrate(unsigned int fromSchemaVersion, unsigned int toSchemaVersion) override;
 		};
 
 	} // namespace db

--- a/src/murmur/database/ChannelPropertyTable.cpp
+++ b/src/murmur/database/ChannelPropertyTable.cpp
@@ -173,13 +173,13 @@ namespace server {
 			}
 		}
 
-		void ChannelPropertyTable::migrate(unsigned int fromSchemeVersion, unsigned int toSchemeVersion) {
+		void ChannelPropertyTable::migrate(unsigned int fromSchemaVersion, unsigned int toSchemaVersion) {
 			// Note: Always hard-code old table and column names in this function in order to ensure that this
 			// migration path always stays the same regardless of whether the respective named constants change.
-			assert(fromSchemeVersion <= toSchemeVersion);
+			assert(fromSchemaVersion <= toSchemaVersion);
 
 			try {
-				if (fromSchemeVersion < 10) {
+				if (fromSchemaVersion < 10) {
 					// In v10 we renamed this table from "channel_info" to "channel_properties"
 					// -> Import all data from the old table into the new one
 					m_sql << "INSERT INTO \"" << getName() << "\" (\"" << column::server_id << "\", \""
@@ -188,12 +188,12 @@ namespace server {
 						  << mdb::Database::OLD_TABLE_SUFFIX << "\"";
 				} else {
 					// Use default implementation to handle migration without change of format
-					mdb::Table::migrate(fromSchemeVersion, toSchemeVersion);
+					mdb::Table::migrate(fromSchemaVersion, toSchemaVersion);
 				}
 			} catch (const soci::soci_error &) {
 				std::throw_with_nested(::mdb::MigrationException(
-					std::string("Failed at migrating table \"") + NAME + "\" from scheme version "
-					+ std::to_string(fromSchemeVersion) + " to " + std::to_string(toSchemeVersion)));
+					std::string("Failed at migrating table \"") + NAME + "\" from schema version "
+					+ std::to_string(fromSchemaVersion) + " to " + std::to_string(toSchemaVersion)));
 			}
 		}
 

--- a/src/murmur/database/ChannelPropertyTable.h
+++ b/src/murmur/database/ChannelPropertyTable.h
@@ -83,7 +83,7 @@ namespace server {
 
 			void clearAllProperties(unsigned int serverID, unsigned int channelID);
 
-			void migrate(unsigned int fromSchemeVersion, unsigned int toSchemeVersion) override;
+			void migrate(unsigned int fromSchemaVersion, unsigned int toSchemaVersion) override;
 
 		protected:
 			std::string doGetProperty(unsigned int serverID, unsigned int channelID, ChannelProperty property);

--- a/src/murmur/database/ChannelTable.cpp
+++ b/src/murmur/database/ChannelTable.cpp
@@ -243,13 +243,13 @@ namespace server {
 		}
 
 
-		void ChannelTable::migrate(unsigned int fromSchemeVersion, unsigned int toSchemeVersion) {
+		void ChannelTable::migrate(unsigned int fromSchemaVersion, unsigned int toSchemaVersion) {
 			// Note: Always hard-code old table and column names in this function in order to ensure that this
 			// migration path always stays the same regardless of whether the respective named constants change.
-			assert(fromSchemeVersion <= toSchemeVersion);
+			assert(fromSchemaVersion <= toSchemaVersion);
 
 			try {
-				if (fromSchemeVersion < 10) {
+				if (fromSchemaVersion < 10) {
 					// In v10 we renamed columns "name" -> "channel_name" and "inheritacl" -> "inherit_acl"
 					// Furthermore, the following changes have been made:
 					// - For the root channel parent_id is no longer NULL but instead equal to the channel's ID
@@ -265,12 +265,12 @@ namespace server {
 						  << mdb::Database::OLD_TABLE_SUFFIX << "\"";
 				} else {
 					// Use default implementation to handle migration without change of format
-					mdb::Table::migrate(fromSchemeVersion, toSchemeVersion);
+					mdb::Table::migrate(fromSchemaVersion, toSchemaVersion);
 				}
 			} catch (const soci::soci_error &) {
 				std::throw_with_nested(::mdb::MigrationException(
-					std::string("Failed at migrating table \"") + NAME + "\" from scheme version "
-					+ std::to_string(fromSchemeVersion) + " to " + std::to_string(toSchemeVersion)));
+					std::string("Failed at migrating table \"") + NAME + "\" from schema version "
+					+ std::to_string(fromSchemaVersion) + " to " + std::to_string(toSchemaVersion)));
 			}
 		}
 

--- a/src/murmur/database/ChannelTable.h
+++ b/src/murmur/database/ChannelTable.h
@@ -65,7 +65,7 @@ namespace server {
 
 			std::vector< unsigned int > getChildrenOf(unsigned int serverID, unsigned int channelID);
 
-			void migrate(unsigned int fromSchemeVersion, unsigned int toSchemeVersion) override;
+			void migrate(unsigned int fromSchemaVersion, unsigned int toSchemaVersion) override;
 		};
 
 	} // namespace db

--- a/src/murmur/database/ConfigTable.cpp
+++ b/src/murmur/database/ConfigTable.cpp
@@ -165,13 +165,13 @@ namespace server {
 		}
 
 
-		void ConfigTable::migrate(unsigned int fromSchemeVersion, unsigned int toSchemeVersion) {
+		void ConfigTable::migrate(unsigned int fromSchemaVersion, unsigned int toSchemaVersion) {
 			// Note: Always hard-code table and column names in this function in order to ensure that this
 			// migration path always stays the same regardless of whether the respective named constants change.
-			assert(fromSchemeVersion <= toSchemeVersion);
+			assert(fromSchemaVersion <= toSchemaVersion);
 
 			try {
-				if (fromSchemeVersion < 10) {
+				if (fromSchemaVersion < 10) {
 					// In v10 we renamed the columns "key" -> "config_name" and "value" -> "config_value"
 					// -> Import all data from the old table into the new one
 					m_sql << "INSERT INTO \"" << getName() << "\" (\"" << column::server_id << "\", \"" << column::key
@@ -179,12 +179,12 @@ namespace server {
 						  << mdb::Database::OLD_TABLE_SUFFIX << "\"";
 				} else {
 					// Use default implementation to handle migration without change of format
-					mdb::Table::migrate(fromSchemeVersion, toSchemeVersion);
+					mdb::Table::migrate(fromSchemaVersion, toSchemaVersion);
 				}
 			} catch (const soci::soci_error &) {
 				std::throw_with_nested(::mdb::MigrationException(
-					std::string("Failed at migrating table \"") + NAME + "\" from scheme version "
-					+ std::to_string(fromSchemeVersion) + " to " + std::to_string(toSchemeVersion)));
+					std::string("Failed at migrating table \"") + NAME + "\" from schema version "
+					+ std::to_string(fromSchemaVersion) + " to " + std::to_string(toSchemaVersion)));
 			}
 		}
 

--- a/src/murmur/database/ConfigTable.h
+++ b/src/murmur/database/ConfigTable.h
@@ -49,7 +49,7 @@ namespace server {
 			void clearAllConfigs(unsigned int serverID);
 
 
-			void migrate(unsigned int fromSchemeVersion, unsigned int toSchemeVersion) override;
+			void migrate(unsigned int fromSchemaVersion, unsigned int toSchemaVersion) override;
 		};
 
 	} // namespace db

--- a/src/murmur/database/GroupMemberTable.cpp
+++ b/src/murmur/database/GroupMemberTable.cpp
@@ -176,13 +176,13 @@ namespace server {
 			}
 		}
 
-		void GroupMemberTable::migrate(unsigned int fromSchemeVersion, unsigned int toSchemeVersion) {
+		void GroupMemberTable::migrate(unsigned int fromSchemaVersion, unsigned int toSchemaVersion) {
 			// Note: Always hard-code table and column names in this function in order to ensure that this
 			// migration path always stays the same regardless of whether the respective named constants change.
-			assert(fromSchemeVersion <= toSchemeVersion);
+			assert(fromSchemaVersion <= toSchemaVersion);
 
 			try {
-				if (fromSchemeVersion < 10) {
+				if (fromSchemaVersion < 10) {
 					// In v10 we renamed the column "addit" -> "add_to_group"
 					// -> Import all data from the old table into the new one
 					m_sql << "INSERT INTO \"" << NAME << "\" (\"" << column::server_id << "\", \"" << column::group_id
@@ -191,12 +191,12 @@ namespace server {
 						  << mdb::Database::OLD_TABLE_SUFFIX << "\"";
 				} else {
 					// Use default implementation to handle migration without change of format
-					mdb::Table::migrate(fromSchemeVersion, toSchemeVersion);
+					mdb::Table::migrate(fromSchemaVersion, toSchemaVersion);
 				}
 			} catch (const soci::soci_error &) {
 				std::throw_with_nested(::mdb::MigrationException(
-					std::string("Failed at migrating table \"") + NAME + "\" from scheme version "
-					+ std::to_string(fromSchemeVersion) + " to " + std::to_string(toSchemeVersion)));
+					std::string("Failed at migrating table \"") + NAME + "\" from schema version "
+					+ std::to_string(fromSchemaVersion) + " to " + std::to_string(toSchemaVersion)));
 			}
 		}
 

--- a/src/murmur/database/GroupMemberTable.h
+++ b/src/murmur/database/GroupMemberTable.h
@@ -55,7 +55,7 @@ namespace server {
 
 			std::vector< DBGroupMember > getEntries(unsigned int serverID, unsigned int groupID);
 
-			void migrate(unsigned int fromSchemeVersion, unsigned int toSchemeVersion) override;
+			void migrate(unsigned int fromSchemaVersion, unsigned int toSchemaVersion) override;
 		};
 
 	} // namespace db

--- a/src/murmur/database/GroupTable.cpp
+++ b/src/murmur/database/GroupTable.cpp
@@ -333,13 +333,13 @@ namespace server {
 			}
 		}
 
-		void GroupTable::migrate(unsigned int fromSchemeVersion, unsigned int toSchemeVersion) {
+		void GroupTable::migrate(unsigned int fromSchemaVersion, unsigned int toSchemaVersion) {
 			// Note: Always hard-code table and column names in this function in order to ensure that this
 			// migration path always stays the same regardless of whether the respective named constants change.
-			assert(fromSchemeVersion <= toSchemeVersion);
+			assert(fromSchemaVersion <= toSchemaVersion);
 
 			try {
-				if (fromSchemeVersion < 10) {
+				if (fromSchemaVersion < 10) {
 					// In v10 we renamed the columns "name" -> "group_name" and "inheritable" -> "is_inheritable"
 					// -> Import all data from the old table into the new one
 					m_sql << "INSERT INTO \"" << NAME << "\" (\"" << column::server_id << "\", \"" << column::group_id
@@ -351,12 +351,12 @@ namespace server {
 						  << mdb::Database::OLD_TABLE_SUFFIX << "\"";
 				} else {
 					// Use default implementation to handle migration without change of format
-					mdb::Table::migrate(fromSchemeVersion, toSchemeVersion);
+					mdb::Table::migrate(fromSchemaVersion, toSchemaVersion);
 				}
 			} catch (const soci::soci_error &) {
 				std::throw_with_nested(::mdb::MigrationException(
-					std::string("Failed at migrating table \"") + NAME + "\" from scheme version "
-					+ std::to_string(fromSchemeVersion) + " to " + std::to_string(toSchemeVersion)));
+					std::string("Failed at migrating table \"") + NAME + "\" from schema version "
+					+ std::to_string(fromSchemaVersion) + " to " + std::to_string(toSchemaVersion)));
 			}
 		}
 

--- a/src/murmur/database/GroupTable.h
+++ b/src/murmur/database/GroupTable.h
@@ -69,7 +69,7 @@ namespace server {
 			std::vector< DBGroup > getAllGroups(unsigned int serverID, unsigned int channelID);
 
 
-			void migrate(unsigned int fromSchemeVersion, unsigned int toSchemeVersion) override;
+			void migrate(unsigned int fromSchemaVersion, unsigned int toSchemaVersion) override;
 		};
 
 	} // namespace db

--- a/src/murmur/database/LogTable.cpp
+++ b/src/murmur/database/LogTable.cpp
@@ -155,13 +155,13 @@ namespace server {
 		}
 
 
-		void LogTable::migrate(unsigned int fromSchemeVersion, unsigned int toSchemeVersion) {
+		void LogTable::migrate(unsigned int fromSchemaVersion, unsigned int toSchemaVersion) {
 			// Note: Always hard-code table and column names in this function in order to ensure that this
 			// migration path always stays the same regardless of whether the respective named constants change.
-			assert(fromSchemeVersion <= toSchemeVersion);
+			assert(fromSchemaVersion <= toSchemaVersion);
 
 			try {
-				if (fromSchemeVersion < 10) {
+				if (fromSchemaVersion < 10) {
 					// In v10 we renamed this table from "slog" to "server_logs"
 					// -> Import all data from the old table into the new one
 					// Note that we also changed the type of the date column from DATE/TIMESTAMP to seconds since
@@ -175,12 +175,12 @@ namespace server {
 						  << mdb::Database::OLD_TABLE_SUFFIX << "\"";
 				} else {
 					// Use default implementation to handle migration without change of format
-					mdb::Table::migrate(fromSchemeVersion, toSchemeVersion);
+					mdb::Table::migrate(fromSchemaVersion, toSchemaVersion);
 				}
 			} catch (const soci::soci_error &) {
 				std::throw_with_nested(::mdb::MigrationException(
-					std::string("Failed at migrating table \"") + NAME + "\" from scheme version "
-					+ std::to_string(fromSchemeVersion) + " to " + std::to_string(toSchemeVersion)));
+					std::string("Failed at migrating table \"") + NAME + "\" from schema version "
+					+ std::to_string(fromSchemaVersion) + " to " + std::to_string(toSchemaVersion)));
 			}
 		}
 

--- a/src/murmur/database/LogTable.h
+++ b/src/murmur/database/LogTable.h
@@ -52,7 +52,7 @@ namespace server {
 
 			std::size_t getLogSize(unsigned int serverID);
 
-			void migrate(unsigned int fromSchemeVersion, unsigned int toSchemeVersion) override;
+			void migrate(unsigned int fromSchemaVersion, unsigned int toSchemaVersion) override;
 		};
 
 	} // namespace db

--- a/src/murmur/database/ServerDatabase.cpp
+++ b/src/murmur/database/ServerDatabase.cpp
@@ -49,26 +49,26 @@ namespace server {
 			};
 		}
 
-		constexpr unsigned int ServerDatabase::DB_SCHEME_VERSION;
+		constexpr unsigned int ServerDatabase::DB_SCHEMA_VERSION;
 
 		ServerDatabase::ServerDatabase(::mdb::Backend backend) : ::mdb::Database(backend) {}
 
-		unsigned int ServerDatabase::getSchemeVersion() const { return DB_SCHEME_VERSION; }
+		unsigned int ServerDatabase::getSchemaVersion() const { return DB_SCHEMA_VERSION; }
 
-		void ServerDatabase::migrateTables(unsigned int fromSchemeVersion, unsigned int toSchemeVersion) {
+		void ServerDatabase::migrateTables(unsigned int fromSchemaVersion, unsigned int toSchemaVersion) {
 			// Ensure that the migration is in a range that we actually support
-			if (toSchemeVersion != DB_SCHEME_VERSION) {
+			if (toSchemaVersion != DB_SCHEMA_VERSION) {
 				throw ::mdb::MigrationException(
-					"Requested to migrate to scheme version " + std::to_string(toSchemeVersion)
-					+ " but can only migrate to latest scheme version (" + std::to_string(DB_SCHEME_VERSION) + ")");
+					"Requested to migrate to schema version " + std::to_string(toSchemaVersion)
+					+ " but can only migrate to latest schema version (" + std::to_string(DB_SCHEMA_VERSION) + ")");
 			}
-			if (fromSchemeVersion < 6) {
-				throw ::mdb::MigrationException("Requested to migrate from scheme version "
-												+ std::to_string(fromSchemeVersion)
+			if (fromSchemaVersion < 6) {
+				throw ::mdb::MigrationException("Requested to migrate from schema version "
+												+ std::to_string(fromSchemaVersion)
 												+ " but support for versions < 6 has been dropped");
 			}
 
-			::mdb::Database::migrateTables(fromSchemeVersion, toSchemeVersion);
+			::mdb::Database::migrateTables(fromSchemaVersion, toSchemaVersion);
 		}
 
 		void ServerDatabase::setupStandardTables() {

--- a/src/murmur/database/ServerDatabase.h
+++ b/src/murmur/database/ServerDatabase.h
@@ -33,18 +33,18 @@ namespace server {
 		class ServerDatabase : public ::mumble::db::Database {
 		public:
 			/**
-			 * A version number keeping track of the scheme that is used for the database. Any change to the scheme
+			 * A version number keeping track of the schema that is used for the database. Any change to the schema
 			 * has to be accompanied by increasing this number. A decrease is never allowed!
-			 * Using a scheme version like this allows us to be able to create migration paths between scheme versions.
+			 * Using a schema version like this allows us to be able to create migration paths between schema versions.
 			 */
-			static constexpr unsigned int DB_SCHEME_VERSION = 10;
+			static constexpr unsigned int DB_SCHEMA_VERSION = 10;
 
 			ServerDatabase(::mumble::db::Backend backend);
 			~ServerDatabase() = default;
 
-			unsigned int getSchemeVersion() const override;
+			unsigned int getSchemaVersion() const override;
 
-			void migrateTables(unsigned int fromSchemeVersion, unsigned int toSchemeVersion) override;
+			void migrateTables(unsigned int fromSchemaVersion, unsigned int toSchemaVersion) override;
 
 			::mumble::db::MetaTable &getMetaTable();
 			ServerTable &getServerTable();

--- a/src/murmur/database/ServerTable.cpp
+++ b/src/murmur/database/ServerTable.cpp
@@ -144,37 +144,37 @@ namespace server {
 			}
 		}
 
-		void ServerTable::migrate(unsigned int fromSchemeVersion, unsigned int toSchemeVersion) {
+		void ServerTable::migrate(unsigned int fromSchemaVersion, unsigned int toSchemaVersion) {
 			// Note: Always hard-code old table and column names in this function in order to ensure that this
 			// migration path always stays the same regardless of whether the respective named constants change.
-			assert(fromSchemeVersion <= toSchemeVersion);
+			assert(fromSchemaVersion <= toSchemaVersion);
 
 			try {
-				if (fromSchemeVersion < 10) {
+				if (fromSchemaVersion < 10) {
 					// In v10 we renamed this table from "servers" to "virtual_servers"
 					// -> Import all data from the old table into the new one
 					m_sql << "INSERT INTO \"" << getName() << "\" (\"" << column::server_id
 						  << "\") SELECT \"server_id\" FROM \"servers" << mdb::Database::OLD_TABLE_SUFFIX << "\"";
 				} else {
 					// Use default implementation to handle migration without change of format
-					mdb::Table::migrate(fromSchemeVersion, toSchemeVersion);
+					mdb::Table::migrate(fromSchemaVersion, toSchemaVersion);
 				}
 			} catch (const soci::soci_error &) {
 				std::throw_with_nested(::mdb::MigrationException(
-					std::string("Failed at migrating table \"") + NAME + "\" from scheme version "
-					+ std::to_string(fromSchemeVersion) + " to " + std::to_string(toSchemeVersion)));
+					std::string("Failed at migrating table \"") + NAME + "\" from schema version "
+					+ std::to_string(fromSchemaVersion) + " to " + std::to_string(toSchemaVersion)));
 			}
 		}
 
-		void ServerTable::postMigrationAction(unsigned int fromSchemeVersion, unsigned int toSchemeVersion) {
-			assert(fromSchemeVersion < toSchemeVersion);
-			(void) toSchemeVersion;
+		void ServerTable::postMigrationAction(unsigned int fromSchemaVersion, unsigned int toSchemaVersion) {
+			assert(fromSchemaVersion < toSchemaVersion);
+			(void) toSchemaVersion;
 
 #define PROCESS_TABLE(Table)                                                                  \
 	m_sql << "UPDATE \"" << Table::NAME << "\" SET \"" << Table::column::server_id << "\"=\"" \
 		  << Table::column::server_id << "\" - 1"
 
-			if (fromSchemeVersion < 10) {
+			if (fromSchemaVersion < 10) {
 				// Since v10 server IDs are expected to start at zero. If this is not yet the case (almost certainly),
 				// shift all server IDs down by one.
 				// Since the server ID has influence on the (default) port it listens to, matching this expectation will

--- a/src/murmur/database/ServerTable.h
+++ b/src/murmur/database/ServerTable.h
@@ -45,8 +45,8 @@ namespace server {
 
 			std::vector< unsigned int > getAllServerIDs();
 
-			void migrate(unsigned int fromSchemeVersion, unsigned int toSchemeVersion) override;
-			void postMigrationAction(unsigned int fromSchemeVersion, unsigned int toSchemeVersion) override;
+			void migrate(unsigned int fromSchemaVersion, unsigned int toSchemaVersion) override;
+			void postMigrationAction(unsigned int fromSchemaVersion, unsigned int toSchemaVersion) override;
 		};
 
 	} // namespace db

--- a/src/murmur/database/UserPropertyTable.cpp
+++ b/src/murmur/database/UserPropertyTable.cpp
@@ -210,13 +210,13 @@ namespace server {
 			}
 		}
 
-		void UserPropertyTable::migrate(unsigned int fromSchemeVersion, unsigned int toSchemeVersion) {
+		void UserPropertyTable::migrate(unsigned int fromSchemaVersion, unsigned int toSchemaVersion) {
 			// Note: Always hard-code old table and column names in this function in order to ensure that this
 			// migration path always stays the same regardless of whether the respective named constants change.
-			assert(fromSchemeVersion <= toSchemeVersion);
+			assert(fromSchemaVersion <= toSchemaVersion);
 
 			try {
-				if (fromSchemeVersion < 10) {
+				if (fromSchemaVersion < 10) {
 					// In v10 we renamed this table from "user_info" to "user_properties"
 					// -> Import all data from the old table into the new one
 					m_sql << "INSERT INTO \"" << getName() << "\" (\"" << column::server_id << "\", \""
@@ -225,12 +225,12 @@ namespace server {
 						  << mdb::Database::OLD_TABLE_SUFFIX << "\"";
 				} else {
 					// Use default implementation to handle migration without change of format
-					mdb::Table::migrate(fromSchemeVersion, toSchemeVersion);
+					mdb::Table::migrate(fromSchemaVersion, toSchemaVersion);
 				}
 			} catch (const soci::soci_error &) {
 				std::throw_with_nested(::mdb::MigrationException(
-					std::string("Failed at migrating table \"") + NAME + "\" from scheme version "
-					+ std::to_string(fromSchemeVersion) + " to " + std::to_string(toSchemeVersion)));
+					std::string("Failed at migrating table \"") + NAME + "\" from schema version "
+					+ std::to_string(fromSchemaVersion) + " to " + std::to_string(toSchemaVersion)));
 			}
 		}
 

--- a/src/murmur/database/UserPropertyTable.h
+++ b/src/murmur/database/UserPropertyTable.h
@@ -86,7 +86,7 @@ namespace server {
 			std::vector< unsigned int > findUsersWithProperty(unsigned int serverID, UserProperty property,
 															  const std::string &value);
 
-			void migrate(unsigned int fromSchemeVersion, unsigned int toSchemeVersion) override;
+			void migrate(unsigned int fromSchemaVersion, unsigned int toSchemaVersion) override;
 
 		protected:
 			std::string doGetProperty(const DBUser &user, UserProperty property);

--- a/src/murmur/database/UserTable.cpp
+++ b/src/murmur/database/UserTable.cpp
@@ -677,13 +677,13 @@ namespace server {
 		}
 
 
-		void UserTable::migrate(unsigned int fromSchemeVersion, unsigned int toSchemeVersion) {
+		void UserTable::migrate(unsigned int fromSchemaVersion, unsigned int toSchemaVersion) {
 			// Note: Always hard-code old table and column names in this function in order to ensure that this
 			// migration path always stays the same regardless of whether the respective named constants change.
-			assert(fromSchemeVersion <= toSchemeVersion);
+			assert(fromSchemaVersion <= toSchemaVersion);
 
 			try {
-				if (fromSchemeVersion < 8) {
+				if (fromSchemaVersion < 8) {
 					// Before v8 there was no last_disconnect column
 					const std::string lastActiveConversion = mdb::utils::dateToEpoch("\"last_active\"", m_backend);
 
@@ -695,7 +695,7 @@ namespace server {
 						  << ::mdb::utils::nonNullOf("\"lastchannel\"").otherwise("0") << ", \"texture\", "
 						  << ::mdb::utils::nonNullOf(lastActiveConversion).otherwise("0") << " FROM \"users"
 						  << ::mdb::Database::OLD_TABLE_SUFFIX << "\"";
-				} else if (fromSchemeVersion < 10) {
+				} else if (fromSchemaVersion < 10) {
 					// In v10, we renamed columns "name" -> "user_name", "pw" -> "password_hash",
 					// "kdfiterations" -> "kdf_iterations" and "lastchannel" -> "last_channel_id"
 					const std::string lastActiveConversion = mdb::utils::dateToEpoch("\"last_active\"", m_backend);
@@ -714,12 +714,12 @@ namespace server {
 						  << ::mdb::Database::OLD_TABLE_SUFFIX << "\"";
 				} else {
 					// Use default implementation to handle migration without change of format
-					mdb::Table::migrate(fromSchemeVersion, toSchemeVersion);
+					mdb::Table::migrate(fromSchemaVersion, toSchemaVersion);
 				}
 			} catch (const soci::soci_error &) {
 				std::throw_with_nested(::mdb::MigrationException(
-					std::string("Failed at migrating table \"") + NAME + "\" from scheme version "
-					+ std::to_string(fromSchemeVersion) + " to " + std::to_string(toSchemeVersion)));
+					std::string("Failed at migrating table \"") + NAME + "\" from schema version "
+					+ std::to_string(fromSchemaVersion) + " to " + std::to_string(toSchemaVersion)));
 			}
 		}
 

--- a/src/murmur/database/UserTable.h
+++ b/src/murmur/database/UserTable.h
@@ -104,7 +104,7 @@ namespace server {
 			std::vector< DBUser > getRegisteredUsers(unsigned int serverID, const std::string &filter = "%");
 
 
-			void migrate(unsigned int fromSchemeVersion, unsigned int toSchemeVersion) override;
+			void migrate(unsigned int fromSchemaVersion, unsigned int toSchemaVersion) override;
 		};
 
 	} // namespace db

--- a/src/tests/TestDatabase/DatabaseTest.cpp
+++ b/src/tests/TestDatabase/DatabaseTest.cpp
@@ -130,7 +130,7 @@ public:
 		}
 	}
 
-	unsigned int getSchemeVersion() const override { return 42; }
+	unsigned int getSchemaVersion() const override { return 42; }
 
 	void connect(const ConnectionParameter &param) {
 		Database::connectToDB(param);
@@ -299,8 +299,8 @@ void DatabaseTest::simpleExport() {
 
 	MetaTable *metaTable = static_cast< MetaTable * >(db.getTable(MetaTable::NAME));
 
-	metaTable->setSchemeVersion(5);
-	QCOMPARE(metaTable->getSchemeVersion(), static_cast< unsigned int >(5));
+	metaTable->setSchemaVersion(5);
+	QCOMPARE(metaTable->getSchemaVersion(), static_cast< unsigned int >(5));
 
 	// clang-format off
 		nlohmann::json expectedJson = {
@@ -316,7 +316,7 @@ void DatabaseTest::simpleExport() {
 									metaTable->findColumn("meta_value")->getType().sqlRepresentation(currentBackend) }
 							},
 							{
-								"rows", nlohmann::json::array({ { "scheme_version", "5" } })
+								"rows", nlohmann::json::array({ { "schema_version", "5" } })
 							}
 						}
 					}
@@ -324,7 +324,7 @@ void DatabaseTest::simpleExport() {
 			},
 			{ "meta_data",
 				{
-				   { "scheme_version", 42 }
+				   { "schema_version", 42 }
 				}
 			}
 		};
@@ -361,7 +361,7 @@ void DatabaseTest::simpleImport() {
 									metaTable->findColumn("meta_value")->getType().sqlRepresentation(currentBackend) }
 							},
 							{
-								"rows", nlohmann::json::array({ { "scheme_version", "12" } })
+								"rows", nlohmann::json::array({ { "schema_version", "12" } })
 							}
 						}
 					},
@@ -384,21 +384,21 @@ void DatabaseTest::simpleImport() {
 				}
 			}, { "meta_data",
 				{
-					{ "scheme_version", 1 }
+					{ "schema_version", 1 }
 				}
 			}
 		};
 	// clang-format on
 
-	QVERIFY(db.getSchemeVersion() != serializedDB["meta_data"]["scheme_version"].get< unsigned int >());
+	QVERIFY(db.getSchemaVersion() != serializedDB["meta_data"]["schema_version"].get< unsigned int >());
 
-	// The scheme_version specified in meta-data doesn't match, so we expect the import to fail (before creating any
+	// The schema_version specified in meta-data doesn't match, so we expect the import to fail (before creating any
 	// tables)
 	QVERIFY(db.getTable("test_table") == nullptr);
 	QVERIFY_THROWS_EXCEPTION(FormatException, db.importFromJSON(serializedDB, true));
 	QVERIFY(!db.tableExistsInDB("test_table"));
 
-	serializedDB["meta_data"]["scheme_version"] = db.getSchemeVersion();
+	serializedDB["meta_data"]["schema_version"] = db.getSchemaVersion();
 
 	// Importing into a non-existent table without telling the DB to create the missing tables on-the-fly should
 	// result in an error
@@ -406,7 +406,7 @@ void DatabaseTest::simpleImport() {
 	QVERIFY_THROWS_EXCEPTION(FormatException, db.importFromJSON(serializedDB, false));
 	QVERIFY(!db.tableExistsInDB("test_table"));
 
-	// Now with the version_scheme fixed and the necessary flag set, the import should succeed
+	// Now with the schema_version fixed and the necessary flag set, the import should succeed
 	db.importFromJSON(serializedDB, true);
 	QVERIFY(db.tableExistsInDB("test_table"));
 	QVERIFY(db.getTable("test_table") != nullptr);

--- a/src/tests/TestDatabase/server/JSONAssembler.h
+++ b/src/tests/TestDatabase/server/JSONAssembler.h
@@ -25,7 +25,7 @@ namespace db {
 
 			JSONAssembler();
 
-			DataPair buildTestData(unsigned int fromSchemeVersion,
+			DataPair buildTestData(unsigned int fromSchemaVersion,
 								   const ::mumble::server::db::ServerDatabase &serverDB);
 
 		private:

--- a/src/tests/TestDatabase/server/table_data/meta_table_input.json
+++ b/src/tests/TestDatabase/server/table_data/meta_table_input.json
@@ -32,7 +32,7 @@
 		],
 		"rows": [
 			[
-				"scheme_version",
+				"schema_version",
 				"10"
 			],
 			[

--- a/src/tests/TestDatabase/server/table_data/meta_table_migrated.json
+++ b/src/tests/TestDatabase/server/table_data/meta_table_migrated.json
@@ -24,7 +24,7 @@
 		],
 		"rows": [
 			[
-				"scheme_version",
+				"schema_version",
 				"10"
 			],
 			[


### PR DESCRIPTION
### Checks

- [x] My commits follow the [commit guidelines](https://github.com/mumble-voip/mumble/blob/master/COMMIT_GUIDELINES.md)

