### PR TITLE
FEAT(client): Add WebRTC based voice activity detection

### DIFF
--- a/docs/dev/build-instructions/cmake_options.md
+++ b/docs/dev/build-instructions/cmake_options.md
@@ -319,6 +319,11 @@ All warnings are treated as errors.
 Build support for WASAPI.
 (Default: ON)
 
+### webrtc-audio-processing
+
+Use WebRTC audio processing for various dsp features.
+(Default: OFF)
+
 ### xboxinput
 
 Build support for global shortcuts from Xbox controllers via the XInput DLL.

--- a/src/mumble/AudioConfigDialog.cpp
+++ b/src/mumble/AudioConfigDialog.cpp
@@ -677,7 +677,7 @@ void AudioInputDialog::on_qrbWebRTC_toggled(bool checked) {
 
 void AudioInputDialog::on_qsWebRTCAggressiveness_valueChanged(int aggressiveness) {
 	AudioInputPtr ai              = Global::get().ai;
-	ai->m_vadWebrtcAggressiveness = static_cast< webrtc::Vad::Aggressiveness >(aggressiveness);
+	ai->updateWebrtcAggressiveness(static_cast< webrtc::Vad::Aggressiveness >(aggressiveness));
 	updateVad();
 }
 #endif

--- a/src/mumble/AudioConfigDialog.cpp
+++ b/src/mumble/AudioConfigDialog.cpp
@@ -11,6 +11,7 @@
 #include "AudioOutputSample.h"
 #include "AudioOutputToken.h"
 #include "NetworkConfig.h"
+#include "Settings.h"
 #include "Utils.h"
 #include "Global.h"
 
@@ -127,10 +128,24 @@ void AudioInputDialog::load(const Settings &r) {
 	loadSlider(qsDoublePush, static_cast< int >(static_cast< float >(r.uiDoublePush) / 1000.f + 0.5f));
 	loadSlider(qsPTTHold, static_cast< int >(r.pttHold));
 
-	if (r.vsVAD == Settings::Amplitude)
-		qrbAmplitude->setChecked(true);
-	else
-		qrbSNR->setChecked(true);
+#ifdef USE_WEBRTC_AUDIO_PROCESSING
+	loadSlider(qsWebRTCAggressiveness, r.fVADWebRTCAggressiveness);
+	qrbWebRTC->show();
+#endif
+
+	switch (r.vsVAD) {
+		case Settings::Amplitude:
+			qrbAmplitude->setChecked(true);
+			break;
+#ifdef USE_WEBRTC_AUDIO_PROCESSING
+		case Settings::WebRTC:
+			qrbWebRTC->setChecked(true);
+			break;
+#endif
+		default:
+			qrbSNR->setChecked(true);
+			break;
+	}
 
 	loadCheckBox(qcbPushWindow, r.bShowPTTButtonWindow);
 	loadCheckBox(qcbEnableCuePTT, r.audioCueEnabledPTT);
@@ -241,11 +256,22 @@ void AudioInputDialog::save() const {
 		s.noiseCancelMode = Settings::NoiseCancelSpeex;
 	}
 
-	s.iMinLoudness     = 18000 - qsAmp->value() + 2000;
-	s.iVoiceHold       = qsTransmitHold->value();
-	s.fVADmin          = static_cast< float >(qsTransmitMin->value()) / 32767.0f;
-	s.fVADmax          = static_cast< float >(qsTransmitMax->value()) / 32767.0f;
-	s.vsVAD            = qrbSNR->isChecked() ? Settings::SignalToNoise : Settings::Amplitude;
+	s.iMinLoudness = 18000 - qsAmp->value() + 2000;
+	s.iVoiceHold   = qsTransmitHold->value();
+	s.fVADmin      = static_cast< float >(qsTransmitMin->value()) / 32767.0f;
+	s.fVADmax      = static_cast< float >(qsTransmitMax->value()) / 32767.0f;
+
+	s.fVADWebRTCAggressiveness = qsWebRTCAggressiveness->value();
+
+	if (qrbAmplitude->isChecked())
+		s.vsVAD = Settings::Amplitude;
+#ifdef USE_WEBRTC_AUDIO_PROCESSING
+	else if (qrbWebRTC->isChecked())
+		s.vsVAD = Settings::WebRTC;
+#endif
+	else
+		s.vsVAD = Settings::SignalToNoise;
+
 	s.iFramesPerPacket = qsFrames->value();
 	s.iFramesPerPacket = (s.iFramesPerPacket == 1) ? 1 : ((s.iFramesPerPacket - 1) * 2);
 	s.uiDoublePush     = static_cast< unsigned int >(qsDoublePush->value() * 1000);
@@ -352,6 +378,20 @@ void AudioInputDialog::on_qsTransmitMin_valueChanged() {
 
 void AudioInputDialog::on_qsTransmitMax_valueChanged() {
 	Mumble::Accessibility::setSliderSemanticValue(qsTransmitMax, Mumble::Accessibility::SliderMode::READ_PERCENT, "%");
+}
+
+void AudioInputDialog::updateVad() {
+	Settings::VADSource vad = Settings::SignalToNoise;
+
+	if (qrbAmplitude->isChecked())
+		vad = Settings::Amplitude;
+#ifdef USE_WEBRTC_AUDIO_PROCESSING
+	else if (qrbWebRTC->isChecked())
+		vad = Settings::WebRTC;
+#endif
+
+	AudioInputPtr ai = Global::get().ai;
+	ai->updateVad(vad);
 }
 
 void AudioInputDialog::updateBitrate() {
@@ -621,6 +661,26 @@ void AudioInputDialog::on_qrbNoiseSupSpeex_toggled(bool checked) {
 void AudioInputDialog::on_qrbNoiseSupBoth_toggled(bool checked) {
 	showSpeexNoiseSuppressionSlider(checked);
 }
+
+#ifdef USE_WEBRTC_AUDIO_PROCESSING
+void AudioInputDialog::on_qrbWebRTC_toggled(bool checked) {
+	updateVad();
+
+	qliWebRTCAggressiveness->setVisible(checked);
+	qsWebRTCAggressiveness->setVisible(checked);
+
+	qliTransmitMax->setVisible(!checked);
+	qsTransmitMax->setVisible(!checked);
+	qliTransmitMin->setVisible(!checked);
+	qsTransmitMin->setVisible(!checked);
+}
+
+void AudioInputDialog::on_qsWebRTCAggressiveness_valueChanged(int aggressiveness) {
+	AudioInputPtr ai              = Global::get().ai;
+	ai->m_vadWebrtcAggressiveness = static_cast< webrtc::Vad::Aggressiveness >(aggressiveness);
+	updateVad();
+}
+#endif
 
 void AudioOutputDialog::enablePulseAudioAttenuationOptionsFor(const QString &outputName) {
 	if (outputName == QLatin1String("PulseAudio")) {

--- a/src/mumble/AudioConfigDialog.h
+++ b/src/mumble/AudioConfigDialog.h
@@ -17,6 +17,7 @@ private:
 	Q_DISABLE_COPY(AudioInputDialog)
 
 	void updateAudioCueEnabled();
+	void updateVad();
 
 protected:
 	QTimer *qtTick;
@@ -67,6 +68,11 @@ public slots:
 	void on_qcbIdleAction_currentIndexChanged(int v);
 	void on_qrbNoiseSupSpeex_toggled(bool checked);
 	void on_qrbNoiseSupBoth_toggled(bool checked);
+
+#ifdef USE_WEBRTC_AUDIO_PROCESSING
+	void on_qrbWebRTC_toggled(bool);
+	void on_qsWebRTCAggressiveness_valueChanged(int);
+#endif
 };
 
 class AudioOutputDialog : public ConfigWidget, public Ui::AudioOutput {

--- a/src/mumble/AudioInput.cpp
+++ b/src/mumble/AudioInput.cpp
@@ -18,7 +18,10 @@
 #include "VoiceRecorder.h"
 #include "Global.h"
 
+#ifdef USE_WEBRTC_AUDIO_PROCESSING
 #include "WebRTC_Priv.h"
+#endif
+
 #include <opus.h>
 
 #ifdef USE_RNNOISE

--- a/src/mumble/AudioInput.cpp
+++ b/src/mumble/AudioInput.cpp
@@ -18,6 +18,7 @@
 #include "VoiceRecorder.h"
 #include "Global.h"
 
+#include "WebRTC_Priv.h"
 #include <opus.h>
 
 #ifdef USE_RNNOISE
@@ -250,6 +251,12 @@ AudioInput::AudioInput()
 #ifdef USE_RNNOISE
 	denoiseState = rnnoise_create(nullptr);
 #endif
+
+#ifdef USE_WEBRTC_AUDIO_PROCESSING
+	m_vadWebrtcAggressiveness = static_cast< webrtc::Vad::Aggressiveness >(Global::get().s.fVADWebRTCAggressiveness);
+#endif
+
+	updateVad(Global::get().s.vsVAD);
 
 	qWarning("AudioInput: %d bits/s, %d hz, %d sample", iAudioQuality, iSampleRate, iFrameSize);
 	iEchoFreq = iMicFreq = iSampleRate;
@@ -941,11 +948,19 @@ void AudioInput::encodeAudioFrame(AudioChunk chunk) {
 						   static_cast< std::streamsize >(iFrameSize * sizeof(short)));
 	}
 
-	fSpeechProb = static_cast< float >(m_preprocessor.getSpeechProb()) / 100.0f;
+	switch (m_vad) {
+#ifdef USE_WEBRTC_AUDIO_PROCESSING
+		case Settings::WebRTC:
+			fSpeechProb = !!m_vadWebrtc->VoiceActivity(psSource, iFrameSize, iSampleRate);
+			break;
+#endif
+		default:
+			fSpeechProb = static_cast< float >(m_preprocessor.getSpeechProb()) / 100.0f;
+	}
 
 	// clean microphone level: peak of filtered signal attenuated by AGC gain
 	dPeakCleanMic = qMax(dPeakSignal - static_cast< float >(gainValue), -96.0f);
-	float level   = (Global::get().s.vsVAD == Settings::SignalToNoise) ? fSpeechProb : (1.0f + dPeakCleanMic / 96.0f);
+	float level   = (m_vad == Settings::Amplitude) ? (1.0f + dPeakCleanMic / 96.0f) : fSpeechProb;
 
 	bool bIsSpeech = false;
 
@@ -1242,6 +1257,15 @@ void AudioInput::updateUserMuteDeafState(const ClientUser *user) {
 		bUserIsMuted = bMuted;
 		onUserMutedChanged();
 	}
+}
+
+void AudioInput::updateVad(Settings::VADSource src) {
+	m_vad = src;
+#ifdef USE_WEBRTC_AUDIO_PROCESSING
+	if (m_vad == Settings::WebRTC) {
+		m_vadWebrtc = webrtc::CreateVad(m_vadWebrtcAggressiveness);
+	}
+#endif
 }
 
 void AudioInput::onUserMutedChanged() {

--- a/src/mumble/AudioInput.cpp
+++ b/src/mumble/AudioInput.cpp
@@ -28,6 +28,7 @@ extern "C" {
 #endif
 
 #include <algorithm>
+#include <atomic>
 #include <cassert>
 #include <chrono>
 #include <exception>
@@ -948,7 +949,9 @@ void AudioInput::encodeAudioFrame(AudioChunk chunk) {
 						   static_cast< std::streamsize >(iFrameSize * sizeof(short)));
 	}
 
-	switch (m_vad) {
+	Settings::VADSource currentVad = m_vad.load();
+
+	switch (currentVad) {
 #ifdef USE_WEBRTC_AUDIO_PROCESSING
 		case Settings::WebRTC:
 			fSpeechProb = !!m_vadWebrtc->VoiceActivity(psSource, iFrameSize, iSampleRate);
@@ -960,7 +963,7 @@ void AudioInput::encodeAudioFrame(AudioChunk chunk) {
 
 	// clean microphone level: peak of filtered signal attenuated by AGC gain
 	dPeakCleanMic = qMax(dPeakSignal - static_cast< float >(gainValue), -96.0f);
-	float level   = (m_vad == Settings::Amplitude) ? (1.0f + dPeakCleanMic / 96.0f) : fSpeechProb;
+	float level   = (currentVad == Settings::Amplitude) ? (1.0f + dPeakCleanMic / 96.0f) : fSpeechProb;
 
 	bool bIsSpeech = false;
 
@@ -1260,20 +1263,20 @@ void AudioInput::updateUserMuteDeafState(const ClientUser *user) {
 }
 
 void AudioInput::updateVad(Settings::VADSource src) {
-	m_vad = src;
 #ifdef USE_WEBRTC_AUDIO_PROCESSING
-	if (m_vad == Settings::WebRTC) {
+	if (src == Settings::WebRTC) {
 		m_vadWebrtc = webrtc::CreateVad(m_vadWebrtcAggressiveness);
 	} else {
 		m_vadWebrtc.reset();
 	}
 #endif
+	m_vad.store(src);
 }
 
 #ifdef USE_WEBRTC_AUDIO_PROCESSING
 void AudioInput::updateWebrtcAggressiveness(webrtc::Vad::Aggressiveness aggressiveness) {
 	m_vadWebrtcAggressiveness = aggressiveness;
-	if (m_vad == Settings::WebRTC && m_vadWebrtc) {
+	if (m_vad.load() == Settings::WebRTC && m_vadWebrtc) {
 		m_vadWebrtc = webrtc::CreateVad(m_vadWebrtcAggressiveness);
 	}
 }

--- a/src/mumble/AudioInput.cpp
+++ b/src/mumble/AudioInput.cpp
@@ -953,9 +953,16 @@ void AudioInput::encodeAudioFrame(AudioChunk chunk) {
 
 	switch (currentVad) {
 #ifdef USE_WEBRTC_AUDIO_PROCESSING
-		case Settings::WebRTC:
-			fSpeechProb = !!m_vadWebrtc->VoiceActivity(psSource, iFrameSize, iSampleRate);
+		case Settings::WebRTC: {
+			auto webrtcVad = std::atomic_load(&m_vadWebrtc);
+
+			if (!webrtcVad) {
+				break;
+			}
+
+			fSpeechProb = !!webrtcVad->VoiceActivity(psSource, iFrameSize, iSampleRate);
 			break;
+		}
 #endif
 		default:
 			fSpeechProb = static_cast< float >(m_preprocessor.getSpeechProb()) / 100.0f;
@@ -1265,9 +1272,14 @@ void AudioInput::updateUserMuteDeafState(const ClientUser *user) {
 void AudioInput::updateVad(Settings::VADSource src) {
 #ifdef USE_WEBRTC_AUDIO_PROCESSING
 	if (src == Settings::WebRTC) {
-		m_vadWebrtc = webrtc::CreateVad(m_vadWebrtcAggressiveness);
+		auto u = webrtc::CreateVad(m_vadWebrtcAggressiveness);
+		if (!u) {
+			qWarning() << "AudioInput: Failed to initialize WebRTC VAD, disabled";
+		}
+		std::shared_ptr< webrtc::Vad > s = std::move(u);
+		std::atomic_store(&m_vadWebrtc, std::move(s));
 	} else {
-		m_vadWebrtc.reset();
+		std::atomic_store(&m_vadWebrtc, std::shared_ptr< webrtc::Vad >(nullptr));
 	}
 #endif
 	m_vad.store(src);
@@ -1277,7 +1289,12 @@ void AudioInput::updateVad(Settings::VADSource src) {
 void AudioInput::updateWebrtcAggressiveness(webrtc::Vad::Aggressiveness aggressiveness) {
 	m_vadWebrtcAggressiveness = aggressiveness;
 	if (m_vad.load() == Settings::WebRTC && m_vadWebrtc) {
-		m_vadWebrtc = webrtc::CreateVad(m_vadWebrtcAggressiveness);
+		auto u = webrtc::CreateVad(m_vadWebrtcAggressiveness);
+		if (!u) {
+			qWarning() << "AudioInput: Failed to initialize WebRTC VAD, disabled";
+		}
+		std::shared_ptr< webrtc::Vad > s = std::move(u);
+		std::atomic_store(&m_vadWebrtc, std::move(s));
 	}
 }
 #endif

--- a/src/mumble/AudioInput.cpp
+++ b/src/mumble/AudioInput.cpp
@@ -1264,9 +1264,20 @@ void AudioInput::updateVad(Settings::VADSource src) {
 #ifdef USE_WEBRTC_AUDIO_PROCESSING
 	if (m_vad == Settings::WebRTC) {
 		m_vadWebrtc = webrtc::CreateVad(m_vadWebrtcAggressiveness);
+	} else {
+		m_vadWebrtc.reset();
 	}
 #endif
 }
+
+#ifdef USE_WEBRTC_AUDIO_PROCESSING
+void AudioInput::updateWebrtcAggressiveness(webrtc::Vad::Aggressiveness aggressiveness) {
+	m_vadWebrtcAggressiveness = aggressiveness;
+	if (m_vad == Settings::WebRTC && m_vadWebrtc) {
+		m_vadWebrtc = webrtc::CreateVad(m_vadWebrtcAggressiveness);
+	}
+}
+#endif
 
 void AudioInput::onUserMutedChanged() {
 }

--- a/src/mumble/AudioInput.cpp
+++ b/src/mumble/AudioInput.cpp
@@ -19,7 +19,7 @@
 #include "Global.h"
 
 #ifdef USE_WEBRTC_AUDIO_PROCESSING
-#include "WebRTC_Priv.h"
+#	include "WebRTC_Priv.h"
 #endif
 
 #include <opus.h>
@@ -955,9 +955,10 @@ void AudioInput::encodeAudioFrame(AudioChunk chunk) {
 	Settings::VADSource currentVad = m_vad.load();
 
 	switch (currentVad) {
+		case Settings::WebRTC:
 #ifdef USE_WEBRTC_AUDIO_PROCESSING
-		case Settings::WebRTC: {
-			auto webrtcVad = std::atomic_load(&m_vadWebrtc);
+		{
+			auto webrtcVad = m_vadWebrtc.load();
 
 			if (!webrtcVad) {
 				break;
@@ -966,6 +967,9 @@ void AudioInput::encodeAudioFrame(AudioChunk chunk) {
 			fSpeechProb = !!webrtcVad->VoiceActivity(psSource, iFrameSize, iSampleRate);
 			break;
 		}
+#else
+			fSpeechProb = static_cast< float >(m_preprocessor.getSpeechProb()) / 100.0f;
+			break;
 #endif
 		default:
 			fSpeechProb = static_cast< float >(m_preprocessor.getSpeechProb()) / 100.0f;
@@ -1279,10 +1283,9 @@ void AudioInput::updateVad(Settings::VADSource src) {
 		if (!u) {
 			qWarning() << "AudioInput: Failed to initialize WebRTC VAD, disabled";
 		}
-		std::shared_ptr< webrtc::Vad > s = std::move(u);
-		std::atomic_store(&m_vadWebrtc, std::move(s));
+		m_vadWebrtc.store(std::move(u));
 	} else {
-		std::atomic_store(&m_vadWebrtc, std::shared_ptr< webrtc::Vad >(nullptr));
+		m_vadWebrtc.store(nullptr);
 	}
 #endif
 	m_vad.store(src);
@@ -1291,13 +1294,12 @@ void AudioInput::updateVad(Settings::VADSource src) {
 #ifdef USE_WEBRTC_AUDIO_PROCESSING
 void AudioInput::updateWebrtcAggressiveness(webrtc::Vad::Aggressiveness aggressiveness) {
 	m_vadWebrtcAggressiveness = aggressiveness;
-	if (m_vad.load() == Settings::WebRTC && m_vadWebrtc) {
+	if (m_vad.load() == Settings::WebRTC && m_vadWebrtc.load()) {
 		auto u = webrtc::CreateVad(m_vadWebrtcAggressiveness);
 		if (!u) {
 			qWarning() << "AudioInput: Failed to initialize WebRTC VAD, disabled";
 		}
-		std::shared_ptr< webrtc::Vad > s = std::move(u);
-		std::atomic_store(&m_vadWebrtc, std::move(s));
+		m_vadWebrtc.store(std::move(u));
 	}
 }
 #endif

--- a/src/mumble/AudioInput.h
+++ b/src/mumble/AudioInput.h
@@ -31,7 +31,7 @@
 #include "Timer.h"
 
 #ifdef USE_WEBRTC_AUDIO_PROCESSING
-#	include "WebRTC_Priv.h"
+#include "WebRTC_Priv.h"
 #endif
 
 class AudioInput;

--- a/src/mumble/AudioInput.h
+++ b/src/mumble/AudioInput.h
@@ -29,6 +29,10 @@
 #include "Settings.h"
 #include "Timer.h"
 
+#ifdef USE_WEBRTC_AUDIO_PROCESSING
+#	include "WebRTC_Priv.h"
+#endif
+
 class AudioInput;
 struct OpusEncoder;
 struct DenoiseState;
@@ -226,6 +230,12 @@ protected:
 	AudioPreprocessor m_preprocessor;
 	SpeexEchoState *sesEcho;
 
+	Settings::VADSource m_vad;
+
+#ifdef USE_WEBRTC_AUDIO_PROCESSING
+	std::unique_ptr< webrtc::Vad > m_vadWebrtc;
+#endif
+
 	/// bResetEncoder is a flag that notifies
 	/// our encoder functions that the encoder
 	/// needs to be reset.
@@ -312,6 +322,13 @@ public:
 	void run() Q_DECL_OVERRIDE = 0;
 	virtual bool isAlive() const;
 	bool isTransmitting() const;
+
+	void updateVad(Settings::VADSource src);
+
+#ifdef USE_WEBRTC_AUDIO_PROCESSING
+	webrtc::Vad::Aggressiveness m_vadWebrtcAggressiveness;
+#endif
+
 
 	void updateUserMuteDeafState(const ClientUser *user);
 

--- a/src/mumble/AudioInput.h
+++ b/src/mumble/AudioInput.h
@@ -234,7 +234,7 @@ protected:
 	std::atomic< Settings::VADSource > m_vad;
 
 #ifdef USE_WEBRTC_AUDIO_PROCESSING
-	std::unique_ptr< webrtc::Vad > m_vadWebrtc;
+	std::shared_ptr< webrtc::Vad > m_vadWebrtc;
 	webrtc::Vad::Aggressiveness m_vadWebrtcAggressiveness;
 #endif
 

--- a/src/mumble/AudioInput.h
+++ b/src/mumble/AudioInput.h
@@ -11,6 +11,7 @@
 #include <QThread>
 
 #include <array>
+#include <atomic>
 #include <cstdint>
 #include <fstream>
 #include <list>
@@ -230,7 +231,7 @@ protected:
 	AudioPreprocessor m_preprocessor;
 	SpeexEchoState *sesEcho;
 
-	Settings::VADSource m_vad;
+	std::atomic< Settings::VADSource > m_vad;
 
 #ifdef USE_WEBRTC_AUDIO_PROCESSING
 	std::unique_ptr< webrtc::Vad > m_vadWebrtc;

--- a/src/mumble/AudioInput.h
+++ b/src/mumble/AudioInput.h
@@ -234,6 +234,7 @@ protected:
 
 #ifdef USE_WEBRTC_AUDIO_PROCESSING
 	std::unique_ptr< webrtc::Vad > m_vadWebrtc;
+	webrtc::Vad::Aggressiveness m_vadWebrtcAggressiveness;
 #endif
 
 	/// bResetEncoder is a flag that notifies
@@ -326,7 +327,7 @@ public:
 	void updateVad(Settings::VADSource src);
 
 #ifdef USE_WEBRTC_AUDIO_PROCESSING
-	webrtc::Vad::Aggressiveness m_vadWebrtcAggressiveness;
+	void updateWebrtcAggressiveness(webrtc::Vad::Aggressiveness);
 #endif
 
 

--- a/src/mumble/AudioInput.h
+++ b/src/mumble/AudioInput.h
@@ -31,7 +31,7 @@
 #include "Timer.h"
 
 #ifdef USE_WEBRTC_AUDIO_PROCESSING
-#include "WebRTC_Priv.h"
+#	include "WebRTC_Priv.h"
 #endif
 
 class AudioInput;
@@ -234,7 +234,7 @@ protected:
 	std::atomic< Settings::VADSource > m_vad;
 
 #ifdef USE_WEBRTC_AUDIO_PROCESSING
-	std::shared_ptr< webrtc::Vad > m_vadWebrtc;
+	std::atomic< std::shared_ptr< webrtc::Vad > > m_vadWebrtc;
 	webrtc::Vad::Aggressiveness m_vadWebrtcAggressiveness;
 #endif
 

--- a/src/mumble/AudioInput.ui
+++ b/src/mumble/AudioInput.ui
@@ -417,7 +417,7 @@
                <string>Use WebRTC GMM based speech detection</string>
               </property>
               <property name="whatsThis">
-               <string>&lt;b&gt;This sets speech detection to use WebRTC VAD algorithm.&lt;/b&gt;&lt;br /&gt;In this mode, a config-free Gaussian Mixture Model was used to detecting speech.</string>
+               <string>&lt;b&gt;This sets speech detection to use the WebRTC VAD algorithm.&lt;/b&gt;&lt;br /&gt;In this mode, a configuration-free Gaussian Mixture Model is used to detect speech.</string>
               </property>
 	      <property name="visible">
                <bool>false</bool>

--- a/src/mumble/AudioInput.ui
+++ b/src/mumble/AudioInput.ui
@@ -411,6 +411,22 @@
               </property>
              </widget>
             </item>
+	    <item>
+             <widget class="QRadioButton" name="qrbWebRTC">
+              <property name="toolTip">
+               <string>Use WebRTC GMM based speech detection</string>
+              </property>
+              <property name="whatsThis">
+               <string>&lt;b&gt;This sets speech detection to use WebRTC VAD algorithm.&lt;/b&gt;&lt;br /&gt;In this mode, a config-free Gaussian Mixture Model was used to detecting speech.</string>
+              </property>
+	      <property name="visible">
+               <bool>false</bool>
+              </property>
+              <property name="text">
+               <string>WebRTC GMM</string>
+              </property>
+             </widget>
+            </item>
            </layout>
           </item>
           <item row="4" column="0">
@@ -488,6 +504,44 @@
          </layout>
         </widget>
         <widget class="QWidget" name="qwContinuous"/>
+       </widget>
+      </item>
+      <item row="5" column="0">
+       <widget class="QLabel" name="qliWebRTCAggressiveness">
+	<property name="visible">
+         <bool>false</bool>
+        </property>
+	<property name="text">
+	 <string>Aggressiveness</string>
+	</property>
+	<property name="buddy">
+	 <cstring>qsWebRTCAggressiveness</cstring>
+	</property>
+       </widget>
+      </item>
+      <item row="5" column="1">
+       <widget class="SemanticSlider" name="qsWebRTCAggressiveness">
+	<property name="visible">
+         <bool>false</bool>
+        </property>
+	<property name="toolTip">
+	 <string>Controls aggressiveness of WebRTC VAD</string>
+	</property>
+	<property name="whatsThis">
+	 <string>Higher values make the VAD more aggressive in filtering noise.</string>
+	</property>
+	<property name="minimum">
+	 <number>0</number>
+        </property>
+	<property name="maximum">
+	 <number>3</number>
+	</property>
+	<property name="singleStep">
+	 <number>1</number>
+	</property>
+	<property name="orientation">
+	 <enum>Qt::Horizontal</enum>
+	</property>
        </widget>
       </item>
      </layout>

--- a/src/mumble/AudioInput.ui
+++ b/src/mumble/AudioInput.ui
@@ -1229,9 +1229,11 @@
   <tabstop>qcbTransmit</tabstop>
   <tabstop>qrbAmplitude</tabstop>
   <tabstop>qrbSNR</tabstop>
+  <tabstop>qrbWebRTC</tabstop>
   <tabstop>qsTransmitHold</tabstop>
   <tabstop>qsTransmitMin</tabstop>
   <tabstop>qsTransmitMax</tabstop>
+  <tabstop>qsWebRTCAggressiveness</tabstop>
   <tabstop>qsQuality</tabstop>
   <tabstop>qsDoublePush</tabstop>
   <tabstop>qsPTTHold</tabstop>

--- a/src/mumble/AudioWizard.cpp
+++ b/src/mumble/AudioWizard.cpp
@@ -666,7 +666,7 @@ void AudioWizard::on_qrWebRTC_toggled(bool on) {
 
 void AudioWizard::on_qsWebRTCAggressiveness_valueChanged(int aggressiveness) {
 	Global::get().s.fVADWebRTCAggressiveness    = aggressiveness;
-	Global::get().ai->m_vadWebrtcAggressiveness = static_cast< webrtc::Vad::Aggressiveness >(aggressiveness);
+	Global::get().ai->updateWebrtcAggressiveness(static_cast< webrtc::Vad::Aggressiveness >(aggressiveness));
 	updateVad();
 }
 #endif

--- a/src/mumble/AudioWizard.cpp
+++ b/src/mumble/AudioWizard.cpp
@@ -15,6 +15,7 @@
 #include "GlobalShortcut.h"
 #include "GlobalShortcutButtons.h"
 
+#include "WebRTC_Priv.h"
 #include <QtGui/QMouseEvent>
 #include <QtWidgets/QGraphicsEllipseItem>
 
@@ -124,6 +125,10 @@ AudioWizard::AudioWizard(QWidget *p) : QWizard(p) {
 	abAmplify->qcInside = Qt::green;
 	abAmplify->qcAbove  = Qt::red;
 
+#ifdef USE_WEBRTC_AUDIO_PROCESSING
+	qrWebRTC->setVisible(true);
+#endif
+
 	for (const auto &shortcut : Global::get().s.qlShortcuts) {
 		if (shortcut.iIndex == Global::get().mw->gsPushTalk->idx) {
 			pttButtons = shortcut.qlButtons;
@@ -135,6 +140,17 @@ AudioWizard::AudioWizard(QWidget *p) : QWizard(p) {
 		qrPTT->setChecked(true);
 	else if (Global::get().s.vsVAD == Settings::Amplitude)
 		qrAmplitude->setChecked(true);
+#ifdef USE_WEBRTC_AUDIO_PROCESSING
+	else if (Global::get().s.vsVAD == Settings::WebRTC) {
+		qrWebRTC->setChecked(true);
+		qsWebRTCAggressiveness->setValue(Global::get().s.fVADWebRTCAggressiveness);
+		qliVadTuningText->hide();
+		qliVadTuningTextHC->hide();
+		qliVadTuningTextWebRTC->show();
+		qsWebRTCAggressiveness->show();
+		qsVAD->hide();
+	}
+#endif
 	else
 		qrSNR->setChecked(true);
 
@@ -607,6 +623,7 @@ void AudioWizard::on_qrSNR_clicked(bool on) {
 	if (on) {
 		Global::get().s.vsVAD      = Settings::SignalToNoise;
 		Global::get().s.atTransmit = Settings::VAD;
+		updateVad();
 		updateTriggerWidgets(false);
 		bTransmitChanged = true;
 	}
@@ -616,10 +633,43 @@ void AudioWizard::on_qrAmplitude_clicked(bool on) {
 	if (on) {
 		Global::get().s.vsVAD      = Settings::Amplitude;
 		Global::get().s.atTransmit = Settings::VAD;
+		updateVad();
 		updateTriggerWidgets(false);
 		bTransmitChanged = true;
 	}
 }
+
+#ifdef USE_WEBRTC_AUDIO_PROCESSING
+void AudioWizard::on_qrWebRTC_toggled(bool on) {
+	if (on) {
+		Global::get().s.vsVAD      = Settings::WebRTC;
+		Global::get().s.atTransmit = Settings::VAD;
+		updateVad();
+		updateTriggerWidgets(false);
+		bTransmitChanged = true;
+
+		qsWebRTCAggressiveness->setValue(Global::get().s.fVADWebRTCAggressiveness);
+
+		qliVadTuningText->hide();
+		qliVadTuningTextHC->hide();
+		qliVadTuningTextWebRTC->show();
+		qsWebRTCAggressiveness->show();
+		qsVAD->hide();
+	} else {
+		qliVadTuningText->setVisible(!Global::get().s.bHighContrast);
+		qliVadTuningTextHC->setVisible(Global::get().s.bHighContrast);
+		qliVadTuningTextWebRTC->hide();
+		qsWebRTCAggressiveness->hide();
+		qsVAD->show();
+	}
+}
+
+void AudioWizard::on_qsWebRTCAggressiveness_valueChanged(int aggressiveness) {
+	Global::get().s.fVADWebRTCAggressiveness    = aggressiveness;
+	Global::get().ai->m_vadWebrtcAggressiveness = static_cast< webrtc::Vad::Aggressiveness >(aggressiveness);
+	updateVad();
+}
+#endif
 
 void AudioWizard::on_qrPTT_clicked(bool on) {
 	if (on) {
@@ -735,6 +785,11 @@ void AudioWizard::on_qcbHighContrast_clicked(bool on) {
 	qliVolumeTuningText->setVisible(!Global::get().s.bHighContrast);
 	qliVolumeTuningTextHC->setVisible(Global::get().s.bHighContrast);
 
+#ifdef USE_WEBRTC_AUDIO_PROCESSING
+	if (Global::get().s.vsVAD == Settings::WebRTC)
+		return;
+#endif
+
 	qliVadTuningText->setVisible(!Global::get().s.bHighContrast);
 	qliVadTuningTextHC->setVisible(Global::get().s.bHighContrast);
 }
@@ -761,6 +816,11 @@ void AudioWizard::on_qrbQualityCustom_clicked() {
 	Global::get().s.iQuality         = sOldSettings.iQuality;
 	Global::get().s.iFramesPerPacket = sOldSettings.iFramesPerPacket;
 	restartAudio(true);
+}
+
+void AudioWizard::updateVad() {
+	AudioInputPtr ai = Global::get().ai;
+	ai->updateVad(Global::get().s.vsVAD);
 }
 
 void AudioWizard::updateEchoCheckbox(AudioInputRegistrar *air) {

--- a/src/mumble/AudioWizard.cpp
+++ b/src/mumble/AudioWizard.cpp
@@ -15,7 +15,10 @@
 #include "GlobalShortcut.h"
 #include "GlobalShortcutButtons.h"
 
+#ifdef USE_WEBRTC_AUDIO_PROCESSING
 #include "WebRTC_Priv.h"
+#endif
+
 #include <QtGui/QMouseEvent>
 #include <QtWidgets/QGraphicsEllipseItem>
 

--- a/src/mumble/AudioWizard.h
+++ b/src/mumble/AudioWizard.h
@@ -21,6 +21,7 @@ private:
 	Q_DISABLE_COPY(AudioWizard)
 
 	void updateEchoCheckbox(AudioInputRegistrar *air);
+	void updateVad();
 
 	/// Which echo cancellation is usable depends on the audio backend and the device combination.
 	/// This function will iterate through the list of available echo cancellation in the audio backend and check with
@@ -67,6 +68,10 @@ public slots:
 	void on_qsVAD_valueChanged(int);
 	void on_qrAmplitude_clicked(bool);
 	void on_qrSNR_clicked(bool);
+#ifdef USE_WEBRTC_AUDIO_PROCESSING
+	void on_qrWebRTC_toggled(bool);
+	void on_qsWebRTCAggressiveness_valueChanged(int);
+#endif
 	void on_qrPTT_clicked(bool);
 	void on_qpbPTT_clicked();
 	void on_qcbEcho_clicked(bool);

--- a/src/mumble/AudioWizard.ui
+++ b/src/mumble/AudioWizard.ui
@@ -577,6 +577,22 @@ Speak loudly, as when you are annoyed or excited. Decrease the volume in the sou
         </widget>
        </item>
        <item>
+        <widget class="QLabel" name="qliVadTuningTextWebRTC">
+         <property name="text">
+          <string>Next you need to choose the voice detection sensitivity. The aggressiveness level controls how strictly speech is detected. Lower levels are more permissive and will pick up quiet or distant speech, but may also trigger on background noise. Higher levels are more strict and will better filter out noise, but may cut off softer speech.</string>
+         </property>
+	 <property name="visible">
+	  <bool>false</bool>
+	 </property>
+         <property name="wordWrap">
+          <bool>true</bool>
+         </property>
+         <property name="textInteractionFlags">
+          <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByMouse</set>
+         </property>
+        </widget>
+       </item>
+       <item>
         <widget class="SemanticSlider" name="qsVAD">
          <property name="accessibleName">
           <string>Voice activity detection level</string>
@@ -595,6 +611,31 @@ Speak loudly, as when you are annoyed or excited. Decrease the volume in the sou
          </property>
          <property name="pageStep">
           <number>1000</number>
+         </property>
+         <property name="orientation">
+          <enum>Qt::Horizontal</enum>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="SemanticSlider" name="qsWebRTCAggressiveness">
+	 <property name="visible">
+	  <bool>false</bool>
+	 </property>
+         <property name="accessibleName">
+          <string>Voice activity detection aggressiveness level</string>
+         </property>
+         <property name="accessibleDescription">
+          <string>This will set the aggressiveness in which Mumble will consider a signal speech. Increase value to make voice activation less sensitive.</string>
+         </property>
+         <property name="minimum">
+          <number>0</number>
+         </property>
+         <property name="maximum">
+          <number>3</number>
+         </property>
+         <property name="singleStep">
+          <number>1</number>
          </property>
          <property name="orientation">
           <enum>Qt::Horizontal</enum>
@@ -678,6 +719,22 @@ Speak loudly, as when you are annoyed or excited. Decrease the volume in the sou
         </property>
         <property name="text">
          <string>Signal-To-Noise ratio</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QRadioButton" name="qrWebRTC">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+	<property name="visible">
+	  <bool>false</bool>
+	</property>
+        <property name="text">
+         <string>WebRTC GMM</string>
         </property>
        </widget>
       </item>

--- a/src/mumble/CMakeLists.txt
+++ b/src/mumble/CMakeLists.txt
@@ -24,6 +24,8 @@ option(bundled-speex "Build the included version of Speex instead of looking for
 option(rnnoise "Use RNNoise for machine learning noise reduction." ON)
 option(bundled-rnnoise "Build the included version of RNNoise instead of looking for one on the system." ${rnnoise})
 
+option(webrtc-audio-processing "Use WebRTC audio processing for various dsp features." OFF)
+
 option(manual-plugin "Include the built-in \"manual\" positional audio plugin." ON)
 
 option(qtspeech "Use Qt's text-to-speech system (part of the Qt Speech module) instead of Mumble's own OS-specific text-to-speech implementations." OFF)
@@ -813,6 +815,25 @@ else()
 	else()
 		target_compile_definitions(mumble_client_object_lib PUBLIC "USE_NO_TTS")
 	endif()
+endif()
+
+if(webrtc-audio-processing)
+	find_pkg(webrtc-audio-processing REQUIRED)
+
+	target_compile_definitions(mumble_client_object_lib
+		PUBLIC
+			"USE_WEBRTC_AUDIO_PROCESSING"
+	)
+
+	target_include_directories(mumble_client_object_lib
+		PUBLIC
+			${webrtc-audio-processing_INCLUDE_DIRS}
+	)
+
+	target_link_libraries(mumble_client_object_lib
+		PUBLIC
+			${webrtc-audio-processing_LIBRARIES}
+	)
 endif()
 
 if(crash-report)

--- a/src/mumble/CMakeLists.txt
+++ b/src/mumble/CMakeLists.txt
@@ -818,22 +818,51 @@ else()
 endif()
 
 if(webrtc-audio-processing)
-	find_pkg(webrtc-audio-processing REQUIRED)
+	find_pkg(webrtc-audio-processing QUIET)
 
-	target_compile_definitions(mumble_client_object_lib
+	if(webrtc-audio-processing_FOUND)
+		set(webrtc_target webrtc-audio-processing)
+	else()
+		find_pkg(webrtc-audio-processing-1 QUIET)
+
+		if(webrtc-audio-processing-1_FOUND)
+			set(webrtc_target webrtc-audio-processing-1)
+		else()
+			find_pkg(webrtc QUIET)
+
+			if(webrtc_FOUND)
+				set(webrtc_target webrtc)
+			else()
+				find_pkg(unofficial-webrtc REQUIRED)
+				set(webrtc_target unofficial-webrtc)
+			endif()
+		endif()
+	endif()
+
+	target_compile_definitions(
+		mumble_client_object_lib
 		PUBLIC
-			"USE_WEBRTC_AUDIO_PROCESSING"
+			USE_WEBRTC_AUDIO_PROCESSING
 	)
 
-	target_include_directories(mumble_client_object_lib
-		PUBLIC
-			${webrtc-audio-processing_INCLUDE_DIRS}
-	)
-
-	target_link_libraries(mumble_client_object_lib
-		PUBLIC
-			${webrtc-audio-processing_LIBRARIES}
-	)
+	if(webrtc_target STREQUAL "unofficial-webrtc")
+		target_link_libraries(
+			mumble_client_object_lib
+			PUBLIC
+				unofficial::webrtc::webrtc
+		)
+	else()
+		target_include_directories(
+			mumble_client_object_lib
+			PUBLIC
+				${${webrtc_target}_INCLUDE_DIRS}
+		)
+		target_link_libraries(
+			mumble_client_object_lib
+			PUBLIC
+				${${webrtc_target}_LIBRARIES}
+		)
+	endif()
 endif()
 
 if(crash-report)

--- a/src/mumble/EnumStringConversions.cpp
+++ b/src/mumble/EnumStringConversions.cpp
@@ -12,7 +12,8 @@
 
 #define VAD_SOURCE_VALUES                                \
 	PROCESS(Settings::VADSource, Amplitude, "Amplitude") \
-	PROCESS(Settings::VADSource, SignalToNoise, "SignalToNoise")
+	PROCESS(Settings::VADSource, SignalToNoise, "SignalToNoise") \
+	PROCESS(Settings::VADSource, WebRTC, "WebRTC")
 
 #define LOOP_MODE_VALUES                        \
 	PROCESS(Settings::LoopMode, None, "None")   \

--- a/src/mumble/Settings.h
+++ b/src/mumble/Settings.h
@@ -190,7 +190,7 @@ struct OverlaySettings {
 
 struct Settings {
 	enum AudioTransmit { Continuous, VAD, PushToTalk };
-	enum VADSource { Amplitude, SignalToNoise };
+	enum VADSource { Amplitude, SignalToNoise, WebRTC };
 	enum LoopMode { None, Local, Server };
 	enum ChannelExpand { NoChannels, ChannelsWithUsers, AllChannels };
 	enum ChannelDrag { Ask, DoNothing, Move };
@@ -280,6 +280,7 @@ struct Settings {
 	VADSource vsVAD                     = Amplitude;
 	float fVADmin                       = 0.80f;
 	float fVADmax                       = 0.98f;
+	int fVADWebRTCAggressiveness        = 0;
 	int iFramesPerPacket                = 2;
 	QString qsAudioInput                = {};
 	QString qsAudioOutput               = {};

--- a/src/mumble/SettingsKeys.h
+++ b/src/mumble/SettingsKeys.h
@@ -62,6 +62,7 @@ const SettingsKey ATTENUATE_LOOPBACK_KEY                      = { "attenuate_loo
 const SettingsKey VAD_MODE_KEY                                = { "vad_mode" };
 const SettingsKey VAD_MIN_KEY                                 = { "vad_min" };
 const SettingsKey VAD_MAX_KEY                                 = { "vad_max" };
+const SettingsKey VAD_WEBRTC_AGGRESSIVENESS_KEY               = { "vad_webrtc_aggressiveness" };
 const SettingsKey NOISE_CANCEL_MODE_KEY                       = { "noise_cancel_mode" };
 const SettingsKey SPEEX_NOISE_CANCEL_STRENGTH_KEY             = { "speex_noise_cancel_strength" };
 const SettingsKey INPUT_CHANNEL_MASK_KEY                      = { "input_channel_mask" };

--- a/src/mumble/SettingsMacros.h
+++ b/src/mumble/SettingsMacros.h
@@ -46,6 +46,7 @@
 	PROCESS(audio, VAD_MODE_KEY, vsVAD)                                                     \
 	PROCESS(audio, VAD_MIN_KEY, fVADmin)                                                    \
 	PROCESS(audio, VAD_MAX_KEY, fVADmax)                                                    \
+	PROCESS(audio, VAD_WEBRTC_AGGRESSIVENESS_KEY, fVADWebRTCAggressiveness)                 \
 	PROCESS(audio, NOISE_CANCEL_MODE_KEY, noiseCancelMode)                                  \
 	PROCESS(audio, SPEEX_NOISE_CANCEL_STRENGTH_KEY, iSpeexNoiseCancelStrength)              \
 	PROCESS(audio, INPUT_CHANNEL_MASK_KEY, uiAudioInputChannelMask)                         \

--- a/src/mumble/WebRTC_Priv.h
+++ b/src/mumble/WebRTC_Priv.h
@@ -1,0 +1,47 @@
+/*
+ *  Copyright (c) 2014 The WebRTC project authors. All Rights Reserved.
+ *
+ *  Use of this source code is governed by a BSD-style license
+ *  that can be found in the LICENSE file in the root of the source
+ *  tree. An additional intellectual property rights grant can be found
+ *  in the file PATENTS.  All contributing project authors may
+ *  be found in the AUTHORS file in the root of the source tree.
+ */
+
+// webrtc::Vad is part of webrtc-audio-processing but this header not included in
+// distribution. However the code base of the library hasn't been updating for
+// years. So we expect this private header to be stable.
+
+#ifndef COMMON_AUDIO_VAD_INCLUDE_VAD_H_
+#define COMMON_AUDIO_VAD_INCLUDE_VAD_H_
+
+#include <memory>
+#include <stddef.h>
+#include <stdint.h>
+
+
+namespace webrtc {
+
+class Vad {
+public:
+	enum Aggressiveness { kVadNormal = 0, kVadLowBitrate = 1, kVadAggressive = 2, kVadVeryAggressive = 3 };
+
+	enum Activity { kPassive = 0, kActive = 1, kError = -1 };
+
+	virtual ~Vad() = default;
+
+	// Calculates a VAD decision for the given audio frame. Valid sample rates
+	// are 8000, 16000, and 32000 Hz; the number of samples must be such that the
+	// frame is 10, 20, or 30 ms long.
+	virtual Activity VoiceActivity(const int16_t *audio, size_t num_samples, int sample_rate_hz) = 0;
+
+	// Resets VAD state.
+	virtual void Reset() = 0;
+};
+
+// Returns a Vad instance that's implemented on top of WebRtcVad.
+std::unique_ptr< Vad > CreateVad(Vad::Aggressiveness aggressiveness);
+
+} // namespace webrtc
+
+#endif // COMMON_AUDIO_VAD_INCLUDE_VAD_H_

--- a/src/mumble/mumble_ar.ts
+++ b/src/mumble/mumble_ar.ts
@@ -1231,6 +1231,30 @@ This value allows you to set the maximum number of users allowed in the channel.
         <source>&lt;b&gt;This shows peak outgoing bandwidth used.&lt;/b&gt;&lt;br /&gt;This shows the peak amount of bandwidth sent out from your machine. Audio bitrate is the maximum bitrate for the audio data alone. Position is the bitrate used for positional information. Overhead is our framing and the IP packet headers (IP and UDP is 75% of this overhead).</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Use WebRTC GMM based speech detection</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&lt;b&gt;This sets speech detection to use the WebRTC VAD algorithm.&lt;/b&gt;&lt;br /&gt;In this mode, a configuration-free Gaussian Mixture Model is used to detect speech.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>WebRTC GMM</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Aggressiveness</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Controls aggressiveness of WebRTC VAD</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Higher values make the VAD more aggressive in filtering noise.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AudioInputDialog</name>
@@ -2275,6 +2299,22 @@ Speak loudly, as when you are annoyed or excited. Decrease the volume in the sou
     </message>
     <message>
         <source>This visually represents the positional audio that is currently being played</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Next you need to choose the voice detection sensitivity. The aggressiveness level controls how strictly speech is detected. Lower levels are more permissive and will pick up quiet or distant speech, but may also trigger on background noise. Higher levels are more strict and will better filter out noise, but may cut off softer speech.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Voice activity detection aggressiveness level</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>This will set the aggressiveness in which Mumble will consider a signal speech. Increase value to make voice activation less sensitive.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>WebRTC GMM</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/mumble/mumble_bg.ts
+++ b/src/mumble/mumble_bg.ts
@@ -1232,6 +1232,30 @@ This value allows you to set the maximum number of users allowed in the channel.
         <source>&lt;b&gt;This shows peak outgoing bandwidth used.&lt;/b&gt;&lt;br /&gt;This shows the peak amount of bandwidth sent out from your machine. Audio bitrate is the maximum bitrate for the audio data alone. Position is the bitrate used for positional information. Overhead is our framing and the IP packet headers (IP and UDP is 75% of this overhead).</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Use WebRTC GMM based speech detection</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&lt;b&gt;This sets speech detection to use the WebRTC VAD algorithm.&lt;/b&gt;&lt;br /&gt;In this mode, a configuration-free Gaussian Mixture Model is used to detect speech.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>WebRTC GMM</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Aggressiveness</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Controls aggressiveness of WebRTC VAD</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Higher values make the VAD more aggressive in filtering noise.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AudioInputDialog</name>
@@ -2276,6 +2300,22 @@ Speak loudly, as when you are annoyed or excited. Decrease the volume in the sou
     </message>
     <message>
         <source>This visually represents the positional audio that is currently being played</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Next you need to choose the voice detection sensitivity. The aggressiveness level controls how strictly speech is detected. Lower levels are more permissive and will pick up quiet or distant speech, but may also trigger on background noise. Higher levels are more strict and will better filter out noise, but may cut off softer speech.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Voice activity detection aggressiveness level</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>This will set the aggressiveness in which Mumble will consider a signal speech. Increase value to make voice activation less sensitive.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>WebRTC GMM</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/mumble/mumble_br.ts
+++ b/src/mumble/mumble_br.ts
@@ -1231,6 +1231,30 @@ This value allows you to set the maximum number of users allowed in the channel.
         <source>&lt;b&gt;This shows peak outgoing bandwidth used.&lt;/b&gt;&lt;br /&gt;This shows the peak amount of bandwidth sent out from your machine. Audio bitrate is the maximum bitrate for the audio data alone. Position is the bitrate used for positional information. Overhead is our framing and the IP packet headers (IP and UDP is 75% of this overhead).</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Use WebRTC GMM based speech detection</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&lt;b&gt;This sets speech detection to use the WebRTC VAD algorithm.&lt;/b&gt;&lt;br /&gt;In this mode, a configuration-free Gaussian Mixture Model is used to detect speech.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>WebRTC GMM</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Aggressiveness</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Controls aggressiveness of WebRTC VAD</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Higher values make the VAD more aggressive in filtering noise.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AudioInputDialog</name>
@@ -2275,6 +2299,22 @@ Speak loudly, as when you are annoyed or excited. Decrease the volume in the sou
     </message>
     <message>
         <source>This visually represents the positional audio that is currently being played</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Next you need to choose the voice detection sensitivity. The aggressiveness level controls how strictly speech is detected. Lower levels are more permissive and will pick up quiet or distant speech, but may also trigger on background noise. Higher levels are more strict and will better filter out noise, but may cut off softer speech.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Voice activity detection aggressiveness level</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>This will set the aggressiveness in which Mumble will consider a signal speech. Increase value to make voice activation less sensitive.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>WebRTC GMM</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/mumble/mumble_ca.ts
+++ b/src/mumble/mumble_ca.ts
@@ -1239,6 +1239,30 @@ Aquest valor us permet establir el nombre màxim d&apos;usuaris permesos al cana
         <source>&lt;b&gt;This shows peak outgoing bandwidth used.&lt;/b&gt;&lt;br /&gt;This shows the peak amount of bandwidth sent out from your machine. Audio bitrate is the maximum bitrate for the audio data alone. Position is the bitrate used for positional information. Overhead is our framing and the IP packet headers (IP and UDP is 75% of this overhead).</source>
         <translation>&lt;b&gt;Això mostra el pic de l&apos;ample de banda de sortida utilitzat.&lt;/b&gt;&lt;br /&gt; Mostra el màxim ample de banda enviat des de la vostra màquina. La taxa de bits d&apos;àudio és la taxa de bits màxima només per a les dades d&apos;àudio. La posició és la taxa de bits utilitzada per a la informació posicional. El superior és el nostre enquadrament i les capçaleres de paquets IP (IP i UDP és 75% d&apos;aquesta sobrecàrrega).</translation>
     </message>
+    <message>
+        <source>Use WebRTC GMM based speech detection</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&lt;b&gt;This sets speech detection to use the WebRTC VAD algorithm.&lt;/b&gt;&lt;br /&gt;In this mode, a configuration-free Gaussian Mixture Model is used to detect speech.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>WebRTC GMM</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Aggressiveness</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Controls aggressiveness of WebRTC VAD</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Higher values make the VAD more aggressive in filtering noise.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AudioInputDialog</name>
@@ -2308,6 +2332,22 @@ Parlaeu en veu alta, com quan esteu molest o emocionat. Disminuiu el volum del t
     <message>
         <source>This visually represents the positional audio that is currently being played</source>
         <translation>Això mostra l&apos;àudio posicional que s&apos;està reproduïnt</translation>
+    </message>
+    <message>
+        <source>Next you need to choose the voice detection sensitivity. The aggressiveness level controls how strictly speech is detected. Lower levels are more permissive and will pick up quiet or distant speech, but may also trigger on background noise. Higher levels are more strict and will better filter out noise, but may cut off softer speech.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Voice activity detection aggressiveness level</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>This will set the aggressiveness in which Mumble will consider a signal speech. Increase value to make voice activation less sensitive.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>WebRTC GMM</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/src/mumble/mumble_cs.ts
+++ b/src/mumble/mumble_cs.ts
@@ -1239,6 +1239,30 @@ Tato hodnota Vám umožňuje nastavit maximální počet povolených uživatelů
         <source>&lt;b&gt;This shows peak outgoing bandwidth used.&lt;/b&gt;&lt;br /&gt;This shows the peak amount of bandwidth sent out from your machine. Audio bitrate is the maximum bitrate for the audio data alone. Position is the bitrate used for positional information. Overhead is our framing and the IP packet headers (IP and UDP is 75% of this overhead).</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Use WebRTC GMM based speech detection</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&lt;b&gt;This sets speech detection to use the WebRTC VAD algorithm.&lt;/b&gt;&lt;br /&gt;In this mode, a configuration-free Gaussian Mixture Model is used to detect speech.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>WebRTC GMM</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Aggressiveness</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Controls aggressiveness of WebRTC VAD</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Higher values make the VAD more aggressive in filtering noise.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AudioInputDialog</name>
@@ -2307,6 +2331,22 @@ Mluvte nahlas, jako kdybyste byli podráždění nebo nadšení. Snižujte hlasi
     </message>
     <message>
         <source>This visually represents the positional audio that is currently being played</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Next you need to choose the voice detection sensitivity. The aggressiveness level controls how strictly speech is detected. Lower levels are more permissive and will pick up quiet or distant speech, but may also trigger on background noise. Higher levels are more strict and will better filter out noise, but may cut off softer speech.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Voice activity detection aggressiveness level</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>This will set the aggressiveness in which Mumble will consider a signal speech. Increase value to make voice activation less sensitive.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>WebRTC GMM</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/mumble/mumble_cy.ts
+++ b/src/mumble/mumble_cy.ts
@@ -1232,6 +1232,30 @@ This value allows you to set the maximum number of users allowed in the channel.
         <source>&lt;b&gt;This shows peak outgoing bandwidth used.&lt;/b&gt;&lt;br /&gt;This shows the peak amount of bandwidth sent out from your machine. Audio bitrate is the maximum bitrate for the audio data alone. Position is the bitrate used for positional information. Overhead is our framing and the IP packet headers (IP and UDP is 75% of this overhead).</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Use WebRTC GMM based speech detection</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&lt;b&gt;This sets speech detection to use the WebRTC VAD algorithm.&lt;/b&gt;&lt;br /&gt;In this mode, a configuration-free Gaussian Mixture Model is used to detect speech.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>WebRTC GMM</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Aggressiveness</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Controls aggressiveness of WebRTC VAD</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Higher values make the VAD more aggressive in filtering noise.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AudioInputDialog</name>
@@ -2276,6 +2300,22 @@ Speak loudly, as when you are annoyed or excited. Decrease the volume in the sou
     </message>
     <message>
         <source>This visually represents the positional audio that is currently being played</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Next you need to choose the voice detection sensitivity. The aggressiveness level controls how strictly speech is detected. Lower levels are more permissive and will pick up quiet or distant speech, but may also trigger on background noise. Higher levels are more strict and will better filter out noise, but may cut off softer speech.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Voice activity detection aggressiveness level</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>This will set the aggressiveness in which Mumble will consider a signal speech. Increase value to make voice activation less sensitive.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>WebRTC GMM</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/mumble/mumble_da.ts
+++ b/src/mumble/mumble_da.ts
@@ -1239,6 +1239,30 @@ Denne værdi tillader dig at indstille det maksimale antal brugere tilladt på k
         <source>&lt;b&gt;This shows peak outgoing bandwidth used.&lt;/b&gt;&lt;br /&gt;This shows the peak amount of bandwidth sent out from your machine. Audio bitrate is the maximum bitrate for the audio data alone. Position is the bitrate used for positional information. Overhead is our framing and the IP packet headers (IP and UDP is 75% of this overhead).</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Use WebRTC GMM based speech detection</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&lt;b&gt;This sets speech detection to use the WebRTC VAD algorithm.&lt;/b&gt;&lt;br /&gt;In this mode, a configuration-free Gaussian Mixture Model is used to detect speech.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>WebRTC GMM</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Aggressiveness</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Controls aggressiveness of WebRTC VAD</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Higher values make the VAD more aggressive in filtering noise.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AudioInputDialog</name>
@@ -2307,6 +2331,22 @@ Tal højlydt som når du er irriteret og ophidset. Formindsk nu lydstyrken i lyd
     </message>
     <message>
         <source>This visually represents the positional audio that is currently being played</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Next you need to choose the voice detection sensitivity. The aggressiveness level controls how strictly speech is detected. Lower levels are more permissive and will pick up quiet or distant speech, but may also trigger on background noise. Higher levels are more strict and will better filter out noise, but may cut off softer speech.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Voice activity detection aggressiveness level</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>This will set the aggressiveness in which Mumble will consider a signal speech. Increase value to make voice activation less sensitive.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>WebRTC GMM</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/mumble/mumble_de.ts
+++ b/src/mumble/mumble_de.ts
@@ -1239,6 +1239,30 @@ Dieser Wert erlaubt das Einstellen der maximal im Kanal erlaubten Benutzeranzahl
         <source>&lt;b&gt;This shows peak outgoing bandwidth used.&lt;/b&gt;&lt;br /&gt;This shows the peak amount of bandwidth sent out from your machine. Audio bitrate is the maximum bitrate for the audio data alone. Position is the bitrate used for positional information. Overhead is our framing and the IP packet headers (IP and UDP is 75% of this overhead).</source>
         <translation>&lt;b&gt;Dies zeigt die maximale ausgehende Bandbreite an.&lt;/b&gt;&lt;br /&gt;Dies zeigt die maximale Bandbreite an, die von deinem Rechner gesendet wird. Audio-Bitrate ist die maximale Bitrate für die Audiodaten allein. Position ist die Bitrate, die für Positionsdaten verwendet wird. Overhead ist unser Framing und die IP-Paket-Header (IP und UDP machen 75% dieses Overheads aus).</translation>
     </message>
+    <message>
+        <source>Use WebRTC GMM based speech detection</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&lt;b&gt;This sets speech detection to use the WebRTC VAD algorithm.&lt;/b&gt;&lt;br /&gt;In this mode, a configuration-free Gaussian Mixture Model is used to detect speech.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>WebRTC GMM</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Aggressiveness</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Controls aggressiveness of WebRTC VAD</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Higher values make the VAD more aggressive in filtering noise.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AudioInputDialog</name>
@@ -2308,6 +2332,22 @@ Sprechen Sie so laut als wären Sie wütend oder aufgeregt. Verringern Sie die M
     <message>
         <source>This visually represents the positional audio that is currently being played</source>
         <translation>Das aktuelle Positionsaudiosignal wird visuell dargestellt</translation>
+    </message>
+    <message>
+        <source>Next you need to choose the voice detection sensitivity. The aggressiveness level controls how strictly speech is detected. Lower levels are more permissive and will pick up quiet or distant speech, but may also trigger on background noise. Higher levels are more strict and will better filter out noise, but may cut off softer speech.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Voice activity detection aggressiveness level</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>This will set the aggressiveness in which Mumble will consider a signal speech. Increase value to make voice activation less sensitive.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>WebRTC GMM</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/src/mumble/mumble_el.ts
+++ b/src/mumble/mumble_el.ts
@@ -1239,6 +1239,30 @@ This value allows you to set the maximum number of users allowed in the channel.
         <source>&lt;b&gt;This shows peak outgoing bandwidth used.&lt;/b&gt;&lt;br /&gt;This shows the peak amount of bandwidth sent out from your machine. Audio bitrate is the maximum bitrate for the audio data alone. Position is the bitrate used for positional information. Overhead is our framing and the IP packet headers (IP and UDP is 75% of this overhead).</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Use WebRTC GMM based speech detection</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&lt;b&gt;This sets speech detection to use the WebRTC VAD algorithm.&lt;/b&gt;&lt;br /&gt;In this mode, a configuration-free Gaussian Mixture Model is used to detect speech.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>WebRTC GMM</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Aggressiveness</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Controls aggressiveness of WebRTC VAD</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Higher values make the VAD more aggressive in filtering noise.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AudioInputDialog</name>
@@ -2307,6 +2331,22 @@ Speak loudly, as when you are annoyed or excited. Decrease the volume in the sou
     </message>
     <message>
         <source>This visually represents the positional audio that is currently being played</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Next you need to choose the voice detection sensitivity. The aggressiveness level controls how strictly speech is detected. Lower levels are more permissive and will pick up quiet or distant speech, but may also trigger on background noise. Higher levels are more strict and will better filter out noise, but may cut off softer speech.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Voice activity detection aggressiveness level</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>This will set the aggressiveness in which Mumble will consider a signal speech. Increase value to make voice activation less sensitive.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>WebRTC GMM</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/mumble/mumble_en.ts
+++ b/src/mumble/mumble_en.ts
@@ -1231,6 +1231,30 @@ This value allows you to set the maximum number of users allowed in the channel.
         <source>&lt;b&gt;This shows peak outgoing bandwidth used.&lt;/b&gt;&lt;br /&gt;This shows the peak amount of bandwidth sent out from your machine. Audio bitrate is the maximum bitrate for the audio data alone. Position is the bitrate used for positional information. Overhead is our framing and the IP packet headers (IP and UDP is 75% of this overhead).</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Use WebRTC GMM based speech detection</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&lt;b&gt;This sets speech detection to use the WebRTC VAD algorithm.&lt;/b&gt;&lt;br /&gt;In this mode, a configuration-free Gaussian Mixture Model is used to detect speech.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>WebRTC GMM</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Aggressiveness</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Controls aggressiveness of WebRTC VAD</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Higher values make the VAD more aggressive in filtering noise.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AudioInputDialog</name>
@@ -2275,6 +2299,22 @@ Speak loudly, as when you are annoyed or excited. Decrease the volume in the sou
     </message>
     <message>
         <source>This visually represents the positional audio that is currently being played</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Next you need to choose the voice detection sensitivity. The aggressiveness level controls how strictly speech is detected. Lower levels are more permissive and will pick up quiet or distant speech, but may also trigger on background noise. Higher levels are more strict and will better filter out noise, but may cut off softer speech.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Voice activity detection aggressiveness level</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>This will set the aggressiveness in which Mumble will consider a signal speech. Increase value to make voice activation less sensitive.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>WebRTC GMM</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/mumble/mumble_en_GB.ts
+++ b/src/mumble/mumble_en_GB.ts
@@ -1239,6 +1239,30 @@ This value allows you to set the maximum number of users allowed in the channel.
         <source>&lt;b&gt;This shows peak outgoing bandwidth used.&lt;/b&gt;&lt;br /&gt;This shows the peak amount of bandwidth sent out from your machine. Audio bitrate is the maximum bitrate for the audio data alone. Position is the bitrate used for positional information. Overhead is our framing and the IP packet headers (IP and UDP is 75% of this overhead).</source>
         <translation>&lt;b&gt;This shows the peak outgoing bandwidth used.&lt;/b&gt;&lt;br /&gt;This shows the peak bandwidth sent out from your machine. Audio bitrate is the maximum bitrate for the audio data alone. Position is the bitrate used for positional information. Overhead is our framing and the IP packet headers (IP and UDP are 75% of this overhead).</translation>
     </message>
+    <message>
+        <source>Use WebRTC GMM based speech detection</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&lt;b&gt;This sets speech detection to use the WebRTC VAD algorithm.&lt;/b&gt;&lt;br /&gt;In this mode, a configuration-free Gaussian Mixture Model is used to detect speech.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>WebRTC GMM</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Aggressiveness</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Controls aggressiveness of WebRTC VAD</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Higher values make the VAD more aggressive in filtering noise.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AudioInputDialog</name>
@@ -2308,6 +2332,22 @@ Speak loudly as if you are annoyed or excited. Decrease the volume in the sound 
     <message>
         <source>This visually represents the positional audio that is currently being played</source>
         <translation>This visually represents the positional audio that is currently being played</translation>
+    </message>
+    <message>
+        <source>Next you need to choose the voice detection sensitivity. The aggressiveness level controls how strictly speech is detected. Lower levels are more permissive and will pick up quiet or distant speech, but may also trigger on background noise. Higher levels are more strict and will better filter out noise, but may cut off softer speech.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Voice activity detection aggressiveness level</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>This will set the aggressiveness in which Mumble will consider a signal speech. Increase value to make voice activation less sensitive.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>WebRTC GMM</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/src/mumble/mumble_eo.ts
+++ b/src/mumble/mumble_eo.ts
@@ -1239,6 +1239,30 @@ This value allows you to set the maximum number of users allowed in the channel.
         <source>&lt;b&gt;This shows peak outgoing bandwidth used.&lt;/b&gt;&lt;br /&gt;This shows the peak amount of bandwidth sent out from your machine. Audio bitrate is the maximum bitrate for the audio data alone. Position is the bitrate used for positional information. Overhead is our framing and the IP packet headers (IP and UDP is 75% of this overhead).</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Use WebRTC GMM based speech detection</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&lt;b&gt;This sets speech detection to use the WebRTC VAD algorithm.&lt;/b&gt;&lt;br /&gt;In this mode, a configuration-free Gaussian Mixture Model is used to detect speech.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>WebRTC GMM</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Aggressiveness</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Controls aggressiveness of WebRTC VAD</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Higher values make the VAD more aggressive in filtering noise.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AudioInputDialog</name>
@@ -2283,6 +2307,22 @@ Speak loudly, as when you are annoyed or excited. Decrease the volume in the sou
     </message>
     <message>
         <source>This visually represents the positional audio that is currently being played</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Next you need to choose the voice detection sensitivity. The aggressiveness level controls how strictly speech is detected. Lower levels are more permissive and will pick up quiet or distant speech, but may also trigger on background noise. Higher levels are more strict and will better filter out noise, but may cut off softer speech.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Voice activity detection aggressiveness level</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>This will set the aggressiveness in which Mumble will consider a signal speech. Increase value to make voice activation less sensitive.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>WebRTC GMM</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/mumble/mumble_es.ts
+++ b/src/mumble/mumble_es.ts
@@ -1239,6 +1239,30 @@ Este valor permite fijar el número máximo de usuarios permitidos en el canal. 
         <source>&lt;b&gt;This shows peak outgoing bandwidth used.&lt;/b&gt;&lt;br /&gt;This shows the peak amount of bandwidth sent out from your machine. Audio bitrate is the maximum bitrate for the audio data alone. Position is the bitrate used for positional information. Overhead is our framing and the IP packet headers (IP and UDP is 75% of this overhead).</source>
         <translation>&lt;b&gt;Esto muestra el ancho de banda saliente maximo utilizado.&lt;/b&gt;&lt;br /&gt;Esto muestra la cantidad maxima de ancho de banda enviado desde su maquina. La tasa de bits de audio es la tasa de bits maxima solo para los datos de audio. La posicion es la tasa de bits utilizada para la informacion posicional. Los gastos generales son encabezados de los paquetes IP (IP y UPD representan el 75% de estos gastos generales).</translation>
     </message>
+    <message>
+        <source>Use WebRTC GMM based speech detection</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&lt;b&gt;This sets speech detection to use the WebRTC VAD algorithm.&lt;/b&gt;&lt;br /&gt;In this mode, a configuration-free Gaussian Mixture Model is used to detect speech.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>WebRTC GMM</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Aggressiveness</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Controls aggressiveness of WebRTC VAD</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Higher values make the VAD more aggressive in filtering noise.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AudioInputDialog</name>
@@ -2308,6 +2332,22 @@ Hable fuerte en voz alta, como cuando está molesto o entusiasmado. Baje el volu
     <message>
         <source>This visually represents the positional audio that is currently being played</source>
         <translation>Representa visualmente el audio posicional que se está reproduciendo</translation>
+    </message>
+    <message>
+        <source>Next you need to choose the voice detection sensitivity. The aggressiveness level controls how strictly speech is detected. Lower levels are more permissive and will pick up quiet or distant speech, but may also trigger on background noise. Higher levels are more strict and will better filter out noise, but may cut off softer speech.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Voice activity detection aggressiveness level</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>This will set the aggressiveness in which Mumble will consider a signal speech. Increase value to make voice activation less sensitive.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>WebRTC GMM</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/src/mumble/mumble_et.ts
+++ b/src/mumble/mumble_et.ts
@@ -1232,6 +1232,30 @@ This value allows you to set the maximum number of users allowed in the channel.
         <source>&lt;b&gt;This shows peak outgoing bandwidth used.&lt;/b&gt;&lt;br /&gt;This shows the peak amount of bandwidth sent out from your machine. Audio bitrate is the maximum bitrate for the audio data alone. Position is the bitrate used for positional information. Overhead is our framing and the IP packet headers (IP and UDP is 75% of this overhead).</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Use WebRTC GMM based speech detection</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&lt;b&gt;This sets speech detection to use the WebRTC VAD algorithm.&lt;/b&gt;&lt;br /&gt;In this mode, a configuration-free Gaussian Mixture Model is used to detect speech.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>WebRTC GMM</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Aggressiveness</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Controls aggressiveness of WebRTC VAD</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Higher values make the VAD more aggressive in filtering noise.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AudioInputDialog</name>
@@ -2276,6 +2300,22 @@ Speak loudly, as when you are annoyed or excited. Decrease the volume in the sou
     </message>
     <message>
         <source>This visually represents the positional audio that is currently being played</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Next you need to choose the voice detection sensitivity. The aggressiveness level controls how strictly speech is detected. Lower levels are more permissive and will pick up quiet or distant speech, but may also trigger on background noise. Higher levels are more strict and will better filter out noise, but may cut off softer speech.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Voice activity detection aggressiveness level</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>This will set the aggressiveness in which Mumble will consider a signal speech. Increase value to make voice activation less sensitive.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>WebRTC GMM</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/mumble/mumble_eu.ts
+++ b/src/mumble/mumble_eu.ts
@@ -1241,6 +1241,30 @@ This value allows you to set the maximum number of users allowed in the channel.
         <source>&lt;b&gt;This shows peak outgoing bandwidth used.&lt;/b&gt;&lt;br /&gt;This shows the peak amount of bandwidth sent out from your machine. Audio bitrate is the maximum bitrate for the audio data alone. Position is the bitrate used for positional information. Overhead is our framing and the IP packet headers (IP and UDP is 75% of this overhead).</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Use WebRTC GMM based speech detection</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&lt;b&gt;This sets speech detection to use the WebRTC VAD algorithm.&lt;/b&gt;&lt;br /&gt;In this mode, a configuration-free Gaussian Mixture Model is used to detect speech.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>WebRTC GMM</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Aggressiveness</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Controls aggressiveness of WebRTC VAD</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Higher values make the VAD more aggressive in filtering noise.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AudioInputDialog</name>
@@ -2285,6 +2309,22 @@ Speak loudly, as when you are annoyed or excited. Decrease the volume in the sou
     </message>
     <message>
         <source>This visually represents the positional audio that is currently being played</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Next you need to choose the voice detection sensitivity. The aggressiveness level controls how strictly speech is detected. Lower levels are more permissive and will pick up quiet or distant speech, but may also trigger on background noise. Higher levels are more strict and will better filter out noise, but may cut off softer speech.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Voice activity detection aggressiveness level</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>This will set the aggressiveness in which Mumble will consider a signal speech. Increase value to make voice activation less sensitive.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>WebRTC GMM</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/mumble/mumble_fa_IR.ts
+++ b/src/mumble/mumble_fa_IR.ts
@@ -1233,6 +1233,30 @@ This value allows you to set the maximum number of users allowed in the channel.
         <source>&lt;b&gt;This shows peak outgoing bandwidth used.&lt;/b&gt;&lt;br /&gt;This shows the peak amount of bandwidth sent out from your machine. Audio bitrate is the maximum bitrate for the audio data alone. Position is the bitrate used for positional information. Overhead is our framing and the IP packet headers (IP and UDP is 75% of this overhead).</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Use WebRTC GMM based speech detection</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&lt;b&gt;This sets speech detection to use the WebRTC VAD algorithm.&lt;/b&gt;&lt;br /&gt;In this mode, a configuration-free Gaussian Mixture Model is used to detect speech.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>WebRTC GMM</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Aggressiveness</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Controls aggressiveness of WebRTC VAD</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Higher values make the VAD more aggressive in filtering noise.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AudioInputDialog</name>
@@ -2277,6 +2301,22 @@ Speak loudly, as when you are annoyed or excited. Decrease the volume in the sou
     </message>
     <message>
         <source>This visually represents the positional audio that is currently being played</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Next you need to choose the voice detection sensitivity. The aggressiveness level controls how strictly speech is detected. Lower levels are more permissive and will pick up quiet or distant speech, but may also trigger on background noise. Higher levels are more strict and will better filter out noise, but may cut off softer speech.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Voice activity detection aggressiveness level</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>This will set the aggressiveness in which Mumble will consider a signal speech. Increase value to make voice activation less sensitive.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>WebRTC GMM</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/mumble/mumble_fi.ts
+++ b/src/mumble/mumble_fi.ts
@@ -1239,6 +1239,30 @@ Tämän numeron ollessa suurempi kuin nolla kanava sallii enintään numeron suu
         <source>&lt;b&gt;This shows peak outgoing bandwidth used.&lt;/b&gt;&lt;br /&gt;This shows the peak amount of bandwidth sent out from your machine. Audio bitrate is the maximum bitrate for the audio data alone. Position is the bitrate used for positional information. Overhead is our framing and the IP packet headers (IP and UDP is 75% of this overhead).</source>
         <translation>&lt;b&gt;Tämä osoittaa yleisimmin käytettyä kaistanleveyttä.&lt;/b&gt; &lt;br /&gt;Tämä osoittaa, kuinka paljon kaistanleveyttä lähetetään pois koneesta. Audio bitrate on suurin biraatti vain äänidatalle. Sijainti on biraatti, jota käytetään positiaalitietoihin. Yläpuolella on kehys ja IP-pakkausotsikot (IP ja UDP ovat 75 % tästä).</translation>
     </message>
+    <message>
+        <source>Use WebRTC GMM based speech detection</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&lt;b&gt;This sets speech detection to use the WebRTC VAD algorithm.&lt;/b&gt;&lt;br /&gt;In this mode, a configuration-free Gaussian Mixture Model is used to detect speech.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>WebRTC GMM</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Aggressiveness</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Controls aggressiveness of WebRTC VAD</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Higher values make the VAD more aggressive in filtering noise.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AudioInputDialog</name>
@@ -2308,6 +2332,22 @@ Puhu kovalla äänellä, aivan kuin olisit ärsyyntynyt tai kiihtynyt. Vähennä
     <message>
         <source>This visually represents the positional audio that is currently being played</source>
         <translation>Tämä esittää visuaalisesti sijainninmukaisen äänen joka nyt kuuluu</translation>
+    </message>
+    <message>
+        <source>Next you need to choose the voice detection sensitivity. The aggressiveness level controls how strictly speech is detected. Lower levels are more permissive and will pick up quiet or distant speech, but may also trigger on background noise. Higher levels are more strict and will better filter out noise, but may cut off softer speech.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Voice activity detection aggressiveness level</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>This will set the aggressiveness in which Mumble will consider a signal speech. Increase value to make voice activation less sensitive.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>WebRTC GMM</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/src/mumble/mumble_fr.ts
+++ b/src/mumble/mumble_fr.ts
@@ -1239,6 +1239,30 @@ Cette valeur vous permet de définir un nombre maximum d&apos;utilisateurs autor
         <source>&lt;b&gt;This shows peak outgoing bandwidth used.&lt;/b&gt;&lt;br /&gt;This shows the peak amount of bandwidth sent out from your machine. Audio bitrate is the maximum bitrate for the audio data alone. Position is the bitrate used for positional information. Overhead is our framing and the IP packet headers (IP and UDP is 75% of this overhead).</source>
         <translation>&lt;b&gt;Ceci montre le débit sortant maximal utilisé.&lt;/b&gt;&lt;br /&gt;Ceci montre le débit maximal envoyé depuis votre machine. Le débit audio est le débit maximal pour les données audio seules. La position est le débit utilisé pour les informations de position. La surcharge correspond à la trame et aux en-têtes de paquets IP (IP et UDP représentent 75 % de cette surcharge).</translation>
     </message>
+    <message>
+        <source>Use WebRTC GMM based speech detection</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&lt;b&gt;This sets speech detection to use the WebRTC VAD algorithm.&lt;/b&gt;&lt;br /&gt;In this mode, a configuration-free Gaussian Mixture Model is used to detect speech.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>WebRTC GMM</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Aggressiveness</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Controls aggressiveness of WebRTC VAD</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Higher values make the VAD more aggressive in filtering noise.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AudioInputDialog</name>
@@ -2308,6 +2332,22 @@ Parlez fort, comme lorsque vous êtes irrité ou excité. Diminuez le volume dan
     <message>
         <source>This visually represents the positional audio that is currently being played</source>
         <translation>Cela représente visuellement l&apos;audio positionnel qui est actuellement joué</translation>
+    </message>
+    <message>
+        <source>Next you need to choose the voice detection sensitivity. The aggressiveness level controls how strictly speech is detected. Lower levels are more permissive and will pick up quiet or distant speech, but may also trigger on background noise. Higher levels are more strict and will better filter out noise, but may cut off softer speech.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Voice activity detection aggressiveness level</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>This will set the aggressiveness in which Mumble will consider a signal speech. Increase value to make voice activation less sensitive.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>WebRTC GMM</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/src/mumble/mumble_gl.ts
+++ b/src/mumble/mumble_gl.ts
@@ -1233,6 +1233,30 @@ This value allows you to set the maximum number of users allowed in the channel.
         <source>&lt;b&gt;This shows peak outgoing bandwidth used.&lt;/b&gt;&lt;br /&gt;This shows the peak amount of bandwidth sent out from your machine. Audio bitrate is the maximum bitrate for the audio data alone. Position is the bitrate used for positional information. Overhead is our framing and the IP packet headers (IP and UDP is 75% of this overhead).</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Use WebRTC GMM based speech detection</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&lt;b&gt;This sets speech detection to use the WebRTC VAD algorithm.&lt;/b&gt;&lt;br /&gt;In this mode, a configuration-free Gaussian Mixture Model is used to detect speech.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>WebRTC GMM</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Aggressiveness</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Controls aggressiveness of WebRTC VAD</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Higher values make the VAD more aggressive in filtering noise.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AudioInputDialog</name>
@@ -2277,6 +2301,22 @@ Speak loudly, as when you are annoyed or excited. Decrease the volume in the sou
     </message>
     <message>
         <source>This visually represents the positional audio that is currently being played</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Next you need to choose the voice detection sensitivity. The aggressiveness level controls how strictly speech is detected. Lower levels are more permissive and will pick up quiet or distant speech, but may also trigger on background noise. Higher levels are more strict and will better filter out noise, but may cut off softer speech.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Voice activity detection aggressiveness level</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>This will set the aggressiveness in which Mumble will consider a signal speech. Increase value to make voice activation less sensitive.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>WebRTC GMM</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/mumble/mumble_he.ts
+++ b/src/mumble/mumble_he.ts
@@ -1240,6 +1240,30 @@ This value allows you to set the maximum number of users allowed in the channel.
         <source>&lt;b&gt;This shows peak outgoing bandwidth used.&lt;/b&gt;&lt;br /&gt;This shows the peak amount of bandwidth sent out from your machine. Audio bitrate is the maximum bitrate for the audio data alone. Position is the bitrate used for positional information. Overhead is our framing and the IP packet headers (IP and UDP is 75% of this overhead).</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Use WebRTC GMM based speech detection</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&lt;b&gt;This sets speech detection to use the WebRTC VAD algorithm.&lt;/b&gt;&lt;br /&gt;In this mode, a configuration-free Gaussian Mixture Model is used to detect speech.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>WebRTC GMM</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Aggressiveness</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Controls aggressiveness of WebRTC VAD</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Higher values make the VAD more aggressive in filtering noise.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AudioInputDialog</name>
@@ -2305,6 +2329,22 @@ Speak loudly, as when you are annoyed or excited. Decrease the volume in the sou
     </message>
     <message>
         <source>This visually represents the positional audio that is currently being played</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Next you need to choose the voice detection sensitivity. The aggressiveness level controls how strictly speech is detected. Lower levels are more permissive and will pick up quiet or distant speech, but may also trigger on background noise. Higher levels are more strict and will better filter out noise, but may cut off softer speech.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Voice activity detection aggressiveness level</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>This will set the aggressiveness in which Mumble will consider a signal speech. Increase value to make voice activation less sensitive.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>WebRTC GMM</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/mumble/mumble_hi.ts
+++ b/src/mumble/mumble_hi.ts
@@ -1232,6 +1232,30 @@ Contains the list of members inherited by the current channel. Uncheck &lt;i&gt;
         <source>&lt;b&gt;This shows peak outgoing bandwidth used.&lt;/b&gt;&lt;br /&gt;This shows the peak amount of bandwidth sent out from your machine. Audio bitrate is the maximum bitrate for the audio data alone. Position is the bitrate used for positional information. Overhead is our framing and the IP packet headers (IP and UDP is 75% of this overhead).</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Use WebRTC GMM based speech detection</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&lt;b&gt;This sets speech detection to use the WebRTC VAD algorithm.&lt;/b&gt;&lt;br /&gt;In this mode, a configuration-free Gaussian Mixture Model is used to detect speech.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>WebRTC GMM</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Aggressiveness</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Controls aggressiveness of WebRTC VAD</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Higher values make the VAD more aggressive in filtering noise.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AudioInputDialog</name>
@@ -2263,6 +2287,22 @@ Mumble is under continuous development, and the development team wants to focus 
     </message>
     <message>
         <source>This visually represents the positional audio that is currently being played</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Next you need to choose the voice detection sensitivity. The aggressiveness level controls how strictly speech is detected. Lower levels are more permissive and will pick up quiet or distant speech, but may also trigger on background noise. Higher levels are more strict and will better filter out noise, but may cut off softer speech.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Voice activity detection aggressiveness level</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>This will set the aggressiveness in which Mumble will consider a signal speech. Increase value to make voice activation less sensitive.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>WebRTC GMM</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/mumble/mumble_hu.ts
+++ b/src/mumble/mumble_hu.ts
@@ -1235,6 +1235,30 @@ This value allows you to set the maximum number of users allowed in the channel.
         <source>&lt;b&gt;This shows peak outgoing bandwidth used.&lt;/b&gt;&lt;br /&gt;This shows the peak amount of bandwidth sent out from your machine. Audio bitrate is the maximum bitrate for the audio data alone. Position is the bitrate used for positional information. Overhead is our framing and the IP packet headers (IP and UDP is 75% of this overhead).</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Use WebRTC GMM based speech detection</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&lt;b&gt;This sets speech detection to use the WebRTC VAD algorithm.&lt;/b&gt;&lt;br /&gt;In this mode, a configuration-free Gaussian Mixture Model is used to detect speech.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>WebRTC GMM</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Aggressiveness</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Controls aggressiveness of WebRTC VAD</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Higher values make the VAD more aggressive in filtering noise.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AudioInputDialog</name>
@@ -2297,6 +2321,22 @@ Speak loudly, as when you are annoyed or excited. Decrease the volume in the sou
     </message>
     <message>
         <source>This visually represents the positional audio that is currently being played</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Next you need to choose the voice detection sensitivity. The aggressiveness level controls how strictly speech is detected. Lower levels are more permissive and will pick up quiet or distant speech, but may also trigger on background noise. Higher levels are more strict and will better filter out noise, but may cut off softer speech.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Voice activity detection aggressiveness level</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>This will set the aggressiveness in which Mumble will consider a signal speech. Increase value to make voice activation less sensitive.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>WebRTC GMM</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/mumble/mumble_it.ts
+++ b/src/mumble/mumble_it.ts
@@ -1239,6 +1239,30 @@ Questo valore ti permette di impostare il numero massimo di utenti consentiti ne
         <source>&lt;b&gt;This shows peak outgoing bandwidth used.&lt;/b&gt;&lt;br /&gt;This shows the peak amount of bandwidth sent out from your machine. Audio bitrate is the maximum bitrate for the audio data alone. Position is the bitrate used for positional information. Overhead is our framing and the IP packet headers (IP and UDP is 75% of this overhead).</source>
         <translation>&lt;b&gt;Questo mostra il picco di banda utilizzata in uscita.&lt;/b&gt;&lt;br /&gt;Questo mostra il picco di banda in uscita dalla tua macchina. Il bitrate audio è il massimo bitrate solamente relativo ai dati audio. &quot;Posizione&quot; indica il bitrate usato per le informazioni posizionali. L&apos;overhead è costituito dall&apos;incapsulamento e dalle intestazioni IP dei pacchetti (IP e UDP rappresentano il 75% di questo overhead).</translation>
     </message>
+    <message>
+        <source>Use WebRTC GMM based speech detection</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&lt;b&gt;This sets speech detection to use the WebRTC VAD algorithm.&lt;/b&gt;&lt;br /&gt;In this mode, a configuration-free Gaussian Mixture Model is used to detect speech.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>WebRTC GMM</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Aggressiveness</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Controls aggressiveness of WebRTC VAD</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Higher values make the VAD more aggressive in filtering noise.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AudioInputDialog</name>
@@ -2308,6 +2332,22 @@ Parla ad alta voce, come quando sei infastidito o eccitato. Poi diminuisci il vo
     <message>
         <source>This visually represents the positional audio that is currently being played</source>
         <translation>Rappresenta la posizione dell&apos;audio che è in riproduzione al momento</translation>
+    </message>
+    <message>
+        <source>Next you need to choose the voice detection sensitivity. The aggressiveness level controls how strictly speech is detected. Lower levels are more permissive and will pick up quiet or distant speech, but may also trigger on background noise. Higher levels are more strict and will better filter out noise, but may cut off softer speech.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Voice activity detection aggressiveness level</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>This will set the aggressiveness in which Mumble will consider a signal speech. Increase value to make voice activation less sensitive.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>WebRTC GMM</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/src/mumble/mumble_ja.ts
+++ b/src/mumble/mumble_ja.ts
@@ -1240,6 +1240,30 @@ This value allows you to set the maximum number of users allowed in the channel.
         <source>&lt;b&gt;This shows peak outgoing bandwidth used.&lt;/b&gt;&lt;br /&gt;This shows the peak amount of bandwidth sent out from your machine. Audio bitrate is the maximum bitrate for the audio data alone. Position is the bitrate used for positional information. Overhead is our framing and the IP packet headers (IP and UDP is 75% of this overhead).</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Use WebRTC GMM based speech detection</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&lt;b&gt;This sets speech detection to use the WebRTC VAD algorithm.&lt;/b&gt;&lt;br /&gt;In this mode, a configuration-free Gaussian Mixture Model is used to detect speech.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>WebRTC GMM</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Aggressiveness</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Controls aggressiveness of WebRTC VAD</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Higher values make the VAD more aggressive in filtering noise.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AudioInputDialog</name>
@@ -2304,6 +2328,22 @@ Speak loudly, as when you are annoyed or excited. Decrease the volume in the sou
     </message>
     <message>
         <source>This visually represents the positional audio that is currently being played</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Next you need to choose the voice detection sensitivity. The aggressiveness level controls how strictly speech is detected. Lower levels are more permissive and will pick up quiet or distant speech, but may also trigger on background noise. Higher levels are more strict and will better filter out noise, but may cut off softer speech.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Voice activity detection aggressiveness level</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>This will set the aggressiveness in which Mumble will consider a signal speech. Increase value to make voice activation less sensitive.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>WebRTC GMM</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/mumble/mumble_ko.ts
+++ b/src/mumble/mumble_ko.ts
@@ -1239,6 +1239,30 @@ This value allows you to set the maximum number of users allowed in the channel.
         <source>&lt;b&gt;This shows peak outgoing bandwidth used.&lt;/b&gt;&lt;br /&gt;This shows the peak amount of bandwidth sent out from your machine. Audio bitrate is the maximum bitrate for the audio data alone. Position is the bitrate used for positional information. Overhead is our framing and the IP packet headers (IP and UDP is 75% of this overhead).</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Use WebRTC GMM based speech detection</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&lt;b&gt;This sets speech detection to use the WebRTC VAD algorithm.&lt;/b&gt;&lt;br /&gt;In this mode, a configuration-free Gaussian Mixture Model is used to detect speech.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>WebRTC GMM</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Aggressiveness</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Controls aggressiveness of WebRTC VAD</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Higher values make the VAD more aggressive in filtering noise.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AudioInputDialog</name>
@@ -2307,6 +2331,22 @@ Speak loudly, as when you are annoyed or excited. Decrease the volume in the sou
     </message>
     <message>
         <source>This visually represents the positional audio that is currently being played</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Next you need to choose the voice detection sensitivity. The aggressiveness level controls how strictly speech is detected. Lower levels are more permissive and will pick up quiet or distant speech, but may also trigger on background noise. Higher levels are more strict and will better filter out noise, but may cut off softer speech.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Voice activity detection aggressiveness level</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>This will set the aggressiveness in which Mumble will consider a signal speech. Increase value to make voice activation less sensitive.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>WebRTC GMM</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/mumble/mumble_lt.ts
+++ b/src/mumble/mumble_lt.ts
@@ -1235,6 +1235,30 @@ This value allows you to set the maximum number of users allowed in the channel.
         <source>&lt;b&gt;This shows peak outgoing bandwidth used.&lt;/b&gt;&lt;br /&gt;This shows the peak amount of bandwidth sent out from your machine. Audio bitrate is the maximum bitrate for the audio data alone. Position is the bitrate used for positional information. Overhead is our framing and the IP packet headers (IP and UDP is 75% of this overhead).</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Use WebRTC GMM based speech detection</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&lt;b&gt;This sets speech detection to use the WebRTC VAD algorithm.&lt;/b&gt;&lt;br /&gt;In this mode, a configuration-free Gaussian Mixture Model is used to detect speech.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>WebRTC GMM</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Aggressiveness</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Controls aggressiveness of WebRTC VAD</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Higher values make the VAD more aggressive in filtering noise.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AudioInputDialog</name>
@@ -2297,6 +2321,22 @@ Speak loudly, as when you are annoyed or excited. Decrease the volume in the sou
     </message>
     <message>
         <source>This visually represents the positional audio that is currently being played</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Next you need to choose the voice detection sensitivity. The aggressiveness level controls how strictly speech is detected. Lower levels are more permissive and will pick up quiet or distant speech, but may also trigger on background noise. Higher levels are more strict and will better filter out noise, but may cut off softer speech.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Voice activity detection aggressiveness level</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>This will set the aggressiveness in which Mumble will consider a signal speech. Increase value to make voice activation less sensitive.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>WebRTC GMM</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/mumble/mumble_nl.ts
+++ b/src/mumble/mumble_nl.ts
@@ -1239,6 +1239,30 @@ Deze waarde laat je toe om een maximum aantal gebruikers in te stellen voor het 
         <source>&lt;b&gt;This shows peak outgoing bandwidth used.&lt;/b&gt;&lt;br /&gt;This shows the peak amount of bandwidth sent out from your machine. Audio bitrate is the maximum bitrate for the audio data alone. Position is the bitrate used for positional information. Overhead is our framing and the IP packet headers (IP and UDP is 75% of this overhead).</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Use WebRTC GMM based speech detection</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&lt;b&gt;This sets speech detection to use the WebRTC VAD algorithm.&lt;/b&gt;&lt;br /&gt;In this mode, a configuration-free Gaussian Mixture Model is used to detect speech.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>WebRTC GMM</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Aggressiveness</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Controls aggressiveness of WebRTC VAD</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Higher values make the VAD more aggressive in filtering noise.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AudioInputDialog</name>
@@ -2307,6 +2331,22 @@ Spreek vervolgens luid, zoals je zou spreken als je geïrriteerd of opgewonden b
     </message>
     <message>
         <source>This visually represents the positional audio that is currently being played</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Next you need to choose the voice detection sensitivity. The aggressiveness level controls how strictly speech is detected. Lower levels are more permissive and will pick up quiet or distant speech, but may also trigger on background noise. Higher levels are more strict and will better filter out noise, but may cut off softer speech.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Voice activity detection aggressiveness level</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>This will set the aggressiveness in which Mumble will consider a signal speech. Increase value to make voice activation less sensitive.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>WebRTC GMM</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/mumble/mumble_no.ts
+++ b/src/mumble/mumble_no.ts
@@ -1239,6 +1239,30 @@ Denne verdien gjør at du setter maksimalt antall brukere tillatt i kanalen. Hvi
         <source>&lt;b&gt;This shows peak outgoing bandwidth used.&lt;/b&gt;&lt;br /&gt;This shows the peak amount of bandwidth sent out from your machine. Audio bitrate is the maximum bitrate for the audio data alone. Position is the bitrate used for positional information. Overhead is our framing and the IP packet headers (IP and UDP is 75% of this overhead).</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Use WebRTC GMM based speech detection</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&lt;b&gt;This sets speech detection to use the WebRTC VAD algorithm.&lt;/b&gt;&lt;br /&gt;In this mode, a configuration-free Gaussian Mixture Model is used to detect speech.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>WebRTC GMM</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Aggressiveness</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Controls aggressiveness of WebRTC VAD</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Higher values make the VAD more aggressive in filtering noise.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AudioInputDialog</name>
@@ -2321,6 +2345,22 @@ Ingen snakking. Krysset (Definitivt ikke tale)</translation>
     </message>
     <message>
         <source>This visually represents the positional audio that is currently being played</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Next you need to choose the voice detection sensitivity. The aggressiveness level controls how strictly speech is detected. Lower levels are more permissive and will pick up quiet or distant speech, but may also trigger on background noise. Higher levels are more strict and will better filter out noise, but may cut off softer speech.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Voice activity detection aggressiveness level</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>This will set the aggressiveness in which Mumble will consider a signal speech. Increase value to make voice activation less sensitive.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>WebRTC GMM</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/mumble/mumble_oc.ts
+++ b/src/mumble/mumble_oc.ts
@@ -1232,6 +1232,30 @@ This value allows you to set the maximum number of users allowed in the channel.
         <source>&lt;b&gt;This shows peak outgoing bandwidth used.&lt;/b&gt;&lt;br /&gt;This shows the peak amount of bandwidth sent out from your machine. Audio bitrate is the maximum bitrate for the audio data alone. Position is the bitrate used for positional information. Overhead is our framing and the IP packet headers (IP and UDP is 75% of this overhead).</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Use WebRTC GMM based speech detection</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&lt;b&gt;This sets speech detection to use the WebRTC VAD algorithm.&lt;/b&gt;&lt;br /&gt;In this mode, a configuration-free Gaussian Mixture Model is used to detect speech.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>WebRTC GMM</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Aggressiveness</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Controls aggressiveness of WebRTC VAD</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Higher values make the VAD more aggressive in filtering noise.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AudioInputDialog</name>
@@ -2276,6 +2300,22 @@ Speak loudly, as when you are annoyed or excited. Decrease the volume in the sou
     </message>
     <message>
         <source>This visually represents the positional audio that is currently being played</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Next you need to choose the voice detection sensitivity. The aggressiveness level controls how strictly speech is detected. Lower levels are more permissive and will pick up quiet or distant speech, but may also trigger on background noise. Higher levels are more strict and will better filter out noise, but may cut off softer speech.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Voice activity detection aggressiveness level</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>This will set the aggressiveness in which Mumble will consider a signal speech. Increase value to make voice activation less sensitive.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>WebRTC GMM</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/mumble/mumble_pl.ts
+++ b/src/mumble/mumble_pl.ts
@@ -1239,6 +1239,30 @@ Określa maksymalną dozwoloną liczbę użytkowników na tym kanale. Jeżeli wa
         <source>&lt;b&gt;This shows peak outgoing bandwidth used.&lt;/b&gt;&lt;br /&gt;This shows the peak amount of bandwidth sent out from your machine. Audio bitrate is the maximum bitrate for the audio data alone. Position is the bitrate used for positional information. Overhead is our framing and the IP packet headers (IP and UDP is 75% of this overhead).</source>
         <translation>&lt;b&gt;Pokazuje szczytowe wykorzystanie przepustowości wychodzącej.&lt;/b&gt;&lt;br /&gt;Pokazuje szczytową wielkość przepustowości wysyłanej z komputera. Szybkość transmisji audio to maksymalna szybkość transmisji samych danych audio. Pozycja to szybkość transmisji używana dla informacji o położeniu. Narzutem jest ramkowanie i nagłówki pakietów IP (IP i UDP stanowią 75% tego narzutu).</translation>
     </message>
+    <message>
+        <source>Use WebRTC GMM based speech detection</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&lt;b&gt;This sets speech detection to use the WebRTC VAD algorithm.&lt;/b&gt;&lt;br /&gt;In this mode, a configuration-free Gaussian Mixture Model is used to detect speech.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>WebRTC GMM</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Aggressiveness</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Controls aggressiveness of WebRTC VAD</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Higher values make the VAD more aggressive in filtering noise.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AudioInputDialog</name>
@@ -2308,6 +2332,22 @@ Mów głośno, tak jakbyś był wkurzony lub podekscytowany. Zmniejsz głośnoś
     <message>
         <source>This visually represents the positional audio that is currently being played</source>
         <translation>Wizualnie przedstawia to dźwięk pozycyjny, który jest aktualnie odtwarzany</translation>
+    </message>
+    <message>
+        <source>Next you need to choose the voice detection sensitivity. The aggressiveness level controls how strictly speech is detected. Lower levels are more permissive and will pick up quiet or distant speech, but may also trigger on background noise. Higher levels are more strict and will better filter out noise, but may cut off softer speech.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Voice activity detection aggressiveness level</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>This will set the aggressiveness in which Mumble will consider a signal speech. Increase value to make voice activation less sensitive.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>WebRTC GMM</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/src/mumble/mumble_pt_BR.ts
+++ b/src/mumble/mumble_pt_BR.ts
@@ -1239,6 +1239,30 @@ Este valor permite que você especifique o número máximo de usuários permitid
         <source>&lt;b&gt;This shows peak outgoing bandwidth used.&lt;/b&gt;&lt;br /&gt;This shows the peak amount of bandwidth sent out from your machine. Audio bitrate is the maximum bitrate for the audio data alone. Position is the bitrate used for positional information. Overhead is our framing and the IP packet headers (IP and UDP is 75% of this overhead).</source>
         <translation>&lt;b&gt;Exibe o pico de uso de largura de banda de saída.&lt;/b&gt;&lt;br /&gt;Exibe a quantidade máxima de largura de banda enviada do seu dispositivo. A taxa de bits de áudio representa o valor máximo somente para os dados de áudio. Posição é a taxa de bits utilizada para informações de posição. Sobrecarga é o nosso enquadramento e cabeçalhos de pacotes de IP (IP e UDP representam 75% dessa sobrecarga).</translation>
     </message>
+    <message>
+        <source>Use WebRTC GMM based speech detection</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&lt;b&gt;This sets speech detection to use the WebRTC VAD algorithm.&lt;/b&gt;&lt;br /&gt;In this mode, a configuration-free Gaussian Mixture Model is used to detect speech.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>WebRTC GMM</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Aggressiveness</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Controls aggressiveness of WebRTC VAD</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Higher values make the VAD more aggressive in filtering noise.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AudioInputDialog</name>
@@ -2308,6 +2332,22 @@ Fale alto, como quando você está incomodado ou animado. Diminua o volume no pa
     <message>
         <source>This visually represents the positional audio that is currently being played</source>
         <translation>Representa visualmente o áudio posicional que está sendo reproduzido no momento</translation>
+    </message>
+    <message>
+        <source>Next you need to choose the voice detection sensitivity. The aggressiveness level controls how strictly speech is detected. Lower levels are more permissive and will pick up quiet or distant speech, but may also trigger on background noise. Higher levels are more strict and will better filter out noise, but may cut off softer speech.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Voice activity detection aggressiveness level</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>This will set the aggressiveness in which Mumble will consider a signal speech. Increase value to make voice activation less sensitive.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>WebRTC GMM</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/src/mumble/mumble_pt_PT.ts
+++ b/src/mumble/mumble_pt_PT.ts
@@ -1239,6 +1239,30 @@ Este valor permite definir o número máximo de utilizadores permitido no canal.
         <source>&lt;b&gt;This shows peak outgoing bandwidth used.&lt;/b&gt;&lt;br /&gt;This shows the peak amount of bandwidth sent out from your machine. Audio bitrate is the maximum bitrate for the audio data alone. Position is the bitrate used for positional information. Overhead is our framing and the IP packet headers (IP and UDP is 75% of this overhead).</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Use WebRTC GMM based speech detection</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&lt;b&gt;This sets speech detection to use the WebRTC VAD algorithm.&lt;/b&gt;&lt;br /&gt;In this mode, a configuration-free Gaussian Mixture Model is used to detect speech.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>WebRTC GMM</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Aggressiveness</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Controls aggressiveness of WebRTC VAD</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Higher values make the VAD more aggressive in filtering noise.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AudioInputDialog</name>
@@ -2307,6 +2331,22 @@ Fale alto, como quando está incomodado ou animado. Diminua o volume no painel d
     </message>
     <message>
         <source>This visually represents the positional audio that is currently being played</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Next you need to choose the voice detection sensitivity. The aggressiveness level controls how strictly speech is detected. Lower levels are more permissive and will pick up quiet or distant speech, but may also trigger on background noise. Higher levels are more strict and will better filter out noise, but may cut off softer speech.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Voice activity detection aggressiveness level</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>This will set the aggressiveness in which Mumble will consider a signal speech. Increase value to make voice activation less sensitive.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>WebRTC GMM</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/mumble/mumble_ro.ts
+++ b/src/mumble/mumble_ro.ts
@@ -1239,6 +1239,30 @@ Această valoare vă permite să setați numărul maxim de utilizatori permis î
         <source>&lt;b&gt;This shows peak outgoing bandwidth used.&lt;/b&gt;&lt;br /&gt;This shows the peak amount of bandwidth sent out from your machine. Audio bitrate is the maximum bitrate for the audio data alone. Position is the bitrate used for positional information. Overhead is our framing and the IP packet headers (IP and UDP is 75% of this overhead).</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Use WebRTC GMM based speech detection</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&lt;b&gt;This sets speech detection to use the WebRTC VAD algorithm.&lt;/b&gt;&lt;br /&gt;In this mode, a configuration-free Gaussian Mixture Model is used to detect speech.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>WebRTC GMM</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Aggressiveness</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Controls aggressiveness of WebRTC VAD</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Higher values make the VAD more aggressive in filtering noise.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AudioInputDialog</name>
@@ -2283,6 +2307,22 @@ Speak loudly, as when you are annoyed or excited. Decrease the volume in the sou
     </message>
     <message>
         <source>This visually represents the positional audio that is currently being played</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Next you need to choose the voice detection sensitivity. The aggressiveness level controls how strictly speech is detected. Lower levels are more permissive and will pick up quiet or distant speech, but may also trigger on background noise. Higher levels are more strict and will better filter out noise, but may cut off softer speech.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Voice activity detection aggressiveness level</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>This will set the aggressiveness in which Mumble will consider a signal speech. Increase value to make voice activation less sensitive.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>WebRTC GMM</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/mumble/mumble_ru.ts
+++ b/src/mumble/mumble_ru.ts
@@ -1239,6 +1239,30 @@ This value allows you to set the maximum number of users allowed in the channel.
         <source>&lt;b&gt;This shows peak outgoing bandwidth used.&lt;/b&gt;&lt;br /&gt;This shows the peak amount of bandwidth sent out from your machine. Audio bitrate is the maximum bitrate for the audio data alone. Position is the bitrate used for positional information. Overhead is our framing and the IP packet headers (IP and UDP is 75% of this overhead).</source>
         <translation>&lt;b&gt;Это показывает пиковую используемую исходящую полосу пропускания.&lt;/b&gt;&lt;br /&gt;Здесь показан пиковый объем полосы пропускания, передаваемый с вашего компьютера. Битрейт аудио - максимальный битрейт только для аудиоданных. Позиция - битрейт, используемый для позиционной информации. Накладные расходы - это наше кадрирование и заголовки IP-пакетов (на IP и UDP приходится 75 % этих накладных расходов).</translation>
     </message>
+    <message>
+        <source>Use WebRTC GMM based speech detection</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&lt;b&gt;This sets speech detection to use the WebRTC VAD algorithm.&lt;/b&gt;&lt;br /&gt;In this mode, a configuration-free Gaussian Mixture Model is used to detect speech.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>WebRTC GMM</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Aggressiveness</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Controls aggressiveness of WebRTC VAD</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Higher values make the VAD more aggressive in filtering noise.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AudioInputDialog</name>
@@ -2308,6 +2332,22 @@ Speak loudly, as when you are annoyed or excited. Decrease the volume in the sou
     <message>
         <source>This visually represents the positional audio that is currently being played</source>
         <translation>Это визуальное представление позиционного аудио, которое воспроизводится в данный момент</translation>
+    </message>
+    <message>
+        <source>Next you need to choose the voice detection sensitivity. The aggressiveness level controls how strictly speech is detected. Lower levels are more permissive and will pick up quiet or distant speech, but may also trigger on background noise. Higher levels are more strict and will better filter out noise, but may cut off softer speech.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Voice activity detection aggressiveness level</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>This will set the aggressiveness in which Mumble will consider a signal speech. Increase value to make voice activation less sensitive.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>WebRTC GMM</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/src/mumble/mumble_si.ts
+++ b/src/mumble/mumble_si.ts
@@ -1227,6 +1227,30 @@ Contains the list of members inherited by the current channel. Uncheck &lt;i&gt;
         <source>&lt;b&gt;This shows peak outgoing bandwidth used.&lt;/b&gt;&lt;br /&gt;This shows the peak amount of bandwidth sent out from your machine. Audio bitrate is the maximum bitrate for the audio data alone. Position is the bitrate used for positional information. Overhead is our framing and the IP packet headers (IP and UDP is 75% of this overhead).</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Use WebRTC GMM based speech detection</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&lt;b&gt;This sets speech detection to use the WebRTC VAD algorithm.&lt;/b&gt;&lt;br /&gt;In this mode, a configuration-free Gaussian Mixture Model is used to detect speech.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>WebRTC GMM</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Aggressiveness</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Controls aggressiveness of WebRTC VAD</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Higher values make the VAD more aggressive in filtering noise.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AudioInputDialog</name>
@@ -2258,6 +2282,22 @@ Mumble is under continuous development, and the development team wants to focus 
     </message>
     <message>
         <source>This visually represents the positional audio that is currently being played</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Next you need to choose the voice detection sensitivity. The aggressiveness level controls how strictly speech is detected. Lower levels are more permissive and will pick up quiet or distant speech, but may also trigger on background noise. Higher levels are more strict and will better filter out noise, but may cut off softer speech.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Voice activity detection aggressiveness level</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>This will set the aggressiveness in which Mumble will consider a signal speech. Increase value to make voice activation less sensitive.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>WebRTC GMM</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/mumble/mumble_sk.ts
+++ b/src/mumble/mumble_sk.ts
@@ -1230,6 +1230,30 @@ Contains the list of members inherited by the current channel. Uncheck &lt;i&gt;
         <source>&lt;b&gt;This shows peak outgoing bandwidth used.&lt;/b&gt;&lt;br /&gt;This shows the peak amount of bandwidth sent out from your machine. Audio bitrate is the maximum bitrate for the audio data alone. Position is the bitrate used for positional information. Overhead is our framing and the IP packet headers (IP and UDP is 75% of this overhead).</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Use WebRTC GMM based speech detection</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&lt;b&gt;This sets speech detection to use the WebRTC VAD algorithm.&lt;/b&gt;&lt;br /&gt;In this mode, a configuration-free Gaussian Mixture Model is used to detect speech.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>WebRTC GMM</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Aggressiveness</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Controls aggressiveness of WebRTC VAD</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Higher values make the VAD more aggressive in filtering noise.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AudioInputDialog</name>
@@ -2261,6 +2285,22 @@ Mumble is under continuous development, and the development team wants to focus 
     </message>
     <message>
         <source>This visually represents the positional audio that is currently being played</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Next you need to choose the voice detection sensitivity. The aggressiveness level controls how strictly speech is detected. Lower levels are more permissive and will pick up quiet or distant speech, but may also trigger on background noise. Higher levels are more strict and will better filter out noise, but may cut off softer speech.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Voice activity detection aggressiveness level</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>This will set the aggressiveness in which Mumble will consider a signal speech. Increase value to make voice activation less sensitive.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>WebRTC GMM</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/mumble/mumble_sq.ts
+++ b/src/mumble/mumble_sq.ts
@@ -1233,6 +1233,30 @@ Contains the list of members inherited by the current channel. Uncheck &lt;i&gt;
         <source>&lt;b&gt;This shows peak outgoing bandwidth used.&lt;/b&gt;&lt;br /&gt;This shows the peak amount of bandwidth sent out from your machine. Audio bitrate is the maximum bitrate for the audio data alone. Position is the bitrate used for positional information. Overhead is our framing and the IP packet headers (IP and UDP is 75% of this overhead).</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Use WebRTC GMM based speech detection</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&lt;b&gt;This sets speech detection to use the WebRTC VAD algorithm.&lt;/b&gt;&lt;br /&gt;In this mode, a configuration-free Gaussian Mixture Model is used to detect speech.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>WebRTC GMM</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Aggressiveness</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Controls aggressiveness of WebRTC VAD</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Higher values make the VAD more aggressive in filtering noise.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AudioInputDialog</name>
@@ -2264,6 +2288,22 @@ Mumble is under continuous development, and the development team wants to focus 
     </message>
     <message>
         <source>This visually represents the positional audio that is currently being played</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Next you need to choose the voice detection sensitivity. The aggressiveness level controls how strictly speech is detected. Lower levels are more permissive and will pick up quiet or distant speech, but may also trigger on background noise. Higher levels are more strict and will better filter out noise, but may cut off softer speech.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Voice activity detection aggressiveness level</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>This will set the aggressiveness in which Mumble will consider a signal speech. Increase value to make voice activation less sensitive.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>WebRTC GMM</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/mumble/mumble_sv.ts
+++ b/src/mumble/mumble_sv.ts
@@ -1239,6 +1239,30 @@ Det värdet tillåter dig att ställa in ett maximalt antal av användare som ä
         <source>&lt;b&gt;This shows peak outgoing bandwidth used.&lt;/b&gt;&lt;br /&gt;This shows the peak amount of bandwidth sent out from your machine. Audio bitrate is the maximum bitrate for the audio data alone. Position is the bitrate used for positional information. Overhead is our framing and the IP packet headers (IP and UDP is 75% of this overhead).</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Use WebRTC GMM based speech detection</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&lt;b&gt;This sets speech detection to use the WebRTC VAD algorithm.&lt;/b&gt;&lt;br /&gt;In this mode, a configuration-free Gaussian Mixture Model is used to detect speech.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>WebRTC GMM</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Aggressiveness</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Controls aggressiveness of WebRTC VAD</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Higher values make the VAD more aggressive in filtering noise.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AudioInputDialog</name>
@@ -2307,6 +2331,22 @@ Tala högt, som om du är irriterad eller upphetsad. Minska volymen i kontrollpa
     </message>
     <message>
         <source>This visually represents the positional audio that is currently being played</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Next you need to choose the voice detection sensitivity. The aggressiveness level controls how strictly speech is detected. Lower levels are more permissive and will pick up quiet or distant speech, but may also trigger on background noise. Higher levels are more strict and will better filter out noise, but may cut off softer speech.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Voice activity detection aggressiveness level</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>This will set the aggressiveness in which Mumble will consider a signal speech. Increase value to make voice activation less sensitive.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>WebRTC GMM</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/mumble/mumble_te.ts
+++ b/src/mumble/mumble_te.ts
@@ -1237,6 +1237,30 @@ This value allows you to set the maximum number of users allowed in the channel.
         <source>&lt;b&gt;This shows peak outgoing bandwidth used.&lt;/b&gt;&lt;br /&gt;This shows the peak amount of bandwidth sent out from your machine. Audio bitrate is the maximum bitrate for the audio data alone. Position is the bitrate used for positional information. Overhead is our framing and the IP packet headers (IP and UDP is 75% of this overhead).</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Use WebRTC GMM based speech detection</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&lt;b&gt;This sets speech detection to use the WebRTC VAD algorithm.&lt;/b&gt;&lt;br /&gt;In this mode, a configuration-free Gaussian Mixture Model is used to detect speech.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>WebRTC GMM</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Aggressiveness</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Controls aggressiveness of WebRTC VAD</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Higher values make the VAD more aggressive in filtering noise.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AudioInputDialog</name>
@@ -2281,6 +2305,22 @@ Speak loudly, as when you are annoyed or excited. Decrease the volume in the sou
     </message>
     <message>
         <source>This visually represents the positional audio that is currently being played</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Next you need to choose the voice detection sensitivity. The aggressiveness level controls how strictly speech is detected. Lower levels are more permissive and will pick up quiet or distant speech, but may also trigger on background noise. Higher levels are more strict and will better filter out noise, but may cut off softer speech.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Voice activity detection aggressiveness level</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>This will set the aggressiveness in which Mumble will consider a signal speech. Increase value to make voice activation less sensitive.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>WebRTC GMM</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/mumble/mumble_th.ts
+++ b/src/mumble/mumble_th.ts
@@ -1231,6 +1231,30 @@ This value allows you to set the maximum number of users allowed in the channel.
         <source>&lt;b&gt;This shows peak outgoing bandwidth used.&lt;/b&gt;&lt;br /&gt;This shows the peak amount of bandwidth sent out from your machine. Audio bitrate is the maximum bitrate for the audio data alone. Position is the bitrate used for positional information. Overhead is our framing and the IP packet headers (IP and UDP is 75% of this overhead).</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Use WebRTC GMM based speech detection</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&lt;b&gt;This sets speech detection to use the WebRTC VAD algorithm.&lt;/b&gt;&lt;br /&gt;In this mode, a configuration-free Gaussian Mixture Model is used to detect speech.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>WebRTC GMM</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Aggressiveness</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Controls aggressiveness of WebRTC VAD</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Higher values make the VAD more aggressive in filtering noise.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AudioInputDialog</name>
@@ -2275,6 +2299,22 @@ Speak loudly, as when you are annoyed or excited. Decrease the volume in the sou
     </message>
     <message>
         <source>This visually represents the positional audio that is currently being played</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Next you need to choose the voice detection sensitivity. The aggressiveness level controls how strictly speech is detected. Lower levels are more permissive and will pick up quiet or distant speech, but may also trigger on background noise. Higher levels are more strict and will better filter out noise, but may cut off softer speech.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Voice activity detection aggressiveness level</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>This will set the aggressiveness in which Mumble will consider a signal speech. Increase value to make voice activation less sensitive.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>WebRTC GMM</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/mumble/mumble_tr.ts
+++ b/src/mumble/mumble_tr.ts
@@ -1239,6 +1239,30 @@ Bu değer kanalda izin verilen azami kullanıcı sayısını ayarlamanıza izin 
         <source>&lt;b&gt;This shows peak outgoing bandwidth used.&lt;/b&gt;&lt;br /&gt;This shows the peak amount of bandwidth sent out from your machine. Audio bitrate is the maximum bitrate for the audio data alone. Position is the bitrate used for positional information. Overhead is our framing and the IP packet headers (IP and UDP is 75% of this overhead).</source>
         <translation>&lt;b&gt;Bu, kullanılan en yüksek giden bant genişliğini gösterir.&lt;/b&gt;&lt;br /&gt;Bu, makinenizden gönderilen en yüksek bant genişliği miktarını gösterir. Ses bit hızı, yalnızca ses verileri için en yüksek bit hızıdır. Konum, konumsal bilgiler için kullanılan bit hızıdır. Ek yük bizim çerçeveleme ve IP paket başlıklarımızdır (IP ve UDP bu ek yükün %75&apos;idir).</translation>
     </message>
+    <message>
+        <source>Use WebRTC GMM based speech detection</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&lt;b&gt;This sets speech detection to use the WebRTC VAD algorithm.&lt;/b&gt;&lt;br /&gt;In this mode, a configuration-free Gaussian Mixture Model is used to detect speech.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>WebRTC GMM</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Aggressiveness</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Controls aggressiveness of WebRTC VAD</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Higher values make the VAD more aggressive in filtering noise.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AudioInputDialog</name>
@@ -2308,6 +2332,22 @@ Sinirli ya da coştuğunuz zamanlardaki gibi yüksek sesle konuşunuz. Kontrol p
     <message>
         <source>This visually represents the positional audio that is currently being played</source>
         <translation>Bu, görsel olarak şimdi çalınan konumsal sesi temsil eder</translation>
+    </message>
+    <message>
+        <source>Next you need to choose the voice detection sensitivity. The aggressiveness level controls how strictly speech is detected. Lower levels are more permissive and will pick up quiet or distant speech, but may also trigger on background noise. Higher levels are more strict and will better filter out noise, but may cut off softer speech.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Voice activity detection aggressiveness level</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>This will set the aggressiveness in which Mumble will consider a signal speech. Increase value to make voice activation less sensitive.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>WebRTC GMM</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/src/mumble/mumble_uk.ts
+++ b/src/mumble/mumble_uk.ts
@@ -1239,6 +1239,30 @@ This value allows you to set the maximum number of users allowed in the channel.
         <source>&lt;b&gt;This shows peak outgoing bandwidth used.&lt;/b&gt;&lt;br /&gt;This shows the peak amount of bandwidth sent out from your machine. Audio bitrate is the maximum bitrate for the audio data alone. Position is the bitrate used for positional information. Overhead is our framing and the IP packet headers (IP and UDP is 75% of this overhead).</source>
         <translation>&lt;b&gt;Це показує максимальну вихідну пропускну здатність, що використовується.&lt;/b&gt;&lt;br /&gt;Це показує максимальну пропускну здатність, надіслану з вашого комп’ютера. Бітрейт аудіо – це максимальний бітрейт лише для аудіоданих. Позиція – це бітрейт, який використовується для позиційної інформації. Накладні витрати — це наше кадрування та заголовки IP-пакетів (IP і UDP становлять 75% цих накладних витрат).</translation>
     </message>
+    <message>
+        <source>Use WebRTC GMM based speech detection</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&lt;b&gt;This sets speech detection to use the WebRTC VAD algorithm.&lt;/b&gt;&lt;br /&gt;In this mode, a configuration-free Gaussian Mixture Model is used to detect speech.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>WebRTC GMM</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Aggressiveness</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Controls aggressiveness of WebRTC VAD</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Higher values make the VAD more aggressive in filtering noise.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AudioInputDialog</name>
@@ -2308,6 +2332,22 @@ Speak loudly, as when you are annoyed or excited. Decrease the volume in the sou
     <message>
         <source>This visually represents the positional audio that is currently being played</source>
         <translation>Це візуально представляє позиційне аудіо, яке зараз відтворюється</translation>
+    </message>
+    <message>
+        <source>Next you need to choose the voice detection sensitivity. The aggressiveness level controls how strictly speech is detected. Lower levels are more permissive and will pick up quiet or distant speech, but may also trigger on background noise. Higher levels are more strict and will better filter out noise, but may cut off softer speech.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Voice activity detection aggressiveness level</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>This will set the aggressiveness in which Mumble will consider a signal speech. Increase value to make voice activation less sensitive.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>WebRTC GMM</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/src/mumble/mumble_zh_CN.ts
+++ b/src/mumble/mumble_zh_CN.ts
@@ -1239,6 +1239,30 @@ This value allows you to set the maximum number of users allowed in the channel.
         <source>&lt;b&gt;This shows peak outgoing bandwidth used.&lt;/b&gt;&lt;br /&gt;This shows the peak amount of bandwidth sent out from your machine. Audio bitrate is the maximum bitrate for the audio data alone. Position is the bitrate used for positional information. Overhead is our framing and the IP packet headers (IP and UDP is 75% of this overhead).</source>
         <translation>&lt;b&gt;显示所用的最大传出带宽。&lt;/b&gt;&lt;br /&gt;显示从您机器发出的带宽的最大值。音频比特率是音频数据本身的最大比特率。位置是定位信息所用的比特率。开销是我们的帧结构和 IP 数据包头（IP 和 UDP 是开销的 75%）。</translation>
     </message>
+    <message>
+        <source>Use WebRTC GMM based speech detection</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&lt;b&gt;This sets speech detection to use the WebRTC VAD algorithm.&lt;/b&gt;&lt;br /&gt;In this mode, a configuration-free Gaussian Mixture Model is used to detect speech.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>WebRTC GMM</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Aggressiveness</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Controls aggressiveness of WebRTC VAD</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Higher values make the VAD more aggressive in filtering noise.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AudioInputDialog</name>
@@ -2308,6 +2332,22 @@ Speak loudly, as when you are annoyed or excited. Decrease the volume in the sou
     <message>
         <source>This visually represents the positional audio that is currently being played</source>
         <translation>可视化展示当前播放的定位音频</translation>
+    </message>
+    <message>
+        <source>Next you need to choose the voice detection sensitivity. The aggressiveness level controls how strictly speech is detected. Lower levels are more permissive and will pick up quiet or distant speech, but may also trigger on background noise. Higher levels are more strict and will better filter out noise, but may cut off softer speech.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Voice activity detection aggressiveness level</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>This will set the aggressiveness in which Mumble will consider a signal speech. Increase value to make voice activation less sensitive.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>WebRTC GMM</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/src/mumble/mumble_zh_HK.ts
+++ b/src/mumble/mumble_zh_HK.ts
@@ -1231,6 +1231,30 @@ This value allows you to set the maximum number of users allowed in the channel.
         <source>&lt;b&gt;This shows peak outgoing bandwidth used.&lt;/b&gt;&lt;br /&gt;This shows the peak amount of bandwidth sent out from your machine. Audio bitrate is the maximum bitrate for the audio data alone. Position is the bitrate used for positional information. Overhead is our framing and the IP packet headers (IP and UDP is 75% of this overhead).</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Use WebRTC GMM based speech detection</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&lt;b&gt;This sets speech detection to use the WebRTC VAD algorithm.&lt;/b&gt;&lt;br /&gt;In this mode, a configuration-free Gaussian Mixture Model is used to detect speech.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>WebRTC GMM</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Aggressiveness</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Controls aggressiveness of WebRTC VAD</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Higher values make the VAD more aggressive in filtering noise.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AudioInputDialog</name>
@@ -2275,6 +2299,22 @@ Speak loudly, as when you are annoyed or excited. Decrease the volume in the sou
     </message>
     <message>
         <source>This visually represents the positional audio that is currently being played</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Next you need to choose the voice detection sensitivity. The aggressiveness level controls how strictly speech is detected. Lower levels are more permissive and will pick up quiet or distant speech, but may also trigger on background noise. Higher levels are more strict and will better filter out noise, but may cut off softer speech.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Voice activity detection aggressiveness level</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>This will set the aggressiveness in which Mumble will consider a signal speech. Increase value to make voice activation less sensitive.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>WebRTC GMM</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/mumble/mumble_zh_TW.ts
+++ b/src/mumble/mumble_zh_TW.ts
@@ -1234,6 +1234,30 @@ This value allows you to set the maximum number of users allowed in the channel.
         <source>&lt;b&gt;This shows peak outgoing bandwidth used.&lt;/b&gt;&lt;br /&gt;This shows the peak amount of bandwidth sent out from your machine. Audio bitrate is the maximum bitrate for the audio data alone. Position is the bitrate used for positional information. Overhead is our framing and the IP packet headers (IP and UDP is 75% of this overhead).</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Use WebRTC GMM based speech detection</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&lt;b&gt;This sets speech detection to use the WebRTC VAD algorithm.&lt;/b&gt;&lt;br /&gt;In this mode, a configuration-free Gaussian Mixture Model is used to detect speech.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>WebRTC GMM</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Aggressiveness</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Controls aggressiveness of WebRTC VAD</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Higher values make the VAD more aggressive in filtering noise.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AudioInputDialog</name>
@@ -2296,6 +2320,22 @@ Speak loudly, as when you are annoyed or excited. Decrease the volume in the sou
     </message>
     <message>
         <source>This visually represents the positional audio that is currently being played</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Next you need to choose the voice detection sensitivity. The aggressiveness level controls how strictly speech is detected. Lower levels are more permissive and will pick up quiet or distant speech, but may also trigger on background noise. Higher levels are more strict and will better filter out noise, but may cut off softer speech.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Voice activity detection aggressiveness level</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>This will set the aggressiveness in which Mumble will consider a signal speech. Increase value to make voice activation less sensitive.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>WebRTC GMM</source>
         <translation type="unfinished"></translation>
     </message>
 </context>


### PR DESCRIPTION
This PR introduces a Voice Activity Detection (VAD) implementation based on the WebRTC Audio Processing library into the client.

WebRTC has been used and tested by various applications and behaves generally great in VoIP. I'm trying to get advanced webrtc audio processing features into mumble and see how far and how great could it get.

The current VAD (amplitude & SNR) struggles with low-volume or distant speech and requires manual tuning depending on the environment, which can be frustrating for users. In contrast, the VAD from WebRTC is designed to be more robust across a wide range of real-world conditions. It leverages more advanced signal analysis to better distinguish speech from noise, resulting in improved detection accuracy without the need for constant user adjustment.

It adds optional dependency for webrtc-audio-processing extracted from the webrtc library by pulseaudio:

https://gitlab.freedesktop.org/pulseaudio/webrtc-audio-processing

The library has been already packed by Debian, Ubuntu, Arch, FreeBSD, etc. So it's easy to obtain in Linux/BSD operating systems. However, the commit didn't introduce a bundled version for compilation which might be beneficial for Windows systems. Unfortunately, the library was in meson so many works need to be done for bundling it.


### Checks

- [X] My commits follow the [commit guidelines](https://github.com/mumble-voip/mumble/blob/master/COMMIT_GUIDELINES.md)

