### PR TITLE
Backport "Merge PR #7345: FIX(shared): QoS delay-load (qWAVE), IPv6 and loopback fixes" to 1.6.x

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -190,6 +190,11 @@ target_link_libraries(shared
 
 if(WIN32)
 	target_link_libraries(shared PUBLIC qwave.lib)
+
+	if(MSVC)
+		target_link_libraries(shared PUBLIC Delayimp.lib)
+		target_link_options(shared PUBLIC "/DELAYLOAD:qwave.dll")
+	endif()
 elseif(APPLE)
 	find_library(LIB_CORESERVICES "CoreServices")
 	target_link_libraries(shared PUBLIC ${LIB_CORESERVICES})

--- a/src/Connection.cpp
+++ b/src/Connection.cpp
@@ -73,11 +73,32 @@ void Connection::setToS() {
 							QOS_NON_ADAPTIVE_FLOW, reinterpret_cast< PQOS_FLOWID >(&dwFlow)))
 		qWarning("Connection: Failed to add flow to QOS");
 #elif defined(Q_OS_UNIX)
-	int val = 0xa0;
-	if (setsockopt(static_cast< int >(qtsSocket->socketDescriptor()), IPPROTO_IP, IP_TOS, &val, sizeof(val))) {
+	const int fd = static_cast< int >(qtsSocket->socketDescriptor());
+	int val      = 0xa0;
+
+	auto setTos = [&](const int level, const int optname) {
+		if (setsockopt(fd, level, optname, &val, sizeof(val)) == 0) {
+			return true;
+		}
+
 		val = 0x60;
-		if (setsockopt(static_cast< int >(qtsSocket->socketDescriptor()), IPPROTO_IP, IP_TOS, &val, sizeof(val)))
-			qWarning("Connection: Failed to set TOS for TCP Socket");
+		return setsockopt(fd, level, optname, &val, sizeof(val)) == 0;
+	};
+
+	bool ok = false;
+	if (qtsSocket->peerAddress().protocol() == QAbstractSocket::IPv6Protocol) {
+		ok = setTos(IPPROTO_IPV6, IPV6_TCLASS);
+		// Dual-stack listen: peer may be IPv4-mapped on an AF_INET6 fd.
+		if (qtsSocket->peerAddress().toIPv4Address()) {
+			val = 0xa0;
+			setTos(IPPROTO_IP, IP_TOS);
+		}
+	} else {
+		ok = setTos(IPPROTO_IP, IP_TOS);
+	}
+
+	if (!ok) {
+		qWarning("Connection: Failed to set TOS/TCLASS");
 	}
 #	if defined(SO_PRIORITY)
 	socklen_t optlen = sizeof(val);

--- a/src/Connection.cpp
+++ b/src/Connection.cpp
@@ -65,10 +65,10 @@ Connection::~Connection() {
 
 void Connection::setToS() {
 #if defined(Q_OS_WIN)
-	if (dwFlow || !hQoS)
+	if (dwFlow || peerAddress().isLoopback() || !hQoS) {
 		return;
+	}
 
-	dwFlow = 0;
 	if (!QOSAddSocketToFlow(hQoS, qtsSocket->socketDescriptor(), nullptr, QOSTrafficTypeAudioVideo,
 							QOS_NON_ADAPTIVE_FLOW, reinterpret_cast< PQOS_FLOWID >(&dwFlow)))
 		qWarning("Connection: Failed to add flow to QOS");

--- a/src/mumble/CMakeLists.txt
+++ b/src/mumble/CMakeLists.txt
@@ -639,9 +639,7 @@ if(WIN32)
 		target_link_libraries(mumble_client_object_lib
 			PUBLIC
 				Boost::dynamic_linking
-				Delayimp.lib
 			)
-		set_property(TARGET mumble_client_object_lib APPEND_STRING PROPERTY LINK_FLAGS " /DELAYLOAD:user32.dll /DELAYLOAD:qwave.dll")
 	endif()
 
 	target_link_libraries(mumble_client_object_lib

--- a/src/mumble/ServerHandler.cpp
+++ b/src/mumble/ServerHandler.cpp
@@ -347,7 +347,8 @@ void ServerHandler::sendMessage(const unsigned char *data, int len, bool force) 
 										  static_cast< unsigned int >(len))) {
 			return;
 		}
-		qusUdp->writeDatagram(reinterpret_cast< const char * >(crypto.data()), len + 4, qhaRemote, usResolvedPort);
+		qusUdp->writeDatagram(reinterpret_cast< const char * >(crypto.data()), len + 4, qhaRemote.toAddress(),
+							  usResolvedPort);
 	}
 }
 
@@ -859,7 +860,7 @@ void ServerHandler::serverConnectionConnected() {
 		qhaRemote      = connection->peerAddress();
 		qhaLocal       = connection->localAddress();
 		usResolvedPort = connection->peerPort();
-		if (qhaLocal.isNull()) {
+		if (!qhaLocal.isValid()) {
 			qFatal("ServerHandler: qhaLocal is unexpectedly a null addr");
 		}
 
@@ -868,9 +869,9 @@ void ServerHandler::serverConnectionConnected() {
 			qFatal("ServerHandler: qusUdp is unexpectedly a null addr");
 		}
 		if (Global::get().s.bUdpForceTcpAddr) {
-			qusUdp->bind(qhaLocal, 0);
+			qusUdp->bind(qhaLocal.toAddress(), 0);
 		} else {
-			if (qhaRemote.protocol() == QAbstractSocket::IPv6Protocol) {
+			if (qhaRemote.isV6()) {
 				qusUdp->bind(QHostAddress(QHostAddress::AnyIPv6), 0);
 			} else {
 				qusUdp->bind(QHostAddress(QHostAddress::Any), 0);
@@ -881,11 +882,36 @@ void ServerHandler::serverConnectionConnected() {
 
 		if (Global::get().s.bQoS) {
 #if defined(Q_OS_UNIX)
-			int val = 0xe0;
-			if (setsockopt(static_cast< int >(qusUdp->socketDescriptor()), IPPROTO_IP, IP_TOS, &val, sizeof(val))) {
+			int val     = 0xe0;
+			auto setTos = [&](const int level, const int optname) {
+				if (setsockopt(static_cast< int >(qusUdp->socketDescriptor()), level, optname, &val, sizeof(val))
+					== 0) {
+					return true;
+				}
+
 				val = 0x80;
-				if (setsockopt(static_cast< int >(qusUdp->socketDescriptor()), IPPROTO_IP, IP_TOS, &val, sizeof(val)))
-					qWarning("ServerHandler: Failed to set TOS for UDP Socket");
+				return setsockopt(static_cast< int >(qusUdp->socketDescriptor()), level, optname, &val, sizeof(val))
+					   == 0;
+			};
+
+			bool ok = false;
+			if (qhaRemote.isV6()) {
+				ok = setTos(IPPROTO_IPV6, IPV6_TCLASS);
+				// Dual-stack: IPv4-mapped datagrams still use IP_TOS on Linux.
+				int v6only    = 1;
+				socklen_t len = sizeof(v6only);
+				if (getsockopt(static_cast< int >(qusUdp->socketDescriptor()), IPPROTO_IPV6, IPV6_V6ONLY, &v6only, &len)
+						== 0
+					&& v6only == 0) {
+					val = 0xe0;
+					setTos(IPPROTO_IP, IP_TOS);
+				}
+			} else {
+				ok = setTos(IPPROTO_IP, IP_TOS);
+			}
+
+			if (!ok) {
+				qWarning("ServerHandler: Failed to set TOS/TCLASS for UDP");
 			}
 #	if defined(SO_PRIORITY)
 			socklen_t optlen = sizeof(val);
@@ -899,12 +925,17 @@ void ServerHandler::serverConnectionConnected() {
 			}
 #	endif
 #elif defined(Q_OS_WIN)
-			if (!dwFlowUDP && !qhaRemote.isLoopback() && hQoS) {
-				struct sockaddr_in addr;
-				memset(&addr, 0, sizeof(addr));
-				addr.sin_family      = AF_INET;
-				addr.sin_port        = htons(usPort);
-				addr.sin_addr.s_addr = htonl(qhaRemote.toIPv4Address());
+			if (!dwFlowUDP && !qhaRemote.toAddress().isLoopback() && hQoS) {
+				struct sockaddr_storage addr;
+				qhaRemote.toSockaddr(&addr);
+
+				if (qhaRemote.isV6()) {
+					auto addrIn       = reinterpret_cast< sockaddr_in6 * >(&addr);
+					addrIn->sin6_port = htons(usResolvedPort);
+				} else {
+					auto addrIn      = reinterpret_cast< sockaddr_in * >(&addr);
+					addrIn->sin_port = htons(usResolvedPort);
+				}
 
 				if (!QOSAddSocketToFlow(hQoS, qusUdp->socketDescriptor(), reinterpret_cast< sockaddr * >(&addr),
 										QOSTrafficTypeVoice, QOS_NON_ADAPTIVE_FLOW,

--- a/src/mumble/ServerHandler.cpp
+++ b/src/mumble/ServerHandler.cpp
@@ -103,7 +103,7 @@ static HANDLE loadQoS() {
 			qWarning("ServerHandler: Failed to create QOS2 handle");
 			hQoS = nullptr;
 		} else {
-			qWarning("ServerHandler: QOS2 loaded");
+			qInfo("ServerHandler: QOS2 loaded");
 		}
 	}
 	return hQoS;

--- a/src/mumble/ServerHandler.cpp
+++ b/src/mumble/ServerHandler.cpp
@@ -163,6 +163,7 @@ ServerHandler::ServerHandler() : database(new Database(QLatin1String("ServerHand
 	hQoS = loadQoS();
 	if (hQoS)
 		Connection::setQoS(hQoS);
+	dwFlowUDP = 0;
 #endif
 
 	QObject::connect(this, &ServerHandler::pingRequested, this, &ServerHandler::sendPingInternal, Qt::QueuedConnection);
@@ -898,14 +899,13 @@ void ServerHandler::serverConnectionConnected() {
 			}
 #	endif
 #elif defined(Q_OS_WIN)
-			if (hQoS) {
+			if (!dwFlowUDP && !qhaRemote.isLoopback() && hQoS) {
 				struct sockaddr_in addr;
 				memset(&addr, 0, sizeof(addr));
 				addr.sin_family      = AF_INET;
 				addr.sin_port        = htons(usPort);
 				addr.sin_addr.s_addr = htonl(qhaRemote.toIPv4Address());
 
-				dwFlowUDP = 0;
 				if (!QOSAddSocketToFlow(hQoS, qusUdp->socketDescriptor(), reinterpret_cast< sockaddr * >(&addr),
 										QOSTrafficTypeVoice, QOS_NON_ADAPTIVE_FLOW,
 										reinterpret_cast< PQOS_FLOWID >(&dwFlowUDP)))

--- a/src/mumble/ServerHandler.h
+++ b/src/mumble/ServerHandler.h
@@ -31,6 +31,7 @@
 
 #define SERVERSEND_EVENT 3501
 
+#include "HostAddress.h"
 #include "Mumble.pb.h"
 #include "MumbleProtocol.h"
 #include "ServerAddress.h"
@@ -105,8 +106,8 @@ protected:
 	DWORD dwFlowUDP;
 #endif
 
-	QHostAddress qhaRemote;
-	QHostAddress qhaLocal;
+	HostAddress qhaRemote;
+	HostAddress qhaLocal;
 	QUdpSocket *qusUdp;
 	QMutex qmUdp;
 

--- a/src/murmur/Meta.cpp
+++ b/src/murmur/Meta.cpp
@@ -42,6 +42,7 @@
 #endif
 
 #ifdef Q_OS_WIN
+#	include <delayimp.h>
 #	include <qos2.h>
 #else
 #	include <pwd.h>
@@ -54,6 +55,38 @@ std::unique_ptr< MetaParams > Meta::mp;
 
 #ifdef Q_OS_WIN
 HANDLE Meta::hQoS = nullptr;
+
+static HANDLE loadQoS() {
+	HRESULT res = E_FAIL;
+
+	// We don't support delay-loading QoS on MinGW. Only enable it for MSVC.
+#	ifdef _MSC_VER
+	__try {
+		res = __HrLoadAllImportsForDll("qwave.dll");
+	}
+
+	__except (EXCEPTION_EXECUTE_HANDLER) {
+		res = E_FAIL;
+	}
+#	endif
+
+	if (!SUCCEEDED(res)) {
+		qWarning("Meta: Failed to load qWave.dll, no QoS available");
+		return nullptr;
+	}
+
+	qInfo("Meta: QOS2 loaded");
+
+	QOS_VERSION ver{ .MajorVersion = 1, .MinorVersion = 0 };
+
+	HANDLE handle;
+	if (!QOSCreateHandle(&ver, &handle)) {
+		qWarning("Meta: Failed to create QOS2 handle");
+		return nullptr;
+	}
+
+	return handle;
+}
 #endif
 
 MetaParams::MetaParams() {
@@ -648,22 +681,8 @@ bool MetaParams::loadSSLSettings() {
 
 Meta::Meta(const ::mumble::db::ConnectionParameter &connectParam) : dbWrapper(connectParam) {
 #ifdef Q_OS_WIN
-	QOS_VERSION qvVer;
-	qvVer.MajorVersion = 1;
-	qvVer.MinorVersion = 0;
-
-	hQoS = nullptr;
-
-	HMODULE hLib = LoadLibrary(L"qWave.dll");
-	if (!hLib) {
-		qWarning("Meta: Failed to load qWave.dll, no QoS available");
-	} else {
-		FreeLibrary(hLib);
-		if (!QOSCreateHandle(&qvVer, &hQoS))
-			qWarning("Meta: Failed to create QOS2 handle");
-		else
-			Connection::setQoS(hQoS);
-	}
+	hQoS = loadQoS();
+	Connection::setQoS(hQoS);
 #endif
 }
 

--- a/src/murmur/Server.cpp
+++ b/src/murmur/Server.cpp
@@ -195,11 +195,30 @@ Server::Server(unsigned int snum, const ::mumble::db::ConnectionParameter &conne
 #endif
 			} else {
 #ifdef Q_OS_UNIX
-				int val = 0xe0;
-				if (setsockopt(sock, IPPROTO_IP, IP_TOS, &val, sizeof(val))) {
+				int val     = 0xe0;
+				auto setTos = [&](const int level, const int optname) {
+					if (setsockopt(sock, level, optname, &val, sizeof(val)) == 0)
+						return true;
 					val = 0x80;
-					if (setsockopt(sock, IPPROTO_IP, IP_TOS, &val, sizeof(val)))
-						log("Server: Failed to set TOS for UDP Socket");
+					return setsockopt(sock, level, optname, &val, sizeof(val)) == 0;
+				};
+
+				bool ok = false;
+				if (addr.ss_family == AF_INET6) {
+					ok = setTos(IPPROTO_IPV6, IPV6_TCLASS);
+					// Dual-stack: IPv4-mapped datagrams still use IP_TOS on Linux.
+					int v6only    = 1;
+					socklen_t len = sizeof(v6only);
+					if (getsockopt(sock, IPPROTO_IPV6, IPV6_V6ONLY, &v6only, &len) == 0 && v6only == 0) {
+						val = 0xe0;
+						setTos(IPPROTO_IP, IP_TOS);
+					}
+				} else {
+					ok = setTos(IPPROTO_IP, IP_TOS);
+				}
+
+				if (!ok) {
+					log(QLatin1String("Failed to set TOS/TCLASS for UDP"));
 				}
 #	if defined(SO_PRIORITY)
 				socklen_t optlen = sizeof(val);


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `1.6.x`:
 - [Merge PR #7345: FIX(shared): QoS delay-load (qWAVE), IPv6 and loopback fixes](https://github.com/mumble-voip/mumble/pull/7345)

<!--- Backport version: unknown -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)