### PR TITLE
FEAT(client): Add option to inhibit system sleep while connected

### DIFF
--- a/src/mumble/CMakeLists.txt
+++ b/src/mumble/CMakeLists.txt
@@ -230,6 +230,8 @@ set(MUMBLE_SOURCES
 	"SettingsKeys.h"
 	"Settings.cpp"
 	"Settings.h"
+	"SleepInhibitor.cpp"
+	"SleepInhibitor.h"
 	"SharedMemory.cpp"
 	"SharedMemory.h"
 	"SocketRPC.cpp"

--- a/src/mumble/LookConfig.cpp
+++ b/src/mumble/LookConfig.cpp
@@ -234,6 +234,7 @@ void LookConfig::load(const Settings &r) {
 
 	loadCheckBox(qcbEnableDeveloperMenu, r.bEnableDeveloperMenu);
 	loadCheckBox(qcbLockLayout, (r.wlWindowLayout == Settings::LayoutCustom) && r.bLockLayout);
+	loadCheckBox(qcbInhibitSleep, r.bInhibitSleep);
 	loadCheckBox(qcbHideTray, r.bHideInTray);
 	loadCheckBox(qcbStateInTray, r.bStateInTray);
 	loadCheckBox(qcbShowUserCount, r.bShowUserCount);
@@ -309,6 +310,7 @@ void LookConfig::save() const {
 	s.quitBehavior              = static_cast< QuitBehavior >(qcbQuitBehavior->currentIndex());
 	s.bEnableDeveloperMenu      = qcbEnableDeveloperMenu->isChecked();
 	s.bLockLayout               = qcbLockLayout->isChecked();
+	s.bInhibitSleep             = qcbInhibitSleep->isChecked();
 	s.bHideInTray               = qcbHideTray->isChecked();
 	s.bStateInTray              = qcbStateInTray->isChecked();
 	s.bShowUserCount            = qcbShowUserCount->isChecked();

--- a/src/mumble/LookConfig.ui
+++ b/src/mumble/LookConfig.ui
@@ -1298,6 +1298,7 @@
   <tabstop>qcbQuitBehavior</tabstop>
   <tabstop>qcbEnableDeveloperMenu</tabstop>
   <tabstop>qcbLockLayout</tabstop>
+  <tabstop>qcbInhibitSleep</tabstop>
   <tabstop>qcbHideTray</tabstop>
   <tabstop>qcbStateInTray</tabstop>
   <tabstop>qcbSearchUserAction</tabstop>

--- a/src/mumble/LookConfig.ui
+++ b/src/mumble/LookConfig.ui
@@ -141,6 +141,16 @@
         </property>
        </widget>
       </item>
+      <item row="5" column="0" colspan="2">
+       <widget class="QCheckBox" name="qcbInhibitSleep">
+        <property name="toolTip">
+         <string>Prevents the computer from sleeping while connected to a server</string>
+        </property>
+        <property name="text">
+         <string>Inhibit system sleep while connected</string>
+        </property>
+       </widget>
+      </item>
      </layout>
     </widget>
    </item>

--- a/src/mumble/MainWindow.h
+++ b/src/mumble/MainWindow.h
@@ -42,6 +42,7 @@ class UserInformation;
 class VoiceRecorderDialog;
 class PositionalAudioViewer;
 class PTTButtonWidget;
+class SleepInhibitor;
 
 namespace Search {
 class SearchDialog;
@@ -205,6 +206,8 @@ protected:
 
 	std::stack< unsigned int > m_previousChannels;
 	std::optional< unsigned int > m_movedBackFromChannel;
+
+	SleepInhibitor *m_sleepInhibitor;
 
 	static constexpr int stateVersion();
 

--- a/src/mumble/Settings.h
+++ b/src/mumble/Settings.h
@@ -432,6 +432,7 @@ struct Settings {
 	bool bLockLayout                     = false;
 	bool bHideInTray                     = false;
 	bool bStateInTray                    = true;
+	bool bInhibitSleep                   = false;
 	bool bUsage                          = true;
 	bool bShowUserCount                  = false;
 	bool bShowVolumeAdjustments          = true;

--- a/src/mumble/SettingsKeys.h
+++ b/src/mumble/SettingsKeys.h
@@ -193,6 +193,7 @@ const SettingsKey OVERLAY_HEADER_STATE                 = { "overlay_header_state
 const SettingsKey SERVER_FILTER_MODE_KEY               = { "server_filter_mode" };
 const SettingsKey HIDE_IN_TRAY_KEY                     = { "hide_in_tray" };
 const SettingsKey DISPLAY_TALKING_STATE_IN_TRAY_KEY    = { "display_talking_state_in_tray" };
+const SettingsKey INHIBIT_SLEEP_KEY                    = { "inhibit_sleep" };
 const SettingsKey SEND_USAGE_STATISTICS_KEY            = { "send_usage_statistics" };
 const SettingsKey DISPLAY_USER_COUNT_KEY               = { "display_user_count" };
 const SettingsKey DISPLAY_VOLUME_ADJUSTMENTS_KEY       = { "display_volume_adjustments" };

--- a/src/mumble/SettingsMacros.h
+++ b/src/mumble/SettingsMacros.h
@@ -152,6 +152,7 @@
 	PROCESS(ui, USER_DRAG_MODE_KEY, ceUserDrag)                                  \
 	PROCESS(ui, ALWAYS_ON_TOP_KEY, aotbAlwaysOnTop)                              \
 	PROCESS(ui, QUIT_BEHAVIOR_KEY, quitBehavior)                                 \
+	PROCESS(ui, INHIBIT_SLEEP_KEY, bInhibitSleep)                               \
 	PROCESS(ui, SHOW_DEVELOPER_MENU_KEY, bEnableDeveloperMenu)                   \
 	PROCESS(ui, LOCK_LAYOUT_KEY, bLockLayout)                                    \
 	PROCESS(ui, MINIMAL_VIEW_KEY, bMinimalView)                                  \

--- a/src/mumble/SleepInhibitor.cpp
+++ b/src/mumble/SleepInhibitor.cpp
@@ -4,7 +4,6 @@
 // Mumble source tree or at <https://www.mumble.info/LICENSE>.
 
 #include "SleepInhibitor.h"
-#include "Global.h"
 
 #if defined(Q_OS_WIN)
 #	include <windows.h>

--- a/src/mumble/SleepInhibitor.cpp
+++ b/src/mumble/SleepInhibitor.cpp
@@ -1,0 +1,95 @@
+// Copyright The Mumble Developers. All rights reserved.
+// Use of this source code is governed by a BSD-style license
+// that can be found in the LICENSE file at the root of the
+// Mumble source tree or at <https://www.mumble.info/LICENSE>.
+
+#include "SleepInhibitor.h"
+#include "Global.h"
+
+#if defined(Q_OS_WIN)
+#	include <windows.h>
+#elif defined(Q_OS_MAC)
+#	include <IOKit/pwr_mgt/IOPMLib.h>
+#elif defined(USE_DBUS)
+#	include <QtDBus/QtDBus>
+#endif
+
+SleepInhibitor::SleepInhibitor(QObject *parent) : QObject(parent) {
+}
+
+SleepInhibitor::~SleepInhibitor() {
+	setInhibit(false);
+}
+
+void SleepInhibitor::setInhibit(bool inhibit) {
+	if (inhibit == m_inhibited) {
+		return;
+	}
+
+	if (inhibit) {
+		platformInhibit();
+	} else {
+		platformDeinhibit();
+	}
+
+	m_inhibited = inhibit;
+}
+
+void SleepInhibitor::platformInhibit() {
+#if defined(Q_OS_WIN)
+	SetThreadExecutionState(ES_CONTINUOUS | ES_SYSTEM_REQUIRED | ES_DISPLAY_REQUIRED);
+#elif defined(Q_OS_MAC)
+	CFStringRef reasonForActivity = CFStringCreateWithCString(kCFAllocatorDefault, "Mumble is in a call", kCFStringEncodingUTF8);
+	IOReturn success = IOPMAssertionCreateWithDescription(kIOPMAssertionTypeNoDisplaySleep,
+	                                                     reasonForActivity,
+	                                                     NULL, NULL, NULL, 0, NULL,
+	                                                     &m_assertionID);
+	CFRelease(reasonForActivity);
+	if (success != kIOReturnSuccess) {
+		qWarning("SleepInhibitor: Failed to create IOPMAssertion");
+		m_assertionID = 0;
+	}
+#elif defined(USE_DBUS)
+	QDBusInterface screensaver("org.freedesktop.ScreenSaver", "/ScreenSaver", "org.freedesktop.ScreenSaver", QDBusConnection::sessionBus());
+	if (screensaver.isValid()) {
+		QDBusReply<uint32_t> reply = screensaver.call("Inhibit", "Mumble", "In a call");
+		if (reply.isValid()) {
+			m_cookie = reply.value();
+		} else {
+			qWarning() << "SleepInhibitor: ScreenSaver Inhibit call failed:" << reply.error().message();
+		}
+	}
+
+	QDBusInterface logind("org.freedesktop.login1", "/org/freedesktop/login1", "org.freedesktop.login1.Manager", QDBusConnection::systemBus());
+	if (logind.isValid()) {
+		QDBusReply<QDBusUnixFileDescriptor> reply = logind.call("Inhibit", "sleep:idle", "Mumble", "In a call", "block");
+		if (reply.isValid()) {
+			m_logindFD = reply.value();
+		} else {
+			qWarning() << "SleepInhibitor: Logind Inhibit call failed:" << reply.error().message();
+		}
+	}
+#endif
+}
+
+void SleepInhibitor::platformDeinhibit() {
+#if defined(Q_OS_WIN)
+	SetThreadExecutionState(ES_CONTINUOUS);
+#elif defined(Q_OS_MAC)
+	if (m_assertionID != 0) {
+		IOPMAssertionRelease(m_assertionID);
+		m_assertionID = 0;
+	}
+#elif defined(USE_DBUS)
+	if (m_cookie != 0) {
+		QDBusInterface screensaver("org.freedesktop.ScreenSaver", "/ScreenSaver", "org.freedesktop.ScreenSaver", QDBusConnection::sessionBus());
+		if (screensaver.isValid()) {
+			screensaver.call("UnInhibit", m_cookie);
+		}
+		m_cookie = 0;
+	}
+	if (m_logindFD.isValid()) {
+		m_logindFD = QDBusUnixFileDescriptor();
+	}
+#endif
+}

--- a/src/mumble/SleepInhibitor.h
+++ b/src/mumble/SleepInhibitor.h
@@ -6,6 +6,8 @@
 #ifndef MUMBLE_MUMBLE_SLEEPINHIBITOR_H_
 #define MUMBLE_MUMBLE_SLEEPINHIBITOR_H_
 
+#include <cstdint>
+
 #include <QtCore/QObject>
 #if defined(USE_DBUS)
 #	include <QtDBus/QDBusUnixFileDescriptor>

--- a/src/mumble/SleepInhibitor.h
+++ b/src/mumble/SleepInhibitor.h
@@ -1,0 +1,39 @@
+// Copyright The Mumble Developers. All rights reserved.
+// Use of this source code is governed by a BSD-style license
+// that can be found in the LICENSE file at the root of the
+// Mumble source tree or at <https://www.mumble.info/LICENSE>.
+
+#ifndef MUMBLE_MUMBLE_SLEEPINHIBITOR_H_
+#define MUMBLE_MUMBLE_SLEEPINHIBITOR_H_
+
+#include <QtCore/QObject>
+#if defined(USE_DBUS)
+#	include <QtDBus/QDBusUnixFileDescriptor>
+#endif
+
+class SleepInhibitor : public QObject {
+	Q_OBJECT
+	Q_DISABLE_COPY(SleepInhibitor)
+
+public:
+	explicit SleepInhibitor(QObject *parent = nullptr);
+	~SleepInhibitor() override;
+
+	void setInhibit(bool inhibit);
+
+private:
+	bool m_inhibited = false;
+#if defined(Q_OS_WIN)
+	// No extra state needed for Windows (ES_CONTINUOUS)
+#elif defined(Q_OS_MAC)
+	uint32_t m_assertionID = 0;
+#elif defined(USE_DBUS)
+	uint32_t m_cookie = 0;
+	QDBusUnixFileDescriptor m_logindFD;
+#endif
+
+	void platformInhibit();
+	void platformDeinhibit();
+};
+
+#endif


### PR DESCRIPTION
As requested in #6899, this commit implements the ability to prevent the
computer from entering sleep mode while active in a call.


This feature is implemented via a new SleepInhibitor class that handles
the necessary platform-specific power management APIs:

- Windows: Uses SetThreadExecutionState to prevent system and display sleep.
- macOS: Uses IOPMAssertionCreateWithDescription to create power claims.
- Linux: Uses D-Bus to interface with org.freedesktop.login1 (Logind) to
  block sleep/idle, with org.freedesktop.ScreenSaver as a fallback.

The setting "Inhibit system sleep while connected" has been added to the
"User Interface" settings tab under the "Application" section.

Tested successfully on my openSUSE Tumbleweed installation.

### Checks

- [x] My commits follow the [commit guidelines](https://github.com/mumble-voip/mumble/blob/master/COMMIT_GUIDELINES.md)

