### PR TITLE
FIX(server): Use of incorrect buffer size

### DIFF
--- a/src/murmur/Server.cpp
+++ b/src/murmur/Server.cpp
@@ -737,6 +737,11 @@ void Server::udpActivated(int socket) {
                      reinterpret_cast< struct sockaddr * >(&from), &fromlen);
 #endif
 
+	if (len < 0) {
+		// Socket error
+		return;
+	}
+
 	std::span< Mumble::Protocol::byte > inputData(&m_udpDecoder.getBuffer()[0], static_cast< std::size_t >(len));
 
 	if (bAllowPing && m_udpDecoder.decodePing(inputData)

--- a/src/murmur/Server.cpp
+++ b/src/murmur/Server.cpp
@@ -722,12 +722,12 @@ void Server::udpActivated(int socket) {
 	msg.msg_controllen = sizeof(controldata);
 
 	int &sock = socket;
-	len       = static_cast< qint32 >(::recvmsg(sock, &msg, MSG_TRUNC));
+	len       = static_cast< qint32 >(::recvmsg(sock, &msg, 0));
 #	else
 	socklen_t fromlen = sizeof(from);
 	int &sock         = socket;
-	len = static_cast< qint32 >(::recvfrom(sock, m_udpDecoder.getBuffer().data(), m_udpDecoder.getBuffer().size(),
-										   MSG_TRUNC, reinterpret_cast< struct sockaddr * >(&from), &fromlen));
+	len = static_cast< qint32 >(::recvfrom(sock, m_udpDecoder.getBuffer().data(), m_udpDecoder.getBuffer().size(), 0,
+										   reinterpret_cast< struct sockaddr * >(&from), &fromlen));
 #	endif
 #else
 	int fromlen = static_cast< int >(sizeof(from));
@@ -876,10 +876,10 @@ void Server::run() {
 				msg.msg_control    = controldata;
 				msg.msg_controllen = sizeof(controldata);
 
-				len = static_cast< qint32 >(::recvmsg(sock, &msg, MSG_TRUNC));
+				len = static_cast< qint32 >(::recvmsg(sock, &msg, 0));
 				Q_UNUSED(fromlen);
 #	else
-				len = static_cast< qint32 >(::recvfrom(sock, encrypt, Mumble::Protocol::MAX_UDP_PACKET_SIZE, MSG_TRUNC,
+				len = static_cast< qint32 >(::recvfrom(sock, encrypt, Mumble::Protocol::MAX_UDP_PACKET_SIZE, 0,
 													   reinterpret_cast< struct sockaddr * >(&from), &fromlen));
 #	endif
 #endif


### PR DESCRIPTION
In case the received message was larger than the buffer we provide, the message is truncated to the buffer's size. However, due to passing the MSG_TRUNC flag, the returned message size was the original message size. Hence, in cases where the message got truncated to fit in our buffer, the returned size was larger than our buffer. This lead to potentially using the buffer as larger than it actually is.


### Checks

- [x] My commits follow the [commit guidelines](https://github.com/mumble-voip/mumble/blob/master/COMMIT_GUIDELINES.md)

