### PR TITLE
FIX(installer): Ignore exit-code 0x666 from VC_redist installer

### DIFF
--- a/installer/MumbleInstall.cs
+++ b/installer/MumbleInstall.cs
@@ -55,6 +55,15 @@ public class MumbleInstall : Project {
 					 * This will still show up in Add/Remove Programs and can be removed there,
 					 * even when Permanent is true. */
 					Permanent = true,
+					ExitCodes = new List<ExitCode>
+					{
+						new ExitCode
+						{
+							// Can not install VC_redist, because newer version is already installed
+							Value = "1638",
+							Behavior = BehaviorValues.success
+						}
+					},
 				});
 		bootstrapper.Variables = new[] {
 				/* Version.ToString() is here to validating the input when the installer is built.


### PR DESCRIPTION
When we run into exit-code 0x666 (ERROR_PRODUCT_VERSION), instead of terminating the entire installer, we ignore the error code and continue.

This exit code is thrown, if a newer version of VC_redist is already installed on the target system and for some reason our check for this condition fails.

Fixes #7084
