### PR TITLE
Backport "Merge PR #7283: FIX: Correct sub-byte netmask handling in HostAddress::match" to 1.5.x

### DIFF
--- a/src/HostAddress.cpp
+++ b/src/HostAddress.cpp
@@ -107,8 +107,7 @@ bool HostAddress::match(const HostAddress &netmask, unsigned int bits) const {
 			// Compare only the first bits bits (no this is not a typo)
 			using mask_t = std::uint8_t;
 			mask_t mask =
-				static_cast< mask_t >(std::numeric_limits< mask_t >::max() >> (sizeof(mask_t) * CHAR_BIT - bits));
-			mask = static_cast< mask_t >(htons(mask));
+				static_cast< mask_t >(std::numeric_limits< mask_t >::max() << (sizeof(mask_t) * CHAR_BIT - bits));
 
 			if ((m_byteRepresentation[i] & mask) != (netmask.m_byteRepresentation[i] & mask)) {
 				return false;

--- a/src/tests/TestServerAddress/TestServerAddress.cpp
+++ b/src/tests/TestServerAddress/TestServerAddress.cpp
@@ -20,6 +20,7 @@ private slots:
 	void equals();
 	void lessThan();
 	void qhash();
+	void match();
 };
 
 void TestServerAddress::defaultCtor() {
@@ -95,6 +96,18 @@ void TestServerAddress::qhash() {
 	QVERIFY(qHash(a1) != qHash(b));
 	QVERIFY(qHash(a1) != qHash(c));
 	QVERIFY(qHash(b) != qHash(c));
+}
+
+void TestServerAddress::match() {
+	// A /20 IPv4 prefix is a 116-bit prefix (96 + 20) whose last compared byte is only partially masked.
+	HostAddress net(QHostAddress("10.16.0.0"));
+
+	QVERIFY(net.match(HostAddress(QHostAddress("10.16.15.255")), 116));
+	QVERIFY(!net.match(HostAddress(QHostAddress("10.16.16.0")), 116));
+
+	// Byte-aligned masks were already handled correctly; keep them covered.
+	QVERIFY(net.match(HostAddress(QHostAddress("10.16.99.99")), 112));
+	QVERIFY(!net.match(HostAddress(QHostAddress("10.17.0.0")), 112));
 }
 
 QTEST_MAIN(TestServerAddress)


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `1.5.x`:
 - [Merge PR #7283: FIX: Correct sub-byte netmask handling in HostAddress::match](https://github.com/mumble-voip/mumble/pull/7283)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)