### PR TITLE
FIX(client): Replace legacy sourceforge DBus domain with info.mumble

### DIFF
--- a/src/mumble/DBus.cpp
+++ b/src/mumble/DBus.cpp
@@ -24,7 +24,7 @@ void MumbleDBus::openUrl(const QString &url, const QDBusMessage &msg) {
 	valid      = valid && (u.scheme() == QLatin1String("mumble"));
 	if (!valid) {
 		QDBusConnection::sessionBus().send(
-			msg.createErrorReply(QLatin1String("net.sourceforge.mumble.Error.url"), QLatin1String("Invalid URL")));
+			msg.createErrorReply(dbusErrorPrefix() + QLatin1String(".url"), QLatin1String("Invalid URL")));
 	} else {
 		Global::get().mw->openUrl(u);
 	}
@@ -32,8 +32,8 @@ void MumbleDBus::openUrl(const QString &url, const QDBusMessage &msg) {
 
 void MumbleDBus::getCurrentUrl(const QDBusMessage &msg) {
 	if (!Global::get().sh || !Global::get().sh->isRunning() || !Global::get().uiSession) {
-		QDBusConnection::sessionBus().send(msg.createErrorReply(
-			QLatin1String("net.sourceforge.mumble.Error.connection"), QLatin1String("Not connected")));
+		QDBusConnection::sessionBus().send(
+			msg.createErrorReply(dbusErrorPrefix() + QLatin1String(".connection"), QLatin1String("Not connected")));
 		return;
 	}
 	QString host, user, pw;
@@ -68,8 +68,8 @@ void MumbleDBus::getCurrentUrl(const QDBusMessage &msg) {
 
 void MumbleDBus::getTalkingUsers(const QDBusMessage &msg) {
 	if (!Global::get().sh || !Global::get().sh->isRunning() || !Global::get().uiSession) {
-		QDBusConnection::sessionBus().send(msg.createErrorReply(
-			QLatin1String("net.sourceforge.mumble.Error.connection"), QLatin1String("Not connected")));
+		QDBusConnection::sessionBus().send(
+			msg.createErrorReply(dbusErrorPrefix() + QLatin1String(".connection"), QLatin1String("Not connected")));
 		return;
 	}
 	QStringList names;
@@ -97,8 +97,8 @@ void MumbleDBus::setTransmitMode(unsigned int mode, const QDBusMessage &msg) {
 			Global::get().s.atTransmit = Settings::PushToTalk;
 			break;
 		default:
-			QDBusConnection::sessionBus().send(msg.createErrorReply(
-				QLatin1String("net.sourceforge.mumble.Error.transmitMode"), QLatin1String("Invalid transmit mode")));
+			QDBusConnection::sessionBus().send(msg.createErrorReply(dbusErrorPrefix() + QLatin1String(".transmitMode"),
+																	QLatin1String("Invalid transmit mode")));
 			return;
 	}
 	QMetaObject::invokeMethod(Global::get().mw, "updateTransmitModeComboBox", Qt::QueuedConnection);

--- a/src/mumble/DBus.h
+++ b/src/mumble/DBus.h
@@ -11,9 +11,12 @@
 class QDBusMessage;
 
 class MumbleDBus : public QDBusAbstractAdaptor {
+protected:
+	virtual QString dbusErrorPrefix() const { return QLatin1String("info.mumble.Error"); }
+
 private:
 	Q_OBJECT
-	Q_CLASSINFO("D-Bus Interface", "net.sourceforge.mumble.Mumble")
+	Q_CLASSINFO("D-Bus Interface", "info.mumble.Mumble")
 	Q_DISABLE_COPY(MumbleDBus)
 	Q_PROPERTY(bool mute READ isSelfMuted WRITE setSelfMuted)
 	Q_PROPERTY(bool deaf READ isSelfDeaf WRITE setSelfDeaf)
@@ -43,6 +46,23 @@ public slots:
 	bool isSelfDeaf();
 	void startTalking();
 	void stopTalking();
+};
+
+/**
+ * Legacy DBus adaptor for backwards compatibility.
+ * Exposes the same interface as MumbleDBus but under the old
+ * net.sourceforge.mumble.Mumble name.
+ */
+class MumbleDBusLegacy : public MumbleDBus {
+protected:
+	QString dbusErrorPrefix() const override { return QLatin1String("net.sourceforge.mumble.Error"); }
+
+private:
+	Q_OBJECT
+	Q_CLASSINFO("D-Bus Interface", "net.sourceforge.mumble.Mumble")
+	Q_DISABLE_COPY(MumbleDBusLegacy)
+public:
+	MumbleDBusLegacy(QObject *parent) : MumbleDBus(parent) {}
 };
 
 #endif

--- a/src/mumble/DBus.h
+++ b/src/mumble/DBus.h
@@ -11,9 +11,12 @@
 class QDBusMessage;
 
 class MumbleDBus : public QDBusAbstractAdaptor {
+protected:
+	virtual constexpr QLatin1String dbusErrorPrefix() const { return QLatin1String("info.mumble.Error"); }
+
 private:
 	Q_OBJECT
-	Q_CLASSINFO("D-Bus Interface", "net.sourceforge.mumble.Mumble")
+	Q_CLASSINFO("D-Bus Interface", "info.mumble.Mumble")
 	Q_DISABLE_COPY(MumbleDBus)
 	Q_PROPERTY(bool mute READ isSelfMuted WRITE setSelfMuted)
 	Q_PROPERTY(bool deaf READ isSelfDeaf WRITE setSelfDeaf)
@@ -43,6 +46,23 @@ public slots:
 	bool isSelfDeaf();
 	void startTalking();
 	void stopTalking();
+};
+
+/**
+ * Legacy DBus adaptor for backwards compatibility.
+ * Exposes the same interface as MumbleDBus but under the old
+ * net.sourceforge.mumble.Mumble name.
+ */
+class MumbleDBusLegacy : public MumbleDBus {
+protected:
+	constexpr QLatin1String dbusErrorPrefix() const override { return QLatin1String("net.sourceforge.mumble.Error"); }
+
+private:
+	Q_OBJECT
+	Q_CLASSINFO("D-Bus Interface", "net.sourceforge.mumble.Mumble")
+	Q_DISABLE_COPY(MumbleDBusLegacy)
+public:
+	MumbleDBusLegacy(QObject *parent) : MumbleDBus(parent) {}
 };
 
 #endif

--- a/src/mumble/main.cpp
+++ b/src/mumble/main.cpp
@@ -588,11 +588,19 @@ int main(int argc, char **argv) {
 #endif
 			bool sent = false;
 #ifdef USE_DBUS
-			QDBusInterface qdbi(QLatin1String("net.sourceforge.mumble.mumble"), QLatin1String("/"),
-								QLatin1String("net.sourceforge.mumble.Mumble"));
+			QDBusInterface qdbi(QLatin1String("info.mumble.mumble"), QLatin1String("/"),
+								QLatin1String("info.mumble.Mumble"));
 
 			QDBusMessage reply = qdbi.call(QLatin1String("openUrl"), QLatin1String(url.toEncoded()));
 			sent               = (reply.type() == QDBusMessage::ReplyMessage);
+
+			if (!sent) {
+				QDBusInterface qdbiLegacy(QLatin1String("net.sourceforge.mumble.mumble"), QLatin1String("/"),
+										  QLatin1String("net.sourceforge.mumble.Mumble"));
+
+				reply = qdbiLegacy.call(QLatin1String("openUrl"), QLatin1String(url.toEncoded()));
+				sent  = (reply.type() == QDBusMessage::ReplyMessage);
+			}
 #else
 			sent = SocketRPC::send(QLatin1String("Mumble"), QLatin1String("url"), param);
 #endif
@@ -601,11 +609,19 @@ int main(int argc, char **argv) {
 		} else {
 			bool sent = false;
 #ifdef USE_DBUS
-			QDBusInterface qdbi(QLatin1String("net.sourceforge.mumble.mumble"), QLatin1String("/"),
-								QLatin1String("net.sourceforge.mumble.Mumble"));
+			QDBusInterface qdbi(QLatin1String("info.mumble.mumble"), QLatin1String("/"),
+								QLatin1String("info.mumble.Mumble"));
 
 			QDBusMessage reply = qdbi.call(QLatin1String("focus"));
 			sent               = (reply.type() == QDBusMessage::ReplyMessage);
+
+			if (!sent) {
+				QDBusInterface qdbiLegacy(QLatin1String("net.sourceforge.mumble.mumble"), QLatin1String("/"),
+										  QLatin1String("net.sourceforge.mumble.Mumble"));
+
+				reply = qdbiLegacy.call(QLatin1String("focus"));
+				sent  = (reply.type() == QDBusMessage::ReplyMessage);
+			}
 #else
 			sent = SocketRPC::send(QLatin1String("Mumble"), QLatin1String("focus"));
 #endif
@@ -801,7 +817,9 @@ int main(int argc, char **argv) {
 
 #ifdef USE_DBUS
 	new MumbleDBus(Global::get().mw);
+	new MumbleDBusLegacy(Global::get().mw);
 	QDBusConnection::sessionBus().registerObject(QLatin1String("/"), Global::get().mw);
+	QDBusConnection::sessionBus().registerService(QLatin1String("info.mumble.mumble"));
 	QDBusConnection::sessionBus().registerService(QLatin1String("net.sourceforge.mumble.mumble"));
 #endif
 


### PR DESCRIPTION
The DBus interface and error reply strings still referenced the old net.sourceforge.mumble domain. These have been updated to use info.mumble instead.

For backwards compatibility, the old service name is still registered alongside the new one, and when connecting to an existing Mumble instance the client tries the new interface name first and falls back to the old one.

Fixes #6963


### Checks

- [x] My commits follow the [commit guidelines](https://github.com/mumble-voip/mumble/blob/master/COMMIT_GUIDELINES.md)

