### PR TITLE
Backport "Merge PR #7341: CI: Bump agilepathway/label-checker action" to 1.6.x

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -12,7 +12,7 @@ jobs:
       state: ${{ steps.check.outputs.label_check }}
     steps:
       - id: check
-        uses: agilepathway/label-checker@v1.6.55
+        uses: agilepathway/label-checker@v1.6.66
         with:
           prefix_mode: true
           any_of: auto-backport-to-


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `1.6.x`:
 - [Merge PR #7341: CI: Bump agilepathway/label-checker action](https://github.com/mumble-voip/mumble/pull/7341)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)