### PR TITLE
Backport "Merge PR #7197: FIX(client): Make invalid certificate dialog actually display certificate" to 1.6.x

### DIFF
--- a/src/mumble/MainWindow.cpp
+++ b/src/mumble/MainWindow.cpp
@@ -3705,10 +3705,10 @@ void MainWindow::serverDisconnected(QAbstractSocket::SocketError err, QString re
 			qmb.setEscapeButton(QMessageBox::No);
 
 			QPushButton *qp = qmb.addButton(tr("&View Certificate"), QMessageBox::ActionRole);
-			forever {
+			while (true) {
 				int res = qmb.exec();
 
-				if ((res == 0) && (qmb.clickedButton() == qp)) {
+				if (qmb.clickedButton() == qp) {
 					ViewCert vc(Global::get().sh->qscCert, this);
 					vc.exec();
 					continue;


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `1.6.x`:
 - [Merge PR #7197: FIX(client): Make invalid certificate dialog actually display certificate](https://github.com/mumble-voip/mumble/pull/7197)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)