### PR TITLE
FEAT(client): Add separate notification types for image messages

### DIFF
--- a/src/mumble/EnumStringConversions.cpp
+++ b/src/mumble/EnumStringConversions.cpp
@@ -133,7 +133,9 @@
 	PROCESS(Log::MsgType, PrivateTextMessage, "PrivateTextMessage")         \
 	PROCESS(Log::MsgType, ChannelListeningAdd, "ChannelListeningAdd")       \
 	PROCESS(Log::MsgType, ChannelListeningRemove, "ChannelListeningRemove") \
-	PROCESS(Log::MsgType, PluginMessage, "PluginMessage")
+	PROCESS(Log::MsgType, PluginMessage, "PluginMessage")                   \
+	PROCESS(Log::MsgType, ImageMessage, "ImageMessage")                     \
+	PROCESS(Log::MsgType, PrivateImageMessage, "PrivateImageMessage")
 
 #define OVERLAY_PRESETS_VALUES                                               \
 	PROCESS(OverlaySettings::OverlayPresets, AvatarAndName, "AvatarAndName") \

--- a/src/mumble/Log.cpp
+++ b/src/mumble/Log.cpp
@@ -461,7 +461,9 @@ const Log::MsgType Log::msgOrder[] = { DebugInfo,
 									   PermissionDenied,
 									   TextMessage,
 									   PrivateTextMessage,
-									   PluginMessage };
+									   PluginMessage,
+									   ImageMessage,
+									   PrivateImageMessage };
 
 const char *Log::msgNames[] = { QT_TRANSLATE_NOOP("Log", "Debug"),
 								QT_TRANSLATE_NOOP("Log", "Critical"),
@@ -494,7 +496,9 @@ const char *Log::msgNames[] = { QT_TRANSLATE_NOOP("Log", "Debug"),
 								QT_TRANSLATE_NOOP("Log", "Private text message"),
 								QT_TRANSLATE_NOOP("Log", "User started listening to channel"),
 								QT_TRANSLATE_NOOP("Log", "User stopped listening to channel"),
-								QT_TRANSLATE_NOOP("Log", "Plugin message") };
+								QT_TRANSLATE_NOOP("Log", "Plugin message"),
+								QT_TRANSLATE_NOOP("Log", "Image message"),
+								QT_TRANSLATE_NOOP("Log", "Private image message") };
 
 QString Log::msgName(MsgType t) const {
 	return tr(msgNames[t]);
@@ -870,6 +874,10 @@ void Log::log(MsgType mt, const QString &console, const QString &terse, bool own
 					case ChannelListeningRemove:
 					case PluginMessage:
 						msgIcon = QSystemTrayIcon::Information;
+						break;
+					case ImageMessage:
+					case PrivateImageMessage:
+						msgIcon = QSystemTrayIcon::NoIcon;
 						break;
 				}
 				emit notificationSpawned(msgName(mt), plain, msgIcon);

--- a/src/mumble/Log.cpp
+++ b/src/mumble/Log.cpp
@@ -461,6 +461,8 @@ const Log::MsgType Log::msgOrder[] = { DebugInfo,
 									   PermissionDenied,
 									   TextMessage,
 									   PrivateTextMessage,
+									   ImageMessage,
+	                                   PrivateImageMessage,
 									   PluginMessage };
 
 const char *Log::msgNames[] = { QT_TRANSLATE_NOOP("Log", "Debug"),
@@ -494,7 +496,9 @@ const char *Log::msgNames[] = { QT_TRANSLATE_NOOP("Log", "Debug"),
 								QT_TRANSLATE_NOOP("Log", "Private text message"),
 								QT_TRANSLATE_NOOP("Log", "User started listening to channel"),
 								QT_TRANSLATE_NOOP("Log", "User stopped listening to channel"),
-								QT_TRANSLATE_NOOP("Log", "Plugin message") };
+								QT_TRANSLATE_NOOP("Log", "Plugin message"),
+								QT_TRANSLATE_NOOP("Log", "Image message"),
+								QT_TRANSLATE_NOOP("Log", "Private image message") };
 
 QString Log::msgName(MsgType t) const {
 	return tr(msgNames[t]);
@@ -840,6 +844,8 @@ void Log::log(MsgType mt, const QString &console, const QString &terse, bool own
 						break;
 					case TextMessage:
 					case PrivateTextMessage:
+					case ImageMessage:
+					case PrivateImageMessage:
 						msgIcon = QSystemTrayIcon::NoIcon;
 						break;
 					case Information:

--- a/src/mumble/Log.h
+++ b/src/mumble/Log.h
@@ -110,12 +110,14 @@ public:
 		PrivateTextMessage,
 		ChannelListeningAdd,
 		ChannelListeningRemove,
-		PluginMessage
+		PluginMessage,
+		ImageMessage,
+		PrivateImageMessage
 	};
 
 	enum LogColorType { Time, Server, Privilege, Source, Target };
 	static const MsgType firstMsgType = DebugInfo;
-	static const MsgType lastMsgType  = ChannelListeningRemove;
+	static const MsgType lastMsgType  = PrivateImageMessage;
 
 	// Display order in settingsscreen, allows to insert new events without breaking config-compatibility with older
 	// versions.

--- a/src/mumble/Messages.cpp
+++ b/src/mumble/Messages.cpp
@@ -1037,9 +1037,17 @@ void MainWindow::msgTextMessage(const MumbleProto::TextMessage &msg) {
 
 	const QString prefixMessage = target.isEmpty() ? name : tr("(%1) %2").arg(target).arg(name);
 
-	Global::get().l->log(privateMessage ? Log::PrivateTextMessage : Log::TextMessage,
-						 tr("%1: %2").arg(prefixMessage).arg(u8(msg.message())), tr("Message from %1").arg(plainName),
-						 false, overrideTTS, pSrc ? pSrc->bLocalIgnoreTTS : false);
+	// Determine if this message contains an image embed
+	const QString messageContent = u8(msg.message());
+	const bool hasImage          = messageContent.contains(QLatin1String("<img"));
+
+	// Select the appropriate message type based on whether the message contains images
+	Log::MsgType msgType = (hasImage) ? (privateMessage ? Log::PrivateImageMessage : Log::ImageMessage)
+									  : (privateMessage ? Log::PrivateTextMessage : Log::TextMessage);
+
+	Global::get().l->log(msgType, tr("%1: %2").arg(prefixMessage).arg(messageContent),
+						 tr("Message from %1").arg(plainName), false, overrideTTS,
+						 pSrc ? pSrc->bLocalIgnoreTTS : false);
 }
 
 /// This message is being received when the server informs the client about the access control list (ACL) for

--- a/src/mumble/Messages.cpp
+++ b/src/mumble/Messages.cpp
@@ -39,6 +39,7 @@
 #include "crypto/CryptState.h"
 #include "Global.h"
 
+#include <QRegularExpression>
 #include <QTextDocumentFragment>
 
 #define ACTOR_INIT                           \
@@ -1039,7 +1040,9 @@ void MainWindow::msgTextMessage(const MumbleProto::TextMessage &msg) {
 
 	// Determine if this message contains an image embed
 	const QString messageContent = u8(msg.message());
-	const bool hasImage          = messageContent.contains(QLatin1String("<img"));
+	static const QRegularExpression imageTagRegex(QLatin1String("<\\s*img\\b"),
+												  QRegularExpression::CaseInsensitiveOption);
+	const bool hasImage = imageTagRegex.match(messageContent).hasMatch();
 
 	// Select the appropriate message type based on whether the message contains images
 	Log::MsgType msgType = (hasImage) ? (privateMessage ? Log::PrivateImageMessage : Log::ImageMessage)

--- a/src/mumble/Messages.cpp
+++ b/src/mumble/Messages.cpp
@@ -40,6 +40,7 @@
 #include "crypto/CryptStateOCB2.h"
 #include "Global.h"
 
+#include <QRegularExpression>
 #include <QTextDocumentFragment>
 
 #define ACTOR_INIT                           \
@@ -1038,9 +1039,31 @@ void MainWindow::msgTextMessage(const MumbleProto::TextMessage &msg) {
 
 	const QString prefixMessage = target.isEmpty() ? name : tr("(%1) %2").arg(target).arg(name);
 
-	Global::get().l->log(privateMessage ? Log::PrivateTextMessage : Log::TextMessage,
-						 tr("%1: %2").arg(prefixMessage).arg(u8(msg.message())), tr("Message from %1").arg(plainName),
-						 false, overrideTTS, pSrc ? pSrc->bLocalIgnoreTTS : false);
+	// Determine if this message contains an image embed
+	const QString messageContent = u8(msg.message());
+	const QRegularExpression imageTagRegex(QLatin1String("<\\s*img\\b"),
+												  QRegularExpression::CaseInsensitiveOption);
+	const bool hasImage = imageTagRegex.match(messageContent).hasMatch();
+
+	// Select the appropriate message type based on whether the message contains images
+	Log::MsgType msgType;
+	if (hasImage) {
+		if (privateMessage) {
+			msgType = Log::PrivateImageMessage;
+		} else {
+			msgType = Log::ImageMessage;
+		}
+	} else {
+		if (privateMessage) {
+			msgType = Log::PrivateTextMessage;
+		} else {
+			msgType = Log::TextMessage;
+		}
+	}
+
+	Global::get().l->log(msgType, tr("%1: %2").arg(prefixMessage).arg(messageContent),
+						 tr("Message from %1").arg(plainName), false, overrideTTS,
+						 pSrc ? pSrc->bLocalIgnoreTTS : false);
 }
 
 /// This message is being received when the server informs the client about the access control list (ACL) for

--- a/src/mumble/Settings.cpp
+++ b/src/mumble/Settings.cpp
@@ -574,6 +574,8 @@ Settings::Settings() {
 	qmMessageSounds[Log::YouMuted]               = QLatin1String(":/UserMutedYouOrByYou.ogg");
 	qmMessageSounds[Log::YouKicked]              = QLatin1String(":/UserKickedYouOrByYou.ogg");
 	qmMessageSounds[Log::Recording]              = QLatin1String(":/RecordingStateChanged.ogg");
+	qmMessageSounds[Log::ImageMessage]           = qmMessageSounds[Log::TextMessage];
+	qmMessageSounds[Log::PrivateImageMessage]    = qmMessageSounds[Log::TextMessage];
 
 	qmMessages[Log::DebugInfo]       = Settings::LogConsole;
 	qmMessages[Log::Warning]         = Settings::LogConsole | Settings::LogBalloon;


### PR DESCRIPTION
The client currently treats messages containing embedded images as regular text messages for logging and notification purposes. That makes it impossible to disable notifications for image posts without also disabling notifications for normal text messages.

This commit keeps image delivery on the existing TextMessage protocol path but classifies incoming messages with embedded content as image messages in the client. It also adds dedicated log/settings entries for image messages and private image messages so their notifications can be configured independently.

Implements https://github.com/mumble-voip/mumble/issues/6970

### Checks

- [x] My commits follow the [commit guidelines](https://github.com/mumble-voip/mumble/blob/master/COMMIT_GUIDELINES.md)

