### PR TITLE
FEAT(client): Add shortcut to toggle whispers for voice activation/continuous transmission modes

### DIFF
--- a/src/mumble/EnumStringConversions.cpp
+++ b/src/mumble/EnumStringConversions.cpp
@@ -247,9 +247,7 @@ PROCESS_ALL_ENUMS
 
 #define BEFORE_CODE(enumType) void stringToEnum(const std::string &str, enumType &e) {
 #define AFTER_CODE                                           \
-	{                                                        \
-		throw "Unable to convert given string to enum type"; \
-	}                                                        \
+	{ throw "Unable to convert given string to enum type"; } \
 	}
 #define PROCESS(enumType, enumValue, stringValue) \
 	if (str == stringValue) {                     \

--- a/src/mumble/EnumStringConversions.cpp
+++ b/src/mumble/EnumStringConversions.cpp
@@ -133,6 +133,7 @@
 	PROCESS(Log::MsgType, PrivateTextMessage, "PrivateTextMessage")         \
 	PROCESS(Log::MsgType, ChannelListeningAdd, "ChannelListeningAdd")       \
 	PROCESS(Log::MsgType, ChannelListeningRemove, "ChannelListeningRemove") \
+	PROCESS(Log::MsgType, WhisperHold, "WhisperHold")                       \
 	PROCESS(Log::MsgType, PluginMessage, "PluginMessage")
 
 #define OVERLAY_PRESETS_VALUES                                               \
@@ -246,7 +247,9 @@ PROCESS_ALL_ENUMS
 
 #define BEFORE_CODE(enumType) void stringToEnum(const std::string &str, enumType &e) {
 #define AFTER_CODE                                           \
-	{ throw "Unable to convert given string to enum type"; } \
+	{                                                        \
+		throw "Unable to convert given string to enum type"; \
+	}                                                        \
 	}
 #define PROCESS(enumType, enumValue, stringValue) \
 	if (str == stringValue) {                     \

--- a/src/mumble/GlobalShortcut.cpp
+++ b/src/mumble/GlobalShortcut.cpp
@@ -46,6 +46,11 @@ static ConfigRegistrar registrarGlobalShortcut(1200, GlobalShortcutConfigDialogN
 
 static const QString UPARROW = QString::fromUtf8("\xE2\x86\x91 ");
 
+static QList< Shortcut > normalizedShortcutList(QList< Shortcut > shortcuts) {
+	std::stable_sort(shortcuts.begin(), shortcuts.end());
+	return shortcuts;
+}
+
 ShortcutActionWidget::ShortcutActionWidget(QWidget *p) : QWidget(p) {
 	int idx = 0;
 
@@ -601,7 +606,8 @@ bool ShortcutDelegate::helpEvent(QHelpEvent *event, QAbstractItemView *, const Q
 	return true;
 }
 
-GlobalShortcutConfig::GlobalShortcutConfig(Settings &st) : ConfigWidget(st) {
+GlobalShortcutConfig::GlobalShortcutConfig(Settings &st)
+	: ConfigWidget(st), qlPreviouslyAppliedShortcuts(normalizedShortcutList(Global::get().s.qlShortcuts)) {
 	setupUi(this);
 	installEventFilter(this);
 
@@ -895,6 +901,15 @@ void GlobalShortcutConfig::reload() {
 }
 
 void GlobalShortcutConfig::accept() const {
+	MainWindow *mw = Global::get().mw;
+	if (mw && Global::get().s.atTransmit == Settings::PushToTalk) {
+		mw->resetWhisperHoldState(MainWindow::tr("Whisper hold cleared: Push-to-Talk enabled."));
+	} else if (mw && qlPreviouslyAppliedShortcuts != normalizedShortcutList(Global::get().s.qlShortcuts)) {
+		mw->resetWhisperHoldState(MainWindow::tr("Whisper hold cleared: Shortcuts changed."));
+	}
+
+	qlPreviouslyAppliedShortcuts = normalizedShortcutList(Global::get().s.qlShortcuts);
+
 	GlobalShortcutEngine::engine->bNeedRemap = true;
 	GlobalShortcutEngine::engine->needRemap();
 	GlobalShortcutEngine::engine->setEnabled(Global::get().s.bShortcutEnable);

--- a/src/mumble/GlobalShortcut.h
+++ b/src/mumble/GlobalShortcut.h
@@ -190,6 +190,7 @@ private:
 	Q_DISABLE_COPY(GlobalShortcutConfig)
 protected:
 	QList< Shortcut > qlShortcuts;
+	mutable QList< Shortcut > qlPreviouslyAppliedShortcuts;
 	QTreeWidgetItem *itemForShortcut(const Shortcut &) const;
 	bool showWarning() const;
 	bool eventFilter(QObject *, QEvent *) Q_DECL_OVERRIDE;

--- a/src/mumble/GlobalShortcutTypes.h
+++ b/src/mumble/GlobalShortcutTypes.h
@@ -63,6 +63,7 @@ enum Type {
 	ListenerAttenuationUp,
 	ListenerAttenuationDown,
 	AdaptivePush,
+	WhisperHold,
 };
 
 // A few assertions meant to catch, if anyone inserts a new value in-between instead of appending

--- a/src/mumble/Log.cpp
+++ b/src/mumble/Log.cpp
@@ -461,6 +461,7 @@ const Log::MsgType Log::msgOrder[] = { DebugInfo,
 									   PermissionDenied,
 									   TextMessage,
 									   PrivateTextMessage,
+									   WhisperHold,
 									   PluginMessage };
 
 const char *Log::msgNames[] = { QT_TRANSLATE_NOOP("Log", "Debug"),
@@ -494,6 +495,7 @@ const char *Log::msgNames[] = { QT_TRANSLATE_NOOP("Log", "Debug"),
 								QT_TRANSLATE_NOOP("Log", "Private text message"),
 								QT_TRANSLATE_NOOP("Log", "User started listening to channel"),
 								QT_TRANSLATE_NOOP("Log", "User stopped listening to channel"),
+								QT_TRANSLATE_NOOP("Log", "Whisper hold changed"),
 								QT_TRANSLATE_NOOP("Log", "Plugin message") };
 
 QString Log::msgName(MsgType t) const {
@@ -868,6 +870,7 @@ void Log::log(MsgType mt, const QString &console, const QString &terse, bool own
 					case ChannelLeaveDisconnect:
 					case ChannelListeningAdd:
 					case ChannelListeningRemove:
+					case WhisperHold:
 					case PluginMessage:
 						msgIcon = QSystemTrayIcon::Information;
 						break;

--- a/src/mumble/Log.h
+++ b/src/mumble/Log.h
@@ -110,12 +110,13 @@ public:
 		PrivateTextMessage,
 		ChannelListeningAdd,
 		ChannelListeningRemove,
+		WhisperHold,
 		PluginMessage
 	};
 
 	enum LogColorType { Time, Server, Privilege, Source, Target };
 	static const MsgType firstMsgType = DebugInfo;
-	static const MsgType lastMsgType  = ChannelListeningRemove;
+	static const MsgType lastMsgType  = WhisperHold;
 
 	// Display order in settingsscreen, allows to insert new events without breaking config-compatibility with older
 	// versions.

--- a/src/mumble/MainWindow.cpp
+++ b/src/mumble/MainWindow.cpp
@@ -514,6 +514,7 @@ void MainWindow::setupGui() {
 	QObject::connect(Global::get().channelListenerManager.get(), &ChannelListenerManager::localVolumeAdjustmentsChanged,
 					 pmModel, &UserModel::on_channelListenerLocalVolumeAdjustmentChanged);
 	QObject::connect(pmModel, &UserModel::userMoved, this, &MainWindow::on_user_moved);
+	QObject::connect(pmModel, &UserModel::localUserChannelChanged, this, &MainWindow::on_localUserChannelChanged);
 
 	// connect slots to PluginManager
 	QObject::connect(pmModel, &UserModel::userAdded, Global::get().pluginManager, &PluginManager::on_userAdded);
@@ -1208,6 +1209,13 @@ void MainWindow::on_user_moved(unsigned int sessionID, const std::optional< unsi
 	}
 
 	(void) newChannelID;
+}
+
+void MainWindow::on_localUserChannelChanged(unsigned int prevChannelID, unsigned int newChannelID) {
+	if (bWhisperHoldTargetApplied && !stWhisperHoldTarget.bUsers
+		&& stWhisperHoldTarget.iChannel == SHORTCUT_TARGET_CURRENT && prevChannelID != newChannelID) {
+		updateTarget();
+	}
 }
 
 void MainWindow::on_qaMoveBack_triggered() {

--- a/src/mumble/MainWindow.cpp
+++ b/src/mumble/MainWindow.cpp
@@ -126,9 +126,7 @@ MainWindow::MainWindow(QWidget *p)
 	else
 		SvgIcon::addSvgPixmapsToIcon(qiIcon, QLatin1String("skin:mumble.svg"));
 #else
-	{
-		SvgIcon::addSvgPixmapsToIcon(qiIcon, QLatin1String("skin:mumble.svg"));
-	}
+	{ SvgIcon::addSvgPixmapsToIcon(qiIcon, QLatin1String("skin:mumble.svg")); }
 
 	// Set application icon except on MacOSX, where the window-icon
 	// shown in the title-bar usually serves as a draggable version of the
@@ -3149,6 +3147,10 @@ void MainWindow::updateTarget() {
 }
 
 void MainWindow::on_gsWhisper_triggered(bool down, QVariant scdata) {
+	if (!scdata.canConvert< ShortcutTarget >()) {
+		return;
+	}
+
 	ShortcutTarget st = scdata.value< ShortcutTarget >();
 
 	if (down) {
@@ -3264,6 +3266,10 @@ void MainWindow::on_gsWhisperHold_triggered(bool down, QVariant scdata) {
 	}
 
 	if (Global::get().s.atTransmit == Settings::PushToTalk) {
+		return;
+	}
+
+	if (!scdata.canConvert< ShortcutTarget >()) {
 		return;
 	}
 
@@ -3594,6 +3600,10 @@ void MainWindow::on_gsAdaptivePush_triggered(bool down, QVariant variant) {
 void MainWindow::whisperReleased(QVariant scdata) {
 	if (Global::get().iPushToTalk <= 0)
 		return;
+
+	if (!scdata.canConvert< ShortcutTarget >()) {
+		return;
+	}
 
 	ShortcutTarget st = scdata.value< ShortcutTarget >();
 
@@ -4333,19 +4343,9 @@ void MainWindow::openAudioStatsDialog() {
 void MainWindow::openConfigDialog() {
 	ConfigDialog *dlg = new ConfigDialog(this);
 
-	Global::get().inConfigUI            = true;
-	QList< Shortcut > previousShortcuts = normalizedShortcutList(Global::get().s.qlShortcuts);
+	Global::get().inConfigUI = true;
 
 	QObject::connect(dlg, &ConfigDialog::settingsAccepted, Global::get().talkingUI, &TalkingUI::on_settingsChanged);
-	QObject::connect(dlg, &ConfigDialog::settingsAccepted, this, [this, previousShortcuts]() mutable {
-		if (Global::get().s.atTransmit == Settings::PushToTalk) {
-			resetWhisperHoldState(tr("Whisper hold cleared: Push-to-Talk enabled."));
-		} else if (previousShortcuts != normalizedShortcutList(Global::get().s.qlShortcuts)) {
-			resetWhisperHoldState(tr("Whisper hold cleared: Shortcuts changed."));
-		}
-
-		previousShortcuts = normalizedShortcutList(Global::get().s.qlShortcuts);
-	});
 	QObject::connect(dlg, &ConfigDialog::settingsAccepted, []() {
 		if (Global::get().s.requireThemeApplication) {
 			Themes::apply();

--- a/src/mumble/MainWindow.cpp
+++ b/src/mumble/MainWindow.cpp
@@ -126,7 +126,9 @@ MainWindow::MainWindow(QWidget *p)
 	else
 		SvgIcon::addSvgPixmapsToIcon(qiIcon, QLatin1String("skin:mumble.svg"));
 #else
-	{ SvgIcon::addSvgPixmapsToIcon(qiIcon, QLatin1String("skin:mumble.svg")); }
+	{
+		SvgIcon::addSvgPixmapsToIcon(qiIcon, QLatin1String("skin:mumble.svg"));
+	}
 
 	// Set application icon except on MacOSX, where the window-icon
 	// shown in the title-bar usually serves as a draggable version of the
@@ -464,6 +466,16 @@ void MainWindow::createActions() {
 	gsAdaptivePush->qsToolTip = tr("When using the push-to-talk transmission mode, this will act as the push-to-talk "
 								   "action. Otherwise, it will act as a push-to-mute action.",
 								   "Global Shortcut");
+
+	gsWhisperHold = new GlobalShortcut(this, GlobalShortcutType::WhisperHold, tr("Whisper Hold", "Global Shortcut"),
+									   QVariant::fromValue(ShortcutTarget()));
+	gsWhisperHold->setObjectName("gsWhisperHold");
+	gsWhisperHold->qsToolTip = tr(
+		"Hold voice activation or continuous transmission on the configured Whisper/Shout target.", "Global Shortcut");
+	gsWhisperHold->qsWhatsThis =
+		tr("This latches or unlatches the configured Whisper/Shout target while using voice activation or continuous "
+		   "transmission. Pressing a different Whisper Hold shortcut switches transmission to that target.",
+		   "Global Shortcut");
 }
 
 void MainWindow::setupGui() {
@@ -717,6 +729,8 @@ void MainWindow::closeEvent(QCloseEvent *e) {
 	}
 
 	sh.reset();
+
+	resetWhisperHoldState();
 
 	storeState(Global::get().s.bMinimalView);
 
@@ -1127,6 +1141,10 @@ void MainWindow::updateImagePath(QString filepath) const {
 
 void MainWindow::setTransmissionMode(Settings::AudioTransmit mode) {
 	if (Global::get().s.atTransmit != mode) {
+		if (mode == Settings::PushToTalk) {
+			resetWhisperHoldState(tr("Whisper hold cleared: Push-to-Talk enabled."));
+		}
+
 		Global::get().s.atTransmit = mode;
 
 		switch (mode) {
@@ -1266,6 +1284,11 @@ static void recreateServerHandler() {
 	// In order for that to work it is ESSENTIAL to use a DIRECT CONNECTION!
 	Global::get().pluginManager->connect(sh.get(), &ServerHandler::aboutToDisconnect, Global::get().pluginManager,
 										 &PluginManager::on_serverDisconnected, Qt::DirectConnection);
+}
+
+static QList< Shortcut > normalizedShortcutList(QList< Shortcut > shortcuts) {
+	std::stable_sort(shortcuts.begin(), shortcuts.end());
+	return shortcuts;
 }
 
 void MainWindow::openUrl(const QUrl &url) {
@@ -3154,7 +3177,9 @@ void MainWindow::on_gsWhisper_triggered(bool down, QVariant scdata) {
 			}
 		}
 
+		removeWhisperHoldTarget(false);
 		addTarget(&st);
+		++iWhisperShoutTargetsActive;
 		updateTarget();
 
 		Global::get().iPushToTalk++;
@@ -3184,6 +3209,83 @@ void MainWindow::removeTarget(ShortcutTarget *st) {
 		qmCurrentTargets.remove(*st);
 	else
 		qmCurrentTargets[*st] -= 1;
+}
+
+/* Whisper Hold acts as a lower-priority target layer below regular
+ * Whisper/Shout PTS. The hold can be logically active while not currently
+ * applied to qmCurrentTargets, for example while a regular Whisper/Shout
+ * target is overriding it, including during the configured PTT hold delay.
+ */
+void MainWindow::applyWhisperHoldTarget() {
+	if (!bWhisperHoldActive || bWhisperHoldTargetApplied || iWhisperShoutTargetsActive > 0) {
+		return;
+	}
+
+	addTarget(&stWhisperHoldTarget);
+	bWhisperHoldTargetApplied = true;
+	updateTarget();
+}
+
+void MainWindow::refreshWhisperHoldTarget() {
+	if (bWhisperHoldActive && iWhisperShoutTargetsActive == 0) {
+		applyWhisperHoldTarget();
+	} else {
+		removeWhisperHoldTarget();
+	}
+}
+
+void MainWindow::removeWhisperHoldTarget(bool update) {
+	if (!bWhisperHoldTargetApplied) {
+		return;
+	}
+
+	removeTarget(&stWhisperHoldTarget);
+	bWhisperHoldTargetApplied = false;
+	if (update) {
+		updateTarget();
+	}
+}
+
+void MainWindow::resetWhisperHoldState(const QString &message) {
+	const bool wasActive = bWhisperHoldActive;
+
+	removeWhisperHoldTarget();
+	bWhisperHoldActive         = false;
+	iWhisperShoutTargetsActive = 0;
+
+	if (wasActive && !message.isEmpty()) {
+		Global::get().l->log(Log::WhisperHold, message);
+	}
+}
+
+void MainWindow::on_gsWhisperHold_triggered(bool down, QVariant scdata) {
+	if (!down) {
+		return;
+	}
+
+	if (Global::get().s.atTransmit == Settings::PushToTalk) {
+		return;
+	}
+
+	ShortcutTarget st = scdata.value< ShortcutTarget >();
+
+	if (bWhisperHoldActive && stWhisperHoldTarget == st) {
+		removeWhisperHoldTarget();
+		bWhisperHoldActive = false;
+		Global::get().l->log(Log::WhisperHold, tr("Whisper hold cleared."));
+		return;
+	}
+
+	if (bWhisperHoldActive) {
+		removeWhisperHoldTarget(false);
+	}
+
+	stWhisperHoldTarget = st;
+	bWhisperHoldActive  = true;
+	refreshWhisperHoldTarget();
+
+	Global::get().l->log(Log::WhisperHold,
+						 tr("Whisper held to: %1.").arg(ShortcutTargetWidget::targetString(stWhisperHoldTarget)));
 }
 
 void MainWindow::on_gsCycleTransmitMode_triggered(bool down, QVariant) {
@@ -3498,7 +3600,15 @@ void MainWindow::whisperReleased(QVariant scdata) {
 	Global::get().iPushToTalk--;
 
 	removeTarget(&st);
-	updateTarget();
+	if (iWhisperShoutTargetsActive > 0) {
+		--iWhisperShoutTargetsActive;
+	}
+
+	if (bWhisperHoldActive && iWhisperShoutTargetsActive == 0) {
+		applyWhisperHoldTarget();
+	} else {
+		updateTarget();
+	}
 }
 
 void MainWindow::onResetAudio() {
@@ -3573,6 +3683,8 @@ void MainWindow::serverConnected() {
 }
 
 void MainWindow::serverDisconnected(QAbstractSocket::SocketError err, QString reason) {
+	resetWhisperHoldState();
+
 	// clear ChannelListener
 	Global::get().channelListenerManager->clear();
 
@@ -4061,6 +4173,7 @@ void MainWindow::disconnectFromServer() {
 	}
 
 	m_reconnectSoundBlocker.reset();
+	resetWhisperHoldState();
 
 	if (Global::get().sh && Global::get().sh->isRunning()) {
 		Global::get().sh->disconnect();
@@ -4220,9 +4333,19 @@ void MainWindow::openAudioStatsDialog() {
 void MainWindow::openConfigDialog() {
 	ConfigDialog *dlg = new ConfigDialog(this);
 
-	Global::get().inConfigUI = true;
+	Global::get().inConfigUI            = true;
+	QList< Shortcut > previousShortcuts = normalizedShortcutList(Global::get().s.qlShortcuts);
 
 	QObject::connect(dlg, &ConfigDialog::settingsAccepted, Global::get().talkingUI, &TalkingUI::on_settingsChanged);
+	QObject::connect(dlg, &ConfigDialog::settingsAccepted, this, [this, previousShortcuts]() mutable {
+		if (Global::get().s.atTransmit == Settings::PushToTalk) {
+			resetWhisperHoldState(tr("Whisper hold cleared: Push-to-Talk enabled."));
+		} else if (previousShortcuts != normalizedShortcutList(Global::get().s.qlShortcuts)) {
+			resetWhisperHoldState(tr("Whisper hold cleared: Shortcuts changed."));
+		}
+
+		previousShortcuts = normalizedShortcutList(Global::get().s.qlShortcuts);
+	});
 	QObject::connect(dlg, &ConfigDialog::settingsAccepted, []() {
 		if (Global::get().s.requireThemeApplication) {
 			Themes::apply();
@@ -4257,9 +4380,16 @@ void MainWindow::openConfigDialog() {
 }
 
 void MainWindow::openAudioWizardDialog() {
-	AudioWizard *aw = new AudioWizard(this);
+	const QList< Shortcut > previousShortcuts = normalizedShortcutList(Global::get().s.qlShortcuts);
+	AudioWizard *aw                           = new AudioWizard(this);
 	aw->exec();
 	delete aw;
+
+	if (Global::get().s.atTransmit == Settings::PushToTalk) {
+		resetWhisperHoldState(tr("Whisper hold cleared: Push-to-Talk enabled."));
+	} else if (previousShortcuts != normalizedShortcutList(Global::get().s.qlShortcuts)) {
+		resetWhisperHoldState(tr("Whisper hold cleared: Shortcuts changed."));
+	}
 }
 
 void MainWindow::openCertWizardDialog() {

--- a/src/mumble/MainWindow.h
+++ b/src/mumble/MainWindow.h
@@ -115,6 +115,7 @@ public:
 	GlobalShortcut *gsMoveBack;
 	GlobalShortcut *gsCycleListenerAttenuationMode, *gsListenerAttenuationUp, *gsListenerAttenuationDown;
 	GlobalShortcut *gsAdaptivePush;
+	GlobalShortcut *gsWhisperHold;
 
 	DockTitleBar *dtbLogDockTitle, *dtbChatDockTitle;
 
@@ -172,6 +173,10 @@ protected:
 	QList< QAction * > qlUserActions;
 
 	QHash< ShortcutTarget, int > qmCurrentTargets;
+	bool bWhisperHoldActive        = false;
+	bool bWhisperHoldTargetApplied = false;
+	int iWhisperShoutTargetsActive = 0;
+	ShortcutTarget stWhisperHoldTarget;
 	/// A map that contains information about the currently active
 	/// shout/whisper targets. The mapping is between a List of
 	/// ShortcutTargets that are all triggered together and the
@@ -183,6 +188,10 @@ protected:
 	/// and a helper-number (see iTargetCounter).
 	QMap< int, int > qmTargetUse;
 	Channel *mapChannel(int idx) const;
+	void applyWhisperHoldTarget();
+	void refreshWhisperHoldTarget();
+	void removeWhisperHoldTarget(bool update = true);
+	void resetWhisperHoldState(const QString &message = QString());
 	/// This is a pure helper number whose job is to always be increased
 	/// if a new VoiceTarget is needed. It will be used as the helper
 	/// number in qmTargetUse.
@@ -359,6 +368,7 @@ public slots:
 	void on_gsListenerAttenuationUp_triggered(bool, QVariant);
 	void on_gsListenerAttenuationDown_triggered(bool, QVariant);
 	void on_gsAdaptivePush_triggered(bool, QVariant);
+	void on_gsWhisperHold_triggered(bool, QVariant);
 
 	void on_Reconnect_timeout();
 	void on_qaTalkingUIToggle_triggered();

--- a/src/mumble/MainWindow.h
+++ b/src/mumble/MainWindow.h
@@ -424,6 +424,7 @@ public slots:
 	void highlightWindow();
 	void on_user_moved(unsigned int sessionID, const std::optional< unsigned int > &prevChannelID,
 					   unsigned int newChannelID);
+	void on_localUserChannelChanged(unsigned int prevChannelID, unsigned int newChannelID);
 	void on_qaMoveBack_triggered();
 signals:
 	/// Signal emitted when the server and the client have finished

--- a/src/mumble/MainWindow.h
+++ b/src/mumble/MainWindow.h
@@ -156,6 +156,7 @@ public:
 	void storeState(bool minimalView);
 
 	void updateChatBar();
+	void resetWhisperHoldState(const QString &message = QString());
 	void openTextMessageDialog(ClientUser *p);
 	void openUserLocalNicknameDialog(const ClientUser &p);
 
@@ -191,7 +192,6 @@ protected:
 	void applyWhisperHoldTarget();
 	void refreshWhisperHoldTarget();
 	void removeWhisperHoldTarget(bool update = true);
-	void resetWhisperHoldState(const QString &message = QString());
 	/// This is a pure helper number whose job is to always be increased
 	/// if a new VoiceTarget is needed. It will be used as the helper
 	/// number in qmTargetUse.

--- a/src/mumble/Settings.cpp
+++ b/src/mumble/Settings.cpp
@@ -584,6 +584,7 @@ Settings::Settings() {
 	qmMessages[Log::OtherSelfMute]   = Settings::LogConsole;
 	qmMessages[Log::OtherMutedOther] = Settings::LogConsole;
 	qmMessages[Log::UserRenamed]     = Settings::LogConsole;
+	qmMessages[Log::WhisperHold]     = Settings::LogConsole;
 	qmMessages[Log::PluginMessage]   = Settings::LogConsole;
 }
 

--- a/src/mumble/UserModel.cpp
+++ b/src/mumble/UserModel.cpp
@@ -1132,6 +1132,7 @@ void UserModel::moveUser(ClientUser *p, Channel *np) {
 	item = moveItem(opi, pi, item);
 
 	if (p->uiSession == Global::get().uiSession) {
+		emit localUserChannelChanged(oc->iId, np->iId);
 		ensureSelfVisible();
 		recheckLinks();
 	}

--- a/src/mumble/UserModel.h
+++ b/src/mumble/UserModel.h
@@ -226,6 +226,11 @@ signals:
 	/// @param prevChannelID The ID of the channel the user is moving from (if any)
 	/// @param newChannelID The ID of the channel the user has moved into
 	void userMoved(unsigned int userSessionID, std::optional< unsigned int > prevChannelID, unsigned int newChannelID);
+	/// A signal emitted after the local user has changed channels.
+	///
+	/// @param prevChannelID The ID of the channel the local user moved from
+	/// @param newChannelID The ID of the channel the local user moved into
+	void localUserChannelChanged(unsigned int prevChannelID, unsigned int newChannelID);
 	/// A signal emitted whenever a user is removed from the model.
 	///
 	/// @param userSessionID The ID of that user's session

--- a/src/mumble/mumble_ar.ts
+++ b/src/mumble/mumble_ar.ts
@@ -4148,6 +4148,10 @@ This field describes the size of an LCD device. The size is given either in pixe
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <source>Whisper hold changed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>the server</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6881,6 +6885,37 @@ the channel&apos;s context menu.</source>
     </message>
     <message>
         <source>This will check if mumble is up to date</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Whisper Hold</source>
+        <comment>Global Shortcut</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hold voice activation or continuous transmission on the configured Whisper/Shout target.</source>
+        <comment>Global Shortcut</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>This latches or unlatches the configured Whisper/Shout target while using voice activation or continuous transmission. Pressing a different Whisper Hold shortcut switches transmission to that target.</source>
+        <comment>Global Shortcut</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Whisper hold cleared: Push-to-Talk enabled.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Whisper hold cleared.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Whisper held to: %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Whisper hold cleared: Shortcuts changed.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/src/mumble/mumble_bg.ts
+++ b/src/mumble/mumble_bg.ts
@@ -4145,6 +4145,10 @@ This field describes the size of an LCD device. The size is given either in pixe
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <source>Whisper hold changed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>the server</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6878,6 +6882,37 @@ the channel&apos;s context menu.</source>
     </message>
     <message>
         <source>This will check if mumble is up to date</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Whisper Hold</source>
+        <comment>Global Shortcut</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hold voice activation or continuous transmission on the configured Whisper/Shout target.</source>
+        <comment>Global Shortcut</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>This latches or unlatches the configured Whisper/Shout target while using voice activation or continuous transmission. Pressing a different Whisper Hold shortcut switches transmission to that target.</source>
+        <comment>Global Shortcut</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Whisper hold cleared: Push-to-Talk enabled.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Whisper hold cleared.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Whisper held to: %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Whisper hold cleared: Shortcuts changed.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/src/mumble/mumble_br.ts
+++ b/src/mumble/mumble_br.ts
@@ -4144,6 +4144,10 @@ This field describes the size of an LCD device. The size is given either in pixe
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <source>Whisper hold changed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>the server</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6877,6 +6881,37 @@ the channel&apos;s context menu.</source>
     </message>
     <message>
         <source>This will check if mumble is up to date</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Whisper Hold</source>
+        <comment>Global Shortcut</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hold voice activation or continuous transmission on the configured Whisper/Shout target.</source>
+        <comment>Global Shortcut</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>This latches or unlatches the configured Whisper/Shout target while using voice activation or continuous transmission. Pressing a different Whisper Hold shortcut switches transmission to that target.</source>
+        <comment>Global Shortcut</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Whisper hold cleared: Push-to-Talk enabled.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Whisper hold cleared.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Whisper held to: %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Whisper hold cleared: Shortcuts changed.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/src/mumble/mumble_ca.ts
+++ b/src/mumble/mumble_ca.ts
@@ -4203,6 +4203,10 @@ Aquest camp descriu la mida d&apos;un dispositiu LCD. La mida es mostra en píxe
         <translation>Missatge de text privat</translation>
     </message>
     <message>
+        <source>Whisper hold changed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>the server</source>
         <translation>el servidor</translation>
     </message>
@@ -6945,6 +6949,37 @@ al menú contextual del canal.</translation>
     <message>
         <source>This will check if mumble is up to date</source>
         <translation>Això comprova si el mumble està actualitzat</translation>
+    </message>
+    <message>
+        <source>Whisper Hold</source>
+        <comment>Global Shortcut</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hold voice activation or continuous transmission on the configured Whisper/Shout target.</source>
+        <comment>Global Shortcut</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>This latches or unlatches the configured Whisper/Shout target while using voice activation or continuous transmission. Pressing a different Whisper Hold shortcut switches transmission to that target.</source>
+        <comment>Global Shortcut</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Whisper hold cleared: Push-to-Talk enabled.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Whisper hold cleared.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Whisper held to: %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Whisper hold cleared: Shortcuts changed.</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>That sound was the mute cue. It activates when you speak while muted. Would you like to keep it enabled?</source>

--- a/src/mumble/mumble_cs.ts
+++ b/src/mumble/mumble_cs.ts
@@ -4198,6 +4198,10 @@ Toto pole popisuje velikost LCD zařízení. Velikost je udávána buď v pixele
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <source>Whisper hold changed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>the server</source>
         <translation>server</translation>
     </message>
@@ -6935,6 +6939,37 @@ kontextové nabídce kanálů.</translation>
     </message>
     <message>
         <source>This will check if mumble is up to date</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Whisper Hold</source>
+        <comment>Global Shortcut</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hold voice activation or continuous transmission on the configured Whisper/Shout target.</source>
+        <comment>Global Shortcut</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>This latches or unlatches the configured Whisper/Shout target while using voice activation or continuous transmission. Pressing a different Whisper Hold shortcut switches transmission to that target.</source>
+        <comment>Global Shortcut</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Whisper hold cleared: Push-to-Talk enabled.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Whisper hold cleared.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Whisper held to: %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Whisper hold cleared: Shortcuts changed.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/src/mumble/mumble_cy.ts
+++ b/src/mumble/mumble_cy.ts
@@ -4148,6 +4148,10 @@ This field describes the size of an LCD device. The size is given either in pixe
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <source>Whisper hold changed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>the server</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6881,6 +6885,37 @@ the channel&apos;s context menu.</source>
     </message>
     <message>
         <source>This will check if mumble is up to date</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Whisper Hold</source>
+        <comment>Global Shortcut</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hold voice activation or continuous transmission on the configured Whisper/Shout target.</source>
+        <comment>Global Shortcut</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>This latches or unlatches the configured Whisper/Shout target while using voice activation or continuous transmission. Pressing a different Whisper Hold shortcut switches transmission to that target.</source>
+        <comment>Global Shortcut</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Whisper hold cleared: Push-to-Talk enabled.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Whisper hold cleared.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Whisper held to: %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Whisper hold cleared: Shortcuts changed.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/src/mumble/mumble_da.ts
+++ b/src/mumble/mumble_da.ts
@@ -4197,6 +4197,10 @@ Dette felt beskriver størrelsen af en LCD-enhed. Størrelsen er enten opgivet i
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <source>Whisper hold changed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>the server</source>
         <translation>serveren</translation>
     </message>
@@ -6934,6 +6938,37 @@ kanalens genvejsmenu.</translation>
     </message>
     <message>
         <source>This will check if mumble is up to date</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Whisper Hold</source>
+        <comment>Global Shortcut</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hold voice activation or continuous transmission on the configured Whisper/Shout target.</source>
+        <comment>Global Shortcut</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>This latches or unlatches the configured Whisper/Shout target while using voice activation or continuous transmission. Pressing a different Whisper Hold shortcut switches transmission to that target.</source>
+        <comment>Global Shortcut</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Whisper hold cleared: Push-to-Talk enabled.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Whisper hold cleared.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Whisper held to: %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Whisper hold cleared: Shortcuts changed.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/src/mumble/mumble_de.ts
+++ b/src/mumble/mumble_de.ts
@@ -4203,6 +4203,10 @@ Sie listet die Geräte alphabetisch sortiert, enthält aber auch die Größe des
         <translation>Private Textnachricht</translation>
     </message>
     <message>
+        <source>Whisper hold changed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>the server</source>
         <translation>den Server</translation>
     </message>
@@ -6945,6 +6949,37 @@ des Kanals auswählen.</translation>
     <message>
         <source>This will check if mumble is up to date</source>
         <translation>Dies prüft, ob mumble auf dem neuesten Stand ist</translation>
+    </message>
+    <message>
+        <source>Whisper Hold</source>
+        <comment>Global Shortcut</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hold voice activation or continuous transmission on the configured Whisper/Shout target.</source>
+        <comment>Global Shortcut</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>This latches or unlatches the configured Whisper/Shout target while using voice activation or continuous transmission. Pressing a different Whisper Hold shortcut switches transmission to that target.</source>
+        <comment>Global Shortcut</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Whisper hold cleared: Push-to-Talk enabled.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Whisper hold cleared.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Whisper held to: %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Whisper hold cleared: Shortcuts changed.</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>That sound was the mute cue. It activates when you speak while muted. Would you like to keep it enabled?</source>

--- a/src/mumble/mumble_el.ts
+++ b/src/mumble/mumble_el.ts
@@ -4203,6 +4203,10 @@ This field describes the size of an LCD device. The size is given either in pixe
         <translation>Προσωπικό γραπτό μήνυμα</translation>
     </message>
     <message>
+        <source>Whisper hold changed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>the server</source>
         <translation>ο διακομιστής</translation>
     </message>
@@ -6944,6 +6948,37 @@ the channel&apos;s context menu.</source>
     </message>
     <message>
         <source>This will check if mumble is up to date</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Whisper Hold</source>
+        <comment>Global Shortcut</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hold voice activation or continuous transmission on the configured Whisper/Shout target.</source>
+        <comment>Global Shortcut</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>This latches or unlatches the configured Whisper/Shout target while using voice activation or continuous transmission. Pressing a different Whisper Hold shortcut switches transmission to that target.</source>
+        <comment>Global Shortcut</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Whisper hold cleared: Push-to-Talk enabled.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Whisper hold cleared.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Whisper held to: %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Whisper hold cleared: Shortcuts changed.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/src/mumble/mumble_en.ts
+++ b/src/mumble/mumble_en.ts
@@ -4143,6 +4143,10 @@ This field describes the size of an LCD device. The size is given either in pixe
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <source>Whisper hold changed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>the server</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6876,6 +6880,37 @@ the channel&apos;s context menu.</source>
     </message>
     <message>
         <source>This will check if mumble is up to date</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Whisper Hold</source>
+        <comment>Global Shortcut</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hold voice activation or continuous transmission on the configured Whisper/Shout target.</source>
+        <comment>Global Shortcut</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>This latches or unlatches the configured Whisper/Shout target while using voice activation or continuous transmission. Pressing a different Whisper Hold shortcut switches transmission to that target.</source>
+        <comment>Global Shortcut</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Whisper hold cleared: Push-to-Talk enabled.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Whisper hold cleared.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Whisper held to: %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Whisper hold cleared: Shortcuts changed.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/src/mumble/mumble_en_GB.ts
+++ b/src/mumble/mumble_en_GB.ts
@@ -4011,22 +4011,22 @@ Without this option enabled, using Mumble&apos;s global shortcuts in privileged 
     <name>GlobalShortcutWin</name>
     <message>
         <source>Mouse</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">Mouse</translation>
     </message>
     <message>
         <source>Keyboard</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">Keyboard</translation>
     </message>
 </context>
 <context>
     <name>GlobalShortcutX</name>
     <message>
         <source>Keyboard</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">Keyboard</translation>
     </message>
     <message>
         <source>Mouse</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">Mouse</translation>
     </message>
 </context>
 <context>
@@ -4195,6 +4195,10 @@ This field describes the size of an LCD device. The size is given either in pixe
     </message>
     <message>
         <source>Private text message</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Whisper hold changed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -4618,11 +4622,11 @@ This setting only applies to new messages; existing messages keep the previous t
     </message>
     <message>
         <source>checked</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">checked</translation>
     </message>
     <message>
         <source>unchecked</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">unchecked</translation>
     </message>
     <message>
         <source>decibels</source>
@@ -6936,6 +6940,37 @@ the channel&apos;s context menu.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <source>Whisper Hold</source>
+        <comment>Global Shortcut</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hold voice activation or continuous transmission on the configured Whisper/Shout target.</source>
+        <comment>Global Shortcut</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>This latches or unlatches the configured Whisper/Shout target while using voice activation or continuous transmission. Pressing a different Whisper Hold shortcut switches transmission to that target.</source>
+        <comment>Global Shortcut</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Whisper hold cleared: Push-to-Talk enabled.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Whisper hold cleared.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Whisper held to: %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Whisper hold cleared: Shortcuts changed.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>That sound was the mute cue. It activates when you speak while muted. Would you like to keep it enabled?</source>
         <translation type="unfinished"></translation>
     </message>
@@ -8221,11 +8256,11 @@ To upgrade these files to their latest versions, click the button below.</source
     </message>
     <message>
         <source>checked</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">checked</translation>
     </message>
     <message>
         <source>unchecked</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">unchecked</translation>
     </message>
     <message>
         <source>Not available</source>
@@ -9115,7 +9150,7 @@ See &lt;a href=&quot;https://github.com/mumble-voip/mumble&quot;&gt;the project 
     <name>ShortcutActionWidget</name>
     <message>
         <source>Unassigned</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">Unassigned</translation>
     </message>
 </context>
 <context>
@@ -9134,7 +9169,7 @@ See &lt;a href=&quot;https://github.com/mumble-voip/mumble&quot;&gt;the project 
     </message>
     <message>
         <source>Unassigned</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">Unassigned</translation>
     </message>
     <message>
         <source>No buttons assigned</source>

--- a/src/mumble/mumble_eo.ts
+++ b/src/mumble/mumble_eo.ts
@@ -4154,6 +4154,10 @@ This field describes the size of an LCD device. The size is given either in pixe
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <source>Whisper hold changed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>the server</source>
         <translation>la servilo</translation>
     </message>
@@ -6889,6 +6893,37 @@ the channel&apos;s context menu.</source>
     </message>
     <message>
         <source>This will check if mumble is up to date</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Whisper Hold</source>
+        <comment>Global Shortcut</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hold voice activation or continuous transmission on the configured Whisper/Shout target.</source>
+        <comment>Global Shortcut</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>This latches or unlatches the configured Whisper/Shout target while using voice activation or continuous transmission. Pressing a different Whisper Hold shortcut switches transmission to that target.</source>
+        <comment>Global Shortcut</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Whisper hold cleared: Push-to-Talk enabled.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Whisper hold cleared.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Whisper held to: %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Whisper hold cleared: Shortcuts changed.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/src/mumble/mumble_es.ts
+++ b/src/mumble/mumble_es.ts
@@ -4204,6 +4204,10 @@ Este campo describe el tamaño de un dispositivo LCD. El tamaño se da, o bien e
         <translation>Mensaje privado de texto</translation>
     </message>
     <message>
+        <source>Whisper hold changed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>the server</source>
         <translation>el servidor</translation>
     </message>
@@ -6946,6 +6950,37 @@ en el menu contextual del canal.</translation>
     <message>
         <source>This will check if mumble is up to date</source>
         <translation>Esto comprobará si Mumble está actualizado</translation>
+    </message>
+    <message>
+        <source>Whisper Hold</source>
+        <comment>Global Shortcut</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hold voice activation or continuous transmission on the configured Whisper/Shout target.</source>
+        <comment>Global Shortcut</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>This latches or unlatches the configured Whisper/Shout target while using voice activation or continuous transmission. Pressing a different Whisper Hold shortcut switches transmission to that target.</source>
+        <comment>Global Shortcut</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Whisper hold cleared: Push-to-Talk enabled.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Whisper hold cleared.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Whisper held to: %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Whisper hold cleared: Shortcuts changed.</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>That sound was the mute cue. It activates when you speak while muted. Would you like to keep it enabled?</source>

--- a/src/mumble/mumble_et.ts
+++ b/src/mumble/mumble_et.ts
@@ -4145,6 +4145,10 @@ This field describes the size of an LCD device. The size is given either in pixe
         <translation>Privaatne tekstisõnum</translation>
     </message>
     <message>
+        <source>Whisper hold changed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>the server</source>
         <translation>server</translation>
     </message>
@@ -6878,6 +6882,37 @@ the channel&apos;s context menu.</source>
     </message>
     <message>
         <source>This will check if mumble is up to date</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Whisper Hold</source>
+        <comment>Global Shortcut</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hold voice activation or continuous transmission on the configured Whisper/Shout target.</source>
+        <comment>Global Shortcut</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>This latches or unlatches the configured Whisper/Shout target while using voice activation or continuous transmission. Pressing a different Whisper Hold shortcut switches transmission to that target.</source>
+        <comment>Global Shortcut</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Whisper hold cleared: Push-to-Talk enabled.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Whisper hold cleared.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Whisper held to: %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Whisper hold cleared: Shortcuts changed.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/src/mumble/mumble_eu.ts
+++ b/src/mumble/mumble_eu.ts
@@ -4161,6 +4161,10 @@ This field describes the size of an LCD device. The size is given either in pixe
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <source>Whisper hold changed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>the server</source>
         <translation>zerbitzaria</translation>
     </message>
@@ -6896,6 +6900,37 @@ the channel&apos;s context menu.</source>
     </message>
     <message>
         <source>This will check if mumble is up to date</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Whisper Hold</source>
+        <comment>Global Shortcut</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hold voice activation or continuous transmission on the configured Whisper/Shout target.</source>
+        <comment>Global Shortcut</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>This latches or unlatches the configured Whisper/Shout target while using voice activation or continuous transmission. Pressing a different Whisper Hold shortcut switches transmission to that target.</source>
+        <comment>Global Shortcut</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Whisper hold cleared: Push-to-Talk enabled.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Whisper hold cleared.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Whisper held to: %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Whisper hold cleared: Shortcuts changed.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/src/mumble/mumble_fa_IR.ts
+++ b/src/mumble/mumble_fa_IR.ts
@@ -4145,6 +4145,10 @@ This field describes the size of an LCD device. The size is given either in pixe
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <source>Whisper hold changed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>the server</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6878,6 +6882,37 @@ the channel&apos;s context menu.</source>
     </message>
     <message>
         <source>This will check if mumble is up to date</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Whisper Hold</source>
+        <comment>Global Shortcut</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hold voice activation or continuous transmission on the configured Whisper/Shout target.</source>
+        <comment>Global Shortcut</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>This latches or unlatches the configured Whisper/Shout target while using voice activation or continuous transmission. Pressing a different Whisper Hold shortcut switches transmission to that target.</source>
+        <comment>Global Shortcut</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Whisper hold cleared: Push-to-Talk enabled.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Whisper hold cleared.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Whisper held to: %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Whisper hold cleared: Shortcuts changed.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/src/mumble/mumble_fi.ts
+++ b/src/mumble/mumble_fi.ts
@@ -4203,6 +4203,10 @@ Kenttä kuvaa LCD-laitteen koon. Koko annetaan joko pikseleinä (graafinen LCD) 
         <translation>Yksityinen tekstiviesti</translation>
     </message>
     <message>
+        <source>Whisper hold changed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>the server</source>
         <translation>palvelin</translation>
     </message>
@@ -6945,6 +6949,37 @@ kanavien alivalikosta.</translation>
     <message>
         <source>This will check if mumble is up to date</source>
         <translation>Tämä tarkistaa onko mumble ajantasalla</translation>
+    </message>
+    <message>
+        <source>Whisper Hold</source>
+        <comment>Global Shortcut</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hold voice activation or continuous transmission on the configured Whisper/Shout target.</source>
+        <comment>Global Shortcut</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>This latches or unlatches the configured Whisper/Shout target while using voice activation or continuous transmission. Pressing a different Whisper Hold shortcut switches transmission to that target.</source>
+        <comment>Global Shortcut</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Whisper hold cleared: Push-to-Talk enabled.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Whisper hold cleared.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Whisper held to: %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Whisper hold cleared: Shortcuts changed.</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>That sound was the mute cue. It activates when you speak while muted. Would you like to keep it enabled?</source>

--- a/src/mumble/mumble_fr.ts
+++ b/src/mumble/mumble_fr.ts
@@ -4203,6 +4203,10 @@ Ce champ décrit la taille d&apos;un périphérique LCD. La taille est donnée e
         <translation>Message privé textuel</translation>
     </message>
     <message>
+        <source>Whisper hold changed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>the server</source>
         <translation>le serveur</translation>
     </message>
@@ -6945,6 +6949,37 @@ pour filtrage depuis le menu du salon.</translation>
     <message>
         <source>This will check if mumble is up to date</source>
         <translation>Ceci vérifiera si mumble est à jour</translation>
+    </message>
+    <message>
+        <source>Whisper Hold</source>
+        <comment>Global Shortcut</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hold voice activation or continuous transmission on the configured Whisper/Shout target.</source>
+        <comment>Global Shortcut</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>This latches or unlatches the configured Whisper/Shout target while using voice activation or continuous transmission. Pressing a different Whisper Hold shortcut switches transmission to that target.</source>
+        <comment>Global Shortcut</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Whisper hold cleared: Push-to-Talk enabled.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Whisper hold cleared.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Whisper held to: %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Whisper hold cleared: Shortcuts changed.</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>That sound was the mute cue. It activates when you speak while muted. Would you like to keep it enabled?</source>

--- a/src/mumble/mumble_gl.ts
+++ b/src/mumble/mumble_gl.ts
@@ -4146,6 +4146,10 @@ This field describes the size of an LCD device. The size is given either in pixe
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <source>Whisper hold changed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>the server</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6879,6 +6883,37 @@ the channel&apos;s context menu.</source>
     </message>
     <message>
         <source>This will check if mumble is up to date</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Whisper Hold</source>
+        <comment>Global Shortcut</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hold voice activation or continuous transmission on the configured Whisper/Shout target.</source>
+        <comment>Global Shortcut</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>This latches or unlatches the configured Whisper/Shout target while using voice activation or continuous transmission. Pressing a different Whisper Hold shortcut switches transmission to that target.</source>
+        <comment>Global Shortcut</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Whisper hold cleared: Push-to-Talk enabled.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Whisper hold cleared.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Whisper held to: %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Whisper hold cleared: Shortcuts changed.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/src/mumble/mumble_he.ts
+++ b/src/mumble/mumble_he.ts
@@ -4195,6 +4195,10 @@ This field describes the size of an LCD device. The size is given either in pixe
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <source>Whisper hold changed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>the server</source>
         <translation>השרת</translation>
     </message>
@@ -6931,6 +6935,37 @@ the channel&apos;s context menu.</source>
     </message>
     <message>
         <source>This will check if mumble is up to date</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Whisper Hold</source>
+        <comment>Global Shortcut</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hold voice activation or continuous transmission on the configured Whisper/Shout target.</source>
+        <comment>Global Shortcut</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>This latches or unlatches the configured Whisper/Shout target while using voice activation or continuous transmission. Pressing a different Whisper Hold shortcut switches transmission to that target.</source>
+        <comment>Global Shortcut</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Whisper hold cleared: Push-to-Talk enabled.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Whisper hold cleared.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Whisper held to: %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Whisper hold cleared: Shortcuts changed.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/src/mumble/mumble_hi.ts
+++ b/src/mumble/mumble_hi.ts
@@ -4172,6 +4172,10 @@ This field describes the size of an LCD device. The size is given either in pixe
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <source>Whisper hold changed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Plugin message</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5928,6 +5932,21 @@ the channel&apos;s context menu.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <source>Whisper Hold</source>
+        <comment>Global Shortcut</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hold voice activation or continuous transmission on the configured Whisper/Shout target.</source>
+        <comment>Global Shortcut</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>This latches or unlatches the configured Whisper/Shout target while using voice activation or continuous transmission. Pressing a different Whisper Hold shortcut switches transmission to that target.</source>
+        <comment>Global Shortcut</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>&amp;Window</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6012,6 +6031,10 @@ the channel&apos;s context menu.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <source>Whisper hold cleared: Push-to-Talk enabled.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Transmit Mode set to Continuous</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6061,6 +6084,14 @@ the channel&apos;s context menu.</source>
     </message>
     <message>
         <source>Reconnecting.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Whisper hold cleared.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Whisper held to: %1.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -6845,6 +6876,10 @@ the channel&apos;s context menu.</source>
     </message>
     <message>
         <source>This will check if mumble is up to date</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Whisper hold cleared: Shortcuts changed.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/src/mumble/mumble_hu.ts
+++ b/src/mumble/mumble_hu.ts
@@ -4191,6 +4191,10 @@ Ez a mező mutatja egy LCD eszköz méretét. A méret vagy pixelben (a grafikus
         <translation>Privát üzenet</translation>
     </message>
     <message>
+        <source>Whisper hold changed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>the server</source>
         <translation>A kiszolgáló</translation>
     </message>
@@ -6925,6 +6929,37 @@ the channel&apos;s context menu.</source>
     </message>
     <message>
         <source>This will check if mumble is up to date</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Whisper Hold</source>
+        <comment>Global Shortcut</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hold voice activation or continuous transmission on the configured Whisper/Shout target.</source>
+        <comment>Global Shortcut</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>This latches or unlatches the configured Whisper/Shout target while using voice activation or continuous transmission. Pressing a different Whisper Hold shortcut switches transmission to that target.</source>
+        <comment>Global Shortcut</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Whisper hold cleared: Push-to-Talk enabled.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Whisper hold cleared.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Whisper held to: %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Whisper hold cleared: Shortcuts changed.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/src/mumble/mumble_it.ts
+++ b/src/mumble/mumble_it.ts
@@ -4203,6 +4203,10 @@ Questo campo descrive la dimensione di un dispositivo LCD. La dimensione è espr
         <translation>Messaggio di testo privato</translation>
     </message>
     <message>
+        <source>Whisper hold changed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>the server</source>
         <translation>il server</translation>
     </message>
@@ -6945,6 +6949,37 @@ contestuale del canale.</translation>
     <message>
         <source>This will check if mumble is up to date</source>
         <translation>Questo controllerà se Mumble sia aggiornato</translation>
+    </message>
+    <message>
+        <source>Whisper Hold</source>
+        <comment>Global Shortcut</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hold voice activation or continuous transmission on the configured Whisper/Shout target.</source>
+        <comment>Global Shortcut</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>This latches or unlatches the configured Whisper/Shout target while using voice activation or continuous transmission. Pressing a different Whisper Hold shortcut switches transmission to that target.</source>
+        <comment>Global Shortcut</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Whisper hold cleared: Push-to-Talk enabled.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Whisper hold cleared.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Whisper held to: %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Whisper hold cleared: Shortcuts changed.</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>That sound was the mute cue. It activates when you speak while muted. Would you like to keep it enabled?</source>

--- a/src/mumble/mumble_ja.ts
+++ b/src/mumble/mumble_ja.ts
@@ -4195,6 +4195,10 @@ This field describes the size of an LCD device. The size is given either in pixe
         <translation>プライベートテキストメッセージ</translation>
     </message>
     <message>
+        <source>Whisper hold changed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>the server</source>
         <translation>サーバ</translation>
     </message>
@@ -6929,6 +6933,37 @@ the channel&apos;s context menu.</source>
     </message>
     <message>
         <source>This will check if mumble is up to date</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Whisper Hold</source>
+        <comment>Global Shortcut</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hold voice activation or continuous transmission on the configured Whisper/Shout target.</source>
+        <comment>Global Shortcut</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>This latches or unlatches the configured Whisper/Shout target while using voice activation or continuous transmission. Pressing a different Whisper Hold shortcut switches transmission to that target.</source>
+        <comment>Global Shortcut</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Whisper hold cleared: Push-to-Talk enabled.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Whisper hold cleared.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Whisper held to: %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Whisper hold cleared: Shortcuts changed.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/src/mumble/mumble_ko.ts
+++ b/src/mumble/mumble_ko.ts
@@ -4202,6 +4202,10 @@ This field describes the size of an LCD device. The size is given either in pixe
         <translation>개인 텍스트 메시지</translation>
     </message>
     <message>
+        <source>Whisper hold changed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>the server</source>
         <translation>서버</translation>
     </message>
@@ -6944,6 +6948,37 @@ the channel&apos;s context menu.</source>
     <message>
         <source>This will check if mumble is up to date</source>
         <translation>이 날짜까지 무상이 있는지 확인합니다</translation>
+    </message>
+    <message>
+        <source>Whisper Hold</source>
+        <comment>Global Shortcut</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hold voice activation or continuous transmission on the configured Whisper/Shout target.</source>
+        <comment>Global Shortcut</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>This latches or unlatches the configured Whisper/Shout target while using voice activation or continuous transmission. Pressing a different Whisper Hold shortcut switches transmission to that target.</source>
+        <comment>Global Shortcut</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Whisper hold cleared: Push-to-Talk enabled.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Whisper hold cleared.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Whisper held to: %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Whisper hold cleared: Shortcuts changed.</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>That sound was the mute cue. It activates when you speak while muted. Would you like to keep it enabled?</source>

--- a/src/mumble/mumble_lt.ts
+++ b/src/mumble/mumble_lt.ts
@@ -4176,6 +4176,10 @@ This field describes the size of an LCD device. The size is given either in pixe
         <translation>Privati tekstinė žinutė</translation>
     </message>
     <message>
+        <source>Whisper hold changed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>the server</source>
         <translation>Serveris</translation>
     </message>
@@ -6910,6 +6914,37 @@ the channel&apos;s context menu.</source>
     </message>
     <message>
         <source>This will check if mumble is up to date</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Whisper Hold</source>
+        <comment>Global Shortcut</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hold voice activation or continuous transmission on the configured Whisper/Shout target.</source>
+        <comment>Global Shortcut</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>This latches or unlatches the configured Whisper/Shout target while using voice activation or continuous transmission. Pressing a different Whisper Hold shortcut switches transmission to that target.</source>
+        <comment>Global Shortcut</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Whisper hold cleared: Push-to-Talk enabled.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Whisper hold cleared.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Whisper held to: %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Whisper hold cleared: Shortcuts changed.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/src/mumble/mumble_nl.ts
+++ b/src/mumble/mumble_nl.ts
@@ -4203,6 +4203,10 @@ Veld beschrijft LCD-apparaatgrootte aangeduid in pixels (voor Grafische LCD&apos
         <translation>Privé-tekstbericht</translation>
     </message>
     <message>
+        <source>Whisper hold changed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>the server</source>
         <translation>de server</translation>
     </message>
@@ -6944,6 +6948,37 @@ context-menu van het kanaal.</translation>
     </message>
     <message>
         <source>This will check if mumble is up to date</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Whisper Hold</source>
+        <comment>Global Shortcut</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hold voice activation or continuous transmission on the configured Whisper/Shout target.</source>
+        <comment>Global Shortcut</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>This latches or unlatches the configured Whisper/Shout target while using voice activation or continuous transmission. Pressing a different Whisper Hold shortcut switches transmission to that target.</source>
+        <comment>Global Shortcut</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Whisper hold cleared: Push-to-Talk enabled.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Whisper hold cleared.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Whisper held to: %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Whisper hold cleared: Shortcuts changed.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/src/mumble/mumble_no.ts
+++ b/src/mumble/mumble_no.ts
@@ -4217,6 +4217,10 @@ Dette feltet beskriver størrelsen på en LCD-enhet. Enten gitt i piksler (for g
         <translation>Privat tekstmelding</translation>
     </message>
     <message>
+        <source>Whisper hold changed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>the server</source>
         <translation>tjeneren</translation>
     </message>
@@ -6959,6 +6963,37 @@ Du kan markere ytterligere kanaler fra filtrering fra kanalens bindeleddsmeny.</
     </message>
     <message>
         <source>This will check if mumble is up to date</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Whisper Hold</source>
+        <comment>Global Shortcut</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hold voice activation or continuous transmission on the configured Whisper/Shout target.</source>
+        <comment>Global Shortcut</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>This latches or unlatches the configured Whisper/Shout target while using voice activation or continuous transmission. Pressing a different Whisper Hold shortcut switches transmission to that target.</source>
+        <comment>Global Shortcut</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Whisper hold cleared: Push-to-Talk enabled.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Whisper hold cleared.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Whisper held to: %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Whisper hold cleared: Shortcuts changed.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/src/mumble/mumble_oc.ts
+++ b/src/mumble/mumble_oc.ts
@@ -4145,6 +4145,10 @@ This field describes the size of an LCD device. The size is given either in pixe
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <source>Whisper hold changed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>the server</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6878,6 +6882,37 @@ the channel&apos;s context menu.</source>
     </message>
     <message>
         <source>This will check if mumble is up to date</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Whisper Hold</source>
+        <comment>Global Shortcut</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hold voice activation or continuous transmission on the configured Whisper/Shout target.</source>
+        <comment>Global Shortcut</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>This latches or unlatches the configured Whisper/Shout target while using voice activation or continuous transmission. Pressing a different Whisper Hold shortcut switches transmission to that target.</source>
+        <comment>Global Shortcut</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Whisper hold cleared: Push-to-Talk enabled.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Whisper hold cleared.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Whisper held to: %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Whisper hold cleared: Shortcuts changed.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/src/mumble/mumble_pl.ts
+++ b/src/mumble/mumble_pl.ts
@@ -4204,6 +4204,10 @@ Te pole opisuje rozmiar urządzenia LCD. Rozmiar jest podany w pikselach lub w z
         <translation>Prywatna wiadomość tekstowa</translation>
     </message>
     <message>
+        <source>Whisper hold changed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>the server</source>
         <translation>serwer</translation>
     </message>
@@ -6946,6 +6950,37 @@ kanały mają być filtrowane.</translation>
     <message>
         <source>This will check if mumble is up to date</source>
         <translation>Sprawdza, czy program Mumble jest aktualny</translation>
+    </message>
+    <message>
+        <source>Whisper Hold</source>
+        <comment>Global Shortcut</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hold voice activation or continuous transmission on the configured Whisper/Shout target.</source>
+        <comment>Global Shortcut</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>This latches or unlatches the configured Whisper/Shout target while using voice activation or continuous transmission. Pressing a different Whisper Hold shortcut switches transmission to that target.</source>
+        <comment>Global Shortcut</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Whisper hold cleared: Push-to-Talk enabled.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Whisper hold cleared.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Whisper held to: %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Whisper hold cleared: Shortcuts changed.</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>That sound was the mute cue. It activates when you speak while muted. Would you like to keep it enabled?</source>

--- a/src/mumble/mumble_pt_BR.ts
+++ b/src/mumble/mumble_pt_BR.ts
@@ -4203,6 +4203,10 @@ Este campo descreve o tamanho de um dispositivo LCD. O tamanho é dado em pixels
         <translation>Mensagem de texto privada</translation>
     </message>
     <message>
+        <source>Whisper hold changed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>the server</source>
         <translation>o servidor</translation>
     </message>
@@ -6944,6 +6948,37 @@ no menu contextual do canal.</translation>
     </message>
     <message>
         <source>This will check if mumble is up to date</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Whisper Hold</source>
+        <comment>Global Shortcut</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hold voice activation or continuous transmission on the configured Whisper/Shout target.</source>
+        <comment>Global Shortcut</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>This latches or unlatches the configured Whisper/Shout target while using voice activation or continuous transmission. Pressing a different Whisper Hold shortcut switches transmission to that target.</source>
+        <comment>Global Shortcut</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Whisper hold cleared: Push-to-Talk enabled.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Whisper hold cleared.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Whisper held to: %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Whisper hold cleared: Shortcuts changed.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/src/mumble/mumble_pt_PT.ts
+++ b/src/mumble/mumble_pt_PT.ts
@@ -4203,6 +4203,10 @@ Este campo descreve o tamanho de um aparelho LCD. O tamanho é dado em pixels (p
         <translation>Mensagem de texto privada</translation>
     </message>
     <message>
+        <source>Whisper hold changed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>the server</source>
         <translation>o servidor</translation>
     </message>
@@ -6944,6 +6948,37 @@ do menu de contexto do canal.</translation>
     </message>
     <message>
         <source>This will check if mumble is up to date</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Whisper Hold</source>
+        <comment>Global Shortcut</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hold voice activation or continuous transmission on the configured Whisper/Shout target.</source>
+        <comment>Global Shortcut</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>This latches or unlatches the configured Whisper/Shout target while using voice activation or continuous transmission. Pressing a different Whisper Hold shortcut switches transmission to that target.</source>
+        <comment>Global Shortcut</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Whisper hold cleared: Push-to-Talk enabled.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Whisper hold cleared.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Whisper held to: %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Whisper hold cleared: Shortcuts changed.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/src/mumble/mumble_ro.ts
+++ b/src/mumble/mumble_ro.ts
@@ -4153,6 +4153,10 @@ This field describes the size of an LCD device. The size is given either in pixe
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <source>Whisper hold changed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>the server</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6886,6 +6890,37 @@ the channel&apos;s context menu.</source>
     </message>
     <message>
         <source>This will check if mumble is up to date</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Whisper Hold</source>
+        <comment>Global Shortcut</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hold voice activation or continuous transmission on the configured Whisper/Shout target.</source>
+        <comment>Global Shortcut</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>This latches or unlatches the configured Whisper/Shout target while using voice activation or continuous transmission. Pressing a different Whisper Hold shortcut switches transmission to that target.</source>
+        <comment>Global Shortcut</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Whisper hold cleared: Push-to-Talk enabled.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Whisper hold cleared.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Whisper held to: %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Whisper hold cleared: Shortcuts changed.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/src/mumble/mumble_ru.ts
+++ b/src/mumble/mumble_ru.ts
@@ -4204,6 +4204,10 @@ This field describes the size of an LCD device. The size is given either in pixe
         <translation>Личное текстовое сообщение</translation>
     </message>
     <message>
+        <source>Whisper hold changed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>the server</source>
         <translation>Сервер</translation>
     </message>
@@ -6948,6 +6952,37 @@ the channel&apos;s context menu.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <source>Whisper Hold</source>
+        <comment>Global Shortcut</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hold voice activation or continuous transmission on the configured Whisper/Shout target.</source>
+        <comment>Global Shortcut</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>This latches or unlatches the configured Whisper/Shout target while using voice activation or continuous transmission. Pressing a different Whisper Hold shortcut switches transmission to that target.</source>
+        <comment>Global Shortcut</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Whisper hold cleared: Push-to-Talk enabled.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Whisper hold cleared.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Whisper held to: %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Whisper hold cleared: Shortcuts changed.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>That sound was the mute cue. It activates when you speak while muted. Would you like to keep it enabled?</source>
         <translation>Сейчас прозвучал сигнал заглушения. Это происходит, когда вы говорите при заглушенном микрофоне. Хотите оставить его включенным?</translation>
     </message>
@@ -7335,7 +7370,7 @@ the channel&apos;s context menu.</source>
     </message>
     <message>
         <source>Silent user display time (in seconds)</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">Время отображения без звука для пользователя (в секундах)</translation>
     </message>
     <message>
         <source>Listener azimuth (in degrees)</source>

--- a/src/mumble/mumble_si.ts
+++ b/src/mumble/mumble_si.ts
@@ -4167,6 +4167,10 @@ This field describes the size of an LCD device. The size is given either in pixe
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <source>Whisper hold changed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>the server</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5869,6 +5873,21 @@ the channel&apos;s context menu.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <source>Whisper Hold</source>
+        <comment>Global Shortcut</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hold voice activation or continuous transmission on the configured Whisper/Shout target.</source>
+        <comment>Global Shortcut</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>This latches or unlatches the configured Whisper/Shout target while using voice activation or continuous transmission. Pressing a different Whisper Hold shortcut switches transmission to that target.</source>
+        <comment>Global Shortcut</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>&amp;Window</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5925,6 +5944,10 @@ the channel&apos;s context menu.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <source>Whisper hold cleared: Push-to-Talk enabled.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Opening URL %1</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5954,6 +5977,14 @@ the channel&apos;s context menu.</source>
     </message>
     <message>
         <source>Reconnecting.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Whisper hold cleared.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Whisper held to: %1.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -6840,6 +6871,10 @@ the channel&apos;s context menu.</source>
     </message>
     <message>
         <source>This will check if mumble is up to date</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Whisper hold cleared: Shortcuts changed.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/src/mumble/mumble_sk.ts
+++ b/src/mumble/mumble_sk.ts
@@ -4171,6 +4171,10 @@ This field describes the size of an LCD device. The size is given either in pixe
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <source>Whisper hold changed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Plugin message</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5909,6 +5913,21 @@ the channel&apos;s context menu.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <source>Whisper Hold</source>
+        <comment>Global Shortcut</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hold voice activation or continuous transmission on the configured Whisper/Shout target.</source>
+        <comment>Global Shortcut</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>This latches or unlatches the configured Whisper/Shout target while using voice activation or continuous transmission. Pressing a different Whisper Hold shortcut switches transmission to that target.</source>
+        <comment>Global Shortcut</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>&amp;Window</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5985,6 +6004,10 @@ the channel&apos;s context menu.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <source>Whisper hold cleared: Push-to-Talk enabled.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Transmit Mode set to Continuous</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6030,6 +6053,14 @@ the channel&apos;s context menu.</source>
     </message>
     <message>
         <source>Reconnecting.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Whisper hold cleared.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Whisper held to: %1.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -6844,6 +6875,10 @@ the channel&apos;s context menu.</source>
     </message>
     <message>
         <source>This will check if mumble is up to date</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Whisper hold cleared: Shortcuts changed.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/src/mumble/mumble_sq.ts
+++ b/src/mumble/mumble_sq.ts
@@ -4173,6 +4173,10 @@ This field describes the size of an LCD device. The size is given either in pixe
         <translation>Përdoruesi reshti së dëgjuari kanalin</translation>
     </message>
     <message>
+        <source>Whisper hold changed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Plugin message</source>
         <translation>Mesazh shtojce</translation>
     </message>
@@ -5992,6 +5996,21 @@ the channel&apos;s context menu.</source>
         <translation>Dukshmëri</translation>
     </message>
     <message>
+        <source>Whisper Hold</source>
+        <comment>Global Shortcut</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hold voice activation or continuous transmission on the configured Whisper/Shout target.</source>
+        <comment>Global Shortcut</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>This latches or unlatches the configured Whisper/Shout target while using voice activation or continuous transmission. Pressing a different Whisper Hold shortcut switches transmission to that target.</source>
+        <comment>Global Shortcut</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>&amp;Window</source>
         <translation>&amp;Dritare</translation>
     </message>
@@ -6048,6 +6067,10 @@ the channel&apos;s context menu.</source>
         <translation>S’u ruajt dot figura: %1</translation>
     </message>
     <message>
+        <source>Whisper hold cleared: Push-to-Talk enabled.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Transmit Mode set to Continuous</source>
         <translation>Filtri jetpack_offline_mode është caktuar si &lt;em&gt;true&lt;/em&gt;.</translation>
     </message>
@@ -6090,6 +6113,14 @@ the channel&apos;s context menu.</source>
     <message>
         <source>Reconnecting.</source>
         <translation>Rilidhje e Jetpack-ut</translation>
+    </message>
+    <message>
+        <source>Whisper hold cleared.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Whisper held to: %1.</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Change your comment</source>
@@ -6949,6 +6980,10 @@ the channel&apos;s context menu.</source>
     <message>
         <source>This will check if mumble is up to date</source>
         <translation>Kjo do të kontrollojë nëse Mumble-i shtë i përditësuar</translation>
+    </message>
+    <message>
+        <source>Whisper hold cleared: Shortcuts changed.</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>That sound was the mute cue. It activates when you speak while muted. Would you like to keep it enabled?</source>

--- a/src/mumble/mumble_sv.ts
+++ b/src/mumble/mumble_sv.ts
@@ -4203,6 +4203,10 @@ Detta fält beskriver storleken av en LCD-enhet. Storleken mäts i pixlar (för 
         <translation>Privat textmeddelande</translation>
     </message>
     <message>
+        <source>Whisper hold changed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>the server</source>
         <translation>servern</translation>
     </message>
@@ -6945,6 +6949,37 @@ kanalens innehållsmeny.</translation>
     <message>
         <source>This will check if mumble is up to date</source>
         <translation>Detta kontrollerar om mumble är uppdaterat</translation>
+    </message>
+    <message>
+        <source>Whisper Hold</source>
+        <comment>Global Shortcut</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hold voice activation or continuous transmission on the configured Whisper/Shout target.</source>
+        <comment>Global Shortcut</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>This latches or unlatches the configured Whisper/Shout target while using voice activation or continuous transmission. Pressing a different Whisper Hold shortcut switches transmission to that target.</source>
+        <comment>Global Shortcut</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Whisper hold cleared: Push-to-Talk enabled.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Whisper hold cleared.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Whisper held to: %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Whisper hold cleared: Shortcuts changed.</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>That sound was the mute cue. It activates when you speak while muted. Would you like to keep it enabled?</source>

--- a/src/mumble/mumble_te.ts
+++ b/src/mumble/mumble_te.ts
@@ -4156,6 +4156,10 @@ This field describes the size of an LCD device. The size is given either in pixe
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <source>Whisper hold changed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>the server</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6889,6 +6893,37 @@ the channel&apos;s context menu.</source>
     </message>
     <message>
         <source>This will check if mumble is up to date</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Whisper Hold</source>
+        <comment>Global Shortcut</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hold voice activation or continuous transmission on the configured Whisper/Shout target.</source>
+        <comment>Global Shortcut</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>This latches or unlatches the configured Whisper/Shout target while using voice activation or continuous transmission. Pressing a different Whisper Hold shortcut switches transmission to that target.</source>
+        <comment>Global Shortcut</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Whisper hold cleared: Push-to-Talk enabled.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Whisper hold cleared.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Whisper held to: %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Whisper hold cleared: Shortcuts changed.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/src/mumble/mumble_th.ts
+++ b/src/mumble/mumble_th.ts
@@ -4143,6 +4143,10 @@ This field describes the size of an LCD device. The size is given either in pixe
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <source>Whisper hold changed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>the server</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6876,6 +6880,37 @@ the channel&apos;s context menu.</source>
     </message>
     <message>
         <source>This will check if mumble is up to date</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Whisper Hold</source>
+        <comment>Global Shortcut</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hold voice activation or continuous transmission on the configured Whisper/Shout target.</source>
+        <comment>Global Shortcut</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>This latches or unlatches the configured Whisper/Shout target while using voice activation or continuous transmission. Pressing a different Whisper Hold shortcut switches transmission to that target.</source>
+        <comment>Global Shortcut</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Whisper hold cleared: Push-to-Talk enabled.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Whisper hold cleared.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Whisper held to: %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Whisper hold cleared: Shortcuts changed.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/src/mumble/mumble_tr.ts
+++ b/src/mumble/mumble_tr.ts
@@ -4202,6 +4202,10 @@ Bu alan LCD aygıtın boyutunu belirtir. Boyut ya piksel olarak (Grafik LCD ekra
         <translation>Özel metin mesajı</translation>
     </message>
     <message>
+        <source>Whisper hold changed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>the server</source>
         <translation>sunucu</translation>
     </message>
@@ -6944,6 +6948,37 @@ filtrelenmesi için ilave kanallar ekleyebilirsiniz.</translation>
     <message>
         <source>This will check if mumble is up to date</source>
         <translation>Bu, mumble&apos;ın güncel olup olmadığını kontrol edecektir</translation>
+    </message>
+    <message>
+        <source>Whisper Hold</source>
+        <comment>Global Shortcut</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hold voice activation or continuous transmission on the configured Whisper/Shout target.</source>
+        <comment>Global Shortcut</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>This latches or unlatches the configured Whisper/Shout target while using voice activation or continuous transmission. Pressing a different Whisper Hold shortcut switches transmission to that target.</source>
+        <comment>Global Shortcut</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Whisper hold cleared: Push-to-Talk enabled.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Whisper hold cleared.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Whisper held to: %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Whisper hold cleared: Shortcuts changed.</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>That sound was the mute cue. It activates when you speak while muted. Would you like to keep it enabled?</source>

--- a/src/mumble/mumble_uk.ts
+++ b/src/mumble/mumble_uk.ts
@@ -4204,6 +4204,10 @@ This field describes the size of an LCD device. The size is given either in pixe
         <translation>Приватне текстове повідомлення</translation>
     </message>
     <message>
+        <source>Whisper hold changed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>the server</source>
         <translation>сервер</translation>
     </message>
@@ -6946,6 +6950,37 @@ the channel&apos;s context menu.</source>
     <message>
         <source>This will check if mumble is up to date</source>
         <translation>Це перевірить, чи Mumble оновлено</translation>
+    </message>
+    <message>
+        <source>Whisper Hold</source>
+        <comment>Global Shortcut</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hold voice activation or continuous transmission on the configured Whisper/Shout target.</source>
+        <comment>Global Shortcut</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>This latches or unlatches the configured Whisper/Shout target while using voice activation or continuous transmission. Pressing a different Whisper Hold shortcut switches transmission to that target.</source>
+        <comment>Global Shortcut</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Whisper hold cleared: Push-to-Talk enabled.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Whisper hold cleared.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Whisper held to: %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Whisper hold cleared: Shortcuts changed.</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>That sound was the mute cue. It activates when you speak while muted. Would you like to keep it enabled?</source>

--- a/src/mumble/mumble_zh_CN.ts
+++ b/src/mumble/mumble_zh_CN.ts
@@ -4202,6 +4202,10 @@ This field describes the size of an LCD device. The size is given either in pixe
         <translation>私人文字消息</translation>
     </message>
     <message>
+        <source>Whisper hold changed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>the server</source>
         <translation>服务器</translation>
     </message>
@@ -6944,6 +6948,37 @@ the channel&apos;s context menu.</source>
     <message>
         <source>This will check if mumble is up to date</source>
         <translation>这会检查 Mumble 是否为最新版</translation>
+    </message>
+    <message>
+        <source>Whisper Hold</source>
+        <comment>Global Shortcut</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hold voice activation or continuous transmission on the configured Whisper/Shout target.</source>
+        <comment>Global Shortcut</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>This latches or unlatches the configured Whisper/Shout target while using voice activation or continuous transmission. Pressing a different Whisper Hold shortcut switches transmission to that target.</source>
+        <comment>Global Shortcut</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Whisper hold cleared: Push-to-Talk enabled.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Whisper hold cleared.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Whisper held to: %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Whisper hold cleared: Shortcuts changed.</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>That sound was the mute cue. It activates when you speak while muted. Would you like to keep it enabled?</source>

--- a/src/mumble/mumble_zh_HK.ts
+++ b/src/mumble/mumble_zh_HK.ts
@@ -4143,6 +4143,10 @@ This field describes the size of an LCD device. The size is given either in pixe
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <source>Whisper hold changed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>the server</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6878,6 +6882,37 @@ the channel&apos;s context menu.</source>
     </message>
     <message>
         <source>This will check if mumble is up to date</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Whisper Hold</source>
+        <comment>Global Shortcut</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hold voice activation or continuous transmission on the configured Whisper/Shout target.</source>
+        <comment>Global Shortcut</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>This latches or unlatches the configured Whisper/Shout target while using voice activation or continuous transmission. Pressing a different Whisper Hold shortcut switches transmission to that target.</source>
+        <comment>Global Shortcut</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Whisper hold cleared: Push-to-Talk enabled.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Whisper hold cleared.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Whisper held to: %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Whisper hold cleared: Shortcuts changed.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/src/mumble/mumble_zh_TW.ts
+++ b/src/mumble/mumble_zh_TW.ts
@@ -4174,6 +4174,10 @@ This field describes the size of an LCD device. The size is given either in pixe
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <source>Whisper hold changed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>the server</source>
         <translation>伺服器</translation>
     </message>
@@ -6908,6 +6912,37 @@ the channel&apos;s context menu.</source>
     </message>
     <message>
         <source>This will check if mumble is up to date</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Whisper Hold</source>
+        <comment>Global Shortcut</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hold voice activation or continuous transmission on the configured Whisper/Shout target.</source>
+        <comment>Global Shortcut</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>This latches or unlatches the configured Whisper/Shout target while using voice activation or continuous transmission. Pressing a different Whisper Hold shortcut switches transmission to that target.</source>
+        <comment>Global Shortcut</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Whisper hold cleared: Push-to-Talk enabled.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Whisper hold cleared.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Whisper held to: %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Whisper hold cleared: Shortcuts changed.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>


### PR DESCRIPTION
Currently, whispering requires setting a whisper/shout shortcut in settings for a designated target, then using that key as a push-to-talk key that overrides the current transmission target. This is fine in push-to-talk mode as it operates in a similar fashion with different key bindings set for other targets, but in automatic transmit modes (continuous/voice activation), this means you are forced to push-to-whisper, rather than just being able to latch to a target for some time while keeping your fingers free.

This branch implements a feature that allows the user to bind "Whisper Hold" keys for automatic transmission modes. In automatic modes it allows the user to latch the transmission target until the key is either pressed again, returning to default state (shout mode) or another whisper hold key is pressed, changing the target once again.

In addition, this feature rests beneath existing whisper/shout functionality, meaning that while latched to a whisper target, holding down a whisper/shout shortcut to any target will activate a temporary override, like a push-to-talk key.

The implementation reuses Mumble's existing whisper target routing functionality without any new audio packet path or server protocol. Whisper Hold stores its own latch state using:
- `bWhisperHoldActive`(user has latched a target)
- `bWhisperHoldTargetApplied` (latched target is currently in `qmCurrentTargets`
- `IWhisperShoutTargetsActive` (regular W/S PTT targets are active, including `pttHold`
- `ShortcutTarget` (selected latch target)

In push-to-talk it has no functionality and is therefore disabled. Switching to PTT through the toolbar, settings, or audio wizard clears the latch. Switching between continuous and voice activation does not clear the latch. The state is also automatically reset on app close, disconnect, or modifying shortcut settings.

The feature also adds a message type for whisper hold. It has no default sound but console is enabled, thus pressing the "Whisper Hold" shortcut for a given target will inform the user in the console that they are being held to a target or if the hold is cleared.

This is my first open-source contribution. It builds on Windows and passes my runtime testing in multiple servers.

Implements #6754 with additional functionality.

### Checks

- [x] My commits follow the [commit guidelines](https://github.com/mumble-voip/mumble/blob/master/COMMIT_GUIDELINES.md)

