### PR TITLE
FIX(client): Request accessibility permission on macOS

### DIFF
--- a/src/mumble/mumble.plist.in
+++ b/src/mumble/mumble.plist.in
@@ -35,5 +35,7 @@
 	<true/>
 	<key>NSMicrophoneUsageDescription</key>
 	<string>Mumble uses your microphone to allow you to talk to other people</string>
+	<key>NSAccessibilityUsageDescription</key>
+	<string>Mumble needs accessibility permission for global shortcuts</string>
 </dict>
 </plist>


### PR DESCRIPTION
macOS requires us to request this permission for global shortcuts

Fixes #7040