### PR TITLE
FEAT(client): Scale chat log images to fit the log

### DIFF
--- a/src/mumble/CustomElements.cpp
+++ b/src/mumble/CustomElements.cpp
@@ -18,9 +18,137 @@
 #include <QtGui/QClipboard>
 #include <QtGui/QContextMenuEvent>
 #include <QtGui/QKeyEvent>
+#include <QtGui/QTextBlock>
+#include <QtGui/QTextImageFormat>
 #include <QtWidgets/QScrollBar>
 
-LogTextBrowser::LogTextBrowser(QWidget *p) : QTextBrowser(p) {
+#include <vector>
+
+/// Custom QTextFormat properties used to remember the natural (unscaled)
+/// display size of an image across refits of the chat log.
+static constexpr int ImageNaturalWidthProperty  = QTextFormat::UserProperty + 1;
+static constexpr int ImageNaturalHeightProperty = QTextFormat::UserProperty + 2;
+
+/// Returns the size at which the image would be displayed if it were not
+/// scaled to fit the viewport: the size from the message's explicit
+/// width/height attributes if present, otherwise the image's own size.
+/// Returns an empty size if it cannot be determined.
+static QSizeF naturalImageSize(QTextDocument *doc, const QTextImageFormat &format) {
+	if (format.hasProperty(ImageNaturalWidthProperty) && format.hasProperty(ImageNaturalHeightProperty)) {
+		return QSizeF(format.doubleProperty(ImageNaturalWidthProperty),
+					  format.doubleProperty(ImageNaturalHeightProperty));
+	}
+
+	const bool hasWidth  = format.hasProperty(QTextFormat::ImageWidth);
+	const bool hasHeight = format.hasProperty(QTextFormat::ImageHeight);
+	if (hasWidth && hasHeight) {
+		return QSizeF(format.width(), format.height());
+	}
+
+	const QVariant resource = doc->resource(QTextDocument::ImageResource, QUrl(format.name()));
+	// The cached resource may be a QImage, a QPixmap (QVariant converts it
+	// to an image) or the still-encoded image data.
+	QImage image = resource.value< QImage >();
+	if (image.isNull() && resource.userType() == QMetaType::QByteArray) {
+		image.loadFromData(resource.toByteArray());
+	}
+	if (image.isNull() || image.width() < 1 || image.height() < 1) {
+		return QSizeF();
+	}
+
+	const QSizeF imageSize(image.width(), image.height());
+	if (hasWidth) {
+		return QSizeF(format.width(), format.width() * imageSize.height() / imageSize.width());
+	}
+	if (hasHeight) {
+		return QSizeF(format.height() * imageSize.width() / imageSize.height(), format.height());
+	}
+	return imageSize;
+}
+
+LogTextBrowser::LogTextBrowser(QWidget *p) : QTextBrowser(p), m_imageFitTimer(new QTimer(this)) {
+	// Refitting images on every single resize step would relayout the whole
+	// document continuously while the user drags a splitter, so debounce.
+	m_imageFitTimer->setSingleShot(true);
+	m_imageFitTimer->setInterval(100);
+	connect(m_imageFitTimer, &QTimer::timeout, this, [this]() {
+		const bool wasAtBottom = isScrolledToBottom();
+		fitImagesToViewport();
+		if (wasAtBottom) {
+			setLogScroll(verticalScrollBar()->maximum());
+		}
+	});
+}
+
+void LogTextBrowser::resizeEvent(QResizeEvent *e) {
+	QTextBrowser::resizeEvent(e);
+	m_imageFitTimer->start();
+}
+
+void LogTextBrowser::fitImagesToViewport(int fromPosition) {
+	QTextDocument *doc = document();
+
+	// Leave some room for the document margin and possible frame decorations
+	// around messages so that a fitted image never triggers the horizontal
+	// scrollbar.
+	const int slack          = static_cast< int >(2 * doc->documentMargin()) + 8;
+	const int availableWidth = viewport()->width() - slack;
+	if (availableWidth < 1) {
+		return;
+	}
+
+	struct PendingFit {
+		int position;
+		int length;
+		QTextImageFormat format;
+	};
+	std::vector< PendingFit > pending;
+
+	for (QTextBlock block = doc->findBlock(fromPosition); block.isValid(); block = block.next()) {
+		for (QTextBlock::iterator it = block.begin(); !it.atEnd(); ++it) {
+			const QTextFragment fragment = it.fragment();
+			if (!fragment.isValid() || !fragment.charFormat().isImageFormat()) {
+				continue;
+			}
+
+			QTextImageFormat format = fragment.charFormat().toImageFormat();
+			const QSizeF natural    = naturalImageSize(doc, format);
+			if (natural.isEmpty()) {
+				continue;
+			}
+
+			QSizeF target = natural;
+			if (natural.width() > availableWidth) {
+				target = QSizeF(availableWidth, availableWidth * natural.height() / natural.width());
+			}
+
+			const qreal currentWidth = format.hasProperty(QTextFormat::ImageWidth) ? format.width() : natural.width();
+			const qreal currentHeight =
+				format.hasProperty(QTextFormat::ImageHeight) ? format.height() : natural.height();
+			if (qAbs(currentWidth - target.width()) < 0.5 && qAbs(currentHeight - target.height()) < 0.5) {
+				continue;
+			}
+
+			format.setProperty(ImageNaturalWidthProperty, natural.width());
+			format.setProperty(ImageNaturalHeightProperty, natural.height());
+			format.setWidth(qMax< qreal >(1, target.width()));
+			format.setHeight(qMax< qreal >(1, target.height()));
+			pending.push_back({ fragment.position(), fragment.length(), format });
+		}
+	}
+
+	if (pending.empty()) {
+		return;
+	}
+
+	QTextCursor cursor(doc);
+	cursor.beginEditBlock();
+	for (const PendingFit &fit : pending) {
+		cursor.setPosition(fit.position);
+		cursor.setPosition(fit.position + fit.length, QTextCursor::KeepAnchor);
+		cursor.setCharFormat(fit.format);
+	}
+	cursor.endEditBlock();
 }
 
 int LogTextBrowser::getLogScroll() {

--- a/src/mumble/CustomElements.cpp
+++ b/src/mumble/CustomElements.cpp
@@ -143,6 +143,10 @@ void LogTextBrowser::refitImages(int fromPosition, int toPosition, bool updateRe
 	}
 	const int availableHeight = qMax(1, static_cast< int >(viewport()->height() * MaxImageHeightFraction));
 
+	// With scaling disabled, the refit restores previously scaled images to
+	// their natural displayed size and their original display resource.
+	const bool scaleToFit = Global::get().s.bChatImageScaleToFit;
+
 	const qreal pixelRatio = viewport()->devicePixelRatio();
 
 	struct PendingFit {
@@ -176,7 +180,7 @@ void LogTextBrowser::refitImages(int fromPosition, int toPosition, bool updateRe
 			}
 
 			QSizeF target = natural;
-			if (natural.width() > availableWidth || natural.height() > availableHeight) {
+			if (scaleToFit && (natural.width() > availableWidth || natural.height() > availableHeight)) {
 				target = natural.scaled(QSizeF(availableWidth, availableHeight), Qt::KeepAspectRatio);
 			}
 
@@ -184,8 +188,11 @@ void LogTextBrowser::refitImages(int fromPosition, int toPosition, bool updateRe
 				// Regenerate the display resource whenever its pixel size does
 				// not match the wanted one (this includes a change of the
 				// device pixel ratio, e.g. because the window moved to a
-				// screen with a different scale factor).
-				const QSize pixelSize = (target * pixelRatio).toSize();
+				// screen with a different scale factor). With scaling
+				// disabled, the wanted resource is the original image itself:
+				// in particular, a huge width/height attribute in a message
+				// must not lead to generating a huge upscaled resource.
+				const QSize pixelSize = scaleToFit ? (target * pixelRatio).toSize() : original.size();
 				const QSize resourceSize =
 					doc->resource(QTextDocument::ImageResource, QUrl(format.name())).value< QImage >().size();
 				if (pixelSize != resourceSize) {

--- a/src/mumble/CustomElements.cpp
+++ b/src/mumble/CustomElements.cpp
@@ -38,7 +38,7 @@ static constexpr qreal MaxImageHeightFraction = 0.6;
 /// scaled to fit the viewport: the size from the message's explicit
 /// width/height attributes if present, otherwise the image's own size.
 /// Returns an empty size if it cannot be determined.
-static QSizeF naturalImageSize(QTextDocument *doc, const QTextImageFormat &format) {
+static QSizeF naturalImageSize(const QTextImageFormat &format, const QImage &image) {
 	if (format.hasProperty(ImageNaturalWidthProperty) && format.hasProperty(ImageNaturalHeightProperty)) {
 		return QSizeF(format.doubleProperty(ImageNaturalWidthProperty),
 					  format.doubleProperty(ImageNaturalHeightProperty));
@@ -50,13 +50,6 @@ static QSizeF naturalImageSize(QTextDocument *doc, const QTextImageFormat &forma
 		return QSizeF(format.width(), format.height());
 	}
 
-	const QVariant resource = doc->resource(QTextDocument::ImageResource, QUrl(format.name()));
-	// The cached resource may be a QImage, a QPixmap (QVariant converts it
-	// to an image) or the still-encoded image data.
-	QImage image = resource.value< QImage >();
-	if (image.isNull() && resource.userType() == QMetaType::QByteArray) {
-		image.loadFromData(resource.toByteArray());
-	}
 	if (image.isNull() || image.width() < 1 || image.height() < 1) {
 		return QSizeF();
 	}
@@ -90,8 +83,21 @@ void LogTextBrowser::resizeEvent(QResizeEvent *e) {
 	m_imageFitTimer->start();
 }
 
+bool LogTextBrowser::event(QEvent *e) {
+	// Moving the window to a screen with a different scale factor changes the
+	// pixel size the displayed image resources should be rendered at, without
+	// necessarily changing the logical viewport size.
+	if (e->type() == QEvent::DevicePixelRatioChange) {
+		m_imageFitTimer->start();
+	}
+	return QTextBrowser::event(e);
+}
+
 void LogTextBrowser::fitImagesToViewport(int fromPosition) {
-	QTextDocument *doc = document();
+	LogDocument *doc = qobject_cast< LogDocument * >(document());
+	if (!doc) {
+		return;
+	}
 
 	// Leave some room for the document margin and possible frame decorations
 	// around messages so that a fitted image never triggers the horizontal
@@ -103,12 +109,28 @@ void LogTextBrowser::fitImagesToViewport(int fromPosition) {
 	}
 	const int availableHeight = qMax(1, static_cast< int >(viewport()->height() * MaxImageHeightFraction));
 
+	const qreal pixelRatio = viewport()->devicePixelRatio();
+	// After a change of the device pixel ratio, the display resources of all
+	// images have to be regenerated, even if their displayed size is
+	// unchanged. Only a refit of the whole document gets to reset the flag:
+	// a partial (insert-time) refit only covers the images of one message.
+	const bool pixelRatioChanged = !qFuzzyCompare(pixelRatio, m_lastImageFitPixelRatio);
+	if (fromPosition == 0) {
+		m_lastImageFitPixelRatio = pixelRatio;
+	}
+
 	struct PendingFit {
 		int position;
 		int length;
 		QTextImageFormat format;
 	};
 	std::vector< PendingFit > pending;
+
+	// The pixel size wanted for each image resource. Identical images share a
+	// single resource entry (the resource name is the data URL), so if
+	// occurrences need different display sizes, the largest one wins and the
+	// smaller occurrences are scaled down from it at paint time.
+	QHash< QString, QSize > displaySizes;
 
 	for (QTextBlock block = doc->findBlock(fromPosition); block.isValid(); block = block.next()) {
 		for (QTextBlock::iterator it = block.begin(); !it.atEnd(); ++it) {
@@ -118,7 +140,8 @@ void LogTextBrowser::fitImagesToViewport(int fromPosition) {
 			}
 
 			QTextImageFormat format = fragment.charFormat().toImageFormat();
-			const QSizeF natural    = naturalImageSize(doc, format);
+			const QImage original   = doc->originalImage(format.name());
+			const QSizeF natural    = naturalImageSize(format, original);
 			if (natural.isEmpty()) {
 				continue;
 			}
@@ -131,7 +154,22 @@ void LogTextBrowser::fitImagesToViewport(int fromPosition) {
 			const qreal currentWidth = format.hasProperty(QTextFormat::ImageWidth) ? format.width() : natural.width();
 			const qreal currentHeight =
 				format.hasProperty(QTextFormat::ImageHeight) ? format.height() : natural.height();
-			if (qAbs(currentWidth - target.width()) < 0.5 && qAbs(currentHeight - target.height()) < 0.5) {
+			const bool sizeUpToDate =
+				qAbs(currentWidth - target.width()) < 0.5 && qAbs(currentHeight - target.height()) < 0.5;
+			if (sizeUpToDate && !pixelRatioChanged) {
+				continue;
+			}
+
+			if (!original.isNull()) {
+				const QSize pixelSize = (target * pixelRatio).toSize();
+				QSize &wanted         = displaySizes[format.name()];
+				if (!wanted.isValid() || pixelSize.width() * pixelSize.height() > wanted.width() * wanted.height()) {
+					wanted = pixelSize;
+				}
+			}
+
+			if (sizeUpToDate) {
+				// Only the display resource needs to be regenerated.
 				continue;
 			}
 
@@ -143,18 +181,38 @@ void LogTextBrowser::fitImagesToViewport(int fromPosition) {
 		}
 	}
 
-	if (pending.empty()) {
-		return;
+	// Qt paints images that are displayed at a size other than their pixel
+	// size without any smoothing filter, which makes downscaled images look
+	// noticeably pixelated. Replace the displayed resources with smoothly
+	// prescaled variants instead (the originals stay available through
+	// LogDocument::originalImage()).
+	for (auto it = displaySizes.cbegin(); it != displaySizes.cend(); ++it) {
+		const QImage original = doc->originalImage(it.key());
+		if (original.isNull() || it.value().isEmpty()) {
+			continue;
+		}
+		QImage display = original;
+		if (it.value() != original.size()) {
+			display = original.scaled(it.value(), Qt::KeepAspectRatio, Qt::SmoothTransformation);
+		}
+		display.setDevicePixelRatio(pixelRatio);
+		doc->addResource(QTextDocument::ImageResource, QUrl(it.key()), display);
 	}
 
-	QTextCursor cursor(doc);
-	cursor.beginEditBlock();
-	for (const PendingFit &fit : pending) {
-		cursor.setPosition(fit.position);
-		cursor.setPosition(fit.position + fit.length, QTextCursor::KeepAnchor);
-		cursor.setCharFormat(fit.format);
+	if (!pending.empty()) {
+		QTextCursor cursor(doc);
+		cursor.beginEditBlock();
+		for (const PendingFit &fit : pending) {
+			cursor.setPosition(fit.position);
+			cursor.setPosition(fit.position + fit.length, QTextCursor::KeepAnchor);
+			cursor.setCharFormat(fit.format);
+		}
+		cursor.endEditBlock();
+	} else if (!displaySizes.isEmpty()) {
+		// Resources were regenerated without any format change, so nothing
+		// triggered a repaint yet.
+		viewport()->update();
 	}
-	cursor.endEditBlock();
 }
 
 int LogTextBrowser::getLogScroll() {

--- a/src/mumble/CustomElements.cpp
+++ b/src/mumble/CustomElements.cpp
@@ -79,7 +79,15 @@ LogTextBrowser::LogTextBrowser(QWidget *p) : QTextBrowser(p), m_imageFitTimer(ne
 }
 
 void LogTextBrowser::resizeEvent(QResizeEvent *e) {
+	const bool wasAtBottom = isScrolledToBottom();
 	QTextBrowser::resizeEvent(e);
+	// Cheap geometry-only pass so that the visible images track the pane
+	// live while it is being resized; the debounced full pass regenerates
+	// the smoothly prescaled image resources once resizing settles.
+	fitVisibleImageGeometry();
+	if (wasAtBottom) {
+		setLogScroll(verticalScrollBar()->maximum());
+	}
 	m_imageFitTimer->start();
 }
 
@@ -94,6 +102,16 @@ bool LogTextBrowser::event(QEvent *e) {
 }
 
 void LogTextBrowser::fitImagesToViewport(int fromPosition) {
+	refitImages(fromPosition, -1, true);
+}
+
+void LogTextBrowser::fitVisibleImageGeometry() {
+	const QTextCursor top    = cursorForPosition(QPoint(0, 0));
+	const QTextCursor bottom = cursorForPosition(QPoint(viewport()->width() - 1, viewport()->height() - 1));
+	refitImages(top.position(), bottom.position(), false);
+}
+
+void LogTextBrowser::refitImages(int fromPosition, int toPosition, bool updateResources) {
 	LogDocument *doc = qobject_cast< LogDocument * >(document());
 	if (!doc) {
 		return;
@@ -110,14 +128,6 @@ void LogTextBrowser::fitImagesToViewport(int fromPosition) {
 	const int availableHeight = qMax(1, static_cast< int >(viewport()->height() * MaxImageHeightFraction));
 
 	const qreal pixelRatio = viewport()->devicePixelRatio();
-	// After a change of the device pixel ratio, the display resources of all
-	// images have to be regenerated, even if their displayed size is
-	// unchanged. Only a refit of the whole document gets to reset the flag:
-	// a partial (insert-time) refit only covers the images of one message.
-	const bool pixelRatioChanged = !qFuzzyCompare(pixelRatio, m_lastImageFitPixelRatio);
-	if (fromPosition == 0) {
-		m_lastImageFitPixelRatio = pixelRatio;
-	}
 
 	struct PendingFit {
 		int position;
@@ -133,6 +143,9 @@ void LogTextBrowser::fitImagesToViewport(int fromPosition) {
 	QHash< QString, QSize > displaySizes;
 
 	for (QTextBlock block = doc->findBlock(fromPosition); block.isValid(); block = block.next()) {
+		if (toPosition >= 0 && block.position() > toPosition) {
+			break;
+		}
 		for (QTextBlock::iterator it = block.begin(); !it.atEnd(); ++it) {
 			const QTextFragment fragment = it.fragment();
 			if (!fragment.isValid() || !fragment.charFormat().isImageFormat()) {
@@ -151,25 +164,27 @@ void LogTextBrowser::fitImagesToViewport(int fromPosition) {
 				target = natural.scaled(QSizeF(availableWidth, availableHeight), Qt::KeepAspectRatio);
 			}
 
-			const qreal currentWidth = format.hasProperty(QTextFormat::ImageWidth) ? format.width() : natural.width();
-			const qreal currentHeight =
-				format.hasProperty(QTextFormat::ImageHeight) ? format.height() : natural.height();
-			const bool sizeUpToDate =
-				qAbs(currentWidth - target.width()) < 0.5 && qAbs(currentHeight - target.height()) < 0.5;
-			if (sizeUpToDate && !pixelRatioChanged) {
-				continue;
-			}
-
-			if (!original.isNull()) {
+			if (updateResources && !original.isNull()) {
+				// Regenerate the display resource whenever its pixel size does
+				// not match the wanted one (this includes a change of the
+				// device pixel ratio, e.g. because the window moved to a
+				// screen with a different scale factor).
 				const QSize pixelSize = (target * pixelRatio).toSize();
-				QSize &wanted         = displaySizes[format.name()];
-				if (!wanted.isValid() || pixelSize.width() * pixelSize.height() > wanted.width() * wanted.height()) {
-					wanted = pixelSize;
+				const QSize resourceSize =
+					doc->resource(QTextDocument::ImageResource, QUrl(format.name())).value< QImage >().size();
+				if (pixelSize != resourceSize) {
+					QSize &wanted = displaySizes[format.name()];
+					if (!wanted.isValid()
+						|| pixelSize.width() * pixelSize.height() > wanted.width() * wanted.height()) {
+						wanted = pixelSize;
+					}
 				}
 			}
 
-			if (sizeUpToDate) {
-				// Only the display resource needs to be regenerated.
+			const qreal currentWidth = format.hasProperty(QTextFormat::ImageWidth) ? format.width() : natural.width();
+			const qreal currentHeight =
+				format.hasProperty(QTextFormat::ImageHeight) ? format.height() : natural.height();
+			if (qAbs(currentWidth - target.width()) < 0.5 && qAbs(currentHeight - target.height()) < 0.5) {
 				continue;
 			}
 

--- a/src/mumble/CustomElements.cpp
+++ b/src/mumble/CustomElements.cpp
@@ -29,6 +29,11 @@
 static constexpr int ImageNaturalWidthProperty  = QTextFormat::UserProperty + 1;
 static constexpr int ImageNaturalHeightProperty = QTextFormat::UserProperty + 2;
 
+/// The fraction of the chat log viewport height that a single image may
+/// occupy. Keeps a tall image from taking over the entire log; the full-size
+/// image is still available via "Open Image".
+static constexpr qreal MaxImageHeightFraction = 0.6;
+
 /// Returns the size at which the image would be displayed if it were not
 /// scaled to fit the viewport: the size from the message's explicit
 /// width/height attributes if present, otherwise the image's own size.
@@ -96,6 +101,7 @@ void LogTextBrowser::fitImagesToViewport(int fromPosition) {
 	if (availableWidth < 1) {
 		return;
 	}
+	const int availableHeight = qMax(1, static_cast< int >(viewport()->height() * MaxImageHeightFraction));
 
 	struct PendingFit {
 		int position;
@@ -118,8 +124,8 @@ void LogTextBrowser::fitImagesToViewport(int fromPosition) {
 			}
 
 			QSizeF target = natural;
-			if (natural.width() > availableWidth) {
-				target = QSizeF(availableWidth, availableWidth * natural.height() / natural.width());
+			if (natural.width() > availableWidth || natural.height() > availableHeight) {
+				target = natural.scaled(QSizeF(availableWidth, availableHeight), Qt::KeepAspectRatio);
 			}
 
 			const qreal currentWidth = format.hasProperty(QTextFormat::ImageWidth) ? format.width() : natural.width();

--- a/src/mumble/CustomElements.cpp
+++ b/src/mumble/CustomElements.cpp
@@ -69,25 +69,41 @@ LogTextBrowser::LogTextBrowser(QWidget *p) : QTextBrowser(p), m_imageFitTimer(ne
 	// document continuously while the user drags a splitter, so debounce.
 	m_imageFitTimer->setSingleShot(true);
 	m_imageFitTimer->setInterval(100);
-	connect(m_imageFitTimer, &QTimer::timeout, this, [this]() {
-		const bool wasAtBottom = isScrolledToBottom();
-		fitImagesToViewport();
-		if (wasAtBottom) {
-			setLogScroll(verticalScrollBar()->maximum());
-		}
-	});
+	connect(m_imageFitTimer, &QTimer::timeout, this, &LogTextBrowser::refitImagesKeepingScrollPosition);
+}
+
+void LogTextBrowser::refitImagesKeepingScrollPosition() {
+	const ScrollAnchor anchor = captureScrollAnchor();
+	fitImagesToViewport();
+	restoreScrollAnchor(anchor);
+}
+
+LogTextBrowser::ScrollAnchor LogTextBrowser::captureScrollAnchor() {
+	if (isScrolledToBottom()) {
+		return { true, 0, 0 };
+	}
+	const QTextCursor top = cursorForPosition(QPoint(0, 0));
+	return { false, top.position(), cursorRect(top).top() };
+}
+
+void LogTextBrowser::restoreScrollAnchor(const ScrollAnchor &anchor) {
+	if (anchor.atBottom) {
+		setLogScroll(verticalScrollBar()->maximum());
+		return;
+	}
+	QTextCursor cursor(document());
+	cursor.setPosition(qBound(0, anchor.position, qMax(0, document()->characterCount() - 1)));
+	setLogScroll(getLogScroll() + cursorRect(cursor).top() - anchor.offset);
 }
 
 void LogTextBrowser::resizeEvent(QResizeEvent *e) {
-	const bool wasAtBottom = isScrolledToBottom();
+	const ScrollAnchor anchor = captureScrollAnchor();
 	QTextBrowser::resizeEvent(e);
 	// Cheap geometry-only pass so that the visible images track the pane
 	// live while it is being resized; the debounced full pass regenerates
 	// the smoothly prescaled image resources once resizing settles.
 	fitVisibleImageGeometry();
-	if (wasAtBottom) {
-		setLogScroll(verticalScrollBar()->maximum());
-	}
+	restoreScrollAnchor(anchor);
 	m_imageFitTimer->start();
 }
 

--- a/src/mumble/CustomElements.cpp
+++ b/src/mumble/CustomElements.cpp
@@ -29,11 +29,6 @@
 static constexpr int ImageNaturalWidthProperty  = QTextFormat::UserProperty + 1;
 static constexpr int ImageNaturalHeightProperty = QTextFormat::UserProperty + 2;
 
-/// The fraction of the chat log viewport height that a single image may
-/// occupy. Keeps a tall image from taking over the entire log; the full-size
-/// image is still available via "Open Image".
-static constexpr qreal MaxImageHeightFraction = 0.6;
-
 /// Returns the size at which the image would be displayed if it were not
 /// scaled to fit the viewport: the size from the message's explicit
 /// width/height attributes if present, otherwise the image's own size.
@@ -141,11 +136,15 @@ void LogTextBrowser::refitImages(int fromPosition, int toPosition, bool updateRe
 	if (availableWidth < 1) {
 		return;
 	}
-	const int availableHeight = qMax(1, static_cast< int >(viewport()->height() * MaxImageHeightFraction));
-
 	// With scaling disabled, the refit restores previously scaled images to
 	// their natural displayed size and their original display resource.
 	const bool scaleToFit = Global::get().s.bChatImageScaleToFit;
+
+	// A limit of zero means that the height of an image is not limited, in
+	// which case it is only bounded by the width of the log.
+	const int maxHeightPercent = qBound(0, Global::get().s.iChatImageMaxHeightPercent, 100);
+	const bool limitHeight     = maxHeightPercent > 0;
+	const int availableHeight  = qMax(1, viewport()->height() * maxHeightPercent / 100);
 
 	const qreal pixelRatio = viewport()->devicePixelRatio();
 
@@ -179,10 +178,18 @@ void LogTextBrowser::refitImages(int fromPosition, int toPosition, bool updateRe
 				continue;
 			}
 
-			QSizeF target = natural;
-			if (scaleToFit && (natural.width() > availableWidth || natural.height() > availableHeight)) {
-				target = natural.scaled(QSizeF(availableWidth, availableHeight), Qt::KeepAspectRatio);
+			// Compute a factor that only ever shrinks the image, so that an
+			// unlimited height cannot produce an unbounded display size.
+			qreal scale = 1;
+			if (scaleToFit) {
+				if (natural.width() > availableWidth) {
+					scale = availableWidth / natural.width();
+				}
+				if (limitHeight && natural.height() * scale > availableHeight) {
+					scale = availableHeight / natural.height();
+				}
 			}
+			const QSizeF target = scale < 1 ? natural * scale : natural;
 
 			if (updateResources && !original.isNull()) {
 				// Regenerate the display resource whenever its pixel size does
@@ -192,7 +199,11 @@ void LogTextBrowser::refitImages(int fromPosition, int toPosition, bool updateRe
 				// disabled, the wanted resource is the original image itself:
 				// in particular, a huge width/height attribute in a message
 				// must not lead to generating a huge upscaled resource.
-				const QSize pixelSize = scaleToFit ? (target * pixelRatio).toSize() : original.size();
+				// Never generate a resource that is larger than the image
+				// itself: upscaling it here would gain no detail, but could
+				// allocate an arbitrary amount of memory for an image whose
+				// message requested a huge display size.
+				const QSize pixelSize = (target * pixelRatio).toSize().boundedTo(original.size());
 				const QSize resourceSize =
 					doc->resource(QTextDocument::ImageResource, QUrl(format.name())).value< QImage >().size();
 				if (pixelSize != resourceSize) {

--- a/src/mumble/CustomElements.h
+++ b/src/mumble/CustomElements.h
@@ -11,10 +11,14 @@
 #include <QtWidgets/QTextBrowser>
 #include <QtWidgets/QTextEdit>
 
+class QTimer;
+
 class LogTextBrowser : public QTextBrowser {
 private:
 	Q_OBJECT
 	Q_DISABLE_COPY(LogTextBrowser)
+
+	QTimer *m_imageFitTimer;
 
 public:
 	LogTextBrowser(QWidget *p = nullptr);
@@ -22,6 +26,14 @@ public:
 	int getLogScroll();
 	void setLogScroll(int scroll_pos);
 	bool isScrolledToBottom();
+
+	/// Scales down images in the document so that they fit the width of the
+	/// viewport, starting at the given document position. Images smaller than
+	/// the viewport are never scaled up.
+	void fitImagesToViewport(int fromPosition = 0);
+
+protected:
+	void resizeEvent(QResizeEvent *e) Q_DECL_OVERRIDE;
 };
 
 class ChatbarTextEdit : public QTextEdit {

--- a/src/mumble/CustomElements.h
+++ b/src/mumble/CustomElements.h
@@ -19,6 +19,7 @@ private:
 	Q_DISABLE_COPY(LogTextBrowser)
 
 	QTimer *m_imageFitTimer;
+	qreal m_lastImageFitPixelRatio = 0;
 
 public:
 	LogTextBrowser(QWidget *p = nullptr);
@@ -34,6 +35,7 @@ public:
 
 protected:
 	void resizeEvent(QResizeEvent *e) Q_DECL_OVERRIDE;
+	bool event(QEvent *e) Q_DECL_OVERRIDE;
 };
 
 class ChatbarTextEdit : public QTextEdit {

--- a/src/mumble/CustomElements.h
+++ b/src/mumble/CustomElements.h
@@ -19,7 +19,18 @@ private:
 	Q_DISABLE_COPY(LogTextBrowser)
 
 	QTimer *m_imageFitTimer;
-	qreal m_lastImageFitPixelRatio = 0;
+
+	/// Refits the images between the given document positions (toPosition < 0
+	/// meaning "to the end of the document"). If updateResources is true, the
+	/// displayed image resources are regenerated as smoothly prescaled
+	/// variants of the original wherever their pixel size no longer matches
+	/// the displayed size.
+	void refitImages(int fromPosition, int toPosition, bool updateResources);
+
+	/// Cheap geometry-only refit of the images visible in the viewport. Fast
+	/// enough to run on every resize event, at the cost of painting the
+	/// images from their previously prescaled resources.
+	void fitVisibleImageGeometry();
 
 public:
 	LogTextBrowser(QWidget *p = nullptr);

--- a/src/mumble/CustomElements.h
+++ b/src/mumble/CustomElements.h
@@ -32,6 +32,18 @@ private:
 	/// images from their previously prescaled resources.
 	void fitVisibleImageGeometry();
 
+	/// The reading position to keep stable while a resize or an image refit
+	/// reflows the log: either pinned to the bottom, or the piece of content
+	/// at the top of the viewport together with its on-screen y position.
+	struct ScrollAnchor {
+		bool atBottom;
+		int position;
+		int offset;
+	};
+
+	ScrollAnchor captureScrollAnchor();
+	void restoreScrollAnchor(const ScrollAnchor &anchor);
+
 public:
 	LogTextBrowser(QWidget *p = nullptr);
 
@@ -43,6 +55,10 @@ public:
 	/// viewport, starting at the given document position. Images smaller than
 	/// the viewport are never scaled up.
 	void fitImagesToViewport(int fromPosition = 0);
+
+	/// Refits all images in the document (see fitImagesToViewport()) while
+	/// keeping the reading position stable.
+	void refitImagesKeepingScrollPosition();
 
 protected:
 	void resizeEvent(QResizeEvent *e) Q_DECL_OVERRIDE;

--- a/src/mumble/Log.cpp
+++ b/src/mumble/Log.cpp
@@ -28,6 +28,8 @@
 #include <QSignalBlocker>
 #include <QtCore/QMutexLocker>
 #include <QtCore/QRegularExpression>
+#include <QtCore/QSet>
+#include <QtCore/QTimer>
 #include <QtGui/QImageWriter>
 #include <QtGui/QScreen>
 #include <QtGui/QTextBlock>
@@ -981,7 +983,73 @@ LogMessage::LogMessage(Log::MsgType mt, const QString &console, const QString &t
 	: mt(mt), console(console), terse(terse), ownMessage(ownMessage), overrideTTS(overrideTTS), ignoreTTS(ignoreTTS) {
 }
 
-LogDocument::LogDocument(QObject *p) : QTextDocument(p) {
+LogDocument::LogDocument(QObject *p) : QTextDocument(p), m_pruneTimer(new QTimer(this)) {
+	// When maximumBlockCount is set, appending to the document can silently
+	// trim the oldest blocks away. Prune stored original images whose
+	// messages are gone, so that the memory use for originals stays bounded
+	// by the messages that are actually in the log. Debounced, as trims can
+	// happen on every insertion.
+	m_pruneTimer->setSingleShot(true);
+	m_pruneTimer->setInterval(1000);
+	connect(m_pruneTimer, &QTimer::timeout, this, &LogDocument::pruneOriginalImages);
+
+	connect(this, &QTextDocument::contentsChange, this, [this](int position, int charsRemoved, int) {
+		if (m_originalImages.isEmpty()) {
+			return;
+		}
+		if (isEmpty()) {
+			// The log was cleared.
+			m_originalImages.clear();
+			m_pruneTimer->stop();
+		} else if (position == 0 && charsRemoved > 0) {
+			// Blocks were trimmed at the front of the document.
+			m_pruneTimer->start();
+		}
+	});
+}
+
+void LogDocument::pruneOriginalImages() {
+	if (m_originalImages.isEmpty()) {
+		return;
+	}
+
+	QSet< QString > referenced;
+	for (QTextBlock block = begin(); block != end(); block = block.next()) {
+		for (QTextBlock::iterator it = block.begin(); !it.atEnd(); ++it) {
+			const QTextCharFormat charFormat = it.fragment().charFormat();
+			if (charFormat.isImageFormat()) {
+				referenced.insert(charFormat.toImageFormat().name());
+			}
+		}
+	}
+
+	for (auto it = m_originalImages.begin(); it != m_originalImages.end();) {
+		if (referenced.contains(it.key())) {
+			++it;
+		} else {
+			it = m_originalImages.erase(it);
+		}
+	}
+}
+
+QImage LogDocument::originalImage(const QString &name) {
+	auto it = m_originalImages.constFind(name);
+	if (it != m_originalImages.constEnd()) {
+		return *it;
+	}
+
+	const QVariant res = resource(QTextDocument::ImageResource, QUrl(name));
+	// The cached resource may be a QImage, a QPixmap (QVariant converts it
+	// to an image) or the still-encoded image data.
+	QImage image = res.value< QImage >();
+	if (image.isNull() && res.userType() == QMetaType::QByteArray) {
+		image.loadFromData(res.toByteArray());
+	}
+
+	if (!image.isNull()) {
+		m_originalImages.insert(name, image);
+	}
+	return image;
 }
 
 QVariant LogDocument::loadResource(int type, const QUrl &url) {

--- a/src/mumble/Log.cpp
+++ b/src/mumble/Log.cpp
@@ -24,6 +24,7 @@
 
 #include <limits>
 #include <type_traits>
+#include <vector>
 
 #include <QSignalBlocker>
 #include <QtCore/QMutexLocker>
@@ -641,6 +642,82 @@ QString Log::imageToImg(QImage img, int maxSize) {
 	return QString();
 }
 
+/// Images at most this many font line heights in both dimensions are
+/// considered part of the text (e.g. emotes) and are kept in the flow of the
+/// message. Anything larger is moved onto its own line by
+/// breakOutLargeImages().
+static constexpr int INLINE_IMAGE_MAX_LINE_HEIGHTS = 3;
+
+/// Moves every image that is larger than a small inline image onto its own
+/// left-aligned line. Without this, an image starts at whatever indentation
+/// the preceding text (usually the "[time] Sender:" prefix) happens to end
+/// at, which wastes horizontal space and looks messy in the log.
+static void breakOutLargeImages(LogDocument &doc) {
+	const int inlineThreshold = INLINE_IMAGE_MAX_LINE_HEIGHTS * QFontMetrics(doc.defaultFont()).height();
+
+	struct ImageRange {
+		int position;
+		int length;
+	};
+	std::vector< ImageRange > images;
+
+	for (QTextBlock block = doc.begin(); block != doc.end(); block = block.next()) {
+		for (QTextBlock::iterator it = block.begin(); !it.atEnd(); ++it) {
+			const QTextFragment fragment = it.fragment();
+			if (!fragment.isValid() || !fragment.charFormat().isImageFormat()) {
+				continue;
+			}
+
+			const QTextImageFormat format = fragment.charFormat().toImageFormat();
+			QSizeF size(format.width(), format.height());
+			if (size.isEmpty()) {
+				size = QSizeF(doc.originalImage(format.name()).size());
+			}
+			if (!size.isEmpty() && size.width() <= inlineThreshold && size.height() <= inlineThreshold) {
+				continue;
+			}
+
+			// Qt can merge adjacent identical images into a single fragment,
+			// so treat every object replacement character as its own image.
+			for (int i = 0; i < fragment.length(); ++i) {
+				images.push_back({ fragment.position() + i, 1 });
+			}
+		}
+	}
+
+	// Process back to front, so that the edits do not shift the positions of
+	// the images that are still to be processed.
+	for (auto it = images.rbegin(); it != images.rend(); ++it) {
+		QTextCursor cursor(&doc);
+
+		// Split off any content that follows the image in its block. A line
+		// break directly after the image would turn into a blank line, so it
+		// is removed.
+		cursor.setPosition(it->position + it->length);
+		if (!cursor.atBlockEnd() && doc.characterAt(cursor.position()) == QChar::LineSeparator) {
+			cursor.deleteChar();
+		}
+		if (!cursor.atBlockEnd()) {
+			cursor.insertBlock();
+		}
+
+		// Split the image off from any content that precedes it in its block.
+		cursor.setPosition(it->position);
+		if (!cursor.atBlockStart() && doc.characterAt(cursor.position() - 1) == QChar::LineSeparator) {
+			cursor.deletePreviousChar();
+		}
+		if (!cursor.atBlockStart()) {
+			cursor.insertBlock();
+		}
+
+		// The image's block may have inherited a different alignment, e.g.
+		// from a <center> tag in the message.
+		QTextBlockFormat leftAligned;
+		leftAligned.setAlignment(Qt::AlignLeft);
+		cursor.mergeBlockFormat(leftAligned);
+	}
+}
+
 QString Log::validHtml(const QString &html, QTextCursor *tc) {
 	LogDocument qtd;
 
@@ -675,6 +752,8 @@ QString Log::validHtml(const QString &html, QTextCursor *tc) {
 			}
 		}
 	}
+
+	breakOutLargeImages(qtd);
 
 	qtd.adjustSize();
 	QSizeF s = qtd.size();

--- a/src/mumble/Log.cpp
+++ b/src/mumble/Log.cpp
@@ -805,7 +805,15 @@ void Log::log(MsgType mt, const QString &console, const QString &terse, bool own
 			dt.time().toString(QLatin1String(Global::get().s.bLog24HourClock ? "HH:mm:ss" : "hh:mm:ss AP"));
 		tc.insertHtml(Log::msgColor(QString::fromLatin1("[%1] ").arg(timeString.toHtmlEscaped()), Log::Time));
 
+		// Track the start of the inserted message with a cursor instead of a
+		// plain position: if the insertion pushes the document over its
+		// maximumBlockCount, the oldest blocks are trimmed away as part of
+		// the same operation, shifting all positions. A cursor is adjusted
+		// for that automatically.
+		QTextCursor insertedStart = tc;
+		insertedStart.setKeepPositionOnInsert(true);
 		validHtml(console, &tc);
+		tlog->fitImagesToViewport(insertedStart.position());
 		tc.movePosition(QTextCursor::End);
 		Global::get().mw->qteLog->setTextCursor(tc);
 

--- a/src/mumble/Log.cpp
+++ b/src/mumble/Log.cpp
@@ -248,6 +248,7 @@ void LogConfig::load(const Settings &r) {
 	qsbMaxBlocks->setValue(r.iMaxLogBlocks);
 	qcb24HourClock->setChecked(r.bLog24HourClock);
 	qsbChatMessageMargins->setValue(r.iChatMessageMargins);
+	qcbChatImageScaleToFit->setChecked(r.bChatImageScaleToFit);
 
 #ifdef USE_NO_TTS
 	qtwMessages->hideColumn(ColTTS);
@@ -295,9 +296,10 @@ void LogConfig::save() const {
 		s.qmMessages[mt]      = static_cast< unsigned int >(v);
 		s.qmMessageSounds[mt] = i->text(ColStaticSoundPath);
 	}
-	s.iMaxLogBlocks       = qsbMaxBlocks->value();
-	s.bLog24HourClock     = qcb24HourClock->isChecked();
-	s.iChatMessageMargins = qsbChatMessageMargins->value();
+	s.iMaxLogBlocks        = qsbMaxBlocks->value();
+	s.bLog24HourClock      = qcb24HourClock->isChecked();
+	s.iChatMessageMargins  = qsbChatMessageMargins->value();
+	s.bChatImageScaleToFit = qcbChatImageScaleToFit->isChecked();
 
 #ifndef USE_NO_TTS
 	s.iTTSVolume          = qsTTSVolume->value();
@@ -318,6 +320,9 @@ void LogConfig::accept() const {
 	Global::get().l->tts->setVolume(s.iTTSVolume);
 #endif
 	Global::get().mw->qteLog->document()->setMaximumBlockCount(s.iMaxLogBlocks);
+	// Apply a change of bChatImageScaleToFit to the already displayed images:
+	// with the setting disabled, the refit restores their natural size.
+	Global::get().mw->qteLog->refitImagesKeepingScrollPosition();
 }
 
 void LogConfig::on_qtwMessages_itemChanged(QTreeWidgetItem *i, int column) {
@@ -653,6 +658,10 @@ static constexpr int INLINE_IMAGE_MAX_LINE_HEIGHTS = 3;
 /// the preceding text (usually the "[time] Sender:" prefix) happens to end
 /// at, which wastes horizontal space and looks messy in the log.
 static void breakOutLargeImages(LogDocument &doc) {
+	if (!Global::get().s.bChatImageScaleToFit) {
+		return;
+	}
+
 	const int inlineThreshold = INLINE_IMAGE_MAX_LINE_HEIGHTS * QFontMetrics(doc.defaultFont()).height();
 
 	struct ImageRange {

--- a/src/mumble/Log.cpp
+++ b/src/mumble/Log.cpp
@@ -249,6 +249,8 @@ void LogConfig::load(const Settings &r) {
 	qcb24HourClock->setChecked(r.bLog24HourClock);
 	qsbChatMessageMargins->setValue(r.iChatMessageMargins);
 	qcbChatImageScaleToFit->setChecked(r.bChatImageScaleToFit);
+	qsbChatImageMaxHeight->setValue(r.iChatImageMaxHeightPercent);
+	on_qcbChatImageScaleToFit_toggled(r.bChatImageScaleToFit);
 
 #ifdef USE_NO_TTS
 	qtwMessages->hideColumn(ColTTS);
@@ -296,10 +298,11 @@ void LogConfig::save() const {
 		s.qmMessages[mt]      = static_cast< unsigned int >(v);
 		s.qmMessageSounds[mt] = i->text(ColStaticSoundPath);
 	}
-	s.iMaxLogBlocks        = qsbMaxBlocks->value();
-	s.bLog24HourClock      = qcb24HourClock->isChecked();
-	s.iChatMessageMargins  = qsbChatMessageMargins->value();
-	s.bChatImageScaleToFit = qcbChatImageScaleToFit->isChecked();
+	s.iMaxLogBlocks              = qsbMaxBlocks->value();
+	s.bLog24HourClock            = qcb24HourClock->isChecked();
+	s.iChatMessageMargins        = qsbChatMessageMargins->value();
+	s.bChatImageScaleToFit       = qcbChatImageScaleToFit->isChecked();
+	s.iChatImageMaxHeightPercent = qsbChatImageMaxHeight->value();
 
 #ifndef USE_NO_TTS
 	s.iTTSVolume          = qsTTSVolume->value();
@@ -323,6 +326,12 @@ void LogConfig::accept() const {
 	// Apply a change of bChatImageScaleToFit to the already displayed images:
 	// with the setting disabled, the refit restores their natural size.
 	Global::get().mw->qteLog->refitImagesKeepingScrollPosition();
+}
+
+void LogConfig::on_qcbChatImageScaleToFit_toggled(bool checked) {
+	// The image height limit only has an effect while images are scaled.
+	qlChatImageMaxHeight->setEnabled(checked);
+	qsbChatImageMaxHeight->setEnabled(checked);
 }
 
 void LogConfig::on_qtwMessages_itemChanged(QTreeWidgetItem *i, int column) {

--- a/src/mumble/Log.h
+++ b/src/mumble/Log.h
@@ -10,13 +10,17 @@
 
 #include <QSystemTrayIcon>
 #include <QtCore/QDate>
+#include <QtCore/QHash>
 #include <QtCore/QMutex>
 #include <QtCore/QVector>
+#include <QtGui/QImage>
 #include <QtGui/QTextCursor>
 #include <QtGui/QTextDocument>
 
 #include "ConfigDialog.h"
 #include "ui_Log.h"
+
+class QTimer;
 
 #ifndef USE_NO_TTS
 class TextToSpeech;
@@ -186,9 +190,22 @@ class LogDocument : public QTextDocument {
 private:
 	Q_OBJECT
 	Q_DISABLE_COPY(LogDocument)
+
+	QHash< QString, QImage > m_originalImages;
+	QTimer *m_pruneTimer;
+
+	/// Drops entries from m_originalImages that are no longer referenced by
+	/// any image in the document.
+	void pruneOriginalImages();
+
 public:
 	LogDocument(QObject *p = nullptr);
 	QVariant loadResource(int, const QUrl &) Q_DECL_OVERRIDE;
+
+	/// Returns the image originally received under the given image resource
+	/// name, even after the displayed resource has been replaced by a scaled
+	/// variant. Returns a null image if the name resolves to no image.
+	QImage originalImage(const QString &name);
 };
 
 class NotificationSoundBlocker {

--- a/src/mumble/Log.h
+++ b/src/mumble/Log.h
@@ -63,6 +63,8 @@ public slots:
 	void on_qtwMessages_itemDoubleClicked(QTreeWidgetItem *, int);
 	void browseForAudioFile();
 
+	void on_qcbChatImageScaleToFit_toggled(bool checked);
+
 	void on_qsNotificationVolume_valueChanged(int value);
 	void on_qsCueVolume_valueChanged(int value);
 	void on_qsTTSVolume_valueChanged(int value);

--- a/src/mumble/Log.ui
+++ b/src/mumble/Log.ui
@@ -469,6 +469,18 @@ The setting only applies for new messages, the already shown ones will retain th
         </property>
        </widget>
       </item>
+      <item row="3" column="0" colspan="2">
+       <widget class="QCheckBox" name="qcbChatImageScaleToFit">
+        <property name="toolTip">
+         <string>If checked, images in the chat log are scaled down to fit the log's width and a part of its height, and are displayed on their own line. The full-size image stays available via the image's context menu.
+
+Whether an image is displayed on its own line only changes for new messages.</string>
+        </property>
+        <property name="text">
+         <string>Scale images to fit the chat log</string>
+        </property>
+       </widget>
+      </item>
      </layout>
     </widget>
    </item>
@@ -564,6 +576,7 @@ The setting only applies for new messages, the already shown ones will retain th
   <tabstop>qsbMaxBlocks</tabstop>
   <tabstop>qcb24HourClock</tabstop>
   <tabstop>qsbChatMessageMargins</tabstop>
+  <tabstop>qcbChatImageScaleToFit</tabstop>
   <tabstop>qcbWhisperFriends</tabstop>
   <tabstop>qsbMessageLimitUsers</tabstop>
  </tabstops>

--- a/src/mumble/Log.ui
+++ b/src/mumble/Log.ui
@@ -481,6 +481,47 @@ Whether an image is displayed on its own line only changes for new messages.</st
         </property>
        </widget>
       </item>
+      <item row="4" column="0">
+       <widget class="QLabel" name="qlChatImageMaxHeight">
+        <property name="toolTip">
+         <string>The maximum height an image may occupy in the chat log, as a percentage of the log's visible height. Images are always scaled to fit the log's width; this additionally keeps a tall image from filling the whole log.</string>
+        </property>
+        <property name="text">
+         <string>Maximum image height</string>
+        </property>
+        <property name="buddy">
+         <cstring>qsbChatImageMaxHeight</cstring>
+        </property>
+       </widget>
+      </item>
+      <item row="4" column="1">
+       <widget class="QSpinBox" name="qsbChatImageMaxHeight">
+        <property name="toolTip">
+         <string>The maximum height an image may occupy in the chat log, as a percentage of the log's visible height. Images are always scaled to fit the log's width; this additionally keeps a tall image from filling the whole log.</string>
+        </property>
+        <property name="accessibleName">
+         <string>Maximum image height</string>
+        </property>
+        <property name="specialValueText">
+         <string>No limit</string>
+        </property>
+        <property name="frame">
+         <bool>true</bool>
+        </property>
+        <property name="suffix">
+         <string> %</string>
+        </property>
+        <property name="minimum">
+         <number>0</number>
+        </property>
+        <property name="maximum">
+         <number>100</number>
+        </property>
+        <property name="singleStep">
+         <number>5</number>
+        </property>
+       </widget>
+      </item>
      </layout>
     </widget>
    </item>
@@ -577,6 +618,7 @@ Whether an image is displayed on its own line only changes for new messages.</st
   <tabstop>qcb24HourClock</tabstop>
   <tabstop>qsbChatMessageMargins</tabstop>
   <tabstop>qcbChatImageScaleToFit</tabstop>
+  <tabstop>qsbChatImageMaxHeight</tabstop>
   <tabstop>qcbWhisperFriends</tabstop>
   <tabstop>qsbMessageLimitUsers</tabstop>
  </tabstops>

--- a/src/mumble/MainWindow.cpp
+++ b/src/mumble/MainWindow.cpp
@@ -487,6 +487,11 @@ void MainWindow::setupGui() {
 #endif
 
 	LogDocument *ld = new LogDocument(qteLog);
+	// The chat log is read-only for the user, so there is no way to trigger
+	// an undo. Without this, every insertion into the log would grow the undo
+	// history indefinitely. This cannot be done in the LogDocument
+	// constructor, as LogDocument is also used for editable widgets.
+	ld->setUndoRedoEnabled(false);
 	qteLog->setDocument(ld);
 
 	qteLog->document()->setMaximumBlockCount(Global::get().s.iMaxLogBlocks);

--- a/src/mumble/MainWindow.cpp
+++ b/src/mumble/MainWindow.cpp
@@ -1099,9 +1099,11 @@ void MainWindow::saveImageAs() {
 	}
 
 	QString resName = qtcSaveImageCursor.charFormat().toImageFormat().name();
-	QVariant res    = qteLog->document()->resource(QTextDocument::ImageResource, resName);
-	QImage img      = res.value< QImage >();
-	bool ok         = img.save(fname);
+	// Fetch the image via LogDocument::originalImage() so that we save the
+	// image as it was received, not the scaled variant displayed in the log.
+	LogDocument *logDoc = qobject_cast< LogDocument * >(qteLog->document());
+	QImage img          = logDoc ? logDoc->originalImage(resName) : QImage();
+	bool ok             = img.save(fname);
 	if (!ok) {
 		// In case fname did not contain a file extension, try saving with an
 		// explicit format.
@@ -4357,8 +4359,10 @@ void MainWindow::showImageDialog() {
 	if (!qtcSaveImageCursor.isNull() && qtcSaveImageCursor.charFormat().isImageFormat()) {
 		QTextImageFormat imgFmt = qtcSaveImageCursor.charFormat().toImageFormat();
 		QString resName         = imgFmt.name();
-		QVariant res            = qteLog->document()->resource(QTextDocument::ImageResource, resName);
-		QImage img              = res.value< QImage >();
+		// Show the image as it was received, not the scaled variant that is
+		// displayed in the log.
+		LogDocument *logDoc = qobject_cast< LogDocument * >(qteLog->document());
+		QImage img          = logDoc ? logDoc->originalImage(resName) : QImage();
 
 		if (!img.isNull()) {
 			QPixmap pixmap             = QPixmap::fromImage(img);

--- a/src/mumble/Settings.h
+++ b/src/mumble/Settings.h
@@ -375,9 +375,10 @@ struct Settings {
 	bool bEnableUIAccess          = true;
 	QList< Shortcut > qlShortcuts = {};
 
-	int iMaxLogBlocks       = 0;
-	bool bLog24HourClock    = true;
-	int iChatMessageMargins = 3;
+	int iMaxLogBlocks         = 0;
+	bool bLog24HourClock      = true;
+	int iChatMessageMargins   = 3;
+	bool bChatImageScaleToFit = true;
 
 	QPoint qpTalkingUI_Position              = UNSPECIFIED_POSITION;
 	bool bShowTalkingUI                      = false;

--- a/src/mumble/Settings.h
+++ b/src/mumble/Settings.h
@@ -375,10 +375,11 @@ struct Settings {
 	bool bEnableUIAccess          = true;
 	QList< Shortcut > qlShortcuts = {};
 
-	int iMaxLogBlocks         = 0;
-	bool bLog24HourClock      = true;
-	int iChatMessageMargins   = 3;
-	bool bChatImageScaleToFit = true;
+	int iMaxLogBlocks              = 0;
+	bool bLog24HourClock           = true;
+	int iChatMessageMargins        = 3;
+	bool bChatImageScaleToFit      = true;
+	int iChatImageMaxHeightPercent = 60;
 
 	QPoint qpTalkingUI_Position              = UNSPECIFIED_POSITION;
 	bool bShowTalkingUI                      = false;

--- a/src/mumble/SettingsKeys.h
+++ b/src/mumble/SettingsKeys.h
@@ -209,6 +209,7 @@ const SettingsKey HIGH_CONTRAST_MODE_KEY               = { "high_contrast_mode" 
 const SettingsKey MAX_LOG_LENGTH_KEY                   = { "max_log_length" };
 const SettingsKey USE_24H_CLOCK_KEY                    = { "use_24h_clock_format" };
 const SettingsKey LOG_MESSAGE_MARGINS_KEY              = { "log_message_margins" };
+const SettingsKey CHAT_IMAGE_SCALE_TO_FIT_KEY          = { "chat_image_scale_to_fit" };
 const SettingsKey DISABLE_PUBLIC_SERVER_LIST_KEY       = { "disable_public_server_list" };
 
 // Last connection

--- a/src/mumble/SettingsKeys.h
+++ b/src/mumble/SettingsKeys.h
@@ -210,6 +210,7 @@ const SettingsKey MAX_LOG_LENGTH_KEY                   = { "max_log_length" };
 const SettingsKey USE_24H_CLOCK_KEY                    = { "use_24h_clock_format" };
 const SettingsKey LOG_MESSAGE_MARGINS_KEY              = { "log_message_margins" };
 const SettingsKey CHAT_IMAGE_SCALE_TO_FIT_KEY          = { "chat_image_scale_to_fit" };
+const SettingsKey CHAT_IMAGE_MAX_HEIGHT_KEY            = { "chat_image_max_height_percent" };
 const SettingsKey DISABLE_PUBLIC_SERVER_LIST_KEY       = { "disable_public_server_list" };
 
 // Last connection

--- a/src/mumble/SettingsMacros.h
+++ b/src/mumble/SettingsMacros.h
@@ -179,6 +179,7 @@
 	PROCESS(ui, MAX_LOG_LENGTH_KEY, iMaxLogBlocks)                               \
 	PROCESS(ui, USE_24H_CLOCK_KEY, bLog24HourClock)                              \
 	PROCESS(ui, LOG_MESSAGE_MARGINS_KEY, iChatMessageMargins)                    \
+	PROCESS(ui, CHAT_IMAGE_SCALE_TO_FIT_KEY, bChatImageScaleToFit)               \
 	PROCESS(ui, DISABLE_PUBLIC_SERVER_LIST_KEY, bDisablePublicList)
 
 

--- a/src/mumble/SettingsMacros.h
+++ b/src/mumble/SettingsMacros.h
@@ -180,6 +180,7 @@
 	PROCESS(ui, USE_24H_CLOCK_KEY, bLog24HourClock)                              \
 	PROCESS(ui, LOG_MESSAGE_MARGINS_KEY, iChatMessageMargins)                    \
 	PROCESS(ui, CHAT_IMAGE_SCALE_TO_FIT_KEY, bChatImageScaleToFit)               \
+	PROCESS(ui, CHAT_IMAGE_MAX_HEIGHT_KEY, iChatImageMaxHeightPercent)           \
 	PROCESS(ui, DISABLE_PUBLIC_SERVER_LIST_KEY, bDisablePublicList)
 
 

--- a/src/mumble/mumble_ar.ts
+++ b/src/mumble/mumble_ar.ts
@@ -4576,6 +4576,16 @@ The setting only applies for new messages, the already shown ones will retain th
         <source>decibels</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>If checked, images in the chat log are scaled down to fit the log&apos;s width and a part of its height, and are displayed on their own line. The full-size image stays available via the image&apos;s context menu.
+
+Whether an image is displayed on its own line only changes for new messages.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Scale images to fit the chat log</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>LookConfig</name>

--- a/src/mumble/mumble_ar.ts
+++ b/src/mumble/mumble_ar.ts
@@ -4586,6 +4586,18 @@ Whether an image is displayed on its own line only changes for new messages.</so
         <source>Scale images to fit the chat log</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>The maximum height an image may occupy in the chat log, as a percentage of the log&apos;s visible height. Images are always scaled to fit the log&apos;s width; this additionally keeps a tall image from filling the whole log.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Maximum image height</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>No limit</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>LookConfig</name>

--- a/src/mumble/mumble_bg.ts
+++ b/src/mumble/mumble_bg.ts
@@ -4573,6 +4573,16 @@ The setting only applies for new messages, the already shown ones will retain th
         <source>decibels</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>If checked, images in the chat log are scaled down to fit the log&apos;s width and a part of its height, and are displayed on their own line. The full-size image stays available via the image&apos;s context menu.
+
+Whether an image is displayed on its own line only changes for new messages.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Scale images to fit the chat log</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>LookConfig</name>

--- a/src/mumble/mumble_bg.ts
+++ b/src/mumble/mumble_bg.ts
@@ -4583,6 +4583,18 @@ Whether an image is displayed on its own line only changes for new messages.</so
         <source>Scale images to fit the chat log</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>The maximum height an image may occupy in the chat log, as a percentage of the log&apos;s visible height. Images are always scaled to fit the log&apos;s width; this additionally keeps a tall image from filling the whole log.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Maximum image height</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>No limit</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>LookConfig</name>

--- a/src/mumble/mumble_br.ts
+++ b/src/mumble/mumble_br.ts
@@ -4572,6 +4572,16 @@ The setting only applies for new messages, the already shown ones will retain th
         <source>decibels</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>If checked, images in the chat log are scaled down to fit the log&apos;s width and a part of its height, and are displayed on their own line. The full-size image stays available via the image&apos;s context menu.
+
+Whether an image is displayed on its own line only changes for new messages.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Scale images to fit the chat log</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>LookConfig</name>

--- a/src/mumble/mumble_br.ts
+++ b/src/mumble/mumble_br.ts
@@ -4582,6 +4582,18 @@ Whether an image is displayed on its own line only changes for new messages.</so
         <source>Scale images to fit the chat log</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>The maximum height an image may occupy in the chat log, as a percentage of the log&apos;s visible height. Images are always scaled to fit the log&apos;s width; this additionally keeps a tall image from filling the whole log.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Maximum image height</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>No limit</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>LookConfig</name>

--- a/src/mumble/mumble_ca.ts
+++ b/src/mumble/mumble_ca.ts
@@ -4634,6 +4634,16 @@ El paràmetre només serà per als missatges nous, els que ja s&apos;han mostrat
         <source>decibels</source>
         <translation>decibels</translation>
     </message>
+    <message>
+        <source>If checked, images in the chat log are scaled down to fit the log&apos;s width and a part of its height, and are displayed on their own line. The full-size image stays available via the image&apos;s context menu.
+
+Whether an image is displayed on its own line only changes for new messages.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Scale images to fit the chat log</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>LookConfig</name>

--- a/src/mumble/mumble_ca.ts
+++ b/src/mumble/mumble_ca.ts
@@ -4644,6 +4644,18 @@ Whether an image is displayed on its own line only changes for new messages.</so
         <source>Scale images to fit the chat log</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>The maximum height an image may occupy in the chat log, as a percentage of the log&apos;s visible height. Images are always scaled to fit the log&apos;s width; this additionally keeps a tall image from filling the whole log.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Maximum image height</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>No limit</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>LookConfig</name>

--- a/src/mumble/mumble_cs.ts
+++ b/src/mumble/mumble_cs.ts
@@ -4627,6 +4627,16 @@ The setting only applies for new messages, the already shown ones will retain th
         <source>decibels</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>If checked, images in the chat log are scaled down to fit the log&apos;s width and a part of its height, and are displayed on their own line. The full-size image stays available via the image&apos;s context menu.
+
+Whether an image is displayed on its own line only changes for new messages.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Scale images to fit the chat log</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>LookConfig</name>

--- a/src/mumble/mumble_cs.ts
+++ b/src/mumble/mumble_cs.ts
@@ -4637,6 +4637,18 @@ Whether an image is displayed on its own line only changes for new messages.</so
         <source>Scale images to fit the chat log</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>The maximum height an image may occupy in the chat log, as a percentage of the log&apos;s visible height. Images are always scaled to fit the log&apos;s width; this additionally keeps a tall image from filling the whole log.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Maximum image height</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>No limit</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>LookConfig</name>

--- a/src/mumble/mumble_cy.ts
+++ b/src/mumble/mumble_cy.ts
@@ -4576,6 +4576,16 @@ The setting only applies for new messages, the already shown ones will retain th
         <source>decibels</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>If checked, images in the chat log are scaled down to fit the log&apos;s width and a part of its height, and are displayed on their own line. The full-size image stays available via the image&apos;s context menu.
+
+Whether an image is displayed on its own line only changes for new messages.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Scale images to fit the chat log</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>LookConfig</name>

--- a/src/mumble/mumble_cy.ts
+++ b/src/mumble/mumble_cy.ts
@@ -4586,6 +4586,18 @@ Whether an image is displayed on its own line only changes for new messages.</so
         <source>Scale images to fit the chat log</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>The maximum height an image may occupy in the chat log, as a percentage of the log&apos;s visible height. Images are always scaled to fit the log&apos;s width; this additionally keeps a tall image from filling the whole log.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Maximum image height</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>No limit</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>LookConfig</name>

--- a/src/mumble/mumble_da.ts
+++ b/src/mumble/mumble_da.ts
@@ -4626,6 +4626,16 @@ The setting only applies for new messages, the already shown ones will retain th
         <source>decibels</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>If checked, images in the chat log are scaled down to fit the log&apos;s width and a part of its height, and are displayed on their own line. The full-size image stays available via the image&apos;s context menu.
+
+Whether an image is displayed on its own line only changes for new messages.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Scale images to fit the chat log</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>LookConfig</name>

--- a/src/mumble/mumble_da.ts
+++ b/src/mumble/mumble_da.ts
@@ -4636,6 +4636,18 @@ Whether an image is displayed on its own line only changes for new messages.</so
         <source>Scale images to fit the chat log</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>The maximum height an image may occupy in the chat log, as a percentage of the log&apos;s visible height. Images are always scaled to fit the log&apos;s width; this additionally keeps a tall image from filling the whole log.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Maximum image height</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>No limit</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>LookConfig</name>

--- a/src/mumble/mumble_de.ts
+++ b/src/mumble/mumble_de.ts
@@ -4634,6 +4634,16 @@ Die Einstellung gilt nur für neue Nachrichten, die bereits angezeigten behalten
         <source>decibels</source>
         <translation>Dezibel</translation>
     </message>
+    <message>
+        <source>If checked, images in the chat log are scaled down to fit the log&apos;s width and a part of its height, and are displayed on their own line. The full-size image stays available via the image&apos;s context menu.
+
+Whether an image is displayed on its own line only changes for new messages.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Scale images to fit the chat log</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>LookConfig</name>

--- a/src/mumble/mumble_de.ts
+++ b/src/mumble/mumble_de.ts
@@ -4644,6 +4644,18 @@ Whether an image is displayed on its own line only changes for new messages.</so
         <source>Scale images to fit the chat log</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>The maximum height an image may occupy in the chat log, as a percentage of the log&apos;s visible height. Images are always scaled to fit the log&apos;s width; this additionally keeps a tall image from filling the whole log.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Maximum image height</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>No limit</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>LookConfig</name>

--- a/src/mumble/mumble_el.ts
+++ b/src/mumble/mumble_el.ts
@@ -4634,6 +4634,16 @@ The setting only applies for new messages, the already shown ones will retain th
         <source>decibels</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>If checked, images in the chat log are scaled down to fit the log&apos;s width and a part of its height, and are displayed on their own line. The full-size image stays available via the image&apos;s context menu.
+
+Whether an image is displayed on its own line only changes for new messages.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Scale images to fit the chat log</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>LookConfig</name>

--- a/src/mumble/mumble_el.ts
+++ b/src/mumble/mumble_el.ts
@@ -4644,6 +4644,18 @@ Whether an image is displayed on its own line only changes for new messages.</so
         <source>Scale images to fit the chat log</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>The maximum height an image may occupy in the chat log, as a percentage of the log&apos;s visible height. Images are always scaled to fit the log&apos;s width; this additionally keeps a tall image from filling the whole log.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Maximum image height</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>No limit</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>LookConfig</name>

--- a/src/mumble/mumble_en.ts
+++ b/src/mumble/mumble_en.ts
@@ -4571,6 +4571,16 @@ The setting only applies for new messages, the already shown ones will retain th
         <source>decibels</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>If checked, images in the chat log are scaled down to fit the log&apos;s width and a part of its height, and are displayed on their own line. The full-size image stays available via the image&apos;s context menu.
+
+Whether an image is displayed on its own line only changes for new messages.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Scale images to fit the chat log</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>LookConfig</name>

--- a/src/mumble/mumble_en.ts
+++ b/src/mumble/mumble_en.ts
@@ -4581,6 +4581,18 @@ Whether an image is displayed on its own line only changes for new messages.</so
         <source>Scale images to fit the chat log</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>The maximum height an image may occupy in the chat log, as a percentage of the log&apos;s visible height. Images are always scaled to fit the log&apos;s width; this additionally keeps a tall image from filling the whole log.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Maximum image height</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>No limit</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>LookConfig</name>

--- a/src/mumble/mumble_en_GB.ts
+++ b/src/mumble/mumble_en_GB.ts
@@ -4628,6 +4628,16 @@ This setting only applies to new messages; existing messages keep the previous t
         <source>decibels</source>
         <translation type="unfinished">decibels</translation>
     </message>
+    <message>
+        <source>If checked, images in the chat log are scaled down to fit the log&apos;s width and a part of its height, and are displayed on their own line. The full-size image stays available via the image&apos;s context menu.
+
+Whether an image is displayed on its own line only changes for new messages.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Scale images to fit the chat log</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>LookConfig</name>
@@ -9213,7 +9223,7 @@ See &lt;a href=&quot;https://github.com/mumble-voip/mumble&quot;&gt;the project 
     </message>
     <message>
         <source>Current selection</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">Current selection</translation>
     </message>
 </context>
 <context>

--- a/src/mumble/mumble_en_GB.ts
+++ b/src/mumble/mumble_en_GB.ts
@@ -4638,6 +4638,18 @@ Whether an image is displayed on its own line only changes for new messages.</so
         <source>Scale images to fit the chat log</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>The maximum height an image may occupy in the chat log, as a percentage of the log&apos;s visible height. Images are always scaled to fit the log&apos;s width; this additionally keeps a tall image from filling the whole log.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Maximum image height</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>No limit</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>LookConfig</name>

--- a/src/mumble/mumble_eo.ts
+++ b/src/mumble/mumble_eo.ts
@@ -4583,6 +4583,16 @@ The setting only applies for new messages, the already shown ones will retain th
         <source>decibels</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>If checked, images in the chat log are scaled down to fit the log&apos;s width and a part of its height, and are displayed on their own line. The full-size image stays available via the image&apos;s context menu.
+
+Whether an image is displayed on its own line only changes for new messages.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Scale images to fit the chat log</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>LookConfig</name>

--- a/src/mumble/mumble_eo.ts
+++ b/src/mumble/mumble_eo.ts
@@ -4593,6 +4593,18 @@ Whether an image is displayed on its own line only changes for new messages.</so
         <source>Scale images to fit the chat log</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>The maximum height an image may occupy in the chat log, as a percentage of the log&apos;s visible height. Images are always scaled to fit the log&apos;s width; this additionally keeps a tall image from filling the whole log.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Maximum image height</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>No limit</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>LookConfig</name>

--- a/src/mumble/mumble_es.ts
+++ b/src/mumble/mumble_es.ts
@@ -4635,6 +4635,16 @@ La configuración solo se aplica a los mensajes nuevos, los que ya se muestran c
         <source>decibels</source>
         <translation>decibelios</translation>
     </message>
+    <message>
+        <source>If checked, images in the chat log are scaled down to fit the log&apos;s width and a part of its height, and are displayed on their own line. The full-size image stays available via the image&apos;s context menu.
+
+Whether an image is displayed on its own line only changes for new messages.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Scale images to fit the chat log</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>LookConfig</name>

--- a/src/mumble/mumble_es.ts
+++ b/src/mumble/mumble_es.ts
@@ -4645,6 +4645,18 @@ Whether an image is displayed on its own line only changes for new messages.</so
         <source>Scale images to fit the chat log</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>The maximum height an image may occupy in the chat log, as a percentage of the log&apos;s visible height. Images are always scaled to fit the log&apos;s width; this additionally keeps a tall image from filling the whole log.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Maximum image height</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>No limit</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>LookConfig</name>

--- a/src/mumble/mumble_et.ts
+++ b/src/mumble/mumble_et.ts
@@ -4573,6 +4573,16 @@ The setting only applies for new messages, the already shown ones will retain th
         <source>decibels</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>If checked, images in the chat log are scaled down to fit the log&apos;s width and a part of its height, and are displayed on their own line. The full-size image stays available via the image&apos;s context menu.
+
+Whether an image is displayed on its own line only changes for new messages.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Scale images to fit the chat log</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>LookConfig</name>

--- a/src/mumble/mumble_et.ts
+++ b/src/mumble/mumble_et.ts
@@ -4583,6 +4583,18 @@ Whether an image is displayed on its own line only changes for new messages.</so
         <source>Scale images to fit the chat log</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>The maximum height an image may occupy in the chat log, as a percentage of the log&apos;s visible height. Images are always scaled to fit the log&apos;s width; this additionally keeps a tall image from filling the whole log.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Maximum image height</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>No limit</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>LookConfig</name>

--- a/src/mumble/mumble_eu.ts
+++ b/src/mumble/mumble_eu.ts
@@ -4590,6 +4590,16 @@ The setting only applies for new messages, the already shown ones will retain th
         <source>decibels</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>If checked, images in the chat log are scaled down to fit the log&apos;s width and a part of its height, and are displayed on their own line. The full-size image stays available via the image&apos;s context menu.
+
+Whether an image is displayed on its own line only changes for new messages.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Scale images to fit the chat log</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>LookConfig</name>

--- a/src/mumble/mumble_eu.ts
+++ b/src/mumble/mumble_eu.ts
@@ -4600,6 +4600,18 @@ Whether an image is displayed on its own line only changes for new messages.</so
         <source>Scale images to fit the chat log</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>The maximum height an image may occupy in the chat log, as a percentage of the log&apos;s visible height. Images are always scaled to fit the log&apos;s width; this additionally keeps a tall image from filling the whole log.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Maximum image height</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>No limit</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>LookConfig</name>

--- a/src/mumble/mumble_fa_IR.ts
+++ b/src/mumble/mumble_fa_IR.ts
@@ -4573,6 +4573,16 @@ The setting only applies for new messages, the already shown ones will retain th
         <source>decibels</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>If checked, images in the chat log are scaled down to fit the log&apos;s width and a part of its height, and are displayed on their own line. The full-size image stays available via the image&apos;s context menu.
+
+Whether an image is displayed on its own line only changes for new messages.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Scale images to fit the chat log</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>LookConfig</name>

--- a/src/mumble/mumble_fa_IR.ts
+++ b/src/mumble/mumble_fa_IR.ts
@@ -4583,6 +4583,18 @@ Whether an image is displayed on its own line only changes for new messages.</so
         <source>Scale images to fit the chat log</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>The maximum height an image may occupy in the chat log, as a percentage of the log&apos;s visible height. Images are always scaled to fit the log&apos;s width; this additionally keeps a tall image from filling the whole log.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Maximum image height</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>No limit</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>LookConfig</name>

--- a/src/mumble/mumble_fi.ts
+++ b/src/mumble/mumble_fi.ts
@@ -4634,6 +4634,16 @@ Tämä vaikuttaa vain uusiin viesteihin, vanhojen viestien aikaleima ei muutu.</
         <source>decibels</source>
         <translation>desibeliä</translation>
     </message>
+    <message>
+        <source>If checked, images in the chat log are scaled down to fit the log&apos;s width and a part of its height, and are displayed on their own line. The full-size image stays available via the image&apos;s context menu.
+
+Whether an image is displayed on its own line only changes for new messages.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Scale images to fit the chat log</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>LookConfig</name>

--- a/src/mumble/mumble_fi.ts
+++ b/src/mumble/mumble_fi.ts
@@ -4644,6 +4644,18 @@ Whether an image is displayed on its own line only changes for new messages.</so
         <source>Scale images to fit the chat log</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>The maximum height an image may occupy in the chat log, as a percentage of the log&apos;s visible height. Images are always scaled to fit the log&apos;s width; this additionally keeps a tall image from filling the whole log.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Maximum image height</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>No limit</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>LookConfig</name>

--- a/src/mumble/mumble_fr.ts
+++ b/src/mumble/mumble_fr.ts
@@ -4634,6 +4634,16 @@ Le paramètre ne s&apos;applique qu&apos;aux nouveaux messages, ceux déjà affi
         <source>decibels</source>
         <translation>décibels</translation>
     </message>
+    <message>
+        <source>If checked, images in the chat log are scaled down to fit the log&apos;s width and a part of its height, and are displayed on their own line. The full-size image stays available via the image&apos;s context menu.
+
+Whether an image is displayed on its own line only changes for new messages.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Scale images to fit the chat log</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>LookConfig</name>

--- a/src/mumble/mumble_fr.ts
+++ b/src/mumble/mumble_fr.ts
@@ -4644,6 +4644,18 @@ Whether an image is displayed on its own line only changes for new messages.</so
         <source>Scale images to fit the chat log</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>The maximum height an image may occupy in the chat log, as a percentage of the log&apos;s visible height. Images are always scaled to fit the log&apos;s width; this additionally keeps a tall image from filling the whole log.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Maximum image height</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>No limit</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>LookConfig</name>

--- a/src/mumble/mumble_gl.ts
+++ b/src/mumble/mumble_gl.ts
@@ -4574,6 +4574,16 @@ The setting only applies for new messages, the already shown ones will retain th
         <source>decibels</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>If checked, images in the chat log are scaled down to fit the log&apos;s width and a part of its height, and are displayed on their own line. The full-size image stays available via the image&apos;s context menu.
+
+Whether an image is displayed on its own line only changes for new messages.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Scale images to fit the chat log</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>LookConfig</name>

--- a/src/mumble/mumble_gl.ts
+++ b/src/mumble/mumble_gl.ts
@@ -4584,6 +4584,18 @@ Whether an image is displayed on its own line only changes for new messages.</so
         <source>Scale images to fit the chat log</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>The maximum height an image may occupy in the chat log, as a percentage of the log&apos;s visible height. Images are always scaled to fit the log&apos;s width; this additionally keeps a tall image from filling the whole log.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Maximum image height</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>No limit</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>LookConfig</name>

--- a/src/mumble/mumble_he.ts
+++ b/src/mumble/mumble_he.ts
@@ -4624,6 +4624,16 @@ The setting only applies for new messages, the already shown ones will retain th
         <source>decibels</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>If checked, images in the chat log are scaled down to fit the log&apos;s width and a part of its height, and are displayed on their own line. The full-size image stays available via the image&apos;s context menu.
+
+Whether an image is displayed on its own line only changes for new messages.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Scale images to fit the chat log</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>LookConfig</name>

--- a/src/mumble/mumble_he.ts
+++ b/src/mumble/mumble_he.ts
@@ -4634,6 +4634,18 @@ Whether an image is displayed on its own line only changes for new messages.</so
         <source>Scale images to fit the chat log</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>The maximum height an image may occupy in the chat log, as a percentage of the log&apos;s visible height. Images are always scaled to fit the log&apos;s width; this additionally keeps a tall image from filling the whole log.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Maximum image height</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>No limit</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>LookConfig</name>

--- a/src/mumble/mumble_hi.ts
+++ b/src/mumble/mumble_hi.ts
@@ -4549,6 +4549,16 @@ The setting only applies for new messages, the already shown ones will retain th
         <source>decibels</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>If checked, images in the chat log are scaled down to fit the log&apos;s width and a part of its height, and are displayed on their own line. The full-size image stays available via the image&apos;s context menu.
+
+Whether an image is displayed on its own line only changes for new messages.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Scale images to fit the chat log</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>LookConfig</name>

--- a/src/mumble/mumble_hi.ts
+++ b/src/mumble/mumble_hi.ts
@@ -4559,6 +4559,18 @@ Whether an image is displayed on its own line only changes for new messages.</so
         <source>Scale images to fit the chat log</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>The maximum height an image may occupy in the chat log, as a percentage of the log&apos;s visible height. Images are always scaled to fit the log&apos;s width; this additionally keeps a tall image from filling the whole log.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Maximum image height</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>No limit</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>LookConfig</name>

--- a/src/mumble/mumble_hu.ts
+++ b/src/mumble/mumble_hu.ts
@@ -4620,6 +4620,16 @@ The setting only applies for new messages, the already shown ones will retain th
         <source>decibels</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>If checked, images in the chat log are scaled down to fit the log&apos;s width and a part of its height, and are displayed on their own line. The full-size image stays available via the image&apos;s context menu.
+
+Whether an image is displayed on its own line only changes for new messages.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Scale images to fit the chat log</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>LookConfig</name>

--- a/src/mumble/mumble_hu.ts
+++ b/src/mumble/mumble_hu.ts
@@ -4630,6 +4630,18 @@ Whether an image is displayed on its own line only changes for new messages.</so
         <source>Scale images to fit the chat log</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>The maximum height an image may occupy in the chat log, as a percentage of the log&apos;s visible height. Images are always scaled to fit the log&apos;s width; this additionally keeps a tall image from filling the whole log.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Maximum image height</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>No limit</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>LookConfig</name>

--- a/src/mumble/mumble_it.ts
+++ b/src/mumble/mumble_it.ts
@@ -4634,6 +4634,16 @@ Questa impostazione si applica solo ai nuovi messaggi, quelli già mostrati mant
         <source>decibels</source>
         <translation>decibel</translation>
     </message>
+    <message>
+        <source>If checked, images in the chat log are scaled down to fit the log&apos;s width and a part of its height, and are displayed on their own line. The full-size image stays available via the image&apos;s context menu.
+
+Whether an image is displayed on its own line only changes for new messages.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Scale images to fit the chat log</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>LookConfig</name>

--- a/src/mumble/mumble_it.ts
+++ b/src/mumble/mumble_it.ts
@@ -4644,6 +4644,18 @@ Whether an image is displayed on its own line only changes for new messages.</so
         <source>Scale images to fit the chat log</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>The maximum height an image may occupy in the chat log, as a percentage of the log&apos;s visible height. Images are always scaled to fit the log&apos;s width; this additionally keeps a tall image from filling the whole log.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Maximum image height</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>No limit</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>LookConfig</name>

--- a/src/mumble/mumble_ja.ts
+++ b/src/mumble/mumble_ja.ts
@@ -4623,6 +4623,16 @@ The setting only applies for new messages, the already shown ones will retain th
         <source>decibels</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>If checked, images in the chat log are scaled down to fit the log&apos;s width and a part of its height, and are displayed on their own line. The full-size image stays available via the image&apos;s context menu.
+
+Whether an image is displayed on its own line only changes for new messages.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Scale images to fit the chat log</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>LookConfig</name>

--- a/src/mumble/mumble_ja.ts
+++ b/src/mumble/mumble_ja.ts
@@ -4633,6 +4633,18 @@ Whether an image is displayed on its own line only changes for new messages.</so
         <source>Scale images to fit the chat log</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>The maximum height an image may occupy in the chat log, as a percentage of the log&apos;s visible height. Images are always scaled to fit the log&apos;s width; this additionally keeps a tall image from filling the whole log.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Maximum image height</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>No limit</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>LookConfig</name>

--- a/src/mumble/mumble_ko.ts
+++ b/src/mumble/mumble_ko.ts
@@ -4633,6 +4633,16 @@ The setting only applies for new messages, the already shown ones will retain th
         <source>decibels</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>If checked, images in the chat log are scaled down to fit the log&apos;s width and a part of its height, and are displayed on their own line. The full-size image stays available via the image&apos;s context menu.
+
+Whether an image is displayed on its own line only changes for new messages.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Scale images to fit the chat log</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>LookConfig</name>

--- a/src/mumble/mumble_ko.ts
+++ b/src/mumble/mumble_ko.ts
@@ -4643,6 +4643,18 @@ Whether an image is displayed on its own line only changes for new messages.</so
         <source>Scale images to fit the chat log</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>The maximum height an image may occupy in the chat log, as a percentage of the log&apos;s visible height. Images are always scaled to fit the log&apos;s width; this additionally keeps a tall image from filling the whole log.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Maximum image height</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>No limit</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>LookConfig</name>

--- a/src/mumble/mumble_lt.ts
+++ b/src/mumble/mumble_lt.ts
@@ -4605,6 +4605,16 @@ The setting only applies for new messages, the already shown ones will retain th
         <source>decibels</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>If checked, images in the chat log are scaled down to fit the log&apos;s width and a part of its height, and are displayed on their own line. The full-size image stays available via the image&apos;s context menu.
+
+Whether an image is displayed on its own line only changes for new messages.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Scale images to fit the chat log</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>LookConfig</name>

--- a/src/mumble/mumble_lt.ts
+++ b/src/mumble/mumble_lt.ts
@@ -4615,6 +4615,18 @@ Whether an image is displayed on its own line only changes for new messages.</so
         <source>Scale images to fit the chat log</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>The maximum height an image may occupy in the chat log, as a percentage of the log&apos;s visible height. Images are always scaled to fit the log&apos;s width; this additionally keeps a tall image from filling the whole log.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Maximum image height</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>No limit</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>LookConfig</name>

--- a/src/mumble/mumble_nl.ts
+++ b/src/mumble/mumble_nl.ts
@@ -4634,6 +4634,16 @@ Deze instelling geldt voor nieuwe berichten, vermits getoonden conformeren aan h
         <source>decibels</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>If checked, images in the chat log are scaled down to fit the log&apos;s width and a part of its height, and are displayed on their own line. The full-size image stays available via the image&apos;s context menu.
+
+Whether an image is displayed on its own line only changes for new messages.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Scale images to fit the chat log</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>LookConfig</name>

--- a/src/mumble/mumble_nl.ts
+++ b/src/mumble/mumble_nl.ts
@@ -4644,6 +4644,18 @@ Whether an image is displayed on its own line only changes for new messages.</so
         <source>Scale images to fit the chat log</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>The maximum height an image may occupy in the chat log, as a percentage of the log&apos;s visible height. Images are always scaled to fit the log&apos;s width; this additionally keeps a tall image from filling the whole log.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Maximum image height</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>No limit</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>LookConfig</name>

--- a/src/mumble/mumble_no.ts
+++ b/src/mumble/mumble_no.ts
@@ -4648,6 +4648,16 @@ Har kun innvirkning for nye meldinger. Gamle meldinger vises i foregående tidsf
         <source>decibels</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>If checked, images in the chat log are scaled down to fit the log&apos;s width and a part of its height, and are displayed on their own line. The full-size image stays available via the image&apos;s context menu.
+
+Whether an image is displayed on its own line only changes for new messages.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Scale images to fit the chat log</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>LookConfig</name>

--- a/src/mumble/mumble_no.ts
+++ b/src/mumble/mumble_no.ts
@@ -4658,6 +4658,18 @@ Whether an image is displayed on its own line only changes for new messages.</so
         <source>Scale images to fit the chat log</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>The maximum height an image may occupy in the chat log, as a percentage of the log&apos;s visible height. Images are always scaled to fit the log&apos;s width; this additionally keeps a tall image from filling the whole log.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Maximum image height</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>No limit</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>LookConfig</name>

--- a/src/mumble/mumble_oc.ts
+++ b/src/mumble/mumble_oc.ts
@@ -4573,6 +4573,16 @@ The setting only applies for new messages, the already shown ones will retain th
         <source>decibels</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>If checked, images in the chat log are scaled down to fit the log&apos;s width and a part of its height, and are displayed on their own line. The full-size image stays available via the image&apos;s context menu.
+
+Whether an image is displayed on its own line only changes for new messages.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Scale images to fit the chat log</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>LookConfig</name>

--- a/src/mumble/mumble_oc.ts
+++ b/src/mumble/mumble_oc.ts
@@ -4583,6 +4583,18 @@ Whether an image is displayed on its own line only changes for new messages.</so
         <source>Scale images to fit the chat log</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>The maximum height an image may occupy in the chat log, as a percentage of the log&apos;s visible height. Images are always scaled to fit the log&apos;s width; this additionally keeps a tall image from filling the whole log.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Maximum image height</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>No limit</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>LookConfig</name>

--- a/src/mumble/mumble_pl.ts
+++ b/src/mumble/mumble_pl.ts
@@ -4635,6 +4635,16 @@ Ustawienie dotyczy tylko nowych wiadomości, te już pokazane zachowają poprzed
         <source>decibels</source>
         <translation>decybele</translation>
     </message>
+    <message>
+        <source>If checked, images in the chat log are scaled down to fit the log&apos;s width and a part of its height, and are displayed on their own line. The full-size image stays available via the image&apos;s context menu.
+
+Whether an image is displayed on its own line only changes for new messages.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Scale images to fit the chat log</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>LookConfig</name>

--- a/src/mumble/mumble_pl.ts
+++ b/src/mumble/mumble_pl.ts
@@ -4645,6 +4645,18 @@ Whether an image is displayed on its own line only changes for new messages.</so
         <source>Scale images to fit the chat log</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>The maximum height an image may occupy in the chat log, as a percentage of the log&apos;s visible height. Images are always scaled to fit the log&apos;s width; this additionally keeps a tall image from filling the whole log.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Maximum image height</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>No limit</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>LookConfig</name>

--- a/src/mumble/mumble_pt_BR.ts
+++ b/src/mumble/mumble_pt_BR.ts
@@ -4634,6 +4634,16 @@ Essa configuração só se aplica para novas mensagens. As mensagens já exibida
         <source>decibels</source>
         <translation>decibéis</translation>
     </message>
+    <message>
+        <source>If checked, images in the chat log are scaled down to fit the log&apos;s width and a part of its height, and are displayed on their own line. The full-size image stays available via the image&apos;s context menu.
+
+Whether an image is displayed on its own line only changes for new messages.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Scale images to fit the chat log</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>LookConfig</name>

--- a/src/mumble/mumble_pt_BR.ts
+++ b/src/mumble/mumble_pt_BR.ts
@@ -4644,6 +4644,18 @@ Whether an image is displayed on its own line only changes for new messages.</so
         <source>Scale images to fit the chat log</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>The maximum height an image may occupy in the chat log, as a percentage of the log&apos;s visible height. Images are always scaled to fit the log&apos;s width; this additionally keeps a tall image from filling the whole log.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Maximum image height</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>No limit</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>LookConfig</name>

--- a/src/mumble/mumble_pt_PT.ts
+++ b/src/mumble/mumble_pt_PT.ts
@@ -4634,6 +4634,16 @@ Essa configuração só se aplica para novas mensagens. As mensagens já exibida
         <source>decibels</source>
         <translation>decibéis</translation>
     </message>
+    <message>
+        <source>If checked, images in the chat log are scaled down to fit the log&apos;s width and a part of its height, and are displayed on their own line. The full-size image stays available via the image&apos;s context menu.
+
+Whether an image is displayed on its own line only changes for new messages.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Scale images to fit the chat log</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>LookConfig</name>
@@ -9098,11 +9108,11 @@ See &lt;a href=&quot;https://github.com/mumble-voip/mumble&quot;&gt;the project 
     </message>
     <message>
         <source>Yes</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">Sim</translation>
     </message>
     <message>
         <source>No</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">Não</translation>
     </message>
     <message>
         <source>&lt;b&gt;Users:&lt;/b&gt;</source>

--- a/src/mumble/mumble_pt_PT.ts
+++ b/src/mumble/mumble_pt_PT.ts
@@ -4644,6 +4644,18 @@ Whether an image is displayed on its own line only changes for new messages.</so
         <source>Scale images to fit the chat log</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>The maximum height an image may occupy in the chat log, as a percentage of the log&apos;s visible height. Images are always scaled to fit the log&apos;s width; this additionally keeps a tall image from filling the whole log.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Maximum image height</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>No limit</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>LookConfig</name>

--- a/src/mumble/mumble_ro.ts
+++ b/src/mumble/mumble_ro.ts
@@ -4581,6 +4581,16 @@ The setting only applies for new messages, the already shown ones will retain th
         <source>decibels</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>If checked, images in the chat log are scaled down to fit the log&apos;s width and a part of its height, and are displayed on their own line. The full-size image stays available via the image&apos;s context menu.
+
+Whether an image is displayed on its own line only changes for new messages.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Scale images to fit the chat log</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>LookConfig</name>

--- a/src/mumble/mumble_ro.ts
+++ b/src/mumble/mumble_ro.ts
@@ -4591,6 +4591,18 @@ Whether an image is displayed on its own line only changes for new messages.</so
         <source>Scale images to fit the chat log</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>The maximum height an image may occupy in the chat log, as a percentage of the log&apos;s visible height. Images are always scaled to fit the log&apos;s width; this additionally keeps a tall image from filling the whole log.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Maximum image height</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>No limit</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>LookConfig</name>

--- a/src/mumble/mumble_ru.ts
+++ b/src/mumble/mumble_ru.ts
@@ -4635,6 +4635,16 @@ The setting only applies for new messages, the already shown ones will retain th
         <source>decibels</source>
         <translation>децибелы</translation>
     </message>
+    <message>
+        <source>If checked, images in the chat log are scaled down to fit the log&apos;s width and a part of its height, and are displayed on their own line. The full-size image stays available via the image&apos;s context menu.
+
+Whether an image is displayed on its own line only changes for new messages.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Scale images to fit the chat log</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>LookConfig</name>

--- a/src/mumble/mumble_ru.ts
+++ b/src/mumble/mumble_ru.ts
@@ -4645,6 +4645,18 @@ Whether an image is displayed on its own line only changes for new messages.</so
         <source>Scale images to fit the chat log</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>The maximum height an image may occupy in the chat log, as a percentage of the log&apos;s visible height. Images are always scaled to fit the log&apos;s width; this additionally keeps a tall image from filling the whole log.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Maximum image height</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>No limit</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>LookConfig</name>

--- a/src/mumble/mumble_si.ts
+++ b/src/mumble/mumble_si.ts
@@ -4544,6 +4544,16 @@ The setting only applies for new messages, the already shown ones will retain th
         <source>decibels</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>If checked, images in the chat log are scaled down to fit the log&apos;s width and a part of its height, and are displayed on their own line. The full-size image stays available via the image&apos;s context menu.
+
+Whether an image is displayed on its own line only changes for new messages.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Scale images to fit the chat log</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>LookConfig</name>

--- a/src/mumble/mumble_si.ts
+++ b/src/mumble/mumble_si.ts
@@ -4554,6 +4554,18 @@ Whether an image is displayed on its own line only changes for new messages.</so
         <source>Scale images to fit the chat log</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>The maximum height an image may occupy in the chat log, as a percentage of the log&apos;s visible height. Images are always scaled to fit the log&apos;s width; this additionally keeps a tall image from filling the whole log.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Maximum image height</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>No limit</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>LookConfig</name>

--- a/src/mumble/mumble_sk.ts
+++ b/src/mumble/mumble_sk.ts
@@ -4548,6 +4548,16 @@ The setting only applies for new messages, the already shown ones will retain th
         <source>decibels</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>If checked, images in the chat log are scaled down to fit the log&apos;s width and a part of its height, and are displayed on their own line. The full-size image stays available via the image&apos;s context menu.
+
+Whether an image is displayed on its own line only changes for new messages.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Scale images to fit the chat log</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>LookConfig</name>

--- a/src/mumble/mumble_sk.ts
+++ b/src/mumble/mumble_sk.ts
@@ -4558,6 +4558,18 @@ Whether an image is displayed on its own line only changes for new messages.</so
         <source>Scale images to fit the chat log</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>The maximum height an image may occupy in the chat log, as a percentage of the log&apos;s visible height. Images are always scaled to fit the log&apos;s width; this additionally keeps a tall image from filling the whole log.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Maximum image height</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>No limit</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>LookConfig</name>

--- a/src/mumble/mumble_sq.ts
+++ b/src/mumble/mumble_sq.ts
@@ -4551,6 +4551,16 @@ The setting only applies for new messages, the already shown ones will retain th
         <source>decibels</source>
         <translation type="unfinished">decibelë</translation>
     </message>
+    <message>
+        <source>If checked, images in the chat log are scaled down to fit the log&apos;s width and a part of its height, and are displayed on their own line. The full-size image stays available via the image&apos;s context menu.
+
+Whether an image is displayed on its own line only changes for new messages.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Scale images to fit the chat log</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>LookConfig</name>

--- a/src/mumble/mumble_sq.ts
+++ b/src/mumble/mumble_sq.ts
@@ -4561,6 +4561,18 @@ Whether an image is displayed on its own line only changes for new messages.</so
         <source>Scale images to fit the chat log</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>The maximum height an image may occupy in the chat log, as a percentage of the log&apos;s visible height. Images are always scaled to fit the log&apos;s width; this additionally keeps a tall image from filling the whole log.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Maximum image height</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>No limit</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>LookConfig</name>

--- a/src/mumble/mumble_sv.ts
+++ b/src/mumble/mumble_sv.ts
@@ -4634,6 +4634,16 @@ Inställningen gäller endast för nya meddelanden, de redan visade meddelandena
         <source>decibels</source>
         <translation>decibeller</translation>
     </message>
+    <message>
+        <source>If checked, images in the chat log are scaled down to fit the log&apos;s width and a part of its height, and are displayed on their own line. The full-size image stays available via the image&apos;s context menu.
+
+Whether an image is displayed on its own line only changes for new messages.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Scale images to fit the chat log</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>LookConfig</name>

--- a/src/mumble/mumble_sv.ts
+++ b/src/mumble/mumble_sv.ts
@@ -4644,6 +4644,18 @@ Whether an image is displayed on its own line only changes for new messages.</so
         <source>Scale images to fit the chat log</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>The maximum height an image may occupy in the chat log, as a percentage of the log&apos;s visible height. Images are always scaled to fit the log&apos;s width; this additionally keeps a tall image from filling the whole log.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Maximum image height</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>No limit</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>LookConfig</name>

--- a/src/mumble/mumble_te.ts
+++ b/src/mumble/mumble_te.ts
@@ -4584,6 +4584,16 @@ The setting only applies for new messages, the already shown ones will retain th
         <source>decibels</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>If checked, images in the chat log are scaled down to fit the log&apos;s width and a part of its height, and are displayed on their own line. The full-size image stays available via the image&apos;s context menu.
+
+Whether an image is displayed on its own line only changes for new messages.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Scale images to fit the chat log</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>LookConfig</name>

--- a/src/mumble/mumble_te.ts
+++ b/src/mumble/mumble_te.ts
@@ -4594,6 +4594,18 @@ Whether an image is displayed on its own line only changes for new messages.</so
         <source>Scale images to fit the chat log</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>The maximum height an image may occupy in the chat log, as a percentage of the log&apos;s visible height. Images are always scaled to fit the log&apos;s width; this additionally keeps a tall image from filling the whole log.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Maximum image height</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>No limit</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>LookConfig</name>

--- a/src/mumble/mumble_th.ts
+++ b/src/mumble/mumble_th.ts
@@ -4571,6 +4571,16 @@ The setting only applies for new messages, the already shown ones will retain th
         <source>decibels</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>If checked, images in the chat log are scaled down to fit the log&apos;s width and a part of its height, and are displayed on their own line. The full-size image stays available via the image&apos;s context menu.
+
+Whether an image is displayed on its own line only changes for new messages.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Scale images to fit the chat log</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>LookConfig</name>

--- a/src/mumble/mumble_th.ts
+++ b/src/mumble/mumble_th.ts
@@ -4581,6 +4581,18 @@ Whether an image is displayed on its own line only changes for new messages.</so
         <source>Scale images to fit the chat log</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>The maximum height an image may occupy in the chat log, as a percentage of the log&apos;s visible height. Images are always scaled to fit the log&apos;s width; this additionally keeps a tall image from filling the whole log.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Maximum image height</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>No limit</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>LookConfig</name>

--- a/src/mumble/mumble_tr.ts
+++ b/src/mumble/mumble_tr.ts
@@ -4633,6 +4633,16 @@ Bu ayar sadece yeni mesajlara uygulanır, zaten görüntülenmiş olanlar öncek
         <source>decibels</source>
         <translation>desibel</translation>
     </message>
+    <message>
+        <source>If checked, images in the chat log are scaled down to fit the log&apos;s width and a part of its height, and are displayed on their own line. The full-size image stays available via the image&apos;s context menu.
+
+Whether an image is displayed on its own line only changes for new messages.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Scale images to fit the chat log</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>LookConfig</name>

--- a/src/mumble/mumble_tr.ts
+++ b/src/mumble/mumble_tr.ts
@@ -4643,6 +4643,18 @@ Whether an image is displayed on its own line only changes for new messages.</so
         <source>Scale images to fit the chat log</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>The maximum height an image may occupy in the chat log, as a percentage of the log&apos;s visible height. Images are always scaled to fit the log&apos;s width; this additionally keeps a tall image from filling the whole log.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Maximum image height</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>No limit</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>LookConfig</name>

--- a/src/mumble/mumble_uk.ts
+++ b/src/mumble/mumble_uk.ts
@@ -4635,6 +4635,16 @@ The setting only applies for new messages, the already shown ones will retain th
         <source>decibels</source>
         <translation>децибел</translation>
     </message>
+    <message>
+        <source>If checked, images in the chat log are scaled down to fit the log&apos;s width and a part of its height, and are displayed on their own line. The full-size image stays available via the image&apos;s context menu.
+
+Whether an image is displayed on its own line only changes for new messages.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Scale images to fit the chat log</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>LookConfig</name>

--- a/src/mumble/mumble_uk.ts
+++ b/src/mumble/mumble_uk.ts
@@ -4645,6 +4645,18 @@ Whether an image is displayed on its own line only changes for new messages.</so
         <source>Scale images to fit the chat log</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>The maximum height an image may occupy in the chat log, as a percentage of the log&apos;s visible height. Images are always scaled to fit the log&apos;s width; this additionally keeps a tall image from filling the whole log.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Maximum image height</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>No limit</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>LookConfig</name>

--- a/src/mumble/mumble_zh_CN.ts
+++ b/src/mumble/mumble_zh_CN.ts
@@ -4633,6 +4633,16 @@ The setting only applies for new messages, the already shown ones will retain th
         <source>decibels</source>
         <translation>分贝</translation>
     </message>
+    <message>
+        <source>If checked, images in the chat log are scaled down to fit the log&apos;s width and a part of its height, and are displayed on their own line. The full-size image stays available via the image&apos;s context menu.
+
+Whether an image is displayed on its own line only changes for new messages.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Scale images to fit the chat log</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>LookConfig</name>

--- a/src/mumble/mumble_zh_CN.ts
+++ b/src/mumble/mumble_zh_CN.ts
@@ -4643,6 +4643,18 @@ Whether an image is displayed on its own line only changes for new messages.</so
         <source>Scale images to fit the chat log</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>The maximum height an image may occupy in the chat log, as a percentage of the log&apos;s visible height. Images are always scaled to fit the log&apos;s width; this additionally keeps a tall image from filling the whole log.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Maximum image height</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>No limit</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>LookConfig</name>

--- a/src/mumble/mumble_zh_HK.ts
+++ b/src/mumble/mumble_zh_HK.ts
@@ -4571,6 +4571,16 @@ The setting only applies for new messages, the already shown ones will retain th
         <source>decibels</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>If checked, images in the chat log are scaled down to fit the log&apos;s width and a part of its height, and are displayed on their own line. The full-size image stays available via the image&apos;s context menu.
+
+Whether an image is displayed on its own line only changes for new messages.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Scale images to fit the chat log</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>LookConfig</name>

--- a/src/mumble/mumble_zh_HK.ts
+++ b/src/mumble/mumble_zh_HK.ts
@@ -4581,6 +4581,18 @@ Whether an image is displayed on its own line only changes for new messages.</so
         <source>Scale images to fit the chat log</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>The maximum height an image may occupy in the chat log, as a percentage of the log&apos;s visible height. Images are always scaled to fit the log&apos;s width; this additionally keeps a tall image from filling the whole log.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Maximum image height</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>No limit</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>LookConfig</name>

--- a/src/mumble/mumble_zh_TW.ts
+++ b/src/mumble/mumble_zh_TW.ts
@@ -4603,6 +4603,16 @@ The setting only applies for new messages, the already shown ones will retain th
         <source>decibels</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>If checked, images in the chat log are scaled down to fit the log&apos;s width and a part of its height, and are displayed on their own line. The full-size image stays available via the image&apos;s context menu.
+
+Whether an image is displayed on its own line only changes for new messages.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Scale images to fit the chat log</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>LookConfig</name>

--- a/src/mumble/mumble_zh_TW.ts
+++ b/src/mumble/mumble_zh_TW.ts
@@ -4613,6 +4613,18 @@ Whether an image is displayed on its own line only changes for new messages.</so
         <source>Scale images to fit the chat log</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>The maximum height an image may occupy in the chat log, as a percentage of the log&apos;s visible height. Images are always scaled to fit the log&apos;s width; this additionally keeps a tall image from filling the whole log.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Maximum image height</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>No limit</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>LookConfig</name>


### PR DESCRIPTION
Images in the chat log are rendered at their full pixel size. A pasted screenshot (up to 1600x1000 after send-side downscaling) is usually far wider than the log pane of a typically sized Mumble window, so it overflows the log and can only be viewed by scrolling horizontally.

With this change, images are scaled down to fit the log's width and at most 60% of its visible height, preserving aspect ratio and never scaling up. The fit is reactive: images track the pane live while it is resized and are re-rendered with smooth filtering once resizing settles. Images larger than emote size are placed on their own left-aligned line instead of starting wherever the "[time] Sender:" prefix ends. "Save Image As..." and "Open Image" still operate on the full-resolution original. A new setting under Messages ("Scale images to fit the chat log", enabled by default) restores the previous rendering when disabled.

This implements the display-scaling part of what is requested in #3282.

[mumble-image-resize-demo.webm](https://github.com/user-attachments/assets/d6ccba5c-eb49-4def-bb44-919690ff7cc3)

Notes for reviewers:

- The scroll position is now anchored during reflows (the equivalent of browser scroll anchoring): when scrolled up, the content at the top of the viewport stays put; when at the bottom, the log stays pinned there.
- Image blocks are forced to Qt::AlignLeft. If AlignLeading is preferred for right-to-left layouts, that is a one-word change.
- The first commit disables the chat log document's undo history. The log is read-only so the history is unusable, and without this every insertion and image refit would grow it indefinitely.

### Checks

- [x] My commits follow the [commit guidelines](https://github.com/mumble-voip/mumble/blob/master/COMMIT_GUIDELINES.md)
