### PR TITLE
Backport "Merge PR #7286: MAINT: Make updatetranslations.py work with versioned lupdate" to 1.6.x

### DIFF
--- a/scripts/updatetranslations.py
+++ b/scripts/updatetranslations.py
@@ -22,6 +22,11 @@ def FindLupdate(vcpkg_triplet: Optional[str] = None) -> Optional[str]:
     logging.debug('Looking for lupdate…')
     if which('lupdate') is not None:
         return 'lupdate'
+
+    for i in reversed(range(5, 10)):
+        if which(f'lupdate{i}'):
+            return f'lupdate{i}'
+
     if vcpkg_triplet is not None:
         vcpkgbin = os.path.join(os.path.expanduser('~'), 'vcpkg', 'installed', vcpkg_triplet, 'tools', 'qt6', 'bin')
         logging.debug('Looking for lupdate in %s…', vcpkgbin)


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `1.6.x`:
 - [Merge PR #7286: MAINT: Make updatetranslations.py work with versioned lupdate](https://github.com/mumble-voip/mumble/pull/7286)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)