### PR TITLE
Backport "Merge PR #7148: FIX(client, server): Detect invalid varint encodings" to 1.5.x

### DIFF
--- a/src/PacketDataStream.h
+++ b/src/PacketDataStream.h
@@ -202,23 +202,38 @@ public:
 		quint64 v = next();
 
 		if ((v & 0x80) == 0x00) {
+			// most significant bit is unset
+			// -> remaining 7-bit are the encoded positive number
 			i = (v & 0x7F);
 		} else if ((v & 0xC0) == 0x80) {
+			// most significant bit is set but second most significant is not
+			// -> remaining 6 bits plus the 8 bits of the subsequent byte encode
+			// a 14-bit positive integer
 			i = (v & 0x3F) << 8 | next();
 		} else if ((v & 0xF0) == 0xF0) {
+			// The four most significant bits are set
 			switch (v & 0xFC) {
 				case 0xF0:
+					// Of the first six most significant bits, only the first four are set
+					// -> this is followed by a regular 32-bit positive integer
 					i = next() << 24 | next() << 16 | next() << 8 | next();
 					break;
 				case 0xF4:
+					// Bit pattern 111101
+					// -> this is followed by a 64-bit integer
 					i = next() << 56 | next() << 48 | next() << 40 | next() << 32 | next() << 24 | next() << 16
 						| next() << 8 | next();
 					break;
 				case 0xF8:
+					// Of the first six most significant bits, only the first five are set
+					// -> this is followed by another varint-encoded integer,
+					// which we understand to be negative
 					*this >> i;
 					i = ~i;
 					break;
 				case 0xFC:
+					// All six most significant bits are set
+					// -> remaining 2 bits encode a 2-bit integer that we understand to be negative
 					i = v & 0x03;
 					i = ~i;
 					break;
@@ -228,8 +243,14 @@ public:
 					break;
 			}
 		} else if ((v & 0xF0) == 0xE0) {
+			// Among the four most significant bits, only the first three are set
+			// -> remaining 4 bits along with the next 3 bytes encode a
+			// 28-bit positive number
 			i = (v & 0x0F) << 24 | next() << 16 | next() << 8 | next();
 		} else if ((v & 0xE0) == 0xC0) {
+			// Among the three most significant bits, only the first two are set
+			// -> remaining 5 bits along with the 2 following bytes, this encodes
+			// a 21-bit positive number
 			i = (v & 0x1F) << 16 | next() << 8 | next();
 		}
 		return *this;

--- a/src/PacketDataStream.h
+++ b/src/PacketDataStream.h
@@ -216,15 +216,28 @@ public:
 			// The four most significant bits are set
 			// This is a special variant where the entire value is encoded in subsequent bytes
 			switch (v & 0xFC) {
-				case 0xF0:
+				case 0xF0: {
 					// Of the first six most significant bits, only the first four are set
 					// -> this is followed by a regular 32-bit positive integer
-					return next() << 24 | next() << 16 | next() << 8 | next();
-				case 0xF4:
+					quint64 result = next() << 24;
+					result |= next() << 16;
+					result |= next() << 8;
+					result |= next();
+					return result;
+				}
+				case 0xF4: {
 					// Bit pattern 111101
 					// -> this is followed by a 64-bit integer
-					return next() << 56 | next() << 48 | next() << 40 | next() << 32 | next() << 24 | next() << 16
-						   | next() << 8 | next();
+					quint64 result = next() << 56;
+					result |= next() << 48;
+					result |= next() << 40;
+					result |= next() << 32;
+					result |= next() << 24;
+					result |= next() << 16;
+					result |= next() << 8;
+					result |= next();
+					return result;
+				}
 				case 0xF8:
 					// Of the first six most significant bits, only the first five are set
 					// -> this is followed by another varint-encoded integer,
@@ -255,13 +268,20 @@ public:
 			// Among the four most significant bits, only the first three are set
 			// -> remaining 4 bits along with the next 3 bytes encode a
 			// 28-bit positive number
-			return (v & 0x0F) << 24 | next() << 16 | next() << 8 | next();
+			quint64 result = (v & 0x0F) << 24;
+			result |= next() << 16;
+			result |= next() << 8;
+			result |= next();
+			return result;
 		}
 		if ((v & 0xE0) == 0xC0) {
 			// Among the three most significant bits, only the first two are set
 			// -> remaining 5 bits along with the 2 following bytes, this encodes
 			// a 21-bit positive number
-			return (v & 0x1F) << 16 | next() << 8 | next();
+			quint64 result = (v & 0x1F) << 16;
+			result |= next() << 8;
+			result |= next();
+			return result;
 		}
 
 		// Unhandled case

--- a/src/PacketDataStream.h
+++ b/src/PacketDataStream.h
@@ -198,61 +198,81 @@ public:
 		return *this;
 	}
 
-	PacketDataStream &operator>>(quint64 &i) {
+	quint64 decode_next_int(std::size_t recursionLevel = 0) {
 		quint64 v = next();
 
 		if ((v & 0x80) == 0x00) {
 			// most significant bit is unset
 			// -> remaining 7-bit are the encoded positive number
-			i = (v & 0x7F);
-		} else if ((v & 0xC0) == 0x80) {
+			return (v & 0x7F);
+		}
+		if ((v & 0xC0) == 0x80) {
 			// most significant bit is set but second most significant is not
 			// -> remaining 6 bits plus the 8 bits of the subsequent byte encode
 			// a 14-bit positive integer
-			i = (v & 0x3F) << 8 | next();
-		} else if ((v & 0xF0) == 0xF0) {
+			return (v & 0x3F) << 8 | next();
+		}
+		if ((v & 0xF0) == 0xF0) {
 			// The four most significant bits are set
+			// This is a special variant where the entire value is encoded in subsequent bytes
 			switch (v & 0xFC) {
 				case 0xF0:
 					// Of the first six most significant bits, only the first four are set
 					// -> this is followed by a regular 32-bit positive integer
-					i = next() << 24 | next() << 16 | next() << 8 | next();
-					break;
+					return next() << 24 | next() << 16 | next() << 8 | next();
 				case 0xF4:
 					// Bit pattern 111101
 					// -> this is followed by a 64-bit integer
-					i = next() << 56 | next() << 48 | next() << 40 | next() << 32 | next() << 24 | next() << 16
-						| next() << 8 | next();
-					break;
+					return next() << 56 | next() << 48 | next() << 40 | next() << 32 | next() << 24 | next() << 16
+						   | next() << 8 | next();
 				case 0xF8:
 					// Of the first six most significant bits, only the first five are set
 					// -> this is followed by another varint-encoded integer,
 					// which we understand to be negative
-					*this >> i;
-					i = ~i;
-					break;
+
+					if (recursionLevel >= 8) {
+						// Normally, we shouldn't recurse more than once so once we have reached
+						// this recursion depth, something fishy is going on. Presumably an
+						// invalid packet or something like that.
+						// In either case, we won't recurse any further and just give up...
+						ok = false;
+						return 0;
+					}
+
+					return ~(decode_next_int(recursionLevel + 1));
 				case 0xFC:
 					// All six most significant bits are set
 					// -> remaining 2 bits encode a 2-bit integer that we understand to be negative
-					i = v & 0x03;
-					i = ~i;
-					break;
-				default:
-					ok = false;
-					i  = 0;
-					break;
+					return ~(v & 0x03);
 			}
-		} else if ((v & 0xF0) == 0xE0) {
+
+			// Unhandled special case
+			ok = false;
+
+			return 0;
+		}
+		if ((v & 0xF0) == 0xE0) {
 			// Among the four most significant bits, only the first three are set
 			// -> remaining 4 bits along with the next 3 bytes encode a
 			// 28-bit positive number
-			i = (v & 0x0F) << 24 | next() << 16 | next() << 8 | next();
-		} else if ((v & 0xE0) == 0xC0) {
+			return (v & 0x0F) << 24 | next() << 16 | next() << 8 | next();
+		}
+		if ((v & 0xE0) == 0xC0) {
 			// Among the three most significant bits, only the first two are set
 			// -> remaining 5 bits along with the 2 following bytes, this encodes
 			// a 21-bit positive number
-			i = (v & 0x1F) << 16 | next() << 8 | next();
+			return (v & 0x1F) << 16 | next() << 8 | next();
 		}
+
+		// Unhandled case
+		ok = false;
+
+		return 0;
+	}
+
+	PacketDataStream &operator>>(quint64 &i) {
+		i = decode_next_int();
+
 		return *this;
 	}
 

--- a/src/tests/TestPacketDataStream/TestPacketDataStream.cpp
+++ b/src/tests/TestPacketDataStream/TestPacketDataStream.cpp
@@ -10,6 +10,10 @@
 #include <QtNetwork>
 #include <QtTest>
 
+#include <algorithm>
+#include <array>
+#include <cstdint>
+
 class TestPacketDataStream : public QObject {
 	Q_OBJECT
 private slots:
@@ -21,6 +25,7 @@ private slots:
 	void floating();
 	void floating_data();
 	void undersize();
+	void recursive();
 };
 
 void TestPacketDataStream::floating_data() {
@@ -147,6 +152,26 @@ void TestPacketDataStream::space() {
 	QVERIFY(!in.isValid());
 	QVERIFY(in.size() == 1);
 	QVERIFY(in.left() == 0);
+}
+
+void TestPacketDataStream::recursive() {
+	// A buffer that has a size of a couple hundred kB
+	// We fill it to mimic a particular case of an invalid packet where
+	// every byte (except the last one) will indicate that another varint
+	// will follow in the next byte(s).
+	std::array< char, 1 << 18 > hugeBuf;
+	std::fill(hugeBuf.begin(), hugeBuf.end(), 0xF8);
+	hugeBuf.back() = 0x02;
+
+	PacketDataStream stream(hugeBuf.data(), static_cast< unsigned int >(hugeBuf.size()));
+	QVERIFY(stream.isValid());
+
+	int val = 0;
+	stream >> val;
+	(void) val;
+
+	// For this kind of packet, we expect the stream to figure out that it is invalid
+	QVERIFY(!stream.isValid());
 }
 
 QTEST_MAIN(TestPacketDataStream)


### PR DESCRIPTION
Backport of https://github.com/mumble-voip/mumble/pull/7148
