### PR TITLE
MAINT(appdata): Use developer block & use canonical dev name

### DIFF
--- a/auxiliary_files/config_files/info.mumble.Mumble.appdata.xml.in
+++ b/auxiliary_files/config_files/info.mumble.Mumble.appdata.xml.in
@@ -6,7 +6,9 @@
 	<summary>Low latency encrypted VoIP client</summary>
 	<project_license>BSD-3-Clause</project_license>
 	<metadata_license>CC0-1.0</metadata_license>
-	<developer_name>The Mumble Dev-Team</developer_name>
+	<developer id="info.mumble">
+		<name>The Mumble Developers</name>
+	</developer>
 	<description>
 		<p>@CMAKE_PROJECT_DESCRIPTION@</p>
 	</description>


### PR DESCRIPTION
It is helpful to validate the project.

See: https://docs.flathub.org/docs/for-app-authors/metainfo-guidelines#developer-name


### Checks

- [x] My commits follow the [commit guidelines](https://github.com/mumble-voip/mumble/blob/master/COMMIT_GUIDELINES.md)

