### PR TITLE
FIX(client): Prevent leftover PulseAudio output when switching to PipeWire

### DIFF
--- a/src/mumble/PulseAudio.cpp
+++ b/src/mumble/PulseAudio.cpp
@@ -200,7 +200,7 @@ void PulseAudioSystem::eventCallback(pa_mainloop_api *api, pa_defer_event *) {
 	PulseAudioInput *pai  = dynamic_cast< PulseAudioInput * >(raw_ai);
 	PulseAudioOutput *pao = dynamic_cast< PulseAudioOutput * >(raw_ao);
 
-	if (raw_ao) {
+	if (pasOutput || raw_ao) {
 		QString odev        = outputDevice();
 		pa_stream_state ost = pasOutput ? m_pulseAudio.stream_get_state(pasOutput) : PA_STREAM_TERMINATED;
 		bool do_stop        = false;
@@ -247,6 +247,11 @@ void PulseAudioSystem::eventCallback(pa_mainloop_api *api, pa_defer_event *) {
 			qWarning("PulseAudio: Stopping output");
 			m_pulseAudio.stream_disconnect(pasOutput);
 			iSinkId = -1;
+
+			if (!pao) {
+				m_pulseAudio.stream_unref(pasOutput);
+				pasOutput = nullptr;
+			}
 		} else if (do_start) {
 			qWarning("PulseAudio: Starting output: %s", qPrintable(odev));
 			pa_buffer_attr buff;


### PR DESCRIPTION
Fixes #7293

## Problem

When switching the audio output system from PulseAudio to PipeWire while Mumble is running, a leftover PulseAudio output named "Mumble" persists until Mumble is restarted. The expected behavior is that the PulseAudio output is cleanly stopped.

## Root Cause

In `PulseAudioSystem::eventCallback()` (line 203), the condition `if (raw_ao)` guards the entire output stream management block. However, when `Audio::stop()` is called during the backend switch, `Global::ao` is set to `nullptr` before the event callback runs. This means `raw_ao` (derived from `Global::get().ao`) is `nullptr`, and the entire block is skipped — even though `pasOutput` (the actual PulseAudio stream) is still active and needs to be disconnected.

The fix proposed by @WUCJ638 in the issue thread: change the guard condition to also check `pasOutput`:

```cpp
// Before
if (raw_ao) {

// After  
if (pasOutput || raw_ao) {
```

This ensures that when `raw_ao` is `nullptr` but `pasOutput` is still active, the callback enters the management block. Inside, the existing logic handles this case correctly: `!pao && (ost == PA_STREAM_READY)` evaluates to `true`, setting `do_stop = true`, which disconnects the stream.

## Testing

- Build verification requires Linux with PulseAudio/PipeWire
- Reproduction steps from #7293:
  1. Set audio output to PulseAudio
  2. Switch to PipeWire while Mumble is running
  3. Verify the leftover "Mumble" output is gone
  4. Restart Mumble and confirm only the PipeWire output persists