### PR TITLE
2026.08.29 Leftover PulseAudio Output (And Input)

### DIFF
--- a/src/mumble/PulseAudio.cpp
+++ b/src/mumble/PulseAudio.cpp
@@ -275,13 +275,16 @@ void PulseAudioSystem::eventCallback(pa_mainloop_api *api, pa_defer_event *) {
 		}
 	}
 
-	if (raw_ai) {
+	// see `if(pasOutput || raw_ao) { ... }`
+	if (pasInput || raw_ai) {
 		QString idev        = inputDevice();
 		pa_stream_state ist = pasInput ? m_pulseAudio.stream_get_state(pasInput) : PA_STREAM_TERMINATED;
 		bool do_stop        = false;
 		bool do_start       = false;
 
-		if (!pai && (ist == PA_STREAM_READY)) {
+		if (!raw_ai) {
+			do_stop = true;
+		} else if (!pai && (ist == PA_STREAM_READY)) {
 			do_stop = true;
 		} else if (pai) {
 			switch (ist) {

--- a/src/mumble/PulseAudio.cpp
+++ b/src/mumble/PulseAudio.cpp
@@ -200,13 +200,20 @@ void PulseAudioSystem::eventCallback(pa_mainloop_api *api, pa_defer_event *) {
 	PulseAudioInput *pai  = dynamic_cast< PulseAudioInput * >(raw_ai);
 	PulseAudioOutput *pao = dynamic_cast< PulseAudioOutput * >(raw_ao);
 
-	if (raw_ao) {
+	// when shutting down AudioOutput: `pasOutput != nullptr` and `raw_ao == nullptr`
+	// when starting      AudioOutput: `pasOutput == nullptr` and `raw_ao != nullptr`
+	if (pasOutput || raw_ao) {
 		QString odev        = outputDevice();
 		pa_stream_state ost = pasOutput ? m_pulseAudio.stream_get_state(pasOutput) : PA_STREAM_TERMINATED;
 		bool do_stop        = false;
 		bool do_start       = false;
 
-		if (!pao && (ost == PA_STREAM_READY)) {
+		// When running `Audio::stop()`, `Global::ao == nullptr`, thus
+  		// `raw_ao == nullptr` and PulseAudio Output is to be shutdown 
+		// because no AudioOutput Device is to be running.
+  		if (!raw_ao) {
+  	    	do_stop = true;  
+		} else if (!pao && (ost == PA_STREAM_READY)) {
 			do_stop = true;
 		} else if (pao) {
 			switch (ost) {


### PR DESCRIPTION
## Summary

This PR is around [Issue#7293](https://github.com/mumble-voip/mumble/issues/7293). All of them are around the leftover of PulseAudio's Devices, which should be handled by `PulseAudioSystem::eventCallback()`:
- the termination of PulseAudio Output after unselecting PulseAudio as Mumble's output system.
- the same implementation for PulseAudio Input.

However, PulseAudio Input could get terminated via the guard logic in `PulseAudioSystem::read_callback()`. The device is certain to get shut down, but this is opposite of the expected behavior. There's an extra commit around it.

To test the new api, we use the following command
```bash
echo "=== PulseAudio Input (RDPSource) ===" && pactl list sources short | grep -A 10 -E "rdp|RDP" && echo -e "\n=== PulseAudio Output (RDPSink) ===" && pactl list sinks short | grep -A 10 -E "rdp|RDP"
```
or watch the log in Mumble's Developer Console.

Only tested on Linux, since PulseAudio is only available in this platform.

## Changes

1. Wider Termination Condition For PulseAudio Output.
    - the normal termination should be like:
        (switching from PulseAudio RDPSink) `Audio::stop()`->(var)`ao->reset()`->`PulseAudioOutput::~PulseAudioOutput()`->`PulseAudioSystem::wakeup_lock()`->`api->defer_enable(pade, true)`->`PulseAudioSystem::eventCallback()` to shut down PulseAudioOutput.
    - However in `PulseAudioSystem::eventCallback()`
		> PulseAudio.cpp(L196+)
		> ```cpp
		>	AudioInputPtr ai      = Global::get().ai;
		>	AudioOutputPtr ao     = Global::get().ao;
		>	AudioInput *raw_ai    = ai.get();
		>	AudioOutput *raw_ao   = ao.get();
		>	PulseAudioInput *pai  = dynamic_cast< PulseAudioInput * >(raw_ai);
		>	PulseAudioOutput *pao = dynamic_cast< PulseAudioOutput * >(raw_ao);
		>	 
		>	if (raw_ao) {
		>		QString odev        = outputDevice();
		> ```

		`Global::ao` is nullptr after running `Global::get().ao.reset()` before entering `ao.reset()` before entering `eventCallback()`.
		> Audio.cpp(L205+)
		>```cpp
		>void Audio::stop() {
		>	AudioInputPtr ai  = Global::get().ai;
		>	AudioOutputPtr ao = Global::get().ao;
		>	Global::get().ao.reset();
		>	Global::get().ai.reset();
		>	……
		>	ai.reset();
		>	ao.reset();
		>}
		>```
	- now the termination is triggered when `pasOutput` is valid(indicating it's running), and `pao` is nullptr, both of which make `do_stop` `true`.

2. Wider Termination Condition For PulseAudio Input.
	- inspired by the **Change 1**, this change is implemented to make the termination more logical.

## Testing

- Verified on Ubuntu(22.04) with G++ 11.4.0, CMake 4.4.3.
- Running one `Debug`-built `mumble`. Joining a server isn't necessary, since Audio Devices are running when selected.
- Input the Command from the column [Summary](#summary), and we can see RDPSink is `SUSPENDED`.
	```bask
	~/workspace/mumble$ echo "=== PulseAudio Input (RDPSource) ===" && pactl list sources short | grep -A 10 -E "rdp|RDP" && echo -e "\n=== PulseAudio Output (RDPSink) ===" && pactl list sinks short | grep -A 10 -E "rdp|RDP"
	=== PulseAudio Input (RDPSource) ===
	1       RDPSink.monitor module-rdp-sink.c       s16le 2ch 44100Hz       SUSPENDED
	2       RDPSource       module-rdp-source.c     s16le 1ch 44100Hz       SUSPENDED

	=== PulseAudio Output (RDPSink) ===
	1       RDPSink module-rdp-sink.c       s16le 2ch 44100Hz       SUSPENDED
	```

### For PulseAudio Output
- Enter Setting >> Audio Output >> Interface >> System (set to `PulseAudio`) >> Apply, and we can see RDPSink is started:
	```log
	<I>2026-08-29 12:22:16.839 Skipped 45 duplicate messages..
	<W>2026-08-29 12:22:16.839 AudioInput: Opus encoder set for high quality speech
	<W>2026-08-29 12:22:16.840 AudioInput: 40000 bits/s, 48000 hz, 480 sample
	<W>2026-08-29 12:22:16.931 AudioInput: Initialized mixer for 1 channel 48000 hz mic and 0 channel 48000 hz echo
	<W>2026-08-29 12:22:16.932 PulseAudio: Starting output: RDPSink
	<W>2026-08-29 12:22:16.936 AudioOutput: Initialized 2 channel 48000 hz mixer
	```
	Running the Command, we can see RDPSink is `RUNNING`.
	```bash
	=== PulseAudio Input (RDPSource) ===
	1       RDPSink.monitor module-rdp-sink.c       s16le 2ch 44100Hz       IDLE
	2       RDPSource       module-rdp-source.c     s16le 1ch 44100Hz       SUSPENDED
	
	=== PulseAudio Output (RDPSink) ===
	1       RDPSink module-rdp-sink.c       s16le 2ch 44100Hz       RUNNING
	```
- Set System to `PipeWire` >> Apply, and we can see PulseAudio Output is stopped:
	```log
	<W>2026-08-29 12:30:54.884 PulseAudio: Stopping output
	<W>2026-08-29 12:30:54.885 AudioInput: Opus encoder set for high quality speech
	<W>2026-08-29 12:30:54.886 AudioInput: 40000 bits/s, 48000 hz, 480 sample
	<W>2026-08-29 12:30:54.892 PulseAudio: Stopping output
	<W>2026-08-29 12:30:54.982 AudioInput: Initialized mixer for 1 channel 48000 hz mic and 0 channel 48000 hz echo
	<W>2026-08-29 12:30:54.984 AudioOutput: Initialized 1 channel 48000 hz mixer
	```
	Running the Command, we can see RDPSink is `SUSPENDED`( or `IDLE`, but after several seconds, it turns into `SUSPENDED`).
	```bash
	wucj638@WUCJ638:~/workspace/mumble$ echo "=== PulseAudio Input (RDPSource) ===" && pactl list sources short | grep -A 10 -E "rdp|RDP" && echo -e "\n=== PulseAudio Output (RDPSink) ===" && pactl list sinks short | grep -A 10 -E "rdp|RDP"
	=== PulseAudio Input (RDPSource) ===
	1       RDPSink.monitor module-rdp-sink.c       s16le 2ch 44100Hz       SUSPENDED
	2       RDPSource       module-rdp-source.c     s16le 1ch 44100Hz       SUSPENDED

	=== PulseAudio Output (RDPSink) ===
	1       RDPSink module-rdp-sink.c       s16le 2ch 44100Hz       SUSPENDED
	```
### For PulseAudio Input

> [Note] Change isn't distinct.

- Enter Setting >> Audio Input >> Interface >> System (set to `PulseAudio`) >> Apply, and we can see RDPSource is started:
	```log
	<W>2026-08-29 14:49:07.844 AudioInput: Opus encoder set for high quality speech
	<W>2026-08-29 14:49:07.844 AudioInput: 40000 bits/s, 48000 hz, 480 sample
	<W>2026-08-29 14:49:07.844 PulseAudio: Starting input RDPSource
	<W>2026-08-29 14:49:07.907 AudioOutput: Initialized 1 channel 48000 hz mixer
	<W>2026-08-29 14:49:08.028 AudioInput: Initialized mixer for 1 channel 48000 hz mic and 0 channel 48000 hz echo
	<I>2026-08-29 14:49:08.039 AudioInput: Using Speex as noise canceller
	warning: The VAD has been replaced by a hack pending a complete rewrite
	```
	Running the Command, we can see RDPSink is `RUNNING`.
	```bash
	=== PulseAudio Input (RDPSource) ===
	1       RDPSink.monitor module-rdp-sink.c       s16le 2ch 44100Hz       SUSPENDED
	2       RDPSource       module-rdp-source.c     s16le 1ch 44100Hz       RUNNING

	=== PulseAudio Output (RDPSink) ===
	1       RDPSink module-rdp-sink.c       s16le 2ch 44100Hz       SUSPENDED
	```
- Set System to `PipeWire` >> Apply, and we can see PulseAudio Input is stopped:
	```log
	<W>2026-08-29 14:51:12.945 PulseAudio: Stopping input
	<I>2026-08-29 14:51:15.537 Skipped 2 duplicate messages..
	<W>2026-08-29 14:51:15.537 AudioInput: Opus encoder set for high quality speech
	<W>2026-08-29 14:51:15.537 AudioInput: 40000 bits/s, 48000 hz, 480 sample
	<W>2026-08-29 14:51:15.592 AudioInput: Initialized mixer for 1 channel 48000 hz mic and 0 channel 48000 hz echo
	<W>2026-08-29 14:51:15.594 AudioOutput: Initialized 1 channel 48000 hz mixer
	```
	Running the Command, we can see RDPSource is `SUSPENDED`( or `IDLE`, but `SUSPENDED` after several seconds).
	```bash
	wucj638@WUCJ638:~/workspace/mumble$ echo "=== PulseAudio Input (RDPSource) ===" && pactl list sources short | grep -A 10 -E "rdp|RDP" && echo -e "\n=== PulseAudio Output (RDPSink) ===" && pactl list sinks short | grep -A 10 -E "rdp|RDP"
	=== PulseAudio Input (RDPSource) ===
	1       RDPSink.monitor module-rdp-sink.c       s16le 2ch 44100Hz       SUSPENDED
	2       RDPSource       module-rdp-source.c     s16le 1ch 44100Hz       SUSPENDED

	=== PulseAudio Output (RDPSink) ===
	1       RDPSink module-rdp-sink.c       s16le 2ch 44100Hz       SUSPENDED
	```

## Checks

- [x] My commits follow the [commit guidelines](https://github.com/mumble-voip/mumble/blob/master/COMMIT_GUIDELINES.md)

