### PR TITLE
Backport "Merge PR #7156: FIX(client, macOS): Move Quit menu to application menu on macOS" to 1.6.x

### DIFF
--- a/src/mumble/MainWindow.cpp
+++ b/src/mumble/MainWindow.cpp
@@ -1666,8 +1666,14 @@ void MainWindow::on_qmServer_aboutToShow() {
 	qmServer->addAction(qaServerTokens);
 	qmServer->addAction(qaServerUserList);
 	qmServer->addAction(qaServerBanList);
+#ifndef Q_OS_MACOS
+	// On macOS, the "Quit" action is automatically placed in the application menu
+	// by Qt when the QAction's menuRole is set to QAction::QuitRole (see MainWindow.ui).
+	// Adding it manually to the "Server" menu would result in duplicate entries.
+	// See GitHub issue #7151: Move the Quit button to the "Mumble" application menu on macOS.
 	qmServer->addSeparator();
 	qmServer->addAction(qaQuit);
+#endif
 
 	qaServerBanList->setEnabled(Global::get().pPermissions & (ChanACL::Ban | ChanACL::Write));
 	qaServerUserList->setEnabled(Global::get().pPermissions & (ChanACL::Register | ChanACL::Write));

--- a/src/mumble/MainWindow.cpp
+++ b/src/mumble/MainWindow.cpp
@@ -179,6 +179,10 @@ MainWindow::MainWindow(QWidget *p)
 	connect(qteChat, SIGNAL(entered(QString)), this, SLOT(sendChatbarText(QString)));
 	connect(qteChat, &ChatbarTextEdit::ctrlEnterPressed, [this](const QString &msg) { sendChatbarText(msg, true); });
 	connect(qteChat, SIGNAL(pastedImage(QString)), this, SLOT(sendChatbarMessage(QString)));
+#ifdef Q_OS_MACOS
+	// Use default preferences icon in the macOS menu bar
+	qaConfigDialog->setIconVisibleInMenu(false);
+#endif
 
 	QObject::connect(qaServerAddToFavorites, &QAction::triggered, this, &MainWindow::addServerAsFavorite);
 

--- a/src/mumble/MainWindow.ui
+++ b/src/mumble/MainWindow.ui
@@ -256,6 +256,9 @@
    <property name="whatsThis">
     <string>Exits the application.</string>
    </property>
+   <property name="menuRole">
+    <enum>QAction::QuitRole</enum>
+   </property>
    <property name="shortcut">
     <string>Ctrl+Q</string>
    </property>


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `1.6.x`:
 - [Merge PR #7156: FIX(client, macOS): Move Quit menu to application menu on macOS](https://github.com/mumble-voip/mumble/pull/7156)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)