### PR TITLE
(FIX): Memory leak when using a DS4 controller

### DIFF
--- a/src/mumble/GlobalShortcut_win.h
+++ b/src/mumble/GlobalShortcut_win.h
@@ -59,6 +59,8 @@ protected:
 
 		constexpr Type type() { return m_type; };
 
+		virtual ~MsgRaw() = default;
+
 	protected:
 		MsgRaw(const Type type) : m_type(type) {}
 


### PR DESCRIPTION
# Summary
When using a DS4 controller (only controller tested) it would create 64 byte unsigned char[] at a rapid pace. leading to commits of over 10gb, workingset >6.9gb, due to no deconstruction on `MsgRaw`.

## Rapid Object Collection
### Memory after a day or two idle.
<img width="2378" height="56" alt="image" src="https://github.com/user-attachments/assets/47953e4d-f461-474c-b928-e21979a9420b" />

## Object collection.

<img width="2560" height="1440" alt="image" src="https://github.com/user-attachments/assets/ca3fdb47-fe6f-4d4b-bd13-75e70d6502f4" />

## Linked HID
```
[054C:09CC] v0100
  Manufacturer : Sony Interactive Entertainment
  Product      : Wireless Controller
  Serial       : (none)
  Usage        : Page=0x0001  Usage=0x0005
  Reports      : IN=64  OUT=32  FEAT=64
  Path         : \\?\hid#vid_054c&pid_09cc&mi_03#8&73b0871&0&0000#{4d1e55b2-f16f-11cf-88cb-001111000030}

```

### Checks

- [x] My commits follow the [commit guidelines](https://github.com/mumble-voip/mumble/blob/master/COMMIT_GUIDELINES.md)

