### PR TITLE
Increase default audio quality and reduce latency (#6936)

### DIFF
--- a/src/mumble/Settings.h
+++ b/src/mumble/Settings.h
@@ -261,7 +261,7 @@ struct Settings {
 	/// The setting is currently only supported by the speech-dispatcher
 	/// backend.
 	QString qsTTSLanguage = {};
-	int iQuality          = 96000;
+	int iQuality          = 80000;
 	int iMinLoudness      = 1000;
 	/// Actual mic hold time is (iVoiceHold / 100) seconds, where iVoiceHold is specified in 'frames',
 	/// each of which is has a size of iFrameSize (see AudioInput.h)

--- a/src/mumble/Settings.h
+++ b/src/mumble/Settings.h
@@ -261,7 +261,7 @@ struct Settings {
 	/// The setting is currently only supported by the speech-dispatcher
 	/// backend.
 	QString qsTTSLanguage = {};
-	int iQuality          = 40000;
+	int iQuality          = 96000;
 	int iMinLoudness      = 1000;
 	/// Actual mic hold time is (iVoiceHold / 100) seconds, where iVoiceHold is specified in 'frames',
 	/// each of which is has a size of iFrameSize (see AudioInput.h)
@@ -280,7 +280,7 @@ struct Settings {
 	VADSource vsVAD                     = Amplitude;
 	float fVADmin                       = 0.80f;
 	float fVADmax                       = 0.98f;
-	int iFramesPerPacket                = 2;
+	int iFramesPerPacket                = 1;
 	QString qsAudioInput                = {};
 	QString qsAudioOutput               = {};
 	float fVolume                       = 1.0f;

--- a/src/mumble/Settings.h
+++ b/src/mumble/Settings.h
@@ -280,7 +280,7 @@ struct Settings {
 	VADSource vsVAD                     = Amplitude;
 	float fVADmin                       = 0.80f;
 	float fVADmax                       = 0.98f;
-	int iFramesPerPacket                = 1;
+	int iFramesPerPacket                = 2;
 	QString qsAudioInput                = {};
 	QString qsAudioOutput               = {};
 	float fVolume                       = 1.0f;


### PR DESCRIPTION
This PR updates the default audio settings as discussed in #6936:

- Bitrate: iQuality increased from 40k to 96k.
- Latency: iFramesPerPacket decreased from 2 (20ms) to 1 (10ms).

Fixes #6936
