### PR TITLE
Backport "Merge PR #7080: FIX(client): Remove warning for shortcuts with a string parameter" to 1.5.x

### DIFF
--- a/src/mumble/GlobalShortcut.cpp
+++ b/src/mumble/GlobalShortcut.cpp
@@ -579,6 +579,8 @@ QString ShortcutDelegate::displayText(const QVariant &item, const QLocale &loc) 
 				return tr("No buttons assigned");
 			}
 		}
+		case QMetaType::QString:
+			return item.value< QString >();
 		default:
 			qWarning("ShortcutDelegate::displayText(): Unknown type %d", item.type());
 	}


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `1.5.x`:
 - [Merge PR #7080: FIX(client): Remove warning for shortcuts with a string parameter](https://github.com/mumble-voip/mumble/pull/7080)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)