### PR TITLE
FIX(client): Call `QLibrary::unload()` after a failed library load

### DIFF
--- a/src/mumble/GKey.cpp
+++ b/src/mumble/GKey.cpp
@@ -113,6 +113,7 @@ GKeyLibrary::GKeyLibrary() {
 			bValid = true;
 			break;
 		}
+		qlLogiGkey.unload();
 	}
 
 	RESOLVE(LogiGkeyInit);

--- a/src/mumble/JackAudio.cpp
+++ b/src/mumble/JackAudio.cpp
@@ -210,6 +210,7 @@ JackAudioSystem::JackAudioSystem() : bAvailable(false), users(0), client(nullptr
 		if (qlJack.load()) {
 			break;
 		}
+		qlJack.unload();
 	}
 
 	if (!qlJack.isLoaded()) {

--- a/src/mumble/PAAudio.cpp
+++ b/src/mumble/PAAudio.cpp
@@ -135,6 +135,7 @@ PortAudioSystem::PortAudioSystem() : bOk(false) {
 		if (qlPortAudio.load()) {
 			break;
 		}
+		qlPortAudio.unload();
 	}
 
 	if (!qlPortAudio.isLoaded()) {

--- a/src/mumble/PipeWire.cpp
+++ b/src/mumble/PipeWire.cpp
@@ -143,6 +143,7 @@ PipeWireSystem::PipeWireSystem() : m_ok(false), m_users(0) {
 		if (m_lib.load()) {
 			break;
 		}
+		m_lib.unload();
 	}
 
 	if (!m_lib.isLoaded()) {

--- a/src/mumble/PulseAudio.cpp
+++ b/src/mumble/PulseAudio.cpp
@@ -1033,6 +1033,7 @@ PulseAudio::PulseAudio() : m_ok(false) {
 		if (m_lib.load()) {
 			break;
 		}
+		m_lib.unload();
 	}
 
 	if (!m_lib.isLoaded()) {


### PR DESCRIPTION
## Summary

This PR is to add a `QLibrary::unload()` for all `QLibrary`\'s loading process, especially when it attempts to load a module with several possible names. These bugs occur during my testing for [Issue#7293](https://github.com/mumble-voip/mumble/issues/7293 "...where I temporarily tackled this by commenting first two library names in Pipewire.cpp").

One `QLibrary` object cannot run `load()` for multiple times in Linux, otherwise failing with "Unknown Error". The key solution is to add an `unload()` before running `load()` again.

Tested on Linux and Windows.

## Changes

To have a better understanding of the process, some necessary modification is made:
- In my PC, Mumble cannot load the x86 libraries, failing with **"Cannot load library portaudio_x86.dll: %1 isn't a valid Win32 Application."** So **I modified the order to load x64 file lastly.**
- I had appended "libportaudio.so" with ".noneixsted" **to simulate loading an inexistent library**, because **I'm unable to rename `libportaudio.so` in a read-only directory**.

Example is from `PAAudio.cpp(L121+)`.

### Previous code
```cpp
PortAudioSystem::PortAudioSystem() : bOk(false) {
	QStringList alternatives;
#ifdef Q_OS_WIN
// Mumble cannot load the x86 file in my computer, so I modifty the
//  order to lastly load x64 file.
	alternatives << QLatin1String("portaudio_x86.dll");
	alternatives << QLatin1String("portaudio_x64.dll");
#elif defined(Q_OS_MAC)
	alternatives << QLatin1String("libportaudio.dylib");
	alternatives << QLatin1String("libportaudio.2.dylib");
#else
// Append "libportaudio.so" with ".noneixsted" to simulate loading
// an inexistent library.
	alternatives << QLatin1String("libportaudio.so.nonexistent");
	alternatives << QLatin1String("libportaudio.so.2");
#endif
	for (const auto &lib : alternatives) {
		qlPortAudio.setFileName(lib);
		if (qlPortAudio.load()) {
			break;
		} else {
			// A log to notify that we fail to load a library.
			qWarning("Error: unable to load %s because: %s"
				, lib.toStdString().c_str()
				, qlPortAudio.errorString().toStdString().c_str()
			);
		}
	}

	if (!qlPortAudio.isLoaded()) {
		return;
	}

	RESOLVE(...)

	const auto ret = Pa_Initialize();
	if (ret != paNoError) {
		qWarning("PortAudioSystem: failed to initialize library - Pa_Initialize() returned: %s", Pa_GetErrorText(ret));
		return;
	}

	qDebug("%s from %s", Pa_GetVersionText(), qPrintable(qlPortAudio.fileName()));
}
```
- in Windows 10 (19045.6456 x64), we have `portaudio_x64.dll` installed, succeeding with output:
	```log
	<W>2026-09-02 21:55:18.269 Error: unable to load portaudio_x86.dll because: Cannot load library portaudio_x86.dll: Cannot find the specific module.
	<D>2026-09-02 21:55:18.335 PortAudio V19.7.0-devel, revision 147dd722548358763a8b649b3e4b41dfffbcfbb6 from portaudio_x64.dll
	```
- in Ubuntu(WSL 22.04), we have `libportaudio.so.2` installed, failing with output:
	```log
	<W>2026-09-02 21:52:35.179 Error: unable to load libportaudio.so.nonexistent because: Cannot load library libportaudio.so.nonexistent: (libportaudio.so.nonexistent: Cannot open shared object file: No such file or directory)
	<W>2026-09-02 21:52:38.580 Error: unable to load libportaudio.so.2 because: Unknown error
	```
	opposite our expected effect, even though `lobportaudio.so.2` is existed.

### New code

We simply add `QLibrary::unload()` to re-initialize the `QLibrary`:
```cpp
	...
#endif
	for (const auto &lib : alternatives) {
		qlPortAudio.setFileName(lib);
		if (qlPortAudio.load()) {
			break;
		} else {
			qWarning("Error: unable to load %s because: %s"
				, lib.toStdString().c_str()
				, qlPortAudio.errorString().toStdString().c_str()
			);
		}
		// Here
		qlPortAudio.unload();
	}

	if (!qlPortAudio.isLoaded()) {
	...
```
- in Windows 10 (19045.6456 x64), we have `portaudio_x64.dll` installed, succeeding with output:
	```log
	<W>2026-09-02 22:04:05.652 Error: unable to load portaudio_x86.dll because: Cannot load library portaudio_x86.dll: Cannot find the specific module.
	<D>2026-09-02 22:04:05.770 PortAudio V19.7.0-devel, revision 147dd722548358763a8b649b3e4b41dfffbcfbb6 from portaudio_x64.dll
	```
- in Ubuntu(WSL 22.04), we have `libportaudio.so.2` installed, succeeding with output:
	```log
	<W>2026-09-02 22:05:49.556 Error: unable to load libportaudio.so.nonexistent because: Cannot load library libportaudio.so.nonexistent: (libportaudio.so.nonexistent: Cannot open shared object file: No such file or directory)
	ALSA lib confmisc.c:855:(parse_card) cannot find card '0'
	...
	ALSA lib pcm.c:2664:(snd_pcm_open_noupdate) Unknown PCM dmix
	<D>2026-09-02 22:05:50.084 PortAudio V19.6.0-devel, revision 396fe4b6699ae929d3a685b3ef8a7e97396139a4 from libportaudio.so.2
	```