### PR TITLE
Backport "Merge PR #7302: FIX(client): Skip UDP ping when TCP mode is forced" to 1.5.x

### DIFF
--- a/src/mumble/Messages.cpp
+++ b/src/mumble/Messages.cpp
@@ -127,7 +127,8 @@ void MainWindow::msgServerSync(const MumbleProto::ServerSync &msg) {
 	}
 	Global::get().uiSession = msg.session();
 
-	Global::get().sh->sendPing(); // Send initial ping to establish UDP connection
+	// Send an initial ping and establish the UDP connection unless TCP mode is forced
+	Global::get().sh->sendPing();
 
 	Global::get().pPermissions = ChanACL::Permissions(static_cast< unsigned int >(msg.permissions()));
 	Global::get().l->clearIgnore();

--- a/src/mumble/ServerHandler.cpp
+++ b/src/mumble/ServerHandler.cpp
@@ -582,7 +582,11 @@ void ServerHandler::sendPingInternal() {
 
 	quint64 t = tTimestamp.elapsed();
 
-	if (qusUdp) {
+	// Skip the UDP ping while TCP mode is forced (or UDP has already been given up on for this
+	// connection). Sending it anyway would let the server discover a working UDP path for this
+	// client and start routing voice packets over UDP again, defeating "Force TCP Mode".
+	const bool forcedTcp = NetworkConfig::TcpModeEnabled() || !bUdp;
+	if (qusUdp && !forcedTcp) {
 		Mumble::Protocol::PingData pingData;
 		pingData.timestamp                    = t;
 		pingData.requestAdditionalInformation = false;


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `1.5.x`:
 - [Merge PR #7302: FIX(client): Skip UDP ping when TCP mode is forced](https://github.com/mumble-voip/mumble/pull/7302)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)