### PR TITLE
Backport "Merge PR #7137: FIX(protocol): Handle protobuf serialization return values" to 1.6.x

### DIFF
--- a/src/Connection.cpp
+++ b/src/Connection.cpp
@@ -173,7 +173,12 @@ void Connection::messageToNetwork(const ::google::protobuf::Message &msg, Mumble
 	qToBigEndian< quint16 >(static_cast< quint16 >(msgType), &uc[0]);
 	qToBigEndian< quint32 >(static_cast< unsigned int >(len), &uc[2]);
 
-	msg.SerializeToArray(uc + 6, static_cast< int >(len));
+	bool success = msg.SerializeToArray(uc + 6, static_cast< int >(len));
+	if (!success) {
+		qWarning("Failed to serialize protobuf message");
+		cache.clear();
+		return;
+	}
 }
 
 void Connection::sendMessage(const ::google::protobuf::Message &msg, Mumble::Protocol::TCPMessageType msgType,

--- a/src/Connection.cpp
+++ b/src/Connection.cpp
@@ -187,6 +187,7 @@ void Connection::sendMessage(const ::google::protobuf::Message &msg, Mumble::Pro
 	if (cache.isEmpty()) {
 		if (!messageToNetwork(msg, msgType, cache)) {
 			qWarning("Sending message to network failed");
+			return;
 		};
 	}
 

--- a/src/Connection.cpp
+++ b/src/Connection.cpp
@@ -158,8 +158,8 @@ void Connection::socketDisconnected() {
 	emit connectionClosed(QAbstractSocket::UnknownSocketError, QString());
 }
 
-void Connection::messageToNetwork(const ::google::protobuf::Message &msg, Mumble::Protocol::TCPMessageType msgType,
-								  QByteArray &cache) {
+[[nodiscard]] bool Connection::messageToNetwork(const ::google::protobuf::Message &msg,
+												Mumble::Protocol::TCPMessageType msgType, QByteArray &cache) {
 #if GOOGLE_PROTOBUF_VERSION >= 3004000
 	std::size_t len = msg.ByteSizeLong();
 #else
@@ -167,7 +167,7 @@ void Connection::messageToNetwork(const ::google::protobuf::Message &msg, Mumble
 	std::size_t len = msg.ByteSize();
 #endif
 	if (len > 0x7fffff)
-		return;
+		return false;
 	cache.resize(static_cast< int >(len + 6));
 	unsigned char *uc = reinterpret_cast< unsigned char * >(cache.data());
 	qToBigEndian< quint16 >(static_cast< quint16 >(msgType), &uc[0]);
@@ -177,14 +177,17 @@ void Connection::messageToNetwork(const ::google::protobuf::Message &msg, Mumble
 	if (!success) {
 		qWarning("Failed to serialize protobuf message");
 		cache.clear();
-		return;
+		return false;
 	}
+	return true;
 }
 
 void Connection::sendMessage(const ::google::protobuf::Message &msg, Mumble::Protocol::TCPMessageType msgType,
 							 QByteArray &cache) {
 	if (cache.isEmpty()) {
-		messageToNetwork(msg, msgType, cache);
+		if (!messageToNetwork(msg, msgType, cache)) {
+			qWarning("Sending message to network failed");
+		};
 	}
 
 	sendMessage(cache);

--- a/src/Connection.h
+++ b/src/Connection.h
@@ -63,7 +63,7 @@ signals:
 public:
 	Connection(QObject *parent, QSslSocket *qtsSocket);
 	~Connection();
-	static void messageToNetwork(const ::google::protobuf::Message &msg, Mumble::Protocol::TCPMessageType msgType,
+	static bool messageToNetwork(const ::google::protobuf::Message &msg, Mumble::Protocol::TCPMessageType msgType,
 								 QByteArray &cache);
 	void sendMessage(const ::google::protobuf::Message &msg, Mumble::Protocol::TCPMessageType msgType,
 					 QByteArray &cache);

--- a/src/MumbleProtocol.cpp
+++ b/src/MumbleProtocol.cpp
@@ -102,7 +102,12 @@ namespace Protocol {
 
 		buffer.resize(serializedSize + offset);
 
-		message.SerializePartialToArray(buffer.data() + offset, static_cast< int >(serializedSize));
+		bool success = message.SerializePartialToArray(buffer.data() + offset, static_cast< int >(serializedSize));
+
+		if (!success) {
+			qWarning("Failed to serialize protobuf message");
+			return 0;
+		}
 
 		return serializedSize;
 	}

--- a/src/MumbleProtocol.cpp
+++ b/src/MumbleProtocol.cpp
@@ -13,6 +13,7 @@
 #include <cassert>
 #include <cmath>
 #include <cstring>
+#include <optional>
 #include <span>
 
 namespace Mumble {
@@ -80,8 +81,9 @@ namespace Protocol {
 #endif
 	}
 
-	std::size_t encodeProtobuf(const ::google::protobuf::Message &message, std::vector< byte > &buffer,
-							   std::size_t offset, std::size_t maxAllowedSize, bool useCachedSize) {
+	[[nodiscard]] std::optional< std::size_t > encodeProtobuf(const ::google::protobuf::Message &message,
+															  std::vector< byte > &buffer, std::size_t offset,
+															  std::size_t maxAllowedSize, bool useCachedSize) {
 		// Serialize to buffer
 		std::size_t serializedSize;
 		if (!useCachedSize) {
@@ -97,17 +99,19 @@ namespace Protocol {
 			qWarning("Protobuf package size (%zu) would exceed UDP packet size limit (%zu)", serializedSize,
 					 maxAllowedSize);
 
-			return 0;
+			return std::nullopt;
 		}
-
-		buffer.resize(serializedSize + offset);
-
-		bool success = message.SerializePartialToArray(buffer.data() + offset, static_cast< int >(serializedSize));
-
+		std::vector< byte > temp(serializedSize);
+		bool success = message.SerializePartialToArray(temp.data(), static_cast< int >(serializedSize));
 		if (!success) {
 			qWarning("Failed to serialize protobuf message");
-			return 0;
+			return std::nullopt;
 		}
+		if (buffer.size() < offset + serializedSize)
+			buffer.resize(offset + serializedSize);
+
+		std::copy(temp.begin(), temp.end(),
+				  buffer.begin() + static_cast< std::vector< byte >::difference_type >(offset));
 
 		return serializedSize;
 	}
@@ -298,7 +302,12 @@ namespace Protocol {
 		m_audioMessage.set_is_terminator(data.isLastFrame);
 
 		// +1 to account for the header byte set below
-		m_staticPartSize      = encodeProtobuf(m_audioMessage, m_byteBuffer, 1, MAX_UDP_PACKET_SIZE, false) + 1;
+		auto maybeSize = encodeProtobuf(m_audioMessage, m_byteBuffer, 1, MAX_UDP_PACKET_SIZE, false);
+		if (!maybeSize) {
+			qWarning("MumbleProtocol: Failed to encode fixed part of audio packet");
+			return; // Abort sending this packet
+		}
+		m_staticPartSize      = maybeSize.value() + 1;
 		m_positionalAudioSize = m_staticPartSize;
 		m_byteBuffer[0]       = static_cast< byte >(UDPMessageType::Audio);
 	}
@@ -333,7 +342,12 @@ namespace Protocol {
 				m_audioMessage.Clear();
 				m_audioMessage.set_target(data.targetOrContext);
 
-				offset += encodeProtobuf(m_audioMessage, m_byteBuffer, offset, MAX_UDP_PACKET_SIZE, false);
+				auto maybeSize = encodeProtobuf(m_audioMessage, m_byteBuffer, offset, MAX_UDP_PACKET_SIZE, false);
+				if (!maybeSize) {
+					qWarning("MumbleProtocol: Failed to encode Client audio message");
+					return {}; // abort update
+				}
+				offset += maybeSize.value();
 
 				return { m_byteBuffer.data(), offset };
 			}
@@ -347,8 +361,13 @@ namespace Protocol {
 						// No pre-encoded snippet found -> use explicit encoding
 						m_audioMessage.Clear();
 						m_audioMessage.set_volume_adjustment(data.volumeAdjustment.factor);
-
-						offset += encodeProtobuf(m_audioMessage, m_byteBuffer, offset, MAX_UDP_PACKET_SIZE, false);
+						auto maybeSize =
+							encodeProtobuf(m_audioMessage, m_byteBuffer, offset, MAX_UDP_PACKET_SIZE, false);
+						if (!maybeSize) {
+							qWarning("MumbleProtocol: Failed to encode Client audio message");
+							return {}; // abort update
+						}
+						offset += maybeSize.value();
 					}
 				}
 
@@ -361,7 +380,12 @@ namespace Protocol {
 					m_audioMessage.Clear();
 					m_audioMessage.set_context(data.targetOrContext);
 
-					offset += encodeProtobuf(m_audioMessage, m_byteBuffer, offset, MAX_UDP_PACKET_SIZE, false);
+					auto maybeSize = encodeProtobuf(m_audioMessage, m_byteBuffer, offset, MAX_UDP_PACKET_SIZE, false);
+					if (!maybeSize) {
+						qWarning("MumbleProtocol: Failed to encode Client audio message");
+						return {}; // abort update
+					}
+					offset += maybeSize.value();
 				}
 
 				return { m_byteBuffer.data(), offset };
@@ -383,7 +407,8 @@ namespace Protocol {
 
 			m_positionalAudioSize =
 				m_staticPartSize
-				+ encodeProtobuf(m_audioMessage, m_byteBuffer, m_staticPartSize, MAX_UDP_PACKET_SIZE, false);
+				+ encodeProtobuf(m_audioMessage, m_byteBuffer, m_staticPartSize, MAX_UDP_PACKET_SIZE, false)
+					  .value_or(0);
 		}
 	}
 
@@ -400,10 +425,13 @@ namespace Protocol {
 
 			// The max size of the properly encoded package is the size of the used field type (uint32) plus 1 byte
 			// overhead for the varint-encoding plus 1 byte of overhead for encoding the message type and field number.
-			bool successful =
-				encodeProtobuf(m_audioMessage, m_preEncodedContext[current], 0, sizeof(std::uint32_t) + 1 + 1, false);
-			(void) successful;
-			assert(successful);
+			auto maybeSize =
+				encodeProtobuf(m_audioMessage, m_preEncodedContext[current], 0, sizeof(std::uint32_t) + 2, false);
+			assert(maybeSize.has_value());
+			if (!maybeSize) {
+				qWarning("Failed to pre-encode audio context %d", current);
+				continue; // or abort, depending on your design
+			}
 		}
 
 		m_audioMessage.Clear();
@@ -420,12 +448,15 @@ namespace Protocol {
 			// Store the pre-encoded packet
 			// The max-size is the size of the used field (float) plus 1 byte overhead for encoding the field type and
 			// number
-			bool successful = encodeProtobuf(
+			auto maybeSize = encodeProtobuf(
 				m_audioMessage,
 				m_preEncodedVolumeAdjustment[static_cast< std::size_t >(dbAdjustment - preEncodedDBAdjustmentBegin)], 0,
 				sizeof(float) + 1, false);
-			(void) successful;
-			assert(successful);
+			assert(maybeSize.has_value());
+			if (!maybeSize) {
+				qWarning("Failed to pre-encode volume adjustment %d", dbAdjustment);
+				continue; // or abort
+			}
 		}
 	}
 
@@ -550,9 +581,14 @@ namespace Protocol {
 		}
 
 		// +1 in order to account for the header byte written below
-		std::size_t serializedSize = encodeProtobuf(m_pingMessage, m_byteBuffer, 1, MAX_UDP_PACKET_SIZE, false) + 1;
-		m_byteBuffer[0]            = static_cast< byte >(UDPMessageType::Ping);
+		auto maybeSize = encodeProtobuf(m_pingMessage, m_byteBuffer, 1, MAX_UDP_PACKET_SIZE, false);
+		if (!maybeSize) {
+			qWarning("Failed to encode ping message");
+			return {}; // Return an empty span to indicate failure
+		}
 
+		std::size_t serializedSize = maybeSize.value() + 1;
+		m_byteBuffer[0]            = static_cast< byte >(UDPMessageType::Ping);
 		return std::span< byte >(m_byteBuffer.data(), serializedSize);
 	}
 

--- a/src/MumbleProtocol.cpp
+++ b/src/MumbleProtocol.cpp
@@ -107,9 +107,7 @@ namespace Protocol {
 			qWarning("Failed to serialize protobuf message");
 			return std::nullopt;
 		}
-		if (buffer.size() < offset + serializedSize)
-			buffer.resize(offset + serializedSize);
-
+		buffer.resize(offset + serializedSize);
 		std::copy(temp.begin(), temp.end(),
 				  buffer.begin() + static_cast< std::vector< byte >::difference_type >(offset));
 
@@ -302,7 +300,8 @@ namespace Protocol {
 		m_audioMessage.set_is_terminator(data.isLastFrame);
 
 		// +1 to account for the header byte set below
-		auto maybeSize = encodeProtobuf(m_audioMessage, m_byteBuffer, 1, MAX_UDP_PACKET_SIZE, false);
+		std::optional< std::size_t > maybeSize =
+			encodeProtobuf(m_audioMessage, m_byteBuffer, 1, MAX_UDP_PACKET_SIZE, false);
 		if (!maybeSize) {
 			qWarning("MumbleProtocol: Failed to encode fixed part of audio packet");
 			return; // Abort sending this packet
@@ -342,7 +341,8 @@ namespace Protocol {
 				m_audioMessage.Clear();
 				m_audioMessage.set_target(data.targetOrContext);
 
-				auto maybeSize = encodeProtobuf(m_audioMessage, m_byteBuffer, offset, MAX_UDP_PACKET_SIZE, false);
+				std::optional< std::size_t > maybeSize =
+					encodeProtobuf(m_audioMessage, m_byteBuffer, offset, MAX_UDP_PACKET_SIZE, false);
 				if (!maybeSize) {
 					qWarning("MumbleProtocol: Failed to encode Client audio message");
 					return {}; // abort update
@@ -361,7 +361,7 @@ namespace Protocol {
 						// No pre-encoded snippet found -> use explicit encoding
 						m_audioMessage.Clear();
 						m_audioMessage.set_volume_adjustment(data.volumeAdjustment.factor);
-						auto maybeSize =
+						std::optional< std::size_t > maybeSize =
 							encodeProtobuf(m_audioMessage, m_byteBuffer, offset, MAX_UDP_PACKET_SIZE, false);
 						if (!maybeSize) {
 							qWarning("MumbleProtocol: Failed to encode Client audio message");
@@ -380,7 +380,8 @@ namespace Protocol {
 					m_audioMessage.Clear();
 					m_audioMessage.set_context(data.targetOrContext);
 
-					auto maybeSize = encodeProtobuf(m_audioMessage, m_byteBuffer, offset, MAX_UDP_PACKET_SIZE, false);
+					std::optional< std::size_t > maybeSize =
+						encodeProtobuf(m_audioMessage, m_byteBuffer, offset, MAX_UDP_PACKET_SIZE, false);
 					if (!maybeSize) {
 						qWarning("MumbleProtocol: Failed to encode Client audio message");
 						return {}; // abort update
@@ -425,7 +426,7 @@ namespace Protocol {
 
 			// The max size of the properly encoded package is the size of the used field type (uint32) plus 1 byte
 			// overhead for the varint-encoding plus 1 byte of overhead for encoding the message type and field number.
-			auto maybeSize =
+			std::optional< std::size_t > maybeSize =
 				encodeProtobuf(m_audioMessage, m_preEncodedContext[current], 0, sizeof(std::uint32_t) + 2, false);
 			assert(maybeSize.has_value());
 			if (!maybeSize) {
@@ -448,7 +449,7 @@ namespace Protocol {
 			// Store the pre-encoded packet
 			// The max-size is the size of the used field (float) plus 1 byte overhead for encoding the field type and
 			// number
-			auto maybeSize = encodeProtobuf(
+			std::optional< std::size_t > maybeSize = encodeProtobuf(
 				m_audioMessage,
 				m_preEncodedVolumeAdjustment[static_cast< std::size_t >(dbAdjustment - preEncodedDBAdjustmentBegin)], 0,
 				sizeof(float) + 1, false);
@@ -581,7 +582,8 @@ namespace Protocol {
 		}
 
 		// +1 in order to account for the header byte written below
-		auto maybeSize = encodeProtobuf(m_pingMessage, m_byteBuffer, 1, MAX_UDP_PACKET_SIZE, false);
+		std::optional< std::size_t > maybeSize =
+			encodeProtobuf(m_pingMessage, m_byteBuffer, 1, MAX_UDP_PACKET_SIZE, false);
 		if (!maybeSize) {
 			qWarning("Failed to encode ping message");
 			return {}; // Return an empty span to indicate failure


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `1.6.x`:
 - [Merge PR #7137: FIX(protocol): Handle protobuf serialization return values](https://github.com/mumble-voip/mumble/pull/7137)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)