### PR TITLE
Backport "Merge PR #7244: FEAT(client): Add UI and CLI options to set preventWindowStates latch" to 1.6.x

### DIFF
--- a/src/mumble/Global.cpp
+++ b/src/mumble/Global.cpp
@@ -139,6 +139,8 @@ Global::Global(const QString &qsConfigPath) {
 
 	channelListenerManager = std::make_unique< ChannelListenerManager >();
 
+	preventWindowStatesCLI = false;
+
 	if (qsConfigPath.isEmpty()) {
 		qdBasePath.setPath(QStandardPaths::writableLocation(QStandardPaths::AppDataLocation));
 

--- a/src/mumble/Global.h
+++ b/src/mumble/Global.h
@@ -109,6 +109,7 @@ public:
 	bool bDebugDumpInput;
 	bool bDebugPrintQueue;
 	std::unique_ptr< ChannelListenerManager > channelListenerManager;
+	bool preventWindowStatesCLI;
 
 	bool bHappyEaster;
 	static const char ccHappyEaster[];

--- a/src/mumble/LookConfig.cpp
+++ b/src/mumble/LookConfig.cpp
@@ -234,6 +234,7 @@ void LookConfig::load(const Settings &r) {
 
 	loadCheckBox(qcbEnableDeveloperMenu, r.bEnableDeveloperMenu);
 	loadCheckBox(qcbLockLayout, (r.wlWindowLayout == Settings::LayoutCustom) && r.bLockLayout);
+	loadCheckBox(qcbRestoreWindowState, !r.preventWindowStates);
 	loadCheckBox(qcbHideTray, r.bHideInTray);
 	loadCheckBox(qcbStateInTray, r.bStateInTray);
 	loadCheckBox(qcbShowUserCount, r.bShowUserCount);
@@ -309,6 +310,7 @@ void LookConfig::save() const {
 	s.quitBehavior              = static_cast< QuitBehavior >(qcbQuitBehavior->currentIndex());
 	s.bEnableDeveloperMenu      = qcbEnableDeveloperMenu->isChecked();
 	s.bLockLayout               = qcbLockLayout->isChecked();
+	s.preventWindowStates       = !qcbRestoreWindowState->isChecked();
 	s.bHideInTray               = qcbHideTray->isChecked();
 	s.bStateInTray              = qcbStateInTray->isChecked();
 	s.bShowUserCount            = qcbShowUserCount->isChecked();

--- a/src/mumble/LookConfig.ui
+++ b/src/mumble/LookConfig.ui
@@ -20,13 +20,13 @@
       <string>Application</string>
      </property>
      <layout class="QGridLayout" name="gridLayout_3" columnstretch="0,0">
-      <item row="0" column="0">
-       <widget class="QLabel" name="qliAlwaysOnTop">
-        <property name="text">
-         <string>Always On Top</string>
+      <item row="4" column="0" colspan="2">
+       <widget class="QCheckBox" name="qcbLockLayout">
+        <property name="whatsThis">
+         <string>When in custom layout mode, checking this disables rearranging.</string>
         </property>
-        <property name="buddy">
-         <cstring>qcbAlwaysOnTop</cstring>
+        <property name="text">
+         <string>Lock layout</string>
         </property>
        </widget>
       </item>
@@ -63,16 +63,6 @@
         </item>
        </widget>
       </item>
-      <item row="1" column="0" colspan="2">
-       <widget class="QCheckBox" name="qcbShowContextMenuInMenuBar">
-        <property name="toolTip">
-         <string>Adds user and channel context menus into the menu bar</string>
-        </property>
-        <property name="text">
-         <string>Show context menu in menu bar</string>
-        </property>
-       </widget>
-      </item>
       <item row="2" column="0">
        <widget class="QLabel" name="qliQuitBehavior">
         <property name="text">
@@ -80,6 +70,16 @@
         </property>
         <property name="buddy">
          <cstring>qcbQuitBehavior</cstring>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="0" colspan="2">
+       <widget class="QCheckBox" name="qcbShowContextMenuInMenuBar">
+        <property name="toolTip">
+         <string>Adds user and channel context menus into the menu bar</string>
+        </property>
+        <property name="text">
+         <string>Show context menu in menu bar</string>
         </property>
        </widget>
       </item>
@@ -131,13 +131,23 @@
         </property>
        </widget>
       </item>
-      <item row="4" column="0" colspan="2">
-       <widget class="QCheckBox" name="qcbLockLayout">
+      <item row="0" column="0">
+       <widget class="QLabel" name="qliAlwaysOnTop">
+        <property name="text">
+         <string>Always On Top</string>
+        </property>
+        <property name="buddy">
+         <cstring>qcbAlwaysOnTop</cstring>
+        </property>
+       </widget>
+      </item>
+      <item row="5" column="0" colspan="2">
+       <widget class="QCheckBox" name="qcbRestoreWindowState">
         <property name="whatsThis">
-         <string>When in custom layout mode, checking this disables rearranging.</string>
+         <string>This controls whether Mumble will try to restore the window geometry and state from previous sessions on startup.</string>
         </property>
         <property name="text">
-         <string>Lock layout</string>
+         <string>Restore window geometry on startup</string>
         </property>
        </widget>
       </item>
@@ -1288,6 +1298,7 @@
   <tabstop>qcbQuitBehavior</tabstop>
   <tabstop>qcbEnableDeveloperMenu</tabstop>
   <tabstop>qcbLockLayout</tabstop>
+  <tabstop>qcbRestoreWindowState</tabstop>
   <tabstop>qcbHideTray</tabstop>
   <tabstop>qcbStateInTray</tabstop>
   <tabstop>qcbSearchUserAction</tabstop>

--- a/src/mumble/MainWindow.cpp
+++ b/src/mumble/MainWindow.cpp
@@ -1439,7 +1439,7 @@ void MainWindow::loadState(const bool minimalView) {
 	// save the geometry and state again to disk.
 	// See: https://github.com/mumble-voip/mumble/issues/7193
 
-	if (Global::get().s.preventWindowStates) {
+	if (Global::get().s.preventWindowStates || Global::get().preventWindowStatesCLI) {
 		qWarning() << "Restoring window state and geometry is blocked by settings latch";
 		return;
 	}
@@ -1482,7 +1482,7 @@ void MainWindow::loadState(const bool minimalView) {
 }
 
 void MainWindow::storeState(const bool minimalView) {
-	if (Global::get().s.preventWindowStates) {
+	if (Global::get().s.preventWindowStates || Global::get().preventWindowStatesCLI) {
 		return;
 	}
 

--- a/src/mumble/PTTButtonWidget.cpp
+++ b/src/mumble/PTTButtonWidget.cpp
@@ -11,13 +11,14 @@ PTTButtonWidget::PTTButtonWidget(QWidget *p) : QWidget(p) {
 
 	setWindowFlags(Qt::Tool | Qt::WindowStaysOnTopHint);
 
-	if (!Global::get().s.preventWindowStates && !Global::get().s.qbaPTTButtonWindowGeometry.isEmpty()) {
+	if (!Global::get().s.preventWindowStates && !Global::get().preventWindowStatesCLI
+		&& !Global::get().s.qbaPTTButtonWindowGeometry.isEmpty()) {
 		restoreGeometry(Global::get().s.qbaPTTButtonWindowGeometry);
 	}
 }
 
 void PTTButtonWidget::closeEvent(QCloseEvent *e) {
-	if (!Global::get().s.preventWindowStates) {
+	if (!Global::get().s.preventWindowStates && !Global::get().preventWindowStatesCLI) {
 		Global::get().s.qbaPTTButtonWindowGeometry = saveGeometry();
 	}
 

--- a/src/mumble/main.cpp
+++ b/src/mumble/main.cpp
@@ -226,6 +226,7 @@ struct CLIOptions {
 	bool dumpInputStreams         = false;
 	bool printEchoCancelQueue     = false;
 	bool skipSettingsBackupPrompt = false;
+	bool noWindowStates           = false;
 
 	std::optional< std::string > configFile;
 	std::optional< std::string > jackClientName;
@@ -293,6 +294,10 @@ CLIOptions parseCLI(int argc, char **argv) {
 
 	app.add_flag("--skip-settings-backup-prompt", options.skipSettingsBackupPrompt,
 				 "Don't show the settings recovery dialog on startup after a crash.")
+		->group(CLIOptions::CLI_GENERAL_SECTION);
+
+	app.add_flag("--no-window-states", options.noWindowStates,
+				 "Disable restoring and saving window state and geometry.")
 		->group(CLIOptions::CLI_GENERAL_SECTION);
 
 
@@ -470,6 +475,9 @@ int main(int argc, char **argv) {
 	}
 	if (options.printEchoCancelQueue) {
 		Global::get().bDebugPrintQueue = true;
+	}
+	if (options.noWindowStates) {
+		Global::get().preventWindowStatesCLI = true;
 	}
 	if (options.defaultCertDir) {
 		qdCert = QDir(QString::fromStdString(*options.defaultCertDir));

--- a/src/mumble/mumble_ar.ts
+++ b/src/mumble/mumble_ar.ts
@@ -5148,6 +5148,14 @@ The setting only applies for new messages, the already shown ones will retain th
         <source>Open Themes Directory</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>This controls whether Mumble will try to restore the window geometry and state from previous sessions on startup.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Restore window geometry on startup</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>MainWindow</name>

--- a/src/mumble/mumble_bg.ts
+++ b/src/mumble/mumble_bg.ts
@@ -5145,6 +5145,14 @@ The setting only applies for new messages, the already shown ones will retain th
         <source>Open Themes Directory</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>This controls whether Mumble will try to restore the window geometry and state from previous sessions on startup.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Restore window geometry on startup</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>MainWindow</name>

--- a/src/mumble/mumble_br.ts
+++ b/src/mumble/mumble_br.ts
@@ -5144,6 +5144,14 @@ The setting only applies for new messages, the already shown ones will retain th
         <source>Open Themes Directory</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>This controls whether Mumble will try to restore the window geometry and state from previous sessions on startup.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Restore window geometry on startup</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>MainWindow</name>

--- a/src/mumble/mumble_ca.ts
+++ b/src/mumble/mumble_ca.ts
@@ -5206,6 +5206,14 @@ El paràmetre només serà per als missatges nous, els que ja s&apos;han mostrat
         <source>Open Themes Directory</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>This controls whether Mumble will try to restore the window geometry and state from previous sessions on startup.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Restore window geometry on startup</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>MainWindow</name>

--- a/src/mumble/mumble_cs.ts
+++ b/src/mumble/mumble_cs.ts
@@ -5199,6 +5199,14 @@ The setting only applies for new messages, the already shown ones will retain th
         <source>Open Themes Directory</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>This controls whether Mumble will try to restore the window geometry and state from previous sessions on startup.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Restore window geometry on startup</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>MainWindow</name>

--- a/src/mumble/mumble_cy.ts
+++ b/src/mumble/mumble_cy.ts
@@ -5148,6 +5148,14 @@ The setting only applies for new messages, the already shown ones will retain th
         <source>Open Themes Directory</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>This controls whether Mumble will try to restore the window geometry and state from previous sessions on startup.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Restore window geometry on startup</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>MainWindow</name>

--- a/src/mumble/mumble_da.ts
+++ b/src/mumble/mumble_da.ts
@@ -5198,6 +5198,14 @@ The setting only applies for new messages, the already shown ones will retain th
         <source>Open Themes Directory</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>This controls whether Mumble will try to restore the window geometry and state from previous sessions on startup.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Restore window geometry on startup</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>MainWindow</name>

--- a/src/mumble/mumble_de.ts
+++ b/src/mumble/mumble_de.ts
@@ -5206,6 +5206,14 @@ Die Einstellung gilt nur für neue Nachrichten, die bereits angezeigten behalten
         <source>Open Themes Directory</source>
         <translation type="unfinished">Themenverzeichnis öffnen</translation>
     </message>
+    <message>
+        <source>This controls whether Mumble will try to restore the window geometry and state from previous sessions on startup.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Restore window geometry on startup</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>MainWindow</name>

--- a/src/mumble/mumble_el.ts
+++ b/src/mumble/mumble_el.ts
@@ -5206,6 +5206,14 @@ The setting only applies for new messages, the already shown ones will retain th
         <source>Open Themes Directory</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>This controls whether Mumble will try to restore the window geometry and state from previous sessions on startup.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Restore window geometry on startup</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>MainWindow</name>

--- a/src/mumble/mumble_en.ts
+++ b/src/mumble/mumble_en.ts
@@ -5143,6 +5143,14 @@ The setting only applies for new messages, the already shown ones will retain th
         <source>Open Themes Directory</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>This controls whether Mumble will try to restore the window geometry and state from previous sessions on startup.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Restore window geometry on startup</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>MainWindow</name>

--- a/src/mumble/mumble_en_GB.ts
+++ b/src/mumble/mumble_en_GB.ts
@@ -4009,22 +4009,22 @@ Without this option enabled, using Mumble&apos;s global shortcuts in privileged 
     <name>GlobalShortcutWin</name>
     <message>
         <source>Mouse</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">Mouse</translation>
     </message>
     <message>
         <source>Keyboard</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">Keyboard</translation>
     </message>
 </context>
 <context>
     <name>GlobalShortcutX</name>
     <message>
         <source>Keyboard</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">Keyboard</translation>
     </message>
     <message>
         <source>Mouse</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">Mouse</translation>
     </message>
 </context>
 <context>
@@ -4616,11 +4616,11 @@ This setting only applies to new messages; existing messages keep the previous t
     </message>
     <message>
         <source>checked</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">checked</translation>
     </message>
     <message>
         <source>unchecked</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">unchecked</translation>
     </message>
     <message>
         <source>decibels</source>
@@ -5196,6 +5196,14 @@ This setting only applies to new messages; existing messages keep the previous t
     </message>
     <message>
         <source>Open Themes Directory</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>This controls whether Mumble will try to restore the window geometry and state from previous sessions on startup.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Restore window geometry on startup</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -8219,11 +8227,11 @@ To upgrade these files to their latest versions, click the button below.</source
     </message>
     <message>
         <source>checked</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">checked</translation>
     </message>
     <message>
         <source>unchecked</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">unchecked</translation>
     </message>
     <message>
         <source>Not available</source>
@@ -9113,7 +9121,7 @@ See &lt;a href=&quot;https://github.com/mumble-voip/mumble&quot;&gt;the project 
     <name>ShortcutActionWidget</name>
     <message>
         <source>Unassigned</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">Unassigned</translation>
     </message>
 </context>
 <context>
@@ -9132,7 +9140,7 @@ See &lt;a href=&quot;https://github.com/mumble-voip/mumble&quot;&gt;the project 
     </message>
     <message>
         <source>Unassigned</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">Unassigned</translation>
     </message>
     <message>
         <source>No buttons assigned</source>

--- a/src/mumble/mumble_eo.ts
+++ b/src/mumble/mumble_eo.ts
@@ -5155,6 +5155,14 @@ The setting only applies for new messages, the already shown ones will retain th
         <source>Open Themes Directory</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>This controls whether Mumble will try to restore the window geometry and state from previous sessions on startup.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Restore window geometry on startup</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>MainWindow</name>

--- a/src/mumble/mumble_es.ts
+++ b/src/mumble/mumble_es.ts
@@ -5207,6 +5207,14 @@ La configuración solo se aplica a los mensajes nuevos, los que ya se muestran c
         <source>Open Themes Directory</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>This controls whether Mumble will try to restore the window geometry and state from previous sessions on startup.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Restore window geometry on startup</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>MainWindow</name>

--- a/src/mumble/mumble_et.ts
+++ b/src/mumble/mumble_et.ts
@@ -5145,6 +5145,14 @@ The setting only applies for new messages, the already shown ones will retain th
         <source>Open Themes Directory</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>This controls whether Mumble will try to restore the window geometry and state from previous sessions on startup.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Restore window geometry on startup</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>MainWindow</name>

--- a/src/mumble/mumble_eu.ts
+++ b/src/mumble/mumble_eu.ts
@@ -5162,6 +5162,14 @@ The setting only applies for new messages, the already shown ones will retain th
         <source>Open Themes Directory</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>This controls whether Mumble will try to restore the window geometry and state from previous sessions on startup.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Restore window geometry on startup</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>MainWindow</name>

--- a/src/mumble/mumble_fa_IR.ts
+++ b/src/mumble/mumble_fa_IR.ts
@@ -5145,6 +5145,14 @@ The setting only applies for new messages, the already shown ones will retain th
         <source>Open Themes Directory</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>This controls whether Mumble will try to restore the window geometry and state from previous sessions on startup.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Restore window geometry on startup</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>MainWindow</name>

--- a/src/mumble/mumble_fi.ts
+++ b/src/mumble/mumble_fi.ts
@@ -5206,6 +5206,14 @@ Tämä vaikuttaa vain uusiin viesteihin, vanhojen viestien aikaleima ei muutu.</
         <source>Open Themes Directory</source>
         <translation>Avaa teemakansio</translation>
     </message>
+    <message>
+        <source>This controls whether Mumble will try to restore the window geometry and state from previous sessions on startup.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Restore window geometry on startup</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>MainWindow</name>

--- a/src/mumble/mumble_fr.ts
+++ b/src/mumble/mumble_fr.ts
@@ -5206,6 +5206,14 @@ Le paramètre ne s&apos;applique qu&apos;aux nouveaux messages, ceux déjà affi
         <source>Open Themes Directory</source>
         <translation>Ouvrir le répertoire des thèmes</translation>
     </message>
+    <message>
+        <source>This controls whether Mumble will try to restore the window geometry and state from previous sessions on startup.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Restore window geometry on startup</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>MainWindow</name>

--- a/src/mumble/mumble_gl.ts
+++ b/src/mumble/mumble_gl.ts
@@ -5146,6 +5146,14 @@ The setting only applies for new messages, the already shown ones will retain th
         <source>Open Themes Directory</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>This controls whether Mumble will try to restore the window geometry and state from previous sessions on startup.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Restore window geometry on startup</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>MainWindow</name>

--- a/src/mumble/mumble_he.ts
+++ b/src/mumble/mumble_he.ts
@@ -5196,6 +5196,14 @@ The setting only applies for new messages, the already shown ones will retain th
         <source>Open Themes Directory</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>This controls whether Mumble will try to restore the window geometry and state from previous sessions on startup.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Restore window geometry on startup</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>MainWindow</name>

--- a/src/mumble/mumble_hi.ts
+++ b/src/mumble/mumble_hi.ts
@@ -5120,6 +5120,14 @@ The setting only applies for new messages, the already shown ones will retain th
         <source>Open Themes Directory</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>This controls whether Mumble will try to restore the window geometry and state from previous sessions on startup.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Restore window geometry on startup</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>MainWindow</name>

--- a/src/mumble/mumble_hu.ts
+++ b/src/mumble/mumble_hu.ts
@@ -5192,6 +5192,14 @@ The setting only applies for new messages, the already shown ones will retain th
         <source>Open Themes Directory</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>This controls whether Mumble will try to restore the window geometry and state from previous sessions on startup.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Restore window geometry on startup</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>MainWindow</name>

--- a/src/mumble/mumble_it.ts
+++ b/src/mumble/mumble_it.ts
@@ -5206,6 +5206,14 @@ Questa impostazione si applica solo ai nuovi messaggi, quelli già mostrati mant
         <source>Open Themes Directory</source>
         <translation>Apri cartella dei temi</translation>
     </message>
+    <message>
+        <source>This controls whether Mumble will try to restore the window geometry and state from previous sessions on startup.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Restore window geometry on startup</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>MainWindow</name>

--- a/src/mumble/mumble_ja.ts
+++ b/src/mumble/mumble_ja.ts
@@ -5195,6 +5195,14 @@ The setting only applies for new messages, the already shown ones will retain th
         <source>Open Themes Directory</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>This controls whether Mumble will try to restore the window geometry and state from previous sessions on startup.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Restore window geometry on startup</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>MainWindow</name>

--- a/src/mumble/mumble_ko.ts
+++ b/src/mumble/mumble_ko.ts
@@ -5205,6 +5205,14 @@ The setting only applies for new messages, the already shown ones will retain th
         <source>Open Themes Directory</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>This controls whether Mumble will try to restore the window geometry and state from previous sessions on startup.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Restore window geometry on startup</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>MainWindow</name>

--- a/src/mumble/mumble_lt.ts
+++ b/src/mumble/mumble_lt.ts
@@ -5177,6 +5177,14 @@ The setting only applies for new messages, the already shown ones will retain th
         <source>Open Themes Directory</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>This controls whether Mumble will try to restore the window geometry and state from previous sessions on startup.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Restore window geometry on startup</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>MainWindow</name>

--- a/src/mumble/mumble_nl.ts
+++ b/src/mumble/mumble_nl.ts
@@ -5206,6 +5206,14 @@ Deze instelling geldt voor nieuwe berichten, vermits getoonden conformeren aan h
         <source>Open Themes Directory</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>This controls whether Mumble will try to restore the window geometry and state from previous sessions on startup.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Restore window geometry on startup</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>MainWindow</name>

--- a/src/mumble/mumble_no.ts
+++ b/src/mumble/mumble_no.ts
@@ -5221,6 +5221,14 @@ Har kun innvirkning for nye meldinger. Gamle meldinger vises i foregående tidsf
         <source>Open Themes Directory</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>This controls whether Mumble will try to restore the window geometry and state from previous sessions on startup.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Restore window geometry on startup</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>MainWindow</name>

--- a/src/mumble/mumble_oc.ts
+++ b/src/mumble/mumble_oc.ts
@@ -5145,6 +5145,14 @@ The setting only applies for new messages, the already shown ones will retain th
         <source>Open Themes Directory</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>This controls whether Mumble will try to restore the window geometry and state from previous sessions on startup.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Restore window geometry on startup</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>MainWindow</name>

--- a/src/mumble/mumble_pl.ts
+++ b/src/mumble/mumble_pl.ts
@@ -5207,6 +5207,14 @@ Ustawienie dotyczy tylko nowych wiadomości, te już pokazane zachowają poprzed
         <source>Open Themes Directory</source>
         <translation>Otwórz katalog motywów</translation>
     </message>
+    <message>
+        <source>This controls whether Mumble will try to restore the window geometry and state from previous sessions on startup.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Restore window geometry on startup</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>MainWindow</name>

--- a/src/mumble/mumble_pt_BR.ts
+++ b/src/mumble/mumble_pt_BR.ts
@@ -5206,6 +5206,14 @@ Essa configuração só se aplica para novas mensagens. As mensagens já exibida
         <source>Open Themes Directory</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>This controls whether Mumble will try to restore the window geometry and state from previous sessions on startup.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Restore window geometry on startup</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>MainWindow</name>

--- a/src/mumble/mumble_pt_PT.ts
+++ b/src/mumble/mumble_pt_PT.ts
@@ -5206,6 +5206,14 @@ Essa configuração só se aplica para novas mensagens. As mensagens já exibida
         <source>Open Themes Directory</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>This controls whether Mumble will try to restore the window geometry and state from previous sessions on startup.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Restore window geometry on startup</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>MainWindow</name>

--- a/src/mumble/mumble_ro.ts
+++ b/src/mumble/mumble_ro.ts
@@ -5153,6 +5153,14 @@ The setting only applies for new messages, the already shown ones will retain th
         <source>Open Themes Directory</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>This controls whether Mumble will try to restore the window geometry and state from previous sessions on startup.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Restore window geometry on startup</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>MainWindow</name>

--- a/src/mumble/mumble_ru.ts
+++ b/src/mumble/mumble_ru.ts
@@ -5207,6 +5207,14 @@ The setting only applies for new messages, the already shown ones will retain th
         <source>Open Themes Directory</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>This controls whether Mumble will try to restore the window geometry and state from previous sessions on startup.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Restore window geometry on startup</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>MainWindow</name>
@@ -7335,7 +7343,7 @@ the channel&apos;s context menu.</source>
     </message>
     <message>
         <source>Silent user display time (in seconds)</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">Время отображения без звука для пользователя (в секундах)</translation>
     </message>
     <message>
         <source>Listener azimuth (in degrees)</source>

--- a/src/mumble/mumble_si.ts
+++ b/src/mumble/mumble_si.ts
@@ -5115,6 +5115,14 @@ The setting only applies for new messages, the already shown ones will retain th
         <source>Open Themes Directory</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>This controls whether Mumble will try to restore the window geometry and state from previous sessions on startup.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Restore window geometry on startup</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>MainWindow</name>

--- a/src/mumble/mumble_sk.ts
+++ b/src/mumble/mumble_sk.ts
@@ -5119,6 +5119,14 @@ The setting only applies for new messages, the already shown ones will retain th
         <source>Open Themes Directory</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>This controls whether Mumble will try to restore the window geometry and state from previous sessions on startup.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Restore window geometry on startup</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>MainWindow</name>

--- a/src/mumble/mumble_sq.ts
+++ b/src/mumble/mumble_sq.ts
@@ -5221,6 +5221,14 @@ The setting only applies for new messages, the already shown ones will retain th
         <source>Open Themes Directory</source>
         <translation>Hap Drejtori Temash</translation>
     </message>
+    <message>
+        <source>This controls whether Mumble will try to restore the window geometry and state from previous sessions on startup.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Restore window geometry on startup</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>MainWindow</name>

--- a/src/mumble/mumble_sv.ts
+++ b/src/mumble/mumble_sv.ts
@@ -5206,6 +5206,14 @@ Inställningen gäller endast för nya meddelanden, de redan visade meddelandena
         <source>Open Themes Directory</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>This controls whether Mumble will try to restore the window geometry and state from previous sessions on startup.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Restore window geometry on startup</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>MainWindow</name>

--- a/src/mumble/mumble_te.ts
+++ b/src/mumble/mumble_te.ts
@@ -5156,6 +5156,14 @@ The setting only applies for new messages, the already shown ones will retain th
         <source>Open Themes Directory</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>This controls whether Mumble will try to restore the window geometry and state from previous sessions on startup.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Restore window geometry on startup</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>MainWindow</name>

--- a/src/mumble/mumble_th.ts
+++ b/src/mumble/mumble_th.ts
@@ -5143,6 +5143,14 @@ The setting only applies for new messages, the already shown ones will retain th
         <source>Open Themes Directory</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>This controls whether Mumble will try to restore the window geometry and state from previous sessions on startup.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Restore window geometry on startup</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>MainWindow</name>

--- a/src/mumble/mumble_tr.ts
+++ b/src/mumble/mumble_tr.ts
@@ -5205,6 +5205,14 @@ Bu ayar sadece yeni mesajlara uygulanır, zaten görüntülenmiş olanlar öncek
         <source>Open Themes Directory</source>
         <translation>Tema Dizinini Aç</translation>
     </message>
+    <message>
+        <source>This controls whether Mumble will try to restore the window geometry and state from previous sessions on startup.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Restore window geometry on startup</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>MainWindow</name>

--- a/src/mumble/mumble_uk.ts
+++ b/src/mumble/mumble_uk.ts
@@ -5207,6 +5207,14 @@ The setting only applies for new messages, the already shown ones will retain th
         <source>Open Themes Directory</source>
         <translation>Відкрити каталог тем</translation>
     </message>
+    <message>
+        <source>This controls whether Mumble will try to restore the window geometry and state from previous sessions on startup.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Restore window geometry on startup</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>MainWindow</name>

--- a/src/mumble/mumble_zh_CN.ts
+++ b/src/mumble/mumble_zh_CN.ts
@@ -5205,6 +5205,14 @@ The setting only applies for new messages, the already shown ones will retain th
         <source>Open Themes Directory</source>
         <translation>打开主题文件夹</translation>
     </message>
+    <message>
+        <source>This controls whether Mumble will try to restore the window geometry and state from previous sessions on startup.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Restore window geometry on startup</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>MainWindow</name>

--- a/src/mumble/mumble_zh_HK.ts
+++ b/src/mumble/mumble_zh_HK.ts
@@ -5143,6 +5143,14 @@ The setting only applies for new messages, the already shown ones will retain th
         <source>Open Themes Directory</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>This controls whether Mumble will try to restore the window geometry and state from previous sessions on startup.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Restore window geometry on startup</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>MainWindow</name>

--- a/src/mumble/mumble_zh_TW.ts
+++ b/src/mumble/mumble_zh_TW.ts
@@ -5175,6 +5175,14 @@ The setting only applies for new messages, the already shown ones will retain th
         <source>Open Themes Directory</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>This controls whether Mumble will try to restore the window geometry and state from previous sessions on startup.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Restore window geometry on startup</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>MainWindow</name>


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `1.6.x`:
 - [Merge PR #7244: FEAT(client): Add UI and CLI options to set preventWindowStates latch](https://github.com/mumble-voip/mumble/pull/7244)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)