### PR TITLE
FIX(client): Skip UDP ping when TCP mode is forced

### DIFF
--- a/src/mumble/Messages.cpp
+++ b/src/mumble/Messages.cpp
@@ -128,7 +128,8 @@ void MainWindow::msgServerSync(const MumbleProto::ServerSync &msg) {
 	}
 	Global::get().uiSession = msg.session();
 
-	Global::get().sh->sendPing(); // Send initial ping to establish UDP connection
+	// Send an initial ping and establish the UDP connection unless TCP mode is forced
+	Global::get().sh->sendPing();
 
 	Global::get().pPermissions = ChanACL::Permissions(static_cast< unsigned int >(msg.permissions()));
 	Global::get().l->clearIgnore();

--- a/src/mumble/ServerHandler.cpp
+++ b/src/mumble/ServerHandler.cpp
@@ -619,7 +619,11 @@ void ServerHandler::sendPingInternal() {
 
 	quint64 t = static_cast< quint64 >(tTimestamp.elapsed().count());
 
-	if (qusUdp) {
+	// Skip the UDP ping while TCP mode is forced (or UDP has already been given up on for this
+	// connection). Sending it anyway would let the server discover a working UDP path for this
+	// client and start routing voice packets over UDP again, defeating "Force TCP Mode".
+	const bool forcedTcp = NetworkConfig::TcpModeEnabled() || !bUdp;
+	if (qusUdp && !forcedTcp) {
 		Mumble::Protocol::PingData pingData;
 		pingData.timestamp                    = t;
 		pingData.requestAdditionalInformation = false;


### PR DESCRIPTION
Fixes #4881.

Force TCP Mode doesn't actually stop `ServerHandler::sendPingInternal()` from sending a ping straight through the UDP socket. That ping call passes `force = true` to `sendMessage()`, which bypasses the TCP-mode check entirely. The server then sees a UDP packet from the client, decides the UDP path works, and starts sending voice traffic back over UDP. Force TCP Mode ends up only protecting the outgoing direction.

The fix here is the same idea as #5278, which a maintainer approved back in 2021 but which never got merged before that PR went stale and was closed. This only builds and sends the UDP ping when `qusUdp` exists and TCP mode isn't in effect (either forced by the user, or already given up on for this connection via `bUdp`). I adapted it to the current ping code, which has since moved to `m_udpPingEncoder` / `Mumble::Protocol::PingData`.

Background write-up: sinhaparth5/mumble#1

I don't have a live client/server setup to test this against right now, so if anyone can confirm the behavior with Force TCP Mode toggled on an actual connection, that would help before this gets merged.
