### PR TITLE
Backport "Merge PR #7241: FIX(client): Multiple workarounds around restoreState and restoreGeometry" to 1.6.x

### DIFF
--- a/src/mumble/ConfigDialog.cpp
+++ b/src/mumble/ConfigDialog.cpp
@@ -76,13 +76,6 @@ ConfigDialog::ConfigDialog(QWidget *p) : QDialog(p) {
 	restoreAllButton->setWhatsThis(tr("This button will restore the defaults for all settings."));
 	restoreAllButton->installEventFilter(new OverrideTabOrderFilter(restoreAllButton, applyButton));
 
-	if (!Global::get().s.qbaConfigGeometry.isEmpty()) {
-#ifdef USE_OVERLAY
-		if (!Global::get().ocIntercept)
-#endif
-			restoreGeometry(Global::get().s.qbaConfigGeometry);
-	}
-
 	updateTabOrder();
 	qlwIcons->setFocus();
 }
@@ -304,11 +297,6 @@ void ConfigDialog::apply() {
 
 void ConfigDialog::accept() {
 	apply();
-
-#ifdef USE_OVERLAY
-	if (!Global::get().ocIntercept)
-#endif
-		Global::get().s.qbaConfigGeometry = saveGeometry();
 
 	// Save settings to disk
 	Global::get().s.save();

--- a/src/mumble/ConnectDialog.cpp
+++ b/src/mumble/ConnectDialog.cpp
@@ -1102,11 +1102,6 @@ ConnectDialog::ConnectDialog(QWidget *p, bool autoconnect) : QDialog(p), bAutoCo
 
 	qmPingCache = Global::get().db->getPingCache();
 
-	if (!Global::get().s.qbaConnectDialogGeometry.isEmpty())
-		restoreGeometry(Global::get().s.qbaConnectDialogGeometry);
-	if (!Global::get().s.qbaConnectDialogHeader.isEmpty())
-		qtwServers->header()->restoreState(Global::get().s.qbaConnectDialogHeader);
-
 	setTabOrder(qtwServers, qleSearchServername);
 	setTabOrder(qleSearchServername, qcbSearchLocation);
 	setTabOrder(qcbSearchLocation, qcbFilter);
@@ -1138,9 +1133,6 @@ ConnectDialog::~ConnectDialog() {
 	}
 	Global::get().db->setFavorites(ql);
 	Global::get().db->setPingCache(qmPingCache);
-
-	Global::get().s.qbaConnectDialogHeader   = qtwServers->header()->saveState();
-	Global::get().s.qbaConnectDialogGeometry = saveGeometry();
 }
 
 void ConnectDialog::accept() {

--- a/src/mumble/MainWindow.cpp
+++ b/src/mumble/MainWindow.cpp
@@ -1439,41 +1439,53 @@ void MainWindow::loadState(const bool minimalView) {
 	// save the geometry and state again to disk.
 	// See: https://github.com/mumble-voip/mumble/issues/7193
 
-	if (minimalView) {
-		QByteArray geometry                    = Global::get().s.qbaMinimalViewGeometry;
-		QByteArray state                       = Global::get().s.qbaMinimalViewState;
-		Global::get().s.qbaMinimalViewGeometry = QByteArray();
-		Global::get().s.qbaMinimalViewState    = QByteArray();
-
-		Global::get().s.save();
-
-		if (!geometry.isEmpty()) {
-			restoreGeometry(geometry);
-		}
-		if (!state.isEmpty()) {
-			restoreState(state, stateVersion());
-		}
-	} else {
-		QByteArray geometry                   = Global::get().s.qbaMainWindowGeometry;
-		QByteArray state                      = Global::get().s.qbaMainWindowState;
-		Global::get().s.qbaMainWindowGeometry = QByteArray();
-		Global::get().s.qbaMainWindowState    = QByteArray();
-
-		Global::get().s.save();
-
-		if (!geometry.isEmpty()) {
-			restoreGeometry(geometry);
-		}
-		if (!state.isEmpty()) {
-			restoreState(state, stateVersion());
-		}
+	if (Global::get().s.preventWindowStates) {
+		qWarning() << "Restoring window state and geometry is blocked by settings latch";
+		return;
 	}
 
+	QByteArray geometry;
+	QByteArray state;
+
+	if (minimalView) {
+		geometry                               = Global::get().s.qbaMinimalViewGeometry;
+		state                                  = Global::get().s.qbaMinimalViewState;
+		Global::get().s.qbaMinimalViewGeometry = QByteArray();
+		Global::get().s.qbaMinimalViewState    = QByteArray();
+	} else {
+		geometry                              = Global::get().s.qbaMainWindowGeometry;
+		state                                 = Global::get().s.qbaMainWindowState;
+		Global::get().s.qbaMainWindowGeometry = QByteArray();
+		Global::get().s.qbaMainWindowState    = QByteArray();
+	}
+
+	// This will remain true permanently, if we crash during restore
+	Global::get().s.preventWindowStates = true;
+	Global::get().s.save();
+
+	qInfo() << "Trying to restore window state and geometry";
+
+	if (!geometry.isEmpty()) {
+		restoreGeometry(geometry);
+	}
+
+	if (!state.isEmpty()) {
+		restoreState(state, stateVersion());
+	}
+
+	qInfo() << "Successfully restored window state and geometry";
+
+	// Write everything back as we did not crash during the restore
+	Global::get().s.preventWindowStates = false;
 	storeState(minimalView);
 	Global::get().s.save();
 }
 
 void MainWindow::storeState(const bool minimalView) {
+	if (Global::get().s.preventWindowStates) {
+		return;
+	}
+
 	if (minimalView) {
 		Global::get().s.qbaMinimalViewGeometry = saveGeometry();
 		Global::get().s.qbaMinimalViewState    = saveState(stateVersion());

--- a/src/mumble/MainWindow.cpp
+++ b/src/mumble/MainWindow.cpp
@@ -1430,21 +1430,47 @@ void MainWindow::setOnTop(bool top) {
 }
 
 void MainWindow::loadState(const bool minimalView) {
+	// The Qt restoreGeometry and restoreState methods are very fragile and can crash the
+	// application. Even providing stateVersion() does not prevent all situations where a
+	// stored geometry or state will result in a crash loop.
+	// Hence, before trying to restore the state or geometry, we overwrite the current saved
+	// ones on disk. This prevents a crash loop as the second execution will have the variables
+	// unset. In case restoreGeometry and restoreState does not crash the application, we can
+	// save the geometry and state again to disk.
+	// See: https://github.com/mumble-voip/mumble/issues/7193
+
 	if (minimalView) {
-		if (!Global::get().s.qbaMinimalViewGeometry.isNull()) {
-			restoreGeometry(Global::get().s.qbaMinimalViewGeometry);
+		QByteArray geometry                    = Global::get().s.qbaMinimalViewGeometry;
+		QByteArray state                       = Global::get().s.qbaMinimalViewState;
+		Global::get().s.qbaMinimalViewGeometry = QByteArray();
+		Global::get().s.qbaMinimalViewState    = QByteArray();
+
+		Global::get().s.save();
+
+		if (!geometry.isEmpty()) {
+			restoreGeometry(geometry);
 		}
-		if (!Global::get().s.qbaMinimalViewState.isNull()) {
-			restoreState(Global::get().s.qbaMinimalViewState, stateVersion());
+		if (!state.isEmpty()) {
+			restoreState(state, stateVersion());
 		}
 	} else {
-		if (!Global::get().s.qbaMainWindowGeometry.isNull()) {
-			restoreGeometry(Global::get().s.qbaMainWindowGeometry);
+		QByteArray geometry                   = Global::get().s.qbaMainWindowGeometry;
+		QByteArray state                      = Global::get().s.qbaMainWindowState;
+		Global::get().s.qbaMainWindowGeometry = QByteArray();
+		Global::get().s.qbaMainWindowState    = QByteArray();
+
+		Global::get().s.save();
+
+		if (!geometry.isEmpty()) {
+			restoreGeometry(geometry);
 		}
-		if (!Global::get().s.qbaMainWindowState.isNull()) {
-			restoreState(Global::get().s.qbaMainWindowState, stateVersion());
+		if (!state.isEmpty()) {
+			restoreState(state, stateVersion());
 		}
 	}
+
+	storeState(minimalView);
+	Global::get().s.save();
 }
 
 void MainWindow::storeState(const bool minimalView) {

--- a/src/mumble/PTTButtonWidget.cpp
+++ b/src/mumble/PTTButtonWidget.cpp
@@ -11,13 +11,16 @@ PTTButtonWidget::PTTButtonWidget(QWidget *p) : QWidget(p) {
 
 	setWindowFlags(Qt::Tool | Qt::WindowStaysOnTopHint);
 
-	if (!Global::get().s.qbaPTTButtonWindowGeometry.isEmpty()) {
+	if (!Global::get().s.preventWindowStates && !Global::get().s.qbaPTTButtonWindowGeometry.isEmpty()) {
 		restoreGeometry(Global::get().s.qbaPTTButtonWindowGeometry);
 	}
 }
 
 void PTTButtonWidget::closeEvent(QCloseEvent *e) {
-	Global::get().s.qbaPTTButtonWindowGeometry = saveGeometry();
+	if (!Global::get().s.preventWindowStates) {
+		Global::get().s.qbaPTTButtonWindowGeometry = saveGeometry();
+	}
+
 	QWidget::closeEvent(e);
 }
 

--- a/src/mumble/Settings.cpp
+++ b/src/mumble/Settings.cpp
@@ -974,8 +974,6 @@ void Settings::legacyLoad(const QString &path) {
 	LOAD(bFilterActive, "ui/filteractive");
 	LOAD(qsImagePath, "ui/imagepath");
 	LOAD(bShowContextMenuInMenuBar, "ui/showcontextmenuinmenubar");
-	LOAD(qbaConnectDialogGeometry, "ui/connect/geometry");
-	LOAD(qbaConnectDialogHeader, "ui/connect/header");
 	LOAD(bShowTransmitModeComboBox, "ui/transmitmodecombobox");
 	LOAD(bHighContrast, "ui/HighContrast");
 	LOAD(iMaxLogBlocks, "ui/MaxLogBlocks");

--- a/src/mumble/Settings.cpp
+++ b/src/mumble/Settings.cpp
@@ -953,7 +953,6 @@ void Settings::legacyLoad(const QString &path) {
 	LOAD(qbaMainWindowState, "ui/state");
 	LOAD(qbaMinimalViewGeometry, "ui/minimalviewgeometry");
 	LOAD(qbaMinimalViewState, "ui/minimalviewstate");
-	LOAD(qbaConfigGeometry, "ui/ConfigGeometry");
 	LOADENUM(wlWindowLayout, "ui/WindowLayout");
 	LOAD(qsUsername, "ui/username");
 	LOAD(qsLastServer, "ui/server");

--- a/src/mumble/Settings.h
+++ b/src/mumble/Settings.h
@@ -419,6 +419,7 @@ struct Settings {
 	QByteArray qbaMainWindowState        = {};
 	QByteArray qbaMinimalViewGeometry    = {};
 	QByteArray qbaMinimalViewState       = {};
+	bool preventWindowStates             = false;
 	WindowLayout wlWindowLayout          = LayoutClassic;
 	ChannelExpand ceExpand               = ChannelsWithUsers;
 	ChannelDrag ceChannelDrag            = Ask;

--- a/src/mumble/Settings.h
+++ b/src/mumble/Settings.h
@@ -439,8 +439,6 @@ struct Settings {
 	bool bChatBarUseSelection            = false;
 	bool bFilterHidesEmptyChannels       = true;
 	bool bFilterActive                   = false;
-	QByteArray qbaConnectDialogHeader    = {};
-	QByteArray qbaConnectDialogGeometry  = {};
 	bool bShowContextMenuInMenuBar       = false;
 
 	// Search settings

--- a/src/mumble/Settings.h
+++ b/src/mumble/Settings.h
@@ -419,7 +419,6 @@ struct Settings {
 	QByteArray qbaMainWindowState        = {};
 	QByteArray qbaMinimalViewGeometry    = {};
 	QByteArray qbaMinimalViewState       = {};
-	QByteArray qbaConfigGeometry         = {};
 	WindowLayout wlWindowLayout          = LayoutClassic;
 	ChannelExpand ceExpand               = ChannelsWithUsers;
 	ChannelDrag ceChannelDrag            = Ask;

--- a/src/mumble/SettingsKeys.h
+++ b/src/mumble/SettingsKeys.h
@@ -187,6 +187,7 @@ const SettingsKey WINDOW_GEOMETRY_KEY                  = { "window_geometry" };
 const SettingsKey WINDOW_GEOMETRY_MINIMAL_VIEW_KEY     = { "minimal_view_window_geometry" };
 const SettingsKey WINDOW_STATE_KEY                     = { "window_state" };
 const SettingsKey WINDOW_STATE_MINIMAL_VIEW_KEY        = { "minimal_view_window_state" };
+const SettingsKey PREVENT_WINDOW_STATES_KEY            = { "prevent_window_states" };
 const SettingsKey CONFIG_GEOMETRY_KEY                  = { "config_geometry" };
 const SettingsKey WINDOW_LAYOUT_KEY                    = { "window_layout" };
 const SettingsKey OVERLAY_HEADER_STATE                 = { "overlay_header_state" };

--- a/src/mumble/SettingsMacros.h
+++ b/src/mumble/SettingsMacros.h
@@ -161,7 +161,6 @@
 	PROCESS(ui, WINDOW_GEOMETRY_MINIMAL_VIEW_KEY, qbaMinimalViewGeometry)        \
 	PROCESS(ui, WINDOW_STATE_KEY, qbaMainWindowState)                            \
 	PROCESS(ui, WINDOW_STATE_MINIMAL_VIEW_KEY, qbaMinimalViewState)              \
-	PROCESS(ui, CONFIG_GEOMETRY_KEY, qbaConfigGeometry)                          \
 	PROCESS(ui, WINDOW_LAYOUT_KEY, wlWindowLayout)                               \
 	PROCESS(ui, SERVER_FILTER_MODE_KEY, ssFilter)                                \
 	PROCESS(ui, HIDE_IN_TRAY_KEY, bHideInTray)                                   \

--- a/src/mumble/SettingsMacros.h
+++ b/src/mumble/SettingsMacros.h
@@ -174,8 +174,6 @@
 	PROCESS(ui, FILTER_HIDES_EMPTY_CHANNEL_KEY, bFilterHidesEmptyChannels)       \
 	PROCESS(ui, FILTER_ACTIVE_KEY, bFilterActive)                                \
 	PROCESS(ui, CONTEXT_MENU_ENTRIES_IN_MENU_BAR_KEY, bShowContextMenuInMenuBar) \
-	PROCESS(ui, CONNECT_DIALOG_GEOMETRY_KEY, qbaConnectDialogGeometry)           \
-	PROCESS(ui, CONNECT_DIALOG_HEADER_STATE_KEY, qbaConnectDialogHeader)         \
 	PROCESS(ui, DISPLAY_TRANSMIT_MODE_COMBOBOX_KEY, bShowTransmitModeComboBox)   \
 	PROCESS(ui, HIGH_CONTRAST_MODE_KEY, bHighContrast)                           \
 	PROCESS(ui, MAX_LOG_LENGTH_KEY, iMaxLogBlocks)                               \

--- a/src/mumble/SettingsMacros.h
+++ b/src/mumble/SettingsMacros.h
@@ -161,6 +161,7 @@
 	PROCESS(ui, WINDOW_GEOMETRY_MINIMAL_VIEW_KEY, qbaMinimalViewGeometry)        \
 	PROCESS(ui, WINDOW_STATE_KEY, qbaMainWindowState)                            \
 	PROCESS(ui, WINDOW_STATE_MINIMAL_VIEW_KEY, qbaMinimalViewState)              \
+	PROCESS(ui, PREVENT_WINDOW_STATES_KEY, preventWindowStates)                  \
 	PROCESS(ui, WINDOW_LAYOUT_KEY, wlWindowLayout)                               \
 	PROCESS(ui, SERVER_FILTER_MODE_KEY, ssFilter)                                \
 	PROCESS(ui, HIDE_IN_TRAY_KEY, bHideInTray)                                   \


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `1.6.x`:
 - [Merge PR #7241: FIX(client): Multiple workarounds around restoreState and restoreGeometry](https://github.com/mumble-voip/mumble/pull/7241)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)