### PR TITLE
Backport "Merge PR #7252: FEAT(client): Print Mumble version to log on startup" to 1.5.x

### DIFF
--- a/src/mumble/main.cpp
+++ b/src/mumble/main.cpp
@@ -203,6 +203,8 @@ int main(int argc, char **argv) {
 	Global::get().le = QSharedPointer< LogEmitter >(new LogEmitter());
 	Global::get().c  = new DeveloperConsole();
 
+	qInfo("This is Mumble v%s", qUtf8Printable(Version::getRelease()));
+
 	os_init();
 
 	bool bAllowMultiple       = false;


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `1.5.x`:
 - [Merge PR #7252: FEAT(client): Print Mumble version to log on startup](https://github.com/mumble-voip/mumble/pull/7252)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)