### PR TITLE
Backport "Merge PR #7252: FEAT(client): Print Mumble version to log on startup" to 1.6.x

### DIFF
--- a/src/mumble/main.cpp
+++ b/src/mumble/main.cpp
@@ -437,6 +437,8 @@ int main(int argc, char **argv) {
 	initLog(logBox);
 	Global::get().c = new DeveloperConsole(logBox);
 
+	qInfo("This is Mumble v%s", qUtf8Printable(Version::getRelease()));
+
 	os_init();
 
 	QUrl url;


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `1.6.x`:
 - [Merge PR #7252: FEAT(client): Print Mumble version to log on startup](https://github.com/mumble-voip/mumble/pull/7252)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)