### PR TITLE
Backport "MAINT: Update external GA actions to latest versions" to 1.6.x

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -30,7 +30,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Backport Action
-        uses: sorenlouv/backport-github-action@v9.5.1
+        uses: sorenlouv/backport-github-action@v12.0.0
         with:
           github_token: ${{ secrets.BACKPORT_TOKEN }}
           auto_backport_label_prefix: auto-backport-to-

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -120,7 +120,7 @@ jobs:
 
     - if: ${{ !inputs.SIGN_WINDOWS_INSTALLER && matrix.type == 'static' }}
       name: Publish
-      uses: actions/upload-artifact@v6
+      uses: actions/upload-artifact@v7
       with:
         name: 'Mumble-${{ matrix.os }}'
         compression-level: 9

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -44,7 +44,7 @@ jobs:
       shell: bash
 
     - name: Check code formatting
-      uses: jidicula/clang-format-action@v4.16.0
+      uses: jidicula/clang-format-action@v4.18.0
       with:
           clang-format-version: '10'
           check-path: '.'


### PR DESCRIPTION
Backport of https://github.com/mumble-voip/mumble/pull/7214