### PR TITLE
Backport "Merge PR #7121: FIX(client): Don't send placeholder when using paste+send if MainWindow is out-of-focus" to 1.6.x

### DIFF
--- a/src/mumble/CustomElements.cpp
+++ b/src/mumble/CustomElements.cpp
@@ -401,7 +401,13 @@ void ChatbarTextEdit::historyDown() {
 }
 
 void ChatbarTextEdit::pasteAndSend_triggered() {
+	if (bDefaultVisible) {
+		// Clear placeholder
+		setPlainText(QString());
+	}
+
 	paste();
+
 	if (!toPlainText().isEmpty()) {
 		addToHistory(toPlainText());
 		emit entered(toPlainText());


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `1.6.x`:
 - [Merge PR #7121: FIX(client): Don&#x27;t send placeholder when using paste+send if MainWindow is out-of-focus](https://github.com/mumble-voip/mumble/pull/7121)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)