### PR TITLE
Backport "Merge PR #7236: FIX(server): Use of incorrect buffer size" to 1.6.x

### DIFF
--- a/src/murmur/Server.cpp
+++ b/src/murmur/Server.cpp
@@ -737,6 +737,11 @@ void Server::udpActivated(int socket) {
                      reinterpret_cast< struct sockaddr * >(&from), &fromlen);
 #endif
 
+	if (len < 0) {
+		// Socket error
+		return;
+	}
+
 	std::span< Mumble::Protocol::byte > inputData(&m_udpDecoder.getBuffer()[0], static_cast< std::size_t >(len));
 
 	if (bAllowPing && m_udpDecoder.decodePing(inputData)

--- a/src/murmur/Server.cpp
+++ b/src/murmur/Server.cpp
@@ -722,12 +722,12 @@ void Server::udpActivated(int socket) {
 	msg.msg_controllen = sizeof(controldata);
 
 	int &sock = socket;
-	len       = static_cast< qint32 >(::recvmsg(sock, &msg, MSG_TRUNC));
+	len       = static_cast< qint32 >(::recvmsg(sock, &msg, 0));
 #	else
 	socklen_t fromlen = sizeof(from);
 	int &sock         = socket;
-	len = static_cast< qint32 >(::recvfrom(sock, m_udpDecoder.getBuffer().data(), m_udpDecoder.getBuffer().size(),
-										   MSG_TRUNC, reinterpret_cast< struct sockaddr * >(&from), &fromlen));
+	len = static_cast< qint32 >(::recvfrom(sock, m_udpDecoder.getBuffer().data(), m_udpDecoder.getBuffer().size(), 0,
+										   reinterpret_cast< struct sockaddr * >(&from), &fromlen));
 #	endif
 #else
 	int fromlen = static_cast< int >(sizeof(from));
@@ -876,10 +876,10 @@ void Server::run() {
 				msg.msg_control    = controldata;
 				msg.msg_controllen = sizeof(controldata);
 
-				len = static_cast< qint32 >(::recvmsg(sock, &msg, MSG_TRUNC));
+				len = static_cast< qint32 >(::recvmsg(sock, &msg, 0));
 				Q_UNUSED(fromlen);
 #	else
-				len = static_cast< qint32 >(::recvfrom(sock, encrypt, Mumble::Protocol::MAX_UDP_PACKET_SIZE, MSG_TRUNC,
+				len = static_cast< qint32 >(::recvfrom(sock, encrypt, Mumble::Protocol::MAX_UDP_PACKET_SIZE, 0,
 													   reinterpret_cast< struct sockaddr * >(&from), &fromlen));
 #	endif
 #endif


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `1.6.x`:
 - [Merge PR #7236: FIX(server): Use of incorrect buffer size](https://github.com/mumble-voip/mumble/pull/7236)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)