### PR TITLE
FIX(client): Don't send placeholder when using paste+send if MainWindow is out-of-focus

### DIFF
--- a/src/mumble/CustomElements.cpp
+++ b/src/mumble/CustomElements.cpp
@@ -401,7 +401,13 @@ void ChatbarTextEdit::historyDown() {
 }
 
 void ChatbarTextEdit::pasteAndSend_triggered() {
+	if (bDefaultVisible) {
+		// Clear placeholder
+		setPlainText(QString());
+	}
+
 	paste();
+
 	if (!toPlainText().isEmpty()) {
 		addToHistory(toPlainText());
 		emit entered(toPlainText());


### PR DESCRIPTION
The 'paste and send' action would accidentally also send the placeholder text, if the MainWindow was out of focus.

This commit adds a check to make sure to clear the chatbar in case the place holder is active during past and send.
