### PR TITLE
FIX(client): Always create CryptState on connection

### DIFF
--- a/src/mumble/ServerHandler.cpp
+++ b/src/mumble/ServerHandler.cpp
@@ -913,8 +913,8 @@ void ServerHandler::serverConnectionConnected() {
 					qWarning("ServerHandler: Failed to add UDP to QOS");
 			}
 #endif
-			csCrypt = std::make_unique< CryptStateOCB2 >();
 		}
+		csCrypt = std::make_unique< CryptStateOCB2 >();
 	}
 
 	emit connected();


### PR DESCRIPTION
csCrypt was accidentally created only when QoS is enabled. This caused a null-pointer crash when connecting with QoS disabled.

Fixes https://github.com/mumble-voip/mumble/issues/7320
Fixes the regression introduced in 7cc5941 (PR #7307).


### Checks

- [x] My commits follow the [commit guidelines](https://github.com/mumble-voip/mumble/blob/master/COMMIT_GUIDELINES.md)

