### PR TITLE
FIX: Correct CaseInsensitiveQString strict comparison operators

### DIFF
--- a/src/QtUtils.cpp
+++ b/src/QtUtils.cpp
@@ -67,7 +67,7 @@ namespace QtUtils {
 
 	bool operator<(const CaseInsensitiveQString &lhs, const CaseInsensitiveQString &rhs) { return lhs.m_str < rhs; }
 
-	bool operator<(const CaseInsensitiveQString &lhs, const QString &rhs) { return rhs >= lhs; }
+	bool operator<(const CaseInsensitiveQString &lhs, const QString &rhs) { return rhs > lhs; }
 
 	bool operator<=(const QString &lhs, const CaseInsensitiveQString &rhs) {
 		return lhs.compare(rhs.m_str, Qt::CaseInsensitive) <= 0;
@@ -83,7 +83,7 @@ namespace QtUtils {
 
 	bool operator>(const CaseInsensitiveQString &lhs, const CaseInsensitiveQString &rhs) { return lhs.m_str > rhs; }
 
-	bool operator>(const CaseInsensitiveQString &lhs, const QString &rhs) { return rhs <= lhs; }
+	bool operator>(const CaseInsensitiveQString &lhs, const QString &rhs) { return rhs < lhs; }
 
 	bool operator>=(const QString &lhs, const CaseInsensitiveQString &rhs) {
 		return lhs.compare(rhs.m_str, Qt::CaseInsensitive) >= 0;

--- a/src/tests/TestCaseInsensitiveQString/TestCaseInsensitiveQString.cpp
+++ b/src/tests/TestCaseInsensitiveQString/TestCaseInsensitiveQString.cpp
@@ -37,6 +37,10 @@ private slots:
 		QVERIFY(QString("abc") < istr);
 		QVERIFY(istr < QString("xyz"));
 		QVERIFY(CaseInsensitiveQString("another") < istr);
+
+		// A strict '<' must be false for equal operands, including case-insensitive equality.
+		QVERIFY(!(istr < QString("test")));
+		QVERIFY(!(istr < QString("TEST")));
 	}
 
 	void less_equal() const {
@@ -57,6 +61,10 @@ private slots:
 		QVERIFY(QString("xyz") > istr);
 		QVERIFY(istr > QString("abc"));
 		QVERIFY(CaseInsensitiveQString("Xenia") > istr);
+
+		// A strict '>' must be false for equal operands, including case-insensitive equality.
+		QVERIFY(!(istr > QString("test")));
+		QVERIFY(!(istr > QString("TEST")));
 	}
 
 	void greater_equal() const {


### PR DESCRIPTION
Fixes #7278

## Problem

In `src/QtUtils.cpp`, `Mumble::QtUtils::CaseInsensitiveQString`'s strict comparison operators against a `QString` are byte-for-byte identical to their non-strict `<=` / `>=` counterparts:

```cpp
bool operator<(const CaseInsensitiveQString &lhs, const QString &rhs)  { return rhs >= lhs; }  // == operator<=
bool operator>(const CaseInsensitiveQString &lhs, const QString &rhs)  { return rhs <= lhs; }  // == operator>=
```

So a strict comparison returns `true` for (case-insensitively) equal operands, e.g. `CaseInsensitiveQString("test") < QString("Test")` is `true`. That violates strict-weak-ordering (`!(a < a)`), and since `CaseInsensitiveQString` is used as a map/hash key, ordered logic built on `<` / `>` can misbehave.

## Fix

Delegate `<` to the already-correct `operator>(const QString&, const CaseInsensitiveQString&)` and `>` to `operator<(const QString&, const CaseInsensitiveQString&)`:

```cpp
bool operator<(const CaseInsensitiveQString &lhs, const QString &rhs) { return rhs > lhs; }
bool operator>(const CaseInsensitiveQString &lhs, const QString &rhs) { return rhs < lhs; }
```

## Testing

Extended `TestCaseInsensitiveQString`'s `less_than()` / `greater_than()` slots with the equal-operand case. The additions fail before this change and pass after; the full `TestCaseInsensitiveQString` suite passes (verified with Qt6 + QtTest).
