### PR TITLE
Backport "Merge PR #6928: DOCS(database): Add some crude high-level docs for DB" to 1.6.x

### DIFF
--- a/docs/dev/ServerDatabase.md
+++ b/docs/dev/ServerDatabase.md
@@ -1,0 +1,84 @@
+# Server database
+
+The Mumble server uses a database to persist data across restarts. This document is about the (high-level) implementation details.
+
+The database implementation consists of two separate parts. First, the general DB wrappers that allow managing the database conveniently from within
+C++ (mostly) without having to worry about the exact backend that is used. Second, the server-specific implementation which encodes the concrete
+identity of tables and ways to access them. The former implementation lives under `src/database` and is completely decoupled from the server and even
+mostly decoupled from Mumble as a whole. The latter lives under `src/murmur/database`.
+
+Overall, we are using [SOCI](https://github.com/SOCI/soci/) for abstracting and unifying the low-level communication with different database backends
+(SQLite, MySQL and PostgreSQL).
+
+
+## Transactions
+
+A core design philosophy of our database implementation is that **every** database operation (READ _and_ WRITE) is encapsulated by a transaction
+ensuring that all operations happen atomically (from a logical point of view). However, we currently don't set any specific transaction isolation
+level since Mumble will operate under the assumption that it is the only process accessing its tables. Furthermore, note that different backends have
+different limitations of what transactions can roll back. Particularly, table creation and deletion which can't be rolled back with MySQL.
+
+Oftentimes, a given function doesn't know whether the parent function has already created a transaction. To avoid creating deeply nested transactions,
+the `Database` and `Table` base classes have a member function `ensureTransaction` that will create a transaction, if none is already in progress. The
+returned `TransactionHolder` RAII object can be treated the same in both cases as it has the necessary logic embedded to deal with cases in which no
+new transaction was created.
+
+
+## Exceptions
+
+Errors during any database operation are communicated by means of exceptions. In order to ensure that the exceptions will have the expected type, make
+sure to always wrap SOCI operations in a `try`-`catch` block that rethrows exceptions wrapped in one of Mumble's own database exception classes. Use
+`std::throw_with_nested` function of the C++ standard.
+
+Example:
+
+```cpp
+try {
+    soci::rowset<soci::row> rs = (sql.prepare << "SELECT ...");
+    // ...
+} catch (const soci::soci_error &e) {
+    std::throw_with_nested(DatabaseError("DB operation failed"));
+}
+```
+
+
+## Database migrations
+
+If a server is started on a database that has an older schema version than the server wants to use, an automatic migration procedure is started that
+will update the database to conform to the new schema. This encompasses a complete re-creation of all tables followed by data migration from the old
+tables into the new ones. Once everything has successfully completed, the old tables will be dropped.
+
+In case any error occurs during this process, the server will bail out and exit/crash after printing some information about the encountered error.
+This is intentional behavior in order to prevent data loss. It is then the users responsibility to manually inspect the error and potentially fix the
+underlying issue in their DB by hand.
+
+
+## Changing the database schema
+
+The database schema is a monotonically increasing number that acts as a version number for the database layout. The layout encompasses the existence
+of specific tables, columns (along with their data types) within tables and constraints, keys, etc. within tables.
+
+Any changes to the database layout needs to be accompanied by the following steps:
+
+1. Increase the schema version by one. The schema version is defined by the constant `ServerDatabase::DB_SCHEMA_VERSION` (see
+   [here](https://github.com/mumble-voip/mumble/blob/3c5a9354514c33a7f989607f5a58ccf29e1a232e/src/murmur/database/ServerDatabase.h#L40).
+2. Adapt the `migrate` function of affected tables to data from the old table (which has the same name but with an added suffix of
+   `Database::OLD_TABLE_SUFFIX`) into the new table. If all data is simply copied from a column in the old table into a column of the same name in the
+   new table, without any required type transformations, it is sufficient to call the base implementation `Table::migrate` which will take care of
+   that. When implementing these function explicitly, it is important that while columns names in the new table should use the constants defined in
+   the `column` namespace, the names of the columns in the old table should always be written out **explicitly**. This is to ensure that even if the
+   names change in newer versions of the table (i.e. the ones in the `column` namespace change), the migration code still works as expected. For an
+   example see [here](https://github.com/mumble-voip/mumble/blob/4ac51e86ff7b2243774d86a4d9fdac548127389a/src/murmur/database/BanTable.cpp#L372).
+3. Add test cases for the migration path as well as the new DB functionality you added.
+
+
+### Migration test cases
+
+Test cases for server migration are steered by the data found in `src/tests/TestDatabase/server/table_data`. This directory contains JSON files
+describing the tables and their contents at different schema versions along with the expected outcome after a successful migration has been performed
+on that data.
+
+By looking through the existing data, you should be able to get a feeling for the format. It should be noted that it is possible to inherit data from
+previous schema versions and then only perform modifications based off that. Again, search the existing examples for how to achieve this. Worst case,
+you can also inspect `src/tests/TestDatabase/server/JSONAssembler.cpp` which is responsible for assembling the final JSON used to initialize the test
+tables.


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `1.6.x`:
 - [Merge PR #6928: DOCS(database): Add some crude high-level docs for DB](https://github.com/mumble-voip/mumble/pull/6928)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)