### PR TITLE
Backport "Merge PR #7324: FIX(client): Call `QLibrary::unload()` after a failed library load" to 1.6.x

### DIFF
--- a/src/mumble/GKey.cpp
+++ b/src/mumble/GKey.cpp
@@ -113,6 +113,7 @@ GKeyLibrary::GKeyLibrary() {
 			bValid = true;
 			break;
 		}
+		qlLogiGkey.unload();
 	}
 
 	RESOLVE(LogiGkeyInit);

--- a/src/mumble/JackAudio.cpp
+++ b/src/mumble/JackAudio.cpp
@@ -210,6 +210,7 @@ JackAudioSystem::JackAudioSystem() : bAvailable(false), users(0), client(nullptr
 		if (qlJack.load()) {
 			break;
 		}
+		qlJack.unload();
 	}
 
 	if (!qlJack.isLoaded()) {

--- a/src/mumble/PAAudio.cpp
+++ b/src/mumble/PAAudio.cpp
@@ -135,6 +135,7 @@ PortAudioSystem::PortAudioSystem() : bOk(false) {
 		if (qlPortAudio.load()) {
 			break;
 		}
+		qlPortAudio.unload();
 	}
 
 	if (!qlPortAudio.isLoaded()) {

--- a/src/mumble/PipeWire.cpp
+++ b/src/mumble/PipeWire.cpp
@@ -143,6 +143,7 @@ PipeWireSystem::PipeWireSystem() : m_ok(false), m_users(0) {
 		if (m_lib.load()) {
 			break;
 		}
+		m_lib.unload();
 	}
 
 	if (!m_lib.isLoaded()) {

--- a/src/mumble/PulseAudio.cpp
+++ b/src/mumble/PulseAudio.cpp
@@ -1033,6 +1033,7 @@ PulseAudio::PulseAudio() : m_ok(false) {
 		if (m_lib.load()) {
 			break;
 		}
+		m_lib.unload();
 	}
 
 	if (!m_lib.isLoaded()) {


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `1.6.x`:
 - [Merge PR #7324: FIX(client): Call `QLibrary::unload()` after a failed library load](https://github.com/mumble-voip/mumble/pull/7324)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)