### PR TITLE
FIX: Emit valid IPv6 strings from HostAddress::toString

### DIFF
--- a/src/HostAddress.cpp
+++ b/src/HostAddress.cpp
@@ -7,8 +7,6 @@
 
 #include "ByteSwap.h"
 
-#include <QRegularExpression>
-
 #ifdef Q_OS_WIN
 #	include "win.h"
 #	include <winsock2.h>
@@ -191,22 +189,8 @@ std::size_t qHash(const HostAddress &ha) {
 QString HostAddress::toString(bool bracketEnclosed) const {
 	if (isV6()) {
 		if (isValid()) {
-			QString str;
-			const char *squareBracketOpen  = "";
-			const char *squareBracketClose = "";
-			if (bracketEnclosed) {
-				squareBracketOpen  = "[";
-				squareBracketClose = "]";
-			}
-
-			const std::uint16_t *shortArray = reinterpret_cast< const std::uint16_t * >(m_byteRepresentation.data());
-
-			str = QString::asprintf("%s%x:%x:%x:%x:%x:%x:%x:%x%s", squareBracketOpen, ntohs(shortArray[0]),
-									ntohs(shortArray[1]), ntohs(shortArray[2]), ntohs(shortArray[3]),
-									ntohs(shortArray[4]), ntohs(shortArray[5]), ntohs(shortArray[6]),
-									ntohs(shortArray[7]), squareBracketClose);
-
-			return str.replace(QRegularExpression(QLatin1String("(:0)+")), QLatin1String(":"));
+			const QString str = toAddress().toString();
+			return bracketEnclosed ? QLatin1Char('[') + str + QLatin1Char(']') : str;
 		} else {
 			return bracketEnclosed ? QLatin1String("[::]") : QLatin1String("::");
 		}

--- a/src/tests/TestServerAddress/TestServerAddress.cpp
+++ b/src/tests/TestServerAddress/TestServerAddress.cpp
@@ -21,6 +21,7 @@ private slots:
 	void lessThan();
 	void qhash();
 	void match();
+	void ipv6ToString();
 };
 
 void TestServerAddress::defaultCtor() {
@@ -108,6 +109,22 @@ void TestServerAddress::match() {
 	// Byte-aligned masks were already handled correctly; keep them covered.
 	QVERIFY(net.match(HostAddress(QHostAddress("10.16.99.99")), 112));
 	QVERIFY(!net.match(HostAddress(QHostAddress("10.17.0.0")), 112));
+}
+
+void TestServerAddress::ipv6ToString() {
+	// An address with more than one separate run of zero groups must still render
+	// as a valid IPv6 string (only the longest run may be collapsed to "::").
+	// Previously the output contained two "::" and could not be parsed back.
+	const char *addresses[] = { "2001:db8:0:0:1:0:0:2", "fe80:0:0:1:0:0:0:1", "2001:0:1:0:0:0:0:1" };
+	for (const char *address : addresses) {
+		const QHostAddress qHostAddress = QHostAddress(QLatin1String(address));
+		const HostAddress original(qHostAddress);
+		const QString rendered = original.toString(false);
+		const QHostAddress parsed(rendered);
+
+		QCOMPARE(parsed.protocol(), QAbstractSocket::IPv6Protocol);
+		QCOMPARE(HostAddress(parsed), original);
+	}
 }
 
 QTEST_MAIN(TestServerAddress)


### PR DESCRIPTION
Fixes #7287

## Problem

The IPv6 branch of `HostAddress::toString()` compresses zero-groups with a naive global regex replace:

```cpp
return str.replace(QRegularExpression(QLatin1String("(:0)+")), QLatin1String(":"));
```

RFC 5952 allows collapsing only the **single longest** run of zero-groups to `::`. This replace collapses **every** run, so an address with two separate zero-runs is rendered with two `::` sequences, which is not a valid IPv6 address and cannot be parsed back:

| stored address | `toString()` | valid? |
|---|---|---|
| `2001:db8:0:0:1:0:0:2` | `2001:db8::1::2` | invalid |
| `fe80:0:0:1:0:0:0:1` | `fe80::1::1` | invalid |
| `2001:0:1:0:0:0:0:1` | `2001::1::1` | invalid |

These strings are admin/user-visible in ban lists (`Ban::toString`/`toKey`), the user-information dialog, and server logs.

## Fix

Delegate formatting to Qt's RFC 5952-correct `QHostAddress::toString()` (via the existing `toAddress()`), exactly as the IPv4 path already does. The now-unused `QRegularExpression` include is removed.

## Testing

Added `TestServerAddress::ipv6ToString`, which renders each two-zero-run address and asserts the result parses back as an IPv6 address that round-trips to the original. The test fails before this change (the output is unparseable) and passes after. Full `TestServerAddress` passes (verified with Qt6 + QtTest).
