### PR TITLE
FIX(server): Voice packet initializing whisper cache getting dropped

### DIFF
--- a/src/murmur/Server.cpp
+++ b/src/murmur/Server.cpp
@@ -1242,17 +1242,13 @@ void Server::processMsg(ServerUser *u, Mumble::Protocol::AudioData audioData, Au
 			}
 		}
 	} else if (u->qmTargets.contains(static_cast< int >(audioData.targetOrContext))) { // Whisper/Shout
-		QSet< ServerUser * > channel;
-		QSet< ServerUser * > direct;
-		QHash< ServerUser *, VolumeAdjustment > cachedListeners;
+		const WhisperTargetCache *cache = nullptr;
 
-		if (u->qmTargetCache.contains(static_cast< int >(audioData.targetOrContext))) {
+		if (auto it = u->qmTargetCache.find(static_cast< int >(audioData.targetOrContext));
+			it != u->qmTargetCache.end()) {
 			ZoneScopedN(TracyConstants::AUDIO_WHISPER_CACHE_STORE);
 
-			const WhisperTargetCache &cache = u->qmTargetCache.value(static_cast< int >(audioData.targetOrContext));
-			channel                         = cache.channelTargets;
-			direct                          = cache.directTargets;
-			cachedListeners                 = cache.listeningTargets;
+			cache = &(*it);
 		} else {
 			ZoneScopedN(TracyConstants::AUDIO_WHISPER_CACHE_CREATE);
 
@@ -1260,7 +1256,7 @@ void Server::processMsg(ServerUser *u, Mumble::Protocol::AudioData audioData, Au
 			qrwlVoiceThread.unlock();
 			qrwlVoiceThread.lockForWrite();
 
-			if (!qhUsers.contains(uiSession)) {
+			if (u != qhUsers.value(uiSession, nullptr)) {
 				return;
 			}
 
@@ -1269,28 +1265,43 @@ void Server::processMsg(ServerUser *u, Mumble::Protocol::AudioData audioData, Au
 			// transaction (ensured by the lock) to avoid running into situations in which a user from the cache
 			// gets deleted without this particular cache entry being purged (which happens, if the cache entry is
 			// in the store at the point of deleting the user).
-			const WhisperTarget &wt  = u->qmTargets.value(static_cast< int >(audioData.targetOrContext));
-			WhisperTargetCache cache = createWhisperTargetCacheFor(*u, wt);
+			const WhisperTarget &wt     = u->qmTargets.value(static_cast< int >(audioData.targetOrContext));
+			WhisperTargetCache newCache = createWhisperTargetCacheFor(*u, wt);
 
-			u->qmTargetCache.insert(static_cast< int >(audioData.targetOrContext), std::move(cache));
+			u->qmTargetCache.insert(static_cast< int >(audioData.targetOrContext), std::move(newCache));
 
 
 			qrwlVoiceThread.unlock();
 			qrwlVoiceThread.lockForRead();
-			if (!qhUsers.contains(uiSession))
+
+			if (u != qhUsers.value(uiSession, nullptr)) {
 				return;
+			}
+
+			it = u->qmTargetCache.find(static_cast< int >(audioData.targetOrContext));
+			if (it == u->qmTargetCache.end()) {
+				return;
+			}
+
+			cache = &(*it);
+		}
+
+		assert(cache);
+		if (!cache) {
+			// Shouldn't happen
+			return;
 		}
 
 		// These users receive the audio because someone is shouting to their channel
-		for (ServerUser *pDst : channel) {
+		for (ServerUser *pDst : cache->channelTargets) {
 			buffer.addReceiver(*u, *pDst, Mumble::Protocol::AudioContext::SHOUT, audioData.containsPositionalData);
 		}
 		// These users receive audio because someone is whispering to them
-		for (ServerUser *pDst : direct) {
+		for (ServerUser *pDst : cache->directTargets) {
 			buffer.addReceiver(*u, *pDst, Mumble::Protocol::AudioContext::WHISPER, audioData.containsPositionalData);
 		}
 		// These users receive audio because someone is sending audio to one of their listeners
-		QHashIterator< ServerUser *, VolumeAdjustment > it(cachedListeners);
+		QHashIterator< ServerUser *, VolumeAdjustment > it(cache->listeningTargets);
 		while (it.hasNext()) {
 			it.next();
 			ServerUser *user                         = it.key();


### PR DESCRIPTION
PR #6372 has refactored the creation of whisper target caches. However, the new control flow path was such that it would not send the voice packet that triggered the creation of this cache entry to the associated targets. Instead, the list of potential receivers would only be populated when restoring from an existing cache entry. Overall, this lead to the first audio packet for a new whisper target to be dropped.

This is now changed by also "restoring" the cache entry in the path that has just created it.


### Checks

- [x] My commits follow the [commit guidelines](https://github.com/mumble-voip/mumble/blob/master/COMMIT_GUIDELINES.md)

