### PR TITLE
CI(ga): Use ccache for faster builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -82,7 +82,7 @@ jobs:
 
     - uses: hendrikmuhs/ccache-action@v1.2
       with:
-        key: ${{ matrix.os }}.${{ matrix.type }}
+        key: ${{ github.head_ref || github.ref_name }}.${{ matrix.os }}.${{ matrix.type }}
         save: ${{ github.event_name != 'pull_request' }}
         append-timestamp: false
 


### PR DESCRIPTION
### Checks

- [x] My commits follow the [commit guidelines](https://github.com/mumble-voip/mumble/blob/master/COMMIT_GUIDELINES.md)

