### PR TITLE
FEAT(Client): Add Documentation dialog with official resource links

### DIFF
--- a/src/mumble/CMakeLists.txt
+++ b/src/mumble/CMakeLists.txt
@@ -145,6 +145,8 @@ set(MUMBLE_SOURCES
 	"Database.h"
 	"DeveloperConsole.cpp"
 	"DeveloperConsole.h"
+	"Documentation.cpp"
+	"Documentation.h"
 	"EchoCancelOption.cpp"
 	"EchoCancelOption.h"
 	"EnumStringConversions.cpp"

--- a/src/mumble/Documentation.cpp
+++ b/src/mumble/Documentation.cpp
@@ -1,0 +1,41 @@
+// Copyright The Mumble Developers. All rights reserved.
+// Use of this source code is governed by a BSD-style license
+// that can be found in the LICENSE file at the root of the
+// Mumble source tree or at <https://www.mumble.info/LICENSE>.
+
+#include "Documentation.h"
+
+#include <QtWidgets/QPushButton>
+#include <QtWidgets/QTextBrowser>
+#include <QtWidgets/QVBoxLayout>
+
+DocumentationDialog::DocumentationDialog(QWidget *parent) : QDialog(parent) {
+	setWindowTitle(tr("Mumble Documentation"));
+	resize(640, 520);
+
+	QVBoxLayout *mainLayout = new QVBoxLayout(this);
+
+	QTextBrowser *documentationView = new QTextBrowser(this);
+	documentationView->setReadOnly(true);
+	documentationView->setOpenExternalLinks(true);
+	documentationView->setAccessibleName(tr("Documentation links"));
+	documentationView->setHtml(
+		tr("<h2>Welcome to Mumble Documentation</h2>"
+		   "<h3>Documentation</h3>"
+		   "<p>You can find official Mumble documentation and support resources below.</p>"
+		   "<p>For new users, start with the <a href=\"https://www.mumble.info/documentation/user/\">User Guide</a>.</p>"
+		   "<p>Configure key bindings with <a href=\"https://www.mumble.info/documentation/user/global-shortcuts/\">Global Shortcuts</a>.</p>"
+		   "<p>Tune your setup with the <a href=\"https://www.mumble.info/documentation/user/audio-settings/\">Audio Settings guide</a>.</p>"
+		   "<p>Browse all topics in <a href=\"https://www.mumble.info/documentation/\">Main Documentation</a>.</p>"
+		   "<h3>Help and Resources</h3>"
+		   "<p>Download the latest release from <a href=\"https://www.mumble.info/downloads/\">Downloads</a>.</p>"
+		   "<p>Report issues or get technical help via <a href=\"https://github.com/mumble-voip/mumble/issues\">GitHub Issues</a>.</p>"
+		   "<p>Read project updates on the <a href=\"https://www.mumble.info/blog/\">Blog</a>.</p>"
+		   "<p>Reach the team through the <a href=\"https://www.mumble.info/contact/\">Contact page</a>.</p>"));
+
+	QPushButton *okButton = new QPushButton(tr("OK"), this);
+	connect(okButton, SIGNAL(clicked()), this, SLOT(accept()));
+
+	mainLayout->addWidget(documentationView);
+	mainLayout->addWidget(okButton);
+}

--- a/src/mumble/Documentation.h
+++ b/src/mumble/Documentation.h
@@ -1,0 +1,20 @@
+// Copyright The Mumble Developers. All rights reserved.
+// Use of this source code is governed by a BSD-style license
+// that can be found in the LICENSE file at the root of the
+// Mumble source tree or at <https://www.mumble.info/LICENSE>.
+
+#ifndef MUMBLE_MUMBLE_DOCUMENTATION_H_
+#define MUMBLE_MUMBLE_DOCUMENTATION_H_
+
+#include <QtWidgets/QDialog>
+
+class DocumentationDialog : public QDialog {
+private:
+	Q_OBJECT
+	Q_DISABLE_COPY(DocumentationDialog)
+
+public:
+	explicit DocumentationDialog(QWidget *parent = nullptr);
+};
+
+#endif

--- a/src/mumble/MainWindow.cpp
+++ b/src/mumble/MainWindow.cpp
@@ -18,6 +18,7 @@
 #include "Connection.h"
 #include "Database.h"
 #include "DeveloperConsole.h"
+#include "Documentation.h"
 #include "Log.h"
 #include "MumbleConstants.h"
 #include "Net.h"
@@ -2874,6 +2875,10 @@ void MainWindow::on_qaHelpAboutQt_triggered() {
 	openAboutQtDialog();
 }
 
+void MainWindow::on_qaHelpDocumentation_triggered() {
+	openDocumentationDialog();
+}
+
 void MainWindow::on_qaHelpVersionCheck_triggered() {
 	versionCheck();
 }
@@ -4269,6 +4274,11 @@ void MainWindow::openAboutDialog() {
 
 void MainWindow::openAboutQtDialog() {
 	QMessageBox::aboutQt(this, tr("About Qt"));
+}
+
+void MainWindow::openDocumentationDialog() {
+	DocumentationDialog documentationDialog(this);
+	documentationDialog.exec();
 }
 
 void MainWindow::versionCheck() {

--- a/src/mumble/MainWindow.h
+++ b/src/mumble/MainWindow.h
@@ -305,6 +305,7 @@ public slots:
 	void on_qaHelpWhatsThis_triggered();
 	void on_qaHelpAbout_triggered();
 	void on_qaHelpAboutQt_triggered();
+	void on_qaHelpDocumentation_triggered();
 	void on_qaHelpVersionCheck_triggered();
 	void on_qaQuit_triggered();
 	void on_qteChat_tabPressed();
@@ -477,6 +478,7 @@ public:
 	void enableAudioTTS(bool enable);
 	void openAboutDialog();
 	void openAboutQtDialog();
+	void openDocumentationDialog();
 	void versionCheck();
 	void enablePositionalAudio(bool enable);
 };

--- a/src/mumble/MainWindow.ui
+++ b/src/mumble/MainWindow.ui
@@ -62,6 +62,7 @@
      <string>&amp;Help</string>
     </property>
     <addaction name="qaHelpWhatsThis"/>
+     <addaction name="qaHelpDocumentation"/>
     <addaction name="separator"/>
     <addaction name="qaHelpAbout"/>
     <addaction name="qaHelpAboutQt"/>
@@ -736,6 +737,17 @@ the channel's context menu.</string>
    </property>
    <property name="menuRole">
     <enum>QAction::AboutQtRole</enum>
+   </property>
+  </action>
+  <action name="qaHelpDocumentation">
+   <property name="text">
+    <string>&amp;Documentation</string>
+   </property>
+   <property name="toolTip">
+    <string>Open links to official Mumble documentation resources</string>
+   </property>
+   <property name="whatsThis">
+    <string>Shows official Mumble documentation and support links.</string>
    </property>
   </action>
   <action name="qaHelpVersionCheck">


### PR DESCRIPTION
### Summary
This pull request adds a new "Documentation" dialog to the Help menu in the Mumble client. The dialog provides users with direct links to official Mumble resources, including:

- User Guide
- Global Shortcuts
- Audio Settings
- Main Documentation
- Downloads
- GitHub Issues
- Blog
- Contact

### Implementation Details
- The dialog is implemented as a new QDialog subclass, following the pattern of the existing About dialog.
- All links are displayed in a QTextBrowser and open in the user's default browser.
- The new action is added to the Help menu and is fully integrated with the existing UI and slot system.


### Notes
- No changes to existing features or settings.
- No new dependencies introduced.

<!-- If this PR addresses a specific issue, add the following line: -->
<!-- Implements #<issue-number> -->


### Checks

- [x] My commits follow the [commit guidelines](https://github.com/mumble-voip/mumble/blob/master/COMMIT_GUIDELINES.md)

