### PR TITLE
fix(installer): add Grounded plugin to Windows installer

### DIFF
--- a/installer/ClientInstaller.cs
+++ b/installer/ClientInstaller.cs
@@ -66,6 +66,7 @@ public class ClientInstaller : MumbleInstall {
 			"gtaiv.dll",
 			"gtasa.dll",
 			"gtav.dll",
+t		"grounded.dll",
 			"gw.dll",
 			"insurgency.dll",
 			"jc2.dll",


### PR DESCRIPTION
Fixes #7165

The Grounded positional audio plugin added by PR #6491 was not included in the Windows MSI installer. This PR adds grounded.dll to the plugin list in ClientInstaller.cs, so it will be packaged in the installer.