### PR TITLE
Backport "Merge PR #7086: FIX(installer): Ignore exit-code 0x666 from VC_redist installer" to 1.5.x

### DIFF
--- a/installer/MumbleInstall.cs
+++ b/installer/MumbleInstall.cs
@@ -55,6 +55,15 @@ public class MumbleInstall : Project {
 					 * This will still show up in Add/Remove Programs and can be removed there,
 					 * even when Permanent is true. */
 					Permanent = true,
+					ExitCodes = new List<ExitCode>
+					{
+						new ExitCode
+						{
+							// Can not install VC_redist, because newer version is already installed
+							Value = "1638",
+							Behavior = BehaviorValues.success
+						}
+					},
 				});
 		bootstrapper.Variables = new[] {
 				/* Version.ToString() is here to validating the input when the installer is built.


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `1.5.x`:
 - [Merge PR #7086: FIX(installer): Ignore exit-code 0x666 from VC_redist installer](https://github.com/mumble-voip/mumble/pull/7086)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)