### PR TITLE
Backport "Merge PR #7108: CI(macos): Ensure postgresql is also linked into PATH" to 1.5.x

### DIFF
--- a/.github/actions/install-dependencies/install_macos_static_x86_64.sh
+++ b/.github/actions/install-dependencies/install_macos_static_x86_64.sh
@@ -17,6 +17,7 @@ make_build_env_available "tar.xz"
 # by default and installing it via homebrew takes forever.
 
 brew install postgresql
+brew link postgresql
 brew services start postgresql
 
 # Give the database some time to start


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `1.5.x`:
 - [Merge PR #7108: CI(macos): Ensure postgresql is also linked into PATH](https://github.com/mumble-voip/mumble/pull/7108)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)