### PR TITLE
Backport "Merge PR #7041: FIX(client): Request accessibility permission on macOS" to 1.5.x

### DIFF
--- a/src/mumble/mumble.plist.in
+++ b/src/mumble/mumble.plist.in
@@ -35,5 +35,7 @@
 	<true/>
 	<key>NSMicrophoneUsageDescription</key>
 	<string>Mumble uses your microphone to allow you to talk to other people</string>
+	<key>NSAccessibilityUsageDescription</key>
+	<string>Mumble needs accessibility permission for global shortcuts</string>
 </dict>
 </plist>


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `1.5.x`:
 - [Merge PR #7041: FIX(client): Request accessibility permission on macOS](https://github.com/mumble-voip/mumble/pull/7041)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)