### PR TITLE
FIX(server): Broken GUI rendering with Qt 6

### DIFF
--- a/src/murmur/ServerApplication.cpp
+++ b/src/murmur/ServerApplication.cpp
@@ -18,7 +18,11 @@ bool ServerApplication::notify(QObject *receiver, QEvent *event) {
 	bool handled = true;
 
 	try {
+#ifdef Q_OS_WIN
+		handled = QApplication::notify(receiver, event);
+#else
 		handled = QCoreApplication::notify(receiver, event);
+#endif
 	} catch (const std::exception &e) {
 		std::cerr << "Terminating due to exception with message \"" << e.what() << "\"" << std::endl;
 		exit(1);


### PR DESCRIPTION
The bug has always been there, but the symptoms only appeared with Qt 6.

Most likely because theme/palette/font messages are now in form of events.

### Checks

- [x] My commits follow the [commit guidelines](https://github.com/mumble-voip/mumble/blob/master/COMMIT_GUIDELINES.md)