### PR TITLE
REFAC(server): Move user last activity timer into ServerUser

### DIFF
--- a/src/Connection.cpp
+++ b/src/Connection.cpp
@@ -46,7 +46,6 @@ Connection::Connection(QObject *p, QSslSocket *qtsSock) : QObject(p) {
 	connect(qtsSocket, SIGNAL(disconnected()), this, SLOT(socketDisconnected()));
 	connect(qtsSocket, SIGNAL(sslErrors(const QList< QSslError > &)), this,
 			SLOT(socketSslErrors(const QList< QSslError > &)));
-	qtLastPacket.restart();
 #ifdef Q_OS_WIN
 	dwFlow = 0;
 #endif
@@ -88,14 +87,6 @@ void Connection::setToS() {
 #	endif
 
 #endif
-}
-
-qint64 Connection::activityTime() const {
-	return qtLastPacket.elapsed();
-}
-
-void Connection::resetActivityTime() {
-	qtLastPacket.restart();
 }
 
 /**

--- a/src/Connection.h
+++ b/src/Connection.h
@@ -14,7 +14,6 @@
 #	include "win.h"
 #endif
 
-#include <QtCore/QElapsedTimer>
 #include <QtCore/QList>
 #include <QtCore/QObject>
 #include <QtNetwork/QSslSocket>
@@ -35,7 +34,6 @@ private:
 	Q_DISABLE_COPY(Connection)
 protected:
 	QSslSocket *qtsSocket;
-	QElapsedTimer qtLastPacket;
 	Mumble::Protocol::TCPMessageType m_type;
 	int iPacketLength;
 #ifdef Q_OS_WIN
@@ -65,8 +63,6 @@ public:
 	void sendMessage(const QByteArray &qbaMsg);
 	void disconnectSocket(bool force = false);
 	void forceFlush();
-	qint64 activityTime() const;
-	void resetActivityTime();
 
 	/// Returns the peer's chain of digital certificates, starting with the peer's immediate certificate
 	/// and ending with the CA's certificate.

--- a/src/murmur/ServerUser.cpp
+++ b/src/murmur/ServerUser.cpp
@@ -47,6 +47,16 @@ ServerUser::~ServerUser() {
 ServerUser::operator QString() const {
 	return QString::fromLatin1("%1:%2(%3)").arg(qsName).arg(uiSession).arg(iId);
 }
+
+std::int64_t ServerUser::activityTime() const {
+	const auto elapsed = m_lastActivityTimer.elapsed< std::chrono::milliseconds >();
+	return elapsed.count();
+}
+
+void ServerUser::resetActivityTime() {
+	m_lastActivityTimer.restart();
+}
+
 BandwidthRecord::BandwidthRecord() {
 	iRecNum = 0;
 	iSum    = 0;

--- a/src/murmur/ServerUser.h
+++ b/src/murmur/ServerUser.h
@@ -92,6 +92,7 @@ private:
 	/// A timer that is used to measure time intervals. It is essential
 	/// that this timer uses a monotonic clock (which is why QElapsedTimer is
 	/// used instead of QTime or QDateTime).
+	/// TODO: Switch to Timer.
 	QElapsedTimer m_timer;
 
 public:
@@ -113,11 +114,16 @@ private:
 protected:
 	Server *s;
 
+	Timer m_lastActivityTimer;
+
 public:
 	enum State { Connected, Authenticated };
 	State sState;
 	ClientType m_clientType;
 	operator QString() const;
+
+	std::int64_t activityTime() const;
+	void resetActivityTime();
 
 	float dUDPPingAvg, dUDPPingVar;
 	float dTCPPingAvg, dTCPPingVar;


### PR DESCRIPTION
1. We reset the timer only when receiving control packets (TCP), but it's related to the user itself and not the connection.
2. Only the server needs it and Connection is shared with the client.