### PR TITLE
Add UDP video protocol + client/server screen sharing support

### DIFF
--- a/.github/actions/install-dependencies/install_macos_static_x86_64.sh
+++ b/.github/actions/install-dependencies/install_macos_static_x86_64.sh
@@ -7,7 +7,7 @@ source "$( dirname "$0" )/common.sh"
 
 verify_required_env_variables_set
 
-brew install coreutils aria2 gnu-tar xz
+brew install coreutils aria2 gnu-tar xz ffmpeg
 
 make_build_env_available "tar.xz"
 

--- a/.github/actions/install-dependencies/install_ubuntu_shared_x86_64.sh
+++ b/.github/actions/install-dependencies/install_ubuntu_shared_x86_64.sh
@@ -35,7 +35,10 @@ sudo apt -y install \
 	zsync \
 	appstream \
 	libpoco-dev \
-	libsqlite3-dev
+	libsqlite3-dev \
+	libavcodec-dev \
+	libswscale-dev \
+	libavutil-dev
 
 # The package was initially called libqt6svg6-dev.
 # Choose correct name based on the Ubuntu version along with some other version-specific setup

--- a/.github/actions/install-dependencies/install_ubuntu_static_x86_64.sh
+++ b/.github/actions/install-dependencies/install_ubuntu_static_x86_64.sh
@@ -14,6 +14,7 @@ sudo apt -y install \
 	`# Still required for qtbase vcpkg package` \
 	'^libxcb.*-dev' libx11-xcb-dev libglu1-mesa-dev libxrender-dev libxi-dev libxkbcommon-dev libxkbcommon-x11-dev libegl1-mesa-dev \
 	`# TODO: can we get rid of these by replacing with vcpkg packages?` \
+	libavcodec-dev libswscale-dev libavutil-dev \
 	libsm-dev \
 	libspeechd-dev \
 	libavahi-compat-libdnssd-dev \

--- a/.github/actions/install-dependencies/install_windows_static_x86_64.sh
+++ b/.github/actions/install-dependencies/install_windows_static_x86_64.sh
@@ -24,6 +24,9 @@ rm -rf "g15_sdk"
 aria2c "https://github.com/oleg-shilo/wixsharp/releases/download/v1.19.0.0/WixSharp.1.19.0.0.7z" --out "WixSharp.7z"
 extract_with_progress "WixSharp.7z" "C:/WixSharp"
 
+aria2c "https://github.com/GyanD/codexffmpeg/releases/download/8.1/ffmpeg-8.1-full_build-shared.zip" --out "ffmpeg.zip"
+extract_with_progress "ffmpeg.zip" "${GITHUB_WORKSPACE}/3rdparty/ffmpeg"
+
 git clone "https://github.com/nathan818fr/vcvars-bash.git" "C:/vcvars-bash"
 
 

--- a/src/Mumble.proto
+++ b/src/Mumble.proto
@@ -245,6 +245,8 @@ message UserState {
 	repeated uint32 listening_channel_remove = 22;
 	// A list of volume adjustments the user has applied to listeners
 	repeated VolumeAdjustment listening_volume_adjustment = 23;
+	// True if the user is currently sharing their screen.
+	optional bool screen_sharing = 24;
 }
 
 // Relays information on the bans. The client may send the BanList message to

--- a/src/MumbleProtocol.cpp
+++ b/src/MumbleProtocol.cpp
@@ -625,6 +625,9 @@ namespace Protocol {
 					return decodeAudio_protobuf(data.subspan(1, data.size() - 1));
 				case UDPMessageType::Ping:
 					return decodePing_protobuf(data.subspan(1, data.size() - 1));
+				case UDPMessageType::Video:
+					// Silently dropping video packets this commit as the rest isn't implemented yet
+					return false;
 			}
 
 			// Unknown package type

--- a/src/MumbleProtocol.cpp
+++ b/src/MumbleProtocol.cpp
@@ -626,8 +626,12 @@ namespace Protocol {
 				case UDPMessageType::Ping:
 					return decodePing_protobuf(data.subspan(1, data.size() - 1));
 				case UDPMessageType::Video:
-					// Silently dropping video packets this commit as the rest isn't implemented yet
-					return false;
+					if (restrictToPing) {
+						// Not a ping
+						return false;
+					}
+
+					return decodeVideo_protobuf(data.subspan(1, data.size() - 1));
 			}
 
 			// Unknown package type
@@ -640,6 +644,12 @@ namespace Protocol {
 	}
 
 	template< Role role > UDPMessageType UDPDecoder< role >::getMessageType() const { return m_messageType; }
+
+	template< Role role > VideoData UDPDecoder< role >::getVideoData() const {
+		assert(m_messageType == UDPMessageType::Video);
+
+		return m_videoData;
+	}
 
 	template< Role role > AudioData UDPDecoder< role >::getAudioData() const {
 		assert(m_messageType == UDPMessageType::Audio);
@@ -847,6 +857,54 @@ namespace Protocol {
 		}
 
 		// Legacy audio packets don't contain volume adjustments
+
+		return true;
+	}
+
+	template< Role role > bool UDPDecoder< role >::decodeVideo_protobuf(const std::span< const byte > data) {
+		m_messageType = UDPMessageType::Video;
+		m_videoData   = {};
+
+		if (!m_videoMessage.ParseFromArray(data.data(), static_cast< int >(data.size()))) {
+			// Invalid format
+			return false;
+		}
+
+		// Sender
+		m_videoData.senderSession = m_videoMessage.sender_session();
+
+		// Codec (string, unlike Audio enum)
+		m_videoData.codec = m_videoMessage.codec();
+
+		// Resolution
+		m_videoData.width  = m_videoMessage.width();
+		m_videoData.height = m_videoMessage.height();
+
+		// Frame / fragmentation info
+		m_videoData.frameNumber   = m_videoMessage.frame_number();
+		m_videoData.fragmentIndex = m_videoMessage.fragment_index();
+		m_videoData.fragmentCount = m_videoMessage.fragment_count();
+		if (m_videoData.fragmentIndex >= m_videoData.fragmentCount) {
+			// Sending more fragments than the fargment count isn't supported.
+			return false;
+		}
+
+		if (m_videoData.width == 0 || m_videoData.height == 0) {
+			// Sending a video with no pixels isn't supported
+			return false;
+		}
+
+		// Payload
+		if (m_videoMessage.video_data().empty()) {
+			// Video packets without payload are invalid
+			return false;
+		}
+
+		std::string &videoPayload = *m_videoMessage.mutable_video_data();
+		m_videoData.payload = std::span< byte >(reinterpret_cast< byte * >(&videoPayload[0]), videoPayload.size());
+
+		// Keyframe flag
+		m_videoData.isKeyFrame = m_videoMessage.is_keyframe();
 
 		return true;
 	}

--- a/src/MumbleProtocol.h
+++ b/src/MumbleProtocol.h
@@ -57,7 +57,8 @@
  */
 #define MUMBLE_ALL_UDP_MESSAGES          \
 	PROCESS_MUMBLE_UDP_MESSAGE(Audio, 0) \
-	PROCESS_MUMBLE_UDP_MESSAGE(Ping, 1)
+	PROCESS_MUMBLE_UDP_MESSAGE(Ping, 1)  \
+	PROCESS_MUMBLE_UDP_MESSAGE(Video, 2)
 
 namespace Mumble {
 namespace Protocol {
@@ -147,6 +148,19 @@ namespace Protocol {
 
 		friend bool operator==(const AudioData &lhs, const AudioData &rhs);
 		friend bool operator!=(const AudioData &lhs, const AudioData &rhs);
+	};
+
+	/// Carries all fields from a decoded MumbleUDP::Video fragment.
+	struct VideoData {
+		std::uint32_t senderSession = 0;
+		std::string codec;
+		std::uint32_t width         = 0;
+		std::uint32_t height        = 0;
+		std::uint64_t frameNumber   = 0;
+		std::uint32_t fragmentIndex = 0;
+		std::uint32_t fragmentCount = 0;
+		std::span< const byte > payload;
+		bool isKeyFrame = false;
 	};
 
 	struct PingData {

--- a/src/MumbleProtocol.h
+++ b/src/MumbleProtocol.h
@@ -152,13 +152,13 @@ namespace Protocol {
 
 	/// Carries all fields from a decoded MumbleUDP::Video fragment.
 	struct VideoData {
-		std::uint32_t senderSession = 0;
-		std::string codec;
-		std::uint32_t width         = 0;
-		std::uint32_t height        = 0;
-		std::uint64_t frameNumber   = 0;
-		std::uint32_t fragmentIndex = 0;
-		std::uint32_t fragmentCount = 0;
+		std::uint32_t senderSession  = 0;
+		MumbleUDP::Video_Codec codec = MumbleUDP::Video_Codec_H264;
+		std::uint32_t width          = 0;
+		std::uint32_t height         = 0;
+		std::uint64_t frameNumber    = 0;
+		std::uint32_t fragmentIndex  = 0;
+		std::uint32_t fragmentCount  = 0;
 		std::span< const byte > payload;
 		bool isKeyFrame = false;
 	};
@@ -279,20 +279,24 @@ namespace Protocol {
 		UDPMessageType getMessageType() const;
 
 		AudioData getAudioData() const;
+		VideoData getVideoData() const;
 		PingData getPingData() const;
 
 	protected:
 		std::vector< byte > m_byteBuffer;
 		UDPMessageType m_messageType;
 		AudioData m_audioData = {};
+		VideoData m_videoData = {};
 		PingData m_pingData   = {};
 		MumbleUDP::Ping m_pingMessage;
 		MumbleUDP::Audio m_audioMessage;
+		MumbleUDP::Video m_videoMessage;
 
 		bool decodePing_legacy(const std::span< const byte > data);
 		bool decodePing_protobuf(const std::span< const byte > data);
 		bool decodeAudio_legacy(const std::span< const byte > data, AudioCodec codec);
 		bool decodeAudio_protobuf(const std::span< const byte > data);
+		bool decodeVideo_protobuf(const std::span< const byte > data);
 	};
 
 } // namespace Protocol

--- a/src/MumbleUDP.proto
+++ b/src/MumbleUDP.proto
@@ -54,6 +54,46 @@ message Audio {
 }
 
 /**
+ * Sent by a client to stream an encoded video frame fragment to other users in the same channel.
+ * The server relays each fragment to all other users in the sender's channel.
+ * Large frames are split into multiple fragments; receivers reassemble them using
+ * frame_number + fragment_index / fragment_count.
+ */
+message Video {
+	// The session of the client that sent this fragment.
+	// When the client sends this to the server the field is ignored; the server always
+	// overwrites it with the authenticated sender's session before forwarding.
+	uint32 sender_session = 1;
+
+	// Codec identifier. Currently only "H264" is defined.
+	enum Codec {
+		H264 = 0;
+	}
+	Codec codec = 2;
+
+	// Width of the complete video frame in pixels.
+	uint32 width = 3;
+
+	// Height of the complete video frame in pixels.
+	uint32 height = 4;
+
+	// Monotonically increasing frame counter.
+	uint64 frame_number = 5;
+
+	// Zero-based index of this fragment within the current frame.
+	uint32 fragment_index = 6;
+
+	// Total number of fragments that make up the current frame.
+	uint32 fragment_count = 7;
+
+	// Encoded video bytes for this fragment (H.264 Annex-B NAL unit stream).
+	bytes video_data = 8;
+
+	// True if this frame is a key frame (IDR). Only meaningful on fragment_index 0.
+	bool is_keyframe = 9;
+}
+
+/**
  * Ping message for checking UDP connectivity (and roundtrip ping) and potentially obtaining further server
  * details (e.g. version).
  */

--- a/src/User.cpp
+++ b/src/User.cpp
@@ -13,6 +13,7 @@ User::User() {
 	bSelfMute = bSelfDeaf = false;
 	bPrioritySpeaker      = false;
 	bRecording            = false;
+	bScreenSharing        = false;
 	bSuppress             = false;
 	cChannel              = 0;
 }

--- a/src/User.h
+++ b/src/User.h
@@ -30,6 +30,7 @@ public:
 	bool bSelfMute, bSelfDeaf;
 	bool bPrioritySpeaker;
 	bool bRecording;
+	bool bScreenSharing;
 	Channel *cChannel;
 	QByteArray qbaTexture;
 	QByteArray qbaTextureHash;

--- a/src/mumble/CMakeLists.txt
+++ b/src/mumble/CMakeLists.txt
@@ -1008,6 +1008,25 @@ if(screen-sharing)
 				target_compile_definitions(mumble_client_object_lib PRIVATE "HAS_X11_WINDOW_LIST")
 			endif()
 		endif()
+
+		# Wayland screen capture via xdg-desktop-portal + PipeWire.
+		# Requires Qt D-Bus (already linked when dbus=ON) and libpipewire-0.3.
+		if(dbus)
+			pkg_check_modules(LIBPIPEWIRE_SCREENSHARE libpipewire-0.3)
+			if(LIBPIPEWIRE_SCREENSHARE_FOUND)
+				target_sources(mumble_client_object_lib PRIVATE
+					"XdgPortalCapture.h"
+					"XdgPortalCapture_unix.cpp"
+				)
+				target_include_directories(mumble_client_object_lib SYSTEM PRIVATE
+					${LIBPIPEWIRE_SCREENSHARE_INCLUDE_DIRS}
+				)
+				target_link_libraries(mumble_client_object_lib PUBLIC
+					${LIBPIPEWIRE_SCREENSHARE_LIBRARIES}
+				)
+				target_compile_definitions(mumble_client_object_lib PRIVATE "HAS_WAYLAND_PORTAL")
+			endif()
+		endif()
 	endif()
 endif()
 

--- a/src/mumble/CMakeLists.txt
+++ b/src/mumble/CMakeLists.txt
@@ -34,6 +34,8 @@ option(portaudio "Build support for PortAudio" ON)
 option(plugin-debug "Build Mumble with debug output for plugin developers." OFF)
 option(plugin-callback-debug "Build Mumble with debug output for plugin callbacks inside of Mumble." OFF)
 
+option(screen-sharing "Build support for screen sharing (requires libavcodec + libswscale with libx264)." ON)
+
 if(WIN32)
 	option(asio "Build support for ASIO audio input." OFF)
 	option(wasapi "Build support for WASAPI." ON)
@@ -218,6 +220,12 @@ set(MUMBLE_SOURCES
 	"RichTextEditor.ui"
 	"Screen.cpp"
 	"Screen.h"
+	"ScreenCapture.cpp"
+	"ScreenCapture.h"
+	"ScreenShareReceiver.cpp"
+	"ScreenShareReceiver.h"
+	"ScreenShareViewer.cpp"
+	"ScreenShareViewer.h"
 	"SearchDialog.cpp"
 	"SearchDialog.h"
 	"SearchDialog.ui"
@@ -921,6 +929,45 @@ endif()
 
 if(plugins)
 	add_dependencies(mumble plugins)
+endif()
+
+if(screen-sharing)
+	if(WIN32)
+		if(NOT FFMPEG_DIR)
+			set(FFMPEG_DIR "${3RDPARTY_DIR}/ffmpeg")
+		endif()
+
+		target_sources(mumble_client_object_lib
+			PRIVATE
+				"ScreenCapture.h"
+				"ScreenCapture.cpp"
+				"ScreenShareReceiver.h"
+				"ScreenShareReceiver.cpp"
+		)
+
+		target_compile_definitions(mumble_client_object_lib PUBLIC "USE_SCREEN_SHARING")
+		target_include_directories(mumble_client_object_lib
+			SYSTEM PUBLIC
+				"${FFMPEG_DIR}/include"
+		)
+	else()
+		find_package(PkgConfig REQUIRED)
+		pkg_check_modules(LIBAVCODEC REQUIRED libavcodec)
+		pkg_check_modules(LIBSWSCALE REQUIRED libswscale)
+		pkg_check_modules(LIBAVUTIL  REQUIRED libavutil)
+
+		target_include_directories(mumble_client_object_lib SYSTEM PUBLIC
+			${LIBAVCODEC_INCLUDE_DIRS}
+			${LIBSWSCALE_INCLUDE_DIRS}
+			${LIBAVUTIL_INCLUDE_DIRS}
+		)
+		target_link_libraries(mumble_client_object_lib PUBLIC
+			${LIBAVCODEC_LIBRARIES}
+			${LIBSWSCALE_LIBRARIES}
+			${LIBAVUTIL_LIBRARIES}
+		)
+		target_compile_definitions(mumble_client_object_lib PUBLIC "USE_SCREEN_SHARING")
+	endif()
 endif()
 
 if(xboxinput)

--- a/src/mumble/CMakeLists.txt
+++ b/src/mumble/CMakeLists.txt
@@ -18,7 +18,7 @@ include(install-library)
 option(update "Check for updates by default." ON)
 
 option(translations "Include languages other than English." ON)
-option(bundle-qt-translations "Bundle Qt's translations as well" ${static}) 
+option(bundle-qt-translations "Bundle Qt's translations as well" ${static})
 
 option(bundled-speex "Build the included version of Speex instead of looking for one on the system." ON)
 option(rnnoise "Use RNNoise for machine learning noise reduction." ON)
@@ -59,7 +59,7 @@ elseif(UNIX)
 	# so single out common options into combined conditions.
 	# https://github.com/mumble-voip/mumble/issues/5488
 	if(${CMAKE_SYSTEM_NAME} STREQUAL "Linux" OR
-	   ${CMAKE_SYSTEM_NAME} STREQUAL "OpenBSD")
+				${CMAKE_SYSTEM_NAME} STREQUAL "OpenBSD")
 		option(xinput2 "Build support for XI2." ON)
 	endif()
 endif()
@@ -843,7 +843,7 @@ if(manual-plugin)
 			"ManualPlugin.ui"
 	)
 
-target_compile_definitions(mumble_client_object_lib PUBLIC "USE_MANUAL_PLUGIN")
+	target_compile_definitions(mumble_client_object_lib PUBLIC "USE_MANUAL_PLUGIN")
 endif()
 
 if(NOT update)
@@ -858,7 +858,7 @@ if(dbus AND (NOT WIN32 AND NOT APPLE))
 			"DBus.cpp"
 			"DBus.h"
 	)
-	
+
 	target_compile_definitions(mumble_client_object_lib PUBLIC "USE_DBUS")
 	target_link_libraries(mumble_client_object_lib PUBLIC Qt6::DBus)
 endif()
@@ -919,7 +919,7 @@ if(overlay)
 			target_sources(mumble_client_object_lib PRIVATE "Overlay_unix.cpp")
 		endif()
 
-                if(NOT CMAKE_SYSTEM_PROCESSOR MATCHES "arm|aarch64")
+		if(NOT CMAKE_SYSTEM_PROCESSOR MATCHES "arm|aarch64")
 			add_dependencies(mumble overlay_gl)
 		endif()
 	endif()
@@ -932,23 +932,26 @@ if(plugins)
 endif()
 
 if(screen-sharing)
+
+	# Shared sources (all platforms)
+	target_sources(mumble_client_object_lib PRIVATE
+						"CaptureSource.h"
+						"CaptureSourceLister.h"
+						"ScreenPickerDialog.h"
+						"ScreenPickerDialog.cpp"
+						"ScreenShareReceiver.h"
+						"ScreenShareReceiver.cpp"
+				)
+
 	if(WIN32)
 		if(NOT FFMPEG_DIR)
 			set(FFMPEG_DIR "${3RDPARTY_DIR}/ffmpeg")
 		endif()
 
-		target_sources(mumble_client_object_lib
-			PRIVATE
-				"ScreenCapture.h"
-				"ScreenCapture.cpp"
-				"ScreenShareReceiver.h"
-				"ScreenShareReceiver.cpp"
-		)
-
 		target_compile_definitions(mumble_client_object_lib PUBLIC "USE_SCREEN_SHARING")
 		target_include_directories(mumble_client_object_lib
-			SYSTEM PUBLIC
-				"${FFMPEG_DIR}/include"
+				SYSTEM PUBLIC
+					"${FFMPEG_DIR}/include"
 		)
 	else()
 		find_package(PkgConfig REQUIRED)
@@ -957,16 +960,54 @@ if(screen-sharing)
 		pkg_check_modules(LIBAVUTIL  REQUIRED libavutil)
 
 		target_include_directories(mumble_client_object_lib SYSTEM PUBLIC
-			${LIBAVCODEC_INCLUDE_DIRS}
-			${LIBSWSCALE_INCLUDE_DIRS}
-			${LIBAVUTIL_INCLUDE_DIRS}
-		)
+												${LIBAVCODEC_INCLUDE_DIRS}
+												${LIBSWSCALE_INCLUDE_DIRS}
+												${LIBAVUTIL_INCLUDE_DIRS}
+								)
+
 		target_link_libraries(mumble_client_object_lib PUBLIC
-			${LIBAVCODEC_LIBRARIES}
-			${LIBSWSCALE_LIBRARIES}
-			${LIBAVUTIL_LIBRARIES}
-		)
+												${LIBAVCODEC_LIBRARIES}
+												${LIBSWSCALE_LIBRARIES}
+												${LIBAVUTIL_LIBRARIES}
+								)
+
 		target_compile_definitions(mumble_client_object_lib PUBLIC "USE_SCREEN_SHARING")
+		if(APPLE)
+			target_sources(mumble_client_object_lib PRIVATE
+																"CaptureSourceLister_macx.mm"
+																"SCKitCapture.h"
+																"SCKitCapture_macx.mm"
+			)
+
+			find_library(LIB_COREGRAPHICS CoreGraphics)
+			if(LIB_COREGRAPHICS)
+				target_link_libraries(mumble_client_object_lib PUBLIC ${LIB_COREGRAPHICS})
+			endif()
+
+			find_library(LIB_SCREENCAPTUREKIT ScreenCaptureKit)
+			if(LIB_SCREENCAPTUREKIT)
+				target_link_libraries(mumble_client_object_lib PUBLIC ${LIB_SCREENCAPTUREKIT})
+			endif()
+
+			find_library(LIB_COREMEDIA CoreMedia)
+			if(LIB_COREMEDIA)
+				target_link_libraries(mumble_client_object_lib PUBLIC ${LIB_COREMEDIA})
+			endif()
+
+			find_library(LIB_COREVIDEO CoreVideo)
+			if(LIB_COREVIDEO)
+				target_link_libraries(mumble_client_object_lib PUBLIC ${LIB_COREVIDEO})
+			endif()
+
+		else()
+			target_sources(mumble_client_object_lib PRIVATE
+																"CaptureSourceLister_unix.cpp"
+			)
+			if(TARGET X11::X11)
+				target_link_libraries(mumble_client_object_lib PUBLIC X11::X11)
+				target_compile_definitions(mumble_client_object_lib PRIVATE "HAS_X11_WINDOW_LIST")
+			endif()
+		endif()
 	endif()
 endif()
 
@@ -997,8 +1038,8 @@ if(g15)
 				"G15LCDEngine_helper.cpp"
 				"G15LCDEngine_helper.h"
 		)
-	target_include_directories(mumble_client_object_lib PUBLIC "${CMAKE_SOURCE_DIR}/helpers")
-	add_dependencies(mumble g15-helper)
+		target_include_directories(mumble_client_object_lib PUBLIC "${CMAKE_SOURCE_DIR}/helpers")
+		add_dependencies(mumble g15-helper)
 	else()
 		find_library(LIB_G15DAEMON_CLIENT "g15daemon_client")
 		if(LIB_G15DAEMON_CLIENT-NOTFOUND)
@@ -1035,8 +1076,8 @@ if(zeroconf)
 		PRIVATE
 			"Zeroconf.cpp"
 			"Zeroconf.h"
-			# Unlike what the name implies, this 3rdparty helper is not actually related to Bonjour.
-			# It just uses the API provided by mDNSResponder, making it compatible with Avahi too.
+				# Unlike what the name implies, this 3rdparty helper is not actually related to Bonjour.
+				# It just uses the API provided by mDNSResponder, making it compatible with Avahi too.
 			"${3RDPARTY_DIR}/qqbonjour/BonjourRecord.h"
 			"${3RDPARTY_DIR}/qqbonjour/BonjourServiceBrowser.cpp"
 			"${3RDPARTY_DIR}/qqbonjour/BonjourServiceBrowser.h"
@@ -1225,13 +1266,13 @@ endif()
 set(TARGET_NAME "mumble_client_object_lib")
 get_property(_isMultiConfig GLOBAL PROPERTY GENERATOR_IS_MULTI_CONFIG)
 if(_isMultiConfig)
-  set(AUTOGEN_INCLUDE_DIR ${CMAKE_CURRENT_BINARY_DIR}/${TARGET_NAME}_autogen/include_$<CONFIG>)
+	set(AUTOGEN_INCLUDE_DIR ${CMAKE_CURRENT_BINARY_DIR}/${TARGET_NAME}_autogen/include_$<CONFIG>)
 else()
-  set(AUTOGEN_INCLUDE_DIR ${CMAKE_CURRENT_BINARY_DIR}/${TARGET_NAME}_autogen/include)
+	set(AUTOGEN_INCLUDE_DIR ${CMAKE_CURRENT_BINARY_DIR}/${TARGET_NAME}_autogen/include)
 endif()
 
 target_include_directories(${TARGET_NAME} INTERFACE
-  $<BUILD_INTERFACE:${AUTOGEN_INCLUDE_DIR}>
+		$<BUILD_INTERFACE:${AUTOGEN_INCLUDE_DIR}>
 )
 
 if(packaging AND WIN32)

--- a/src/mumble/CaptureSource.h
+++ b/src/mumble/CaptureSource.h
@@ -1,0 +1,28 @@
+// Copyright The Mumble Developers. All rights reserved.
+// Use of this source code is governed by a BSD-style license
+// that can be found in the LICENSE file at the root of the
+// Mumble source tree or at <https://www.mumble.info/LICENSE>.
+
+#ifndef MUMBLE_MUMBLE_CAPTURESOURCE_H_
+#define MUMBLE_MUMBLE_CAPTURESOURCE_H_
+
+#ifdef USE_SCREEN_SHARING
+
+#	include <QtCore/QString>
+#	include <QtCore/QtGlobal>
+#	include <QtGui/QPixmap>
+
+/// Identifies a single capture source — either an entire screen/monitor or a specific window.
+struct CaptureSource {
+	enum class Type { EntireScreen, Window };
+
+	Type type               = Type::EntireScreen;
+	int screenIndex         = 0; ///< Index into QGuiApplication::screens() — used when type == EntireScreen.
+	quintptr nativeWindowId = 0; ///< Platform window handle: CGWindowID on macOS, XID on X11, HWND on Windows.
+
+	QString displayName; ///< Human-readable label shown in the picker (e.g. "Display 1 (2560×1440)").
+	QPixmap thumbnail;   ///< Scaled preview (≈160×90), populated by listCaptureSources().
+};
+
+#endif // USE_SCREEN_SHARING
+#endif // MUMBLE_MUMBLE_CAPTURESOURCE_H_

--- a/src/mumble/CaptureSourceLister.h
+++ b/src/mumble/CaptureSourceLister.h
@@ -1,0 +1,26 @@
+// Copyright The Mumble Developers. All rights reserved.
+// Use of this source code is governed by a BSD-style license
+// that can be found in the LICENSE file at the root of the
+// Mumble source tree or at <https://www.mumble.info/LICENSE>.
+
+#ifndef MUMBLE_MUMBLE_CAPTURESOURCELISTER_H_
+#define MUMBLE_MUMBLE_CAPTURESOURCELISTER_H_
+
+#ifdef USE_SCREEN_SHARING
+
+#	include "CaptureSource.h"
+
+#	include <QtCore/QList>
+#	include <QtGui/QImage>
+
+/// Returns all available capture sources — screens first, then visible application windows.
+/// Thumbnails are populated. Must be called on the GUI thread.
+QList< CaptureSource > listCaptureSources();
+
+/// Grabs one full-resolution frame from the given source and returns it as QImage (Format_RGBA8888).
+/// On macOS uses CGWindowListCreateImage for Window sources; uses QScreen::grabWindow elsewhere.
+/// Must be called on the GUI thread (screen capture APIs require it).
+QImage grabCaptureSource(const CaptureSource &source);
+
+#endif // USE_SCREEN_SHARING
+#endif // MUMBLE_MUMBLE_CAPTURESOURCELISTER_H_

--- a/src/mumble/CaptureSourceLister_macx.mm
+++ b/src/mumble/CaptureSourceLister_macx.mm
@@ -1,0 +1,197 @@
+// Copyright The Mumble Developers. All rights reserved.
+// Use of this source code is governed by a BSD-style license
+// that can be found in the LICENSE file at the root of the
+// Mumble source tree or at <https://www.mumble.info/LICENSE>.
+
+#ifdef USE_SCREEN_SHARING
+
+#import <CoreGraphics/CoreGraphics.h>
+#import <Foundation/Foundation.h>
+
+#include "CaptureSourceLister.h"
+
+#include <QtGui/QGuiApplication>
+#include <QtGui/QImage>
+#include <QtGui/QPixmap>
+#include <QtGui/QScreen>
+
+static constexpr int THUMBNAIL_WIDTH = 160;
+static constexpr int THUMBNAIL_HEIGHT = 90;
+
+/// Convert a CoreGraphics image to a QImage using a CGBitmapContext.
+/// The result uses Format_ARGB32_Premultiplied (BGRA / premultiplied alpha).
+static QImage qImageFromCGImage(CGImageRef cgImage) {
+  if (!cgImage)
+    return {};
+
+  const size_t width = CGImageGetWidth(cgImage);
+  const size_t height = CGImageGetHeight(cgImage);
+
+  QImage image(static_cast<int>(width), static_cast<int>(height),
+               QImage::Format_ARGB32_Premultiplied);
+  image.fill(Qt::transparent);
+
+  CGColorSpaceRef colorSpace = CGColorSpaceCreateDeviceRGB();
+  CGContextRef ctx = CGBitmapContextCreate(
+      image.bits(), width, height,
+      8, // bits per component
+      static_cast<size_t>(image.bytesPerLine()), colorSpace,
+      kCGImageAlphaPremultipliedFirst | kCGBitmapByteOrder32Host);
+  CGColorSpaceRelease(colorSpace);
+  if (!ctx)
+    return {};
+
+  CGContextDrawImage(ctx,
+                     CGRectMake(0, 0, static_cast<CGFloat>(width),
+                                static_cast<CGFloat>(height)),
+                     cgImage);
+  CGContextRelease(ctx);
+  return image;
+}
+
+static QPixmap pixmapFromCGImage(CGImageRef cgImage) {
+  if (!cgImage)
+    return {};
+  QImage img = qImageFromCGImage(cgImage);
+  if (img.isNull())
+    return {};
+  return QPixmap::fromImage(img.scaled(THUMBNAIL_WIDTH, THUMBNAIL_HEIGHT,
+                                       Qt::KeepAspectRatio,
+                                       Qt::SmoothTransformation));
+}
+
+static QString cfStringToQString(CFStringRef str) {
+  if (!str)
+    return {};
+  // Fast path: ASCII/UTF-8 buffer
+  const char *cStr = CFStringGetCStringPtr(str, kCFStringEncodingUTF8);
+  if (cStr)
+    return QString::fromUtf8(cStr);
+  // Slow path: allocate
+  CFIndex length = CFStringGetLength(str);
+  QByteArray buf(static_cast<int>(length * 4 + 1), '\0');
+  if (CFStringGetCString(str, buf.data(), buf.size(), kCFStringEncodingUTF8))
+    return QString::fromUtf8(buf.constData());
+  return {};
+}
+
+QList<CaptureSource> listCaptureSources() {
+  QList<CaptureSource> sources;
+
+  // --- Screens ---
+  const QList<QScreen *> screens = QGuiApplication::screens();
+  for (int i = 0; i < screens.size(); ++i) {
+    QScreen *screen = screens.at(i);
+    CaptureSource s;
+    s.type = CaptureSource::Type::EntireScreen;
+    s.screenIndex = i;
+    s.displayName = QObject::tr("Display %1 (%2×%3)")
+                        .arg(i + 1)
+                        .arg(screen->size().width())
+                        .arg(screen->size().height());
+
+    // Grab thumbnail using Qt — works for screens on macOS at picker time.
+    QPixmap px = screen->grabWindow(0);
+    if (!px.isNull()) {
+      s.thumbnail = QPixmap::fromImage(
+          px.toImage().scaled(THUMBNAIL_WIDTH, THUMBNAIL_HEIGHT,
+                              Qt::KeepAspectRatio, Qt::SmoothTransformation));
+    }
+    sources.append(s);
+  }
+
+  // --- Windows (CoreGraphics) ---
+  CFArrayRef windowList = CGWindowListCopyWindowInfo(
+      kCGWindowListOptionOnScreenOnly | kCGWindowListExcludeDesktopElements,
+      kCGNullWindowID);
+  if (!windowList)
+    return sources;
+
+  CFIndex count = CFArrayGetCount(windowList);
+  for (CFIndex i = 0; i < count; ++i) {
+    auto *info =
+        static_cast<CFDictionaryRef>(CFArrayGetValueAtIndex(windowList, i));
+    if (!info)
+      continue;
+
+    // Only include normal application windows (layer 0).
+    auto *layerRef =
+        static_cast<CFNumberRef>(CFDictionaryGetValue(info, kCGWindowLayer));
+    if (!layerRef)
+      continue;
+    int layer = 0;
+    CFNumberGetValue(layerRef, kCFNumberIntType, &layer);
+    if (layer != 0)
+      continue;
+
+    // Skip Window Server (system compositor) entries.
+    auto *ownerNameRef = static_cast<CFStringRef>(
+        CFDictionaryGetValue(info, kCGWindowOwnerName));
+    const QString ownerName = cfStringToQString(ownerNameRef);
+    if (ownerName == QLatin1String("Window Server"))
+      continue;
+
+    // Window ID.
+    auto *windowNumRef =
+        static_cast<CFNumberRef>(CFDictionaryGetValue(info, kCGWindowNumber));
+    if (!windowNumRef)
+      continue;
+    uint32_t windowId = 0;
+    CFNumberGetValue(windowNumRef, kCFNumberSInt32Type, &windowId);
+
+    // Window name (may be empty for some apps).
+    auto *windowNameRef =
+        static_cast<CFStringRef>(CFDictionaryGetValue(info, kCGWindowName));
+    const QString windowName = cfStringToQString(windowNameRef);
+
+    // Display name: "AppName - WindowTitle" or just "AppName".
+    QString displayName = ownerName;
+    if (!windowName.isEmpty() && windowName != ownerName)
+      displayName += QLatin1String(" - ") + windowName;
+
+    // Thumbnail via CoreGraphics window capture.
+    CGImageRef cgImg = CGWindowListCreateImage(
+        CGRectNull, kCGWindowListOptionIncludingWindow,
+        static_cast<CGWindowID>(windowId), kCGWindowImageDefault);
+    QPixmap thumbnail = pixmapFromCGImage(cgImg);
+    if (cgImg)
+      CGImageRelease(cgImg);
+
+    CaptureSource s;
+    s.type = CaptureSource::Type::Window;
+    s.nativeWindowId = static_cast<quintptr>(windowId);
+    s.displayName = displayName;
+    s.thumbnail = thumbnail;
+    sources.append(s);
+  }
+
+  CFRelease(windowList);
+  return sources;
+}
+
+QImage grabCaptureSource(const CaptureSource &source) {
+  if (source.type == CaptureSource::Type::EntireScreen) {
+    const QList<QScreen *> screens = QGuiApplication::screens();
+    if (source.screenIndex < 0 || source.screenIndex >= screens.size())
+      return {};
+    QPixmap px = screens.at(source.screenIndex)->grabWindow(0);
+    if (px.isNull())
+      return {};
+    return px.toImage().convertToFormat(QImage::Format_RGBA8888);
+  }
+
+  // Window capture — must use CoreGraphics on macOS.
+  // Qt's QScreen::grabWindow(WId) does NOT capture specific windows on macOS
+  // because WId is an NSView pointer, not a CGWindowID.
+  CGImageRef cgImage = CGWindowListCreateImage(
+      CGRectNull, kCGWindowListOptionIncludingWindow,
+      static_cast<CGWindowID>(source.nativeWindowId), kCGWindowImageDefault);
+  if (!cgImage)
+    return {};
+
+  QImage img = qImageFromCGImage(cgImage);
+  CGImageRelease(cgImage);
+  return img.convertToFormat(QImage::Format_RGBA8888);
+}
+
+#endif // USE_SCREEN_SHARING

--- a/src/mumble/CaptureSourceLister_unix.cpp
+++ b/src/mumble/CaptureSourceLister_unix.cpp
@@ -1,0 +1,157 @@
+// Copyright The Mumble Developers. All rights reserved.
+// Use of this source code is governed by a BSD-style license
+// that can be found in the LICENSE file at the root of the
+// Mumble source tree or at <https://www.mumble.info/LICENSE>.
+
+#ifdef USE_SCREEN_SHARING
+
+#	include "CaptureSourceLister.h"
+
+#	include <QtGui/QGuiApplication>
+#	include <QtGui/QPixmap>
+#	include <QtGui/QScreen>
+
+// X11 window enumeration — only available when running on X11 (not Wayland).
+#	ifdef HAS_X11_WINDOW_LIST
+#		include <X11/Xatom.h>
+#		include <X11/Xlib.h>
+#	endif
+
+static constexpr int THUMBNAIL_WIDTH  = 160;
+static constexpr int THUMBNAIL_HEIGHT = 90;
+
+static QPixmap scaledThumbnail(const QPixmap &px) {
+	if (px.isNull())
+		return {};
+	return QPixmap::fromImage(
+		px.toImage().scaled(THUMBNAIL_WIDTH, THUMBNAIL_HEIGHT, Qt::KeepAspectRatio, Qt::SmoothTransformation));
+}
+
+#	ifdef HAS_X11_WINDOW_LIST
+/// Read the _NET_CLIENT_LIST_STACKING property from the root window to get the ordered
+/// list of managed windows (top of stack last, which is the natural display order).
+static QList< Window > getX11WindowList(Display *display) {
+	QList< Window > result;
+	Atom netClientList = XInternAtom(display, "_NET_CLIENT_LIST_STACKING", True);
+	if (netClientList == None)
+		netClientList = XInternAtom(display, "_NET_CLIENT_LIST", True);
+	if (netClientList == None)
+		return result;
+
+	Atom actualType;
+	int actualFormat;
+	unsigned long itemCount, bytesAfter;
+	unsigned char *data = nullptr;
+	if (XGetWindowProperty(display, DefaultRootWindow(display), netClientList, 0, ~0L, False, XA_WINDOW, &actualType,
+						   &actualFormat, &itemCount, &bytesAfter, &data)
+		== Success) {
+		if (data) {
+			auto *windows = reinterpret_cast< Window * >(data);
+			// Reverse: top of stack (most recently active) first.
+			for (long i = static_cast< long >(itemCount) - 1; i >= 0; --i)
+				result.append(windows[i]);
+			XFree(data);
+		}
+	}
+	return result;
+}
+
+static QString getX11WindowTitle(Display *display, Window window) {
+	// Try _NET_WM_NAME (UTF-8) first.
+	Atom netWmName  = XInternAtom(display, "_NET_WM_NAME", False);
+	Atom utf8String = XInternAtom(display, "UTF8_STRING", False);
+	Atom actualType;
+	int actualFormat;
+	unsigned long itemCount, bytesAfter;
+	unsigned char *data = nullptr;
+
+	if (XGetWindowProperty(display, window, netWmName, 0, 1024, False, utf8String, &actualType, &actualFormat,
+						   &itemCount, &bytesAfter, &data)
+			== Success
+		&& data) {
+		QString title = QString::fromUtf8(reinterpret_cast< const char * >(data));
+		XFree(data);
+		if (!title.isEmpty())
+			return title;
+	}
+
+	// Fallback to XFetchName (Latin-1).
+	char *name = nullptr;
+	if (XFetchName(display, window, &name) && name) {
+		QString title = QString::fromLatin1(name);
+		XFree(name);
+		return title;
+	}
+	return {};
+}
+#	endif // HAS_X11_WINDOW_LIST
+
+QList< CaptureSource > listCaptureSources() {
+	QList< CaptureSource > sources;
+
+	// Screens — always available.
+	const QList< QScreen * > screens = QGuiApplication::screens();
+	for (int i = 0; i < screens.size(); ++i) {
+		QScreen *screen = screens.at(i);
+		CaptureSource s;
+		s.type        = CaptureSource::Type::EntireScreen;
+		s.screenIndex = i;
+		s.displayName =
+			QObject::tr("Display %1 (%2×%3)").arg(i + 1).arg(screen->size().width()).arg(screen->size().height());
+		s.thumbnail = scaledThumbnail(screen->grabWindow(0));
+		sources.append(s);
+	}
+
+#	ifdef HAS_X11_WINDOW_LIST
+	// Windows — X11 only.  Wayland's XOpenDisplay returns nullptr, so this block
+	// is naturally skipped when running under a Wayland compositor.
+	Display *display = XOpenDisplay(nullptr);
+	if (display) {
+		const QList< Window > windowIds = getX11WindowList(display);
+		for (Window xid : windowIds) {
+			const QString title = getX11WindowTitle(display, xid);
+			if (title.isEmpty())
+				continue;
+
+			// Thumbnail via Qt (QScreen::grabWindow(XID) works on X11).
+			QPixmap px;
+			if (QScreen *screen = QGuiApplication::primaryScreen())
+				px = scaledThumbnail(screen->grabWindow(static_cast< WId >(xid)));
+
+			CaptureSource s;
+			s.type           = CaptureSource::Type::Window;
+			s.nativeWindowId = static_cast< quintptr >(xid);
+			s.displayName    = title;
+			s.thumbnail      = px;
+			sources.append(s);
+		}
+		XCloseDisplay(display);
+	}
+#	endif // HAS_X11_WINDOW_LIST
+
+	return sources;
+}
+
+QImage grabCaptureSource(const CaptureSource &source) {
+	if (source.type == CaptureSource::Type::EntireScreen) {
+		const QList< QScreen * > screens = QGuiApplication::screens();
+		if (source.screenIndex < 0 || source.screenIndex >= screens.size())
+			return {};
+		QPixmap px = screens.at(source.screenIndex)->grabWindow(0);
+		if (px.isNull()) {
+			return {};
+		}
+		return px.toImage().convertToFormat(QImage::Format_RGBA8888);
+	}
+
+	// Window capture on X11: QScreen::grabWindow(XID) works.
+	QScreen *screen = QGuiApplication::primaryScreen();
+	if (!screen)
+		return {};
+	QPixmap px = screen->grabWindow(static_cast< WId >(source.nativeWindowId));
+	if (px.isNull())
+		return {};
+	return px.toImage().convertToFormat(QImage::Format_RGBA8888);
+}
+
+#endif // USE_SCREEN_SHARING

--- a/src/mumble/CaptureSourceLister_win.cpp
+++ b/src/mumble/CaptureSourceLister_win.cpp
@@ -1,0 +1,107 @@
+// Copyright The Mumble Developers. All rights reserved.
+// Use of this source code is governed by a BSD-style license
+// that can be found in the LICENSE file at the root of the
+// Mumble source tree or at <https://www.mumble.info/LICENSE>.
+
+#ifdef USE_SCREEN_SHARING
+
+#	include "CaptureSourceLister.h"
+
+#	include <QtGui/QGuiApplication>
+#	include <QtGui/QPixmap>
+#	include <QtGui/QScreen>
+
+#	include <windows.h>
+
+static constexpr int THUMBNAIL_WIDTH  = 160;
+static constexpr int THUMBNAIL_HEIGHT = 90;
+
+struct EnumWindowsContext {
+	QList< CaptureSource > *sources;
+};
+
+static BOOL CALLBACK enumWindowsProc(HWND hwnd, LPARAM lParam) {
+	auto *ctx = reinterpret_cast< EnumWindowsContext * >(lParam);
+
+	if (!IsWindowVisible(hwnd))
+		return TRUE;
+	if (GetWindowTextLengthW(hwnd) == 0)
+		return TRUE;
+	// Skip tool windows (e.g. system tray popups).
+	LONG exStyle = GetWindowLongW(hwnd, GWL_EXSTYLE);
+	if (exStyle & WS_EX_TOOLWINDOW)
+		return TRUE;
+
+	wchar_t title[512] = {};
+	GetWindowTextW(hwnd, title, 512);
+	const QString displayName = QString::fromWCharArray(title);
+
+	// Thumbnail: grab via Qt (works for windows on Windows via QScreen::grabWindow(HWND)).
+	QPixmap px;
+	QScreen *screen = QGuiApplication::primaryScreen();
+	if (screen) {
+		px = screen->grabWindow(reinterpret_cast< WId >(hwnd));
+		if (!px.isNull()) {
+			px = QPixmap::fromImage(
+				px.toImage().scaled(THUMBNAIL_WIDTH, THUMBNAIL_HEIGHT, Qt::KeepAspectRatio, Qt::SmoothTransformation));
+		}
+	}
+
+	CaptureSource s;
+	s.type           = CaptureSource::Type::Window;
+	s.nativeWindowId = reinterpret_cast< quintptr >(hwnd);
+	s.displayName    = displayName;
+	s.thumbnail      = px;
+	ctx->sources->append(s);
+	return TRUE;
+}
+
+QList< CaptureSource > listCaptureSources() {
+	QList< CaptureSource > sources;
+
+	// Screens.
+	const QList< QScreen * > screens = QGuiApplication::screens();
+	for (int i = 0; i < screens.size(); ++i) {
+		QScreen *screen = screens.at(i);
+		CaptureSource s;
+		s.type        = CaptureSource::Type::EntireScreen;
+		s.screenIndex = i;
+		s.displayName =
+			QObject::tr("Display %1 (%2×%3)").arg(i + 1).arg(screen->size().width()).arg(screen->size().height());
+		QPixmap px = screen->grabWindow(0);
+		if (!px.isNull()) {
+			s.thumbnail = QPixmap::fromImage(
+				px.toImage().scaled(THUMBNAIL_WIDTH, THUMBNAIL_HEIGHT, Qt::KeepAspectRatio, Qt::SmoothTransformation));
+		}
+		sources.append(s);
+	}
+
+	// Windows.
+	EnumWindowsContext ctx{ &sources };
+	EnumWindows(enumWindowsProc, reinterpret_cast< LPARAM >(&ctx));
+
+	return sources;
+}
+
+QImage grabCaptureSource(const CaptureSource &source) {
+	if (source.type == CaptureSource::Type::EntireScreen) {
+		const QList< QScreen * > screens = QGuiApplication::screens();
+		if (source.screenIndex < 0 || source.screenIndex >= screens.size())
+			return {};
+		QPixmap px = screens.at(source.screenIndex)->grabWindow(0);
+		if (px.isNull())
+			return {};
+		return px.toImage().convertToFormat(QImage::Format_RGBA8888);
+	}
+
+	// Qt's grabWindow with HWND works on Windows.
+	QScreen *screen = QGuiApplication::primaryScreen();
+	if (!screen)
+		return {};
+	QPixmap px = screen->grabWindow(static_cast< WId >(source.nativeWindowId));
+	if (px.isNull())
+		return {};
+	return px.toImage().convertToFormat(QImage::Format_RGBA8888);
+}
+
+#endif // USE_SCREEN_SHARING

--- a/src/mumble/ClientUser.cpp
+++ b/src/mumble/ClientUser.cpp
@@ -242,6 +242,13 @@ void ClientUser::setRecording(bool recording) {
 	emit recordingStateChanged();
 }
 
+void ClientUser::setScreenSharing(bool sharing) {
+	if (bScreenSharing == sharing)
+		return;
+	bScreenSharing = sharing;
+	emit screenSharingStateChanged();
+}
+
 void ClientUser::setLocalVolumeAdjustment(float adjustment) {
 	float oldAdjustment = m_localVolume;
 	m_localVolume       = adjustment;

--- a/src/mumble/ClientUser.h
+++ b/src/mumble/ClientUser.h
@@ -85,6 +85,7 @@ public slots:
 	void setSelfDeaf(bool deaf);
 	void setPrioritySpeaker(bool priority);
 	void setRecording(bool recording);
+	void setScreenSharing(bool sharing);
 	void setLocalVolumeAdjustment(float adjustment);
 	void setLocalNickname(const QString &nickname);
 signals:
@@ -92,6 +93,7 @@ signals:
 	void muteDeafStateChanged();
 	void prioritySpeakerStateChanged();
 	void recordingStateChanged();
+	void screenSharingStateChanged();
 	void localVolumeAdjustmentsChanged(float newAdjustment, float oldAdjustment);
 	void localNicknameChanged();
 };

--- a/src/mumble/Global.h
+++ b/src/mumble/Global.h
@@ -23,6 +23,8 @@ class ServerHandler;
 class AudioInput;
 class AudioOutput;
 class Database;
+class ScreenCapture;
+class ScreenShareReceiver;
 class Log;
 class PluginManager;
 class QSettings;
@@ -54,6 +56,8 @@ public:
 	std::shared_ptr< ServerHandler > sh;
 	std::shared_ptr< AudioInput > ai;
 	std::shared_ptr< AudioOutput > ao;
+	ScreenCapture *sc                        = nullptr;
+	ScreenShareReceiver *screenShareReceiver = nullptr;
 	/**
 	 * @remark Must only be accessed from the main event loop
 	 */

--- a/src/mumble/MainWindow.cpp
+++ b/src/mumble/MainWindow.cpp
@@ -28,6 +28,7 @@
 #	include "OverlayClient.h"
 #endif
 #include "../SignalCurry.h"
+#include "CaptureSource.h"
 #include "ChannelListenerManager.h"
 #include "FailedConnectionDialog.h"
 #include "ListenerVolumeSlider.h"
@@ -40,6 +41,10 @@
 #include "RichTextEditor.h"
 #include "Screen.h"
 #include "ScreenCapture.h"
+#include "ScreenPickerDialog.h"
+#ifdef Q_OS_MAC
+#	include "SCKitCapture.h"
+#endif
 #include "ScreenShareReceiver.h"
 #include "ScreenShareViewer.h"
 #include "SearchDialog.h"
@@ -4177,6 +4182,53 @@ void MainWindow::screenShare() {
 			Global::get().sc = new ScreenCapture(this);
 			connect(Global::get().sc, &ScreenCapture::frameEncoded, this, &MainWindow::sendScreenShareFrame);
 		}
+
+#if defined(USE_SCREEN_SHARING) && defined(Q_OS_MAC)
+		if (sckit_isNativePickerAvailable()) {
+			// Async path: show native SCContentSharingPicker.
+			// The picker is a non-blocking OS overlay; we return immediately and wait for signals.
+			const quint32 session = p->uiSession;
+			auto *sc              = Global::get().sc;
+
+			// One-shot: when the stream actually starts, tell the server.
+			connect(
+				sc, &ScreenCapture::captureStarted, this,
+				[this, session, sc]() {
+					disconnect(sc, &ScreenCapture::captureStarted, this, nullptr);
+					disconnect(sc, &ScreenCapture::captureAborted, this, nullptr);
+					if (Global::get().sh) {
+						MumbleProto::UserState mpus;
+						mpus.set_session(session);
+						mpus.set_screen_sharing(true);
+						Global::get().sh->sendMessage(mpus);
+					}
+				},
+				Qt::SingleShotConnection);
+
+			// One-shot: if the user cancels, revert the toggle.
+			connect(
+				sc, &ScreenCapture::captureAborted, this,
+				[this, sc]() {
+					disconnect(sc, &ScreenCapture::captureStarted, this, nullptr);
+					disconnect(sc, &ScreenCapture::captureAborted, this, nullptr);
+					qaScreenShare->setChecked(false);
+				},
+				Qt::SingleShotConnection);
+
+			sc->startCaptureNative();
+			return; // Don't send UserState yet — wait for captureStarted.
+		}
+#endif
+
+#ifdef USE_SCREEN_SHARING
+		// Sync path: show ScreenPickerDialog (non-macOS or macOS < 14).
+		ScreenPickerDialog dlg(this);
+		if (dlg.exec() != QDialog::Accepted) {
+			qaScreenShare->setChecked(false);
+			return;
+		}
+		Global::get().sc->setSource(dlg.selectedSource());
+#endif
 		Global::get().sc->startCapture();
 
 		MumbleProto::UserState mpus;

--- a/src/mumble/MainWindow.cpp
+++ b/src/mumble/MainWindow.cpp
@@ -1781,6 +1781,11 @@ void MainWindow::qmUser_aboutToShow() {
 		qmUser->addAction(qaUserTextureReset);
 	}
 
+	if (p && !isSelf && p->bScreenSharing) {
+		qmUser->addSeparator();
+		qmUser->addAction(qaUserViewScreenShare);
+	}
+
 	qmUser->addAction(qaUserTextMessage);
 	if (Global::get().sh && Global::get().sh->m_version >= Version::fromComponents(1, 2, 2))
 		qmUser->addAction(qaUserInformation);
@@ -4239,7 +4244,25 @@ void MainWindow::onRemoteFrameDecoded(quint32 senderSession, QImage frame) {
 	}
 
 	ScreenShareViewer *viewer = m_screenShareViewers[senderSession];
+	// Always store the latest frame, but never reopen a window the user closed.
+	// Ideally, the user should subcribe to the server. Otherwise, when a user doesn't have the stream open
+	// it will use bandwith for no reason
 	viewer->updateFrame(frame);
+}
+
+void MainWindow::on_qaUserViewScreenShare_triggered() {
+	ClientUser *p = getContextMenuTargets().user;
+	if (!p || !p->bScreenSharing)
+		return;
+
+	if (!m_screenShareViewers.contains(p->uiSession)) {
+		ScreenShareViewer *viewer = new ScreenShareViewer(p->uiSession, p->qsName, this);
+		m_screenShareViewers.insert(p->uiSession, viewer);
+	}
+
+	ScreenShareViewer *viewer = m_screenShareViewers[p->uiSession];
+	// Clears dismissed flag, shows, raises, and repaints with the last frame.
+	viewer->showAndRefresh();
 }
 
 void MainWindow::onRemoteScreenShareStopped(quint32 senderSession) {

--- a/src/mumble/MainWindow.cpp
+++ b/src/mumble/MainWindow.cpp
@@ -44,6 +44,8 @@
 #include "ScreenPickerDialog.h"
 #ifdef Q_OS_MAC
 #	include "SCKitCapture.h"
+#elif defined(HAS_WAYLAND_PORTAL)
+#	include "XdgPortalCapture.h"
 #endif
 #include "ScreenShareReceiver.h"
 #include "ScreenShareViewer.h"
@@ -4183,40 +4185,49 @@ void MainWindow::screenShare() {
 			connect(Global::get().sc, &ScreenCapture::frameEncoded, this, &MainWindow::sendScreenShareFrame);
 		}
 
-#if defined(USE_SCREEN_SHARING) && defined(Q_OS_MAC)
-		if (sckit_isNativePickerAvailable()) {
-			// Async path: show native SCContentSharingPicker.
-			// The picker is a non-blocking OS overlay; we return immediately and wait for signals.
-			const quint32 session = p->uiSession;
-			auto *sc              = Global::get().sc;
+#if defined(USE_SCREEN_SHARING) && (defined(Q_OS_MAC) || defined(HAS_WAYLAND_PORTAL))
+		{
+			bool useNativePicker = false;
+#	ifdef Q_OS_MAC
+			useNativePicker = sckit_isNativePickerAvailable();
+#	else
+			useNativePicker = xdg_portal_isNativePickerAvailable();
+#	endif
+			if (useNativePicker) {
+				// Async path: show native OS picker (SCContentSharingPicker on macOS,
+				// xdg-desktop-portal on Wayland Linux).
+				// The picker is a non-blocking overlay; we return immediately and wait for signals.
+				const quint32 session = p->uiSession;
+				auto *sc              = Global::get().sc;
 
-			// One-shot: when the stream actually starts, tell the server.
-			connect(
-				sc, &ScreenCapture::captureStarted, this,
-				[this, session, sc]() {
-					disconnect(sc, &ScreenCapture::captureStarted, this, nullptr);
-					disconnect(sc, &ScreenCapture::captureAborted, this, nullptr);
-					if (Global::get().sh) {
-						MumbleProto::UserState mpus;
-						mpus.set_session(session);
-						mpus.set_screen_sharing(true);
-						Global::get().sh->sendMessage(mpus);
-					}
-				},
-				Qt::SingleShotConnection);
+				// One-shot: when the stream actually starts, tell the server.
+				connect(
+					sc, &ScreenCapture::captureStarted, this,
+					[this, session, sc]() {
+						disconnect(sc, &ScreenCapture::captureStarted, this, nullptr);
+						disconnect(sc, &ScreenCapture::captureAborted, this, nullptr);
+						if (Global::get().sh) {
+							MumbleProto::UserState mpus;
+							mpus.set_session(session);
+							mpus.set_screen_sharing(true);
+							Global::get().sh->sendMessage(mpus);
+						}
+					},
+					Qt::SingleShotConnection);
 
-			// One-shot: if the user cancels, revert the toggle.
-			connect(
-				sc, &ScreenCapture::captureAborted, this,
-				[this, sc]() {
-					disconnect(sc, &ScreenCapture::captureStarted, this, nullptr);
-					disconnect(sc, &ScreenCapture::captureAborted, this, nullptr);
-					qaScreenShare->setChecked(false);
-				},
-				Qt::SingleShotConnection);
+				// One-shot: if the user cancels, revert the toggle.
+				connect(
+					sc, &ScreenCapture::captureAborted, this,
+					[this, sc]() {
+						disconnect(sc, &ScreenCapture::captureStarted, this, nullptr);
+						disconnect(sc, &ScreenCapture::captureAborted, this, nullptr);
+						qaScreenShare->setChecked(false);
+					},
+					Qt::SingleShotConnection);
 
-			sc->startCaptureNative();
-			return; // Don't send UserState yet — wait for captureStarted.
+				sc->startCaptureNative();
+				return; // Don't send UserState yet — wait for captureStarted.
+			}
 		}
 #endif
 

--- a/src/mumble/MainWindow.cpp
+++ b/src/mumble/MainWindow.cpp
@@ -39,6 +39,9 @@
 #include "QtWidgetUtils.h"
 #include "RichTextEditor.h"
 #include "Screen.h"
+#include "ScreenCapture.h"
+#include "ScreenShareReceiver.h"
+#include "ScreenShareViewer.h"
 #include "SearchDialog.h"
 #include "ServerHandler.h"
 #include "ServerInformation.h"
@@ -73,6 +76,7 @@
 #include <QtCore/QUrlQuery>
 #include <QtGui/QClipboard>
 #include <QtGui/QDesktopServices>
+#include <QtGui/QGuiApplication>
 #include <QtGui/QImageReader>
 #include <QtGui/QScreen>
 #include <QtGui/QWindow>
@@ -215,6 +219,12 @@ MainWindow::MainWindow(QWidget *p)
 	QObject::connect(this, &MainWindow::channelStateChanged, this, &MainWindow::on_channelStateChanged);
 
 	QAccessible::installFactory(AccessibleSlider::semanticSliderFactory);
+
+	// Create the screen-share receiver and connect its frameDecoded signal so that decoded
+	// frames from remote users are delivered on the GUI thread (queued connection).
+	Global::get().screenShareReceiver = new ScreenShareReceiver(this);
+	connect(Global::get().screenShareReceiver, &ScreenShareReceiver::frameDecoded, this,
+			&MainWindow::onRemoteFrameDecoded, Qt::QueuedConnection);
 }
 
 // Loading a state that was stored by a different version of Qt can lead to a crash.
@@ -2823,6 +2833,10 @@ void MainWindow::on_qaRecording_triggered() {
 	recording();
 }
 
+void MainWindow::on_qaScreenShare_triggered() {
+	screenShare();
+}
+
 void MainWindow::on_qaAudioTTS_triggered() {
 	enableAudioTTS(qaAudioTTS->isChecked());
 }
@@ -3553,6 +3567,7 @@ void MainWindow::serverConnected() {
 	Global::get().uiMaxUsers      = 0;
 
 	enableRecording(true);
+	qaScreenShare->setEnabled(true);
 
 	if (Global::get().s.bMute || Global::get().s.bDeaf) {
 		Global::get().sh->setSelfMuteDeafState(Global::get().s.bMute, Global::get().s.bDeaf);
@@ -3665,8 +3680,12 @@ void MainWindow::serverDisconnected(QAbstractSocket::SocketError err, QString re
 	qmUser_aboutToShow();
 	on_qmConfig_aboutToShow();
 
-	// We can't record without a server anyway, so we disable the functionality here
+	// We can't record or share screen without a server, so disable that functionality here
 	enableRecording(false);
+	qaScreenShare->setEnabled(false);
+	if (Global::get().sc && Global::get().sc->isCapturing()) {
+		Global::get().sc->stopCapture();
+	}
 
 	if (!Global::get().sh->qlErrors.isEmpty()) {
 		for (const QSslError &e : Global::get().sh->qlErrors) {
@@ -4138,6 +4157,99 @@ void MainWindow::recording() {
 		connect(voiceRecorderDialog, SIGNAL(finished(int)), this, SLOT(voiceRecorderDialog_finished(int)));
 		QObject::connect(Global::get().sh.get(), &ServerHandler::disconnected, voiceRecorderDialog, &QDialog::reject);
 		voiceRecorderDialog->show();
+	}
+}
+
+void MainWindow::screenShare() {
+	ClientUser *p = ClientUser::get(Global::get().uiSession);
+	if (!p || !Global::get().sh)
+		return;
+
+	const bool currentlySharing = Global::get().sc && Global::get().sc->isCapturing();
+
+	if (!currentlySharing) {
+		if (!Global::get().sc) {
+			Global::get().sc = new ScreenCapture(this);
+			connect(Global::get().sc, &ScreenCapture::frameEncoded, this, &MainWindow::sendScreenShareFrame);
+		}
+		Global::get().sc->startCapture();
+
+		MumbleProto::UserState mpus;
+		mpus.set_session(p->uiSession);
+		mpus.set_screen_sharing(true);
+		Global::get().sh->sendMessage(mpus);
+	} else {
+		Global::get().sc->stopCapture();
+
+		MumbleProto::UserState mpus;
+		mpus.set_session(p->uiSession);
+		mpus.set_screen_sharing(false);
+		Global::get().sh->sendMessage(mpus);
+	}
+}
+
+void MainWindow::sendScreenShareFrame(QByteArray encodedData, quint64 frameNumber, bool isKeyFrame) {
+	ServerHandlerPtr sh = Global::get().sh;
+	ClientUser *p       = ClientUser::get(Global::get().uiSession);
+	if (!p || !sh || encodedData.isEmpty())
+		return;
+
+	// Fragment the encoded frame into UDP-safe chunks and send each as a MumbleUDP::Video message.
+	// 900 is a bit of a hardcoded arbitrary data. But it seems like a safe value for most MTU
+	static constexpr int MAX_FRAGMENT_BYTES = 900;
+	const int dataSize                      = static_cast< int >(encodedData.size());
+	const int fragmentCount                 = (dataSize + MAX_FRAGMENT_BYTES - 1) / MAX_FRAGMENT_BYTES;
+
+	QScreen *screen  = QGuiApplication::primaryScreen();
+	const int width  = screen ? screen->size().width() : 0;
+	const int height = screen ? screen->size().height() : 0;
+
+	for (int i = 0; i < fragmentCount; ++i) {
+		const int offset    = i * MAX_FRAGMENT_BYTES;
+		const int chunkSize = std::min(MAX_FRAGMENT_BYTES, dataSize - offset);
+
+		MumbleUDP::Video videoMsg;
+		videoMsg.set_sender_session(p->uiSession);
+		videoMsg.set_codec(MumbleUDP::Video_Codec_H264);
+		videoMsg.set_width(static_cast< std::uint32_t >(width));
+		videoMsg.set_height(static_cast< std::uint32_t >(height));
+		videoMsg.set_frame_number(frameNumber);
+		videoMsg.set_fragment_index(static_cast< std::uint32_t >(i));
+		videoMsg.set_fragment_count(static_cast< std::uint32_t >(fragmentCount));
+		videoMsg.set_video_data(encodedData.constData() + offset, static_cast< std::size_t >(chunkSize));
+		videoMsg.set_is_keyframe(isKeyFrame && i == 0);
+
+		const int msgSize = static_cast< int >(videoMsg.ByteSizeLong());
+		std::vector< unsigned char > packet(static_cast< std::size_t >(msgSize + 1));
+		packet[0] = static_cast< unsigned char >(Mumble::Protocol::UDPMessageType::Video);
+		if (!videoMsg.SerializeToArray(packet.data() + 1, msgSize))
+			continue;
+
+		sh->sendMessage(packet.data(), static_cast< int >(packet.size()));
+	}
+}
+
+void MainWindow::onRemoteFrameDecoded(quint32 senderSession, QImage frame) {
+	ClientUser *sender = ClientUser::get(senderSession);
+	const QString name = sender ? sender->qsName : tr("Unknown");
+
+	if (!m_screenShareViewers.contains(senderSession)) {
+		ScreenShareViewer *viewer = new ScreenShareViewer(senderSession, name, this);
+		m_screenShareViewers.insert(senderSession, viewer);
+	}
+
+	ScreenShareViewer *viewer = m_screenShareViewers[senderSession];
+	viewer->updateFrame(frame);
+}
+
+void MainWindow::onRemoteScreenShareStopped(quint32 senderSession) {
+	if (Global::get().screenShareReceiver)
+		Global::get().screenShareReceiver->resetSender(senderSession);
+
+	if (m_screenShareViewers.contains(senderSession)) {
+		ScreenShareViewer *viewer = m_screenShareViewers.take(senderSession);
+		viewer->close();
+		viewer->deleteLater();
 	}
 }
 

--- a/src/mumble/MainWindow.h
+++ b/src/mumble/MainWindow.h
@@ -6,8 +6,10 @@
 #ifndef MUMBLE_MUMBLE_MAINWINDOW_H_
 #define MUMBLE_MUMBLE_MAINWINDOW_H_
 
+#include <QtCore/QMap>
 #include <QtCore/QPointer>
 #include <QtCore/QtGlobal>
+#include <QtGui/QImage>
 #include <QtNetwork/QAbstractSocket>
 #include <QtWidgets/QMainWindow>
 
@@ -33,6 +35,7 @@ class ACLEditor;
 class BanEditor;
 class UserEdit;
 class ServerHandler;
+class ScreenShareViewer;
 class GlobalShortcut;
 class TextToSpeech;
 class UserModel;
@@ -124,6 +127,7 @@ public:
 	Tokens *tokenEdit;
 
 	VoiceRecorderDialog *voiceRecorderDialog;
+	QMap< quint32, ScreenShareViewer * > m_screenShareViewers;
 
 	MumbleProto::Reject_RejectType rtLast;
 	bool bRetryServer;
@@ -291,6 +295,7 @@ public slots:
 	void on_qaAudioMute_triggered();
 	void on_qaAudioDeaf_triggered();
 	void on_qaRecording_triggered();
+	void on_qaScreenShare_triggered();
 	void on_qaAudioTTS_triggered();
 	void on_qaAudioUnlink_triggered();
 	void on_qaAudioStats_triggered();
@@ -466,6 +471,10 @@ public:
 	void openServerBanListDialog();
 	void toggleSelfPrioritySpeaker();
 	void recording();
+	void screenShare();
+	void sendScreenShareFrame(QByteArray encodedData, quint64 frameNumber, bool isKeyFrame);
+	void onRemoteFrameDecoded(quint32 senderSession, QImage frame);
+	void onRemoteScreenShareStopped(quint32 senderSession);
 	void openSelfCommentDialog();
 	void changeServerTexture();
 	void removeServerTexture();

--- a/src/mumble/MainWindow.h
+++ b/src/mumble/MainWindow.h
@@ -273,6 +273,7 @@ public slots:
 	void on_qaUserTextMessage_triggered();
 	void on_qaUserRegister_triggered();
 	void on_qaUserInformation_triggered();
+	void on_qaUserViewScreenShare_triggered();
 	void on_qaUserFriendAdd_triggered();
 	void on_qaUserFriendRemove_triggered();
 	void on_qaUserFriendUpdate_triggered();

--- a/src/mumble/MainWindow.ui
+++ b/src/mumble/MainWindow.ui
@@ -961,6 +961,21 @@ the channel's context menu.</string>
     <bool>true</bool>
    </property>
   </action>
+  <action name="qaUserViewScreenShare">
+   <property name="icon">
+    <iconset>
+     <normaloff>skin:actions/screenshare.svg</normaloff>skin:actions/screenshare.svg</iconset>
+   </property>
+   <property name="text">
+    <string>View &amp;Screen Share</string>
+   </property>
+   <property name="toolTip">
+    <string>Open the screen share viewer for this user</string>
+   </property>
+   <property name="iconVisibleInMenu">
+    <bool>true</bool>
+   </property>
+  </action>
   <action name="qaSelfComment">
    <property name="icon">
     <iconset>

--- a/src/mumble/MainWindow.ui
+++ b/src/mumble/MainWindow.ui
@@ -82,6 +82,7 @@
     <addaction name="qaSelfPrioritySpeaker"/>
     <addaction name="separator"/>
     <addaction name="qaRecording"/>
+    <addaction name="qaScreenShare"/>
     <addaction name="separator"/>
     <addaction name="qaSelfComment"/>
     <addaction name="qaServerTexture"/>
@@ -188,6 +189,7 @@
    <addaction name="qaAudioMute"/>
    <addaction name="qaAudioDeaf"/>
    <addaction name="qaRecording"/>
+   <addaction name="qaScreenShare"/>
    <addaction name="separator"/>
    <addaction name="qaSelfComment"/>
    <addaction name="separator"/>
@@ -1014,6 +1016,30 @@ the channel's context menu.</string>
    </property>
    <property name="whatsThis">
     <string>This will open the audio recording dialog.</string>
+   </property>
+   <property name="iconVisibleInMenu">
+    <bool>true</bool>
+   </property>
+  </action>
+  <action name="qaScreenShare">
+   <property name="icon">
+    <iconset>
+     <normaloff>skin:actions/screenshare.svg</normaloff>skin:actions/screenshare.svg</iconset>
+   </property>
+   <property name="checkable">
+    <bool>true</bool>
+   </property>
+   <property name="enabled">
+    <bool>false</bool>
+   </property>
+   <property name="text">
+    <string>Share &amp;Screen</string>
+   </property>
+   <property name="toolTip">
+    <string>Start or stop sharing your screen with others in the channel</string>
+   </property>
+   <property name="whatsThis">
+    <string>Captures and streams your primary screen as H.264 video to all users in the current channel.</string>
    </property>
    <property name="iconVisibleInMenu">
     <bool>true</bool>

--- a/src/mumble/Messages.cpp
+++ b/src/mumble/Messages.cpp
@@ -595,6 +595,34 @@ void MainWindow::msgUserState(const MumbleProto::UserState &msg) {
 		}
 	}
 
+	if (msg.has_screen_sharing()) {
+		pDst->setScreenSharing(msg.screen_sharing());
+
+		// Do nothing during initial sync
+		if (pSelf) {
+			if (pDst == pSelf) {
+				// Reflect the toggle state back onto the toolbar button.
+				Global::get().mw->qaScreenShare->setChecked(pDst->bScreenSharing);
+				if (pDst->bScreenSharing) {
+					Global::get().l->log(Log::Information, tr("Screen sharing started."));
+				} else {
+					Global::get().l->log(Log::Information, tr("Screen sharing stopped."));
+				}
+			} else if (pDst->cChannel == pSelf->cChannel || pDst->cChannel->allLinks().contains(pSelf->cChannel)) {
+				if (pDst->bScreenSharing) {
+					Global::get().l->log(
+						Log::Information,
+						tr("%1 started sharing their screen.").arg(Log::formatClientUser(pDst, Log::Source)));
+				} else {
+					Global::get().l->log(
+						Log::Information,
+						tr("%1 stopped sharing their screen.").arg(Log::formatClientUser(pDst, Log::Source)));
+					Global::get().mw->onRemoteScreenShareStopped(pDst->uiSession);
+				}
+			}
+		}
+	}
+
 	if (msg.has_priority_speaker()) {
 		if (pSelf
 			&& ((pDst->cChannel == pSelf->cChannel) || (pDst->cChannel->allLinks().contains(pSelf->cChannel))

--- a/src/mumble/SCKitCapture.h
+++ b/src/mumble/SCKitCapture.h
@@ -1,0 +1,34 @@
+// Copyright The Mumble Developers. All rights reserved.
+// Use of this source code is governed by a BSD-style license
+// that can be found in the LICENSE file at the root of the
+// Mumble source tree or at <https://www.mumble.info/LICENSE>.
+
+#ifndef MUMBLE_MUMBLE_SCKITCAPTURE_H_
+#define MUMBLE_MUMBLE_SCKITCAPTURE_H_
+
+#if defined(Q_OS_MAC) && defined(USE_SCREEN_SHARING)
+
+#	include <QtCore/QString>
+#	include <QtGui/QImage>
+#	include <functional>
+
+/// Returns true if the native macOS SCContentSharingPicker is available (macOS 14.0+).
+bool sckit_isNativePickerAvailable();
+
+/// Shows the native macOS screen/window picker (SCContentSharingPicker) and, upon selection,
+/// begins delivering captured frames via SCStream.
+///
+/// All callbacks are guaranteed to be invoked on the Qt/Cocoa main thread.
+///
+/// @param onStarted  Called once when the SCStream is successfully running.
+/// @param onCancelled  Called if the user dismisses the picker without choosing a source.
+/// @param onError  Called with a description string if stream startup fails.
+/// @param onFrame  Called for each captured frame (QImage::Format_RGBA8888, ~15 fps).
+void sckit_startWithNativePicker(std::function< void() > onStarted, std::function< void() > onCancelled,
+								 std::function< void(QString) > onError, std::function< void(QImage) > onFrame);
+
+/// Stops the active SCStream and deactivates the picker.
+void sckit_stop();
+
+#endif // Q_OS_MAC && USE_SCREEN_SHARING
+#endif // MUMBLE_MUMBLE_SCKITCAPTURE_H_

--- a/src/mumble/SCKitCapture_macx.mm
+++ b/src/mumble/SCKitCapture_macx.mm
@@ -1,0 +1,275 @@
+// Copyright The Mumble Developers. All rights reserved.
+// Use of this source code is governed by a BSD-style license
+// that can be found in the LICENSE file at the root of the
+// Mumble source tree or at <https://www.mumble.info/LICENSE>.
+
+// CMake only compiles this file on Apple platforms, so use __APPLE__ (compiler-native)
+// rather than Q_OS_MAC (Qt-defined) which requires a Qt header to be included first.
+#if defined(__APPLE__) && defined(USE_SCREEN_SHARING)
+
+#	import <Foundation/Foundation.h>
+#	import <ScreenCaptureKit/ScreenCaptureKit.h>
+
+#	include "SCKitCapture.h"
+
+#	include <QtGui/QImage>
+
+static constexpr int SCKIT_FPS = 15;
+
+// ---------------------------------------------------------------------------
+// Objective-C delegate — implements picker + stream + output protocols.
+// Instantiated by sckit_startWithNativePicker and released by sckit_stop.
+// ---------------------------------------------------------------------------
+API_AVAILABLE(macos(14.0))
+@interface SCKitDelegate
+	: NSObject< SCContentSharingPickerObserver, SCStreamDelegate, SCStreamOutput >
+
+@property(nonatomic, strong) SCStream *stream;
+@property(nonatomic, copy) void (^onStarted)();
+@property(nonatomic, copy) void (^onCancelled)();
+@property(nonatomic, copy) void (^onError)(NSString *);
+@property(nonatomic, copy) void (^onFrame)(QImage);
+@property(nonatomic, assign) CGSize lastContentSize;
+
+- (void)startStreamWithFilter:(SCContentFilter *)filter;
+
+@end
+
+@implementation SCKitDelegate
+
+/// Called when the user picks a source or changes their selection.
+- (void)contentSharingPicker:(SCContentSharingPicker *)picker
+		  didUpdateWithFilter:(SCContentFilter *)filter
+					forStream:(SCStream *)stream {
+	(void) picker;
+	(void) stream;
+	if (self.stream) {
+		// Update an already-running stream (user switched source mid-session).
+		// Push both the new content filter and a matching configuration so the
+		// output resolution is correct for the newly selected source.
+		SCStreamConfiguration *config = [self configForFilter:filter];
+		[self.stream updateContentFilter:filter completionHandler:nil];
+		[self.stream updateConfiguration:config completionHandler:nil];
+	} else {
+		[self startStreamWithFilter:filter];
+	}
+}
+
+/// Called when the user dismisses the picker without choosing anything.
+/// When the picker was shown without a pre-existing stream, `stream` is nil.
+- (void)contentSharingPicker:(SCContentSharingPicker *)picker
+		didCancelForStream:(SCStream *)stream {
+	(void) picker;
+	(void) stream;
+	if (!self.stream && self.onCancelled) {
+		dispatch_async(dispatch_get_main_queue(), self.onCancelled);
+	}
+}
+
+/// Called when presenting the picker fails at the system level.
+- (void)contentSharingPickerStartDidFailWithError:(NSError *)error {
+	NSString *msg = error.localizedDescription;
+	if (self.onError) {
+		dispatch_async(dispatch_get_main_queue(), ^{
+			self.onError(msg);
+		});
+	}
+}
+
+/// Builds an SCStreamConfiguration for an explicit pixel size.
+/// If size is zero (unknown), falls back to 1920×1080.
+/// Both dimensions are rounded down to an even number (required by YUV420P).
+- (SCStreamConfiguration *)configForSize:(CGSize)size {
+	if (CGSizeEqualToSize(size, CGSizeZero))
+		size = CGSizeMake(1920, 1080);
+	// Round down to even dimensions.
+	size.width  = std::floor(size.width / 2) * 2;
+	size.height = std::floor(size.height / 2) * 2;
+
+	SCStreamConfiguration *config = [[SCStreamConfiguration alloc] init];
+	config.pixelFormat            = kCVPixelFormatType_32BGRA;
+	config.minimumFrameInterval   = CMTimeMake(1, SCKIT_FPS);
+	config.showsCursor            = YES;
+	config.width                  = static_cast< size_t >(size.width);
+	config.height                 = static_cast< size_t >(size.height);
+	return config;
+}
+
+/// Builds an SCStreamConfiguration sized to the given filter's content rect.
+/// Falls back to 1920×1080 for display-level or desktop-independent filters
+/// where contentRect is zero or infinite — the actual window size is discovered
+/// on the first frame via SCStreamFrameInfoContentRect and the config is updated.
+- (SCStreamConfiguration *)configForFilter:(SCContentFilter *)filter {
+	CGSize contentSize = filter.contentRect.size;
+	// CGRectInfinite is returned for desktopIndependentWindow filters; treat as unknown.
+	if (CGSizeEqualToSize(contentSize, CGRectInfinite.size))
+		contentSize = CGSizeZero;
+	return [self configForSize:contentSize];
+}
+
+/// Creates and starts an SCStream for the given filter.
+- (void)startStreamWithFilter:(SCContentFilter *)filter {
+	SCStreamConfiguration *config = [self configForFilter:filter];
+
+	NSError *addError = nil;
+	dispatch_queue_t queue = dispatch_queue_create("info.mumble.screenshare.sckit", DISPATCH_QUEUE_SERIAL);
+
+	self.stream = [[SCStream alloc] initWithFilter:filter configuration:config delegate:self];
+	[self.stream addStreamOutput:self type:SCStreamOutputTypeScreen sampleHandlerQueue:queue error:&addError];
+	if (addError) {
+		NSString *msg = addError.localizedDescription;
+		if (self.onError)
+			dispatch_async(dispatch_get_main_queue(), ^{
+				self.onError(msg);
+			});
+		self.stream = nil;
+		return;
+	}
+
+	[self.stream startCaptureWithCompletionHandler:^(NSError *startError) {
+		if (startError) {
+			NSString *msg = startError.localizedDescription;
+			if (self.onError)
+				dispatch_async(dispatch_get_main_queue(), ^{
+					self.onError(msg);
+				});
+			self.stream = nil;
+		} else {
+			if (self.onStarted)
+				dispatch_async(dispatch_get_main_queue(), self.onStarted);
+		}
+	}];
+}
+
+// ---------------------------------------------------------------------------
+// SCStreamOutput — frame delivery
+// ---------------------------------------------------------------------------
+- (void)stream:(SCStream *)stream
+		didOutputSampleBuffer:(CMSampleBufferRef)sampleBuffer
+					   ofType:(SCStreamOutputType)type {
+	(void) stream;
+	if (type != SCStreamOutputTypeScreen)
+		return;
+
+	CVPixelBufferRef pixelBuffer = CMSampleBufferGetImageBuffer(sampleBuffer);
+	if (!pixelBuffer)
+		return;
+
+	CVPixelBufferLockBaseAddress(pixelBuffer, kCVPixelBufferLock_ReadOnly);
+
+	CFArrayRef attachments  = CMSampleBufferGetSampleAttachmentsArray(sampleBuffer, false);
+	CFDictionaryRef attachment = (CFDictionaryRef) CFArrayGetValueAtIndex(attachments, 0);
+	CFDictionaryRef frameInfo =
+		(CFDictionaryRef) CFDictionaryGetValue(attachment, (__bridge const void *) SCStreamFrameInfoContentRect);
+
+	CGRect rect;
+	int width            = static_cast< int >(CVPixelBufferGetWidth(pixelBuffer));
+	int height           = static_cast< int >(CVPixelBufferGetHeight(pixelBuffer));
+	const int stride     = static_cast< int >(CVPixelBufferGetBytesPerRow(pixelBuffer));
+	const uchar *basePtr = static_cast< const uchar * >(CVPixelBufferGetBaseAddress(pixelBuffer));
+	if (CGRectMakeWithDictionaryRepresentation(frameInfo, &rect)) {
+		width  = static_cast< int >(std::round(rect.size.width * 2)) & ~1;
+		height = static_cast< int >(std::round(rect.size.height * 2)) & ~1;
+	}
+
+	// kCVPixelFormatType_32BGRA on little-endian (Apple Silicon / Intel macOS)
+	// maps to QImage::Format_ARGB32 (stored as 0xAARRGGBB in memory as BB GG RR AA).
+	QImage frame(basePtr, width, height, stride, QImage::Format_ARGB32);
+	// Deep-copy before unlocking the pixel buffer.
+	QImage copy = frame.copy().convertToFormat(QImage::Format_RGBA8888);
+
+	CVPixelBufferUnlockBaseAddress(pixelBuffer, kCVPixelBufferLock_ReadOnly);
+
+	dispatch_async(dispatch_get_main_queue(), ^{
+		if (self.onFrame)
+			self.onFrame(copy);
+	});
+}
+
+// ---------------------------------------------------------------------------
+// SCStreamDelegate — error handling
+// ---------------------------------------------------------------------------
+- (void)stream:(SCStream *)stream didStopWithError:(NSError *)error {
+	(void) stream;
+	if (error && self.onError) {
+		NSString *msg = error.localizedDescription;
+		dispatch_async(dispatch_get_main_queue(), ^{
+			self.onError(msg);
+		});
+	}
+}
+
+@end
+
+// ---------------------------------------------------------------------------
+// Global session — only one SCKit session active at a time.
+// ---------------------------------------------------------------------------
+API_AVAILABLE(macos(14.0))
+static SCKitDelegate *g_delegate = nil;
+
+// ---------------------------------------------------------------------------
+// C++ interface (sckit_stop declared first so sckit_startWithNativePicker can call it)
+// ---------------------------------------------------------------------------
+
+void sckit_stop();
+
+bool sckit_isNativePickerAvailable() {
+	if (@available(macOS 14.0, *)) {
+		return true;
+	}
+	return false;
+}
+
+void sckit_startWithNativePicker(std::function< void() > onStarted,
+								 std::function< void() > onCancelled,
+								 std::function< void(QString) > onError,
+								 std::function< void(QImage) > onFrame) {
+	if (@available(macOS 14.0, *)) {
+		sckit_stop(); // Clean up any previous session.
+
+		SCKitDelegate *delegate = [[SCKitDelegate alloc] init];
+		delegate.onStarted      = [onStarted]() { onStarted(); };
+		delegate.onCancelled    = [onCancelled]() { onCancelled(); };
+		delegate.onError        = [onError](NSString *msg) {
+			onError(QString::fromNSString(msg));
+		};
+		delegate.onFrame        = [onFrame](QImage img) { onFrame(img); };
+		g_delegate              = delegate;
+
+		SCContentSharingPicker *picker = SCContentSharingPicker.sharedPicker;
+		[picker addObserver:delegate];
+		picker.active = YES;
+
+		// Request screen recording permission first; this also populates SCShareableContent
+		// which the picker needs internally.  Only then show the picker.
+		[SCShareableContent getShareableContentWithCompletionHandler:^(SCShareableContent *content,
+																	   NSError *permError) {
+			(void) content;
+			dispatch_async(dispatch_get_main_queue(), ^{
+				if (permError) {
+					onError(QString::fromNSString(permError.localizedDescription));
+					return;
+				}
+				[SCContentSharingPicker.sharedPicker present];
+			});
+		}];
+	}
+}
+
+void sckit_stop() {
+	if (@available(macOS 14.0, *)) {
+		if (g_delegate) {
+			SCContentSharingPicker *picker = SCContentSharingPicker.sharedPicker;
+			[picker removeObserver:g_delegate];
+			picker.active = NO;
+
+			if (g_delegate.stream) {
+				[g_delegate.stream stopCaptureWithCompletionHandler:nil];
+				g_delegate.stream = nil;
+			}
+			g_delegate = nil;
+		}
+	}
+}
+
+#endif // __APPLE__ && USE_SCREEN_SHARING

--- a/src/mumble/ScreenCapture.cpp
+++ b/src/mumble/ScreenCapture.cpp
@@ -13,6 +13,8 @@
 #	include <QtGui/QImage>
 #	ifdef Q_OS_MAC
 #		include "SCKitCapture.h"
+#	elif defined(HAS_WAYLAND_PORTAL)
+#		include "XdgPortalCapture.h"
 #	endif
 #endif
 
@@ -60,6 +62,8 @@ void ScreenCapture::stopCapture() {
 #ifdef USE_SCREEN_SHARING
 #	ifdef Q_OS_MAC
 	sckit_stop();
+#	elif defined(HAS_WAYLAND_PORTAL)
+	xdg_portal_stop();
 #	endif
 	destroyEncoder();
 #endif
@@ -76,7 +80,7 @@ void ScreenCapture::setSource(const CaptureSource &source) {
 	destroyEncoder(); // Reset so the encoder reinitialises at the new source's resolution.
 }
 
-#	ifdef Q_OS_MAC
+#	if defined(Q_OS_MAC) || defined(HAS_WAYLAND_PORTAL)
 void ScreenCapture::startCaptureNative() {
 	if (m_capturing)
 		return;
@@ -84,38 +88,39 @@ void ScreenCapture::startCaptureNative() {
 	// Keep a safe pointer — the lambdas below must not capture `this` without guard.
 	QPointer< ScreenCapture > self = this;
 
-	sckit_startWithNativePicker(
-		// onStarted: SCStream is running — flip the capturing flag and notify MainWindow.
-		[self]() {
-			if (!self)
-				return;
-			self->m_capturing   = true;
-			self->m_frameNumber = 0;
-			emit self->captureStarted();
-		},
-		// onCancelled: user dismissed the picker without choosing a source.
-		[self]() {
-			if (!self)
-				return;
-			emit self->captureAborted();
-		},
-		// onError: stream startup failed after the picker was shown.
-		[self](QString error) {
-			if (!self)
-				return;
-			Global::get().l->log(Log::Warning, QObject::tr("Screen capture failed: %1").arg(error));
-			self->m_capturing = false;
-			self->destroyEncoder();
-			emit self->captureAborted();
-		},
-		// onFrame: frame delivered on the main thread; encode and forward.
-		[self](QImage frame) {
-			if (!self || !self->m_capturing)
-				return;
-			self->encodeImage(frame);
-		});
+	auto onStarted = [self]() {
+		if (!self)
+			return;
+		self->m_capturing   = true;
+		self->m_frameNumber = 0;
+		emit self->captureStarted();
+	};
+	auto onCancelled = [self]() {
+		if (!self)
+			return;
+		emit self->captureAborted();
+	};
+	auto onError = [self](QString error) {
+		if (!self)
+			return;
+		Global::get().l->log(Log::Warning, QObject::tr("Screen capture failed: %1").arg(error));
+		self->m_capturing = false;
+		self->destroyEncoder();
+		emit self->captureAborted();
+	};
+	auto onFrame = [self](QImage frame) {
+		if (!self || !self->m_capturing)
+			return;
+		self->encodeImage(frame);
+	};
+
+#		ifdef Q_OS_MAC
+	sckit_startWithNativePicker(std::move(onStarted), std::move(onCancelled), std::move(onError), std::move(onFrame));
+#		else
+	xdg_portal_startCapture(std::move(onStarted), std::move(onCancelled), std::move(onError), std::move(onFrame));
+#		endif
 }
-#	endif // Q_OS_MAC
+#	endif // Q_OS_MAC || HAS_WAYLAND_PORTAL
 
 void ScreenCapture::encodeImage(const QImage &srcImage) {
 	// Caller must supply a non-null Format_RGB888 image.
@@ -123,9 +128,14 @@ void ScreenCapture::encodeImage(const QImage &srcImage) {
 		return;
 
 	// Convert to Format_RGBA8888 for mapping to AV_PIX_FMT_RGB24.
-	QImage image     = srcImage.convertToFormat(QImage::Format_RGBA8888);
-	const int width  = image.width();
-	const int height = image.height();
+	QImage image = srcImage.convertToFormat(QImage::Format_RGBA8888);
+	// libx264 (YUV420P) requires even dimensions — crop one pixel if needed.
+	const int width  = image.width() & ~1;
+	const int height = image.height() & ~1;
+	if (width <= 0 || height <= 0)
+		return;
+	if (width != image.width() || height != image.height())
+		image = image.copy(0, 0, width, height);
 
 	// (Re-)initialise the encoder when the resolution changes.
 	if (!m_codecCtx || m_encoderWidth != width || m_encoderHeight != height) {
@@ -169,8 +179,7 @@ void ScreenCapture::captureFrame() {
 	// Delegate platform-specific grab to CaptureSourceLister.
 	QImage image = grabCaptureSource(m_source);
 	if (image.isNull()) {
-		Global::get().l->log(Log::Warning, QObject::tr("Screen capture failed. "
-													   "If running under Wayland, set QT_QPA_PLATFORM=xcb."));
+		Global::get().l->log(Log::Warning, QObject::tr("Screen capture failed."));
 		stopCapture();
 		return;
 	}

--- a/src/mumble/ScreenCapture.cpp
+++ b/src/mumble/ScreenCapture.cpp
@@ -1,0 +1,193 @@
+// Copyright The Mumble Developers. All rights reserved.
+// Use of this source code is governed by a BSD-style license
+// that can be found in the LICENSE file at the root of the
+// Mumble source tree or at <https://www.mumble.info/LICENSE>.
+
+#include "ScreenCapture.h"
+
+#include "Log.h"
+
+#ifdef USE_SCREEN_SHARING
+#	include <QtGui/QGuiApplication>
+#	include <QtGui/QImage>
+#	include <QtGui/QPixmap>
+#	include <QtGui/QScreen>
+#endif
+
+#include "Global.h"
+
+// These values are still hardcoded. This should probably be a setting.
+// For now these values seem alright for testing
+static constexpr int CAPTURE_INTERVAL_MS = 66;        // ~15 fps
+static constexpr int VIDEO_BITRATE       = 1'500'000; // 1.5 Mbps
+static constexpr int VIDEO_FPS           = 15;
+static constexpr int VIDEO_GOP_SIZE      = 5; // keyframe every ~333 ms — limits UDP error propagation
+
+ScreenCapture::ScreenCapture(QObject *parent) : QObject(parent) {
+	m_captureTimer = new QTimer(this);
+	m_captureTimer->setInterval(CAPTURE_INTERVAL_MS);
+	connect(m_captureTimer, &QTimer::timeout, this, &ScreenCapture::captureFrame);
+}
+
+ScreenCapture::~ScreenCapture() {
+	stopCapture();
+}
+
+void ScreenCapture::startCapture() {
+#ifndef USE_SCREEN_SHARING
+	// This way it's sent to the chatbox. I don't know if this should be a qWarning instead.
+	Global::get().l->log(Log::Warning,
+						 QObject::tr("Screen sharing requires Mumble to be built with -Dscreen-sharing=ON."));
+#else
+	if (m_capturing)
+		return;
+
+	m_frameNumber = 0;
+	m_capturing   = true;
+	m_captureTimer->start();
+#endif
+}
+
+void ScreenCapture::stopCapture() {
+	if (!m_capturing)
+		return;
+
+	m_captureTimer->stop();
+	m_capturing = false;
+
+#ifdef USE_SCREEN_SHARING
+	destroyEncoder();
+#endif
+}
+
+bool ScreenCapture::isCapturing() const {
+	return m_capturing;
+}
+
+void ScreenCapture::captureFrame() {
+#ifdef USE_SCREEN_SHARING
+	QScreen *screen = QGuiApplication::primaryScreen();
+	if (!screen)
+		return;
+
+	// Grab the entire primary screen.
+	QPixmap pixmap = screen->grabWindow(0);
+	if (pixmap.isNull()) {
+		// grabWindow(0) fails silently under Wayland.
+		// In the future, this should be replaced with dg-desktop-portal
+		Global::get().l->log(Log::Warning, QObject::tr("Screen capture failed: grabWindow returned null. "));
+		stopCapture();
+		return;
+	}
+
+	// Convert to Format_RGBA8888 for mapping to AV_PIX_FMT_RGB24.
+	QImage image     = pixmap.toImage().convertToFormat(QImage::Format_RGBA8888);
+	const int width  = image.width();
+	const int height = image.height();
+
+	// (Re-)initialise the encoder if this is the first frame or the resolution changed.
+	if (!m_codecCtx || m_encoderWidth != width || m_encoderHeight != height) {
+		destroyEncoder();
+		if (!initEncoder(width, height))
+			return;
+	}
+
+	// Colour-space conversion: RGBA24 to YUV420P.
+	m_swsCtx = sws_getCachedContext(m_swsCtx, width, height, AV_PIX_FMT_RGBA, width, height, AV_PIX_FMT_YUV420P,
+									SWS_BICUBIC, nullptr, nullptr, nullptr);
+	if (!m_swsCtx)
+		return;
+
+	if (av_frame_make_writable(m_frame) < 0)
+		return;
+
+	const uint8_t *srcData[1] = { image.constBits() };
+	int srcLinesize[1]        = { static_cast< int >(image.bytesPerLine()) };
+	sws_scale(m_swsCtx, srcData, srcLinesize, 0, height, m_frame->data, m_frame->linesize);
+
+	m_frame->pts = static_cast< int64_t >(m_frameNumber);
+
+	if (avcodec_send_frame(m_codecCtx, m_frame) < 0)
+		return;
+
+	while (avcodec_receive_packet(m_codecCtx, m_packet) == 0) {
+		QByteArray encodedData(reinterpret_cast< const char * >(m_packet->data), m_packet->size);
+		const bool isKey = (m_packet->flags & AV_PKT_FLAG_KEY) != 0;
+		emit frameEncoded(encodedData, m_frameNumber, isKey);
+		av_packet_unref(m_packet);
+	}
+
+	++m_frameNumber;
+#endif
+}
+
+#ifdef USE_SCREEN_SHARING
+bool ScreenCapture::initEncoder(int width, int height) {
+	// To use hardware-accelerated encoding (e.g. h264_videotoolbox on macOS,
+	// h264_nvenc on NVIDIA), replace "libx264" with the appropriate encoder name
+	// and add any codec-specific option calls below.
+	const char *encoderName = "libx264";
+	const AVCodec *codec    = avcodec_find_encoder_by_name(encoderName);
+	if (!codec) {
+		// I'm logging straight into the chatbox here so I can test things. But this probably should be a qWarning
+		Global::get().l->log(Log::Warning,
+							 QObject::tr("H.264 encoder (libx264) not available. "
+										 "Ensure libx264 is installed and libavcodec was compiled with it."));
+		return false;
+	}
+
+	m_codecCtx = avcodec_alloc_context3(codec);
+	if (!m_codecCtx)
+		return false;
+
+	m_codecCtx->width     = width;
+	m_codecCtx->height    = height;
+	m_codecCtx->time_base = { 1, VIDEO_FPS };
+	m_codecCtx->pix_fmt   = AV_PIX_FMT_YUV420P;
+	m_codecCtx->bit_rate  = VIDEO_BITRATE;
+	m_codecCtx->gop_size  = VIDEO_GOP_SIZE;
+
+	// Minimise encoding latency. These could maybe be settings?
+	av_opt_set(m_codecCtx->priv_data, "preset", "superfast", 0);
+	av_opt_set(m_codecCtx->priv_data, "tune", "zerolatency", 0);
+
+	if (avcodec_open2(m_codecCtx, codec, nullptr) < 0) {
+		avcodec_free_context(&m_codecCtx);
+		return false;
+	}
+
+	m_frame         = av_frame_alloc();
+	m_frame->format = AV_PIX_FMT_YUV420P;
+	m_frame->width  = width;
+	m_frame->height = height;
+	if (av_frame_get_buffer(m_frame, 0) < 0) {
+		av_frame_free(&m_frame);
+		avcodec_free_context(&m_codecCtx);
+		return false;
+	}
+
+	m_packet = av_packet_alloc();
+
+	m_encoderWidth  = width;
+	m_encoderHeight = height;
+	return true;
+}
+
+void ScreenCapture::destroyEncoder() {
+	if (m_swsCtx) {
+		sws_freeContext(m_swsCtx);
+		m_swsCtx = nullptr;
+	}
+	if (m_frame) {
+		av_frame_free(&m_frame);
+	}
+	if (m_packet) {
+		av_packet_free(&m_packet);
+	}
+	if (m_codecCtx) {
+		avcodec_free_context(&m_codecCtx);
+	}
+	m_encoderWidth  = 0;
+	m_encoderHeight = 0;
+}
+#endif

--- a/src/mumble/ScreenCapture.cpp
+++ b/src/mumble/ScreenCapture.cpp
@@ -8,10 +8,12 @@
 #include "Log.h"
 
 #ifdef USE_SCREEN_SHARING
-#	include <QtGui/QGuiApplication>
+#	include "CaptureSourceLister.h"
+#	include <QtCore/QPointer>
 #	include <QtGui/QImage>
-#	include <QtGui/QPixmap>
-#	include <QtGui/QScreen>
+#	ifdef Q_OS_MAC
+#		include "SCKitCapture.h"
+#	endif
 #endif
 
 #include "Global.h"
@@ -56,6 +58,9 @@ void ScreenCapture::stopCapture() {
 	m_capturing = false;
 
 #ifdef USE_SCREEN_SHARING
+#	ifdef Q_OS_MAC
+	sckit_stop();
+#	endif
 	destroyEncoder();
 #endif
 }
@@ -64,28 +69,65 @@ bool ScreenCapture::isCapturing() const {
 	return m_capturing;
 }
 
-void ScreenCapture::captureFrame() {
 #ifdef USE_SCREEN_SHARING
-	QScreen *screen = QGuiApplication::primaryScreen();
-	if (!screen)
+
+void ScreenCapture::setSource(const CaptureSource &source) {
+	m_source = source;
+	destroyEncoder(); // Reset so the encoder reinitialises at the new source's resolution.
+}
+
+#	ifdef Q_OS_MAC
+void ScreenCapture::startCaptureNative() {
+	if (m_capturing)
 		return;
 
-	// Grab the entire primary screen.
-	QPixmap pixmap = screen->grabWindow(0);
-	if (pixmap.isNull()) {
-		// grabWindow(0) fails silently under Wayland.
-		// In the future, this should be replaced with dg-desktop-portal
-		Global::get().l->log(Log::Warning, QObject::tr("Screen capture failed: grabWindow returned null. "));
-		stopCapture();
+	// Keep a safe pointer — the lambdas below must not capture `this` without guard.
+	QPointer< ScreenCapture > self = this;
+
+	sckit_startWithNativePicker(
+		// onStarted: SCStream is running — flip the capturing flag and notify MainWindow.
+		[self]() {
+			if (!self)
+				return;
+			self->m_capturing   = true;
+			self->m_frameNumber = 0;
+			emit self->captureStarted();
+		},
+		// onCancelled: user dismissed the picker without choosing a source.
+		[self]() {
+			if (!self)
+				return;
+			emit self->captureAborted();
+		},
+		// onError: stream startup failed after the picker was shown.
+		[self](QString error) {
+			if (!self)
+				return;
+			Global::get().l->log(Log::Warning, QObject::tr("Screen capture failed: %1").arg(error));
+			self->m_capturing = false;
+			self->destroyEncoder();
+			emit self->captureAborted();
+		},
+		// onFrame: frame delivered on the main thread; encode and forward.
+		[self](QImage frame) {
+			if (!self || !self->m_capturing)
+				return;
+			self->encodeImage(frame);
+		});
+}
+#	endif // Q_OS_MAC
+
+void ScreenCapture::encodeImage(const QImage &srcImage) {
+	// Caller must supply a non-null Format_RGB888 image.
+	if (srcImage.isNull())
 		return;
-	}
 
 	// Convert to Format_RGBA8888 for mapping to AV_PIX_FMT_RGB24.
-	QImage image     = pixmap.toImage().convertToFormat(QImage::Format_RGBA8888);
+	QImage image     = srcImage.convertToFormat(QImage::Format_RGBA8888);
 	const int width  = image.width();
 	const int height = image.height();
 
-	// (Re-)initialise the encoder if this is the first frame or the resolution changed.
+	// (Re-)initialise the encoder when the resolution changes.
 	if (!m_codecCtx || m_encoderWidth != width || m_encoderHeight != height) {
 		destroyEncoder();
 		if (!initEncoder(width, height))
@@ -118,6 +160,23 @@ void ScreenCapture::captureFrame() {
 	}
 
 	++m_frameNumber;
+}
+
+#endif // USE_SCREEN_SHARING
+
+void ScreenCapture::captureFrame() {
+#ifdef USE_SCREEN_SHARING
+	// Delegate platform-specific grab to CaptureSourceLister.
+	QImage image = grabCaptureSource(m_source);
+	if (image.isNull()) {
+		Global::get().l->log(Log::Warning, QObject::tr("Screen capture failed. "
+													   "If running under Wayland, set QT_QPA_PLATFORM=xcb."));
+		stopCapture();
+		return;
+	}
+
+	// Ensure Format_RGB888 (24-bit RGB, no alpha) for AV_PIX_FMT_RGB24 mapping.
+	encodeImage(image.convertToFormat(QImage::Format_RGB888));
 #endif
 }
 

--- a/src/mumble/ScreenCapture.h
+++ b/src/mumble/ScreenCapture.h
@@ -24,7 +24,9 @@ extern "C" {
 ///
 /// On macOS 14+, startCaptureNative() shows the OS-native SCContentSharingPicker and streams
 /// frames via SCStream; captureStarted() / captureAborted() signals report the async outcome.
-/// On other platforms (or macOS < 14), use setSource() + startCapture() with ScreenPickerDialog.
+/// On Linux under Wayland, startCaptureNative() uses the xdg-desktop-portal ScreenCast interface
+/// and delivers frames via a PipeWire stream.
+/// On other platforms (or macOS < 14, or X11), use setSource() + startCapture() with ScreenPickerDialog.
 ///
 /// Requires the build option -Dscreen-sharing=ON (links libavcodec/libswscale).
 class ScreenCapture : public QObject {
@@ -44,10 +46,11 @@ public:
 	/// Sets the capture source for the non-native picker path. Call before startCapture().
 	void setSource(const CaptureSource &source);
 
-#	ifdef Q_OS_MAC
-	/// Shows the native macOS SCContentSharingPicker (macOS 14+) and starts capturing
-	/// the selected source via SCStream. Asynchronous: returns immediately.
-	/// captureStarted() is emitted when the stream is running; captureAborted() if cancelled/failed.
+#	if defined(Q_OS_MAC) || defined(HAS_WAYLAND_PORTAL)
+	/// Shows the platform-native picker and starts capturing asynchronously.
+	/// On macOS 14+: uses SCContentSharingPicker / SCStream.
+	/// On Linux (Wayland): uses xdg-desktop-portal ScreenCast + PipeWire.
+	/// captureStarted() is emitted when frames begin; captureAborted() if cancelled/failed.
 	void startCaptureNative();
 #	endif
 #endif
@@ -56,8 +59,8 @@ signals:
 	/// Emitted for every successfully encoded frame.
 	void frameEncoded(QByteArray encodedData, quint64 frameNumber, bool isKeyFrame);
 
-#if defined(USE_SCREEN_SHARING) && defined(Q_OS_MAC)
-	/// Emitted on the main thread when the native SCStream starts delivering frames.
+#if defined(USE_SCREEN_SHARING) && (defined(Q_OS_MAC) || defined(HAS_WAYLAND_PORTAL))
+	/// Emitted on the main thread when the native stream starts delivering frames.
 	void captureStarted();
 	/// Emitted on the main thread when the native picker is cancelled or the stream fails.
 	void captureAborted();

--- a/src/mumble/ScreenCapture.h
+++ b/src/mumble/ScreenCapture.h
@@ -1,0 +1,68 @@
+// Copyright The Mumble Developers. All rights reserved.
+// Use of this source code is governed by a BSD-style license
+// that can be found in the LICENSE file at the root of the
+// Mumble source tree or at <https://www.mumble.info/LICENSE>.
+
+#ifndef MUMBLE_MUMBLE_SCREENCAPTURE_H_
+#define MUMBLE_MUMBLE_SCREENCAPTURE_H_
+
+#include <QtCore/QByteArray>
+#include <QtCore/QObject>
+#include <QtCore/QTimer>
+#include <cstdint>
+
+#ifdef USE_SCREEN_SHARING
+extern "C" {
+#	include <libavcodec/avcodec.h>
+#	include <libavutil/opt.h>
+#	include <libswscale/swscale.h>
+}
+#endif
+
+/// Captures the primary display at ~15 fps and emits encoded video frames via frameEncoded().
+///
+/// Requires the build option -Dscreen-sharing=ON (links libavcodec/libswscale).
+/// Without that option the class is still present but startCapture() logs a warning and
+/// returns immediately without capturing anything.
+class ScreenCapture : public QObject {
+private:
+	Q_OBJECT
+	Q_DISABLE_COPY(ScreenCapture)
+
+public:
+	explicit ScreenCapture(QObject *parent = nullptr);
+	~ScreenCapture() override;
+
+	void startCapture();
+	void stopCapture();
+	bool isCapturing() const;
+
+signals:
+	/// Emitted for every successfully encoded frame.
+	/// @param encodedData  Codec-specific encoded byte stream (currently H.264 Annex-B).
+	/// @param frameNumber  Monotonically increasing counter starting at 0.
+	/// @param isKeyFrame  True when the frame is an IDR / key frame.
+	void frameEncoded(QByteArray encodedData, quint64 frameNumber, bool isKeyFrame);
+
+private slots:
+	void captureFrame();
+
+private:
+#ifdef USE_SCREEN_SHARING
+	bool initEncoder(int width, int height);
+	void destroyEncoder();
+
+	AVCodecContext *m_codecCtx = nullptr;
+	AVFrame *m_frame           = nullptr;
+	AVPacket *m_packet         = nullptr;
+	SwsContext *m_swsCtx       = nullptr;
+	int m_encoderWidth         = 0;
+	int m_encoderHeight        = 0;
+#endif
+
+	QTimer *m_captureTimer = nullptr;
+	quint64 m_frameNumber  = 0;
+	bool m_capturing       = false;
+};
+
+#endif // MUMBLE_MUMBLE_SCREENCAPTURE_H_

--- a/src/mumble/ScreenCapture.h
+++ b/src/mumble/ScreenCapture.h
@@ -12,6 +12,7 @@
 #include <cstdint>
 
 #ifdef USE_SCREEN_SHARING
+#	include "CaptureSource.h"
 extern "C" {
 #	include <libavcodec/avcodec.h>
 #	include <libavutil/opt.h>
@@ -19,11 +20,13 @@ extern "C" {
 }
 #endif
 
-/// Captures the primary display at ~15 fps and emits encoded video frames via frameEncoded().
+/// Captures a selected screen or window at ~15 fps and emits encoded video frames via frameEncoded().
+///
+/// On macOS 14+, startCaptureNative() shows the OS-native SCContentSharingPicker and streams
+/// frames via SCStream; captureStarted() / captureAborted() signals report the async outcome.
+/// On other platforms (or macOS < 14), use setSource() + startCapture() with ScreenPickerDialog.
 ///
 /// Requires the build option -Dscreen-sharing=ON (links libavcodec/libswscale).
-/// Without that option the class is still present but startCapture() logs a warning and
-/// returns immediately without capturing anything.
 class ScreenCapture : public QObject {
 private:
 	Q_OBJECT
@@ -37,12 +40,28 @@ public:
 	void stopCapture();
 	bool isCapturing() const;
 
+#ifdef USE_SCREEN_SHARING
+	/// Sets the capture source for the non-native picker path. Call before startCapture().
+	void setSource(const CaptureSource &source);
+
+#	ifdef Q_OS_MAC
+	/// Shows the native macOS SCContentSharingPicker (macOS 14+) and starts capturing
+	/// the selected source via SCStream. Asynchronous: returns immediately.
+	/// captureStarted() is emitted when the stream is running; captureAborted() if cancelled/failed.
+	void startCaptureNative();
+#	endif
+#endif
+
 signals:
 	/// Emitted for every successfully encoded frame.
-	/// @param encodedData  Codec-specific encoded byte stream (currently H.264 Annex-B).
-	/// @param frameNumber  Monotonically increasing counter starting at 0.
-	/// @param isKeyFrame  True when the frame is an IDR / key frame.
 	void frameEncoded(QByteArray encodedData, quint64 frameNumber, bool isKeyFrame);
+
+#if defined(USE_SCREEN_SHARING) && defined(Q_OS_MAC)
+	/// Emitted on the main thread when the native SCStream starts delivering frames.
+	void captureStarted();
+	/// Emitted on the main thread when the native picker is cancelled or the stream fails.
+	void captureAborted();
+#endif
 
 private slots:
 	void captureFrame();
@@ -51,6 +70,9 @@ private:
 #ifdef USE_SCREEN_SHARING
 	bool initEncoder(int width, int height);
 	void destroyEncoder();
+	void encodeImage(const QImage &srcImage); ///< Shared encode path used by both capture modes.
+
+	CaptureSource m_source; ///< Defaults to EntireScreen, screenIndex=0 (primary display).
 
 	AVCodecContext *m_codecCtx = nullptr;
 	AVFrame *m_frame           = nullptr;

--- a/src/mumble/ScreenPickerDialog.cpp
+++ b/src/mumble/ScreenPickerDialog.cpp
@@ -1,0 +1,70 @@
+// Copyright The Mumble Developers. All rights reserved.
+// Use of this source code is governed by a BSD-style license
+// that can be found in the LICENSE file at the root of the
+// Mumble source tree or at <https://www.mumble.info/LICENSE>.
+
+#ifdef USE_SCREEN_SHARING
+
+#	include "ScreenPickerDialog.h"
+
+#	include "CaptureSourceLister.h"
+
+#	include <QtWidgets/QDialogButtonBox>
+#	include <QtWidgets/QLabel>
+#	include <QtWidgets/QListWidget>
+#	include <QtWidgets/QPushButton>
+#	include <QtWidgets/QVBoxLayout>
+
+ScreenPickerDialog::ScreenPickerDialog(QWidget *parent) : QDialog(parent) {
+	setWindowTitle(tr("Choose what to share"));
+	setMinimumSize(640, 480);
+
+	m_list = new QListWidget(this);
+	m_list->setViewMode(QListView::IconMode);
+	m_list->setIconSize(QSize(160, 90));
+	m_list->setResizeMode(QListView::Adjust);
+	m_list->setSpacing(8);
+	m_list->setWordWrap(true);
+	m_list->setMovement(QListView::Static);
+	m_list->setSelectionMode(QAbstractItemView::SingleSelection);
+	connect(m_list, &QListWidget::itemDoubleClicked, this, &ScreenPickerDialog::onItemDoubleClicked);
+
+	auto *hint = new QLabel(tr("Select a screen or window to share, then click Share."), this);
+	hint->setWordWrap(true);
+
+	auto *buttons = new QDialogButtonBox(QDialogButtonBox::Ok | QDialogButtonBox::Cancel, this);
+	buttons->button(QDialogButtonBox::Ok)->setText(tr("Share"));
+	connect(buttons, &QDialogButtonBox::accepted, this, &QDialog::accept);
+	connect(buttons, &QDialogButtonBox::rejected, this, &QDialog::reject);
+
+	auto *layout = new QVBoxLayout(this);
+	layout->addWidget(hint);
+	layout->addWidget(m_list, 1);
+	layout->addWidget(buttons);
+	setLayout(layout);
+
+	// Populate list.
+	m_sources = listCaptureSources();
+	for (const CaptureSource &src : m_sources) {
+		QIcon icon = src.thumbnail.isNull() ? QIcon() : QIcon(src.thumbnail);
+		auto *item = new QListWidgetItem(icon, src.displayName);
+		item->setToolTip(src.displayName);
+		m_list->addItem(item);
+	}
+
+	if (m_list->count() > 0)
+		m_list->setCurrentRow(0);
+}
+
+CaptureSource ScreenPickerDialog::selectedSource() const {
+	const int row = m_list->currentRow();
+	if (row >= 0 && row < m_sources.size())
+		return m_sources.at(row);
+	return {};
+}
+
+void ScreenPickerDialog::onItemDoubleClicked(QListWidgetItem *) {
+	accept();
+}
+
+#endif // USE_SCREEN_SHARING

--- a/src/mumble/ScreenPickerDialog.h
+++ b/src/mumble/ScreenPickerDialog.h
@@ -1,0 +1,41 @@
+// Copyright The Mumble Developers. All rights reserved.
+// Use of this source code is governed by a BSD-style license
+// that can be found in the LICENSE file at the root of the
+// Mumble source tree or at <https://www.mumble.info/LICENSE>.
+
+#ifndef MUMBLE_MUMBLE_SCREENPICKERDIALOG_H_
+#define MUMBLE_MUMBLE_SCREENPICKERDIALOG_H_
+
+#ifdef USE_SCREEN_SHARING
+
+#	include "CaptureSource.h"
+
+#	include <QtCore/QList>
+#	include <QtWidgets/QDialog>
+
+class QListWidget;
+class QListWidgetItem;
+
+/// Modal dialog that lists available screens and windows for screen sharing.
+/// Call exec(); if accepted, use selectedSource() to retrieve the chosen source.
+class ScreenPickerDialog : public QDialog {
+	Q_OBJECT
+	Q_DISABLE_COPY(ScreenPickerDialog)
+
+public:
+	explicit ScreenPickerDialog(QWidget *parent = nullptr);
+
+	/// Returns the source selected by the user, or a default-constructed CaptureSource
+	/// (EntireScreen, screenIndex 0) if nothing was explicitly selected.
+	CaptureSource selectedSource() const;
+
+private slots:
+	void onItemDoubleClicked(QListWidgetItem *item);
+
+private:
+	QListWidget *m_list;
+	QList< CaptureSource > m_sources;
+};
+
+#endif // USE_SCREEN_SHARING
+#endif // MUMBLE_MUMBLE_SCREENPICKERDIALOG_H_

--- a/src/mumble/ScreenShareReceiver.cpp
+++ b/src/mumble/ScreenShareReceiver.cpp
@@ -1,0 +1,238 @@
+// Copyright The Mumble Developers. All rights reserved.
+// Use of this source code is governed by a BSD-style license
+// that can be found in the LICENSE file at the root of the
+// Mumble source tree or at <https://www.mumble.info/LICENSE>.
+
+#include "ScreenShareReceiver.h"
+
+#include "MumbleProtocol.h"
+
+#ifdef USE_SCREEN_SHARING
+/// Maps the protocol's Codec enum to the corresponding FFmpeg codec ID.
+/// To add support for a new codec: add the proto enum value in MumbleUDP.proto,
+/// then add a case here returning the appropriate AV_CODEC_ID_*.
+static AVCodecID codecIdForProtoCodec(MumbleUDP::Video::Codec c) {
+	switch (c) {
+		case MumbleUDP::Video::H264:
+			return AV_CODEC_ID_H264;
+		default:
+			return AV_CODEC_ID_NONE;
+	}
+}
+#endif
+
+ScreenShareReceiver::ScreenShareReceiver(QObject *parent) : QObject(parent) {
+}
+
+ScreenShareReceiver::~ScreenShareReceiver() {
+#ifdef USE_SCREEN_SHARING
+	// Tear down all decoders.
+	for (std::pair< const unsigned int, DecoderState > &kv : m_decoders) {
+		DecoderState &ds = kv.second;
+		if (ds.swsCtx) {
+			sws_freeContext(ds.swsCtx);
+		}
+		if (ds.frame) {
+			av_frame_free(&ds.frame);
+		}
+		if (ds.packet) {
+			av_packet_free(&ds.packet);
+		}
+		if (ds.codecCtx) {
+			avcodec_free_context(&ds.codecCtx);
+		}
+	}
+#endif
+}
+
+
+void ScreenShareReceiver::handleVideoPacket(const Mumble::Protocol::VideoData &videoData) {
+#ifndef USE_SCREEN_SHARING
+	Q_UNUSED(videoData);
+#else
+	const quint32 session   = videoData.senderSession;
+	const quint64 frameNum  = videoData.frameNumber;
+	const quint32 fragIdx   = videoData.fragmentIndex;
+	const quint32 fragCount = videoData.fragmentCount;
+
+	if (fragCount == 0 || fragIdx >= fragCount)
+		return;
+
+	PendingFrame &pf = m_fragmentBuffer[session][frameNum];
+
+	// Initialize frame on first fragment
+	if (pf.fragmentCount == 0) {
+		pf.fragmentCount = fragCount;
+		pf.fragments.resize(fragCount);
+		pf.width  = videoData.width;
+		pf.height = videoData.height;
+		pf.codec  = videoData.codec;
+	}
+
+	// OR keyframe flag (UDP fragments may arrive out of order)
+	pf.isKeyFrame |= videoData.isKeyFrame;
+
+	// Store fragment (copy once per fragment, unavoidable unless lifetime guaranteed)
+	if (pf.fragments[fragIdx].isEmpty()) {
+		pf.fragments[fragIdx] = QByteArray(reinterpret_cast< const char * >(videoData.payload.data()),
+										   static_cast< int >(videoData.payload.size()));
+	}
+
+	// Early exit until complete
+	for (const QByteArray &frag : pf.fragments) {
+		if (frag.isEmpty())
+			return;
+	}
+
+	// Compute total size once
+	size_t totalSize = 0;
+	for (const QByteArray &frag : pf.fragments)
+		totalSize += static_cast< size_t >(frag.size());
+
+	QByteArray complete;
+	complete.resize(static_cast< int >(totalSize));
+
+	char *dst = complete.data();
+	for (const QByteArray &frag : pf.fragments) {
+		memcpy(dst, frag.constData(), static_cast< size_t >(frag.size()));
+		dst += frag.size();
+	}
+
+	// Capture frame metadata
+	const quint32 fw                    = pf.width;
+	const quint32 fh                    = pf.height;
+	const bool isKeyFrm                 = pf.isKeyFrame;
+	const MumbleUDP::Video::Codec codec = pf.codec;
+
+	// Cleanup old frames for this session
+	std::map< unsigned long long, PendingFrame > &senderMap = m_fragmentBuffer[session];
+
+	// Using auto here as type because this is an iterator
+	for (auto it = senderMap.begin(); it != senderMap.end();) {
+		if (it->first <= frameNum)
+			it = senderMap.erase(it);
+		else
+			++it;
+	}
+
+	decodeCompleteFrame(session, complete, fw, fh, isKeyFrm, codec);
+#endif
+}
+
+void ScreenShareReceiver::resetSender(quint32 senderSession) {
+#ifdef USE_SCREEN_SHARING
+	m_fragmentBuffer.erase(senderSession);
+	destroyDecoder(senderSession);
+#else
+	Q_UNUSED(senderSession);
+#endif
+}
+
+#ifdef USE_SCREEN_SHARING
+bool ScreenShareReceiver::ensureDecoder(quint32 session, MumbleUDP::Video::Codec protoCodec) {
+	if (m_decoders.count(session) && m_decoders[session].codecCtx)
+		return true;
+
+	const AVCodecID avCodecId = codecIdForProtoCodec(protoCodec);
+	if (avCodecId == AV_CODEC_ID_NONE)
+		return false;
+
+	const AVCodec *codec = avcodec_find_decoder(avCodecId);
+	if (!codec)
+		return false;
+
+	DecoderState ds;
+	ds.codec    = protoCodec;
+	ds.codecCtx = avcodec_alloc_context3(codec);
+	if (!ds.codecCtx)
+		return false;
+
+	if (avcodec_open2(ds.codecCtx, codec, nullptr) < 0) {
+		avcodec_free_context(&ds.codecCtx);
+		return false;
+	}
+
+	ds.frame            = av_frame_alloc();
+	ds.packet           = av_packet_alloc();
+	m_decoders[session] = ds;
+	return true;
+}
+
+void ScreenShareReceiver::destroyDecoder(quint32 session) {
+	auto it = m_decoders.find(session);
+	if (it == m_decoders.end())
+		return;
+
+	DecoderState &ds = it->second;
+	if (ds.swsCtx) {
+		sws_freeContext(ds.swsCtx);
+	}
+	if (ds.frame) {
+		av_frame_free(&ds.frame);
+	}
+	if (ds.packet) {
+		av_packet_free(&ds.packet);
+	}
+	if (ds.codecCtx) {
+		avcodec_free_context(&ds.codecCtx);
+	}
+	m_decoders.erase(it);
+}
+
+void ScreenShareReceiver::decodeCompleteFrame(quint32 session, const QByteArray &encodedData, quint32 /*width*/,
+											  quint32 /*height*/, bool isKeyFrame, MumbleUDP::Video::Codec codec) {
+	if (!ensureDecoder(session, codec))
+		return;
+
+	DecoderState &ds = m_decoders[session];
+
+	// Drop non-keyframes until the decoder has seen at least one IDR.
+	// Without SPS/PPS (which come with the keyframe) the decoder can't
+	// reference picture parameters and emits "non-existing PPS" errors.
+	if (!ds.gotKeyFrame && !isKeyFrame)
+		return;
+
+	if (isKeyFrame) {
+		// Flush any buffered decoder state from a previous stream so the new
+		// IDR is treated as a clean start.
+		avcodec_flush_buffers(ds.codecCtx);
+		ds.gotKeyFrame = true;
+	}
+
+	av_packet_unref(ds.packet);
+	ds.packet->data = reinterpret_cast< uint8_t * >(const_cast< char * >(encodedData.constData()));
+	ds.packet->size = static_cast< int >(encodedData.size());
+
+	if (avcodec_send_packet(ds.codecCtx, ds.packet) < 0) {
+		// Packet was rejected (e.g. corrupted reference frame from UDP loss).
+		// Flush and wait for the next keyframe so we don't propagate corruption.
+		avcodec_flush_buffers(ds.codecCtx);
+		ds.gotKeyFrame = false;
+		return;
+	}
+
+	while (avcodec_receive_frame(ds.codecCtx, ds.frame) == 0) {
+		const int dw = ds.frame->width;
+		const int dh = ds.frame->height;
+
+		// (Re-)create the sws context if dimensions changed.
+		if (!ds.swsCtx || ds.swsWidth != dw || ds.swsHeight != dh) {
+			if (ds.swsCtx)
+				sws_freeContext(ds.swsCtx);
+			ds.swsCtx = sws_getContext(dw, dh, static_cast< AVPixelFormat >(ds.frame->format), dw, dh, AV_PIX_FMT_RGB24,
+									   SWS_BILINEAR, nullptr, nullptr, nullptr);
+			ds.swsWidth  = dw;
+			ds.swsHeight = dh;
+		}
+		if (!ds.swsCtx)
+			continue;
+
+		QImage img(dw, dh, QImage::Format_RGB888);
+		uint8_t *dstData[1] = { img.bits() };
+		int dstStride[1]    = { static_cast< int >(img.bytesPerLine()) };
+		sws_scale(ds.swsCtx, ds.frame->data, ds.frame->linesize, 0, dh, dstData, dstStride);
+
+		emit frameDecoded(session, img);
+	}
+}
+#endif

--- a/src/mumble/ScreenShareReceiver.cpp
+++ b/src/mumble/ScreenShareReceiver.cpp
@@ -219,7 +219,7 @@ void ScreenShareReceiver::decodeCompleteFrame(quint32 session, const QByteArray 
 		if (!ds.swsCtx || ds.swsWidth != dw || ds.swsHeight != dh) {
 			if (ds.swsCtx)
 				sws_freeContext(ds.swsCtx);
-			ds.swsCtx = sws_getContext(dw, dh, static_cast< AVPixelFormat >(ds.frame->format), dw, dh, AV_PIX_FMT_RGB24,
+			ds.swsCtx = sws_getContext(dw, dh, static_cast< AVPixelFormat >(ds.frame->format), dw, dh, AV_PIX_FMT_RGBA,
 									   SWS_BILINEAR, nullptr, nullptr, nullptr);
 			ds.swsWidth  = dw;
 			ds.swsHeight = dh;
@@ -227,7 +227,7 @@ void ScreenShareReceiver::decodeCompleteFrame(quint32 session, const QByteArray 
 		if (!ds.swsCtx)
 			continue;
 
-		QImage img(dw, dh, QImage::Format_RGB888);
+		QImage img(dw, dh, QImage::Format_RGBA8888);
 		uint8_t *dstData[1] = { img.bits() };
 		int dstStride[1]    = { static_cast< int >(img.bytesPerLine()) };
 		sws_scale(ds.swsCtx, ds.frame->data, ds.frame->linesize, 0, dh, dstData, dstStride);

--- a/src/mumble/ScreenShareReceiver.h
+++ b/src/mumble/ScreenShareReceiver.h
@@ -71,7 +71,6 @@ private:
 		/// Drop P-frames until the decoder has seen at least one IDR keyframe.
 		bool gotKeyFrame = false;
 	};
-
 	std::map< quint32, DecoderState > m_decoders;
 
 	bool ensureDecoder(quint32 session, MumbleUDP::Video::Codec codec);

--- a/src/mumble/ScreenShareReceiver.h
+++ b/src/mumble/ScreenShareReceiver.h
@@ -1,0 +1,84 @@
+// Copyright The Mumble Developers. All rights reserved.
+// Use of this source code is governed by a BSD-style license
+// that can be found in the LICENSE file at the root of the
+// Mumble source tree or at <https://www.mumble.info/LICENSE>.
+
+#ifndef MUMBLE_MUMBLE_SCREENSHARERECEIVER_H_
+#define MUMBLE_MUMBLE_SCREENSHARERECEIVER_H_
+
+#include "MumbleProtocol.h"
+#include "MumbleUDP.pb.h"
+
+#include <QtCore/QObject>
+#include <QtGui/QImage>
+
+#include <cstdint>
+#include <map>
+#include <vector>
+
+#ifdef USE_SCREEN_SHARING
+extern "C" {
+#	include <libavcodec/avcodec.h>
+#	include <libswscale/swscale.h>
+}
+#endif
+
+/// Reassembles UDP video fragments and decodes video frames.
+///
+/// Thread-safe to call handleVideoPacket() from a non-GUI thread;
+/// frameDecoded() is emitted via a queued connection and delivered on the
+/// GUI thread when connected with Qt::QueuedConnection.
+class ScreenShareReceiver : public QObject {
+private:
+	Q_OBJECT
+	Q_DISABLE_COPY(ScreenShareReceiver)
+
+public:
+	explicit ScreenShareReceiver(QObject *parent = nullptr);
+	~ScreenShareReceiver() override;
+
+	/// Called (potentially from the ServerHandler thread) for every incoming Video UDP message.
+	void handleVideoPacket(const Mumble::Protocol::VideoData &videoData);
+
+	/// Tear down decoder state for a sender who stopped sharing.
+	void resetSender(quint32 senderSession);
+
+signals:
+	void frameDecoded(quint32 senderSession, QImage frame);
+
+private:
+#ifdef USE_SCREEN_SHARING
+	struct PendingFrame {
+		quint32 fragmentCount = 0;
+		std::vector< QByteArray > fragments;
+		bool isKeyFrame               = false;
+		quint32 width                 = 0;
+		quint32 height                = 0;
+		MumbleUDP::Video::Codec codec = MumbleUDP::Video::H264;
+	};
+
+	/// sender_session -> frame_number -> pending fragment data
+	std::map< quint32, std::map< quint64, PendingFrame > > m_fragmentBuffer;
+
+	struct DecoderState {
+		AVCodecContext *codecCtx      = nullptr;
+		AVFrame *frame                = nullptr;
+		AVPacket *packet              = nullptr;
+		SwsContext *swsCtx            = nullptr;
+		int swsWidth                  = 0;
+		int swsHeight                 = 0;
+		MumbleUDP::Video::Codec codec = MumbleUDP::Video::H264;
+		/// Drop P-frames until the decoder has seen at least one IDR keyframe.
+		bool gotKeyFrame = false;
+	};
+
+	std::map< quint32, DecoderState > m_decoders;
+
+	bool ensureDecoder(quint32 session, MumbleUDP::Video::Codec codec);
+	void destroyDecoder(quint32 session);
+	void decodeCompleteFrame(quint32 session, const QByteArray &encodedData, quint32 width, quint32 height,
+							 bool isKeyFrame, MumbleUDP::Video::Codec codec);
+#endif
+};
+
+#endif // MUMBLE_MUMBLE_SCREENSHARERECEIVER_H_

--- a/src/mumble/ScreenShareViewer.cpp
+++ b/src/mumble/ScreenShareViewer.cpp
@@ -5,8 +5,8 @@
 
 #include "ScreenShareViewer.h"
 
+#include <QtGui/QCloseEvent>
 #include <QtWidgets/QLabel>
-#include <QtWidgets/QScrollArea>
 #include <QtWidgets/QVBoxLayout>
 
 ScreenShareViewer::ScreenShareViewer(quint32 senderSession, const QString &senderName, QWidget *parent)
@@ -16,30 +16,41 @@ ScreenShareViewer::ScreenShareViewer(quint32 senderSession, const QString &sende
 
 	m_imageLabel = new QLabel(this);
 	m_imageLabel->setAlignment(Qt::AlignCenter);
-	m_imageLabel->setSizePolicy(QSizePolicy::Ignored, QSizePolicy::Ignored);
+	m_imageLabel->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
 	m_imageLabel->setMinimumSize(320, 240);
 	m_imageLabel->setText(tr("Waiting for first frame…"));
 
-	m_scrollArea = new QScrollArea(this);
-	m_scrollArea->setWidget(m_imageLabel);
-	m_scrollArea->setWidgetResizable(false);
-	m_scrollArea->setAlignment(Qt::AlignCenter);
-
 	QVBoxLayout *layout = new QVBoxLayout(this);
 	layout->setContentsMargins(0, 0, 0, 0);
-	layout->addWidget(m_scrollArea);
+	layout->addWidget(m_imageLabel);
 
 	resize(800, 600);
+}
+
+bool ScreenShareViewer::isDismissed() const {
+	return m_dismissed;
+}
+
+void ScreenShareViewer::showAndRefresh() {
+	m_dismissed = false;
+	show();
+	raise();
+	activateWindow();
+	updateImageDisplay();
+}
+
+void ScreenShareViewer::closeEvent(QCloseEvent *event) {
+	// Remember that the user explicitly closed the window so we don't reopen it
+	// automatically when new frames arrive.
+	m_dismissed = true;
+	QDialog::closeEvent(event);
 }
 
 void ScreenShareViewer::updateImageDisplay() {
 	if (m_currentFrame.isNull())
 		return;
 
-	// Get the available size in the scroll area
-	QSize areaSize = m_scrollArea->viewport()->size();
-
-	// Scale the image to fit, keeping aspect ratio
+	QSize areaSize = size();
 	QPixmap scaled = QPixmap::fromImage(m_currentFrame).scaled(areaSize, Qt::KeepAspectRatio, Qt::SmoothTransformation);
 
 	m_imageLabel->setPixmap(scaled);
@@ -57,13 +68,8 @@ void ScreenShareViewer::updateFrame(QImage frame) {
 
 	m_currentFrame = frame;
 
-	// Show scaled version to fit the window
-	updateImageDisplay();
-
-	// Auto-resize the window on first real frame (up to the available screen).
-	if (!isVisible()) {
-		QSize desired = frame.size().boundedTo(QSize(1280, 800));
-		resize(desired);
-		show();
-	}
+	// Always update the image data so the viewer shows the latest frame
+	// when the user re-opens it via the context menu.
+	if (isVisible())
+		updateImageDisplay();
 }

--- a/src/mumble/ScreenShareViewer.cpp
+++ b/src/mumble/ScreenShareViewer.cpp
@@ -1,0 +1,69 @@
+// Copyright The Mumble Developers. All rights reserved.
+// Use of this source code is governed by a BSD-style license
+// that can be found in the LICENSE file at the root of the
+// Mumble source tree or at <https://www.mumble.info/LICENSE>.
+
+#include "ScreenShareViewer.h"
+
+#include <QtWidgets/QLabel>
+#include <QtWidgets/QScrollArea>
+#include <QtWidgets/QVBoxLayout>
+
+ScreenShareViewer::ScreenShareViewer(quint32 senderSession, const QString &senderName, QWidget *parent)
+	: QDialog(parent, Qt::Window), m_senderSession(senderSession) {
+	setWindowTitle(tr("%1's screen").arg(senderName));
+	setAttribute(Qt::WA_DeleteOnClose, false);
+
+	m_imageLabel = new QLabel(this);
+	m_imageLabel->setAlignment(Qt::AlignCenter);
+	m_imageLabel->setSizePolicy(QSizePolicy::Ignored, QSizePolicy::Ignored);
+	m_imageLabel->setMinimumSize(320, 240);
+	m_imageLabel->setText(tr("Waiting for first frame…"));
+
+	m_scrollArea = new QScrollArea(this);
+	m_scrollArea->setWidget(m_imageLabel);
+	m_scrollArea->setWidgetResizable(false);
+	m_scrollArea->setAlignment(Qt::AlignCenter);
+
+	QVBoxLayout *layout = new QVBoxLayout(this);
+	layout->setContentsMargins(0, 0, 0, 0);
+	layout->addWidget(m_scrollArea);
+
+	resize(800, 600);
+}
+
+void ScreenShareViewer::updateImageDisplay() {
+	if (m_currentFrame.isNull())
+		return;
+
+	// Get the available size in the scroll area
+	QSize areaSize = m_scrollArea->viewport()->size();
+
+	// Scale the image to fit, keeping aspect ratio
+	QPixmap scaled = QPixmap::fromImage(m_currentFrame).scaled(areaSize, Qt::KeepAspectRatio, Qt::SmoothTransformation);
+
+	m_imageLabel->setPixmap(scaled);
+	m_imageLabel->resize(scaled.size());
+}
+
+void ScreenShareViewer::resizeEvent(QResizeEvent *event) {
+	QDialog::resizeEvent(event);
+	updateImageDisplay();
+}
+
+void ScreenShareViewer::updateFrame(QImage frame) {
+	if (frame.isNull())
+		return;
+
+	m_currentFrame = frame;
+
+	// Show scaled version to fit the window
+	updateImageDisplay();
+
+	// Auto-resize the window on first real frame (up to the available screen).
+	if (!isVisible()) {
+		QSize desired = frame.size().boundedTo(QSize(1280, 800));
+		resize(desired);
+		show();
+	}
+}

--- a/src/mumble/ScreenShareViewer.h
+++ b/src/mumble/ScreenShareViewer.h
@@ -21,19 +21,26 @@ private:
 public:
 	explicit ScreenShareViewer(quint32 senderSession, const QString &senderName, QWidget *parent = nullptr);
 
+	/// Returns true once the user has explicitly closed the window.
+	/// While dismissed, new frames update the stored image but do not reopen the window.
+	bool isDismissed() const;
+	/// Show the window and repaint with the last stored frame.
+	void showAndRefresh();
+
 public slots:
 	void updateFrame(QImage frame);
 
 protected:
 	void resizeEvent(QResizeEvent *event) override;
+	void closeEvent(QCloseEvent *event) override;
 
 private:
 	void updateImageDisplay();
 
 	QLabel *m_imageLabel;
-	QScrollArea *m_scrollArea;
 	quint32 m_senderSession;
 	QImage m_currentFrame;
+	bool m_dismissed = false;
 };
 
 #endif // MUMBLE_MUMBLE_SCREENSHAREVIEWER_H_

--- a/src/mumble/ScreenShareViewer.h
+++ b/src/mumble/ScreenShareViewer.h
@@ -1,0 +1,39 @@
+// Copyright The Mumble Developers. All rights reserved.
+// Use of this source code is governed by a BSD-style license
+// that can be found in the LICENSE file at the root of the
+// Mumble source tree or at <https://www.mumble.info/LICENSE>.
+
+#ifndef MUMBLE_MUMBLE_SCREENSHAREVIEWER_H_
+#define MUMBLE_MUMBLE_SCREENSHAREVIEWER_H_
+
+#include <QtGui/QImage>
+#include <QtWidgets/QDialog>
+
+class QLabel;
+class QScrollArea;
+
+/// Floating window that displays the screen share stream from a single remote user.
+class ScreenShareViewer : public QDialog {
+private:
+	Q_OBJECT
+	Q_DISABLE_COPY(ScreenShareViewer)
+
+public:
+	explicit ScreenShareViewer(quint32 senderSession, const QString &senderName, QWidget *parent = nullptr);
+
+public slots:
+	void updateFrame(QImage frame);
+
+protected:
+	void resizeEvent(QResizeEvent *event) override;
+
+private:
+	void updateImageDisplay();
+
+	QLabel *m_imageLabel;
+	QScrollArea *m_scrollArea;
+	quint32 m_senderSession;
+	QImage m_currentFrame;
+};
+
+#endif // MUMBLE_MUMBLE_SCREENSHAREVIEWER_H_

--- a/src/mumble/ServerHandler.cpp
+++ b/src/mumble/ServerHandler.cpp
@@ -26,6 +26,7 @@
 #include "ProtoUtils.h"
 #include "RichTextEditor.h"
 #include "SSL.h"
+#include "ScreenShareReceiver.h"
 #include "ServerResolver.h"
 #include "ServerResolverRecord.h"
 #include "User.h"
@@ -296,7 +297,9 @@ void ServerHandler::udpReady() {
 					break;
 				};
 				case Mumble::Protocol::UDPMessageType::Video:
-					// Video packets are not yet handled by this client; silently discard.
+					const Mumble::Protocol::VideoData videoData = m_udpDecoder.getVideoData();
+
+					handleVideoPacket(videoData);
 					break;
 			}
 		}
@@ -317,6 +320,18 @@ void ServerHandler::handleVoicePacket(const Mumble::Protocol::AudioData &audioDa
 			 && sender->qsFriendName.isEmpty())) {
 		ao->addFrameToBuffer(sender, audioData);
 	}
+}
+
+void ServerHandler::handleVideoPacket(const Mumble::Protocol::VideoData &videoData) {
+	ClientUser *sender = ClientUser::get(videoData.senderSession);
+	if (!sender || !sender->bScreenSharing)
+		return;
+
+	// Forward to the receiver for fragment reassembly and decoding.
+	// ScreenShareReceiver::frameDecoded is connected with Qt::QueuedConnection so
+	// the actual display happens on the GUI thread.
+	if (Global::get().screenShareReceiver)
+		Global::get().screenShareReceiver->handleVideoPacket(videoData);
 }
 
 void ServerHandler::sendMessage(const unsigned char *data, int len, bool force) {

--- a/src/mumble/ServerHandler.cpp
+++ b/src/mumble/ServerHandler.cpp
@@ -295,6 +295,9 @@ void ServerHandler::udpReady() {
 					handleVoicePacket(audioData);
 					break;
 				};
+				case Mumble::Protocol::UDPMessageType::Video:
+					// Video packets are not yet handled by this client; silently discard.
+					break;
 			}
 		}
 	}

--- a/src/mumble/ServerHandler.h
+++ b/src/mumble/ServerHandler.h
@@ -111,6 +111,7 @@ protected:
 	QMutex qmUdp;
 
 	void handleVoicePacket(const Mumble::Protocol::AudioData &audioData);
+	void handleVideoPacket(const Mumble::Protocol::VideoData &videoData);
 
 public:
 	Timer tTimestamp;

--- a/src/mumble/UserModel.cpp
+++ b/src/mumble/UserModel.cpp
@@ -240,6 +240,7 @@ UserModel::UserModel(QObject *p) : QAbstractItemModel(p) {
 	qiTalkingWhisper  = QIcon(QLatin1String("skin:talking_whisper.svg"));
 	qiPrioritySpeaker = QIcon(QLatin1String("skin:priority_speaker.svg"));
 	qiRecording       = QIcon(QLatin1String("skin:actions/media-record.svg"));
+	qiScreenSharing   = QIcon(QLatin1String("skin:actions/screenshare.svg"));
 	qiMutedPushToMute.addFile(QLatin1String("skin:muted_pushtomute.svg"));
 	qiMutedSelf       = QIcon(QLatin1String("skin:muted_self.svg"));
 	qiMutedServer     = QIcon(QLatin1String("skin:muted_server.svg"));
@@ -492,6 +493,8 @@ QVariant UserModel::data(const QModelIndex &idx, int role) const {
 					l << qiPrioritySpeaker;
 				if (p->bRecording)
 					l << qiRecording;
+				if (p->bScreenSharing)
+					l << qiScreenSharing;
 				// ClientUser doesn't contain a push-to-mute
 				// state because it isn't sent to the server.
 				// We can show the icon only for the local user.
@@ -1056,6 +1059,7 @@ ClientUser *UserModel::addUser(unsigned int id, const QString &name) {
 	connect(p, SIGNAL(muteDeafStateChanged()), this, SLOT(userStateChanged()));
 	connect(p, SIGNAL(prioritySpeakerStateChanged()), this, SLOT(userStateChanged()));
 	connect(p, SIGNAL(recordingStateChanged()), this, SLOT(userStateChanged()));
+	connect(p, SIGNAL(screenSharingStateChanged()), this, SLOT(userStateChanged()));
 	connect(p, &ClientUser::localVolumeAdjustmentsChanged, this, &UserModel::userStateChanged);
 	connect(p, &ClientUser::localNicknameChanged, this, &UserModel::userStateChanged);
 

--- a/src/mumble/UserModel.h
+++ b/src/mumble/UserModel.h
@@ -74,6 +74,7 @@ protected:
 	QIcon qiMutedPushToMute, qiMutedSelf, qiMutedServer, qiMutedLocal, qiIgnoredLocal, qiMutedSuppressed;
 	QIcon qiPrioritySpeaker;
 	QIcon qiRecording;
+	QIcon qiScreenSharing;
 	QIcon qiDeafenedSelf, qiDeafenedServer;
 	QIcon qiAuthenticated, qiChannel, qiLinkedChannel, qiActiveChannel;
 	QIcon qiFriend;

--- a/src/mumble/UserView.cpp
+++ b/src/mumble/UserView.cpp
@@ -178,6 +178,8 @@ void UserView::mouseReleaseEvent(QMouseEvent *evt) {
 				commentIconPxOffset -= m_iconTotalDimension;
 			if (clientUser->bRecording)
 				commentIconPxOffset -= m_iconTotalDimension;
+			if (clientUser->bScreenSharing)
+				commentIconPxOffset -= m_iconTotalDimension;
 			if (clientUser->bPrioritySpeaker)
 				commentIconPxOffset -= m_iconTotalDimension;
 			if (clientUser->bMute)

--- a/src/mumble/XdgPortalCapture.h
+++ b/src/mumble/XdgPortalCapture.h
@@ -1,0 +1,39 @@
+// Copyright The Mumble Developers. All rights reserved.
+// Use of this source code is governed by a BSD-style license
+// that can be found in the LICENSE file at the root of the
+// Mumble source tree or at <https://www.mumble.info/LICENSE>.
+
+#ifndef MUMBLE_MUMBLE_XDGPORTALCAPTURE_H_
+#define MUMBLE_MUMBLE_XDGPORTALCAPTURE_H_
+
+// Use __linux__ (compiler-native) rather than Q_OS_LINUX so this guard works even when
+// included before Qt headers have been processed.
+#if defined(__linux__) && defined(USE_SCREEN_SHARING) && defined(HAS_WAYLAND_PORTAL)
+
+#	include <QtCore/QString>
+#	include <QtGui/QImage>
+#	include <functional>
+
+/// Returns true if Wayland portal screen capture is available.
+/// Requires: running under a Wayland compositor (QPA platform == "wayland"),
+/// the xdg-desktop-portal D-Bus service to be present, and PipeWire to be running.
+bool xdg_portal_isNativePickerAvailable();
+
+/// Shows the xdg-desktop-portal ScreenCast picker and, upon selection,
+/// begins delivering captured frames via a PipeWire stream.
+///
+/// Mirrors the macOS sckit_startWithNativePicker() API.
+/// All callbacks are invoked on the Qt main thread.
+///
+/// @param onStarted    Called once when the PipeWire stream starts delivering frames.
+/// @param onCancelled  Called if the user dismisses the portal picker without a selection.
+/// @param onError      Called with a description string if the session or stream fails.
+/// @param onFrame      Called for each captured frame (QImage::Format_RGBA8888, ~15 fps).
+void xdg_portal_startCapture(std::function< void() > onStarted, std::function< void() > onCancelled,
+							 std::function< void(QString) > onError, std::function< void(QImage) > onFrame);
+
+/// Stops the active PipeWire stream and closes the portal session.
+void xdg_portal_stop();
+
+#endif // __linux__ && USE_SCREEN_SHARING && HAS_WAYLAND_PORTAL
+#endif // MUMBLE_MUMBLE_XDGPORTALCAPTURE_H_

--- a/src/mumble/XdgPortalCapture_unix.cpp
+++ b/src/mumble/XdgPortalCapture_unix.cpp
@@ -1,0 +1,518 @@
+// Copyright The Mumble Developers. All rights reserved.
+// Use of this source code is governed by a BSD-style license
+// that can be found in the LICENSE file at the root of the
+// Mumble source tree or at <https://www.mumble.info/LICENSE>.
+
+// CMake only compiles this file on Linux, so use __linux__ (compiler-native)
+// rather than Q_OS_LINUX (Qt-defined) which requires a Qt header to be included first.
+#if defined(__linux__) && defined(USE_SCREEN_SHARING) && defined(HAS_WAYLAND_PORTAL)
+
+#	include "XdgPortalCapture.h"
+
+#	include <QtCore/QObject>
+#	include <QtCore/QPointer>
+#	include <QtCore/QRandomGenerator>
+#	include <QtCore/QString>
+#	include <QtDBus/QDBusConnection>
+#	include <QtDBus/QDBusInterface>
+#	include <QtDBus/QDBusMessage>
+#	include <QtDBus/QDBusMetaType>
+#	include <QtDBus/QDBusPendingCall>
+#	include <QtDBus/QDBusPendingCallWatcher>
+#	include <QtDBus/QDBusPendingReply>
+#	include <QtDBus/QDBusUnixFileDescriptor>
+#	include <QtGui/QGuiApplication>
+#	include <QtGui/QImage>
+
+// PipeWire and SPA headers (system, not bundled — bundled headers lack spa/param/video/).
+extern "C" {
+#	include <pipewire/pipewire.h>
+#	include <spa/param/video/format-utils.h>
+#	include <spa/utils/result.h>
+}
+
+#	include <unistd.h> // dup()
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+static constexpr uint32_t PORTAL_CURSOR_MODE_EMBEDDED = 2;
+// Source type flags: 1=monitor, 2=window — request both.
+static constexpr uint32_t PORTAL_SOURCE_TYPES = 3;
+
+static constexpr char PORTAL_SERVICE[]    = "org.freedesktop.portal.Desktop";
+static constexpr char PORTAL_OBJECT[]     = "/org/freedesktop/portal/desktop";
+static constexpr char PORTAL_INTERFACE[]  = "org.freedesktop.portal.ScreenCast";
+static constexpr char REQUEST_INTERFACE[] = "org.freedesktop.portal.Request";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/// Generates a unique token safe for use as a D-Bus object path component.
+static QString makeToken() {
+	return QStringLiteral("mumble_%1").arg(QRandomGenerator::global()->generate());
+}
+
+
+// ---------------------------------------------------------------------------
+// PipeWire data structure
+// ---------------------------------------------------------------------------
+struct PwCapture {
+	pw_thread_loop *loop    = nullptr;
+	pw_context *context     = nullptr;
+	pw_core *core           = nullptr;
+	pw_stream *stream       = nullptr;
+	spa_video_info_raw info = {};
+
+	std::function< void() > onStarted;
+	std::function< void(QImage) > onFrame;
+	std::function< void(QString) > onError;
+
+	bool started = false;
+};
+
+static void pw_on_param_changed(void *userdata, uint32_t id, const struct spa_pod *param) {
+	auto *data = static_cast< PwCapture * >(userdata);
+	if (id != SPA_PARAM_Format || !param)
+		return;
+
+	if (spa_format_video_raw_parse(param, &data->info) < 0)
+		return;
+
+	// Negotiate buffer parameters based on the negotiated video size.
+	const uint32_t stride = SPA_ROUND_UP_N(data->info.size.width * 4u, 4u);
+	const uint32_t size   = stride * data->info.size.height;
+
+	uint8_t buf[512];
+	struct spa_pod_builder b = SPA_POD_BUILDER_INIT(buf, sizeof(buf));
+	const struct spa_pod *params[1];
+	params[0] = static_cast< const struct spa_pod * >(spa_pod_builder_add_object(
+		&b, SPA_TYPE_OBJECT_ParamBuffers, SPA_PARAM_Buffers, SPA_PARAM_BUFFERS_buffers,
+		SPA_POD_CHOICE_RANGE_Int(4, 2, 32), SPA_PARAM_BUFFERS_blocks, SPA_POD_Int(1), SPA_PARAM_BUFFERS_size,
+		SPA_POD_Int(static_cast< int >(size)), SPA_PARAM_BUFFERS_stride, SPA_POD_Int(static_cast< int >(stride)),
+		SPA_PARAM_BUFFERS_align, SPA_POD_Int(16)));
+
+	pw_stream_update_params(data->stream, params, 1);
+}
+
+static void pw_on_process(void *userdata) {
+	auto *data = static_cast< PwCapture * >(userdata);
+
+	struct pw_buffer *buf = pw_stream_dequeue_buffer(data->stream);
+	if (!buf)
+		return;
+
+	struct spa_buffer *sbuf = buf->buffer;
+	if (sbuf->n_datas == 0) {
+		pw_stream_queue_buffer(data->stream, buf);
+		return;
+	}
+	void *pixels = sbuf->datas[0].data;
+	if (!pixels || sbuf->datas[0].chunk->size == 0) {
+		pw_stream_queue_buffer(data->stream, buf);
+		return;
+	}
+
+	const int width         = static_cast< int >(data->info.size.width);
+	const int height        = static_cast< int >(data->info.size.height);
+	const int32_t rawStride = sbuf->datas[0].chunk->stride;
+	const int stride =
+		static_cast< int >(rawStride > 0 ? static_cast< uint32_t >(rawStride) : data->info.size.width * 4u);
+
+	// The portal provides BGRx (kCVPixelFormatType_32BGRA equivalent on Linux) or RGBx.
+	// BGRx on little-endian matches QImage::Format_ARGB32 memory layout (BB GG RR xx).
+	QImage::Format fmt;
+	switch (data->info.format) {
+		case SPA_VIDEO_FORMAT_BGRx:
+		case SPA_VIDEO_FORMAT_BGRA:
+			fmt = QImage::Format_ARGB32;
+			break;
+		case SPA_VIDEO_FORMAT_RGBx:
+		case SPA_VIDEO_FORMAT_RGBA:
+			fmt = QImage::Format_RGBX8888;
+			break;
+		default:
+			fmt = QImage::Format_ARGB32;
+			break;
+	}
+
+	// Deep-copy immediately: the PipeWire buffer must be re-queued before we return.
+	QImage copy = QImage(static_cast< const uchar * >(pixels), width, height, stride, fmt).copy();
+	pw_stream_queue_buffer(data->stream, buf);
+
+	const QImage rgba = copy.convertToFormat(QImage::Format_RGBA8888);
+
+	// Fire the first-started callback exactly once, then deliver frames.
+	// Both callbacks are dispatched to the Qt main thread.
+	if (!data->started) {
+		data->started = true;
+		QMetaObject::invokeMethod(
+			qApp, [cb = data->onStarted]() { cb(); }, Qt::QueuedConnection);
+	}
+	QMetaObject::invokeMethod(
+		qApp, [cb = data->onFrame, rgba]() { cb(rgba); }, Qt::QueuedConnection);
+}
+
+static void pw_on_stream_state_changed(void *userdata, enum pw_stream_state /*old*/, enum pw_stream_state state,
+									   const char *error) {
+	auto *data = static_cast< PwCapture * >(userdata);
+	if (state == PW_STREAM_STATE_ERROR && data->onError) {
+		const QString msg = error ? QString::fromUtf8(error) : QStringLiteral("PipeWire stream error");
+		QMetaObject::invokeMethod(
+			qApp, [cb = data->onError, msg]() { cb(msg); }, Qt::QueuedConnection);
+	}
+}
+
+// Zero-init via IIFE so -Wmissing-field-initializers never fires, even when
+// PipeWire adds new fields in future versions.
+static const struct pw_stream_events s_pwStreamEvents = [] {
+	struct pw_stream_events e = {};
+	e.version                 = PW_VERSION_STREAM_EVENTS;
+	e.state_changed           = pw_on_stream_state_changed;
+	e.param_changed           = pw_on_param_changed;
+	e.process                 = pw_on_process;
+	return e;
+}();
+
+// ---------------------------------------------------------------------------
+// XdgPortalSession — manages the portal D-Bus handshake and PipeWire stream.
+// Lives on (and must be used from) the Qt main thread.
+// ---------------------------------------------------------------------------
+class XdgPortalSession : public QObject {
+	Q_OBJECT
+
+public:
+	explicit XdgPortalSession(std::function< void() > onStarted, std::function< void() > onCancelled,
+							  std::function< void(QString) > onError, std::function< void(QImage) > onFrame,
+							  QObject *parent = nullptr)
+		: QObject(parent), m_onStarted(std::move(onStarted)), m_onCancelled(std::move(onCancelled)),
+		  m_onError(std::move(onError)), m_onFrame(std::move(onFrame)) {}
+
+	~XdgPortalSession() override { cleanup(); }
+
+	void start() { createSession(); }
+
+private:
+	// Helper: send a portal call, get the returned request path, then subscribe
+	// to org.freedesktop.portal.Request.Response on that exact path.
+	void portalCall(const QString &method, QList< QVariant > args, const char *responseSlot) {
+		QDBusMessage msg =
+			QDBusMessage::createMethodCall(QString::fromLatin1(PORTAL_SERVICE), QString::fromLatin1(PORTAL_OBJECT),
+										   QString::fromLatin1(PORTAL_INTERFACE), method);
+		for (auto &a : args)
+			msg << a;
+
+		QDBusPendingCall call = QDBusConnection::sessionBus().asyncCall(msg);
+		auto *watcher         = new QDBusPendingCallWatcher(call, this);
+		connect(watcher, &QDBusPendingCallWatcher::finished, this, [this, responseSlot](QDBusPendingCallWatcher *w) {
+			w->deleteLater();
+			QDBusPendingReply< QDBusObjectPath > reply = *w;
+			if (reply.isError()) {
+				m_onError(QStringLiteral("Portal call failed: %1").arg(reply.error().message()));
+				return;
+			}
+			const QString path = reply.value().path();
+			QDBusConnection::sessionBus().connect(QString::fromLatin1(PORTAL_SERVICE), path,
+												  QString::fromLatin1(REQUEST_INTERFACE), QStringLiteral("Response"),
+												  this, responseSlot);
+		});
+	}
+
+	// ---- Phase 1: CreateSession -------------------------------------------
+	void createSession() {
+		QVariantMap options;
+		options[QStringLiteral("session_handle_token")] = makeToken();
+		options[QStringLiteral("handle_token")]         = makeToken();
+
+		portalCall(QStringLiteral("CreateSession"), { QVariant::fromValue(options) },
+				   SLOT(onCreateSessionResponse(uint, QVariantMap)));
+	}
+
+	// ---- Phase 2: SelectSources -------------------------------------------
+	void selectSources() {
+		QVariantMap options;
+		options[QStringLiteral("handle_token")] = makeToken();
+		options[QStringLiteral("types")]        = QVariant::fromValue(static_cast< quint32 >(PORTAL_SOURCE_TYPES));
+		options[QStringLiteral("multiple")]     = false;
+		options[QStringLiteral("cursor_mode")] =
+			QVariant::fromValue(static_cast< quint32 >(PORTAL_CURSOR_MODE_EMBEDDED));
+
+		portalCall(QStringLiteral("SelectSources"),
+				   { QVariant::fromValue(QDBusObjectPath(m_sessionHandle)), QVariant::fromValue(options) },
+				   SLOT(onSelectSourcesResponse(uint, QVariantMap)));
+	}
+
+	// ---- Phase 3: Start ---------------------------------------------------
+	void startSession() {
+		QVariantMap options;
+		options[QStringLiteral("handle_token")] = makeToken();
+
+		portalCall(QStringLiteral("Start"),
+				   { QVariant::fromValue(QDBusObjectPath(m_sessionHandle)), QVariant(QString()),
+					 QVariant::fromValue(options) },
+				   SLOT(onStartResponse(uint, QVariantMap)));
+	}
+
+	// ---- Phase 4: OpenPipeWireRemote + stream setup -----------------------
+	void openPipeWireRemote(quint32 nodeId) {
+		QVariantMap options;
+		QDBusMessage msg =
+			QDBusMessage::createMethodCall(QString::fromLatin1(PORTAL_SERVICE), QString::fromLatin1(PORTAL_OBJECT),
+										   QString::fromLatin1(PORTAL_INTERFACE), QStringLiteral("OpenPipeWireRemote"));
+		msg << QVariant::fromValue(QDBusObjectPath(m_sessionHandle)) << options;
+
+		QDBusPendingCall call = QDBusConnection::sessionBus().asyncCall(msg);
+		auto *watcher         = new QDBusPendingCallWatcher(call, this);
+		connect(watcher, &QDBusPendingCallWatcher::finished, this, [this, nodeId](QDBusPendingCallWatcher *w) {
+			w->deleteLater();
+			QDBusPendingReply< QDBusUnixFileDescriptor > reply = *w;
+			if (reply.isError()) {
+				m_onError(QStringLiteral("OpenPipeWireRemote failed: %1").arg(reply.error().message()));
+				return;
+			}
+			const int rawFd = reply.value().fileDescriptor();
+			if (rawFd < 0) {
+				m_onError(QStringLiteral("OpenPipeWireRemote returned invalid fd"));
+				return;
+			}
+			// dup() because QDBusUnixFileDescriptor closes its fd on destruction.
+			const int fd = ::dup(rawFd);
+			if (fd < 0) {
+				m_onError(QStringLiteral("dup() of PipeWire fd failed"));
+				return;
+			}
+			startPipeWireStream(fd, nodeId);
+		});
+	}
+
+	// ---- PipeWire stream setup --------------------------------------------
+	void startPipeWireStream(int fd, quint32 nodeId) {
+		pw_init(nullptr, nullptr);
+
+		m_pw.onStarted = m_onStarted;
+		m_pw.onFrame   = m_onFrame;
+		m_pw.onError   = m_onError;
+
+		m_pw.loop = pw_thread_loop_new("mumble-screenshare-pw", nullptr);
+		if (!m_pw.loop) {
+			m_onError(QStringLiteral("Failed to create PipeWire thread loop"));
+			::close(fd);
+			return;
+		}
+
+		m_pw.context = pw_context_new(pw_thread_loop_get_loop(m_pw.loop), nullptr, 0);
+		if (!m_pw.context) {
+			m_onError(QStringLiteral("Failed to create PipeWire context"));
+			::close(fd);
+			return;
+		}
+
+		if (pw_thread_loop_start(m_pw.loop) < 0) {
+			m_onError(QStringLiteral("Failed to start PipeWire thread loop"));
+			::close(fd);
+			return;
+		}
+
+		pw_thread_loop_lock(m_pw.loop);
+
+		// Connect using the portal fd — PipeWire takes ownership of the fd.
+		m_pw.core = pw_context_connect_fd(m_pw.context, fd, nullptr, 0);
+		if (!m_pw.core) {
+			pw_thread_loop_unlock(m_pw.loop);
+			m_onError(QStringLiteral("Failed to connect to PipeWire (portal fd)"));
+			return;
+		}
+
+		m_pw.stream = pw_stream_new(m_pw.core, "mumble-screenshare",
+									pw_properties_new(PW_KEY_MEDIA_TYPE, "Video", PW_KEY_MEDIA_CATEGORY, "Capture",
+													  PW_KEY_MEDIA_ROLE, "Screen", nullptr));
+		if (!m_pw.stream) {
+			pw_thread_loop_unlock(m_pw.loop);
+			m_onError(QStringLiteral("Failed to create PipeWire stream"));
+			return;
+		}
+
+		pw_stream_add_listener(m_pw.stream, &m_pwStreamListener, &s_pwStreamEvents, &m_pw);
+
+		// Announce the video formats we accept.
+		uint8_t buf[1024];
+		struct spa_pod_builder b = SPA_POD_BUILDER_INIT(buf, sizeof(buf));
+		const struct spa_pod *params[1];
+
+		// SPA_RECTANGLE / SPA_FRACTION produce temporaries; take addresses of named locals
+		// because C++ forbids taking the address of a temporary (unlike C99 compound literals).
+		const struct spa_rectangle szDefault = SPA_RECTANGLE(1920, 1080);
+		const struct spa_rectangle szMin     = SPA_RECTANGLE(1, 1);
+		const struct spa_rectangle szMax     = SPA_RECTANGLE(8192, 8192);
+		const struct spa_fraction fpsDefault = SPA_FRACTION(15, 1);
+		const struct spa_fraction fpsMin     = SPA_FRACTION(0, 1);
+		const struct spa_fraction fpsMax     = SPA_FRACTION(60, 1);
+
+		// clang-format off
+		params[0] = static_cast< const struct spa_pod * >(spa_pod_builder_add_object(
+			&b,
+			SPA_TYPE_OBJECT_Format,    SPA_PARAM_EnumFormat,
+			SPA_FORMAT_mediaType,      SPA_POD_Id(SPA_MEDIA_TYPE_video),
+			SPA_FORMAT_mediaSubtype,   SPA_POD_Id(SPA_MEDIA_SUBTYPE_raw),
+			SPA_FORMAT_VIDEO_format,   SPA_POD_CHOICE_ENUM_Id(
+				5,
+				SPA_VIDEO_FORMAT_BGRx,
+				SPA_VIDEO_FORMAT_BGRx,
+				SPA_VIDEO_FORMAT_BGRA,
+				SPA_VIDEO_FORMAT_RGBx,
+				SPA_VIDEO_FORMAT_RGBA),
+			SPA_FORMAT_VIDEO_size,     SPA_POD_CHOICE_RANGE_Rectangle(
+				&szDefault, &szMin, &szMax),
+			SPA_FORMAT_VIDEO_framerate, SPA_POD_CHOICE_RANGE_Fraction(
+				&fpsDefault, &fpsMin, &fpsMax)));
+		// clang-format on
+
+		const int ret = pw_stream_connect(
+			m_pw.stream, PW_DIRECTION_INPUT, nodeId,
+			static_cast< enum pw_stream_flags >(PW_STREAM_FLAG_AUTOCONNECT | PW_STREAM_FLAG_MAP_BUFFERS), params, 1);
+
+		pw_thread_loop_unlock(m_pw.loop);
+
+		if (ret < 0) {
+			m_onError(QStringLiteral("pw_stream_connect failed: %1").arg(QString::fromUtf8(spa_strerror(ret))));
+		}
+	}
+
+	void cleanup() {
+		if (m_pw.loop)
+			pw_thread_loop_stop(m_pw.loop);
+
+		if (m_pw.stream) {
+			pw_stream_destroy(m_pw.stream);
+			m_pw.stream = nullptr;
+		}
+		if (m_pw.core) {
+			pw_core_disconnect(m_pw.core);
+			m_pw.core = nullptr;
+		}
+		if (m_pw.context) {
+			pw_context_destroy(m_pw.context);
+			m_pw.context = nullptr;
+		}
+		if (m_pw.loop) {
+			pw_thread_loop_destroy(m_pw.loop);
+			m_pw.loop = nullptr;
+		}
+	}
+
+private slots:
+	void onCreateSessionResponse(uint response, const QVariantMap &results) {
+		if (response != 0) {
+			if (response == 1)
+				m_onCancelled();
+			else
+				m_onError(QStringLiteral("CreateSession failed (response %1)").arg(response));
+			return;
+		}
+		m_sessionHandle = results.value(QStringLiteral("session_handle")).toString();
+		if (m_sessionHandle.isEmpty()) {
+			m_onError(QStringLiteral("CreateSession returned empty session handle"));
+			return;
+		}
+		selectSources();
+	}
+
+	void onSelectSourcesResponse(uint response, const QVariantMap & /*results*/) {
+		if (response != 0) {
+			if (response == 1)
+				m_onCancelled();
+			else
+				m_onError(QStringLiteral("SelectSources failed (response %1)").arg(response));
+			return;
+		}
+		startSession();
+	}
+
+	void onStartResponse(uint response, const QVariantMap &results) {
+		if (response != 0) {
+			if (response == 1)
+				m_onCancelled();
+			else
+				m_onError(QStringLiteral("Start failed (response %1)").arg(response));
+			return;
+		}
+
+		// results["streams"] is a(ua{sv}) — array of structs {node_id, properties}.
+		// In Qt D-Bus this arrives as QDBusArgument; extract the first stream's node_id.
+		const QVariant streamsVar = results.value(QStringLiteral("streams"));
+		if (!streamsVar.isValid()) {
+			m_onError(QStringLiteral("Portal Start response contained no streams"));
+			return;
+		}
+
+		// The QDBusArgument for a(ua{sv}) needs to be iterated manually.
+		quint32 nodeId = UINT32_MAX;
+		if (streamsVar.canConvert< QDBusArgument >()) {
+			const QDBusArgument arg = streamsVar.value< QDBusArgument >();
+			arg.beginArray();
+			if (!arg.atEnd()) {
+				arg.beginStructure();
+				arg >> nodeId;
+				arg.endStructure();
+			}
+			arg.endArray();
+		}
+
+		if (nodeId == UINT32_MAX) {
+			m_onError(QStringLiteral("Could not extract PipeWire node ID from portal response"));
+			return;
+		}
+
+		openPipeWireRemote(nodeId);
+	}
+
+private:
+	std::function< void() > m_onStarted;
+	std::function< void() > m_onCancelled;
+	std::function< void(QString) > m_onError;
+	std::function< void(QImage) > m_onFrame;
+
+	QString m_sessionHandle;
+
+	PwCapture m_pw;
+	spa_hook m_pwStreamListener = {};
+};
+
+// ---------------------------------------------------------------------------
+// Global session — only one active at a time.
+// ---------------------------------------------------------------------------
+static XdgPortalSession *g_session = nullptr;
+
+// ---------------------------------------------------------------------------
+// Public C++ API
+// ---------------------------------------------------------------------------
+
+bool xdg_portal_isNativePickerAvailable() {
+	// We require Qt to be running under a Wayland compositor.
+	if (QGuiApplication::platformName() != QLatin1String("wayland"))
+		return false;
+
+	// Check that the portal service is registered on the session bus.
+	QDBusInterface iface(QString::fromLatin1(PORTAL_SERVICE), QString::fromLatin1(PORTAL_OBJECT),
+						 QStringLiteral("org.freedesktop.DBus.Introspectable"), QDBusConnection::sessionBus());
+	return iface.isValid();
+}
+
+void xdg_portal_startCapture(std::function< void() > onStarted, std::function< void() > onCancelled,
+							 std::function< void(QString) > onError, std::function< void(QImage) > onFrame) {
+	xdg_portal_stop();
+
+	g_session =
+		new XdgPortalSession(std::move(onStarted), std::move(onCancelled), std::move(onError), std::move(onFrame));
+	g_session->start();
+}
+
+void xdg_portal_stop() {
+	delete g_session;
+	g_session = nullptr;
+}
+
+#	include "XdgPortalCapture_unix.moc"
+
+#endif // __linux__ && USE_SCREEN_SHARING && HAS_WAYLAND_PORTAL

--- a/src/murmur/Messages.cpp
+++ b/src/murmur/Messages.cpp
@@ -945,7 +945,7 @@ void Server::msgUserState(ServerUser *uSource, MumbleProto::UserState &msg) {
 	// Prevent self-targeting state changes from being applied to others
 	if ((pDstServerUser != uSource)
 		&& (msg.has_self_deaf() || msg.has_self_mute() || msg.has_plugin_context() || msg.has_plugin_identity()
-			|| msg.has_recording() || msg.listening_channel_add_size() > 0
+			|| msg.has_recording() || msg.has_screen_sharing() || msg.listening_channel_add_size() > 0
 			|| msg.listening_channel_remove_size() > 0)) {
 		return;
 	}
@@ -1072,6 +1072,25 @@ void Server::msgUserState(ServerUser *uSource, MumbleProto::UserState &msg) {
 			mptm.set_message(u8(QString(QLatin1String("User '%1' stopped recording")).arg(pDstServerUser->qsName)));
 		}
 
+		sendAll(mptm, Version::fromComponents(1, 2, 3), Version::CompareMode::LessThan);
+
+		bBroadcast = true;
+	}
+
+	if (msg.has_screen_sharing() && (pDstServerUser->bScreenSharing != msg.screen_sharing())) {
+		assert(uSource == pDstServerUser);
+
+		pDstServerUser->bScreenSharing = msg.screen_sharing();
+
+		MumbleProto::TextMessage mptm;
+		mptm.add_tree_id(0);
+		if (pDstServerUser->bScreenSharing) {
+			mptm.set_message(
+				u8(QString(QLatin1String("User '%1' started screen sharing")).arg(pDstServerUser->qsName)));
+		} else {
+			mptm.set_message(
+				u8(QString(QLatin1String("User '%1' stopped screen sharing")).arg(pDstServerUser->qsName)));
+		}
 		sendAll(mptm, Version::fromComponents(1, 2, 3), Version::CompareMode::LessThan);
 
 		bBroadcast = true;

--- a/src/murmur/Server.cpp
+++ b/src/murmur/Server.cpp
@@ -1022,9 +1022,11 @@ void Server::run() {
 							}
 							break;
 						}
-						case Mumble::Protocol::UDPMessageType::Video:
-							// Video packets are not handled by the decoder path; silently discard.
+						case Mumble::Protocol::UDPMessageType::Video: {
+							Mumble::Protocol::VideoData videoData = m_udpDecoder.getVideoData();
+							processVideoMsg(u, videoData);
 							break;
+						}
 					}
 				}
 #ifdef Q_OS_UNIX
@@ -1164,6 +1166,51 @@ void Server::addListener(QHash< ServerUser *, VolumeAdjustment > &listeners, Ser
 
 	if (it == listeners.end() || it->factor < volumeAdjustment.factor) {
 		listeners[&user] = volumeAdjustment;
+	}
+}
+
+void Server::processVideoMsg(ServerUser *u, const Mumble::Protocol::VideoData &videoData) {
+	ZoneScoped;
+
+	if (u->sState != ServerUser::Authenticated || !u->bScreenSharing || !u->cChannel)
+		return;
+
+	QByteArray cache;
+
+	MumbleUDP::Video videoMsg;
+
+	videoMsg.set_sender_session(u->uiSession);
+	videoMsg.set_codec(videoData.codec);
+	videoMsg.set_width(videoData.width);
+	videoMsg.set_height(videoData.height);
+	videoMsg.set_frame_number(videoData.frameNumber);
+	videoMsg.set_fragment_index(videoData.fragmentIndex);
+	videoMsg.set_fragment_count(videoData.fragmentCount);
+	videoMsg.set_is_keyframe(videoData.isKeyFrame);
+
+	videoMsg.set_video_data(reinterpret_cast< const char * >(videoData.payload.data()),
+							static_cast< int >(videoData.payload.size()));
+	const std::size_t size = videoMsg.ByteSizeLong();
+
+	if (size > static_cast< std::size_t >(std::numeric_limits< int >::max())) {
+		return;
+	}
+
+	std::vector< unsigned char > packet(size + 1);
+	packet[0] = static_cast< unsigned char >(Mumble::Protocol::UDPMessageType::Video);
+
+	if (!videoMsg.SerializeToArray(packet.data() + 1, static_cast< int >(size))) {
+		return;
+	}
+
+	// Broadcast packet to all users in channel
+	for (User *p : u->cChannel->qlUsers) {
+		ServerUser *dst = static_cast< ServerUser * >(p);
+
+		if (dst == u)
+			continue;
+
+		sendMessage(*dst, packet.data(), static_cast< int >(packet.size()), cache);
 	}
 }
 
@@ -1743,6 +1790,9 @@ void Server::message(Mumble::Protocol::TCPMessageType type, const QByteArray &qb
 
 					processMsg(u, std::move(audioData), m_tcpAudioReceivers, m_tcpAudioEncoder);
 				}
+			} else if (m_tcpTunnelDecoder.getMessageType() == Mumble::Protocol::UDPMessageType::Video) {
+				Mumble::Protocol::VideoData videoData = m_tcpTunnelDecoder.getVideoData();
+				processVideoMsg(u, videoData);
 			}
 		}
 

--- a/src/murmur/Server.cpp
+++ b/src/murmur/Server.cpp
@@ -1022,6 +1022,9 @@ void Server::run() {
 							}
 							break;
 						}
+						case Mumble::Protocol::UDPMessageType::Video:
+							// Video packets are not handled by the decoder path; silently discard.
+							break;
 					}
 				}
 #ifdef Q_OS_UNIX

--- a/src/murmur/Server.h
+++ b/src/murmur/Server.h
@@ -328,6 +328,7 @@ public:
 	void addListener(QHash< ServerUser *, VolumeAdjustment > &listeners, ServerUser &user, const Channel &channel);
 	void processMsg(ServerUser *u, Mumble::Protocol::AudioData audioData, AudioReceiverBuffer &buffer,
 					Mumble::Protocol::UDPAudioEncoder< Mumble::Protocol::Role::Server > &encoder);
+	void processVideoMsg(ServerUser *u, const Mumble::Protocol::VideoData &videoData);
 	void sendMessage(ServerUser &u, const unsigned char *data, int len, QByteArray &cache, bool force = false);
 	void run();
 

--- a/themes/Default/actions/screenshare.svg
+++ b/themes/Default/actions/screenshare.svg
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 500 500">
+  <rect x="60" y="80" width="380" height="240" rx="24" ry="24"
+        fill="none" stroke="#4A90D9" stroke-width="36"/>
+  <rect x="210" y="320" width="80" height="70" rx="8" ry="8" fill="#4A90D9"/>
+  <rect x="150" y="378" width="200" height="32" rx="12" ry="12" fill="#4A90D9"/>
+  <polygon points="185,140 185,280 355,210" fill="#4A90D9" opacity="0.9"/>
+</svg>

--- a/themes/DefaultTheme.qrc
+++ b/themes/DefaultTheme.qrc
@@ -70,6 +70,7 @@
     <file alias="actions/format-text-italic.svg">Default/actions/format-text-italic.svg</file>
     <file alias="actions/format-text-underline.svg">Default/actions/format-text-underline.svg</file>
     <file alias="actions/media-record.svg">Default/actions/media-record.svg</file>
+    <file alias="actions/screenshare.svg">Default/actions/screenshare.svg</file>
     <file alias="categories/applications-internet.svg">Default/categories/applications-internet.svg</file>
     <file alias="places/network-workgroup.svg">Default/network-workgroup.svg</file>
     <file alias="controls/arrow_down.svg">Default/controls/arrow_down.svg</file>


### PR DESCRIPTION
This change introduces initial support for screen sharing in Mumble by extending the protocol, server, and client to handle a new UDP video message type.
The current implementation focuses on wiring and basic functionality.

I intend to keep this PR more as a tracker. Per component, I hope to make PRs and track them in this list.

## Protocol
To ensure video streaming works, a video message type for the Mumble protocol is added.
This video message type contains codec, resolution, fragmentation metadata, the video payload, and a keyframe flag.
This probably should get expanded further to enable Scalable Video Coding (SVC) in the future.

- [x] Add UDP video message type
- [x] Define basic video packet structure (codec, resolution, fragmentation metadata, payload, keyframe flag)
- [ ] Extend protocol for additional codecs
- [ ] Investigate support for scalable video coding (SVC)
- [ ] Review and stabilize fragmentation design

## Server
Add a simple relay that doesn't decode the video packets but simply passes on the video content to the other users in the channel. Decoding and encoding of video packets is done on client devices to reduce computational load on the server.
Ideally, the only computational load that gets added to the server is for deciding which packet needs to get sent to what user.

- [x] Implement basic UDP video packet relay
- [x] Integrate screen-sharing state handling
- [ ] Validate and harden packet handling (bounds, malformed data, etc.)
- [ ] Improve packet routing efficiency
- [ ] Evaluate whether partial decoding or inspection is needed

## Client
Added a screen capture implementation. This screen capture implementation uses FFmpeg libraries to encode captured frames. As it stands, QT does not implement neat window picker implementations for video capture, especially for macOS and Wayland.

- [x] Implement screen capture
- [x] Integrate FFmpeg-based encoding
- [x] Add basic streaming pipeline
- [x] Add receiving and viewing components
- [ ] Improve capture performance and stability
- [ ] Add proper window/screen selection UX
- [ ] Improve decoding/rendering performance
- [ ] Support additional codecs

## Build
FFmpeg libraries would become a new dependency for Mumble on the client.

- [x] Add FFmpeg as a client dependency
- [ ] Review cross-platform build integration
- [ ] Ensure CI coverage for FFmpeg builds
- [ ] Evaluate optional vs required dependency

## Notes
This PR is kept as a draft and is an initial implementation and not considered complete.
UDP video handling is minimal and currently only supports the H.264 codec.
I intend this PR to keep track of progress on this larger feature and hope to stabilize parts of the PR step by step.

---

Fixes / relates to: #4150
