### PR TITLE
FEAT(server): Honor root channel's Enter ACL when connecting users

### DIFF
--- a/src/murmur/Messages.cpp
+++ b/src/murmur/Messages.cpp
@@ -298,21 +298,27 @@ void Server::msgAuthenticate(ServerUser *uSource, MumbleProto::Authenticate &msg
 	}
 
 	Channel *lc = nullptr;
-	if (uSource->iId >= 0 && Meta::mp->bRememberChan) {
-		unsigned int lastChannelID = m_dbWrapper.getLastChannelID(iServerNum, static_cast< unsigned int >(uSource->iId),
-																  static_cast< unsigned int >(iRememberChanDuration),
-																  tUptime.elapsed< std::chrono::seconds >());
-		lc                         = qhChannels.value(lastChannelID);
-	}
+	if (ok) {
+		if (uSource->iId >= 0 && Meta::mp->bRememberChan) {
+			unsigned int lastChannelID = m_dbWrapper.getLastChannelID(
+				iServerNum, static_cast< unsigned int >(uSource->iId),
+				static_cast< unsigned int >(iRememberChanDuration), tUptime.elapsed< std::chrono::seconds >());
+			lc = qhChannels.value(lastChannelID);
+		}
 
-	if (!lc || !hasPermission(uSource, lc, ChanACL::Enter) || isChannelFull(lc, uSource)) {
-		lc = qhChannels.value(iDefaultChan);
 		if (!lc || !hasPermission(uSource, lc, ChanACL::Enter) || isChannelFull(lc, uSource)) {
-			lc = root;
-			if (isChannelFull(lc, uSource)) {
-				reason = QString::fromLatin1("Server channels are full");
-				rtType = MumbleProto::Reject_RejectType_ServerFull;
-				ok     = false;
+			lc = qhChannels.value(iDefaultChan);
+			if (!lc || !hasPermission(uSource, lc, ChanACL::Enter) || isChannelFull(lc, uSource)) {
+				lc = root;
+				if (!hasPermission(uSource, lc, ChanACL::Enter)) {
+					reason = "You do not have permission to enter this server";
+					rtType = MumbleProto::Reject_RejectType_None;
+					ok     = false;
+				} else if (isChannelFull(lc, uSource)) {
+					reason = QString::fromLatin1("Server channels are full");
+					rtType = MumbleProto::Reject_RejectType_ServerFull;
+					ok     = false;
+				}
 			}
 		}
 	}


### PR DESCRIPTION
It was found that the root channel's(or default channel for that matter) Enter permission wasn't properly being evaluated when an unregistered user attempts to join a server that has been configured with ACL permissions to block all unregistered users.

In my testing I also found that the fallback to root logic made it so that if an error occurred during user connecting to a server(such as wrong password) the error would not report the actual rejection message/reason.

Now when the server's root or default channel is configured to not allow unregistered users, when an unregistered user connects they will be rejected and presented a new error message "Server connection rejected: You do not have permission to enter this server."

### Testing
Verified manually against a local server with this ACL configuration on the root channel:

- deny Enter + Traverse for ~all
- allow Enter + Traverse for ~auth

User                                  |  Result

- Unregistered user          |  Rejected: "You do not have permission to enter this server"
- Registered user (~auth) | 	Connects normally
- SuperUser (~admin)                     | Connects normally

Also verified that remembered-channel landing still works as expected.

Closes #7176


### Checks

- [+] My commits follow the [commit guidelines](https://github.com/mumble-voip/mumble/blob/master/COMMIT_GUIDELINES.md)

