### PR TITLE
CI(build): tar macOS app bundle so the artifact stays launchable

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -112,6 +112,16 @@ jobs:
           os: ${{ matrix.os }}
           arch: ${{ matrix.arch }}
 
+      # actions/upload-artifact zips its inputs and does not preserve Unix file
+      # modes or symlinks, so an uploaded Mumble.app arrives with a non-executable
+      # main binary (and broken framework symlinks) and macOS refuses to launch it.
+      # Tar the bundle first so those attributes survive inside the archive; users
+      # extract the tarball after downloading.
+    - if: ${{ !inputs.SIGN_WINDOWS_INSTALLER && matrix.type == 'static' && startsWith(matrix.os, 'macos') }}
+      name: Package macOS app bundle
+      run: tar -C build -czf build/Mumble.app.tar.gz Mumble.app
+      shell: bash
+
     - if: ${{ !inputs.SIGN_WINDOWS_INSTALLER && matrix.type == 'static' }}
       name: Publish
       uses: actions/upload-artifact@v7
@@ -120,7 +130,7 @@ jobs:
         compression-level: 9
         path: |
           build/mumble
-          build/Mumble.app
+          build/Mumble.app.tar.gz
           build/mumble-server
           build/**/mumble*.msi
           build/**/mumble*.exe


### PR DESCRIPTION
## Summary

Today, the `Mumble-macos-14` CI artifact can't be opened after download: `actions/upload-artifact` zips its inputs without preserving Unix file modes or symlinks, so the uploaded `Mumble.app` arrives with a non-executable main binary (mode `644`) and broken framework symlinks, and macOS refuses to launch it with a generic "can't be opened" error. This change fixes that by tarring the `.app` bundle on macOS before uploading, so the executable bit and symlinks survive inside the archive.

> [!NOTE]
> Generated via Claude Code.

## What Changed

- Added a macOS-only `Package macOS app bundle` step that runs `tar -C build -czf build/Mumble.app.tar.gz Mumble.app` before the `Publish` step.
- Changed the `Publish` upload path from `build/Mumble.app` to `build/Mumble.app.tar.gz`. Other platforms are unaffected (the tarball path simply doesn't exist there and is skipped).
- Users now extract `Mumble.app.tar.gz` after downloading, and the app launches without a manual `chmod +x`.

## Notes

- This is the standard workaround for [actions/upload-artifact#38](https://github.com/actions/upload-artifact/issues/38) (permissions/symlinks are not preserved); tar is the recommended packaging step for bundles.
- The `mumble-server` binary in the same artifact has the same latent issue, but this PR is scoped to the GUI `.app` that users actually run; happy to extend it if desired.

## Test Plan

- [ ] macOS `build (macos-14, static)` job produces a `Mumble.app.tar.gz` in the artifact
- [ ] Downloaded + extracted `Mumble.app` launches without `chmod +x` (main binary is executable, framework symlinks intact)
- [ ] Non-macOS artifacts unchanged