### PR TITLE
 BUILD(cmake): fix MUMBLE_TARGET_ARCH for macOS universal builds (Unix Makefiles)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -95,6 +95,14 @@ include(os)
 target_architecture(MUMBLE_TARGET_ARCH)
 string(TOLOWER "${MUMBLE_TARGET_ARCH}" MUMBLE_TARGET_ARCH)
 
+# On macOS universal builds, CMAKE_OSX_ARCHITECTURES (and thus target_architecture())
+# can result in a CMake list (e.g. "arm64;x86_64"). Using that list directly in
+# compile definitions breaks quoting for some generators (notably Unix Makefiles).
+# For those cases, expose a stable, single-string arch identifier.
+if(APPLE AND MUMBLE_TARGET_ARCH MATCHES ";")
+	set(MUMBLE_TARGET_ARCH "universal")
+endif()
+
 if(NOT ${CMAKE_SYSTEM_NAME} STREQUAL "OpenBSD")
 	option(overlay "Build overlay." ${client})
 	if(64_BIT AND NOT MUMBLE_TARGET_ARCH STREQUAL "arm64")


### PR DESCRIPTION
## Problem

When configuring a macOS universal binary with:

```bash
cmake .. -DCMAKE_OSX_ARCHITECTURES="arm64;x86_64"
```

the `target_architecture()` macro returns a semicolon-separated CMake list
(e.g. `arm64;x86_64`). When this value is later embedded in a compile
definition such as:

```cmake
target_compile_definitions(... MUMBLE_TARGET_ARCH="${MUMBLE_TARGET_ARCH}")
```

the semicolon is interpreted by the **Unix Makefiles** generator as a shell
metacharacter, producing broken compiler invocations and causing the build to
fail immediately in the `shared` and `mumble_client_object_lib` targets.

## Fix

Detect the multi-arch case on Apple platforms and normalise
`MUMBLE_TARGET_ARCH` to the stable string `"universal"` before it is used
in any compile definitions or logic:

```cmake
if(APPLE AND MUMBLE_TARGET_ARCH MATCHES ";")
    set(MUMBLE_TARGET_ARCH "universal")
endif()
```

This mirrors the convention used by existing macOS packaging scripts
(e.g. `macx/scripts/osxdist.py`) and is consistent with how Apple's own
toolchain refers to fat/universal binaries.

The fix is a no-op for single-architecture builds (`arm64` or `x86_64` only).

## Testing

Verified with CMake 3.x + Unix Makefiles generator on macOS 15 (Apple M2, arm64):

- `-DCMAKE_OSX_ARCHITECTURES="arm64;x86_64"` — CMake configure now succeeds; compile definitions no longer contain a bare semicolon.
- `-DCMAKE_OSX_ARCHITECTURES="arm64"` — unaffected (single-arch path unchanged).

Relates to #4876 (Apple Silicon / Universal build request).
