### PR TITLE
Backport "Merge PR #7313: FIX(server): Generate the full password alphabet" to 1.6.x

### DIFF
--- a/src/PasswordGenerator.cpp
+++ b/src/PasswordGenerator.cpp
@@ -44,7 +44,7 @@ QString PasswordGenerator::generatePassword(int length) {
 	uint32_t numAlphabetEntries = sizeof(password_alphabet);
 
 	for (int i = 0; i < length; i++) {
-		uint32_t index = CryptographicRandom::uniform(numAlphabetEntries - 1);
+		uint32_t index = CryptographicRandom::uniform(numAlphabetEntries);
 		buf[i]         = password_alphabet[index];
 	}
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `1.6.x`:
 - [Merge PR #7313: FIX(server): Generate the full password alphabet](https://github.com/mumble-voip/mumble/pull/7313)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)