### PR TITLE
FEAT(client): Enhance image viewer with zoom and pan capabilities

### DIFF
--- a/src/mumble/widgets/ResponsiveImageDialog.cpp
+++ b/src/mumble/widgets/ResponsiveImageDialog.cpp
@@ -5,11 +5,12 @@
 
 #include "ResponsiveImageDialog.h"
 
+#include <QtGui/QWheelEvent>
 #include <QtWidgets/QApplication>
-#include <QtWidgets/QLabel>
-#include <QtWidgets/QScrollArea>
+#include <QtWidgets/QGraphicsPixmapItem>
 #include <QtWidgets/QVBoxLayout>
 
+#include <QtCore/QTimer>
 #include <algorithm>
 
 ResponsiveImageDialog::ResponsiveImageDialog(const QPixmap &pixmap, QWidget *parent)
@@ -20,34 +21,59 @@ ResponsiveImageDialog::ResponsiveImageDialog(const QPixmap &pixmap, QWidget *par
 	setMaximumSize(QWIDGETSIZE_MAX, QWIDGETSIZE_MAX);
 
 	QVBoxLayout *layout = new QVBoxLayout(this);
-	layout->setContentsMargins(10, 10, 10, 10);
+	layout->setContentsMargins(0, 0, 0, 0);
 	layout->setSpacing(0);
 
-	QScrollArea *scrollArea = new QScrollArea(this);
-	scrollArea->setWidgetResizable(true);
-	scrollArea->setHorizontalScrollBarPolicy(Qt::ScrollBarAsNeeded);
-	scrollArea->setVerticalScrollBarPolicy(Qt::ScrollBarAsNeeded);
-	scrollArea->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
+	m_scene = new QGraphicsScene(this);
+	m_scene->addPixmap(m_pixmap);
 
-	m_label = new QLabel(this);
-	m_label->setAlignment(Qt::AlignCenter);
-	m_label->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
-	m_label->setMinimumSize(100, 75);
-	m_label->setScaledContents(true); // Allow stretching
-	m_label->setPixmap(m_pixmap);
+	m_view = new QGraphicsView(m_scene, this);
+	m_view->setDragMode(QGraphicsView::ScrollHandDrag);
+	m_view->setRenderHint(QPainter::SmoothPixmapTransform);
+	m_view->setHorizontalScrollBarPolicy(Qt::ScrollBarAsNeeded);
+	m_view->setVerticalScrollBarPolicy(Qt::ScrollBarAsNeeded);
+	m_view->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
 
-	scrollArea->setWidget(m_label);
-	layout->addWidget(scrollArea);
+	// Use no frame shape for a cleaner look.
+	m_view->setFrameShape(QFrame::NoFrame);
 
-	// Set initial size to image size, but clamp to reasonable min/max
-	int initialWidth  = std::clamp(pixmap.width() + 60, 300, 1200);
-	int initialHeight = std::clamp(pixmap.height() + 60, 200, 900);
+	layout->addWidget(m_view);
+
+	// Setup zooming with wheel events.
+	m_view->viewport()->installEventFilter(this);
+	m_view->installEventFilter(this);
+
+	// Set initial size to image size, but clamp it to reasonable min/max values.
+	int initialWidth  = std::clamp(pixmap.width() + 40, 300, 1200);
+	int initialHeight = std::clamp(pixmap.height() + 40, 200, 900);
 	resize(initialWidth, initialHeight);
 }
 
-void ResponsiveImageDialog::resizeEvent(QResizeEvent *event) {
-	QDialog::resizeEvent(event);
-	// No aspect ratio: let QLabel::setScaledContents handle stretching
-	// No need to manually scale pixmap
-	m_label->setPixmap(m_pixmap);
+void ResponsiveImageDialog::showEvent(QShowEvent *event) {
+	QDialog::showEvent(event);
+	// Ensure fitInView is called after the window layout is fully initialized.
+	QTimer::singleShot(0, this, [this]() { m_view->fitInView(m_scene->itemsBoundingRect(), Qt::KeepAspectRatio); });
+}
+
+void ResponsiveImageDialog::changeEvent(QEvent *event) {
+	if (event->type() == QEvent::WindowStateChange) {
+		QTimer::singleShot(0, this, [this]() { m_view->fitInView(m_scene->itemsBoundingRect(), Qt::KeepAspectRatio); });
+	}
+	QDialog::changeEvent(event);
+}
+
+bool ResponsiveImageDialog::eventFilter(QObject *obj, QEvent *event) {
+	if (obj == m_view->viewport() && event->type() == QEvent::Wheel) {
+		QWheelEvent *wheelEvent = static_cast< QWheelEvent * >(event);
+		// Zoom in or out.
+		if (wheelEvent->angleDelta().y() > 0) {
+			m_view->scale(1.1, 1.1);
+		} else if (wheelEvent->angleDelta().y() < 0) {
+			m_view->scale(1.0 / 1.1, 1.0 / 1.1);
+		}
+		return true; // Event handled.
+	} else if (obj == m_view && event->type() == QEvent::Resize) {
+		m_view->fitInView(m_scene->itemsBoundingRect(), Qt::KeepAspectRatio);
+	}
+	return QDialog::eventFilter(obj, event);
 }

--- a/src/mumble/widgets/ResponsiveImageDialog.h
+++ b/src/mumble/widgets/ResponsiveImageDialog.h
@@ -8,22 +8,25 @@
 
 #include <QtGui/QPixmap>
 #include <QtWidgets/QDialog>
-#include <QtWidgets/QLabel>
-#include <QtWidgets/QScrollArea>
+#include <QtWidgets/QGraphicsScene>
+#include <QtWidgets/QGraphicsView>
 #include <QtWidgets/QVBoxLayout>
 
 class ResponsiveImageDialog : public QDialog {
 	Q_OBJECT
 
 private:
-	QLabel *m_label;
+	QGraphicsView *m_view;
+	QGraphicsScene *m_scene;
 	QPixmap m_pixmap;
 
 public:
 	explicit ResponsiveImageDialog(const QPixmap &pixmap, QWidget *parent = nullptr);
 
 protected:
-	void resizeEvent(QResizeEvent *event) override;
+	void showEvent(QShowEvent *event) override;
+	void changeEvent(QEvent *event) override;
+	bool eventFilter(QObject *obj, QEvent *event) override;
 };
 
 #endif // MUMBLE_MUMBLE_WIDGETS_RESPONSIVEIMAGEDIALOG_H_


### PR DESCRIPTION
This improves the current image viewer originally implemented 9 months ago.

It now preserves the image aspect ratio correctly by introducing zoom support, click-and-drag navigation, and panning functionality for a more usable viewing experience.

It was tested and works correctly on my openSUSE Tumbleweed installation 

### Checks

- [x] My commits follow the [commit guidelines](https://github.com/mumble-voip/mumble/blob/master/COMMIT_GUIDELINES.md)