### PR TITLE
FIX: Report oversized DataType sizes as UnknownDataTypeException

### DIFF
--- a/src/database/DataType.cpp
+++ b/src/database/DataType.cpp
@@ -218,7 +218,12 @@ namespace db {
 
 			try {
 				size = std::stoull(strRepr.substr(i + 1, strRepr.size() - 1));
-			} catch (const std::invalid_argument &e) {
+			} catch (const std::logic_error &e) {
+				// std::stoull throws std::invalid_argument (no conversion) or
+				// std::out_of_range (value too large); both derive from
+				// std::logic_error. Funnel either into UnknownDataTypeException so
+				// callers such as Table::importFromJSON get the expected exception
+				// type instead of an uncaught std::out_of_range.
 				throw UnknownDataTypeException("Size of data type \"" + strRepr
 											   + "\" could not be parsed: " + e.what());
 			}

--- a/src/tests/TestDatabase/DatabaseTest.cpp
+++ b/src/tests/TestDatabase/DatabaseTest.cpp
@@ -170,6 +170,7 @@ private slots:
 	void indices();
 	void triggers();
 	void dataTypes();
+	void dataTypeFromSQLRepresentation();
 	void keyValueTable();
 	void unicode();
 	void fetchMinimumFreeID();
@@ -851,6 +852,23 @@ void DatabaseTest::dataTypes() {
 	}
 
 	MUMBLE_END_TEST_CASE
+}
+
+// fromSQLRepresentation must funnel std::stoull parse failures (including the
+// std::out_of_range from an oversized size) into UnknownDataTypeException, which is
+// the exception type Table::importFromJSON expects.
+void DatabaseTest::dataTypeFromSQLRepresentation() {
+	// An oversized size overflows unsigned long long (std::out_of_range); a
+	// non-numeric size is std::invalid_argument. Both must surface as
+	// UnknownDataTypeException, not leak as a raw std exception.
+	QVERIFY_THROWS_EXCEPTION(UnknownDataTypeException,
+							 DataType::fromSQLRepresentation("VARCHAR(99999999999999999999)"));
+	QVERIFY_THROWS_EXCEPTION(UnknownDataTypeException, DataType::fromSQLRepresentation("VARCHAR(abc)"));
+
+	// A well-formed sized type must still parse correctly.
+	DataType type = DataType::fromSQLRepresentation("VARCHAR(255)");
+	QVERIFY(type == DataType::VarChar);
+	QCOMPARE(type.getSize(), static_cast< std::size_t >(255));
 }
 
 // This test ensures that our KeyValueTable helper class actually works as expected


### PR DESCRIPTION
Fixes #7314

`DataType::fromSQLRepresentation` parses a type's size with `std::stoull` but caught only `std::invalid_argument`. `std::stoull` also throws `std::out_of_range` when the value exceeds `unsigned long long`, so `VARCHAR(99999999999999999999)` leaked a raw `std::out_of_range` instead of the intended `UnknownDataTypeException`.

`Table::importFromJSON` catches only `UnknownDataTypeException` (rethrowing it as `FormatException`), so the leaked exception propagated uncaught out of the import path, which otherwise promises a clean `FormatException` for malformed input.

The fix catches `std::logic_error` — the common base of both `std::invalid_argument` and `std::out_of_range` — so every `std::stoull` failure becomes an `UnknownDataTypeException`.

Adds a `TestDataType` unit test covering the oversized, non-numeric and well-formed size cases. Verified fails-before (`std::out_of_range` leaks) / passes-after against Qt6.