### PR TITLE
FIX(server): Reject unauthenticated use of reserved names

### DIFF
--- a/src/murmur/Server.cpp
+++ b/src/murmur/Server.cpp
@@ -2694,8 +2694,9 @@ int Server::authenticate(QString &name, const QString &password, int sessionId, 
 		if (userID < 0 && certhash.isEmpty()) {
 			// The only alternative to password-based authentication is the one based on certificates.
 			// If none was provided and password authentication did not apply, then we report that
-			// we don't know this user.
-			return UNKNOWN_USER;
+			// we don't know this user - UNLESS the requested name belongs to a registered account.
+			// In that case we must fail as AUTHENTICATION_FAILED to prevent impersonating that user.
+			return usedReservedName ? AUTHENTICATION_FAILED : UNKNOWN_USER;
 		}
 
 		if (userID < 0) {


### PR DESCRIPTION
A client connecting without a certificate (and without a password) could log in as a guest under the name of a certificate-registered account, impersonating that user. Fail with AUTHENTICATION_FAILED instead, so presenting no certificate is not more permissive than presenting a wrong one.


### Checks

- [x] My commits follow the [commit guidelines](https://github.com/mumble-voip/mumble/blob/master/COMMIT_GUIDELINES.md)

