### PR TITLE
FIX: Correct sub-byte netmask handling in HostAddress::match

### DIFF
--- a/src/HostAddress.cpp
+++ b/src/HostAddress.cpp
@@ -112,8 +112,7 @@ bool HostAddress::match(const HostAddress &netmask, unsigned int bits) const {
 			// Compare only the first bits bits (no this is not a typo)
 			using mask_t = std::uint8_t;
 			mask_t mask =
-				static_cast< mask_t >(std::numeric_limits< mask_t >::max() >> (sizeof(mask_t) * CHAR_BIT - bits));
-			mask = static_cast< mask_t >(htons(mask));
+				static_cast< mask_t >(std::numeric_limits< mask_t >::max() << (sizeof(mask_t) * CHAR_BIT - bits));
 
 			if ((m_byteRepresentation[i] & mask) != (netmask.m_byteRepresentation[i] & mask)) {
 				return false;

--- a/src/tests/TestServerAddress/TestServerAddress.cpp
+++ b/src/tests/TestServerAddress/TestServerAddress.cpp
@@ -20,6 +20,7 @@ private slots:
 	void equals();
 	void lessThan();
 	void qhash();
+	void match();
 };
 
 void TestServerAddress::defaultCtor() {
@@ -95,6 +96,18 @@ void TestServerAddress::qhash() {
 	QVERIFY(qHash(a1) != qHash(b));
 	QVERIFY(qHash(a1) != qHash(c));
 	QVERIFY(qHash(b) != qHash(c));
+}
+
+void TestServerAddress::match() {
+	// A /20 IPv4 prefix is a 116-bit prefix (96 + 20) whose last compared byte is only partially masked.
+	HostAddress net(QHostAddress("10.16.0.0"));
+
+	QVERIFY(net.match(HostAddress(QHostAddress("10.16.15.255")), 116));
+	QVERIFY(!net.match(HostAddress(QHostAddress("10.16.16.0")), 116));
+
+	// Byte-aligned masks were already handled correctly; keep them covered.
+	QVERIFY(net.match(HostAddress(QHostAddress("10.16.99.99")), 112));
+	QVERIFY(!net.match(HostAddress(QHostAddress("10.17.0.0")), 112));
 }
 
 QTEST_MAIN(TestServerAddress)


### PR DESCRIPTION
Fixes #7282

## Problem

`HostAddress::match(const HostAddress &netmask, unsigned int bits)` computes the mask for the final, non-byte-aligned part of a CIDR prefix incorrectly, so `match()` is too permissive for any prefix length that is not a multiple of 8.

```cpp
mask_t mask = static_cast< mask_t >(std::numeric_limits< mask_t >::max() >> (sizeof(mask_t) * CHAR_BIT - bits));
mask = static_cast< mask_t >(htons(mask));
```

- A CIDR mask must keep the **high** bits of the byte (`0xFF << (8 - bits)`, e.g. `bits=4` → `0xF0`), but this keeps the **low** bits (`0xFF >> (8 - bits)` → `0x0F`).
- `htons()` on an 8-bit value then truncates to `uint8_t`: on a little-endian host `htons(0x0F) == 0x0F00` → `0x00`, so the mask becomes **0** and the partial byte is not compared at all.

Bans use `iMask ∈ [8,128]` (`Ban::isValid`) and `Server.cpp` calls `haAddress.match(ha, iMask)`; an IPv4 `/20` becomes `iMask = 116`. So a `10.16.0.0/20` ban (intended `10.16.0.0`–`10.16.15.255`) also matches `10.16.16.0` and beyond — an over-broad ban. Byte-aligned masks work by accident since there is no partial byte.

## Fix

Build the mask as `0xFF << (8 - bits)` and drop the `htons()` call.

## Testing

Added a `HostAddress::match` test to `TestServerAddress` using a non-byte-aligned mask (`/20` → 116 bits): the outside address `10.16.16.0` differs only in the partially-masked byte, so it exercises the sub-byte mask. The new test fails before this change and passes after; the full `TestServerAddress` suite passes (verified with Qt6 + QtTest).
