### PR TITLE
CI: Update ccache action

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -80,7 +80,7 @@ jobs:
           path: '${{ env.MUMBLE_ENVIRONMENT_DIR }}'
           key: ${{ env.MUMBLE_ENVIRONMENT_VERSION }}
 
-    - uses: hendrikmuhs/ccache-action@v1.2
+    - uses: hendrikmuhs/ccache-action@v1.2.24
       with:
         key: ${{ github.base_ref || github.ref_name }}.${{ matrix.os }}.${{ matrix.type }}
         save: ${{ github.event_name != 'pull_request' }}


### PR DESCRIPTION
Upstream didn't update the "floating" v1.2 tag for newer releases. See https://github.com/hendrikmuhs/ccache-action/issues/437


### Checks

- [x] My commits follow the [commit guidelines](https://github.com/mumble-voip/mumble/blob/master/COMMIT_GUIDELINES.md)

