### PR TITLE
FIX(client, server): Ensure we never write to invalid socket

### DIFF
--- a/src/Connection.cpp
+++ b/src/Connection.cpp
@@ -6,6 +6,7 @@
 #include "Connection.h"
 #include "Mumble.pb.h"
 #include "SSL.h"
+#include "crypto/CryptStateOCB2.h"
 
 #include <QtCore/QtEndian>
 #include <QtNetwork/QHostAddress>

--- a/src/Connection.cpp
+++ b/src/Connection.cpp
@@ -195,8 +195,11 @@ void Connection::sendMessage(const ::google::protobuf::Message &msg, Mumble::Pro
 }
 
 void Connection::sendMessage(const QByteArray &qbaMsg) {
-	if (!qbaMsg.isEmpty())
-		qtsSocket->write(qbaMsg);
+	if (qbaMsg.isEmpty() || qtsSocket->state() != QAbstractSocket::SocketState::ConnectedState) {
+		return;
+	}
+
+	qtsSocket->write(qbaMsg);
 }
 
 void Connection::forceFlush() {

--- a/src/Connection.h
+++ b/src/Connection.h
@@ -15,13 +15,13 @@
 #endif
 
 #include "crypto/CryptState.h"
-#include "crypto/CryptStateOCB2.h"
 
 #include <QtCore/QElapsedTimer>
 #include <QtCore/QList>
 #include <QtCore/QMutex>
 #include <QtCore/QObject>
 #include <QtNetwork/QSslSocket>
+
 #include <memory>
 
 #ifdef Q_OS_WIN

--- a/src/mumble/Messages.cpp
+++ b/src/mumble/Messages.cpp
@@ -37,6 +37,7 @@
 #include "VersionCheck.h"
 #include "ViewCert.h"
 #include "crypto/CryptState.h"
+#include "crypto/CryptStateOCB2.h"
 #include "Global.h"
 
 #include <QTextDocumentFragment>


### PR DESCRIPTION
Due to various circumstances it is possible that a connection object is
accessed to send messages after its associated socket has been closed.
To avoid running into trouble because of that, we now explicitly check
the socket state before writing anything to it. This is kind of a
workaround but the proper fix would require a much larger redesign of
how shared object's lifetime in Mumble are managed.

### Checks

- [x] My commits follow the [commit guidelines](https://github.com/mumble-voip/mumble/blob/master/COMMIT_GUIDELINES.md)

