### PR TITLE
Backport "Merge PR #7322: FIX(server): Broken GUI rendering with Qt 6" to 1.6.x

### DIFF
--- a/src/murmur/ServerApplication.cpp
+++ b/src/murmur/ServerApplication.cpp
@@ -18,7 +18,11 @@ bool ServerApplication::notify(QObject *receiver, QEvent *event) {
 	bool handled = true;
 
 	try {
+#ifdef Q_OS_WIN
+		handled = QApplication::notify(receiver, event);
+#else
 		handled = QCoreApplication::notify(receiver, event);
+#endif
 	} catch (const std::exception &e) {
 		std::cerr << "Terminating due to exception with message \"" << e.what() << "\"" << std::endl;
 		exit(1);


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `1.6.x`:
 - [Merge PR #7322: FIX(server): Broken GUI rendering with Qt 6](https://github.com/mumble-voip/mumble/pull/7322)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)