### PR TITLE
Backport "Merge PR #7185: FIX(client): Package "Grounded" plugin with Windows installer" to 1.6.x

### DIFF
--- a/installer/ClientInstaller.cs
+++ b/installer/ClientInstaller.cs
@@ -63,6 +63,7 @@ public class ClientInstaller : MumbleInstall {
 			"ffxiv.dll",
 			"ffxiv_x64.dll",
 			"gmod.dll",
+			"grounded.dll",
 			"gtaiv.dll",
 			"gtasa.dll",
 			"gtav.dll",


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `1.6.x`:
 - [Merge PR #7185: FIX(client): Package &quot;Grounded&quot; plugin with Windows installer](https://github.com/mumble-voip/mumble/pull/7185)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)