### PR TITLE
FIX(server): Replace GetModuleHandle() with LoadLibrary() in Zeroconf

### DIFF
--- a/src/murmur/Zeroconf.cpp
+++ b/src/murmur/Zeroconf.cpp
@@ -8,7 +8,7 @@
 #define GET_SYMBOL(symbol) (symbol = reinterpret_cast< decltype(symbol) >(GetProcAddress(m_module, #symbol)))
 
 #ifdef Q_OS_WIN
-Zeroconf::Zeroconf() : m_ok(false), m_reg(std::make_shared< Reg >()) {
+Zeroconf::Zeroconf() : m_ok(false), m_reg(std::make_unique< Reg >()) {
 	if (m_reg->isOk()) {
 		m_ok = true;
 		return;
@@ -70,8 +70,8 @@ void Zeroconf::helperError(const DNSServiceErrorType error) {
 }
 
 #ifdef Q_OS_WIN
-Zeroconf::Reg::Reg() : m_instance(nullptr, InstanceDeleter{ DnsServiceFreeInstance }) {
-	m_module = GetModuleHandle(L"dnsapi.dll");
+Zeroconf::Reg::Reg() : m_instance(nullptr, InstanceDeleter{ DnsServiceFreeInstance }), m_asyncDone(nullptr) {
+	m_module = LoadLibrary(L"dnsapi.dll");
 	if (!m_module) {
 		return;
 	}
@@ -82,11 +82,16 @@ Zeroconf::Reg::Reg() : m_instance(nullptr, InstanceDeleter{ DnsServiceFreeInstan
 	GET_SYMBOL(DnsServiceDeRegister);
 	GET_SYMBOL(DnsServiceRegisterCancel);
 
-	if (!DnsServiceConstructInstance || !DnsServiceFreeInstance || !DnsServiceRegister || !DnsServiceDeRegister
-		|| !DnsServiceRegisterCancel) {
-		FreeModule(m_module);
-		m_module = nullptr;
+	if (DnsServiceConstructInstance && DnsServiceFreeInstance && DnsServiceRegister && DnsServiceDeRegister
+		&& DnsServiceRegisterCancel) {
+		m_asyncDone = CreateEventW(nullptr, true, true, nullptr);
+		if (m_asyncDone) {
+			return;
+		}
 	}
+
+	FreeLibrary(m_module);
+	m_module = nullptr;
 }
 
 Zeroconf::Reg::~Reg() {
@@ -95,6 +100,10 @@ Zeroconf::Reg::~Reg() {
 	}
 
 	cancel();
+
+	WaitForSingleObject(m_asyncDone, INFINITE);
+
+	CloseHandle(m_asyncDone);
 	FreeLibrary(m_module);
 }
 
@@ -118,7 +127,9 @@ bool Zeroconf::Reg::cancel() {
 		req.Version                     = DNS_QUERY_REQUEST_VERSION1;
 		req.pServiceInstance            = m_instance.get();
 		req.pRegisterCompletionCallback = callback;
-		req.pQueryContext               = new CallbackCtx(weak_from_this());
+		req.pQueryContext               = this;
+
+		ResetEvent(m_asyncDone);
 
 		const auto ret = DnsServiceDeRegister(&req, nullptr);
 		if (ret != DNS_REQUEST_PENDING) {
@@ -135,6 +146,8 @@ bool Zeroconf::Reg::request(const BonjourRecord &record, const uint16_t port) {
 	if (!isOk()) {
 		return false;
 	}
+
+	WaitForSingleObject(m_asyncDone, INFINITE);
 
 	DWORD size = 0;
 	GetComputerNameEx(ComputerNameDnsHostname, nullptr, &size);
@@ -163,10 +176,12 @@ bool Zeroconf::Reg::request(const BonjourRecord &record, const uint16_t port) {
 	req.Version                     = DNS_QUERY_REQUEST_VERSION1;
 	req.pServiceInstance            = instance;
 	req.pRegisterCompletionCallback = callback;
-	req.pQueryContext               = new CallbackCtx(weak_from_this());
+	req.pQueryContext               = this;
 
 	m_cancel = DNS_SERVICE_CANCEL{};
 	m_instance.reset(instance);
+
+	ResetEvent(m_asyncDone);
 
 	const auto ret = DnsServiceRegister(&req, &m_cancel.value());
 	if (ret != DNS_REQUEST_PENDING) {
@@ -182,16 +197,13 @@ bool Zeroconf::Reg::request(const BonjourRecord &record, const uint16_t port) {
 }
 
 void WINAPI Zeroconf::Reg::callback(const DWORD status, void *userdata, DNS_SERVICE_INSTANCE *instance) {
-	auto ctx = std::unique_ptr< CallbackCtx >(static_cast< CallbackCtx * >(userdata));
-	if (auto self = ctx->regWeak.lock()) {
-		self->m_instance.reset(instance);
+	auto &self = *static_cast< Reg * >(userdata);
 
-		if (!self->m_cancel) {
-			// No cancel handle, which means this is a de-registration.
-			return;
-		}
+	self.m_instance.reset(instance);
 
-		self->m_cancel.reset();
+	if (self.m_cancel) {
+		// Cancel handle present, this is a registration.
+		self.m_cancel.reset();
 
 		switch (status) {
 			case ERROR_SUCCESS:
@@ -203,6 +215,8 @@ void WINAPI Zeroconf::Reg::callback(const DWORD status, void *userdata, DNS_SERV
 						 status);
 		}
 	}
+
+	SetEvent(self.m_asyncDone);
 }
 #endif
 

--- a/src/murmur/Zeroconf.h
+++ b/src/murmur/Zeroconf.h
@@ -33,7 +33,7 @@ protected:
 #ifdef Q_OS_WIN
 	class Reg : public std::enable_shared_from_this< Reg > {
 	public:
-		constexpr auto isOk() const { return m_module != nullptr; }
+		constexpr auto isOk() const { return m_module && m_asyncDone; }
 
 		bool cancel();
 		bool request(const BonjourRecord &record, const uint16_t port);
@@ -42,10 +42,6 @@ protected:
 		~Reg();
 
 	protected:
-		struct CallbackCtx {
-			std::weak_ptr< Reg > regWeak;
-		};
-
 		struct InstanceDeleter {
 			using FreeFn = VOID(WINAPI *)(PDNS_SERVICE_INSTANCE);
 
@@ -75,9 +71,10 @@ protected:
 
 	private:
 		HMODULE m_module;
+		HANDLE m_asyncDone;
 	};
 
-	std::shared_ptr< Reg > m_reg;
+	std::unique_ptr< Reg > m_reg;
 #endif
 	std::unique_ptr< BonjourServiceRegister > m_helper;
 


### PR DESCRIPTION
`GetModuleHandle()` only returns a handle if the library is already loaded, which doesn't appear to be the case anymore. Evidently Qt Network now only loads `dnsapi.dll` when it actually needs to call DNS-related functions. In fact the client doesn't seem to be affected: `GetModuleHandle()` still returns a valid handle.

`LoadLibrary()` is the correct choice in any case, as it explicitly loads the library or increases its reference count if already loaded.

### Checks

- [x] My commits follow the [commit guidelines](https://github.com/mumble-voip/mumble/blob/master/COMMIT_GUIDELINES.md)

