### PR TITLE
FIX(server): Generate the full password alphabet

### DIFF
--- a/src/PasswordGenerator.cpp
+++ b/src/PasswordGenerator.cpp
@@ -44,7 +44,7 @@ QString PasswordGenerator::generatePassword(int length) {
 	uint32_t numAlphabetEntries = sizeof(password_alphabet);
 
 	for (int i = 0; i < length; i++) {
-		uint32_t index = CryptographicRandom::uniform(numAlphabetEntries - 1);
+		uint32_t index = CryptographicRandom::uniform(numAlphabetEntries);
 		buf[i]         = password_alphabet[index];
 	}
 


### PR DESCRIPTION
Fixes #7312

`PasswordGenerator::generatePassword` selected each character with `CryptographicRandom::uniform(numAlphabetEntries - 1)`. `uniform(upperBound)` returns a value strictly less than `upperBound`, and `password_alphabet` is a braced `char[]` of 55 entries with no NUL terminator (`sizeof == 55`), so `uniform(54)` produced indices `0..53` and the last entry `'9'` was never generated — dropping a character from the alphabet and slightly lowering the entropy of every generated password (including the server SuperUser password).

Pass the full count to `uniform()`, matching the sibling getter `mumble_password_generator_alphabet()` which already iterates all 55 entries.

The existing `TestPasswordGenerator::random()` only checked that generated characters *belong* to the alphabet, so it missed this; I extended it with `coversWholeAlphabet()`, which asserts every alphabet character is reachable. Verified fails-before (`'9'` missing) / passes-after against Qt6 + OpenSSL.