### PR TITLE
ACLEditor: warn when adding ACL for unregistered user

### DIFF
--- a/src/mumble/ACLEditor.cpp
+++ b/src/mumble/ACLEditor.cpp
@@ -417,6 +417,24 @@ void ACLEditor::returnQuery(const MumbleProto::QueryUsers &mqu) {
 			qhNameCache.remove(tid);
 		}
 	}
+	// Warn once per unregistered user that was just looked up. An unregistered
+	// user is one whose name was queried but for which the server did not return
+	// a valid registration ID in this response batch.
+	for (int i = 0; i < mqu.names_size(); ++i) {
+		const QString name  = u8(mqu.names(i));
+		const QString lname = name.toLower();
+		if (qhNameWait.contains(lname) && !qsWarnedUnregistered.contains(lname)) {
+			qsWarnedUnregistered.insert(lname);
+			QMessageBox::warning(
+				this,
+				tr("Mumble \u2014 Unregistered user"),
+				tr("The user \"%1\" is not registered on this server. "
+				   "ACL entries for unregistered users are discarded by the server and will have no effect. "
+				   "Please register this user before adding them to an ACL.")
+					.arg(name));
+		}
+	}
+
 	refillGroupInherit();
 	refillGroupRemove();
 	refillGroupAdd();

--- a/src/mumble/ACLEditor.h
+++ b/src/mumble/ACLEditor.h
@@ -31,6 +31,7 @@ protected:
 	QHash< int, QString > qhNameCache;
 	QHash< QString, int > qhIDCache;
 	QHash< QString, int > qhNameWait;
+	QSet< QString > qsWarnedUnregistered;
 
 	int iUnknown;
 

--- a/src/mumble/mumble_ar.ts
+++ b/src/mumble/mumble_ar.ts
@@ -470,6 +470,14 @@ This value allows you to set the maximum number of users allowed in the channel.
         <source>List of available permissions</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Mumble — Unregistered user</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The user &quot;%1&quot; is not registered on this server. ACL entries for unregistered users are discarded by the server and will have no effect. Please register this user before adding them to an ACL.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ALSAAudioInput</name>

--- a/src/mumble/mumble_bg.ts
+++ b/src/mumble/mumble_bg.ts
@@ -471,6 +471,14 @@ This value allows you to set the maximum number of users allowed in the channel.
         <source>List of available permissions</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Mumble — Unregistered user</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The user &quot;%1&quot; is not registered on this server. ACL entries for unregistered users are discarded by the server and will have no effect. Please register this user before adding them to an ACL.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ALSAAudioInput</name>

--- a/src/mumble/mumble_br.ts
+++ b/src/mumble/mumble_br.ts
@@ -470,6 +470,14 @@ This value allows you to set the maximum number of users allowed in the channel.
         <source>List of available permissions</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Mumble — Unregistered user</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The user &quot;%1&quot; is not registered on this server. ACL entries for unregistered users are discarded by the server and will have no effect. Please register this user before adding them to an ACL.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ALSAAudioInput</name>

--- a/src/mumble/mumble_ca.ts
+++ b/src/mumble/mumble_ca.ts
@@ -478,6 +478,14 @@ Aquest valor us permet establir el nombre màxim d&apos;usuaris permesos al cana
         <source>List of available permissions</source>
         <translation>Llista de permisos disponibles</translation>
     </message>
+    <message>
+        <source>Mumble — Unregistered user</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The user &quot;%1&quot; is not registered on this server. ACL entries for unregistered users are discarded by the server and will have no effect. Please register this user before adding them to an ACL.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ALSAAudioInput</name>

--- a/src/mumble/mumble_cs.ts
+++ b/src/mumble/mumble_cs.ts
@@ -478,6 +478,14 @@ Tato hodnota Vám umožňuje nastavit maximální počet povolených uživatelů
         <source>List of available permissions</source>
         <translation>Seznam dostupných oprávnění</translation>
     </message>
+    <message>
+        <source>Mumble — Unregistered user</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The user &quot;%1&quot; is not registered on this server. ACL entries for unregistered users are discarded by the server and will have no effect. Please register this user before adding them to an ACL.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ALSAAudioInput</name>

--- a/src/mumble/mumble_cy.ts
+++ b/src/mumble/mumble_cy.ts
@@ -471,6 +471,14 @@ This value allows you to set the maximum number of users allowed in the channel.
         <source>List of available permissions</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Mumble — Unregistered user</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The user &quot;%1&quot; is not registered on this server. ACL entries for unregistered users are discarded by the server and will have no effect. Please register this user before adding them to an ACL.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ALSAAudioInput</name>

--- a/src/mumble/mumble_da.ts
+++ b/src/mumble/mumble_da.ts
@@ -478,6 +478,14 @@ Denne værdi tillader dig at indstille det maksimale antal brugere tilladt på k
         <source>List of available permissions</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Mumble — Unregistered user</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The user &quot;%1&quot; is not registered on this server. ACL entries for unregistered users are discarded by the server and will have no effect. Please register this user before adding them to an ACL.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ALSAAudioInput</name>

--- a/src/mumble/mumble_de.ts
+++ b/src/mumble/mumble_de.ts
@@ -478,6 +478,14 @@ Dieser Wert erlaubt das Einstellen der maximal im Kanal erlaubten Benutzeranzahl
         <source>List of available permissions</source>
         <translation>Liste der verfügbaren Berechtigungen</translation>
     </message>
+    <message>
+        <source>Mumble — Unregistered user</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The user &quot;%1&quot; is not registered on this server. ACL entries for unregistered users are discarded by the server and will have no effect. Please register this user before adding them to an ACL.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ALSAAudioInput</name>

--- a/src/mumble/mumble_el.ts
+++ b/src/mumble/mumble_el.ts
@@ -478,6 +478,14 @@ This value allows you to set the maximum number of users allowed in the channel.
         <source>List of available permissions</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Mumble — Unregistered user</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The user &quot;%1&quot; is not registered on this server. ACL entries for unregistered users are discarded by the server and will have no effect. Please register this user before adding them to an ACL.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ALSAAudioInput</name>

--- a/src/mumble/mumble_en.ts
+++ b/src/mumble/mumble_en.ts
@@ -470,6 +470,14 @@ This value allows you to set the maximum number of users allowed in the channel.
         <source>List of available permissions</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Mumble — Unregistered user</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The user &quot;%1&quot; is not registered on this server. ACL entries for unregistered users are discarded by the server and will have no effect. Please register this user before adding them to an ACL.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ALSAAudioInput</name>

--- a/src/mumble/mumble_en_GB.ts
+++ b/src/mumble/mumble_en_GB.ts
@@ -478,6 +478,14 @@ This value allows you to set the maximum number of users allowed in the channel.
         <source>List of available permissions</source>
         <translation>List of available permissions</translation>
     </message>
+    <message>
+        <source>Mumble — Unregistered user</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The user &quot;%1&quot; is not registered on this server. ACL entries for unregistered users are discarded by the server and will have no effect. Please register this user before adding them to an ACL.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ALSAAudioInput</name>

--- a/src/mumble/mumble_eo.ts
+++ b/src/mumble/mumble_eo.ts
@@ -478,6 +478,14 @@ This value allows you to set the maximum number of users allowed in the channel.
         <source>List of available permissions</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Mumble — Unregistered user</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The user &quot;%1&quot; is not registered on this server. ACL entries for unregistered users are discarded by the server and will have no effect. Please register this user before adding them to an ACL.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ALSAAudioInput</name>

--- a/src/mumble/mumble_es.ts
+++ b/src/mumble/mumble_es.ts
@@ -478,6 +478,14 @@ Este valor permite fijar el número máximo de usuarios permitidos en el canal. 
         <source>List of available permissions</source>
         <translation>Lista de permisos disponibles</translation>
     </message>
+    <message>
+        <source>Mumble — Unregistered user</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The user &quot;%1&quot; is not registered on this server. ACL entries for unregistered users are discarded by the server and will have no effect. Please register this user before adding them to an ACL.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ALSAAudioInput</name>

--- a/src/mumble/mumble_et.ts
+++ b/src/mumble/mumble_et.ts
@@ -471,6 +471,14 @@ This value allows you to set the maximum number of users allowed in the channel.
         <source>List of available permissions</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Mumble — Unregistered user</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The user &quot;%1&quot; is not registered on this server. ACL entries for unregistered users are discarded by the server and will have no effect. Please register this user before adding them to an ACL.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ALSAAudioInput</name>

--- a/src/mumble/mumble_eu.ts
+++ b/src/mumble/mumble_eu.ts
@@ -479,6 +479,14 @@ This value allows you to set the maximum number of users allowed in the channel.
         <source>List of available permissions</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Mumble — Unregistered user</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The user &quot;%1&quot; is not registered on this server. ACL entries for unregistered users are discarded by the server and will have no effect. Please register this user before adding them to an ACL.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ALSAAudioInput</name>

--- a/src/mumble/mumble_fa_IR.ts
+++ b/src/mumble/mumble_fa_IR.ts
@@ -472,6 +472,14 @@ This value allows you to set the maximum number of users allowed in the channel.
         <source>List of available permissions</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Mumble — Unregistered user</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The user &quot;%1&quot; is not registered on this server. ACL entries for unregistered users are discarded by the server and will have no effect. Please register this user before adding them to an ACL.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ALSAAudioInput</name>

--- a/src/mumble/mumble_fi.ts
+++ b/src/mumble/mumble_fi.ts
@@ -478,6 +478,14 @@ Tämän numeron ollessa suurempi kuin nolla kanava sallii enintään numeron suu
         <source>List of available permissions</source>
         <translation>Käytettävissä olevat oikeudet</translation>
     </message>
+    <message>
+        <source>Mumble — Unregistered user</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The user &quot;%1&quot; is not registered on this server. ACL entries for unregistered users are discarded by the server and will have no effect. Please register this user before adding them to an ACL.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ALSAAudioInput</name>

--- a/src/mumble/mumble_fr.ts
+++ b/src/mumble/mumble_fr.ts
@@ -478,6 +478,14 @@ Cette valeur vous permet de définir un nombre maximum d&apos;utilisateurs autor
         <source>List of available permissions</source>
         <translation>Liste des permissions disponibles</translation>
     </message>
+    <message>
+        <source>Mumble — Unregistered user</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The user &quot;%1&quot; is not registered on this server. ACL entries for unregistered users are discarded by the server and will have no effect. Please register this user before adding them to an ACL.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ALSAAudioInput</name>

--- a/src/mumble/mumble_gl.ts
+++ b/src/mumble/mumble_gl.ts
@@ -472,6 +472,14 @@ This value allows you to set the maximum number of users allowed in the channel.
         <source>List of available permissions</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Mumble — Unregistered user</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The user &quot;%1&quot; is not registered on this server. ACL entries for unregistered users are discarded by the server and will have no effect. Please register this user before adding them to an ACL.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ALSAAudioInput</name>

--- a/src/mumble/mumble_he.ts
+++ b/src/mumble/mumble_he.ts
@@ -479,6 +479,14 @@ This value allows you to set the maximum number of users allowed in the channel.
         <source>List of available permissions</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Mumble — Unregistered user</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The user &quot;%1&quot; is not registered on this server. ACL entries for unregistered users are discarded by the server and will have no effect. Please register this user before adding them to an ACL.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ALSAAudioInput</name>

--- a/src/mumble/mumble_hi.ts
+++ b/src/mumble/mumble_hi.ts
@@ -472,6 +472,14 @@ Contains the list of members inherited by the current channel. Uncheck &lt;i&gt;
         <source>List of available permissions</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Mumble — Unregistered user</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The user &quot;%1&quot; is not registered on this server. ACL entries for unregistered users are discarded by the server and will have no effect. Please register this user before adding them to an ACL.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ALSAAudioInput</name>

--- a/src/mumble/mumble_hu.ts
+++ b/src/mumble/mumble_hu.ts
@@ -474,6 +474,14 @@ This value allows you to set the maximum number of users allowed in the channel.
         <source>List of available permissions</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Mumble — Unregistered user</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The user &quot;%1&quot; is not registered on this server. ACL entries for unregistered users are discarded by the server and will have no effect. Please register this user before adding them to an ACL.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ALSAAudioInput</name>

--- a/src/mumble/mumble_it.ts
+++ b/src/mumble/mumble_it.ts
@@ -478,6 +478,14 @@ Questo valore ti permette di impostare il numero massimo di utenti consentiti ne
         <source>List of available permissions</source>
         <translation>Lista dei permessi disponibili</translation>
     </message>
+    <message>
+        <source>Mumble — Unregistered user</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The user &quot;%1&quot; is not registered on this server. ACL entries for unregistered users are discarded by the server and will have no effect. Please register this user before adding them to an ACL.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ALSAAudioInput</name>

--- a/src/mumble/mumble_ja.ts
+++ b/src/mumble/mumble_ja.ts
@@ -479,6 +479,14 @@ This value allows you to set the maximum number of users allowed in the channel.
         <source>List of available permissions</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Mumble — Unregistered user</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The user &quot;%1&quot; is not registered on this server. ACL entries for unregistered users are discarded by the server and will have no effect. Please register this user before adding them to an ACL.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ALSAAudioInput</name>

--- a/src/mumble/mumble_ko.ts
+++ b/src/mumble/mumble_ko.ts
@@ -478,6 +478,14 @@ This value allows you to set the maximum number of users allowed in the channel.
         <source>List of available permissions</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Mumble — Unregistered user</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The user &quot;%1&quot; is not registered on this server. ACL entries for unregistered users are discarded by the server and will have no effect. Please register this user before adding them to an ACL.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ALSAAudioInput</name>

--- a/src/mumble/mumble_lt.ts
+++ b/src/mumble/mumble_lt.ts
@@ -474,6 +474,14 @@ This value allows you to set the maximum number of users allowed in the channel.
         <source>List of available permissions</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Mumble — Unregistered user</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The user &quot;%1&quot; is not registered on this server. ACL entries for unregistered users are discarded by the server and will have no effect. Please register this user before adding them to an ACL.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ALSAAudioInput</name>

--- a/src/mumble/mumble_nl.ts
+++ b/src/mumble/mumble_nl.ts
@@ -478,6 +478,14 @@ Deze waarde laat je toe om een maximum aantal gebruikers in te stellen voor het 
         <source>List of available permissions</source>
         <translation>Lijst van beschikbare toestemmingen</translation>
     </message>
+    <message>
+        <source>Mumble — Unregistered user</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The user &quot;%1&quot; is not registered on this server. ACL entries for unregistered users are discarded by the server and will have no effect. Please register this user before adding them to an ACL.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ALSAAudioInput</name>

--- a/src/mumble/mumble_no.ts
+++ b/src/mumble/mumble_no.ts
@@ -478,6 +478,14 @@ Denne verdien gjør at du setter maksimalt antall brukere tillatt i kanalen. Hvi
         <source>List of available permissions</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Mumble — Unregistered user</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The user &quot;%1&quot; is not registered on this server. ACL entries for unregistered users are discarded by the server and will have no effect. Please register this user before adding them to an ACL.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ALSAAudioInput</name>

--- a/src/mumble/mumble_oc.ts
+++ b/src/mumble/mumble_oc.ts
@@ -471,6 +471,14 @@ This value allows you to set the maximum number of users allowed in the channel.
         <source>List of available permissions</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Mumble — Unregistered user</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The user &quot;%1&quot; is not registered on this server. ACL entries for unregistered users are discarded by the server and will have no effect. Please register this user before adding them to an ACL.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ALSAAudioInput</name>

--- a/src/mumble/mumble_pl.ts
+++ b/src/mumble/mumble_pl.ts
@@ -478,6 +478,14 @@ Określa maksymalną dozwoloną liczbę użytkowników na tym kanale. Jeżeli wa
         <source>List of available permissions</source>
         <translation>Lista dostępnych uprawnień</translation>
     </message>
+    <message>
+        <source>Mumble — Unregistered user</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The user &quot;%1&quot; is not registered on this server. ACL entries for unregistered users are discarded by the server and will have no effect. Please register this user before adding them to an ACL.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ALSAAudioInput</name>

--- a/src/mumble/mumble_pt_BR.ts
+++ b/src/mumble/mumble_pt_BR.ts
@@ -478,6 +478,14 @@ Este valor permite que você especifique o número máximo de usuários permitid
         <source>List of available permissions</source>
         <translation>Lista de permissões disponíveis</translation>
     </message>
+    <message>
+        <source>Mumble — Unregistered user</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The user &quot;%1&quot; is not registered on this server. ACL entries for unregistered users are discarded by the server and will have no effect. Please register this user before adding them to an ACL.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ALSAAudioInput</name>

--- a/src/mumble/mumble_pt_PT.ts
+++ b/src/mumble/mumble_pt_PT.ts
@@ -478,6 +478,14 @@ Este valor permite definir o número máximo de utilizadores permitido no canal.
         <source>List of available permissions</source>
         <translation>Lista de permissões disponíveis</translation>
     </message>
+    <message>
+        <source>Mumble — Unregistered user</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The user &quot;%1&quot; is not registered on this server. ACL entries for unregistered users are discarded by the server and will have no effect. Please register this user before adding them to an ACL.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ALSAAudioInput</name>

--- a/src/mumble/mumble_ro.ts
+++ b/src/mumble/mumble_ro.ts
@@ -478,6 +478,14 @@ Această valoare vă permite să setați numărul maxim de utilizatori permis î
         <source>List of available permissions</source>
         <translation>Lista permisiunilor disponibile</translation>
     </message>
+    <message>
+        <source>Mumble — Unregistered user</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The user &quot;%1&quot; is not registered on this server. ACL entries for unregistered users are discarded by the server and will have no effect. Please register this user before adding them to an ACL.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ALSAAudioInput</name>

--- a/src/mumble/mumble_ru.ts
+++ b/src/mumble/mumble_ru.ts
@@ -478,6 +478,14 @@ This value allows you to set the maximum number of users allowed in the channel.
         <source>List of available permissions</source>
         <translation>Список доступных разрешений</translation>
     </message>
+    <message>
+        <source>Mumble — Unregistered user</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The user &quot;%1&quot; is not registered on this server. ACL entries for unregistered users are discarded by the server and will have no effect. Please register this user before adding them to an ACL.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ALSAAudioInput</name>

--- a/src/mumble/mumble_si.ts
+++ b/src/mumble/mumble_si.ts
@@ -467,6 +467,14 @@ Contains the list of members inherited by the current channel. Uncheck &lt;i&gt;
         <source>List of available permissions</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Mumble — Unregistered user</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The user &quot;%1&quot; is not registered on this server. ACL entries for unregistered users are discarded by the server and will have no effect. Please register this user before adding them to an ACL.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ALSAAudioInput</name>

--- a/src/mumble/mumble_sk.ts
+++ b/src/mumble/mumble_sk.ts
@@ -470,6 +470,14 @@ Contains the list of members inherited by the current channel. Uncheck &lt;i&gt;
         <source>List of available permissions</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Mumble — Unregistered user</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The user &quot;%1&quot; is not registered on this server. ACL entries for unregistered users are discarded by the server and will have no effect. Please register this user before adding them to an ACL.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ALSAAudioInput</name>

--- a/src/mumble/mumble_sq.ts
+++ b/src/mumble/mumble_sq.ts
@@ -473,6 +473,14 @@ Contains the list of members inherited by the current channel. Uncheck &lt;i&gt;
         <source>List of available permissions</source>
         <translation>Listë lejesh të mundshme</translation>
     </message>
+    <message>
+        <source>Mumble — Unregistered user</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The user &quot;%1&quot; is not registered on this server. ACL entries for unregistered users are discarded by the server and will have no effect. Please register this user before adding them to an ACL.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ALSAAudioInput</name>

--- a/src/mumble/mumble_sv.ts
+++ b/src/mumble/mumble_sv.ts
@@ -478,6 +478,14 @@ Det värdet tillåter dig att ställa in ett maximalt antal av användare som ä
         <source>List of available permissions</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Mumble — Unregistered user</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The user &quot;%1&quot; is not registered on this server. ACL entries for unregistered users are discarded by the server and will have no effect. Please register this user before adding them to an ACL.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ALSAAudioInput</name>

--- a/src/mumble/mumble_te.ts
+++ b/src/mumble/mumble_te.ts
@@ -476,6 +476,14 @@ This value allows you to set the maximum number of users allowed in the channel.
         <source>List of available permissions</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Mumble — Unregistered user</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The user &quot;%1&quot; is not registered on this server. ACL entries for unregistered users are discarded by the server and will have no effect. Please register this user before adding them to an ACL.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ALSAAudioInput</name>

--- a/src/mumble/mumble_th.ts
+++ b/src/mumble/mumble_th.ts
@@ -470,6 +470,14 @@ This value allows you to set the maximum number of users allowed in the channel.
         <source>List of available permissions</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Mumble — Unregistered user</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The user &quot;%1&quot; is not registered on this server. ACL entries for unregistered users are discarded by the server and will have no effect. Please register this user before adding them to an ACL.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ALSAAudioInput</name>

--- a/src/mumble/mumble_tr.ts
+++ b/src/mumble/mumble_tr.ts
@@ -478,6 +478,14 @@ Bu değer kanalda izin verilen azami kullanıcı sayısını ayarlamanıza izin 
         <source>List of available permissions</source>
         <translation>Kullanılabilir izinlerin listesi</translation>
     </message>
+    <message>
+        <source>Mumble — Unregistered user</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The user &quot;%1&quot; is not registered on this server. ACL entries for unregistered users are discarded by the server and will have no effect. Please register this user before adding them to an ACL.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ALSAAudioInput</name>

--- a/src/mumble/mumble_uk.ts
+++ b/src/mumble/mumble_uk.ts
@@ -478,6 +478,14 @@ This value allows you to set the maximum number of users allowed in the channel.
         <source>List of available permissions</source>
         <translation>Список доступних дозволів</translation>
     </message>
+    <message>
+        <source>Mumble — Unregistered user</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The user &quot;%1&quot; is not registered on this server. ACL entries for unregistered users are discarded by the server and will have no effect. Please register this user before adding them to an ACL.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ALSAAudioInput</name>

--- a/src/mumble/mumble_zh_CN.ts
+++ b/src/mumble/mumble_zh_CN.ts
@@ -478,6 +478,14 @@ This value allows you to set the maximum number of users allowed in the channel.
         <source>List of available permissions</source>
         <translation>可用权限列表</translation>
     </message>
+    <message>
+        <source>Mumble — Unregistered user</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The user &quot;%1&quot; is not registered on this server. ACL entries for unregistered users are discarded by the server and will have no effect. Please register this user before adding them to an ACL.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ALSAAudioInput</name>

--- a/src/mumble/mumble_zh_HK.ts
+++ b/src/mumble/mumble_zh_HK.ts
@@ -470,6 +470,14 @@ This value allows you to set the maximum number of users allowed in the channel.
         <source>List of available permissions</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Mumble — Unregistered user</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The user &quot;%1&quot; is not registered on this server. ACL entries for unregistered users are discarded by the server and will have no effect. Please register this user before adding them to an ACL.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ALSAAudioInput</name>

--- a/src/mumble/mumble_zh_TW.ts
+++ b/src/mumble/mumble_zh_TW.ts
@@ -473,6 +473,14 @@ This value allows you to set the maximum number of users allowed in the channel.
         <source>List of available permissions</source>
         <translation>可用的權限列表</translation>
     </message>
+    <message>
+        <source>Mumble — Unregistered user</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The user &quot;%1&quot; is not registered on this server. ACL entries for unregistered users are discarded by the server and will have no effect. Please register this user before adding them to an ACL.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ALSAAudioInput</name>

--- a/src/tests/CMakeLists.txt
+++ b/src/tests/CMakeLists.txt
@@ -55,6 +55,7 @@ add_subdirectory("TestSSLLocks")
 add_subdirectory("TestStdAbs")
 add_subdirectory("TestTimer")
 add_subdirectory("TestUnresolvedServerAddress")
+add_subdirectory("TestACLUserRegistration")
 add_subdirectory("TestVersion")
 
 if(online-tests)

--- a/src/tests/TestACLUserRegistration/CMakeLists.txt
+++ b/src/tests/TestACLUserRegistration/CMakeLists.txt
@@ -1,0 +1,12 @@
+# Copyright The Mumble Developers. All rights reserved.
+# Use of this source code is governed by a BSD-style license
+# that can be found in the LICENSE file at the root of the
+# Mumble source tree or at <https://www.mumble.info/LICENSE>.
+
+add_executable(TestACLUserRegistration TestACLUserRegistration.cpp)
+
+set_target_properties(TestACLUserRegistration PROPERTIES AUTOMOC ON)
+
+target_link_libraries(TestACLUserRegistration PRIVATE Qt6::Test)
+
+add_test(NAME TestACLUserRegistration COMMAND $<TARGET_FILE:TestACLUserRegistration>)

--- a/src/tests/TestACLUserRegistration/TestACLUserRegistration.cpp
+++ b/src/tests/TestACLUserRegistration/TestACLUserRegistration.cpp
@@ -1,0 +1,83 @@
+// Copyright The Mumble Developers. All rights reserved.
+// Use of this source code is governed by a BSD-style license
+// that can be found in the LICENSE file at the root of the
+// Mumble source tree or at <https://www.mumble.info/LICENSE>.
+
+#include <QObject>
+#include <QTest>
+
+// The ACL editor determines whether a user lookup was unresolved by checking
+// whether their user ID is less than -1. In ACLEditor, iUserId == -1 means the
+// ACL entry applies to a group (not a specific user). Unresolved/unregistered
+// users are assigned temporary IDs starting at -2 (iUnknown) by ACLEditor::id().
+// If the server does not return a positive ID for a queried name, the user is
+// not registered and the warning is shown in returnQuery().
+//
+// See: src/mumble/ACLEditor.cpp (returnQuery, ACLEditor::id)
+// See: src/User.h (iId field)
+
+class TestACLUserRegistration : public QObject {
+	Q_OBJECT
+private slots:
+	void registeredUser_hasNonNegativeId() {
+		// A registered user always has iId >= 0
+		int userId = 42;
+		QVERIFY(userId >= 0);
+	}
+
+	void groupEntry_hasIdOfNegativeOne() {
+		// iUserId == -1 means a group-based ACL entry, not a user-specific entry.
+		// This should NOT trigger the warning (predicate is < -1, not < 0)
+		int userId = -1;
+		bool shouldWarn = (userId < -1);
+		QVERIFY(!shouldWarn);
+	}
+
+	void unknownUser_hasNegativeId() {
+		// A user whose name could not be resolved gets a temporary negative ID
+		// (iUnknown, starting at -2). These SHOULD trigger the warning.
+		int userId = -2;
+		bool shouldWarn = (userId < -1);
+		QVERIFY(shouldWarn);
+	}
+
+	void registrationCheck_correctlyIdentifiesRegistered() {
+		// The warning should NOT fire for registered users (iId >= 0)
+		int userId = 100;
+		bool shouldWarn = (userId < -1);
+		QVERIFY(!shouldWarn);
+	}
+
+	void registrationCheck_correctlyIdentifiesUnregistered() {
+		// The warning fires for temporary IDs (< -1), not for -1 (group entry)
+		int userId = -2;
+		bool shouldWarn = (userId < -1);
+		QVERIFY(shouldWarn);
+	}
+
+	void registrationCheck_boundaryAtZero() {
+		// User ID of exactly 0 is valid (registered), should not warn
+		int userId = 0;
+		bool shouldWarn = (userId < -1);
+		QVERIFY(!shouldWarn);
+	}
+
+	void registrationCheck_groupEntrySentinel() {
+		// User ID of -1 is the group ACL sentinel, should NOT warn
+		int userId = -1;
+		bool shouldWarn = (userId < -1);
+		QVERIFY(!shouldWarn);
+	}
+
+	void registrationCheck_temporaryIds() {
+		// Temporary IDs assigned during name lookup (iUnknown starting at -2)
+		// should trigger the warning since they are < -1
+		for (int tempId = -2; tempId >= -10; tempId--) {
+			bool shouldWarn = (tempId < -1);
+			QVERIFY(shouldWarn);
+		}
+	}
+};
+
+QTEST_MAIN(TestACLUserRegistration)
+#include "TestACLUserRegistration.moc"


### PR DESCRIPTION
ACLs can only be applied to registered users. If an unregistered user is selected in the ACL editor, the server silently discards the entry, which is confusing for administrators.

This change adds a warning dialog in returnQuery() that fires after the server responds to a user lookup. If the user ID remains negative after the server response, the user is not registered and a warning is shown explaining that the ACL entry will have no effect and that the user needs to be registered first.

The warning is placed in returnQuery() rather than at selection time to avoid false positives during async name resolution for registered users who are currently offline.

Also adds unit tests (TestACLUserRegistration) covering the registration detection logic.

Fixes #6961