### PR TITLE
CI(client): Include Mac OS client app bundle in build artifacts

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -120,6 +120,7 @@ jobs:
         compression-level: 9
         path: |
           build/mumble
+          build/Mumble.app
           build/mumble-server
           build/**/mumble*.msi
           build/**/mumble*.exe

--- a/src/mumble/CMakeLists.txt
+++ b/src/mumble/CMakeLists.txt
@@ -376,11 +376,13 @@ if(WIN32)
 		set_property(TARGET mumble APPEND_STRING PROPERTY LINK_FLAGS " /MANIFESTUAC:\"level=\'asInvoker\' uiAccess=\'true\'\"")
 	endif()
 elseif(APPLE)
+	set_source_files_properties("${MUMBLE_ICNS}" PROPERTIES MACOSX_PACKAGE_LOCATION "Resources")
+	target_sources(mumble PRIVATE "${MUMBLE_ICNS}")
+
 	set_target_properties(mumble
 		PROPERTIES
 			OUTPUT_NAME "Mumble"
 			MACOSX_BUNDLE TRUE
-			RESOURCE ${MUMBLE_ICNS}
 			MACOSX_BUNDLE_INFO_PLIST ${MUMBLE_PLIST}
 	)
 endif()


### PR DESCRIPTION
## Summary

Include the macOS Mumble client (Mumble.app) in CI build artifacts, which previously only included mumble-server. Also add a post-build command to copy the app icon into the bundle's Resources directory, as the Ninja generator doesn't handle the RESOURCE target property during build.

## Testing
- After adding the missing file path to the workflow it appeared in the resulting zip and was able to be opened on my macbook, however, I noticed that the app had no icon.
- I asked Claude to fix the missing icon issue and verified that the icon was present for the app bundle in the resulting artifact.

### Checks

- [x] My commits follow the [commit guidelines](https://github.com/mumble-voip/mumble/blob/master/COMMIT_GUIDELINES.md)

