### PR TITLE
Backport "Merge PR #7272: BUILD: Fix offline build" to 1.6.x

### DIFF
--- a/3rdparty/rnnoise-build/CMakeLists.txt
+++ b/3rdparty/rnnoise-build/CMakeLists.txt
@@ -43,35 +43,55 @@ target_include_directories(rnnoise
 		"${RNNOISE_SRC_DIR}/src"
 )
 
-file(READ "${RNNOISE_SRC_DIR}/model_version" rnnoise_model_hash)
-string(STRIP ${rnnoise_model_hash} rnnoise_model_hash)
-string(CONCAT rnnoise_model_url "${RNNOISE_MODEL_URL}" "${rnnoise_model_hash}" ".tar.gz")
-
-FetchContent_Declare(
-  rnnoise_model
-  URL      "${rnnoise_model_url}"
-  URL_HASH SHA256=${rnnoise_model_hash}
-  DOWNLOAD_EXTRACT_TIMESTAMP 1
+set(RNNOISE_MODEL_DIR "")
+set(RNNOISE_MODEL_SRC_FILES_MISSING FALSE)
+set(RNNOISE_MODEL_SRC_FILES
+	"rnnoise_data.c"
+	"rnnoise_data.h"
+	"rnnoise_data_little.c"
+	"rnnoise_data_little.h"
 )
 
-FetchContent_MakeAvailable(rnnoise_model)
+foreach(src_file IN LISTS RNNOISE_MODEL_SRC_FILES)
+	if(NOT EXISTS "${PROJECT_SOURCE_DIR}/rnnoise-model/src/${src_file}")
+		set(RNNOISE_MODEL_SRC_FILES_MISSING TRUE)
+		break()
+	endif()
+endforeach()
+
+if(RNNOISE_MODEL_SRC_FILES_MISSING)
+  file(READ "${RNNOISE_SRC_DIR}/model_version" rnnoise_model_hash)
+  string(STRIP ${rnnoise_model_hash} rnnoise_model_hash)
+  string(CONCAT rnnoise_model_url "${RNNOISE_MODEL_URL}" "${rnnoise_model_hash}" ".tar.gz")
+
+  FetchContent_Declare(
+      rnnoise_model
+	  URL      "${rnnoise_model_url}"
+	  URL_HASH SHA256=${rnnoise_model_hash}
+	  DOWNLOAD_EXTRACT_TIMESTAMP 1
+  )
+
+  FetchContent_MakeAvailable(rnnoise_model)
+  set(RNNOISE_MODEL_DIR "${rnnoise_model_SOURCE_DIR}")
+else()
+  set(RNNOISE_MODEL_DIR "${PROJECT_SOURCE_DIR}/rnnoise-model")
+endif()
 
 set(RNNOISE_GENERATED_DIR "${CMAKE_CURRENT_BINARY_DIR}/generated")
 file(MAKE_DIRECTORY "${RNNOISE_GENERATED_DIR}")
 
-add_custom_command(
-    OUTPUT
-        "${RNNOISE_GENERATED_DIR}/rnnoise_data.c"
-        "${RNNOISE_GENERATED_DIR}/rnnoise_data.h"
-        "${RNNOISE_GENERATED_DIR}/rnnoise_data_little.c"
-        "${RNNOISE_GENERATED_DIR}/rnnoise_data_little.h"
+set(RNNOISE_MODEL_FILES)
+set(RNNOISE_GENERATED_FILES)
+foreach(src_file IN LISTS RNNOISE_MODEL_SRC_FILES)
+	list(APPEND RNNOISE_MODEL_FILES "${RNNOISE_MODEL_DIR}/src/${src_file}")
+	list(APPEND RNNOISE_GENERATED_FILES "${RNNOISE_GENERATED_DIR}/${src_file}")
+endforeach()
 
+add_custom_command(
+	OUTPUT ${RNNOISE_GENERATED_FILES}
     WORKING_DIRECTORY "${RNNOISE_SRC_DIR}"
     COMMAND "${CMAKE_COMMAND}" -E copy
-        "${rnnoise_model_SOURCE_DIR}/src/rnnoise_data.c"
-        "${rnnoise_model_SOURCE_DIR}/src/rnnoise_data.h"
-        "${rnnoise_model_SOURCE_DIR}/src/rnnoise_data_little.c"
-        "${rnnoise_model_SOURCE_DIR}/src/rnnoise_data_little.h"
+		${RNNOISE_MODEL_FILES}
         "${RNNOISE_GENERATED_DIR}"
     COMMENT "Downloading RNNoise model files"
 )

--- a/scripts/create_source_archive.py
+++ b/scripts/create_source_archive.py
@@ -15,6 +15,10 @@ import argparse
 import platform
 import subprocess
 import tempfile
+from urllib.request import urlretrieve
+import shutil
+import hashlib
+import re
 
 
 def git(args: List[str]) -> str:
@@ -106,6 +110,41 @@ def create_tar_archive(
     return archive_name
 
 
+def download_rnnoise_model(base_dir: str) -> None:
+    """Download and unpack the rnnoise model for the repository."""
+    model_version_path = os.path.join(base_dir, "3rdparty/rnnoise-src/model_version")
+    with open(model_version_path, "r", encoding="utf-8") as file:
+        model_version = file.read().strip()
+
+    if re.fullmatch(r"[0-9a-fA-F]{64}", model_version) is None:
+        raise ValueError("RNNoise model version must be a SHA-256 digest")
+
+    model_name = f"rnnoise_data-{model_version}.tar.gz"
+    download_dir = os.path.join(base_dir, "rnnoise-model")
+    model_path = os.path.join(download_dir, model_name)
+
+    os.mkdir(download_dir)
+
+    rnnoise_model_url = f"https://media.xiph.org/rnnoise/models/{model_name}"
+
+    urlretrieve(rnnoise_model_url, model_path)
+
+    sha256_hash = hashlib.sha256()
+    with open(model_path, "rb") as f:
+        for byte_block in iter(lambda: f.read(4096), b""):
+            sha256_hash.update(byte_block)
+
+    calculated_hash = sha256_hash.hexdigest()
+    if calculated_hash != model_version:
+        raise ValueError(
+            "The downloaded rnnoise model's calculated SHA256 hash does not "
+            f"match the expected SHA256 hash. Expected: {model_version}; "
+            f"calculated: {calculated_hash}"
+        )
+    shutil.unpack_archive(model_path, download_dir)
+    os.remove(model_path)
+
+
 def main() -> None:
     parser = argparse.ArgumentParser(
         "Creates a source archive of a git repository (including submodules)"
@@ -154,6 +193,8 @@ def main() -> None:
                 tmp_repo,
             ]
         )
+
+        download_rnnoise_model(tmp_repo)
 
         files: List[str] = get_file_paths(tmp_repo)
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `1.6.x`:
 - [Merge PR #7272: BUILD: Fix offline build](https://github.com/mumble-voip/mumble/pull/7272)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)