### PR TITLE
Backport "FIX(client, audio): Opus expects frame size per channel"

### DIFF
--- a/src/mumble/AudioOutputSpeech.cpp
+++ b/src/mumble/AudioOutputSpeech.cpp
@@ -346,7 +346,7 @@ bool AudioOutputSpeech::prepareSampleBuffer(unsigned int frameCount) {
 					// packet normally in order to be able to play it.
 					decodedSamples = opus_decode_float(
 						opusState, qba.isEmpty() ? nullptr : reinterpret_cast< const unsigned char * >(qba.constData()),
-						qba.size(), pOut, static_cast< int >(iAudioBufferSize), 0);
+						qba.size(), pOut, static_cast< int >(iAudioBufferSize / channels), 0);
 				} else {
 					// If the packet is non-empty, but the associated user is locally muted,
 					// we don't have to decode the packet. Instead it is enough to know how many
@@ -398,7 +398,8 @@ bool AudioOutputSpeech::prepareSampleBuffer(unsigned int frameCount) {
 				}
 			} else {
 				assert(m_codec == Mumble::Protocol::AudioCodec::Opus);
-				decodedSamples = opus_decode_float(opusState, nullptr, 0, pOut, static_cast< int >(iFrameSize), 0);
+				decodedSamples =
+					opus_decode_float(opusState, nullptr, 0, pOut, static_cast< int >(iFrameSizePerChannel), 0);
 				decodedSamples *= static_cast< int >(channels);
 
 				if (decodedSamples < 0) {


### PR DESCRIPTION
Backport of #7032 


### Checks

- [x] My commits follow the [commit guidelines](https://github.com/mumble-voip/mumble/blob/master/COMMIT_GUIDELINES.md)

