### PR TITLE
FEAT(windows client): Add support for the Universal Mute button

### DIFF
--- a/docs/dev/build-instructions/cmake_options.md
+++ b/docs/dev/build-instructions/cmake_options.md
@@ -319,6 +319,11 @@ All warnings are treated as errors.
 Build support for WASAPI.
 (Default: ON)
 
+### win-universal-mute
+
+Build support for Windows Universal Mute (Win11 22H2+) with simple fallback for earlier versions.
+(Default: ON)
+
 ### xboxinput
 
 Build support for global shortcuts from Xbox controllers via the XInput DLL.

--- a/src/mumble/CMakeLists.txt
+++ b/src/mumble/CMakeLists.txt
@@ -39,6 +39,9 @@ if(WIN32)
 	option(wasapi "Build support for WASAPI." ON)
 	option(xboxinput "Build support for global shortcuts from Xbox controllers via the XInput DLL." ON)
 	option(gkey "Build support for Logitech G-Keys. Note: This feature does not require any build-time dependencies, and requires Logitech Gaming Software to be installed to have any effect at runtime." ON)
+	if(MSVC)
+		option(win-universal-mute "Build support for Windows Universal Mute (Win11 22H2+) with simple fallback for earlier versions." ON)
+	endif()
 elseif(UNIX)
 	if(APPLE)
 		option(coreaudio "Build support for CoreAudio." ON)
@@ -657,6 +660,18 @@ if(WIN32)
 			hid.lib
 			wintrust.lib
 	)
+
+	if(win-universal-mute)
+		target_sources(mumble_client_object_lib PRIVATE
+			"UniversalMute.cpp"
+			"UniversalMute.h"
+		)
+		target_compile_definitions(mumble_client_object_lib PUBLIC "USE_WIN_UNIVERSAL_MUTE")
+		# WinRT required; delay-load so the binary still starts on Windows 7 where runtimeobject.dll
+		# does not exist. IsWindows8OrGreater() must guard call sites at runtime.
+		target_link_libraries(mumble_client_object_lib PUBLIC runtimeobject.lib)
+		set_property(TARGET mumble_client_object_lib APPEND_STRING PROPERTY LINK_FLAGS " /DELAYLOAD:runtimeobject.dll")
+	endif()
 else()
 	target_sources(mumble_client_object_lib PRIVATE "SharedMemory_unix.cpp")
 

--- a/src/mumble/MainWindow.cpp
+++ b/src/mumble/MainWindow.cpp
@@ -3564,7 +3564,7 @@ void MainWindow::serverConnected() {
 	qaServerBanList->setEnabled(true);
 
 #ifdef USE_WIN_UNIVERSAL_MUTE
-	m_universalMuter->startCall(L"Connecting...", L"Mumble");
+	m_universalMuter->startCall(tr("Connecting...").toStdWString(), tr("Mumble").toStdWString());
 #endif
 
 	Channel *root = Channel::get(Mumble::ROOT_CHANNEL_ID);

--- a/src/mumble/MainWindow.cpp
+++ b/src/mumble/MainWindow.cpp
@@ -513,6 +513,23 @@ void MainWindow::setupGui() {
 	qaAudioMute->setChecked(Global::get().s.bMute);
 	qaAudioDeaf->setChecked(Global::get().s.bDeaf);
 
+#ifdef USE_WIN_UNIVERSAL_MUTE
+	m_universalMuter.emplace(
+		[this]() {
+			// Fired on a WinRT thread pool thread — marshal to Qt main thread.
+			QMetaObject::invokeMethod(this, [this]() {
+				qaAudioMute->setChecked(true);
+				on_qaAudioMute_triggered();
+			}, Qt::QueuedConnection);
+		},
+		[this]() {
+			QMetaObject::invokeMethod(this, [this]() {
+				qaAudioMute->setChecked(false);
+				on_qaAudioMute_triggered();
+			}, Qt::QueuedConnection);
+		});
+#endif
+
 	updateAudioToolTips();
 
 #ifdef USE_NO_TTS
@@ -2754,6 +2771,14 @@ void MainWindow::on_qaAudioMute_triggered() {
 		Global::get().sh->setSelfMuteDeafState(Global::get().s.bMute, Global::get().s.bDeaf);
 	}
 
+#ifdef USE_WIN_UNIVERSAL_MUTE
+	if (Global::get().s.bMute) {
+		m_universalMuter->setMuted();
+	} else {
+		m_universalMuter->setUnmuted();
+	}
+#endif
+
 	updateAudioToolTips();
 	emit talkingStatusChanged();
 }
@@ -2798,6 +2823,14 @@ void MainWindow::on_qaAudioDeaf_triggered() {
 	if (Global::get().sh) {
 		Global::get().sh->setSelfMuteDeafState(Global::get().s.bMute, Global::get().s.bDeaf);
 	}
+
+#ifdef USE_WIN_UNIVERSAL_MUTE
+	if (Global::get().s.bMute) {
+		m_universalMuter->setMuted();
+	} else {
+		m_universalMuter->setUnmuted();
+	}
+#endif
 
 	updateAudioToolTips();
 	emit talkingStatusChanged();
@@ -3530,6 +3563,10 @@ void MainWindow::serverConnected() {
 	updateFavoriteButton();
 	qaServerBanList->setEnabled(true);
 
+#ifdef USE_WIN_UNIVERSAL_MUTE
+	m_universalMuter->startCall(L"Connecting...", L"Mumble");
+#endif
+
 	Channel *root = Channel::get(Mumble::ROOT_CHANNEL_ID);
 	pmModel->renameChannel(root, tr("Root"));
 	pmModel->setCommentHash(root, QByteArray());
@@ -3563,6 +3600,10 @@ void MainWindow::serverConnected() {
 }
 
 void MainWindow::serverDisconnected(QAbstractSocket::SocketError err, QString reason) {
+#ifdef USE_WIN_UNIVERSAL_MUTE
+	m_universalMuter->tryEndCall();
+#endif
+
 	// clear ChannelListener
 	Global::get().channelListenerManager->clear();
 

--- a/src/mumble/MainWindow.h
+++ b/src/mumble/MainWindow.h
@@ -24,6 +24,10 @@
 #include <optional>
 #include <stack>
 
+#ifdef USE_WIN_UNIVERSAL_MUTE
+#	include "UniversalMute.h"
+#endif
+
 #include "ui_MainWindow.h"
 
 #define MB_QEVENT (QEvent::User + 939)
@@ -205,6 +209,12 @@ protected:
 
 	std::stack< unsigned int > m_previousChannels;
 	std::optional< unsigned int > m_movedBackFromChannel;
+
+#ifdef USE_WIN_UNIVERSAL_MUTE
+	// A std::optional simply because we initialize this in setupGui(), not the
+	// constructor.
+	std::optional< UniversalMuter > m_universalMuter;
+#endif
 
 	static constexpr int stateVersion();
 

--- a/src/mumble/Messages.cpp
+++ b/src/mumble/Messages.cpp
@@ -188,6 +188,11 @@ void MainWindow::msgServerSync(const MumbleProto::ServerSync &msg) {
 
 	Global::get().sh->setServerSynchronized(true);
 
+#ifdef USE_WIN_UNIVERSAL_MUTE
+	if (user->cChannel)
+		m_universalMuter->trySetCallName(user->cChannel->qsName.toStdWString());
+#endif
+
 	emit serverSynchronized();
 }
 

--- a/src/mumble/UniversalMute.cpp
+++ b/src/mumble/UniversalMute.cpp
@@ -1,0 +1,148 @@
+// Copyright The Mumble Developers. All rights reserved.
+// Use of this source code is governed by a BSD-style license
+// that can be found in the LICENSE file at the root of the
+// Mumble source tree or at <https://www.mumble.info/LICENSE>.
+
+#include "UniversalMute.h"
+
+#include "win.h"
+
+// clang-format off
+#include <versionhelpers.h>
+#include <wrl.h>
+#include <wrl/event.h>
+#include <wrl/wrappers/corewrappers.h>
+#include <roapi.h>
+#include <windows.applicationmodel.calls.h>
+// clang-format on
+
+using namespace Microsoft::WRL;
+using namespace Microsoft::WRL::Wrappers;
+using namespace ABI::Windows::ApplicationModel::Calls;
+using namespace ABI::Windows::Foundation;
+
+struct UniversalMuter::Impl {
+	std::function< void() > onMuted;
+	std::function< void() > onUnmuted;
+	ComPtr< IVoipCallCoordinator > coordinator;
+	ComPtr< IVoipPhoneCall > call;
+	EventRegistrationToken muteStateToken{};
+};
+
+namespace {
+// C++/WinRT would be a bit simpler, but requires a newer couroutine ABI than
+// we are currently using (requires _COROUTINE_ABI=2, while Qt is compiled with
+// _COROUTINE_ABI=1). If the app fully upgrades to C++20, we can migrate to C++/WinRT.
+//
+// https://github.com/microsoft/cppwinrt/issues/1281
+ComPtr< IVoipCallCoordinator > tryCreateCallCoordinator() {
+	// WinRT was added in Windows 8; check for that before using WinRT.
+	// The /DELAYLOAD:runtimeobject.dll linker flag ensures we don't attempt
+	// to load the DLL on older versions.
+	if (!IsWindows8OrGreater()) {
+		return nullptr;
+	}
+
+	ComPtr< IVoipCallCoordinatorStatics > statics;
+	HRESULT hr = RoGetActivationFactory(
+		HStringReference(RuntimeClass_Windows_ApplicationModel_Calls_VoipCallCoordinator).Get(),
+		IID_PPV_ARGS(&statics));
+	if (FAILED(hr)) {
+		return nullptr;
+	}
+
+	ComPtr< IVoipCallCoordinator > coordinator;
+	hr = statics->GetDefault(&coordinator);
+	if (FAILED(hr)) {
+		return nullptr;
+	}
+
+	return coordinator;
+}
+}
+
+UniversalMuter::UniversalMuter(std::function< void() > onMuted, std::function< void() > onUnmuted)
+	: m_impl(std::make_shared< Impl >()) {
+	m_impl->onMuted   = std::move(onMuted);
+	m_impl->onUnmuted = std::move(onUnmuted);
+
+	m_impl->coordinator = tryCreateCallCoordinator();
+	if (!m_impl->coordinator)
+		return;
+
+	// Capture a weak_ptr so the callback safely no-ops if UniversalMuter is destroyed
+	// while a callback is in flight (e.g. racing with remove_MuteStateChanged).
+	std::weak_ptr< Impl > weakImpl = m_impl;
+	auto handler = Callback< ITypedEventHandler< VoipCallCoordinator *, MuteChangeEventArgs * > >(
+		[weakImpl](IVoipCallCoordinator *, IMuteChangeEventArgs *args) -> HRESULT {
+			auto impl = weakImpl.lock();
+			if (!impl)
+				return S_OK;
+			boolean muted = FALSE;
+			args->get_Muted(&muted);
+
+			// The callbacks are responsible for calling setMuted/setUnmuted when they have
+			// processed the event.
+			if (muted) {
+				if (impl->onMuted)
+					impl->onMuted();
+			} else {
+				if (impl->onUnmuted)
+					impl->onUnmuted();
+			}
+			return S_OK;
+		});
+
+	// Ignore failures; best effort.
+	m_impl->coordinator->add_MuteStateChanged(handler.Get(), &m_impl->muteStateToken);
+}
+
+UniversalMuter::~UniversalMuter() {
+	if (m_impl->coordinator)
+		m_impl->coordinator->remove_MuteStateChanged(m_impl->muteStateToken);
+	tryEndCall();
+}
+
+void UniversalMuter::startCall(const std::wstring &contactName, const std::wstring &serviceName) {
+	if (!m_impl->coordinator)
+		return;
+
+	ComPtr< IVoipPhoneCall > call;
+	HString context, hContactName, hServiceName;
+	context.Set(L"");
+	hContactName.Set(contactName.c_str());
+	hServiceName.Set(serviceName.c_str());
+
+	// RequestNewOutgoingCall may fail with E_ACCESSDENIED if the app lacks package identity.
+	// The coordinator and MuteStateChanged events remain active regardless.
+	HRESULT hr = m_impl->coordinator->RequestNewOutgoingCall(context.Get(), hContactName.Get(),
+															 hServiceName.Get(),
+															 VoipPhoneCallMedia_Audio, &call);
+	if (SUCCEEDED(hr))
+		m_impl->call = call;
+}
+
+void UniversalMuter::tryEndCall() {
+	if (!m_impl->call)
+		return;
+	m_impl->call->NotifyCallEnded();
+	m_impl->call.Reset();
+}
+
+void UniversalMuter::trySetCallName(const std::wstring &callName) {
+	if (!m_impl->call)
+		return;
+	HString name;
+	name.Set(callName.c_str());
+	m_impl->call->put_ContactName(name.Get());
+}
+
+void UniversalMuter::setMuted() {
+	if (m_impl->coordinator)
+		m_impl->coordinator->NotifyMuted();
+}
+
+void UniversalMuter::setUnmuted() {
+	if (m_impl->coordinator)
+		m_impl->coordinator->NotifyUnmuted();
+}

--- a/src/mumble/UniversalMute.h
+++ b/src/mumble/UniversalMute.h
@@ -1,0 +1,48 @@
+// Copyright The Mumble Developers. All rights reserved.
+// Use of this source code is governed by a BSD-style license
+// that can be found in the LICENSE file at the root of the
+// Mumble source tree or at <https://www.mumble.info/LICENSE>.
+
+#ifndef MUMBLE_MUMBLE_UNIVERSAL_MUTE_H_
+#define MUMBLE_MUMBLE_UNIVERSAL_MUTE_H_
+
+#include <functional>
+#include <memory>
+#include <string>
+
+// A wrapper around the Windows 10 VoIP Call API, specifically enough to
+// interact with the Windows 11 Universal Mute feature. This ensures physical mute buttons
+// in recent laptops can mute Mumble.
+//
+// Universal Mute is only supported on Windows 11 22H2 and later, but this class
+// gracefully no-ops on unsupported platforms.
+//
+// https://stackoverflow.com/questions/74683703/how-do-i-support-call-mute-universal-mute-in-my-app-for-windows-11-22h2
+class UniversalMuter {
+public:
+	// The onMuted/onUnmuted callbacks are called when the user mutes/unmutes themselves using
+	// the Universal Mute button. They must call setMuted()/setUnmuted() here when they have
+	// processed the event, or the button won't actually change state.
+	UniversalMuter(std::function< void() > onMuted, std::function< void() > onUnmuted);
+	~UniversalMuter();
+
+	UniversalMuter(const UniversalMuter &)            = delete;
+	UniversalMuter &operator=(const UniversalMuter &) = delete;
+	UniversalMuter(UniversalMuter &&)                 = delete;
+	UniversalMuter &operator=(UniversalMuter &&)      = delete;
+
+	void setMuted();
+	void setUnmuted();
+
+	void startCall(const std::wstring &contactName, const std::wstring &serviceName);
+	void tryEndCall();
+
+	void trySetCallName(const std::wstring &callName);
+
+private:
+	// Use the PIMPL pattern to avoid including WRL/WinRT headers in the public header.
+	struct Impl;
+	std::shared_ptr< Impl > m_impl;
+};
+
+#endif // MUMBLE_MUMBLE_UNIVERSAL_MUTE_H_

--- a/src/mumble/mumble_ar.ts
+++ b/src/mumble/mumble_ar.ts
@@ -6884,6 +6884,10 @@ the channel&apos;s context menu.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <source>Connecting...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>That sound was the mute cue. It activates when you speak while muted. Would you like to keep it enabled?</source>
         <translation type="unfinished"></translation>
     </message>

--- a/src/mumble/mumble_bg.ts
+++ b/src/mumble/mumble_bg.ts
@@ -6881,6 +6881,10 @@ the channel&apos;s context menu.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <source>Connecting...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>That sound was the mute cue. It activates when you speak while muted. Would you like to keep it enabled?</source>
         <translation type="unfinished"></translation>
     </message>

--- a/src/mumble/mumble_br.ts
+++ b/src/mumble/mumble_br.ts
@@ -6880,6 +6880,10 @@ the channel&apos;s context menu.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <source>Connecting...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>That sound was the mute cue. It activates when you speak while muted. Would you like to keep it enabled?</source>
         <translation type="unfinished"></translation>
     </message>

--- a/src/mumble/mumble_ca.ts
+++ b/src/mumble/mumble_ca.ts
@@ -6947,6 +6947,10 @@ al menú contextual del canal.</translation>
         <translation>Això comprova si el mumble està actualitzat</translation>
     </message>
     <message>
+        <source>Connecting...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>That sound was the mute cue. It activates when you speak while muted. Would you like to keep it enabled?</source>
         <translation>Aquest so és el senyal de treure la paraula. S&apos;activa quan es parla mentre es no teniu la paraula. Voleu mantenir-ho activat?</translation>
     </message>

--- a/src/mumble/mumble_cs.ts
+++ b/src/mumble/mumble_cs.ts
@@ -6938,6 +6938,10 @@ kontextové nabídce kanálů.</translation>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <source>Connecting...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>That sound was the mute cue. It activates when you speak while muted. Would you like to keep it enabled?</source>
         <translation type="unfinished"></translation>
     </message>

--- a/src/mumble/mumble_cy.ts
+++ b/src/mumble/mumble_cy.ts
@@ -6884,6 +6884,10 @@ the channel&apos;s context menu.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <source>Connecting...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>That sound was the mute cue. It activates when you speak while muted. Would you like to keep it enabled?</source>
         <translation type="unfinished"></translation>
     </message>

--- a/src/mumble/mumble_da.ts
+++ b/src/mumble/mumble_da.ts
@@ -6937,6 +6937,10 @@ kanalens genvejsmenu.</translation>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <source>Connecting...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>That sound was the mute cue. It activates when you speak while muted. Would you like to keep it enabled?</source>
         <translation type="unfinished"></translation>
     </message>

--- a/src/mumble/mumble_de.ts
+++ b/src/mumble/mumble_de.ts
@@ -6947,6 +6947,10 @@ des Kanals auswählen.</translation>
         <translation>Dies prüft, ob mumble auf dem neuesten Stand ist</translation>
     </message>
     <message>
+        <source>Connecting...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>That sound was the mute cue. It activates when you speak while muted. Would you like to keep it enabled?</source>
         <translation>Dieser Sound war der Stumm-Hinweis. Er wird aktiviert, wenn gesprochen wird, obwohl eine Stummschaltung besteht. Aktiviert lassen?</translation>
     </message>

--- a/src/mumble/mumble_el.ts
+++ b/src/mumble/mumble_el.ts
@@ -6947,6 +6947,10 @@ the channel&apos;s context menu.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <source>Connecting...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>That sound was the mute cue. It activates when you speak while muted. Would you like to keep it enabled?</source>
         <translation type="unfinished"></translation>
     </message>

--- a/src/mumble/mumble_en.ts
+++ b/src/mumble/mumble_en.ts
@@ -6879,6 +6879,10 @@ the channel&apos;s context menu.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <source>Connecting...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>That sound was the mute cue. It activates when you speak while muted. Would you like to keep it enabled?</source>
         <translation type="unfinished"></translation>
     </message>

--- a/src/mumble/mumble_en_GB.ts
+++ b/src/mumble/mumble_en_GB.ts
@@ -6934,6 +6934,10 @@ the channel&apos;s context menu.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <source>Connecting...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>That sound was the mute cue. It activates when you speak while muted. Would you like to keep it enabled?</source>
         <translation type="unfinished"></translation>
     </message>

--- a/src/mumble/mumble_eo.ts
+++ b/src/mumble/mumble_eo.ts
@@ -6892,6 +6892,10 @@ the channel&apos;s context menu.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <source>Connecting...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>That sound was the mute cue. It activates when you speak while muted. Would you like to keep it enabled?</source>
         <translation type="unfinished"></translation>
     </message>

--- a/src/mumble/mumble_es.ts
+++ b/src/mumble/mumble_es.ts
@@ -6948,6 +6948,10 @@ en el menu contextual del canal.</translation>
         <translation>Esto comprobará si Mumble está actualizado</translation>
     </message>
     <message>
+        <source>Connecting...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>That sound was the mute cue. It activates when you speak while muted. Would you like to keep it enabled?</source>
         <translation>Ese sonido era la señal de silencio. Se activa cuando hablas estando silenciado. ¿Quieres mantenerlo activado?</translation>
     </message>

--- a/src/mumble/mumble_et.ts
+++ b/src/mumble/mumble_et.ts
@@ -6881,6 +6881,10 @@ the channel&apos;s context menu.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <source>Connecting...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>That sound was the mute cue. It activates when you speak while muted. Would you like to keep it enabled?</source>
         <translation type="unfinished"></translation>
     </message>

--- a/src/mumble/mumble_eu.ts
+++ b/src/mumble/mumble_eu.ts
@@ -6899,6 +6899,10 @@ the channel&apos;s context menu.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <source>Connecting...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>That sound was the mute cue. It activates when you speak while muted. Would you like to keep it enabled?</source>
         <translation type="unfinished"></translation>
     </message>

--- a/src/mumble/mumble_fa_IR.ts
+++ b/src/mumble/mumble_fa_IR.ts
@@ -6881,6 +6881,10 @@ the channel&apos;s context menu.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <source>Connecting...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>That sound was the mute cue. It activates when you speak while muted. Would you like to keep it enabled?</source>
         <translation type="unfinished"></translation>
     </message>

--- a/src/mumble/mumble_fi.ts
+++ b/src/mumble/mumble_fi.ts
@@ -6947,6 +6947,10 @@ kanavien alivalikosta.</translation>
         <translation>Tämä tarkistaa onko mumble ajantasalla</translation>
     </message>
     <message>
+        <source>Connecting...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>That sound was the mute cue. It activates when you speak while muted. Would you like to keep it enabled?</source>
         <translation>Tuo ääni oli mykistyksen äänimerkki. Se kuuluu kun puhut mykistettynä. Haluatko pitää äänimerkin päällä?</translation>
     </message>

--- a/src/mumble/mumble_fr.ts
+++ b/src/mumble/mumble_fr.ts
@@ -6947,6 +6947,10 @@ pour filtrage depuis le menu du salon.</translation>
         <translation>Ceci vérifiera si mumble est à jour</translation>
     </message>
     <message>
+        <source>Connecting...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>That sound was the mute cue. It activates when you speak while muted. Would you like to keep it enabled?</source>
         <translation>Ce son était l&apos;indicateur de l&apos;état muet. Il s&apos;active lorsque vous parlez alors que vous êtes muet. Souhaitez-vous le garder activé&#x202f;?</translation>
     </message>

--- a/src/mumble/mumble_gl.ts
+++ b/src/mumble/mumble_gl.ts
@@ -6882,6 +6882,10 @@ the channel&apos;s context menu.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <source>Connecting...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>That sound was the mute cue. It activates when you speak while muted. Would you like to keep it enabled?</source>
         <translation type="unfinished"></translation>
     </message>

--- a/src/mumble/mumble_he.ts
+++ b/src/mumble/mumble_he.ts
@@ -6934,6 +6934,10 @@ the channel&apos;s context menu.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <source>Connecting...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>That sound was the mute cue. It activates when you speak while muted. Would you like to keep it enabled?</source>
         <translation type="unfinished"></translation>
     </message>

--- a/src/mumble/mumble_hi.ts
+++ b/src/mumble/mumble_hi.ts
@@ -6064,6 +6064,10 @@ the channel&apos;s context menu.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <source>Connecting...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Change your comment</source>
         <translation type="unfinished"></translation>
     </message>

--- a/src/mumble/mumble_hu.ts
+++ b/src/mumble/mumble_hu.ts
@@ -6928,6 +6928,10 @@ the channel&apos;s context menu.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <source>Connecting...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>That sound was the mute cue. It activates when you speak while muted. Would you like to keep it enabled?</source>
         <translation type="unfinished"></translation>
     </message>

--- a/src/mumble/mumble_it.ts
+++ b/src/mumble/mumble_it.ts
@@ -6947,6 +6947,10 @@ contestuale del canale.</translation>
         <translation>Questo controllerà se Mumble sia aggiornato</translation>
     </message>
     <message>
+        <source>Connecting...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>That sound was the mute cue. It activates when you speak while muted. Would you like to keep it enabled?</source>
         <translation>Quel suono era l&apos;attivazione del muto. Si attiva quando parli mentre sei mutato. Voui mantenerlo attivo?</translation>
     </message>

--- a/src/mumble/mumble_ja.ts
+++ b/src/mumble/mumble_ja.ts
@@ -6932,6 +6932,10 @@ the channel&apos;s context menu.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <source>Connecting...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>That sound was the mute cue. It activates when you speak while muted. Would you like to keep it enabled?</source>
         <translation type="unfinished"></translation>
     </message>

--- a/src/mumble/mumble_ko.ts
+++ b/src/mumble/mumble_ko.ts
@@ -6946,6 +6946,10 @@ the channel&apos;s context menu.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <source>Connecting...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>That sound was the mute cue. It activates when you speak while muted. Would you like to keep it enabled?</source>
         <translation type="unfinished"></translation>
     </message>

--- a/src/mumble/mumble_lt.ts
+++ b/src/mumble/mumble_lt.ts
@@ -6913,6 +6913,10 @@ the channel&apos;s context menu.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <source>Connecting...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>That sound was the mute cue. It activates when you speak while muted. Would you like to keep it enabled?</source>
         <translation type="unfinished"></translation>
     </message>

--- a/src/mumble/mumble_nl.ts
+++ b/src/mumble/mumble_nl.ts
@@ -6947,6 +6947,10 @@ context-menu van het kanaal.</translation>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <source>Connecting...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>That sound was the mute cue. It activates when you speak while muted. Would you like to keep it enabled?</source>
         <translation type="unfinished"></translation>
     </message>

--- a/src/mumble/mumble_no.ts
+++ b/src/mumble/mumble_no.ts
@@ -6962,6 +6962,10 @@ Du kan markere ytterligere kanaler fra filtrering fra kanalens bindeleddsmeny.</
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <source>Connecting...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>That sound was the mute cue. It activates when you speak while muted. Would you like to keep it enabled?</source>
         <translation type="unfinished"></translation>
     </message>

--- a/src/mumble/mumble_oc.ts
+++ b/src/mumble/mumble_oc.ts
@@ -6881,6 +6881,10 @@ the channel&apos;s context menu.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <source>Connecting...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>That sound was the mute cue. It activates when you speak while muted. Would you like to keep it enabled?</source>
         <translation type="unfinished"></translation>
     </message>

--- a/src/mumble/mumble_pl.ts
+++ b/src/mumble/mumble_pl.ts
@@ -6948,6 +6948,10 @@ kanały mają być filtrowane.</translation>
         <translation>Sprawdza, czy program Mumble jest aktualny</translation>
     </message>
     <message>
+        <source>Connecting...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>That sound was the mute cue. It activates when you speak while muted. Would you like to keep it enabled?</source>
         <translation>Ten dźwięk był niemym sygnałem. Włącza się, gdy mówisz po wyciszeniu. Czy chcesz, aby była on włączony?</translation>
     </message>

--- a/src/mumble/mumble_pt_BR.ts
+++ b/src/mumble/mumble_pt_BR.ts
@@ -6947,6 +6947,10 @@ no menu contextual do canal.</translation>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <source>Connecting...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>That sound was the mute cue. It activates when you speak while muted. Would you like to keep it enabled?</source>
         <translation type="unfinished"></translation>
     </message>

--- a/src/mumble/mumble_pt_PT.ts
+++ b/src/mumble/mumble_pt_PT.ts
@@ -6947,6 +6947,10 @@ do menu de contexto do canal.</translation>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <source>Connecting...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>That sound was the mute cue. It activates when you speak while muted. Would you like to keep it enabled?</source>
         <translation type="unfinished"></translation>
     </message>

--- a/src/mumble/mumble_ro.ts
+++ b/src/mumble/mumble_ro.ts
@@ -6889,6 +6889,10 @@ the channel&apos;s context menu.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <source>Connecting...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>That sound was the mute cue. It activates when you speak while muted. Would you like to keep it enabled?</source>
         <translation type="unfinished"></translation>
     </message>

--- a/src/mumble/mumble_ru.ts
+++ b/src/mumble/mumble_ru.ts
@@ -6948,6 +6948,10 @@ the channel&apos;s context menu.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <source>Connecting...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>That sound was the mute cue. It activates when you speak while muted. Would you like to keep it enabled?</source>
         <translation>Сейчас прозвучал сигнал заглушения. Это происходит, когда вы говорите при заглушенном микрофоне. Хотите оставить его включенным?</translation>
     </message>

--- a/src/mumble/mumble_si.ts
+++ b/src/mumble/mumble_si.ts
@@ -5957,6 +5957,10 @@ the channel&apos;s context menu.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <source>Connecting...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Change your comment</source>
         <translation type="unfinished"></translation>
     </message>

--- a/src/mumble/mumble_sk.ts
+++ b/src/mumble/mumble_sk.ts
@@ -6033,6 +6033,10 @@ the channel&apos;s context menu.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <source>Connecting...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Change your comment</source>
         <translation type="unfinished"></translation>
     </message>

--- a/src/mumble/mumble_sq.ts
+++ b/src/mumble/mumble_sq.ts
@@ -6092,6 +6092,10 @@ the channel&apos;s context menu.</source>
         <translation>Rilidhje e Jetpack-ut</translation>
     </message>
     <message>
+        <source>Connecting...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Change your comment</source>
         <translation>Ndryshoni komentin tuaj</translation>
     </message>

--- a/src/mumble/mumble_sv.ts
+++ b/src/mumble/mumble_sv.ts
@@ -6947,6 +6947,10 @@ kanalens innehållsmeny.</translation>
         <translation>Detta kontrollerar om mumble är uppdaterat</translation>
     </message>
     <message>
+        <source>Connecting...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>That sound was the mute cue. It activates when you speak while muted. Would you like to keep it enabled?</source>
         <translation>Det ljudet var den tysta signalen. Den aktiveras när du talar medan ljudet är tyst. Vill du behålla det aktiverat?</translation>
     </message>

--- a/src/mumble/mumble_te.ts
+++ b/src/mumble/mumble_te.ts
@@ -6892,6 +6892,10 @@ the channel&apos;s context menu.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <source>Connecting...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>That sound was the mute cue. It activates when you speak while muted. Would you like to keep it enabled?</source>
         <translation type="unfinished"></translation>
     </message>

--- a/src/mumble/mumble_th.ts
+++ b/src/mumble/mumble_th.ts
@@ -6879,6 +6879,10 @@ the channel&apos;s context menu.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <source>Connecting...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>That sound was the mute cue. It activates when you speak while muted. Would you like to keep it enabled?</source>
         <translation type="unfinished"></translation>
     </message>

--- a/src/mumble/mumble_tr.ts
+++ b/src/mumble/mumble_tr.ts
@@ -6946,6 +6946,10 @@ filtrelenmesi için ilave kanallar ekleyebilirsiniz.</translation>
         <translation>Bu, mumble&apos;ın güncel olup olmadığını kontrol edecektir</translation>
     </message>
     <message>
+        <source>Connecting...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>That sound was the mute cue. It activates when you speak while muted. Would you like to keep it enabled?</source>
         <translation>Bu ses, susturulduğunuzun işaretiydi. Susturulduğunuzda konuşursanız etkinleşir. Bunu faal olarak muhafaza etmek ister misiniz?</translation>
     </message>

--- a/src/mumble/mumble_uk.ts
+++ b/src/mumble/mumble_uk.ts
@@ -6948,6 +6948,10 @@ the channel&apos;s context menu.</source>
         <translation>Це перевірить, чи Mumble оновлено</translation>
     </message>
     <message>
+        <source>Connecting...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>That sound was the mute cue. It activates when you speak while muted. Would you like to keep it enabled?</source>
         <translation>Цей звук був сигналом вимкнення звуку. Він активується, коли ви говорите з вимкненим звуком. Бажаєте залишити його ввімкненим?</translation>
     </message>

--- a/src/mumble/mumble_zh_CN.ts
+++ b/src/mumble/mumble_zh_CN.ts
@@ -6946,6 +6946,10 @@ the channel&apos;s context menu.</source>
         <translation>这会检查 Mumble 是否为最新版</translation>
     </message>
     <message>
+        <source>Connecting...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>That sound was the mute cue. It activates when you speak while muted. Would you like to keep it enabled?</source>
         <translation>此声音是静音提示。您在静音时发言会激活它。您希望保持启用吗？</translation>
     </message>

--- a/src/mumble/mumble_zh_HK.ts
+++ b/src/mumble/mumble_zh_HK.ts
@@ -6881,6 +6881,10 @@ the channel&apos;s context menu.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <source>Connecting...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>That sound was the mute cue. It activates when you speak while muted. Would you like to keep it enabled?</source>
         <translation type="unfinished"></translation>
     </message>

--- a/src/mumble/mumble_zh_TW.ts
+++ b/src/mumble/mumble_zh_TW.ts
@@ -6911,6 +6911,10 @@ the channel&apos;s context menu.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <source>Connecting...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>That sound was the mute cue. It activates when you speak while muted. Would you like to keep it enabled?</source>
         <translation type="unfinished"></translation>
     </message>


### PR DESCRIPTION
Today, Mumble does not support the Universal Mute button in Windows, which additionally means that physical mute buttons in newer laptops cannot mute Mumble. This change adds support for these button (and the Windows-wide shortcut `Win+Alt+K`) by  using the Windows VOIP API.

<img width="406" height="258" alt="the Universal Mute button" src="https://github.com/user-attachments/assets/33cb5275-58a8-47f9-bb4a-fb825aec1275" />

### What changed?

* Add a `UniversalMuter` on Windows builds that wraps the WinRT [`Windows.ApplicationModel.Calls.VoipCallCordinator`'](https://learn.microsoft.com/en-us/uwp/api/windows.applicationmodel.calls.voipcallcoordinator?view=winrt-26100) APIs.
* Use this `UniversalMuter` to read/write mute state during calls.
* Documented a bit more on how to build on Windows, especially using the pre-made vcpkg triplets.

A bit of background: I've wanted to implement this for a while now. I wrote the most popular [StackOverflow question about the Universal Mute API](https://stackoverflow.com/questions/74683703/how-do-i-support-call-mute-universal-mute-in-my-app-for-windows-11-22h2) while I worked at Microsoft (I had no affiliation with writing the API), wrote a simple [C# demo app](https://github.com/citelao/Universal-Mute) for it, and I wrote [a Rust plugin for Mumble](https://github.com/citelao/mumble-universal-mute) that does the same thing. 

I used Claude Code to help generate this work.

### Checks

Deployed locally on Windows 11.

* [x] When first launched, no call is in progress.
* [x] Upon joining a channel, the Universal Mute button lights up.
* [x] Upon joining a channel, the Universal Mute button reflects my initial mute state.
* [x] When the Universal Mute button is pressed, toggles mute/unmute in Mumble.
* [x] When Mumble is muted/unmuted, the Universal Mute button reflects the new state.
* [x] When Mumble is deafened/undeafened, the Universal Mute button reflects the new state.
* [x] Upon leaving a call, the Universal Mute button turns off.
* [x] State stays consistent even after hammering the button.
* [x] My commits follow the [commit guidelines](https://github.com/mumble-voip/mumble/blob/master/COMMIT_GUIDELINES.md)

Happy to address any feedback!