### PR TITLE
Backport "Merge PR #7037: MAINT(appdata): Use developer block & use canonical dev name" to 1.5.x

### DIFF
--- a/auxiliary_files/config_files/info.mumble.Mumble.appdata.xml.in
+++ b/auxiliary_files/config_files/info.mumble.Mumble.appdata.xml.in
@@ -6,7 +6,9 @@
 	<summary>Low latency encrypted VoIP client</summary>
 	<project_license>BSD-3-Clause</project_license>
 	<metadata_license>CC0-1.0</metadata_license>
-	<developer_name>The Mumble Dev-Team</developer_name>
+	<developer id="info.mumble">
+		<name>The Mumble Developers</name>
+	</developer>
 	<description>
 		<p>@CMAKE_PROJECT_DESCRIPTION@</p>
 	</description>


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `1.5.x`:
 - [Merge PR #7037: MAINT(appdata): Use developer block &amp; use canonical dev name](https://github.com/mumble-voip/mumble/pull/7037)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)