### PR TITLE
Backport "Merge PR #7245: FIX(client): Apply skipSettingsBackupPrompt flag for loading settings" to 1.6.x

### DIFF
--- a/src/mumble/main.cpp
+++ b/src/mumble/main.cpp
@@ -644,9 +644,9 @@ int main(int argc, char **argv) {
 
 	// Load preferences
 	if (settingsFile.isEmpty()) {
-		Global::get().s.load();
+		Global::get().s.load(options.skipSettingsBackupPrompt);
 	} else {
-		Global::get().s.load(settingsFile);
+		Global::get().s.load(settingsFile, options.skipSettingsBackupPrompt);
 	}
 	if (!Global::get().migratedDBPath.isEmpty()) {
 		// We have migrated the DB to a new location. Make sure that the settings hold the correct (new) path and that


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `1.6.x`:
 - [Merge PR #7245: FIX(client): Apply skipSettingsBackupPrompt flag for loading settings](https://github.com/mumble-voip/mumble/pull/7245)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)