### PR TITLE
Backport "Merge PR #7120: FIX(client): Fix color scheme detection on Sway" to 1.6.x

### DIFF
--- a/src/mumble/Themes.cpp
+++ b/src/mumble/Themes.cpp
@@ -163,7 +163,14 @@ bool Themes::apply() {
 
 bool Themes::detectSystemDarkTheme() {
 #if QT_VERSION >= QT_VERSION_CHECK(6, 5, 0)
-	return QGuiApplication::styleHints()->colorScheme() == Qt::ColorScheme::Dark;
+	Qt::ColorScheme colorScheme = QGuiApplication::styleHints()->colorScheme();
+	if (colorScheme != Qt::ColorScheme::Unknown) {
+		return colorScheme == Qt::ColorScheme::Dark;
+	}
+	// colorScheme() can return Unknown on some platforms (e.g. wlroots compositors),
+	// so fall back to comparing palette lightness values
+	QPalette defaultPalette;
+	return defaultPalette.color(QPalette::WindowText).lightness() > defaultPalette.color(QPalette::Window).lightness();
 #else
 #	if defined(Q_OS_WIN)
 	QSettings settings("HKEY_CURRENT_USER\\Software\\Microsoft\\Windows\\CurrentVersion\\Themes\\Personalize",


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `1.6.x`:
 - [Merge PR #7120: FIX(client): Fix color scheme detection on Sway](https://github.com/mumble-voip/mumble/pull/7120)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)