### PR TITLE
Backport "Merge PR #7168: FIX(client, server): Ensure we never write to invalid socket" to 1.6.x

### DIFF
--- a/src/Connection.cpp
+++ b/src/Connection.cpp
@@ -6,6 +6,7 @@
 #include "Connection.h"
 #include "Mumble.pb.h"
 #include "SSL.h"
+#include "crypto/CryptStateOCB2.h"
 
 #include <QtCore/QtEndian>
 #include <QtNetwork/QHostAddress>

--- a/src/Connection.cpp
+++ b/src/Connection.cpp
@@ -195,8 +195,11 @@ void Connection::sendMessage(const ::google::protobuf::Message &msg, Mumble::Pro
 }
 
 void Connection::sendMessage(const QByteArray &qbaMsg) {
-	if (!qbaMsg.isEmpty())
-		qtsSocket->write(qbaMsg);
+	if (qbaMsg.isEmpty() || qtsSocket->state() != QAbstractSocket::SocketState::ConnectedState) {
+		return;
+	}
+
+	qtsSocket->write(qbaMsg);
 }
 
 void Connection::forceFlush() {

--- a/src/Connection.h
+++ b/src/Connection.h
@@ -15,13 +15,13 @@
 #endif
 
 #include "crypto/CryptState.h"
-#include "crypto/CryptStateOCB2.h"
 
 #include <QtCore/QElapsedTimer>
 #include <QtCore/QList>
 #include <QtCore/QMutex>
 #include <QtCore/QObject>
 #include <QtNetwork/QSslSocket>
+
 #include <memory>
 
 #ifdef Q_OS_WIN

--- a/src/mumble/Messages.cpp
+++ b/src/mumble/Messages.cpp
@@ -37,6 +37,7 @@
 #include "VersionCheck.h"
 #include "ViewCert.h"
 #include "crypto/CryptState.h"
+#include "crypto/CryptStateOCB2.h"
 #include "Global.h"
 
 #include <QTextDocumentFragment>


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `1.6.x`:
 - [Merge PR #7168: FIX(client, server): Ensure we never write to invalid socket](https://github.com/mumble-voip/mumble/pull/7168)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)