### PR TITLE
FIX(server): Ensure qdBasePath always exists

### DIFF
--- a/src/murmur/Meta.cpp
+++ b/src/murmur/Meta.cpp
@@ -213,6 +213,10 @@ void MetaParams::read(QString fname) {
 		if (qsAbsSettingsFilePath.isEmpty()) {
 			qdBasePath            = QDir(datapaths.at(0));
 			qsAbsSettingsFilePath = qdBasePath.absolutePath() + QLatin1String("/mumble-server.ini");
+
+			if (!qdBasePath.exists()) {
+				qdBasePath.mkpath(".");
+			}
 		}
 	} else {
 		QFile f(fname);


### PR DESCRIPTION
In case the server started without a settings file, qdBasePath would only be configued but never created. This caused e.g. the database SQLite backend to attempt to create a file in a non-existing directory, which lead to errors.

We now ensure that we explicitly create the directory in such cases.

Fixes #7316


### Checks

- [x] My commits follow the [commit guidelines](https://github.com/mumble-voip/mumble/blob/master/COMMIT_GUIDELINES.md)

