### PR TITLE
Backport "Merge PR #7036: MAINT(appdata): Add vcs-browser URL" to 1.5.x

### DIFF
--- a/auxiliary_files/config_files/info.mumble.Mumble.appdata.xml.in
+++ b/auxiliary_files/config_files/info.mumble.Mumble.appdata.xml.in
@@ -19,6 +19,7 @@
 	<url type="help">https://www.mumble.info/documentation</url>
 	<url type="donation">https://liberapay.com/mumble</url>
 	<url type="translate">https://github.com/mumble-voip/mumble/blob/master/README.md#translating</url>
+	<url type="vcs-browser">https://github.com/mumble-voip/mumble</url>
 	<launchable type="desktop-id">info.mumble.Mumble.desktop</launchable>
 	<screenshots>
 		<screenshot type="default">


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `1.5.x`:
 - [Merge PR #7036: MAINT(appdata): Add vcs-browser URL](https://github.com/mumble-voip/mumble/pull/7036)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)