### PR TITLE
FIX(client): Make invalid certificate dialog actually display certificate

### DIFF
--- a/src/mumble/MainWindow.cpp
+++ b/src/mumble/MainWindow.cpp
@@ -3705,10 +3705,10 @@ void MainWindow::serverDisconnected(QAbstractSocket::SocketError err, QString re
 			qmb.setEscapeButton(QMessageBox::No);
 
 			QPushButton *qp = qmb.addButton(tr("&View Certificate"), QMessageBox::ActionRole);
-			forever {
+			while (true) {
 				int res = qmb.exec();
 
-				if ((res == 0) && (qmb.clickedButton() == qp)) {
+				if (qmb.clickedButton() == qp) {
 					ViewCert vc(Global::get().sh->qscCert, this);
 					vc.exec();
 					continue;


### PR DESCRIPTION
The code to open the certificate viewer from the invalid certificate dialog was relying on the undefined behavior of ``QMessageBox::exec()`` when a custom button was clicked.

As described in https://doc.qt.io/qt-6/qmessagebox.html#exec the result is not necessarily 0 when clicking a custom button.

This commit removes the check for 0 in the custom button case.