### PR TITLE
BUILD: Fix compilation error due to undefined CHAR_BIT macro

### DIFF
--- a/src/HostAddress.cpp
+++ b/src/HostAddress.cpp
@@ -21,6 +21,7 @@
 #endif
 
 #include <cassert>
+#include <climits>
 #include <cstdint>
 #include <utility>
 


### PR DESCRIPTION
Noticed on Arch Linux with GCC 16.2.1 and Clang 22.1.8.
```
/tmp/mumble/src/HostAddress.cpp: In member function 'bool HostAddress::match(const HostAddress&, unsigned int) const': /tmp/mumble/src/HostAddress.cpp:114:113: error: 'CHAR_BIT' was not declared in this scope
  114 |                      static_cast< mask_t >(std::numeric_limits< mask_t >::max() << (sizeof(mask_t) * CHAR_BIT - bits));
      |                                                                                                      ^~~~~~~~
/tmp/mumble/src/HostAddress.cpp:24:1: note: 'CHAR_BIT' is defined in header '<climits>'; this is probably fixable by adding '#include <climits>'
   23 | #include <cassert>
  +++ |+#include <climits>
   24 | #include <cstdint>
make[2]: *** [src/CMakeFiles/shared.dir/build.make:177: src/CMakeFiles/shared.dir/HostAddress.cpp.o] Error 1
make[1]: *** [CMakeFiles/Makefile2:328: src/CMakeFiles/shared.dir/all] Error 2
make: *** [Makefile:136: all] Error 2
```
See also: https://cplusplus.com/reference/climits/


### Checks

- [x] My commits follow the [commit guidelines](https://github.com/mumble-voip/mumble/blob/master/COMMIT_GUIDELINES.md)

