### PR TITLE
REFAC(shared): Move CryptState object out of Connection

### DIFF
--- a/src/Connection.cpp
+++ b/src/Connection.cpp
@@ -6,7 +6,6 @@
 #include "Connection.h"
 #include "Mumble.pb.h"
 #include "SSL.h"
-#include "crypto/CryptStateOCB2.h"
 
 #include <QtCore/QtEndian>
 #include <QtNetwork/QHostAddress>
@@ -29,7 +28,6 @@ Connection::Connection(QObject *p, QSslSocket *qtsSock) : QObject(p) {
 	qtsSocket->setParent(this);
 	iPacketLength        = -1;
 	bDisconnectedEmitted = false;
-	csCrypt              = std::make_unique< CryptStateOCB2 >();
 
 	static bool bDeclared = false;
 	if (!bDeclared) {

--- a/src/Connection.h
+++ b/src/Connection.h
@@ -14,15 +14,10 @@
 #	include "win.h"
 #endif
 
-#include "crypto/CryptState.h"
-
 #include <QtCore/QElapsedTimer>
 #include <QtCore/QList>
-#include <QtCore/QMutex>
 #include <QtCore/QObject>
 #include <QtNetwork/QSslSocket>
-
-#include <memory>
 
 #ifdef Q_OS_WIN
 #	include <ws2tcpip.h>
@@ -73,11 +68,6 @@ public:
 	qint64 activityTime() const;
 	void resetActivityTime();
 
-#ifdef MURMUR
-	/// qmCrypt locks access to csCrypt.
-	QMutex qmCrypt;
-#endif
-	std::unique_ptr< CryptState > csCrypt;
 	/// Returns the peer's chain of digital certificates, starting with the peer's immediate certificate
 	/// and ending with the CA's certificate.
 	QList< QSslCertificate > peerCertificateChain() const;

--- a/src/mumble/Messages.cpp
+++ b/src/mumble/Messages.cpp
@@ -1074,27 +1074,24 @@ void MainWindow::msgPing(const MumbleProto::Ping &) {
 }
 
 void MainWindow::msgCryptSetup(const MumbleProto::CryptSetup &msg) {
-	ConnectionPtr c = Global::get().sh->cConnection;
-	if (!c)
-		return;
 	if (msg.has_key() && msg.has_client_nonce() && msg.has_server_nonce()) {
 		const std::string &key          = msg.key();
 		const std::string &client_nonce = msg.client_nonce();
 		const std::string &server_nonce = msg.server_nonce();
-		if (!c->csCrypt->setKey(key, client_nonce, server_nonce)) {
+		if (!Global::get().sh->csCrypt->setKey(key, client_nonce, server_nonce)) {
 			qWarning("Messages: Cipher resync failed: Invalid key/nonce from the server!");
 		}
 	} else if (msg.has_server_nonce()) {
 		const std::string &server_nonce = msg.server_nonce();
 		if (server_nonce.size() == AES_BLOCK_SIZE) {
-			c->csCrypt->m_statsLocal.resync++;
-			if (!c->csCrypt->setDecryptIV(server_nonce)) {
+			Global::get().sh->csCrypt->m_statsLocal.resync++;
+			if (!Global::get().sh->csCrypt->setDecryptIV(server_nonce)) {
 				qWarning("Messages: Cipher resync failed: Invalid nonce from the server!");
 			}
 		}
 	} else {
 		MumbleProto::CryptSetup mpcs;
-		mpcs.set_client_nonce(c->csCrypt->getEncryptIV());
+		mpcs.set_client_nonce(Global::get().sh->csCrypt->getEncryptIV());
 		Global::get().sh->sendMessage(mpcs);
 	}
 }

--- a/src/mumble/ServerHandler.cpp
+++ b/src/mumble/ServerHandler.cpp
@@ -32,6 +32,8 @@
 #include "Utils.h"
 #include "Global.h"
 
+#include "crypto/CryptStateOCB2.h"
+
 #include <QPainter>
 #include <QtCore/QtEndian>
 #include <QtGui/QImageReader>
@@ -255,7 +257,7 @@ void ServerHandler::udpReady() {
 		if (!connection)
 			continue;
 
-		if (!connection->csCrypt->isValid())
+		if (!csCrypt->isValid())
 			continue;
 
 		if (buflen < 5)
@@ -266,11 +268,10 @@ void ServerHandler::udpReady() {
 		// 4 bytes is the overhead of the encryption
 		assert(buffer.size() >= buflen - 4);
 
-		if (!connection->csCrypt->decrypt(reinterpret_cast< const unsigned char * >(encrypted), buffer.data(),
-										  buflen)) {
-			if (connection->csCrypt->tLastGood.elapsed() > std::chrono::seconds(5)) {
-				if (connection->csCrypt->tLastRequest.elapsed() > std::chrono::seconds(5)) {
-					connection->csCrypt->tLastRequest.restart();
+		if (!csCrypt->decrypt(reinterpret_cast< const unsigned char * >(encrypted), buffer.data(), buflen)) {
+			if (csCrypt->tLastGood.elapsed() > std::chrono::seconds(5)) {
+				if (csCrypt->tLastRequest.elapsed() > std::chrono::seconds(5)) {
+					csCrypt->tLastRequest.restart();
 					MumbleProto::CryptSetup mpcs;
 					sendMessage(mpcs);
 				}
@@ -326,7 +327,7 @@ void ServerHandler::sendMessage(const unsigned char *data, int len, bool force) 
 		return;
 
 	ConnectionPtr connection(cConnection);
-	if (!connection || !connection->csCrypt->isValid())
+	if (!connection || !csCrypt->isValid())
 		return;
 
 	if (!force && (NetworkConfig::TcpModeEnabled() || !bUdp)) {
@@ -342,8 +343,8 @@ void ServerHandler::sendMessage(const unsigned char *data, int len, bool force) 
 		QApplication::postEvent(this,
 								new ServerHandlerMessageEvent(qba, Mumble::Protocol::TCPMessageType::UDPTunnel, true));
 	} else {
-		if (!connection->csCrypt->encrypt(reinterpret_cast< const unsigned char * >(data), crypto.data(),
-										  static_cast< unsigned int >(len))) {
+		if (!csCrypt->encrypt(reinterpret_cast< const unsigned char * >(data), crypto.data(),
+							  static_cast< unsigned int >(len))) {
 			return;
 		}
 		qusUdp->writeDatagram(reinterpret_cast< const char * >(crypto.data()), len + 4, qhaRemote, usResolvedPort);
@@ -512,6 +513,7 @@ void ServerHandler::run() {
 		if (qusUdp) {
 			QMutexLocker qml(&qmUdp);
 
+			csCrypt.reset();
 #ifdef Q_OS_WIN
 			if (hQoS) {
 				if (!QOSRemoveSocketFromFlow(hQoS, 0, dwFlowUDP, 0)) {
@@ -637,10 +639,10 @@ void ServerHandler::sendPingInternal() {
 	MumbleProto::Ping mpp;
 
 	mpp.set_timestamp(t);
-	mpp.set_good(connection->csCrypt->m_statsLocal.good);
-	mpp.set_late(connection->csCrypt->m_statsLocal.late);
-	mpp.set_lost(connection->csCrypt->m_statsLocal.lost);
-	mpp.set_resync(connection->csCrypt->m_statsLocal.resync);
+	mpp.set_good(csCrypt->m_statsLocal.good);
+	mpp.set_late(csCrypt->m_statsLocal.late);
+	mpp.set_lost(csCrypt->m_statsLocal.lost);
+	mpp.set_resync(csCrypt->m_statsLocal.resync);
 
 
 	if (boost::accumulators::count(accUDP)) {
@@ -685,21 +687,21 @@ void ServerHandler::message(Mumble::Protocol::TCPMessageType type, const QByteAr
 			// connection is still OK.
 			iInFlightTCPPings = 0;
 
-			connection->csCrypt->m_statsRemote.good   = msg.good();
-			connection->csCrypt->m_statsRemote.late   = msg.late();
-			connection->csCrypt->m_statsRemote.lost   = msg.lost();
-			connection->csCrypt->m_statsRemote.resync = msg.resync();
+			csCrypt->m_statsRemote.good   = msg.good();
+			csCrypt->m_statsRemote.late   = msg.late();
+			csCrypt->m_statsRemote.lost   = msg.lost();
+			csCrypt->m_statsRemote.resync = msg.resync();
 			accTCP(static_cast< double >(static_cast< std::uint64_t >(tTimestamp.elapsed().count()) - msg.timestamp())
 				   / 1000.0);
 
-			if (((connection->csCrypt->m_statsRemote.good == 0) || (connection->csCrypt->m_statsLocal.good == 0))
-				&& bUdp && (tTimestamp.elapsed() > std::chrono::seconds(20))) {
+			if (((csCrypt->m_statsRemote.good == 0) || (csCrypt->m_statsLocal.good == 0)) && bUdp
+				&& (tTimestamp.elapsed() > std::chrono::seconds(20))) {
 				bUdp = false;
 				if (!NetworkConfig::TcpModeEnabled()) {
-					if ((connection->csCrypt->m_statsRemote.good == 0) && (connection->csCrypt->m_statsLocal.good == 0))
+					if ((csCrypt->m_statsRemote.good == 0) && (csCrypt->m_statsLocal.good == 0))
 						Global::get().mw->msgBox(
 							tr("UDP packets cannot be sent to or received from the server. Switching to TCP mode."));
-					else if (connection->csCrypt->m_statsRemote.good == 0)
+					else if (csCrypt->m_statsRemote.good == 0)
 						Global::get().mw->msgBox(
 							tr("UDP packets cannot be sent to the server. Switching to TCP mode."));
 					else
@@ -708,8 +710,7 @@ void ServerHandler::message(Mumble::Protocol::TCPMessageType type, const QByteAr
 
 					database->setUdp(qbaDigest, false);
 				}
-			} else if (!bUdp && (connection->csCrypt->m_statsRemote.good > 3)
-					   && (connection->csCrypt->m_statsLocal.good > 3)) {
+			} else if (!bUdp && (csCrypt->m_statsRemote.good > 3) && (csCrypt->m_statsLocal.good > 3)) {
 				bUdp = true;
 				if (!NetworkConfig::TcpModeEnabled()) {
 					Global::get().mw->msgBox(
@@ -912,6 +913,7 @@ void ServerHandler::serverConnectionConnected() {
 					qWarning("ServerHandler: Failed to add UDP to QOS");
 			}
 #endif
+			csCrypt = std::make_unique< CryptStateOCB2 >();
 		}
 	}
 

--- a/src/mumble/ServerHandler.h
+++ b/src/mumble/ServerHandler.h
@@ -39,6 +39,7 @@
 #include <memory>
 
 class Connection;
+class CryptState;
 class Database;
 class PacketDataStream;
 class QUdpSocket;
@@ -119,6 +120,7 @@ public:
 	QList< QSslError > qlErrors;
 	QList< QSslCertificate > qscCert;
 	QSslCipher qscCipher;
+	std::unique_ptr< CryptState > csCrypt;
 	ConnectionPtr cConnection;
 	QByteArray qbaDigest;
 	std::shared_ptr< VoiceRecorder > recorder;

--- a/src/mumble/ServerInformation.cpp
+++ b/src/mumble/ServerInformation.cpp
@@ -14,6 +14,8 @@
 #include "ViewCert.h"
 #include "Global.h"
 
+#include "crypto/CryptState.h"
+
 #include <QTableWidgetItem>
 
 #include <boost/accumulators/accumulators.hpp>
@@ -136,7 +138,7 @@ void ServerInformation::updateConnectionDetails() {
 		connection_udp_encryption->setText("128 bit OCB-AES128");
 		connection_udp_latency->setText(latencyString.arg(latency, 0, 'f', 1).arg(deviation, 0, 'f', 1));
 
-		populateUDPStatistics(*connection);
+		populateUDPStatistics();
 	}
 
 
@@ -155,7 +157,7 @@ void ServerInformation::updateConnectionDetails() {
 	qgbTCPParameters->updateAccessibleText();
 }
 
-void ServerInformation::populateUDPStatistics(const Connection &connection) {
+void ServerInformation::populateUDPStatistics() {
 	// statistics
 	constexpr int TO_SERVER_COL   = 0;
 	constexpr int FROM_SERVER_COL = 1;
@@ -164,14 +166,19 @@ void ServerInformation::populateUDPStatistics(const Connection &connection) {
 	constexpr int LOST_ROW        = 2;
 	constexpr int RESYNC_ROW      = 3;
 
-	QTableWidgetItem *toGoodItem     = new QTableWidgetItem(QString::number(connection.csCrypt->m_statsRemote.good));
-	QTableWidgetItem *fromGoodItem   = new QTableWidgetItem(QString::number(connection.csCrypt->m_statsLocal.good));
-	QTableWidgetItem *toLateItem     = new QTableWidgetItem(QString::number(connection.csCrypt->m_statsRemote.late));
-	QTableWidgetItem *fromLateItem   = new QTableWidgetItem(QString::number(connection.csCrypt->m_statsLocal.late));
-	QTableWidgetItem *toLostItem     = new QTableWidgetItem(QString::number(connection.csCrypt->m_statsRemote.lost));
-	QTableWidgetItem *fromLostItem   = new QTableWidgetItem(QString::number(connection.csCrypt->m_statsLocal.lost));
-	QTableWidgetItem *toResyncItem   = new QTableWidgetItem(QString::number(connection.csCrypt->m_statsRemote.resync));
-	QTableWidgetItem *fromResyncItem = new QTableWidgetItem(QString::number(connection.csCrypt->m_statsLocal.resync));
+	QTableWidgetItem *toGoodItem = new QTableWidgetItem(QString::number(Global::get().sh->csCrypt->m_statsRemote.good));
+	QTableWidgetItem *fromGoodItem =
+		new QTableWidgetItem(QString::number(Global::get().sh->csCrypt->m_statsLocal.good));
+	QTableWidgetItem *toLateItem = new QTableWidgetItem(QString::number(Global::get().sh->csCrypt->m_statsRemote.late));
+	QTableWidgetItem *fromLateItem =
+		new QTableWidgetItem(QString::number(Global::get().sh->csCrypt->m_statsLocal.late));
+	QTableWidgetItem *toLostItem = new QTableWidgetItem(QString::number(Global::get().sh->csCrypt->m_statsRemote.lost));
+	QTableWidgetItem *fromLostItem =
+		new QTableWidgetItem(QString::number(Global::get().sh->csCrypt->m_statsLocal.lost));
+	QTableWidgetItem *toResyncItem =
+		new QTableWidgetItem(QString::number(Global::get().sh->csCrypt->m_statsRemote.resync));
+	QTableWidgetItem *fromResyncItem =
+		new QTableWidgetItem(QString::number(Global::get().sh->csCrypt->m_statsLocal.resync));
 
 	connection_udp_statisticsTable->setItem(GOOD_ROW, TO_SERVER_COL, toGoodItem);
 	connection_udp_statisticsTable->setItem(GOOD_ROW, FROM_SERVER_COL, fromGoodItem);

--- a/src/mumble/ServerInformation.h
+++ b/src/mumble/ServerInformation.h
@@ -10,8 +10,6 @@
 
 #include "ui_ServerInformation.h"
 
-class Connection;
-
 class ServerInformation : public QDialog, private Ui::ServerInformation {
 	Q_OBJECT
 	Q_DISABLE_COPY(ServerInformation)
@@ -31,7 +29,7 @@ private:
 	void updateServerInformation();
 	void updateAudioBandwidth();
 	void updateConnectionDetails();
-	void populateUDPStatistics(const Connection &connection);
+	void populateUDPStatistics();
 };
 
 #endif // MUMBLE_MUMBLE_SERVERINFORMATION_H_

--- a/src/murmur/Server.cpp
+++ b/src/murmur/Server.cpp
@@ -31,6 +31,8 @@
 
 #include "Utils.h"
 
+#include "crypto/CryptState.h"
+
 #include "murmur/database/DBUserData.h"
 #include "murmur/database/UserProperty.h"
 

--- a/src/murmur/ServerUser.cpp
+++ b/src/murmur/ServerUser.cpp
@@ -13,6 +13,8 @@
 #	include "Utils.h"
 #endif
 
+#include "crypto/CryptStateOCB2.h"
+
 #include <chrono>
 
 ServerUser::ServerUser(Server *p, QSslSocket *socket)
@@ -35,8 +37,12 @@ ServerUser::ServerUser(Server *p, QSslSocket *socket)
 	iLastPermissionCheck = -1;
 
 	bOpus = false;
+
+	csCrypt = std::make_unique< CryptStateOCB2 >();
 }
 
+ServerUser::~ServerUser() {
+}
 
 ServerUser::operator QString() const {
 	return QString::fromLatin1("%1:%2(%3)").arg(qsName).arg(uiSession).arg(iId);

--- a/src/murmur/ServerUser.h
+++ b/src/murmur/ServerUser.h
@@ -27,6 +27,8 @@
 #	include <sys/socket.h>
 #endif
 
+#include <memory>
+#include <mutex>
 #include <vector>
 
 // Unfortunately, this needs to be "large enough" to hold
@@ -42,7 +44,7 @@ struct BandwidthRecord {
 	Timer tIdleControl;
 	unsigned short a_iBW[N_BANDWIDTH_SLOTS];
 	Timer a_qtWhen[N_BANDWIDTH_SLOTS];
-	mutable QMutex qmMutex;
+	mutable std::mutex qmMutex;
 
 	BandwidthRecord();
 	bool addFrame(int size, int maxpersec);
@@ -102,6 +104,8 @@ public:
 	LeakyBucket(unsigned int tokensPerSec, unsigned int maxTokens);
 };
 
+class CryptState;
+
 class ServerUser : public Connection, public ServerUserInfo {
 private:
 	Q_OBJECT
@@ -153,7 +157,13 @@ public:
 	BandwidthRecord bwr;
 	struct sockaddr_storage saiUdpAddress;
 	struct sockaddr_storage saiTcpLocalAddress;
+
+	/// qmCrypt locks access to csCrypt.
+	std::mutex qmCrypt;
+	std::unique_ptr< CryptState > csCrypt;
+
 	ServerUser(Server *parent, QSslSocket *socket);
+	~ServerUser();
 };
 
 #endif


### PR DESCRIPTION
It's strictly related to UDP and should not be in `Connection` (strictly TCP).