### PR TITLE
FIX(client): Apply skipSettingsBackupPrompt flag for loading settings

### DIFF
--- a/src/mumble/main.cpp
+++ b/src/mumble/main.cpp
@@ -636,9 +636,9 @@ int main(int argc, char **argv) {
 
 	// Load preferences
 	if (settingsFile.isEmpty()) {
-		Global::get().s.load();
+		Global::get().s.load(options.skipSettingsBackupPrompt);
 	} else {
-		Global::get().s.load(settingsFile);
+		Global::get().s.load(settingsFile, options.skipSettingsBackupPrompt);
 	}
 	if (!Global::get().migratedDBPath.isEmpty()) {
 		// We have migrated the DB to a new location. Make sure that the settings hold the correct (new) path and that


### PR DESCRIPTION
During the rebase of #6243 onto a9b1356 this change was missed and the flag was not applied properly.

This commit adds back the flag to the loading function.