### PR TITLE
Backport "Merge PR #7298: BUILD: Fix compilation error due to undefined CHAR_BIT macro" to 1.6.x

### DIFF
--- a/src/HostAddress.cpp
+++ b/src/HostAddress.cpp
@@ -21,6 +21,7 @@
 #endif
 
 #include <cassert>
+#include <climits>
 #include <cstdint>
 #include <utility>
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `1.6.x`:
 - [Merge PR #7298: BUILD: Fix compilation error due to undefined CHAR_BIT macro](https://github.com/mumble-voip/mumble/pull/7298)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)