### PR TITLE
[WIP] Unix display independent global shortcuts solution.

### DIFF
--- a/src/mumble/CMakeLists.txt
+++ b/src/mumble/CMakeLists.txt
@@ -660,6 +660,8 @@ else()
 	if(NOT APPLE)
 		find_pkg(X11 COMPONENTS Xext REQUIRED)
 
+		target_compile_definitions(mumble_client_object_lib PUBLIC "USE_WAYLAND")
+		target_link_libraries(mumble_client_object_lib PUBLIC input udev xkbcommon)
 		if(xinput2)
 			find_pkg(X11 COMPONENTS Xi REQUIRED)
 			target_link_libraries(mumble_client_object_lib PUBLIC X11::Xi)

--- a/src/mumble/GlobalShortcut.cpp
+++ b/src/mumble/GlobalShortcut.cpp
@@ -631,12 +631,6 @@ GlobalShortcutConfig::GlobalShortcutConfig(Settings &st) : ConfigWidget(st) {
 	qcbEnableGlobalShortcuts->setVisible(canDisable);
 
 	qlWaylandNote->setVisible(false);
-#ifdef Q_OS_LINUX
-	if (EnvUtils::waylandIsUsed()) {
-		// Our global shortcut system doesn't work properly with Wayland
-		qlWaylandNote->setVisible(true);
-	}
-#endif
 
 #ifdef Q_OS_MAC
 	// Help Mac users enable accessibility access for Mumble...

--- a/src/mumble/GlobalShortcut_unix.h
+++ b/src/mumble/GlobalShortcut_unix.h
@@ -13,6 +13,14 @@
 
 #include <X11/X.h>
 
+#ifdef USE_WAYLAND
+extern "C" {
+#	include <libudev.h>
+#	include <libinput.h>
+#	include <xkbcommon/xkbcommon.h>
+}
+#endif
+
 #define NUM_BUTTONS 0x2ff
 
 struct _XDisplay;
@@ -20,6 +28,26 @@ typedef _XDisplay Display;
 
 class QFileSystemWatcher;
 class QSocketNotifier;
+
+#ifdef USE_WAYLAND
+class GlobalShortcutWayland : public GlobalShortcutEngine {
+private:
+	Q_OBJECT
+public:
+	udev *_udev;
+	libinput *_libinput;
+	xkb_context *xkb_ctx;
+	xkb_keymap *xkb_km;
+	xkb_state *xkb;
+	GlobalShortcutWayland();
+	~GlobalShortcutWayland() Q_DECL_OVERRIDE;
+	ButtonInfo buttonInfo(const QVariant &) Q_DECL_OVERRIDE;
+public slots:
+	void libinputEvent(int);
+protected:
+	bool init();
+};
+#endif
 
 class GlobalShortcutX : public GlobalShortcutEngine {
 private:

--- a/src/mumble/Settings.cpp
+++ b/src/mumble/Settings.cpp
@@ -542,14 +542,6 @@ Settings::Settings() {
 	lmLoopMode = Server;
 #endif
 
-
-#ifdef Q_OS_LINUX
-	if (EnvUtils::waylandIsUsed()) {
-		// Due to the issues we're currently having on Wayland, we disable shortcuts by default
-		bShortcutEnable = false;
-	}
-#endif
-
 	for (int i = Log::firstMsgType; i <= Log::lastMsgType; ++i) {
 		qmMessages.insert(i,
 						  Settings::LogConsole | Settings::LogBalloon | Settings::LogTTS | Settings::LogMessageLimit);


### PR DESCRIPTION
Read /dev/input/event* for keyboard events using libinput and udev for working global shortcuts on Wayland. This solution will also work on any other desktop environment on Linux + FreeBSD (it uses the same /dev/input thing).

Right now it's just a prototype to indicate that it:
1) is being developed by someone;
2) is possible to do on wayland;
3) fills someone's requirements.

The commits will be rebased after, PR just for the feedback from maintainers. Don't branch of this commits.

### Checks

- [ ] My commits follow the [commit guidelines](https://github.com/mumble-voip/mumble/blob/master/COMMIT_GUIDELINES.md)
It doesn't, see above.
