### PR TITLE
FEAT(protocol): Add chat history messages

### DIFF
--- a/src/Mumble.proto
+++ b/src/Mumble.proto
@@ -290,6 +290,69 @@ message TextMessage {
 	required string message = 5;
 }
 
+message ChatHistoryRequest {
+	// What kind of history the client is requesting.
+	enum Scope {
+		Channel = 0;
+		Direct = 1;
+	}
+
+	optional Scope scope = 1 [default = Channel];
+
+	// Used for channel history.
+	optional uint32 channel_id = 2;
+
+	// Used for direct/user history.
+	optional uint32 user_id = 3;
+
+	// Used for direct/session history, especially for unregistered users.
+	optional uint32 session = 4;
+
+	// Pagination cursor. If set, the server should return messages older than this id.
+	optional uint64 before_message_id = 5;
+
+	// Maximum number of messages requested.
+	optional uint32 limit = 6 [default = 50];
+}
+
+message ChatHistoryMessage {
+	// Stable server-side id of the stored message.
+	optional uint64 message_id = 1;
+
+	// Sender information.
+	optional uint32 actor_session = 2;
+	optional uint32 actor_user_id = 3;
+	optional string actor_name = 4;
+
+	// Original target information.
+	optional uint32 channel_id = 5;
+	repeated uint32 session = 6;
+	repeated uint32 user_id = 7;
+
+	// Unix timestamp in milliseconds.
+	optional uint64 timestamp_ms = 8;
+
+	// Message body. Same format expectations as TextMessage.
+	optional string message = 9;
+}
+
+message ChatHistoryChunk {
+	repeated ChatHistoryMessage messages = 1;
+
+	// Whether the server has older messages available for this query.
+	optional bool has_more = 2 [default = false];
+
+	// Echo of the request scope/target.
+	optional ChatHistoryRequest.Scope scope = 3 [default = Channel];
+	optional uint32 channel_id = 4;
+	optional uint32 user_id = 5;
+	optional uint32 session = 6;
+
+	// Useful cursors for the client.
+	optional uint64 oldest_message_id = 7;
+	optional uint64 newest_message_id = 8;
+}
+
 message PermissionDenied {
 	enum DenyType {
 		// Operation denied for other reason, see reason field.

--- a/src/MumbleProtocol.h
+++ b/src/MumbleProtocol.h
@@ -21,34 +21,36 @@
  *
  * Warning: Only append to the end. Never insert in between or remove an existing entry.
  */
-#define MUMBLE_ALL_TCP_MESSAGES                         \
-	PROCESS_MUMBLE_TCP_MESSAGE(Version, 0)              \
-	PROCESS_MUMBLE_TCP_MESSAGE(UDPTunnel, 1)            \
-	PROCESS_MUMBLE_TCP_MESSAGE(Authenticate, 2)         \
-	PROCESS_MUMBLE_TCP_MESSAGE(Ping, 3)                 \
-	PROCESS_MUMBLE_TCP_MESSAGE(Reject, 4)               \
-	PROCESS_MUMBLE_TCP_MESSAGE(ServerSync, 5)           \
-	PROCESS_MUMBLE_TCP_MESSAGE(ChannelRemove, 6)        \
-	PROCESS_MUMBLE_TCP_MESSAGE(ChannelState, 7)         \
-	PROCESS_MUMBLE_TCP_MESSAGE(UserRemove, 8)           \
-	PROCESS_MUMBLE_TCP_MESSAGE(UserState, 9)            \
-	PROCESS_MUMBLE_TCP_MESSAGE(BanList, 10)             \
-	PROCESS_MUMBLE_TCP_MESSAGE(TextMessage, 11)         \
-	PROCESS_MUMBLE_TCP_MESSAGE(PermissionDenied, 12)    \
-	PROCESS_MUMBLE_TCP_MESSAGE(ACL, 13)                 \
-	PROCESS_MUMBLE_TCP_MESSAGE(QueryUsers, 14)          \
-	PROCESS_MUMBLE_TCP_MESSAGE(CryptSetup, 15)          \
-	PROCESS_MUMBLE_TCP_MESSAGE(ContextActionModify, 16) \
-	PROCESS_MUMBLE_TCP_MESSAGE(ContextAction, 17)       \
-	PROCESS_MUMBLE_TCP_MESSAGE(UserList, 18)            \
-	PROCESS_MUMBLE_TCP_MESSAGE(VoiceTarget, 19)         \
-	PROCESS_MUMBLE_TCP_MESSAGE(PermissionQuery, 20)     \
-	PROCESS_MUMBLE_TCP_MESSAGE(CodecVersion, 21)        \
-	PROCESS_MUMBLE_TCP_MESSAGE(UserStats, 22)           \
-	PROCESS_MUMBLE_TCP_MESSAGE(RequestBlob, 23)         \
-	PROCESS_MUMBLE_TCP_MESSAGE(ServerConfig, 24)        \
-	PROCESS_MUMBLE_TCP_MESSAGE(SuggestConfig, 25)       \
-	PROCESS_MUMBLE_TCP_MESSAGE(PluginDataTransmission, 26)
+#define MUMBLE_ALL_TCP_MESSAGES                             \
+	PROCESS_MUMBLE_TCP_MESSAGE(Version, 0)                  \
+	PROCESS_MUMBLE_TCP_MESSAGE(UDPTunnel, 1)                \
+	PROCESS_MUMBLE_TCP_MESSAGE(Authenticate, 2)             \
+	PROCESS_MUMBLE_TCP_MESSAGE(Ping, 3)                     \
+	PROCESS_MUMBLE_TCP_MESSAGE(Reject, 4)                   \
+	PROCESS_MUMBLE_TCP_MESSAGE(ServerSync, 5)               \
+	PROCESS_MUMBLE_TCP_MESSAGE(ChannelRemove, 6)            \
+	PROCESS_MUMBLE_TCP_MESSAGE(ChannelState, 7)             \
+	PROCESS_MUMBLE_TCP_MESSAGE(UserRemove, 8)               \
+	PROCESS_MUMBLE_TCP_MESSAGE(UserState, 9)                \
+	PROCESS_MUMBLE_TCP_MESSAGE(BanList, 10)                 \
+	PROCESS_MUMBLE_TCP_MESSAGE(TextMessage, 11)             \
+	PROCESS_MUMBLE_TCP_MESSAGE(PermissionDenied, 12)        \
+	PROCESS_MUMBLE_TCP_MESSAGE(ACL, 13)                     \
+	PROCESS_MUMBLE_TCP_MESSAGE(QueryUsers, 14)              \
+	PROCESS_MUMBLE_TCP_MESSAGE(CryptSetup, 15)              \
+	PROCESS_MUMBLE_TCP_MESSAGE(ContextActionModify, 16)     \
+	PROCESS_MUMBLE_TCP_MESSAGE(ContextAction, 17)           \
+	PROCESS_MUMBLE_TCP_MESSAGE(UserList, 18)                \
+	PROCESS_MUMBLE_TCP_MESSAGE(VoiceTarget, 19)             \
+	PROCESS_MUMBLE_TCP_MESSAGE(PermissionQuery, 20)         \
+	PROCESS_MUMBLE_TCP_MESSAGE(CodecVersion, 21)            \
+	PROCESS_MUMBLE_TCP_MESSAGE(UserStats, 22)               \
+	PROCESS_MUMBLE_TCP_MESSAGE(RequestBlob, 23)             \
+	PROCESS_MUMBLE_TCP_MESSAGE(ServerConfig, 24)            \
+	PROCESS_MUMBLE_TCP_MESSAGE(SuggestConfig, 25)           \
+	PROCESS_MUMBLE_TCP_MESSAGE(PluginDataTransmission, 26)  \
+	PROCESS_MUMBLE_TCP_MESSAGE(ChatHistoryRequest, 27)		\
+	PROCESS_MUMBLE_TCP_MESSAGE(ChatHistoryChunk, 28)
 
 /**
  * "X-macro" for all Mumble Protobuf UDP messages types.

--- a/src/mumble/Messages.cpp
+++ b/src/mumble/Messages.cpp
@@ -1244,6 +1244,18 @@ void MainWindow::msgUserStats(const MumbleProto::UserStats &msg) {
 	}
 }
 
+/// ChatHistoryRequest is sent by the client to request persisted chat history from the server.
+/// Thus the client should not normally receive this message.
+void MainWindow::msgChatHistoryRequest(const MumbleProto::ChatHistoryRequest &msg) {
+	Q_UNUSED(msg);
+}
+
+/// ChatHistoryChunk is sent by the server in response to a ChatHistoryRequest and contains
+/// a page of persisted chat messages. The client-side UI handling is not implemented yet.
+void MainWindow::msgChatHistoryChunk(const MumbleProto::ChatHistoryChunk &msg) {
+	Q_UNUSED(msg);
+}
+
 /// This message is only ever sent by the client in order to request binary data that otherwise
 /// wouldn't be included in the normal messages (e.Global::get(). big images). Thus this implementation does
 /// nothing.

--- a/src/murmur/Messages.cpp
+++ b/src/murmur/Messages.cpp
@@ -2558,6 +2558,30 @@ void Server::msgPluginDataTransmission(ServerUser *sender, MumbleProto::PluginDa
 	}
 }
 
+void Server::msgChatHistoryRequest(ServerUser *uSource, MumbleProto::ChatHistoryRequest &msg) {
+	ZoneScoped;
+
+	MSG_SETUP(ServerUser::Authenticated);
+	Q_UNUSED(msg);
+
+	// Chat history storage and retrieval are not implemented yet.
+	MumbleProto::PermissionDenied mppd;
+	mppd.set_type(MumbleProto::PermissionDenied_DenyType_Text);
+	mppd.set_reason("Chat history is not implemented yet.");
+
+	sendMessage(uSource, mppd);
+}
+
+void Server::msgChatHistoryChunk(ServerUser *uSource, MumbleProto::ChatHistoryChunk &msg) {
+	ZoneScoped;
+
+	MSG_SETUP(ServerUser::Authenticated);
+	Q_UNUSED(msg);
+
+	// ChatHistoryChunk is sent by the server only.
+	log(uSource, "Received unexpected ChatHistoryChunk message from client");
+}
+
 #undef RATELIMIT
 #undef MSG_SETUP
 #undef MSG_SETUP_NO_UNIDLE


### PR DESCRIPTION
This introduces protocol-level groundwork for future chat history support.

It adds `ChatHistoryRequest`, `ChatHistoryMessage` and `ChatHistoryChunk` as protobuf messages and registers the corresponding TCP message types. It also adds temporary no-op handlers on both client and server sides so the new message types are part of the protocol without implementing storage, retrieval or UI behavior yet.

The goal is to establish the protocol shape first before adding database persistence and client-side history rendering in follow-up changes.


### Checks

- [x] My commits follow the [commit guidelines](https://github.com/mumble-voip/mumble/blob/master/COMMIT_GUIDELINES.md)

