### PR TITLE
FIX(client): Remove warning for shortcuts with a string parameter

### DIFF
--- a/src/mumble/GlobalShortcut.cpp
+++ b/src/mumble/GlobalShortcut.cpp
@@ -582,6 +582,8 @@ QString ShortcutDelegate::displayText(const QVariant &item, const QLocale &loc) 
 				return tr("No buttons assigned");
 			}
 		}
+		case QMetaType::QString:
+			return item.value< QString >();
 		default:
 			qWarning("ShortcutDelegate::displayText(): Unknown type %d", item.typeId());
 	}


### PR DESCRIPTION
Shortcuts with a string parameter (eg. Send Text Message) were generating this harmless warning: "ShortcutDelegate::displayText(): Unknown type 10".


### Checks

- [x] My commits follow the [commit guidelines](https://github.com/mumble-voip/mumble/blob/master/COMMIT_GUIDELINES.md)

