### PR TITLE
Add Ice Server.removeAuthenticator

### DIFF
--- a/src/murmur/MumbleServer.ice
+++ b/src/murmur/MumbleServer.ice
@@ -515,6 +515,12 @@ module MumbleServer
 		 */
 		void setAuthenticator(ServerAuthenticator *auth) throws ServerBootedException, InvalidCallbackException, InvalidSecretException, ReadOnlyModeException;
 
+		/** Remove any external authenticator previously registered via {@link setAuthenticator}.
+		 *  After this call, authentications are handled by the server's built-in authentication again.
+		 *  It is not an error to call this when no authenticator is set.
+		 */
+		void removeAuthenticator() throws ServerBootedException, InvalidSecretException, ReadOnlyModeException;
+
 		/** Retrieve configuration item.
 		 * @param key Configuration key.
 		 * @return Configuration value. If this is empty, see {@link Meta.getDefaultConf}

--- a/src/murmur/MumbleServer.ice
+++ b/src/murmur/MumbleServer.ice
@@ -519,7 +519,7 @@ module MumbleServer
 		 *  After this call, authentications are handled by the server's built-in authentication again.
 		 *  It is not an error to call this when no authenticator is set.
 		 */
-		void removeAuthenticator() throws ServerBootedException, InvalidSecretException, ReadOnlyModeException;
+		idempotent void removeAuthenticator() throws ServerBootedException, InvalidSecretException, ReadOnlyModeException;
 
 		/** Retrieve configuration item.
 		 * @param key Configuration key.

--- a/src/murmur/MumbleServerI.h
+++ b/src/murmur/MumbleServerI.h
@@ -28,6 +28,9 @@ public:
 	virtual void setAuthenticator_async(const ::MumbleServer::AMD_Server_setAuthenticatorPtr &,
 										const ::MumbleServer::ServerAuthenticatorPrx &, const ::Ice::Current &);
 
+	virtual void removeAuthenticator_async(const ::MumbleServer::AMD_Server_removeAuthenticatorPtr &,
+										   const ::Ice::Current &);
+
 	virtual void id_async(const ::MumbleServer::AMD_Server_idPtr &, const Ice::Current &);
 
 	virtual void getConf_async(const ::MumbleServer::AMD_Server_getConfPtr &, const ::std::string &,

--- a/src/murmur/MumbleServerIce.cpp
+++ b/src/murmur/MumbleServerIce.cpp
@@ -1083,6 +1083,24 @@ static void impl_Server_setAuthenticator(const ::MumbleServer::AMD_Server_setAut
 	ICE_IMPL_END
 }
 
+static void impl_Server_removeAuthenticator(const ::MumbleServer::AMD_Server_removeAuthenticatorPtr &cb,
+											int server_id) {
+	ICE_IMPL_BEGIN
+
+	VERIFY_DB_NOT_IN_READONLY;
+	NEED_SERVER;
+
+	if (mi->getServerAuthenticator(server))
+		server->disconnectAuthenticator(mi);
+
+	mi->removeServerAuthenticator(server);
+	mi->removeServerUpdatingAuthenticator(server);
+
+	cb->ice_response();
+
+	ICE_IMPL_END
+}
+
 #define ACCESS_Server_id_READ
 static void impl_Server_id(const ::MumbleServer::AMD_Server_idPtr cb, int server_id) {
 	ICE_IMPL_BEGIN


### PR DESCRIPTION
## Summary
- Adds `Server::removeAuthenticator()` to the Ice API so an external authenticator can be cleared
- Falls back to built-in authentication after removal
- Idempotent when no authenticator is set
## Test plan
- [ ] Register an authenticator via Ice, then call `removeAuthenticator`
- [ ] Confirm subsequent logins use built-in auth
- [ ] Call `removeAuthenticator` with none set and confirm no error