### PR TITLE
FIX(ipc): Fall back to a writable runtime directory

### DIFF
--- a/ipcutils/IPCUtils.cpp
+++ b/ipcutils/IPCUtils.cpp
@@ -6,6 +6,7 @@
 #include "IPCUtils.h"
 
 #ifndef _WIN32
+#	include <cstdio>
 #	include <cstdlib>
 #	include <string>
 #	include <system_error>
@@ -59,6 +60,14 @@ namespace {
 		return S_ISDIR(st.st_mode) && st.st_uid == getuid() && (st.st_mode & 07777) == S_IRWXU;
 	}
 
+	// Prints the warning message the XDG Base Directory Specification mandates for falling back
+	// away from $XDG_RUNTIME_DIR. ipcutils doesn't depend on Qt (it's a static library linked into
+	// overlay_gl, which gets injected into other processes), so qWarning() isn't available here.
+	void warnRuntimeDirFallback(const std::filesystem::path &dir) {
+		std::fprintf(stderr, "Mumble: $XDG_RUNTIME_DIR is not available, falling back to \"%s\" for IPC endpoints\n",
+					 dir.c_str());
+	}
+
 } // namespace
 #endif
 
@@ -84,6 +93,7 @@ std::filesystem::path getRuntimeDirectory() {
 		if (isUsableDirectory(runUserDir)) {
 			std::filesystem::path candidate = runUserDir / "info.mumble.Mumble";
 			ensureDirectoryCreated(candidate);
+			warnRuntimeDirFallback(candidate);
 			return candidate;
 		}
 
@@ -97,6 +107,7 @@ std::filesystem::path getRuntimeDirectory() {
 			std::filesystem::path candidate = tmpDir / ("info.mumble.Mumble-" + std::to_string(getuid()));
 			ensureDirectoryCreated(candidate);
 			if (isPrivateOwnedDirectory(candidate)) {
+				warnRuntimeDirFallback(candidate);
 				return candidate;
 			}
 		}
@@ -105,6 +116,7 @@ std::filesystem::path getRuntimeDirectory() {
 		// not be created, since there is nothing else left to try.
 		std::filesystem::path candidate = std::filesystem::path(".") / "info.mumble.Mumble";
 		ensureDirectoryCreated(candidate);
+		warnRuntimeDirFallback(candidate);
 		return candidate;
 	}();
 

--- a/ipcutils/IPCUtils.cpp
+++ b/ipcutils/IPCUtils.cpp
@@ -7,28 +7,108 @@
 
 #ifndef _WIN32
 #	include <cstdlib>
+#	include <string>
+#	include <system_error>
 
+#	include <sys/stat.h>
 #	include <unistd.h>
 #endif
 
 namespace Mumble {
 
+#ifndef _WIN32
+namespace {
+
+	// Creates the given directory if it doesn't exist yet, using only non-throwing
+	// std::filesystem calls, so that this never throws even on a read-only or sandboxed
+	// filesystem. If the directory was created by this call, its permissions are restricted to
+	// the owner (0700), since it is then a directory Mumble controls; an already-existing
+	// directory's permissions are left untouched, since it may belong to the user or another
+	// application.
+	void ensureDirectoryCreated(const std::filesystem::path &dir) {
+		std::error_code ec;
+		bool created = std::filesystem::create_directories(dir, ec);
+		if (created) {
+			std::error_code permEc;
+			std::filesystem::permissions(dir, std::filesystem::perms::owner_all, std::filesystem::perm_options::replace,
+										 permEc);
+		}
+	}
+
+	// Returns whether the given path is an existing directory the current user can both write to
+	// and enter.
+	bool isUsableDirectory(const std::filesystem::path &dir) {
+		std::error_code ec;
+		if (!std::filesystem::is_directory(dir, ec) || ec) {
+			return false;
+		}
+
+		return ::access(dir.c_str(), W_OK | X_OK) == 0;
+	}
+
+	// Returns whether the given path is a real directory (not a symlink) owned by the current
+	// user with permissions restricted to exactly 0700. lstat() is used instead of
+	// std::filesystem::is_directory() so that a symlink someone else planted at this path is
+	// rejected instead of followed.
+	bool isPrivateOwnedDirectory(const std::filesystem::path &dir) {
+		struct stat st;
+		if (::lstat(dir.c_str(), &st) != 0) {
+			return false;
+		}
+
+		return S_ISDIR(st.st_mode) && st.st_uid == getuid() && (st.st_mode & 07777) == S_IRWXU;
+	}
+
+} // namespace
+#endif
+
 std::filesystem::path getRuntimeDirectory() {
 #ifdef _WIN32
 	return {};
 #else
-	std::filesystem::path runtimeDir;
+	static const std::filesystem::path dir = [] {
+		const char *xdgRuntimeDir = std::getenv("XDG_RUNTIME_DIR");
+		if (xdgRuntimeDir != nullptr && xdgRuntimeDir[0] != '\0') {
+			std::filesystem::path base(xdgRuntimeDir);
+			if (isUsableDirectory(base)) {
+				std::filesystem::path candidate = base / "info.mumble.Mumble";
+				ensureDirectoryCreated(candidate);
+				return candidate;
+			}
+		}
 
-	const char *xdgRuntimeDir = std::getenv("XDG_RUNTIME_DIR");
-	if (xdgRuntimeDir != nullptr && xdgRuntimeDir[0] != '\0') {
-		runtimeDir = std::filesystem::path(xdgRuntimeDir) / "info.mumble.Mumble";
-	} else {
-		runtimeDir = std::filesystem::path("/run/user") / std::to_string(getuid()) / "info.mumble.Mumble";
-	}
+		// /run/user/<uid> is normally created and maintained by the system (e.g. by
+		// systemd-logind), so this process must not attempt to create it or its /run parent
+		// itself. Only use it if it is already there and usable.
+		std::filesystem::path runUserDir = std::filesystem::path("/run/user") / std::to_string(getuid());
+		if (isUsableDirectory(runUserDir)) {
+			std::filesystem::path candidate = runUserDir / "info.mumble.Mumble";
+			ensureDirectoryCreated(candidate);
+			return candidate;
+		}
 
-	std::filesystem::create_directories(runtimeDir);
+		// Fall back to the system's shared temp directory. Since it is typically writable by
+		// every local user, the leaf name is qualified with the current uid and only accepted if
+		// it turns out to be a private directory this process itself owns; if another user got
+		// there first, or the path is a symlink, the candidate is discarded instead of being used.
+		std::error_code ec;
+		std::filesystem::path tmpDir = std::filesystem::temp_directory_path(ec);
+		if (!ec && !tmpDir.empty()) {
+			std::filesystem::path candidate = tmpDir / ("info.mumble.Mumble-" + std::to_string(getuid()));
+			ensureDirectoryCreated(candidate);
+			if (isPrivateOwnedDirectory(candidate)) {
+				return candidate;
+			}
+		}
 
-	return runtimeDir;
+		// Last resort: the current directory. This is returned unconditionally, even if it could
+		// not be created, since there is nothing else left to try.
+		std::filesystem::path candidate = std::filesystem::path(".") / "info.mumble.Mumble";
+		ensureDirectoryCreated(candidate);
+		return candidate;
+	}();
+
+	return dir;
 #endif
 }
 

--- a/ipcutils/IPCUtils.h
+++ b/ipcutils/IPCUtils.h
@@ -28,7 +28,7 @@ namespace Mumble {
 /// Since on Windows named pipes aren't part of the fs, it returns an empty path.
 /// Its result is computed once and cached, so repeated calls always return the same path and the
 /// fallback warning is only ever printed once per process.
-/// @throws std::filesystem::filesystem_error if the directory doesn't exist and can't be created.
+/// This function never throws; the directory's path is returned even if it couldn't be created.
 std::filesystem::path getRuntimeDirectory();
 
 /// The path (on *nix) or the name (on win) on which Mumble's overlay listens for connections.

--- a/ipcutils/IPCUtils.h
+++ b/ipcutils/IPCUtils.h
@@ -13,7 +13,18 @@
 namespace Mumble {
 
 /// The directory Mumble places its IPC endpoints in. It is created if it doesn't exist yet.
+/// The following candidates are tried in order, and the first usable one is used:
+///  - $XDG_RUNTIME_DIR, if it names an existing directory this process can write to and enter.
+///  - /run/user/<uid>, if it already exists and is usable; its creation is the system's
+///    responsibility (e.g. systemd-logind), so this function never attempts to create it.
+///  - A directory named "info.mumble.Mumble", qualified with the current uid, inside the
+///    system's shared temp directory. Since that directory is typically writable by every local
+///    user, the candidate is only accepted if it turns out to be a real, non-symlinked directory
+///    owned by the current user with permissions restricted to exactly 0700; otherwise another
+///    local user may have created it first, and it is discarded.
+///  - The current directory, as an unconditional last resort.
 /// Since on Windows named pipes aren't part of the fs, it returns an empty path.
+/// Its result is computed once and cached, so repeated calls always return the same path.
 /// @throws std::filesystem::filesystem_error if the directory doesn't exist and can't be created.
 std::filesystem::path getRuntimeDirectory();
 

--- a/ipcutils/IPCUtils.h
+++ b/ipcutils/IPCUtils.h
@@ -23,8 +23,11 @@ namespace Mumble {
 ///    owned by the current user with permissions restricted to exactly 0700; otherwise another
 ///    local user may have created it first, and it is discarded.
 ///  - The current directory, as an unconditional last resort.
+/// Whenever a candidate other than $XDG_RUNTIME_DIR ends up being used, a warning is printed to
+/// stderr.
 /// Since on Windows named pipes aren't part of the fs, it returns an empty path.
-/// Its result is computed once and cached, so repeated calls always return the same path.
+/// Its result is computed once and cached, so repeated calls always return the same path and the
+/// fallback warning is only ever printed once per process.
 /// @throws std::filesystem::filesystem_error if the directory doesn't exist and can't be created.
 std::filesystem::path getRuntimeDirectory();
 

--- a/ipcutils/IPCUtils_c.cpp
+++ b/ipcutils/IPCUtils_c.cpp
@@ -8,17 +8,9 @@
 
 #include <cstdlib>
 #include <cstring>
-#include <filesystem>
 
 char *get_overlay_pipe_path(void) {
-	// getOverlayPipePath() may throw if the runtime directory can't be created. That exception must
-	// not unwind into the extern "C" caller, so it's turned into a NULL return instead.
-	std::string path;
-	try {
-		path = Mumble::getOverlayPipePath().string();
-	} catch (const std::filesystem::filesystem_error &) {
-		return nullptr;
-	}
+	std::string path = Mumble::getOverlayPipePath().string();
 
 	if (path.empty()) {
 		return nullptr;


### PR DESCRIPTION
## Problem

Current master does not start on macOS. The client aborts right after the version banner:

```
<I> This is Mumble v1.7.0
libc++abi: terminating due to uncaught exception of type std::__1::__fs::filesystem::filesystem_error: filesystem error: in create_directories: Read-only file system ["/run"]
```

`Mumble::getRuntimeDirectory()` falls back to `/run/user/<uid>` whenever `XDG_RUNTIME_DIR` is unset and then calls the throwing overload of `std::filesystem::create_directories`. On macOS `XDG_RUNTIME_DIR` is never set, `/run` does not exist and the root filesystem is read-only, so the exception propagates out of `main()`.

Before #5961 the socket path fell back to `$HOME/.MumbleSocket`, so 1.6.x is unaffected. Any Unix system without `/run/user/<uid>` (non-systemd setups, some containers, FreeBSD) takes the same path.

Reported in #7304.

## Change

`getRuntimeDirectory()` now walks a list of candidates and uses the first one that works out:

1. `$XDG_RUNTIME_DIR`, if it names a directory the current user can write to and enter
2. `/run/user/<uid>`, but only when it already exists, since creating it is the job of the system
3. `info.mumble.Mumble-<uid>` inside the system's temporary directory
4. the current directory, as an unconditional last resort

The endpoint directory is named `info.mumble.Mumble` under the first two candidates, as before.

The temporary directory is shared between all local users, so the third candidate gets two safeguards. Its name carries the uid, so two users on the same machine don't end up fighting over one directory. And it is only accepted once `lstat()` confirms it is a real directory, not a symlink, owned by the current user, with permissions of exactly 0700 — otherwise it is discarded and the next candidate is tried. Without that check another local account could create the directory first and keep access to it: the sticky bit on `/tmp` stops them from removing our entries, but not from owning a subdirectory they created before us.

That matters because more than the overlay pipe lives there. When a second Mumble instance is started with a `mumble://` URL, `main.cpp` hands the whole URL — password included, if it carries one — to the running instance over the socket in this directory. On Linux that goes through DBus, so this is mainly about macOS and builds without DBus.

As mandated by the XDG Base Directory Specification, a warning is printed whenever a replacement for `$XDG_RUNTIME_DIR` ends up being used. It goes to stderr rather than through `qWarning()`, because `ipcutils` has no Qt dependency: it is linked into `overlay_gl`, which gets injected into other processes. The resolved directory is computed once and cached in a function-local static, so repeated calls always agree on the same path and the warning is printed at most once per process.

Directories that Mumble creates itself are restricted to owner-only permissions (0700). Directories that already existed are left untouched, since they may belong to the user or another application.

Every filesystem call uses the non-throwing `std::error_code` overload, so the function can no longer terminate the process. Behaviour on Linux with `XDG_RUNTIME_DIR` set, and on Windows, is unchanged.

The resulting socket path stays within the `sun_path` limit of 104 bytes on macOS and 108 on Linux: 84 bytes with the per-user `$TMPDIR` macOS hands out, 46 bytes under `/run/user/<uid>`.

The last commit drops the `@throws` documentation and the `try`/`catch` in `get_overlay_pipe_path()`, which the previously throwing implementation left behind.

## Testing

Built and run on macOS 26.6.2, arm64, Qt 6.11.1, `-Dserver=OFF -Dtests=OFF`. The client starts, prints the warning once and creates its socket at `$TMPDIR/info.mumble.Mumble-501/MumbleSocket`, with the directory at 0700 and owned by the user.

Directory resolution was exercised separately, with the environment varied around it:

- `$XDG_RUNTIME_DIR` pointing at a usable directory: used as is, no warning printed
- `$XDG_RUNTIME_DIR` pointing at a directory that does not exist: skipped, the next candidate is used and the warning is printed
- no `$XDG_RUNTIME_DIR`: the directory below the temporary directory is created with permissions 0700
- the directory below the temporary directory already there with permissions 0777: discarded, the current directory is used
- a symlink to a directory in its place: discarded as well, the current directory is used
- `TMPDIR` pointing at a path that does not exist: the current directory is used
- `getRuntimeDirectory()` called repeatedly in one process: the same path every time, with exactly one warning per process

### Checks

- [x] My commits follow the [commit guidelines](https://github.com/mumble-voip/mumble/blob/master/COMMIT_GUIDELINES.md)
