### PR TITLE
Backport "Merge PR #7279: FIX: Correct CaseInsensitiveQString strict comparison operators" to 1.6.x

### DIFF
--- a/src/QtUtils.cpp
+++ b/src/QtUtils.cpp
@@ -67,7 +67,7 @@ namespace QtUtils {
 
 	bool operator<(const CaseInsensitiveQString &lhs, const CaseInsensitiveQString &rhs) { return lhs.m_str < rhs; }
 
-	bool operator<(const CaseInsensitiveQString &lhs, const QString &rhs) { return rhs >= lhs; }
+	bool operator<(const CaseInsensitiveQString &lhs, const QString &rhs) { return rhs > lhs; }
 
 	bool operator<=(const QString &lhs, const CaseInsensitiveQString &rhs) {
 		return lhs.compare(rhs.m_str, Qt::CaseInsensitive) <= 0;
@@ -83,7 +83,7 @@ namespace QtUtils {
 
 	bool operator>(const CaseInsensitiveQString &lhs, const CaseInsensitiveQString &rhs) { return lhs.m_str > rhs; }
 
-	bool operator>(const CaseInsensitiveQString &lhs, const QString &rhs) { return rhs <= lhs; }
+	bool operator>(const CaseInsensitiveQString &lhs, const QString &rhs) { return rhs < lhs; }
 
 	bool operator>=(const QString &lhs, const CaseInsensitiveQString &rhs) {
 		return lhs.compare(rhs.m_str, Qt::CaseInsensitive) >= 0;

--- a/src/tests/TestCaseInsensitiveQString/TestCaseInsensitiveQString.cpp
+++ b/src/tests/TestCaseInsensitiveQString/TestCaseInsensitiveQString.cpp
@@ -37,6 +37,10 @@ private slots:
 		QVERIFY(QString("abc") < istr);
 		QVERIFY(istr < QString("xyz"));
 		QVERIFY(CaseInsensitiveQString("another") < istr);
+
+		// A strict '<' must be false for equal operands, including case-insensitive equality.
+		QVERIFY(!(istr < QString("test")));
+		QVERIFY(!(istr < QString("TEST")));
 	}
 
 	void less_equal() const {
@@ -57,6 +61,10 @@ private slots:
 		QVERIFY(QString("xyz") > istr);
 		QVERIFY(istr > QString("abc"));
 		QVERIFY(CaseInsensitiveQString("Xenia") > istr);
+
+		// A strict '>' must be false for equal operands, including case-insensitive equality.
+		QVERIFY(!(istr > QString("test")));
+		QVERIFY(!(istr > QString("TEST")));
 	}
 
 	void greater_equal() const {


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `1.6.x`:
 - [Merge PR #7279: FIX: Correct CaseInsensitiveQString strict comparison operators](https://github.com/mumble-voip/mumble/pull/7279)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)