### PR TITLE
Backport "Merge PR #7235: (FIX): Memory leak when using a DS4 controller" to 1.6.x

### DIFF
--- a/src/mumble/GlobalShortcut_win.h
+++ b/src/mumble/GlobalShortcut_win.h
@@ -59,6 +59,8 @@ protected:
 
 		constexpr Type type() { return m_type; };
 
+		virtual ~MsgRaw() = default;
+
 	protected:
 		MsgRaw(const Type type) : m_type(type) {}
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `1.6.x`:
 - [Merge PR #7235: (FIX): Memory leak when using a DS4 controller](https://github.com/mumble-voip/mumble/pull/7235)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)