### PR TITLE
FEAT(api): Add Whisper/Shout Plugin API

### DIFF
--- a/plugins/CMakeLists.txt
+++ b/plugins/CMakeLists.txt
@@ -18,12 +18,18 @@ list(APPEND AVAILABLE_PLUGINS
 	"link"
 )
 
-if(${CMAKE_BUILD_TYPE} MATCHES Debug)
+if(${CMAKE_BUILD_TYPE} MATCHES Debug OR ${CMAKE_BUILD_TYPE} MATCHES RelWithDebInfo)
 	message("Including TestPlugin in debug mode")
 	list(APPEND AVAILABLE_PLUGINS
 		"testPlugin"
 		"deadLockPlugin"
 	)
+
+	if(WIN32)
+		list(APPEND AVAILABLE_PLUGINS
+		"testShout"
+	)
+	endif()
 endif()
 
 if(WIN32 OR (UNIX AND CMAKE_SYSTEM_NAME STREQUAL "Linux"))

--- a/plugins/MumblePlugin.h
+++ b/plugins/MumblePlugin.h
@@ -43,7 +43,7 @@
 #		define MUMBLE_PLUGIN_API_MAJOR_MACRO 1
 #	endif
 #	ifndef MUMBLE_PLUGIN_API_MINOR_MACRO
-#		define MUMBLE_PLUGIN_API_MINOR_MACRO 2
+#		define MUMBLE_PLUGIN_API_MINOR_MACRO 3
 #	endif
 #	ifndef MUMBLE_PLUGIN_API_PATCH_MACRO
 #		define MUMBLE_PLUGIN_API_PATCH_MACRO 0
@@ -233,6 +233,7 @@ enum Mumble_ErrorCode {
 	MUMBLE_EC_DATA_ID_TOO_LONG,
 	MUMBLE_EC_API_REQUEST_TIMEOUT,
 	MUMBLE_EC_OPERATION_UNSUPPORTED_BY_SERVER,
+	MUMBLE_EC_PLUGIN_WHISPER_SHOUT_NOT_FOUND
 };
 
 /**
@@ -617,6 +618,8 @@ MUMBLE_PLUGIN_CONSTEXPR inline const char *mumble_errorMessage(int16_t errorCode
 		case MUMBLE_EC_OPERATION_UNSUPPORTED_BY_SERVER:
 			return "The requested API operation depends on server-side functionality, not supported by the server "
 				   "you're connected to";
+		case MUMBLE_EC_PLUGIN_WHISPER_SHOUT_NOT_FOUND:
+			return "The given allocID for the whisper/shout targets isn't found.";
 	}
 
 	return "Unknown error code";
@@ -1515,6 +1518,32 @@ struct MUMBLE_API_STRUCT_NAME {
 																			mumble_channelid_t channelID,
 																			const char **description);
 
+#	if SELECTED_API_VERSION >= MUMBLE_PLUGIN_VERSION_CHECK(1, 3, 0)
+	/**
+	 * Checks whether the local user is currently using a Push-To-Talk (PTT) transmission, i.e. whether a PTT-style
+	 * transmission is currently active. This includes shout/whisper targets triggered via the Plugin-API as well as
+	 * regular PTT shortcuts. It does **not** distinguish between those sources.
+	 *
+	 * @param callerID The ID of the plugin calling this function
+	 * @param[out] isUsingPTT A pointer to the memory the result shall be written to. It is set to true if the local
+	 * user is currently transmitting via a PTT-style mechanism (iPushToTalk >= 1)
+	 * @returns The error code. If everything went well, STATUS_OK will be returned. Only then the passed pointer may
+	 * be accessed.
+	 */
+	mumble_error_t(MUMBLE_PLUGIN_CALLING_CONVENTION *isLocalUserUsingPTT)(mumble_plugin_id_t callerID,
+																		  bool *isUsingPTT);
+
+	/**
+	 * Gets the current talking state of the local user (e.g. passive, talking, whispering/shouting or muted).
+	 *
+	 * @param callerID The ID of the plugin calling this function
+	 * @param[out] talkingState A pointer to the memory the state shall be written to
+	 * @returns The error code. If everything went well, STATUS_OK will be returned. Only then the passed pointer may
+	 * be accessed.
+	 */
+	mumble_error_t(MUMBLE_PLUGIN_CALLING_CONVENTION *getLocalUserTalkingState)(mumble_plugin_id_t callerID,
+																			   mumble_talking_state_t *talkingState);
+#	endif
 
 	// -------- Request functions --------
 
@@ -1608,7 +1637,46 @@ struct MUMBLE_API_STRUCT_NAME {
 																				 mumble_connection_t connection,
 																				 const char *comment);
 
+#	if SELECTED_API_VERSION >= MUMBLE_PLUGIN_VERSION_CHECK(1, 3, 0)
+	/**
+	 * Starts a Whisper/Shout transmission for the local user targeting the given users and/or channels.
+	 *
+	 * This makes the local user whisper (or shout, when targeting many channels) to the specified targets as if
+	 * a corresponding whisper target had been activated. The affected targets are kept alive until a matching call
+	 * to @ref requestStopLocalUserWhisperShout is made. Each successful call allocates a new target group that is
+	 * identified by the returned @p allocID.
+	 *
+	 * @param callerID The ID of the plugin calling this function
+	 * @param users An array of user IDs the local user shall whisper to. May be NULL if no users are targeted.
+	 * @param userCount The number of entries in the @p users array
+	 * @param channels An array of channel IDs the local user shall whisper/shout to. May be NULL if no channels are
+	 * targeted.
+	 * @param channelCount The number of entries in the @p channels array
+	 * @param[out] allocID A pointer to the memory the allocated whisper-target ID shall be written to. This ID must
+	 * be passed to @ref requestStopLocalUserWhisperShout in order to stop the transmission. Only valid if STATUS_OK
+	 * is returned.
+	 * @returns The error code. If everything went well, STATUS_OK will be returned. Only then the pointer passed via
+	 * @p allocID may be accessed.
+	 */
+	mumble_error_t(MUMBLE_PLUGIN_CALLING_CONVENTION *requestStartLocalUserWhisperShout)(
+		mumble_plugin_id_t callerID, mumble_connection_t connection, const mumble_userid_t *users,
+		const size_t userCount, const mumble_channelid_t *channels, const size_t channelCount, uint32_t *allocID);
 
+	/**
+	 * Stops a previously started Whisper/Shout transmission for the local user.
+	 *
+	 * This removes the whisper targets that were allocated by the corresponding call to
+	 * @ref requestStartLocalUserWhisperShout identified by @p allocID and ends the transmission.
+	 *
+	 * @param callerID The ID of the plugin calling this function
+	 * @param allocID The whisper-target ID that was returned by @ref requestStartLocalUserWhisperShout
+	 * @returns The error code. If everything went well, STATUS_OK will be returned. If no whisper target with the
+	 * given ID exists, MUMBLE_EC_PLUGIN_WHISPER_SHOUT_NOT_FOUND is returned.
+	 */
+	mumble_error_t(MUMBLE_PLUGIN_CALLING_CONVENTION *requestStopLocalUserWhisperShout)(mumble_plugin_id_t callerID,
+																					   mumble_connection_t connection,
+																					   const uint32_t allocID);
+#	endif
 
 	// -------- Find functions --------
 

--- a/plugins/testShout/CMakeLists.txt
+++ b/plugins/testShout/CMakeLists.txt
@@ -1,0 +1,7 @@
+# Copyright The Mumble Developers. All rights reserved.
+# Use of this source code is governed by a BSD-style license
+# that can be found in the LICENSE file at the root of the
+# Mumble source tree or at <https://www.mumble.info/LICENSE>.
+if(WIN32)
+	add_library(testShout SHARED "testShout.cpp")
+endif()

--- a/plugins/testShout/testShout.cpp
+++ b/plugins/testShout/testShout.cpp
@@ -1,0 +1,556 @@
+// Copyright The Mumble Developers. All rights reserved.
+// Use of this source code is governed by a BSD-style license
+// that can be found in the LICENSE file at the root of the
+// Mumble source tree or at <https://www.mumble.info/LICENSE>.
+
+#include "../MumblePlugin.h"
+
+#include <windows.h>
+
+#include <atomic>
+#include <condition_variable>
+#include <cstdint>
+#include <cstdio>
+#include <cstring>
+#include <functional>
+#include <iomanip>
+#include <mutex>
+#include <sstream>
+#include <string>
+#include <thread>
+#include <vector>
+
+////////////////////////////////////////////////////////////
+// Global plugin state
+////////////////////////////////////////////////////////////
+
+mumble_api_t mumAPI;
+std::atomic< mumble_connection_t > activeConnection = -1;
+mumble_plugin_id_t ownID                            = 0;
+
+// Set to false to stop the interactive console thread.
+std::atomic< bool > g_running{ false };
+
+// Set to true once mumble_registerAPIFunctions has been called (mumAPI valid).
+std::atomic< bool > g_apiReady{ false };
+
+// The dedicated console thread.
+std::thread g_consoleThread;
+
+// Cached raw console handles (set up by openConsole()).
+static HANDLE g_hConsoleOut = INVALID_HANDLE_VALUE;
+static HANDLE g_hConsoleIn  = INVALID_HANDLE_VALUE;
+
+
+////////////////////////////////////////////////////////////
+// Console I/O (raw Win32 handles, no C/C++ stdio)
+////////////////////////////////////////////////////////////
+
+// Write raw text to our dedicated console. Falls back to OutputDebugStringA when
+// no console is available (visible in Visual Studio's "Output" window / DebugView).
+static void consoleWrite(const std::string &text) {
+	if (g_hConsoleOut != INVALID_HANDLE_VALUE) {
+		DWORD written = 0;
+		WriteConsoleA(g_hConsoleOut, text.c_str(), static_cast< DWORD >(text.size()), &written, nullptr);
+		return;
+	}
+	OutputDebugStringA(text.c_str());
+}
+
+// Read a single line (without trailing newline) from the console. Returns false
+// on EOF / closed handle.
+static bool consoleReadLine(std::string &out) {
+	out.clear();
+	if (g_hConsoleIn == INVALID_HANDLE_VALUE) {
+		return false;
+	}
+
+	// ReadFile on a console input handle reads raw bytes and is far more reliable
+	// than ReadConsoleA (which is affected by console input modes / mouse events).
+	char chunk[256];
+	DWORD got = 0;
+	std::string accumulated;
+
+	for (;;) {
+		if (!ReadFile(g_hConsoleIn, chunk, sizeof(chunk), &got, nullptr) || got == 0) {
+			if (accumulated.empty()) {
+				return false;
+			}
+			break;
+		}
+
+		for (DWORD i = 0; i < got; i++) {
+			char c = chunk[i];
+			if (c == '\r' || c == '\n') {
+				out = accumulated;
+				return true;
+			}
+			if (c == '\b') { // backspace
+				if (!accumulated.empty()) {
+					accumulated.pop_back();
+					consoleWrite("\b \b");
+				}
+				continue;
+			}
+			if (c == '\x03') { // Ctrl-C
+				return false;
+			}
+			accumulated.push_back(c);
+		}
+	}
+
+	out = accumulated;
+	return true;
+}
+
+// Print a full line to the console + debugger output.
+static void printLine(const std::string &message) {
+	std::string line = "[TestShout] " + message + "\n";
+	consoleWrite(line);
+	OutputDebugStringA(line.c_str());
+}
+
+// Log to the console + debugger + Mumble's own plugin log (once API is ready).
+static void logLine(const std::string &message) {
+	printLine(message);
+	if (g_apiReady.load() && ownID != 0) {
+		mumAPI.log(ownID, message.c_str());
+	}
+}
+
+
+////////////////////////////////////////////////////////////
+// Thread-communicating API dispatch (request/response queue)
+////////////////////////////////////////////////////////////
+//
+// The console thread enqueues a command (a std::function that performs the API
+// calls and produces a response string) and waits on a condition variable. The
+// command is then executed and the response returned. This decouples "who asks"
+// from "who runs", and - critically - neither thread blocks the other: the main
+// thread never waits on the console thread, so no deadlock can occur. Mumble
+// executes each API function on its main thread with a built-in timeout.
+
+struct CommandResponse {
+	bool done = false;
+	std::string output;
+};
+
+static std::function< std::string() > g_pendingCommand;
+static CommandResponse g_response;
+static bool g_commandPending = false;
+
+
+////////////////////////////////////////////////////////////
+// Helpers
+////////////////////////////////////////////////////////////
+
+static const char *talkingStateToString(mumble_talking_state_t state) {
+	switch (state) {
+		case MUMBLE_TS_INVALID:
+			return "Invalid";
+		case MUMBLE_TS_PASSIVE:
+			return "Passive";
+		case MUMBLE_TS_TALKING:
+			return "Talking";
+		case MUMBLE_TS_WHISPERING:
+			return "Whispering";
+		case MUMBLE_TS_SHOUTING:
+			return "Shouting";
+		case MUMBLE_TS_TALKING_MUTED:
+			return "Talking (muted)";
+		default:
+			return "Unknown";
+	}
+}
+
+static const char *errorMessageSafe(mumble_error_t error) {
+	return mumble_errorMessage(error);
+}
+
+
+////////////////////////////////////////////////////////////
+// Command handlers (each returns a response string)
+////////////////////////////////////////////////////////////
+
+// Command 1: read whether the local user is currently using PTT.
+// NOTE: the API does not expose the raw iPushToTalk counter, only a boolean.
+static std::string cmdReadPTT() {
+	bool usingPTT        = false;
+	mumble_error_t error = mumAPI.isLocalUserUsingPTT(ownID, &usingPTT);
+
+	if (error != MUMBLE_STATUS_OK) {
+		return std::string("isLocalUserUsingPTT failed: \n  ") + errorMessageSafe(error);
+	}
+
+	return std::string("isLocalUserUsingPTT = ") + (usingPTT ? "true" : "false");
+}
+
+// Command 2: read the local user's current talking state.
+static std::string cmdReadTalkingState() {
+	mumble_talking_state_t state = MUMBLE_TS_INVALID;
+	mumble_error_t error         = mumAPI.getLocalUserTalkingState(ownID, &state);
+
+	if (error != MUMBLE_STATUS_OK) {
+		return std::string("getLocalUserTalkingState failed: \n  ") + errorMessageSafe(error);
+	}
+
+	return std::string("Local user talking state = ") + talkingStateToString(state) + " ("
+		   + std::to_string(static_cast< int >(state)) + ")";
+}
+
+// Command 3: list all users/channels, then ask for user IDs and channel IDs, and
+// finally apply them via requestSetLocalUserShoutingTargets.
+//
+// NOTE: this command needs interactive sub-prompts, so it is handled specially in
+// the console loop rather than as a pure function. See cmdSetTargetsInteractive().
+static std::string cmdSetTargets(const std::vector< mumble_userid_t > &users,
+								 const std::vector< mumble_channelid_t > &channels) {
+	uint32_t allocID;
+	mumble_error_t error = mumAPI.requestStartLocalUserWhisperShout(
+		ownID, activeConnection.load(), users.empty() ? nullptr : users.data(), users.size(),
+		channels.empty() ? nullptr : channels.data(), channels.size(), &allocID);
+
+	if (error == MUMBLE_STATUS_OK) {
+		return "Whisper/Shout targets set: " + std::to_string(users.size()) + " user(s), "
+			   + std::to_string(channels.size())
+			   + " channel(s).\n"
+				 "To stop whisper/shout targets, use this allocID: "
+			   + std::to_string(allocID) + ".";
+	}
+	return std::string("requestSetLocalUserShoutingTargets failed: \n  ") + errorMessageSafe(error);
+}
+
+
+// Command 5: deactivate PTT-style shout transmission (iPushToTalk--).
+static std::string cmdDisableShouting() {
+	std::string strAllocID;
+	printLine("Input allocID: ");
+	consoleReadLine(strAllocID);
+	uint32_t allocID;
+	try {
+		allocID = std::stoul(strAllocID);
+	} catch (...) {
+		return "Invalid allocID.";
+	}
+	mumble_error_t error = mumAPI.requestStopLocalUserWhisperShout(ownID, activeConnection.load(), allocID);
+
+	if (error == MUMBLE_STATUS_OK) {
+		return "Shouting disabled (iPushToTalk decremented).";
+	}
+	return std::string("requestDisableLocalUserShouting failed: \n  ") + errorMessageSafe(error);
+}
+
+
+static void cmdPrintAvailableUserAndChannels() {
+	if (activeConnection.load() < 0) {
+		printLine("Not connected to a server (activeConnection == -1). Connect first.");
+		return;
+	}
+	mumble_userid_t *users = nullptr;
+	size_t userCount       = 0;
+
+	if (mumAPI.getAllUsers(ownID, activeConnection.load(), &users, &userCount) != MUMBLE_STATUS_OK) {
+		printLine("Failed to fetch user list...");
+		return;
+	}
+
+	std::string result = "Users on this server (" + std::to_string(userCount) + "):";
+	for (size_t i = 0; i < userCount; i++) {
+		const char *name = nullptr;
+		if (mumAPI.getUserName(ownID, activeConnection.load(), users[i], &name) == MUMBLE_STATUS_OK) {
+			result += "\n  User  id=" + std::to_string(users[i]) + "  name=\"" + std::string(name) + "\"";
+		} else {
+			result += "\n  User  id=" + std::to_string(users[i]) + "  name=(null)";
+		}
+
+		mumAPI.freeMemory(ownID, name);
+	}
+	printLine(result);
+	mumAPI.freeMemory(ownID, users);
+
+	mumble_channelid_t *channels = nullptr;
+	size_t channelCount          = 0;
+	if (mumAPI.getAllChannels(ownID, activeConnection.load(), &channels, &channelCount) != MUMBLE_STATUS_OK) {
+		printLine("Failed to fetch channel list...");
+		return;
+	}
+
+	result = "Channels on this server (" + std::to_string(channelCount) + "):";
+	for (size_t i = 0; i < channelCount; i++) {
+		const char *name = nullptr;
+		std::ostringstream line;
+		line << "\n  Channel  id=" << std::left << std::setw(12) << channels[i];
+		if (mumAPI.getChannelName(ownID, activeConnection.load(), channels[i], &name) == MUMBLE_STATUS_OK) {
+			line << "  name=\"" << std::string(name) << "\"";
+			mumAPI.freeMemory(ownID, name);
+		} else {
+			line << "  name=<unavailable>";
+		}
+		result += line.str();
+	}
+	printLine(result);
+	mumAPI.freeMemory(ownID, channels);
+}
+
+
+////////////////////////////////////////////////////////////
+// Command 4 (interactive): list + prompt + apply
+////////////////////////////////////////////////////////////
+
+// Prints the list of users and channels, then reads the target IDs from the
+// console and applies them. Runs on the console thread, but each API call is
+// routed through dispatchCommand() so it is thread-safe.
+static void cmdSetTargetsInteractive() {
+	if (activeConnection.load() < 0) {
+		printLine("Not connected to a server (activeConnection == -1). Connect first.");
+		return;
+	}
+
+	cmdPrintAvailableUserAndChannels();
+
+	consoleWrite("[TestShout] Enter user IDs to shout at (space-separated, empty for none): \n>");
+	std::string userLine;
+	consoleReadLine(userLine);
+
+	std::vector< mumble_userid_t > targetUsers;
+	{
+		std::istringstream iss(userLine);
+		uint32_t id = 0;
+		while (iss >> id) {
+			targetUsers.push_back(id);
+		}
+	}
+
+	// ----- Read channel IDs (space-separated) -----
+	consoleWrite("[TestShout] Enter channel IDs to shout to (space-separated, empty for none): \n>");
+	std::string channelLine;
+	consoleReadLine(channelLine);
+
+	std::vector< mumble_channelid_t > targetChannels;
+	{
+		std::istringstream iss(channelLine);
+		int32_t id = 0;
+		while (iss >> id) {
+			targetChannels.push_back(id);
+		}
+	}
+
+	printLine(cmdSetTargets(targetUsers, targetChannels));
+}
+
+
+////////////////////////////////////////////////////////////
+// Interactive console loop (runs on the dedicated thread)
+////////////////////////////////////////////////////////////
+
+static void printMenu() {
+	consoleWrite("\n[TestShout] ==== Menu ====\n"
+				 "  1 : Read whether local user is using PTT\n"
+				 "  2 : Read local user talking state\n"
+				 "  3 : List users/channels \n"
+				 "  4 : Start whispering/shouting after listing users/channels\n"
+				 "  5 : Stop whispering/shouting (requestDisableLocalUserShouting)\n"
+				 "[TestShout] Choice: ");
+}
+
+static void loop_main() {
+	while (g_running.load()) {
+		printMenu();
+
+		std::string line;
+		if (!consoleReadLine(line)) {
+			break;
+		}
+
+		if (line.empty()) {
+			continue;
+		}
+
+		if (line == "1") {
+			printLine(cmdReadPTT());
+		} else if (line == "2") {
+			printLine(cmdReadTalkingState());
+		} else if (line == "3") {
+			cmdPrintAvailableUserAndChannels();
+		} else if (line == "4") {
+			cmdSetTargetsInteractive();
+		} else if (line == "5") {
+			printLine(cmdDisableShouting());
+		} else {
+			consoleWrite("[TestShout] Unknown choice: \"" + line + "\"\n");
+		}
+	}
+}
+
+
+////////////////////////////////////////////////////////////
+// Console setup
+////////////////////////////////////////////////////////////
+
+// Create a dedicated console window (Mumble is a GUI app and has no console of its
+// own) and cache its raw handles. We deliberately do NOT use freopen()/std::cout
+// because those rely on C/C++ stdio stream state that is unreliable inside a GUI
+// process. Instead we keep the HANDLEs and use WriteConsoleA/ReadFile directly.
+static void openConsole() {
+	bool consoleCreated = false;
+	if (AllocConsole()) {
+		consoleCreated = true;
+		SetConsoleTitleA("TestShout Plugin Console");
+	}
+	// else: a console already exists (e.g. Mumble was started from a console).
+
+	g_hConsoleOut = GetStdHandle(STD_OUTPUT_HANDLE);
+	g_hConsoleIn  = GetStdHandle(STD_INPUT_HANDLE);
+
+	// Put console input in a sane mode: line input + echo, no mouse/window events.
+	if (g_hConsoleIn != INVALID_HANDLE_VALUE) {
+		SetConsoleMode(g_hConsoleIn, ENABLE_LINE_INPUT | ENABLE_ECHO_INPUT | ENABLE_PROCESSED_INPUT);
+	}
+
+	std::string diag = "Console ready (AllocConsole=" + std::string(consoleCreated ? "true" : "false")
+					   + ", hIn=" + std::to_string(reinterpret_cast< uintptr_t >(g_hConsoleIn))
+					   + ", hOut=" + std::to_string(reinterpret_cast< uintptr_t >(g_hConsoleOut)) + ")";
+	consoleWrite("[TestShout] " + diag + "\n");
+	OutputDebugStringA(("[TestShout] " + diag + "\n").c_str());
+}
+
+
+////////////////////////////////////////////////////////////
+// Obligatory plugin functions
+////////////////////////////////////////////////////////////
+
+mumble_error_t mumble_init(uint32_t id) {
+	ownID = id;
+
+	// Bring up the dedicated console window first so logging is visible.
+	openConsole();
+
+	printLine("Initialized with plugin ID " + std::to_string(id));
+	int ac = -1;
+	mumAPI.getActiveServerConnection(ownID, &ac);
+	if (ac != -1) {
+		activeConnection.store(ac);
+		printLine("Connected to server " + std::to_string(activeConnection));
+	}
+
+	// NOTE: per PluginLifecycle.md, mumble_registerAPIFunctions is called BEFORE
+	// mumble_init, so mumAPI is already valid here. But we still gate API calls on
+	// g_apiReady for safety and start the console thread here.
+	g_running.store(true);
+	g_consoleThread = std::thread(loop_main);
+
+	consoleWrite(".:========[ Test Shout Plugin v1.0.0 ]========:.\n"
+				 "|| Plugin Author: WuCJ638                     ||\n"
+				 "||                Deepseek V4 Pro             ||\n"
+				 "||============================================||\n"
+				 "|| - This plugin is for testing API around    ||\n"
+				 "||   whispering/shouting feature.             ||\n"
+				 "|| - DO NOT CLOSE THIS WINDOW WHILE THE PLUG- ||\n"
+				 "||   -IN IS STILL RUNNING! Exiting logic has  ||\n"
+				 "||   not been implemented yet.                ||\n"
+				 "':============================================:'\n");
+	return MUMBLE_STATUS_OK;
+}
+
+void mumble_shutdown() {
+	// I don't know how to close this console safely.
+	// Since it's just a testing tool, I'm not going to dive deeper
+	// into completing the shutdown logic.
+	g_running.store(false);
+
+	CancelIoEx(g_hConsoleIn, nullptr);
+
+	// The console thread may be blocked in ReadFile(). Detach instead of join to
+	// avoid blocking plugin shutdown; the OS reclaims the console at exit.
+	if (g_consoleThread.joinable()) {
+		g_consoleThread.join();
+	}
+
+	CloseHandle(g_hConsoleOut);
+	CloseHandle(g_hConsoleIn);
+
+	if (g_apiReady.load() && ownID != 0) {
+		mumAPI.log(ownID, "TestShout shutdown");
+	}
+}
+
+MumbleStringWrapper mumble_getName() {
+	static const char *name = "TestShout";
+
+	MumbleStringWrapper wrapper;
+	wrapper.data           = name;
+	wrapper.size           = strlen(name);
+	wrapper.needsReleasing = false;
+
+	return wrapper;
+}
+
+mumble_version_t mumble_getAPIVersion() {
+	return MUMBLE_PLUGIN_API_VERSION;
+}
+
+void mumble_registerAPIFunctions(void *api) {
+	// Copy the whole API struct; the passed pointer must not be stored.
+	mumAPI = MUMBLE_API_CAST(api);
+	g_apiReady.store(true);
+}
+
+void mumble_releaseResource(const void *pointer) {
+	// This plugin never returns resources that need releasing.
+	(void) pointer;
+}
+
+
+////////////////////////////////////////////////////////////
+// Optional plugin functions
+////////////////////////////////////////////////////////////
+
+mumble_version_t mumble_getVersion() {
+	return { 1, 0, 0 };
+}
+
+MumbleStringWrapper mumble_getAuthor() {
+	static const char *author = "WuCJ638, Deepseek V4 Pro";
+
+	MumbleStringWrapper wrapper;
+	wrapper.data           = author;
+	wrapper.size           = strlen(author);
+	wrapper.needsReleasing = false;
+
+	return wrapper;
+}
+
+MumbleStringWrapper mumble_getDescription() {
+	static const char *description = "Interactive CLI test plugin for the local-user shouting API.";
+
+	MumbleStringWrapper wrapper;
+	wrapper.data           = description;
+	wrapper.size           = strlen(description);
+	wrapper.needsReleasing = false;
+
+	return wrapper;
+}
+
+uint32_t mumble_getFeatures() {
+	return MUMBLE_FEATURE_NONE;
+}
+
+uint32_t mumble_deactivateFeatures(uint32_t features) {
+	return features;
+}
+
+
+////////////////////////////////////////////////////////////
+// Event callbacks (may be invoked from Mumble's threads)
+////////////////////////////////////////////////////////////
+
+void mumble_onServerConnected(mumble_connection_t connection) {
+	activeConnection.store(connection);
+}
+
+void mumble_onServerDisconnected(mumble_connection_t connection) {
+	activeConnection.store(-1);
+}
+
+void mumble_onServerSynchronized(mumble_connection_t connection) {
+}

--- a/src/mumble/API.h
+++ b/src/mumble/API.h
@@ -111,6 +111,10 @@ public slots:
 							 const char **hash, std::shared_ptr< api_promise_t > promise);
 	void getServerHash_v_1_0_x(mumble_plugin_id_t callerID, mumble_connection_t connection, const char **hash,
 							   std::shared_ptr< api_promise_t > promise);
+	void isLocalUserUsingPTT_v_1_3_x(mumble_plugin_id_t callerID, bool *isUsingPTT,
+									 std::shared_ptr< api_promise_t > promise);
+	void getLocalUserTalkingState_v_1_3_x(mumble_plugin_id_t callerID, mumble_talking_state_t *talkingState,
+										  std::shared_ptr< api_promise_t > promise);
 	void requestLocalUserTransmissionMode_v_1_0_x(mumble_plugin_id_t callerID,
 												  mumble_transmission_mode_t transmissionMode,
 												  std::shared_ptr< api_promise_t > promise);
@@ -132,6 +136,12 @@ public slots:
 									  std::shared_ptr< api_promise_t > promise);
 	void requestSetLocalUserComment_v_1_0_x(mumble_plugin_id_t callerID, mumble_connection_t connection,
 											const char *comment, std::shared_ptr< api_promise_t > promise);
+	void requestStartLocalUserWhisperShout_v_1_3_x(mumble_plugin_id_t callerID, mumble_connection_t connection,
+												   const mumble_userid_t *users, const size_t userCount,
+												   const mumble_channelid_t *channels, const size_t channelCount,
+												   uint32_t *allocID, std::shared_ptr< api_promise_t > promise);
+	void requestStopLocalUserWhisperShout_v_1_3_x(mumble_plugin_id_t callerID, mumble_connection_t connection,
+												  const uint32_t allocID, std::shared_ptr< api_promise_t > promise);
 	void findUserByName_v_1_0_x(mumble_plugin_id_t callerID, mumble_connection_t connection, const char *userName,
 								mumble_userid_t *userID, std::shared_ptr< api_promise_t > promise);
 	void findChannelByName_v_1_0_x(mumble_plugin_id_t callerID, mumble_connection_t connection, const char *channelName,
@@ -173,6 +183,9 @@ MumbleAPI_v_1_0_x getMumbleAPI_v_1_0_x();
 
 /// @returns The Mumble API struct (v1.2.x)
 MumbleAPI_v_1_2_x getMumbleAPI_v_1_2_x();
+
+/// @returns The Mumble API struct (v1.3.x)
+MumbleAPI_v_1_3_x getMumbleAPI_v_1_3_x();
 
 /// Converts from the Qt key-encoding to the API's key encoding.
 ///

--- a/src/mumble/API_v_1_x_x.cpp
+++ b/src/mumble/API_v_1_x_x.cpp
@@ -140,7 +140,7 @@ MumbleAPI::MumbleAPI() {
 	REGISTER_METATYPE(mumble_plugin_id_t);
 	REGISTER_METATYPE(mumble_settings_key_t);
 	REGISTER_METATYPE(mumble_transmission_mode_t);
-	REGISTER_METATYPE(mumble_userid_t);
+	REGISTER_METATYPE(mumble_talking_state_t);
 	REGISTER_METATYPE(mumble_userid_t);
 	REGISTER_METATYPE(std::size_t);
 	REGISTER_METATYPE(uint8_t);
@@ -740,6 +740,75 @@ void MumbleAPI::getServerHash_v_1_0_x(mumble_plugin_id_t callerID, mumble_connec
 	EXIT_WITH(MUMBLE_STATUS_OK);
 }
 
+void MumbleAPI::isLocalUserUsingPTT_v_1_3_x(mumble_plugin_id_t callerID, bool *isUsingPTT,
+											std::shared_ptr< api_promise_t > promise) {
+	if (QThread::currentThread() != thread()) {
+		// Invoke in main thread
+		QMetaObject::invokeMethod(this, "isLocalUserUsingPTT_v_1_3_x", Qt::QueuedConnection,
+								  Q_ARG(mumble_plugin_id_t, callerID), Q_ARG(bool *, isUsingPTT),
+								  Q_ARG(std::shared_ptr< api_promise_t >, promise));
+
+		return;
+	}
+	api_promise_t::lock_guard_t guard = promise->lock();
+	if (promise->isCancelled()) {
+		return;
+	}
+
+	VERIFY_PLUGIN_ID(callerID);
+
+	*isUsingPTT = Global::get().iPushToTalk >= 1;
+
+	EXIT_WITH(MUMBLE_STATUS_OK);
+}
+
+
+void MumbleAPI::getLocalUserTalkingState_v_1_3_x(mumble_plugin_id_t callerID, mumble_talking_state_t *talkingState,
+												 std::shared_ptr< api_promise_t > promise) {
+	if (QThread::currentThread() != thread()) {
+		// Invoke in main thread
+		QMetaObject::invokeMethod(this, "getLocalUserTalkingState_v_1_3_x", Qt::QueuedConnection,
+								  Q_ARG(mumble_plugin_id_t, callerID), Q_ARG(mumble_talking_state_t *, talkingState),
+								  Q_ARG(std::shared_ptr< api_promise_t >, promise));
+
+		return;
+	}
+
+	api_promise_t::lock_guard_t guard = promise->lock();
+	if (promise->isCancelled()) {
+		return;
+	}
+
+	VERIFY_PLUGIN_ID(callerID);
+
+	ClientUser *user = ClientUser::get(Global::get().uiSession);
+	if (!user) {
+		EXIT_WITH(MUMBLE_EC_USER_NOT_FOUND);
+	} else {
+		switch (user->tsState) {
+			case Settings::TalkState::Passive:
+				*talkingState = MUMBLE_TS_PASSIVE;
+				break;
+			case Settings::TalkState::Talking:
+				*talkingState = MUMBLE_TS_TALKING;
+				break;
+			case Settings::TalkState::Whispering:
+				*talkingState = MUMBLE_TS_WHISPERING;
+				break;
+			case Settings::TalkState::Shouting:
+				*talkingState = MUMBLE_TS_SHOUTING;
+				break;
+			case Settings::TalkState::MutedTalking:
+				*talkingState = MUMBLE_TS_TALKING_MUTED;
+				break;
+			default:
+				*talkingState = MUMBLE_TS_INVALID;
+				EXIT_WITH(MUMBLE_EC_INTERNAL_ERROR);
+		}
+		EXIT_WITH(MUMBLE_STATUS_OK);
+	}
+}
+
 void MumbleAPI::requestLocalUserTransmissionMode_v_1_0_x(mumble_plugin_id_t callerID,
 														 mumble_transmission_mode_t transmissionMode,
 														 std::shared_ptr< api_promise_t > promise) {
@@ -1091,6 +1160,121 @@ void MumbleAPI::requestSetLocalUserComment_v_1_0_x(mumble_plugin_id_t callerID, 
 	Global::get().mw->pmModel->setComment(localUser, QString::fromUtf8(comment));
 
 	EXIT_WITH(MUMBLE_STATUS_OK);
+}
+
+void MumbleAPI::requestStartLocalUserWhisperShout_v_1_3_x(mumble_plugin_id_t callerID, mumble_connection_t connection,
+														  const mumble_userid_t *users, const size_t userCount,
+														  const mumble_channelid_t *channels, const size_t channelCount,
+														  uint32_t *allocID, std::shared_ptr< api_promise_t > promise) {
+	if (QThread::currentThread() != thread()) {
+		// Invoke in main thread
+		QMetaObject::invokeMethod(this, "requestStartLocalUserWhisperShout_v_1_3_x", Qt::QueuedConnection,
+								  Q_ARG(mumble_plugin_id_t, callerID), Q_ARG(mumble_connection_t, connection),
+								  Q_ARG(const mumble_userid_t *, users), Q_ARG(const size_t, userCount),
+								  Q_ARG(const mumble_channelid_t *, channels), Q_ARG(const size_t, channelCount),
+								  Q_ARG(uint32_t *, allocID), Q_ARG(std::shared_ptr< api_promise_t >, promise));
+
+		return;
+	}
+
+	api_promise_t::lock_guard_t guard = promise->lock();
+	if (promise->isCancelled()) {
+		return;
+	}
+
+	VERIFY_PLUGIN_ID(callerID);
+	VERIFY_CONNECTION(connection);
+	ENSURE_CONNECTION_SYNCHRONIZED(connection);
+
+	MainWindow *mw = Global::get().mw;
+
+	if (!mw) {
+		EXIT_WITH(MUMBLE_EC_INTERNAL_ERROR);
+	} else {
+		*allocID = mw->allocatePluginTarget();
+		// Add Users.
+		if (userCount > 0) {
+			ShortcutTarget stUser;
+			stUser.bUsers = true;
+			for (size_t u = 0; u < userCount; u++) {
+				mumble_userid_t user = users[u];
+				if (ClientUser::get(user)) {
+					stUser.qlSessions << user;
+					stUser.qlUsers << ClientUser::get(user)->qsHash;
+				} else {
+					qWarning("[MumbleAPI::requestStartLocalUserWhisperShout_v_1_3_x]"
+							 "user %u not found!",
+							 user);
+				}
+			}
+			mw->addTarget(&stUser);
+			mw->addPluginTarget(*allocID, stUser);
+		}
+
+		// Add Channels. One `st` for each channel.
+		for (size_t c = 0; c < channelCount; c++) {
+			mumble_channelid_t channel = channels[c];
+			if (Channel::get(static_cast< unsigned int >(channel))) {
+				ShortcutTarget stChan;
+				stChan.bUsers    = false;
+				stChan.iChannel  = static_cast< int >(channels[c]);
+				stChan.bLinks    = false;
+				stChan.bChildren = false;
+				mw->addTarget(&stChan);
+				mw->addPluginTarget(*allocID, stChan);
+			} else {
+				qWarning("[MumbleAPI::requestStartLocalUserWhisperShout_v_1_3_x]"
+						 "channel %u not found!",
+						 channel);
+			}
+		}
+		mw->updateTarget();
+		Global::get().iPushToTalk++;
+
+		EXIT_WITH(MUMBLE_STATUS_OK);
+	} // if (!mw) else ...
+}
+
+void MumbleAPI::requestStopLocalUserWhisperShout_v_1_3_x(mumble_plugin_id_t callerID, mumble_connection_t connection,
+														 const uint32_t allocID,
+														 std::shared_ptr< api_promise_t > promise) {
+	if (QThread::currentThread() != thread()) {
+		// Invoke in main thread
+		QMetaObject::invokeMethod(this, "requestStopLocalUserWhisperShout_v_1_3_x", Qt::QueuedConnection,
+								  Q_ARG(mumble_plugin_id_t, callerID), Q_ARG(mumble_connection_t, connection),
+								  Q_ARG(const uint32_t, allocID), Q_ARG(std::shared_ptr< api_promise_t >, promise));
+
+		return;
+	}
+
+	api_promise_t::lock_guard_t guard = promise->lock();
+	if (promise->isCancelled()) {
+		return;
+	}
+
+	VERIFY_PLUGIN_ID(callerID);
+	VERIFY_CONNECTION(connection);
+	ENSURE_CONNECTION_SYNCHRONIZED(connection);
+
+	auto *mw = Global::get().mw;
+	if (!mw) {
+		EXIT_WITH(MUMBLE_EC_INTERNAL_ERROR);
+	} else {
+		const auto *pTargets = mw->getPluginTargets(allocID);
+		if (!pTargets) {
+			EXIT_WITH(MUMBLE_EC_PLUGIN_WHISPER_SHOUT_NOT_FOUND);
+		} else {
+			for (auto it = pTargets->begin(); it != pTargets->end(); it++) {
+				mw->removeTarget(&*it);
+			}
+			mw->clearPluginTargets(allocID);
+			mw->updateTarget();
+			if (Global::get().iPushToTalk > 0) {
+				Global::get().iPushToTalk--;
+			}
+			EXIT_WITH(MUMBLE_STATUS_OK);
+		}
+	}
 }
 
 void MumbleAPI::findUserByName_v_1_0_x(mumble_plugin_id_t callerID, mumble_connection_t connection,
@@ -1926,6 +2110,31 @@ C_WRAPPER(playSample_v_1_2_x)
 #undef TYPED_ARGS
 #undef ARG_NAMES
 
+#define TYPED_ARGS mumble_plugin_id_t callerID, bool *isUsingPTT
+#define ARG_NAMES callerID, isUsingPTT
+C_WRAPPER(isLocalUserUsingPTT_v_1_3_x)
+#undef TYPED_ARGS
+#undef ARG_NAMES
+
+#define TYPED_ARGS mumble_plugin_id_t callerID, mumble_talking_state_t *talkingState
+#define ARG_NAMES callerID, talkingState
+C_WRAPPER(getLocalUserTalkingState_v_1_3_x)
+#undef TYPED_ARGS
+#undef ARG_NAMES
+
+#define TYPED_ARGS                                                                                                     \
+	mumble_plugin_id_t callerID, mumble_connection_t connection, const mumble_userid_t *users, const size_t userCount, \
+		const mumble_channelid_t *channels, const size_t channelCount, uint32_t *allocID
+#define ARG_NAMES callerID, connection, users, userCount, channels, channelCount, allocID
+C_WRAPPER(requestStartLocalUserWhisperShout_v_1_3_x)
+#undef TYPED_ARGS
+#undef ARG_NAMES
+
+#define TYPED_ARGS mumble_plugin_id_t callerID, mumble_connection_t connection, const uint32_t allocID
+#define ARG_NAMES callerID, connection, allocID
+C_WRAPPER(requestStopLocalUserWhisperShout_v_1_3_x)
+#undef TYPED_ARGS
+#undef ARG_NAMES
 
 #undef C_WRAPPER
 
@@ -2001,6 +2210,51 @@ MumbleAPI_v_1_2_x getMumbleAPI_v_1_2_x() {
 			 requestLocalUserMute_v_1_0_x,
 			 requestLocalUserDeaf_v_1_0_x,
 			 requestSetLocalUserComment_v_1_0_x,
+			 findUserByName_v_1_0_x,
+			 findChannelByName_v_1_0_x,
+			 getMumbleSetting_bool_v_1_0_x,
+			 getMumbleSetting_int_v_1_0_x,
+			 getMumbleSetting_double_v_1_0_x,
+			 getMumbleSetting_string_v_1_0_x,
+			 setMumbleSetting_bool_v_1_0_x,
+			 setMumbleSetting_int_v_1_0_x,
+			 setMumbleSetting_double_v_1_0_x,
+			 setMumbleSetting_string_v_1_0_x,
+			 sendData_v_1_0_x,
+			 log_v_1_0_x,
+			 playSample_v_1_2_x };
+}
+
+MumbleAPI_v_1_3_x getMumbleAPI_v_1_3_x() {
+	return { freeMemory_v_1_0_x,
+			 getActiveServerConnection_v_1_0_x,
+			 isConnectionSynchronized_v_1_0_x,
+			 getLocalUserID_v_1_0_x,
+			 getUserName_v_1_0_x,
+			 getChannelName_v_1_0_x,
+			 getAllUsers_v_1_0_x,
+			 getAllChannels_v_1_0_x,
+			 getChannelOfUser_v_1_0_x,
+			 getUsersInChannel_v_1_0_x,
+			 getLocalUserTransmissionMode_v_1_0_x,
+			 isUserLocallyMuted_v_1_0_x,
+			 isLocalUserMuted_v_1_0_x,
+			 isLocalUserDeafened_v_1_0_x,
+			 getUserHash_v_1_0_x,
+			 getServerHash_v_1_0_x,
+			 getUserComment_v_1_0_x,
+			 getChannelDescription_v_1_0_x,
+			 isLocalUserUsingPTT_v_1_3_x,
+			 getLocalUserTalkingState_v_1_3_x,
+			 requestLocalUserTransmissionMode_v_1_0_x,
+			 requestUserMove_v_1_0_x,
+			 requestMicrophoneActivationOverwrite_v_1_0_x,
+			 requestLocalMute_v_1_0_x,
+			 requestLocalUserMute_v_1_0_x,
+			 requestLocalUserDeaf_v_1_0_x,
+			 requestSetLocalUserComment_v_1_0_x,
+			 requestStartLocalUserWhisperShout_v_1_3_x,
+			 requestStopLocalUserWhisperShout_v_1_3_x,
 			 findUserByName_v_1_0_x,
 			 findChannelByName_v_1_0_x,
 			 getMumbleSetting_bool_v_1_0_x,

--- a/src/mumble/MainWindow.cpp
+++ b/src/mumble/MainWindow.cpp
@@ -126,7 +126,9 @@ MainWindow::MainWindow(QWidget *p)
 	else
 		SvgIcon::addSvgPixmapsToIcon(qiIcon, QLatin1String("skin:mumble.svg"));
 #else
-	{ SvgIcon::addSvgPixmapsToIcon(qiIcon, QLatin1String("skin:mumble.svg")); }
+	{
+		SvgIcon::addSvgPixmapsToIcon(qiIcon, QLatin1String("skin:mumble.svg"));
+	}
 
 	// Set application icon except on MacOSX, where the window-icon
 	// shown in the title-bar usually serves as a draggable version of the
@@ -1228,6 +1230,36 @@ void MainWindow::on_qaMoveBack_triggered() {
 	handler->joinChannel(Global::get().uiSession, prevChannel->iId);
 
 	qaMoveBack->setEnabled(!m_previousChannels.empty());
+}
+
+uint32_t MainWindow::allocatePluginTarget() {
+	while (this->qlPluginTargets.contains(this->iPluginTargetsCounter)) {
+		++this->iPluginTargetsCounter;
+	}
+	this->qlPluginTargets.insert(iPluginTargetsCounter, QList< ShortcutTarget >());
+	return iPluginTargetsCounter++;
+}
+
+bool MainWindow::addPluginTarget(const uint32_t allocID, const ShortcutTarget &st) {
+	if (!this->qlPluginTargets.contains(allocID)) {
+		return false;
+	}
+	this->qlPluginTargets[allocID] << st;
+	return true;
+}
+
+void MainWindow::clearPluginTargets(const uint32_t allocID) {
+	if (this->qlPluginTargets.contains(allocID)) {
+		this->qlPluginTargets.remove(allocID);
+	}
+}
+
+const QList< ShortcutTarget > *MainWindow::getPluginTargets(const uint32_t allocID) const {
+	auto it = this->qlPluginTargets.constFind(allocID);
+	if (it != this->qlPluginTargets.constEnd()) {
+		return &(it.value());
+	}
+	return nullptr;
 }
 
 static void recreateServerHandler() {
@@ -3207,14 +3239,14 @@ void MainWindow::on_gsWhisper_triggered(bool down, QVariant scdata) {
  * the number of push-to-talk events for a given ShortcutTarget.  If this number
  * reaches 0, the ShortcutTarget is removed from qmCurrentTargets.
  */
-void MainWindow::addTarget(ShortcutTarget *st) {
+void MainWindow::addTarget(const ShortcutTarget *st) {
 	if (qmCurrentTargets.contains(*st))
 		qmCurrentTargets[*st] += 1;
 	else
 		qmCurrentTargets[*st] = 1;
 }
 
-void MainWindow::removeTarget(ShortcutTarget *st) {
+void MainWindow::removeTarget(const ShortcutTarget *st) {
 	if (!qmCurrentTargets.contains(*st))
 		return;
 

--- a/src/mumble/MainWindow.cpp
+++ b/src/mumble/MainWindow.cpp
@@ -3083,13 +3083,24 @@ void MainWindow::updateTarget() {
 					}
 				}
 			} else if (st.bUsers) {
-				for (const QString &hash : st.qlUsers) {
-					ClientUser *p = pmModel->getUser(hash);
-					if (p)
-						nt.qlSessions.append(p->uiSession);
+				// If users' ids have provided, we needn't find user again
+				// by their hash.
+				if (st.qlSessions.isEmpty()) {
+					for (const QString &hash : st.qlUsers) {
+						ClientUser *p = pmModel->getUser(hash);
+						if (p)
+							nt.qlSessions.append(p->uiSession);
+					}
+				} else {
+					for (auto& session : st.qlSessions) {
+						if (ClientUser::get(session)) {
+							nt.qlSessions.append(session);
+						}
+					}
 				}
-				if (!nt.qlSessions.isEmpty())
+				if (!nt.qlSessions.isEmpty()) {
 					ql << nt;
+				}
 			} else {
 				Channel *c = mapChannel(st.iChannel);
 				if (c) {

--- a/src/mumble/MainWindow.cpp
+++ b/src/mumble/MainWindow.cpp
@@ -105,7 +105,8 @@ OpenURLEvent::OpenURLEvent(QUrl u) : QEvent(static_cast< QEvent::Type >(OU_QEVEN
 }
 
 MainWindow::MainWindow(QWidget *p)
-	: QMainWindow(p), m_localVolumeLabel(make_qt_unique< MenuLabel >(tr("Local Volume Adjustment:"), this)),
+	: QMainWindow(p), iPluginTargetsCounter(0), iTargetCounter(0),
+	  m_localVolumeLabel(make_qt_unique< MenuLabel >(tr("Local Volume Adjustment:"), this)),
 	  m_userLocalVolumeSlider(make_qt_unique< UserLocalVolumeSlider >(this)),
 	  m_listenerVolumeSlider(make_qt_unique< ListenerVolumeSlider >(this)) {
 	SvgIcon::addSvgPixmapsToIcon(qiIconMuteSelf, QLatin1String("skin:muted_self.svg"));
@@ -126,9 +127,7 @@ MainWindow::MainWindow(QWidget *p)
 	else
 		SvgIcon::addSvgPixmapsToIcon(qiIcon, QLatin1String("skin:mumble.svg"));
 #else
-	{
-		SvgIcon::addSvgPixmapsToIcon(qiIcon, QLatin1String("skin:mumble.svg"));
-	}
+	{ SvgIcon::addSvgPixmapsToIcon(qiIcon, QLatin1String("skin:mumble.svg")); }
 
 	// Set application icon except on MacOSX, where the window-icon
 	// shown in the title-bar usually serves as a draggable version of the
@@ -3092,7 +3091,7 @@ void MainWindow::updateTarget() {
 							nt.qlSessions.append(p->uiSession);
 					}
 				} else {
-					for (auto& session : st.qlSessions) {
+					for (auto &session : st.qlSessions) {
 						if (ClientUser::get(session)) {
 							nt.qlSessions.append(session);
 						}

--- a/src/mumble/MainWindow.h
+++ b/src/mumble/MainWindow.h
@@ -423,10 +423,27 @@ public slots:
 					   unsigned int newChannelID);
 	void on_qaMoveBack_triggered();
 
+	/// @brief  Allocates a new plugin target ID (`allocID in short`) for whisper/shout targets.
+	/// @return The ID of an allocated bunch of targets. It is useful for visiting and removing
+	///         the list it represents.
 	uint32_t allocatePluginTarget();
+
+	/// @brief         Adds a shortcut target to the specified plugin target.
+	/// @param allocID The ID of the plugin target. It should be returned from `allocatePluginTarget()`.
+	/// @param st      The ShortcutTarget to add.
+	/// @return        True if the `allocID` is valid target was added successfully, false otherwise.
 	bool addPluginTarget(const uint32_t allocID, const ShortcutTarget &st);
+
+	/// @brief         Clears all shortcut targets for the specified plugin target.
+	/// @param allocID The ID of the plugin target to clear. It should be returned from
+	///                `allocatePluginTarget()`. If the `allocID` is invalid, this function does nothing.
 	void clearPluginTargets(const uint32_t allocID);
+
+	/// @brief         Returns the list of shortcut targets.
+	/// @param allocID The ID of the plugin target.
+	/// @return        A pointer to the QList of ShortcutTargets, or nullptr if not found.
 	const QList< ShortcutTarget > *getPluginTargets(const uint32_t allocID) const;
+
 signals:
 	/// Signal emitted when the server and the client have finished
 	/// synchronizing (after a new connection).

--- a/src/mumble/MainWindow.h
+++ b/src/mumble/MainWindow.h
@@ -171,6 +171,13 @@ protected:
 	QList< QAction * > qlChannelActions;
 	QList< QAction * > qlUserActions;
 
+	uint32_t iPluginTargetsCounter;
+	/// A list to store multiple shout/whisper targets, implemented for
+	/// plugin to invoke shout/whisper feature (similar to PTT).
+	/// key: the plugin ID
+	/// val: a list of ShortcutTargets to whisper.
+	QHash< uint32_t, QList< ShortcutTarget > > qlPluginTargets;
+
 	QHash< ShortcutTarget, int > qmCurrentTargets;
 	/// A map that contains information about the currently active
 	/// shout/whisper targets. The mapping is between a List of
@@ -321,8 +328,8 @@ public slots:
 	void on_gsMuteSelf_down(QVariant);
 	void on_gsDeafSelf_down(QVariant);
 	void on_gsWhisper_triggered(bool, QVariant);
-	void addTarget(ShortcutTarget *);
-	void removeTarget(ShortcutTarget *);
+	void addTarget(const ShortcutTarget *);
+	void removeTarget(const ShortcutTarget *);
 	void on_gsListenChannel_triggered(bool, QVariant);
 	void on_gsCycleTransmitMode_triggered(bool, QVariant);
 	void on_gsToggleMainWindowVisibility_triggered(bool, QVariant);
@@ -415,6 +422,11 @@ public slots:
 	void on_user_moved(unsigned int sessionID, const std::optional< unsigned int > &prevChannelID,
 					   unsigned int newChannelID);
 	void on_qaMoveBack_triggered();
+
+	uint32_t allocatePluginTarget();
+	bool addPluginTarget(const uint32_t allocID, const ShortcutTarget &st);
+	void clearPluginTargets(const uint32_t allocID);
+	const QList< ShortcutTarget > *getPluginTargets(const uint32_t allocID) const;
 signals:
 	/// Signal emitted when the server and the client have finished
 	/// synchronizing (after a new connection).

--- a/src/mumble/MumbleAPI_structs.h
+++ b/src/mumble/MumbleAPI_structs.h
@@ -18,11 +18,21 @@
 
 // Re-include the API definition
 #undef EXTERNAL_MUMBLE_PLUGIN_MUMBLE_API_
-// But this time, overwrite the version
+// But this time, overwrite the version to 1.0
 #undef MUMBLE_PLUGIN_API_MAJOR_MACRO
 #define MUMBLE_PLUGIN_API_MAJOR_MACRO 1
 #undef MUMBLE_PLUGIN_API_MINOR_MACRO
 #define MUMBLE_PLUGIN_API_MINOR_MACRO 0
+
+#include "MumblePlugin.h"
+
+// Re-include the API definition
+#undef EXTERNAL_MUMBLE_PLUGIN_MUMBLE_API_
+// But this time, overwrite the version to 1.2
+#undef MUMBLE_PLUGIN_API_MAJOR_MACRO
+#define MUMBLE_PLUGIN_API_MAJOR_MACRO 1
+#undef MUMBLE_PLUGIN_API_MINOR_MACRO
+#define MUMBLE_PLUGIN_API_MINOR_MACRO 2
 
 #include "MumblePlugin.h"
 

--- a/src/mumble/Plugin.cpp
+++ b/src/mumble/Plugin.cpp
@@ -329,6 +329,9 @@ mumble_error_t Plugin::init() {
 	} else if (apiVersion >= mumble_version_t({ 1, 2, 0 }) && apiVersion < mumble_version_t({ 1, 3, 0 })) {
 		MumbleAPI_v_1_2_x api = API::getMumbleAPI_v_1_2_x();
 		registerAPIFunctions(&api);
+	} else if (apiVersion >= mumble_version_t({ 1, 3, 0 }) && apiVersion < mumble_version_t({ 1, 4, 0 })) {
+		MumbleAPI_v_1_3_x api = API::getMumbleAPI_v_1_3_x();
+		registerAPIFunctions(&api);
 	} else {
 		// The API version could not be obtained -> this is an invalid plugin that shouldn't have been loaded in the
 		// first place


### PR DESCRIPTION
# 2026.08.15 Add Whisper/Shout Plugin API

> [Note] I renamed the branch `master` to `Add_Whisper_Shout_API`, making [#7296](https://github.com/mumble-voip/mumble/pull/7296) forced to close.

## Summary

This PR is around [Issue#7218](https://github.com/mumble-voip/mumble/issues/7218). All of them are around Whisper/Shout Plugin API:
- Adding getters for local user's PTT and Talking State;
- Adding switch for PTT(handling both talking and whispering/shouting logic)

To test the new api, a plugin named `TestShout` is created, activated by opening Mumble **with `Debug` or `RelWithDebInfo` mode.**
Only tested on Windows.

## ~~Notes~~
1. ~~I'm still figuring out problems from **Changes 3**.~~

## Changes

1. Access to Testing-centered Plugin in `RelWithDebInfo`;
    - For convenience when debugging Mumble with `RelWithDebInfo`;
    - It provides access to those who **fails to build the project with `Debug` mode**.
2. Const Parameters for `addTarget()` and `removeTarget()` in `MainWindow`.
    - Previously a `const_cast` is needed when providing `(volatile) ShortcutTarget` as a parameter;
    - `ShortcutTarget*` is certain not to be modified, so it's safe to use `const`;`
3. Checker for User's Hash in `MainWindow::updateTarget()` around `ShourtcutTarget`.
    - Previously, the checker would ignore the provided `uiSession`, pushing user id fetched from user's hash into it again.
    - ~~It's weird that **this logic obstacles the whisper/shout ability to affect multiple targets**, only the last target inside the ShortcutTarget would get affected.~~
    - Multiple users share the same hash code, **when they use the same certificate**, which seldom happens and it does when running Mumble with `mumble.exe -m` without changing the certificate.
    - reimplemented by the following code, and multiple whisper/shout targets work.
    > `MainWindow::updateTarget() L3083-L3102`
    >```cpp
    > ...
    > } else if (st.bUsers) {
    >     // If users' ids have provided, we needn't find user again
    >     // by their hash.
    >     if (st.qlSessions.isEmpty()) {
    >         for (const QString &hash : st.qlUsers) {
    >             ClientUser *p = pmModel->getUser(hash);
    >             if (p)
    >                 nt.qlSessions.append(p->uiSession);
    >         }
    >     } else {
    >         for (auto& session : st.qlSessions) {
    >             if (ClientUser::get(session)) {
    >                 nt.qlSessions.append(session);
    >             }
    >         }
    >     }
    >     if (!nt.qlSessions.isEmpty()) {
    >         ql << nt;
    >     }
    > } else {
    > ...
    > ```

## Adds

1. Whisper/Shout Switch;
    - `requestStartLocalUserWhisperShout()`, paired with `requestStopLocalUserWhisperShout()` to start/stop a determined whisper/shout operation;
    - To set whisper/shout targets, provide their id(userID by `uiSession`, channelID by `iChannel`);
    - The start function would return an `allocID` corresponding to the provided targets, which is essential or the stop function；
    - The start function would check whether the user or channel is valid, otherwise warning the user；
    - If no targets are provided, the pair would function as a switch of talking;
    - The pair imitates the behavior of `on_gsWhisper_triggered()` and `whisperReleased() ` in `MainWindow`.
2. New Container for Bunched Whisper/Shout Targets;
    - `QHash< short, QList< ShortcutTarget > > MainWindow::qlPluginTargets` is supposed to support Whisper/Shout Switch;
    - Several getter and setter functions are added to access the container.
    - See their comments for more details.
3. Getter for LocalUser's PTT and Talking State;
4. Interactive Plugin to test the new API.
- Open Mumble with `Debug`(or `RelWithDebInfo`) mode to wake up the plugin console;
- Enter one Mumble server and use the plugin according to the menu output in the console.

## Testing

- Verified on Windows 10 (22h2) with MSVC 19.51, CMake 4.2.0.
- Mumble and Mumble-server(Murmur) are locally built with `RelWithDebInfo` mode.
- Running multiple `RelWithDebMode`-built `Mumble.exe` with parameter `-m`;
- User `WuCJ638` works as the plugin tester, and `Test-` as whisper/shout target;
- Enable plugin "TestShout", with interactive console appearing;  
    <img width="2303" height="1537" alt="st1" src="https://github.com/user-attachments/assets/09f34ed4-69ee-4e21-9fd3-b85ec0d93133" />
- WuCJ638 starts a whisper/shout, targeting user 1, 3, with `allocID` 0;  
    <img width="1124" height="1538" alt="st2" src="https://github.com/user-attachments/assets/9944d1d3-5b9a-4500-bf6a-f39dd3b45d6c" />
- WuCJ638 starts a whisper/shout, targeting user 2, with `allocID` 1;  
    <img width="1120" height="1536" alt="st3" src="https://github.com/user-attachments/assets/124327a7-b9f6-4ad0-8819-6c3c40636b8b" />
- WuCJ638 stops the whisper/shout, with `allocID` 1;  
    <img width="1116" height="1538" alt="st4" src="https://github.com/user-attachments/assets/b745efc4-555c-42b6-b818-f9c53cc1ab1c" />
- WuCJ638 stops the whisper/shout, with `allocID` 3, with error output;  
    <img width="1122" height="1535" alt="st5" src="https://github.com/user-attachments/assets/d33f8ec1-47a0-4a9c-bace-e5f892337d9b" />
- WuCJ638 stops the whisper/shout, with `allocID` 0;  
    <img width="1122" height="1535" alt="st6" src="https://github.com/user-attachments/assets/6461ecb0-6924-47e8-a865-9333ad567360" />
- WuCJ638 starts a whisper/shout, targeting no user, with `allocID` 2;  
    <img width="1119" height="1534" alt="st7" src="https://github.com/user-attachments/assets/bf5db3e5-b315-4645-9ba3-4dc6c63b070a" />
- WuCJ638 stops the whisper/shout, with `allocID` 2;  
    <img width="969" height="721" alt="st8" src="https://github.com/user-attachments/assets/015f297b-9312-43cd-9ed1-5e4a12700601" />

~~(after all the screenshots, I finally found that I mistook "whisper" with "whispering". It's just a grammar error.)~~

## Other Bugs Found During the Implementation and Testing

The following bugs are found during the implementation and testing. Since they aren't related to my current PR, they haven't been fixed yet.
I'm pleased to fix them later, but at present they aren't my priority.

1. ~~Invalid Multiple Whisper/Shout Users in Hotkey;~~
    - ~~We're unable to set multiple users on setting hotkey for whisper/shout.~~
    - ~~Only one user would be kept.~~
    - Occurs when multiple users share the same certificate, thus sharing the same hash code.
    <img width="1496" height="1358" alt="bug1" src="https://github.com/user-attachments/assets/afb64bd5-a99d-4a52-a76c-75f291998aa3" />
2. ~~Implicit Crash on Restarting.~~
