### PR TITLE
Backport "Merge PR #7119: FIX(server): Skip group member modification with negative user IDs" to 1.6.x

### DIFF
--- a/src/murmur/DBWrapper.cpp
+++ b/src/murmur/DBWrapper.cpp
@@ -651,10 +651,10 @@ void DBWrapper::updateChannelData(unsigned int serverID, const Channel &channel)
 			m_serverDB.getGroupMemberTable().addEntry(serverID, groupID,
 													  static_cast< unsigned int >(addedGroupMemberID), true);
 		}
-		for (int removeddGroupMemberID : currentGroup->qsRemove) {
-			assert(removeddGroupMemberID >= 0);
+		for (int removedGroupMemberID : currentGroup->qsRemove) {
+			assert(removedGroupMemberID >= 0);
 			m_serverDB.getGroupMemberTable().addEntry(serverID, groupID,
-													  static_cast< unsigned int >(removeddGroupMemberID), false);
+													  static_cast< unsigned int >(removedGroupMemberID), false);
 		}
 	}
 

--- a/src/murmur/MumbleServerIce.cpp
+++ b/src/murmur/MumbleServerIce.cpp
@@ -1724,11 +1724,21 @@ static void impl_Server_setACL(const ::MumbleServer::AMD_Server_setACLPtr cb, in
 			::Group *g      = new ::Group(channel, name);
 			g->bInherit     = gi.inherit;
 			g->bInheritable = gi.inheritable;
-			QVector< int > addVec(gi.add.begin(), gi.add.end());
-			QVector< int > removeVec(gi.remove.begin(), gi.remove.end());
 
-			g->qsAdd       = QSet< int >(addVec.begin(), addVec.end());
-			g->qsRemove    = QSet< int >(removeVec.begin(), removeVec.end());
+			for (int id : gi.add) {
+				if (server->getRegisteredUserName(static_cast< int >(id)).isEmpty()) {
+					continue;
+				}
+				g->qsAdd << static_cast< int >(id);
+			}
+
+			for (int id : gi.remove) {
+				if (server->getRegisteredUserName(static_cast< int >(id)).isEmpty()) {
+					continue;
+				}
+				g->qsRemove << static_cast< int >(id);
+			}
+
 			g->qsTemporary = hOldTemp.value(name);
 		}
 		for (const ::MumbleServer::ACL &ai : acls) {


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `1.6.x`:
 - [Merge PR #7119: FIX(server): Skip group member modification with negative user IDs](https://github.com/mumble-voip/mumble/pull/7119)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)