### PR TITLE
FEAT(client): Add RPC whisper control

### DIFF
--- a/src/mumble/DBus.cpp
+++ b/src/mumble/DBus.cpp
@@ -141,3 +141,19 @@ void MumbleDBus::startTalking() {
 void MumbleDBus::stopTalking() {
 	Global::get().mw->on_PushToTalk_triggered(false, QVariant());
 }
+
+void MumbleDBus::startWhisper(const QString &channel, bool subchannels, bool links, bool forceCenter,
+							  const QString &group, const QDBusMessage &msg) {
+	if (!Global::get().mw->setRpcWhispering(true, channel, 0, false, subchannels, links, forceCenter, group)) {
+		QDBusConnection::sessionBus().send(msg.createErrorReply(
+			QLatin1String("net.sourceforge.mumble.Error.whisper"), QLatin1String("Unable to start whisper")));
+	}
+}
+
+void MumbleDBus::stopWhisper(const QString &channel, bool subchannels, bool links, bool forceCenter,
+							 const QString &group, const QDBusMessage &msg) {
+	if (!Global::get().mw->setRpcWhispering(false, channel, 0, false, subchannels, links, forceCenter, group)) {
+		QDBusConnection::sessionBus().send(msg.createErrorReply(
+			QLatin1String("net.sourceforge.mumble.Error.whisper"), QLatin1String("Unable to stop whisper")));
+	}
+}

--- a/src/mumble/DBus.h
+++ b/src/mumble/DBus.h
@@ -43,6 +43,10 @@ public slots:
 	bool isSelfDeaf();
 	void startTalking();
 	void stopTalking();
+	void startWhisper(const QString &channel, bool subchannels, bool links, bool forceCenter, const QString &group,
+					  const QDBusMessage &);
+	void stopWhisper(const QString &channel, bool subchannels, bool links, bool forceCenter, const QString &group,
+					 const QDBusMessage &);
 };
 
 #endif

--- a/src/mumble/MainWindow.cpp
+++ b/src/mumble/MainWindow.cpp
@@ -3003,11 +3003,30 @@ bool MainWindow::setRpcWhispering(bool down, const QString &channelName, int cha
 		return false;
 	}
 
+	auto releaseTarget = [this](const ShortcutTarget &activeTarget) {
+		ShortcutTarget target = activeTarget;
+
+		if (!qmCurrentTargets.contains(target)) {
+			updateTarget();
+			return;
+		}
+
+		if (Global::get().iPushToTalk > 0) {
+			Global::get().iPushToTalk--;
+		}
+
+		removeTarget(&target);
+		updateTarget();
+	};
+
 	if (!down && !useChannelID && channelName.trimmed().isEmpty()) {
 		const QList< ShortcutTarget > activeTargets = qsActiveRpcWhisperTargets.values();
 		qsActiveRpcWhisperTargets.clear();
 		for (const ShortcutTarget &activeTarget : activeTargets) {
-			on_gsWhisper_triggered(false, QVariant::fromValue(activeTarget));
+			releaseTarget(activeTarget);
+		}
+		if (activeTargets.isEmpty()) {
+			updateTarget();
 		}
 		return true;
 	}
@@ -3044,7 +3063,14 @@ bool MainWindow::setRpcWhispering(bool down, const QString &channelName, int cha
 		}
 
 		qsActiveRpcWhisperTargets.insert(target);
-	} else if (!qsActiveRpcWhisperTargets.remove(target)) {
+	} else {
+		const bool activeTarget = qsActiveRpcWhisperTargets.remove(target);
+		const bool currentTarget = qmCurrentTargets.contains(target);
+		if (!activeTarget && !currentTarget) {
+			return true;
+		}
+
+		releaseTarget(target);
 		return true;
 	}
 
@@ -3290,7 +3316,7 @@ void MainWindow::on_gsWhisper_triggered(bool down, QVariant scdata) {
 		updateTarget();
 
 		Global::get().iPushToTalk++;
-	} else if (Global::get().iPushToTalk > 0) {
+	} else if (Global::get().iPushToTalk > 0 || qmCurrentTargets.contains(st)) {
 		SignalCurry *fwd = new SignalCurry(scdata, true, this);
 		connect(fwd, SIGNAL(called(QVariant)), SLOT(whisperReleased(QVariant)));
 		QTimer::singleShot(static_cast< int >(Global::get().s.pttHold), fwd, SLOT(call()));
@@ -3622,12 +3648,11 @@ void MainWindow::on_gsAdaptivePush_triggered(bool down, QVariant variant) {
 }
 
 void MainWindow::whisperReleased(QVariant scdata) {
-	if (Global::get().iPushToTalk <= 0)
-		return;
-
 	ShortcutTarget st = scdata.value< ShortcutTarget >();
 
-	Global::get().iPushToTalk--;
+	if (Global::get().iPushToTalk > 0) {
+		Global::get().iPushToTalk--;
+	}
 
 	removeTarget(&st);
 	updateTarget();

--- a/src/mumble/MainWindow.cpp
+++ b/src/mumble/MainWindow.cpp
@@ -69,6 +69,7 @@
 #endif
 
 #include <QAccessible>
+#include <QtCore/QReadLocker>
 #include <QtCore/QStandardPaths>
 #include <QtCore/QUrlQuery>
 #include <QtGui/QClipboard>
@@ -95,6 +96,82 @@
 #include <optional>
 
 #include "widgets/EventFilters.h"
+
+namespace {
+
+Channel *findChildChannelByName(Channel *parent, const QString &name) {
+	QList< Channel * > caseInsensitiveMatches;
+
+	for (Channel *child : parent->qlChannels) {
+		if (child->qsName == name) {
+			return child;
+		}
+
+		if (QString::compare(child->qsName, name, Qt::CaseInsensitive) == 0) {
+			caseInsensitiveMatches.append(child);
+		}
+	}
+
+	return caseInsensitiveMatches.count() == 1 ? caseInsensitiveMatches.constFirst() : nullptr;
+}
+
+std::optional< int > resolveRpcChannelTarget(const QString &channelName) {
+	const QString target = channelName.trimmed();
+
+	if (target.isEmpty() || QString::compare(target, QLatin1String("current"), Qt::CaseInsensitive) == 0) {
+		return SHORTCUT_TARGET_CURRENT;
+	}
+
+	if (QString::compare(target, QLatin1String("parent"), Qt::CaseInsensitive) == 0) {
+		return SHORTCUT_TARGET_PARENT;
+	}
+
+	if (QString::compare(target, QLatin1String("root"), Qt::CaseInsensitive) == 0 || target == QLatin1String("/")) {
+		return SHORTCUT_TARGET_ROOT;
+	}
+
+	QReadLocker lock(&Channel::c_qrwlChannels);
+
+	if (target.contains(QLatin1Char('/'))) {
+		Channel *channel = Channel::c_qhChannels.value(Mumble::ROOT_CHANNEL_ID);
+		if (!channel) {
+			return std::nullopt;
+		}
+
+		const QStringList path = target.split(QLatin1Char('/'), Qt::SkipEmptyParts);
+		for (const QString &pathElement : path) {
+			channel = findChildChannelByName(channel, pathElement);
+			if (!channel) {
+				return std::nullopt;
+			}
+		}
+
+		return static_cast< int >(channel->iId);
+	}
+
+	QList< Channel * > exactMatches;
+	QList< Channel * > caseInsensitiveMatches;
+
+	for (Channel *channel : Channel::c_qhChannels) {
+		if (channel->qsName == target) {
+			exactMatches.append(channel);
+		} else if (QString::compare(channel->qsName, target, Qt::CaseInsensitive) == 0) {
+			caseInsensitiveMatches.append(channel);
+		}
+	}
+
+	if (exactMatches.count() == 1) {
+		return static_cast< int >(exactMatches.constFirst()->iId);
+	}
+
+	if (exactMatches.isEmpty() && caseInsensitiveMatches.count() == 1) {
+		return static_cast< int >(caseInsensitiveMatches.constFirst()->iId);
+	}
+
+	return std::nullopt;
+}
+
+} // namespace
 
 MessageBoxEvent::MessageBoxEvent(QString m) : QEvent(static_cast< QEvent::Type >(MB_QEVENT)) {
 	msg = m;
@@ -2918,6 +2995,61 @@ void MainWindow::pttReleased() {
 	if (Global::get().iPushToTalk > 0) {
 		Global::get().iPushToTalk--;
 	}
+}
+
+bool MainWindow::setRpcWhispering(bool down, const QString &channelName, int channelID, bool useChannelID,
+								  bool children, bool links, bool forceCenter, const QString &group) {
+	if (!Global::get().sh || !Global::get().sh->isRunning() || !Global::get().uiSession) {
+		return false;
+	}
+
+	if (!down && !useChannelID && channelName.trimmed().isEmpty()) {
+		const QList< ShortcutTarget > activeTargets = qsActiveRpcWhisperTargets.values();
+		qsActiveRpcWhisperTargets.clear();
+		for (const ShortcutTarget &activeTarget : activeTargets) {
+			on_gsWhisper_triggered(false, QVariant::fromValue(activeTarget));
+		}
+		return true;
+	}
+
+	ShortcutTarget target;
+	target.bUsers       = false;
+	target.bChildren    = children;
+	target.bLinks       = links;
+	target.bForceCenter = forceCenter;
+	target.qsGroup      = group.trimmed();
+
+	if (useChannelID) {
+		if (channelID < 0) {
+			return false;
+		}
+
+		if (down && !Channel::get(static_cast< unsigned int >(channelID))) {
+			return false;
+		}
+
+		target.iChannel = channelID;
+	} else {
+		std::optional< int > resolvedChannel = resolveRpcChannelTarget(channelName);
+		if (!resolvedChannel) {
+			return false;
+		}
+
+		target.iChannel = *resolvedChannel;
+	}
+
+	if (down) {
+		if (qsActiveRpcWhisperTargets.contains(target)) {
+			return true;
+		}
+
+		qsActiveRpcWhisperTargets.insert(target);
+	} else if (!qsActiveRpcWhisperTargets.remove(target)) {
+		return true;
+	}
+
+	on_gsWhisper_triggered(down, QVariant::fromValue(target));
+	return true;
 }
 
 void MainWindow::on_PushToMute_triggered(bool down, QVariant) {

--- a/src/mumble/MainWindow.h
+++ b/src/mumble/MainWindow.h
@@ -7,6 +7,7 @@
 #define MUMBLE_MUMBLE_MAINWINDOW_H_
 
 #include <QtCore/QPointer>
+#include <QtCore/QSet>
 #include <QtCore/QtGlobal>
 #include <QtNetwork/QAbstractSocket>
 #include <QtWidgets/QMainWindow>
@@ -157,6 +158,8 @@ public:
 	void updateChatBar();
 	void openTextMessageDialog(ClientUser *p);
 	void openUserLocalNicknameDialog(const ClientUser &p);
+	bool setRpcWhispering(bool down, const QString &channelName, int channelID, bool useChannelID, bool children,
+						  bool links, bool forceCenter, const QString &group);
 
 #ifdef Q_OS_WIN
 	bool nativeEvent(const QByteArray &eventType, void *message, qintptr *result) Q_DECL_OVERRIDE;
@@ -172,6 +175,7 @@ protected:
 	QList< QAction * > qlUserActions;
 
 	QHash< ShortcutTarget, int > qmCurrentTargets;
+	QSet< ShortcutTarget > qsActiveRpcWhisperTargets;
 	/// A map that contains information about the currently active
 	/// shout/whisper targets. The mapping is between a List of
 	/// ShortcutTargets that are all triggered together and the

--- a/src/mumble/Messages.cpp
+++ b/src/mumble/Messages.cpp
@@ -145,6 +145,7 @@ void MainWindow::msgServerSync(const MumbleProto::ServerSync &msg) {
 	// VoiceTargets
 	qmTargetUse.clear();
 	qmTargets.clear();
+	qsActiveRpcWhisperTargets.clear();
 	const int uniqueTargetIDCount = 5;
 	for (int i = 1; i < uniqueTargetIDCount + 1; ++i) {
 		qmTargetUse.insert(i, i);

--- a/src/mumble/SocketRPC.cpp
+++ b/src/mumble/SocketRPC.cpp
@@ -110,8 +110,46 @@ void SocketRPCClient::processXml() {
 
 			ack = true;
 		} else if (request.nodeName() == QLatin1String("self")) {
+			bool selfCommandSeen      = false;
+			bool selfCommandSucceeded = true;
+			auto markSelfCommand      = [&selfCommandSeen]() { selfCommandSeen = true; };
+			auto handleWhisperCommand = [&](const QString &command, bool down) {
+				iter = qmRequest.find(command);
+				if (iter == qmRequest.constEnd()) {
+					return;
+				}
+
+				markSelfCommand();
+
+				bool useChannelID = false;
+				int channelID     = 0;
+				iter              = qmRequest.find(QLatin1String("channel_id"));
+				if (iter != qmRequest.constEnd()) {
+					bool ok      = false;
+					channelID    = iter.value().toInt(&ok);
+					useChannelID = ok;
+					if (!ok) {
+						selfCommandSucceeded = false;
+						return;
+					}
+				}
+
+				const QString channelName = qmRequest.value(QLatin1String("channel")).toString();
+				const bool children       = qmRequest.value(QLatin1String("subchannels")).toBool()
+									  || qmRequest.value(QLatin1String("children")).toBool();
+				const bool links          = qmRequest.value(QLatin1String("links")).toBool();
+				const bool forceCenter    = qmRequest.value(QLatin1String("force_center")).toBool();
+				const QString group       = qmRequest.value(QLatin1String("group")).toString();
+
+				selfCommandSucceeded =
+					selfCommandSucceeded
+					&& Global::get().mw->setRpcWhispering(down, channelName, channelID, useChannelID, children, links,
+														   forceCenter, group);
+			};
+
 			iter = qmRequest.find(QLatin1String("mute"));
 			if (iter != qmRequest.constEnd()) {
+				markSelfCommand();
 				bool set = iter.value().toBool();
 				if (set != Global::get().s.bMute) {
 					Global::get().mw->qaAudioMute->setChecked(!set);
@@ -120,6 +158,7 @@ void SocketRPCClient::processXml() {
 			}
 			iter = qmRequest.find(QLatin1String("unmute"));
 			if (iter != qmRequest.constEnd()) {
+				markSelfCommand();
 				bool set = iter.value().toBool();
 				if (set == Global::get().s.bMute) {
 					Global::get().mw->qaAudioMute->setChecked(set);
@@ -128,6 +167,7 @@ void SocketRPCClient::processXml() {
 			}
 			iter = qmRequest.find(QLatin1String("togglemute"));
 			if (iter != qmRequest.constEnd()) {
+				markSelfCommand();
 				bool set = iter.value().toBool();
 				if (set == Global::get().s.bMute) {
 					Global::get().mw->qaAudioMute->setChecked(set);
@@ -139,6 +179,7 @@ void SocketRPCClient::processXml() {
 			}
 			iter = qmRequest.find(QLatin1String("deaf"));
 			if (iter != qmRequest.constEnd()) {
+				markSelfCommand();
 				bool set = iter.value().toBool();
 				if (set != Global::get().s.bDeaf) {
 					Global::get().mw->qaAudioDeaf->setChecked(!set);
@@ -147,6 +188,7 @@ void SocketRPCClient::processXml() {
 			}
 			iter = qmRequest.find(QLatin1String("undeaf"));
 			if (iter != qmRequest.constEnd()) {
+				markSelfCommand();
 				bool set = iter.value().toBool();
 				if (set == Global::get().s.bDeaf) {
 					Global::get().mw->qaAudioDeaf->setChecked(set);
@@ -155,6 +197,7 @@ void SocketRPCClient::processXml() {
 			}
 			iter = qmRequest.find(QLatin1String("toggledeaf"));
 			if (iter != qmRequest.constEnd()) {
+				markSelfCommand();
 				bool set = iter.value().toBool();
 				if (set == Global::get().s.bDeaf) {
 					Global::get().mw->qaAudioDeaf->setChecked(set);
@@ -166,13 +209,20 @@ void SocketRPCClient::processXml() {
 			}
 			iter = qmRequest.find(QLatin1String("starttalking"));
 			if (iter != qmRequest.constEnd()) {
+				markSelfCommand();
 				Global::get().mw->on_PushToTalk_triggered(true, QVariant());
 			}
 			iter = qmRequest.find(QLatin1String("stoptalking"));
 			if (iter != qmRequest.constEnd()) {
+				markSelfCommand();
 				Global::get().mw->on_PushToTalk_triggered(false, QVariant());
 			}
-			ack = true;
+			handleWhisperCommand(QLatin1String("startwhisper"), true);
+			handleWhisperCommand(QLatin1String("stopwhisper"), false);
+			handleWhisperCommand(QLatin1String("startshout"), true);
+			handleWhisperCommand(QLatin1String("stopshout"), false);
+
+			ack = selfCommandSeen ? selfCommandSucceeded : true;
 		} else if (request.nodeName() == QLatin1String("url")) {
 			if (Global::get().sh && Global::get().sh->isRunning() && Global::get().uiSession) {
 				QString host, user, pw;

--- a/src/mumble/main.cpp
+++ b/src/mumble/main.cpp
@@ -236,6 +236,12 @@ struct CLIOptions {
 	std::optional< std::string > defaultCertDir;
 
 	std::optional< std::string > rpcCommand;
+	std::optional< std::string > rpcChannel;
+	std::optional< unsigned int > rpcChannelID;
+	std::optional< std::string > rpcGroup;
+	bool rpcSubchannels = false;
+	bool rpcLinks       = false;
+	bool rpcForceCenter = false;
 
 	static constexpr const char *CLI_GENERAL_SECTION  = "General";
 	static constexpr const char *CLI_LANGUAGE_SECTION = "Language";
@@ -247,7 +253,18 @@ struct CLIOptions {
 };
 
 const std::set< std::string > CLIOptions::knownRpcCommands = {
-	"mute", "unmute", "togglemute", "deaf", "undeaf", "toggledeaf", "starttalking", "stoptalking",
+	"mute",
+	"unmute",
+	"togglemute",
+	"deaf",
+	"undeaf",
+	"toggledeaf",
+	"starttalking",
+	"stoptalking",
+	"startwhisper",
+	"stopwhisper",
+	"startshout",
+	"stopshout",
 };
 
 CLIOptions parseCLI(int argc, char **argv) {
@@ -353,6 +370,22 @@ CLIOptions parseCLI(int argc, char **argv) {
 	rpc->add_option("action", options.rpcCommand, "Action to perform")
 		->required()
 		->check(CLI::IsMember(CLIOptions::knownRpcCommands, CLI::ignore_case));
+	CLI::Option *rpcChannel =
+		rpc->add_option("--channel", options.rpcChannel,
+						"Channel target for startwhisper/startshout. Stop actions may omit a target to clear active "
+						"RPC whispers. Accepts Current, Parent, Root, an exact channel name, or a slash-separated "
+						"channel path.")
+			->option_text("<channel>");
+	CLI::Option *rpcChannelID =
+		rpc->add_option("--channel-id", options.rpcChannelID, "Channel ID target for startwhisper/startshout.")
+			->option_text("<id>");
+	rpcChannel->excludes(rpcChannelID);
+	rpc->add_flag("--subchannels,--children", options.rpcSubchannels,
+				  "Also whisper to the target channel's subchannels.");
+	rpc->add_flag("--links", options.rpcLinks, "Also whisper to channels linked to the target channel.");
+	rpc->add_flag("--force-center", options.rpcForceCenter,
+				  "Do not send positional audio information while whispering.");
+	rpc->add_option("--group", options.rpcGroup, "Restrict the whisper to a channel ACL group.")->option_text("<group>");
 
 	try {
 		app.parse(argc, argv);
@@ -570,8 +603,26 @@ int main(int argc, char **argv) {
 	if (options.rpcMode) {
 		bool sent = false;
 		QMap< QString, QVariant > param;
-		QString rpcCommand = QString::fromStdString(*options.rpcCommand);
+		QString rpcCommand = QString::fromStdString(*options.rpcCommand).toLower();
 		param.insert(rpcCommand, rpcCommand);
+		if (options.rpcChannel) {
+			param.insert(QLatin1String("channel"), QString::fromStdString(*options.rpcChannel));
+		}
+		if (options.rpcChannelID) {
+			param.insert(QLatin1String("channel_id"), *options.rpcChannelID);
+		}
+		if (options.rpcSubchannels) {
+			param.insert(QLatin1String("subchannels"), true);
+		}
+		if (options.rpcLinks) {
+			param.insert(QLatin1String("links"), true);
+		}
+		if (options.rpcForceCenter) {
+			param.insert(QLatin1String("force_center"), true);
+		}
+		if (options.rpcGroup) {
+			param.insert(QLatin1String("group"), QString::fromStdString(*options.rpcGroup));
+		}
 		sent = SocketRPC::send(QLatin1String("Mumble"), QLatin1String("self"), param);
 		if (sent) {
 			return 0;


### PR DESCRIPTION
## Disclaimer
The changes in this PR were created with Codex. I do not understand the architecture of Mumble and therefore cannot say whether Codex's approach is in line with Mumble's architecture. Therefore, I do not recommend to actually pull this but to view it as a spark of inspiration for the feature request #6958.


## Codex summary
This adds client RPC actions for starting and stopping whisper/shout
 transmission without relying on global shortcuts. This is useful on
 Wayland systems where global shortcut capture is not reliably available,
 as discussed in #5257.

 The new commands reuse the existing ShortcutTarget and VoiceTarget
 machinery and support channel names, channel IDs, subchannels, links,
 force-center, and group restriction. Stop actions may omit the target and
 clear active RPC whispers started through RPC, which makes external
 keybinding tools easier to use reliably.

 Implements #6958

### Checks

- [x] My commits follow the [commit guidelines](https://github.com/mumble-voip/mumble/blob/master/COMMIT_GUIDELINES.md)

