### PR TITLE
Cmake format check test

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -49,3 +49,21 @@ jobs:
           clang-format-version: '10'
           check-path: '.'
           exclude-regex: '(\\.git/.*|3rdparty/.*|build/.*|.*proto$)'
+
+    - name: Install neocmakelsp
+      run: cargo install neocmakelsp
+      shell: bash
+
+    - name: Check CMake formatting
+      run: |
+        failed=0
+        while IFS= read -r file; do
+          if ! diff -q <(neocmakelsp format "$file") "$file" > /dev/null; then
+            echo "Not formatted: $file"
+            failed=1
+          fi
+        done < <(find . -type f \( -name "CMakeLists.txt" -o -name "*.cmake" \) \
+          -not -path "./3rdparty/*" \
+          -not -path "./build/*")
+        exit $failed
+      shell: bash

--- a/CODING_GUIDELINES.md
+++ b/CODING_GUIDELINES.md
@@ -8,6 +8,9 @@ We use [clang-format](https://clang.llvm.org/docs/ClangFormat.html) to format ou
 When making changes to the source code, please always reformat the changed files using this tool in order to ensure a consistent formatting across the
 code base.
 
+For CMake files (`CMakeLists.txt` and `*.cmake`), we use [neocmakelsp](https://github.com/Decodetalkers/neocmakelsp) as a formatter. Please reformat
+any changed CMake files using `neocmakelsp format --override <file>` before submitting.
+
 
 ## Use of `auto`
 


### PR DESCRIPTION
CMake files in the project had no enforced formatting standard. This commit adds neocmakelsp as the designated formatter for CMakeLists.txt and *.cmake files (excluding 3rdparty/ and build/).

The PR check workflow now installs neocmakelsp via cargo and verifies that all CMake files are correctly formatted by diffing each file against the formatter output, failing if any file differs.

CODING_GUIDELINES.md is updated to document neocmakelsp as the formatter for CMake files and instruct contributors to run it before submitting.


### Checks

- [ ] My commits follow the [commit guidelines](https://github.com/mumble-voip/mumble/blob/master/COMMIT_GUIDELINES.md)

