### PR TITLE
FIX(server): Fix linking with SOCI when bundled-soci=OFF is used

### DIFF
--- a/src/database/CMakeLists.txt
+++ b/src/database/CMakeLists.txt
@@ -77,7 +77,7 @@ else()
 	find_package("Soci" 4.1.0 COMPONENTS ${components} CONFIG REQUIRED)
 endif()
 
-target_link_libraries(mumble_database PUBLIC SOCI::soci)
+target_link_libraries(mumble_database PUBLIC SOCI::SOCI)
 
 
 if (NOT TARGET nlohmann_json)


### PR DESCRIPTION
`SOCI::soci` does not exist. It's probably just a typo since
`SOCI::SOCI` works fine.

Tested with NixOS and build runs through successfully.


### Checks

- [x] My commits follow the [commit guidelines](https://github.com/mumble-voip/mumble/blob/master/COMMIT_GUIDELINES.md)

