### PR TITLE
Improved invalid channel name error message to include server regex

### DIFF
--- a/src/mumble/mumble_en.ts
+++ b/src/mumble/mumble_en.ts
@@ -6054,7 +6054,7 @@ The setting only applies for new messages, the already shown ones will retain th
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Denied: Invalid channel name.</source>
+        <source>Denied: Invalid channel name. Allowed pattern: [ \-=\\w\#\[\]\{\}\(\)\@\|]+ (this is set by the server)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>


### PR DESCRIPTION
TRANSLATION (ui): The error message for an invalid channel name was updated to include regex and hint

Some users were confused as to why their channel names were invalid so the error message was improved by providing the regex that is used to check the name as well as giving a hint stating that this is not hard-coded but rather a server setting. The regex is now included in the error message as such: "Denied: Invalid channel name. Allowed pattern: [ \-=\\w\#\[\]\{\}\(\)\@\|]+ (this is set by the server)".

Closes #3993