### PR TITLE
FIX(client): Fix color scheme detection on Sway

### DIFF
--- a/src/mumble/Themes.cpp
+++ b/src/mumble/Themes.cpp
@@ -163,7 +163,14 @@ bool Themes::apply() {
 
 bool Themes::detectSystemDarkTheme() {
 #if QT_VERSION >= QT_VERSION_CHECK(6, 5, 0)
-	return QGuiApplication::styleHints()->colorScheme() == Qt::ColorScheme::Dark;
+	Qt::ColorScheme colorScheme = QGuiApplication::styleHints()->colorScheme();
+	if (colorScheme != Qt::ColorScheme::Unknown) {
+		return colorScheme == Qt::ColorScheme::Dark;
+	}
+	// colorScheme() can return Unknown on some platforms (e.g. wlroots compositors),
+	// so fall back to comparing palette lightness values
+	QPalette defaultPalette;
+	return defaultPalette.color(QPalette::WindowText).lightness() > defaultPalette.color(QPalette::Window).lightness();
 #else
 #	if defined(Q_OS_WIN)
 	QSettings settings("HKEY_CURRENT_USER\\Software\\Microsoft\\Windows\\CurrentVersion\\Themes\\Personalize",


### PR DESCRIPTION
Mumble has code for colour scheme preference controlling what theme is used but this does not work on Sway (and presumably other wlroots-based compositors).

It was found that the reason the feature was not working is because `colorScheme()` was returning `ColorScheme::Unknown`.
This fix uses the fallback method of checking the colour palette in the event that `ColorScheme::Unknown` is returned.

### Checks

- [x] My commits follow the [commit guidelines](https://github.com/mumble-voip/mumble/blob/master/COMMIT_GUIDELINES.md)

